### PR TITLE
feat: add user story template and improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Melde einen Fehler
+description: Report a bug
 title: "[Bug]: "
 labels: ["bug"]
 assignees: []
@@ -8,63 +8,63 @@ body:
   - type: dropdown
     id: persona
     attributes:
-      label: Betroffene Persona
-      description: Wer ist von diesem Fehler betroffen?
+      label: Affected Persona
+      description: Who is affected by this bug?
       options:
         - Volunteer Vera
         - Organizer Olaf
         - Contributor Caro
         - Maintainer Milo
-        - Alle
+        - All
     validations:
       required: true
 
   - type: dropdown
-    id: prioritaet
+    id: priority
     attributes:
-      label: Priorität
+      label: Priority
       options:
-        - Niedrig
-        - Mittel
-        - Hoch
+        - Low
+        - Medium
+        - High
     validations:
       required: true
 
   - type: textarea
-    id: beschreibung
+    id: description
     attributes:
-      label: Beschreibung
-      description: Was passiert und was sollte stattdessen passieren?
+      label: Description
+      description: What happens and what should happen instead?
       placeholder: |
-        **Tatsächliches Verhalten:** Was passiert gerade?
-        **Erwartetes Verhalten:** Was sollte stattdessen passieren?
+        **Actual behaviour:** What is currently happening?
+        **Expected behaviour:** What should happen instead?
     validations:
       required: true
 
   - type: textarea
-    id: reproduktion
+    id: reproduction
     attributes:
-      label: Schritte zur Reproduktion
-      description: So lässt sich der Fehler nachstellen
+      label: Steps to Reproduce
+      description: How can the bug be reproduced?
       placeholder: |
-        1. Schritt 1
-        2. Schritt 2
-        3. Schritt 3
+        1. Step 1
+        2. Step 2
+        3. Step 3
     validations:
       required: true
 
   - type: textarea
-    id: umgebung
+    id: environment
     attributes:
-      label: Umgebung
-      description: In welcher Umgebung tritt der Fehler auf?
+      label: Environment
+      description: In which environment does the bug occur?
       placeholder: |
         - Browser / Version:
-        - Betriebssystem:
-        - Einsatzbereit-Version / Branch:
+        - Operating System:
+        - Einsatzbereit Version / Branch:
 
   - type: textarea
     id: extra
     attributes:
-      label: Zusätzliche Informationen
-      placeholder: Screenshots, Logs, Links, Kontext
+      label: Additional Information
+      placeholder: Screenshots, logs, links, context

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,20 @@ assignees: []
 
 body:
   - type: dropdown
+    id: persona
+    attributes:
+      label: Betroffene Persona
+      description: Wer ist von diesem Fehler betroffen?
+      options:
+        - Volunteer Vera
+        - Organizer Olaf
+        - Contributor Caro
+        - Maintainer Milo
+        - Alle
+    validations:
+      required: true
+
+  - type: dropdown
     id: prioritaet
     attributes:
       label: Priorität
@@ -21,7 +35,9 @@ body:
     attributes:
       label: Beschreibung
       description: Was passiert und was sollte stattdessen passieren?
-      placeholder: Beschreibe den Fehler in wenigen Sätzen.
+      placeholder: |
+        **Tatsächliches Verhalten:** Was passiert gerade?
+        **Erwartetes Verhalten:** Was sollte stattdessen passieren?
     validations:
       required: true
 
@@ -36,6 +52,16 @@ body:
         3. Schritt 3
     validations:
       required: true
+
+  - type: textarea
+    id: umgebung
+    attributes:
+      label: Umgebung
+      description: In welcher Umgebung tritt der Fehler auf?
+      placeholder: |
+        - Browser / Version:
+        - Betriebssystem:
+        - Einsatzbereit-Version / Branch:
 
   - type: textarea
     id: extra

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -53,19 +53,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: estimation
-    attributes:
-      label: Estimation (Story Points)
-      options:
-        - "1"
-        - "2"
-        - "3"
-        - "5"
-        - "8"
-        - "13"
-        - Too large – split up
-
   - type: textarea
     id: additional_info
     attributes:

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,5 +1,5 @@
 name: User Story
-description: Beschreibe eine Anforderung aus Nutzerperspektive
+description: Describe a requirement from a user's perspective
 title: "[Story]: "
 labels: ["user-story"]
 assignees: []
@@ -9,7 +9,7 @@ body:
     id: persona
     attributes:
       label: Persona
-      description: Welche Persona steht im Mittelpunkt dieser Story?
+      description: Which persona does this story focus on?
       options:
         - Volunteer Vera
         - Organizer Olaf
@@ -22,41 +22,41 @@ body:
     id: user_story
     attributes:
       label: User Story
-      description: Beschreibe die Anforderung im Standard-Format
+      description: Describe the requirement in the standard format
       placeholder: |
