### PR TITLE
chore(renovate): add customManagers to track Keycloak version in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ einsatzbereit/
 | | |
 |---|---|
 | Backend | .NET 10, EF Core 9, PostgreSQL 18 |
-| Auth | Keycloak 26.5 (OIDC, JWT) |
+| Auth | Keycloak 26.5.6 (OIDC, JWT) |
 | Frontend | Vite SPA, React 19, React Router v7, Tailwind CSS 4 |
 | API client | NSwag-generated — **never hand-edit** `api-client.ts` |
 | Tests (BE) | xUnit 3, Testcontainers, Respawn, NetArchTest |

--- a/docs/Architektur/images/container-view.puml
+++ b/docs/Architektur/images/container-view.puml
@@ -11,7 +11,7 @@ System_Boundary(einsatzbereit, "Einsatzbereit") {
     Container(frontend, "Single Page Application", "React 19, Vite, TypeScript, Tailwind CSS 4", "Provides the web UI for volunteers and organizers. Handles OIDC login and token management.")
     Container(backend, "Backend API", ".NET 10, ASP.NET Core Minimal API", "Implements business logic. Exposes versioned REST API. Validates JWT tokens. Manages data via EF Core.")
     ContainerDb(db, "Application Database", "PostgreSQL 18", "Stores volunteer opportunities, organizations, engagements, and user associations.")
-    Container(keycloak, "Identity Provider", "Keycloak 26.5", "Handles authentication via OIDC. Manages users, roles, and organizations. Issues signed JWT access tokens.")
+    Container(keycloak, "Identity Provider", "Keycloak 26.5.6", "Handles authentication via OIDC. Manages users, roles, and organizations. Issues signed JWT access tokens.")
 }
 
 Rel(volunteer, frontend, "Uses", "HTTPS")

--- a/docs/Architektur/images/deployment-local.puml
+++ b/docs/Architektur/images/deployment-local.puml
@@ -16,7 +16,7 @@ Deployment_Node(machine, "Developer Machine", "Windows / macOS / Linux") {
         }
 
         Deployment_Node(keycloak_node, "keycloak") {
-            Container(keycloak, "Identity Provider", "Keycloak 26.5", ":8080")
+            Container(keycloak, "Identity Provider", "Keycloak 26.5.6", ":8080")
         }
 
         Deployment_Node(postgres_node, "postgres") {

--- a/docs/Architektur/src/04_solution_strategy.adoc
+++ b/docs/Architektur/src/04_solution_strategy.adoc
@@ -67,7 +67,7 @@ The following table summarizes the key architectural decisions and how they addr
 |MediatR
 
 |Authentication / Authorization
-|Keycloak 26.5, OIDC, JWT Bearer
+|Keycloak 26.5.6, OIDC, JWT Bearer
 
 |Database
 |PostgreSQL 18

--- a/docs/Architektur/src/05_building_block_view.adoc
+++ b/docs/Architektur/src/05_building_block_view.adoc
@@ -30,7 +30,7 @@ Contained Building Blocks::
 |Exposes the versioned REST API. Implements all business logic via CQRS handlers. Validates JWT tokens, enforces role-based authorization, persists data via EF Core.
 
 |Identity Provider
-|Keycloak 26.5
+|Keycloak 26.5.6
 |Handles user authentication via OIDC Authorization Code Flow. Manages users, roles (`user`, `organisator`, `admin`), and organizations. Issues and signs JWT access tokens.
 
 |Application Database

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,21 @@
   "dependencyDashboard": true,
   "automerge": false,
   "labels": ["dependencies", "renovate"],
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^keycloak/CLAUDE\\.md$",
+        "^docs/Architektur/src/.*\\.adoc$",
+        "^docs/Architektur/images/.*\\.puml$"
+      ],
+      "matchStrings": [
+        "Keycloak (?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)",
+        "quay\\.io/keycloak/keycloak:(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "quay.io/keycloak/keycloak"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^CLAUDE\\.md$",
         "^keycloak/CLAUDE\\.md$",
         "^docs/Architektur/src/.*\\.adoc$",
         "^docs/Architektur/images/.*\\.puml$"


### PR DESCRIPTION
## Summary

Renovate PR #56 only updated the two Dockerfiles — the Docker manager doesn't scan `.md`, `.adoc`, or `.puml` files. Several documentation files with hardcoded Keycloak version references are silently missed on every upgrade.

- **Add `customManagers`** to `renovate.json` with a regex that scans `keycloak/CLAUDE.md`, `docs/**/*.adoc`, and `docs/**/*.puml` for `Keycloak X.Y.Z` and `quay.io/keycloak/keycloak:X.Y.Z` patterns
- **Expand abbreviated version strings** in 4 doc files (`Keycloak 26.5` → `Keycloak 26.5.6`) so the regex can match them going forward

Files intentionally excluded from Renovate tracking:
- `docs/Architektur/src/07_deployment_view.adoc` — references the project's own custom image tag (`keycloak/v26.5.6.1`), not the upstream image
- `VERSIONING.md` — historical changelog entries

## Test plan

- [ ] Merge this PR first, then merge PR #56 for the actual 26.5.6 → 26.6.1 upgrade (Renovate will then also update the doc files automatically)
- [ ] Trigger a Renovate run via the Dependency Dashboard to verify the new `customManagers` are picked up without errors
- [ ] On the next Keycloak release, confirm Renovate opens a single PR touching both Dockerfiles and all doc files

https://claude.ai/code/session_01MW1Yxn3djd3GmsVEKzKJhS