### PR TITLE
fix(renovate): disable pin update type for msbuild-sdk

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
     {
       "matchManagers": ["msbuild-sdk"],
       "rangeStrategy": "replace"
+    },
+    {
+      "matchManagers": ["msbuild-sdk"],
+      "matchUpdateTypes": ["pin"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
rangeStrategy: replace only controls range formatting during version bumps but does not suppress the separate "pin" update type, which converts 13.2.4 to [13.2.4]. Explicitly disabling pin updates for msbuild-sdk prevents Renovate from reopening this PR.

https://claude.ai/code/session_01UkPttWCBU7JwbM2nuenj62