-        Als <Persona>
-        möchte ich <Aktion / Ziel>
-        damit <Nutzen / Mehrwert>
+        As a <persona>
+        I want to <action / goal>
+        so that <benefit / value>
     validations:
       required: true
 
   - type: textarea
-    id: akzeptanzkriterien
+    id: acceptance_criteria
     attributes:
-      label: Akzeptanzkriterien
-      description: Wann gilt diese Story als abgeschlossen? (Given/When/Then)
+      label: Acceptance Criteria
+      description: When is this story done? (Given/When/Then)
       placeholder: |
-        - Gegeben: <Ausgangssituation>
-          Wenn: <Aktion>
-          Dann: <erwartetes Ergebnis>
+        - Given: <initial context>
+          When: <action>
+          Then: <expected outcome>
     validations:
       required: true
 
   - type: dropdown
-    id: prioritaet
+    id: priority
     attributes:
-      label: Priorität
+      label: Priority
       options:
-        - Niedrig
-        - Mittel
-        - Hoch
+        - Low
+        - Medium
+        - High
     validations:
       required: true
 
   - type: dropdown
-    id: schaetzung
+    id: estimation
     attributes:
-      label: Schätzung (Story Points)
+      label: Estimation (Story Points)
       options:
         - "1"
         - "2"
@@ -64,14 +64,14 @@ body:
         - "5"
         - "8"
         - "13"
-        - Zu groß – aufteilen
+        - Too large – split up
 
   - type: textarea
-    id: zusaetzliche_infos
+    id: additional_info
     attributes:
-      label: Zusätzliche Informationen
+      label: Additional Information
       placeholder: |
         - Screenshots
         - Links
-        - Kontext
-        - Abhängigkeiten
+        - Context
+        - Dependencies

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,0 +1,77 @@
+name: User Story
+description: Beschreibe eine Anforderung aus Nutzerperspektive
+title: "[Story]: "
+labels: ["user-story"]
+assignees: []
+
+body:
+  - type: dropdown
+    id: persona
+    attributes:
+      label: Persona
+      description: Welche Persona steht im Mittelpunkt dieser Story?
+      options:
+        - Volunteer Vera
+        - Organizer Olaf
+        - Contributor Caro
+        - Maintainer Milo
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_story
+    attributes:
+      label: User Story
+      description: Beschreibe die Anforderung im Standard-Format
+      placeholder: |
+        Als <Persona>
+        möchte ich <Aktion / Ziel>
+        damit <Nutzen / Mehrwert>
+    validations:
+      required: true
+
+  - type: textarea
+    id: akzeptanzkriterien
+    attributes:
+      label: Akzeptanzkriterien
+      description: Wann gilt diese Story als abgeschlossen? (Given/When/Then)
+      placeholder: |
+        - Gegeben: <Ausgangssituation>
+          Wenn: <Aktion>
+          Dann: <erwartetes Ergebnis>
+    validations:
+      required: true
+
+  - type: dropdown
+    id: prioritaet
+    attributes:
+      label: Priorität
+      options:
+        - Niedrig
+        - Mittel
+        - Hoch
+    validations:
+      required: true
+
+  - type: dropdown
+    id: schaetzung
+    attributes:
+      label: Schätzung (Story Points)
+      options:
+        - "1"
+        - "2"
+        - "3"
+        - "5"
+        - "8"
+        - "13"
+        - Zu groß – aufteilen
+
+  - type: textarea
+    id: zusaetzliche_infos
+    attributes:
+      label: Zusätzliche Informationen
+      placeholder: |
+        - Screenshots
+        - Links
+        - Kontext
+        - Abhängigkeiten


### PR DESCRIPTION
## Summary

- Adds a new **User Story** issue template (`[Story]:` prefix, label: `user-story`) with persona dropdown, Given/When/Then acceptance criteria, story point estimation, and priority
- Improves the existing **Bug Report** template with an affected persona dropdown, structured expected-vs-actual description format, and an environment field
- Both templates use the four project personas: **Volunteer Vera**, **Organizer Olaf**, **Contributor Caro**, **Maintainer Milo**

## Changes

### New: `.github/ISSUE_TEMPLATE/user_story.yml`
| Field | Type | Notes |
|---|---|---|
| Persona | Dropdown | Vera / Olaf / Caro / Milo |
| User Story | Textarea | Als … möchte ich … damit … |
| Akzeptanzkriterien | Textarea | Given/When/Then format |
| Priorität | Dropdown | Niedrig / Mittel / Hoch |
| Schätzung | Dropdown | Fibonacci (1–13) + "Zu groß – aufteilen" |
| Zusätzliche Informationen | Textarea | Optional |

### Updated: `.github/ISSUE_TEMPLATE/bug_report.yml`
- Added **Betroffene Persona** dropdown (Vera / Olaf / Caro / Milo / Alle)
- Improved **Beschreibung** placeholder to prompt for actual vs. expected behaviour
- Added **Umgebung** field (Browser, OS, branch/version)

https://claude.ai/code/session_01P8dydV7TEoWHkQhkhwmhdo