### PR TITLE
fix(renovate): scope pin rangeStrategy to nuget manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,17 @@ dotnet tool run openapi
 - No dead code - remove, don't comment out
 - Consistency within a module beats personal preference
 
+## Dependency Management
+
+Dependencies are managed by [Renovate](https://docs.renovatebot.com/) (config: `renovate.json`).
+
+| Manager      | Range strategy | Notes                                                                 |
+|--------------|----------------|-----------------------------------------------------------------------|
+| `nuget`      | `pin`          | NuGet `PackageVersion` entries use exact-version brackets (e.g. `[10.0.7]`) via `Directory.Packages.props`. |
+| `msbuild-sdk`| `replace`      | MSBuild SDK references (e.g. `Aspire.AppHost.Sdk`) must stay floating - bracketed pins like `[13.2.4]` break SDK resolution. Pin update PRs are explicitly disabled for this manager. |
+
+When adding a new manager, set its `rangeStrategy` explicitly in a `packageRules` entry rather than relying on a global default.
+
 ## Architecture Decisions
 
 Significant architectural decisions are documented as ADRs under `docs/ADRs/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ Dependencies are managed by [Renovate](https://docs.renovatebot.com/) (config: `
 | `nuget`      | `pin`          | NuGet `PackageVersion` entries use exact-version brackets (e.g. `[10.0.7]`) via `Directory.Packages.props`. |
 | `npm`        | `pin`          | `frontend/package.json` keeps exact versions (no `^`/`~`); Renovate auto-pins any new caret/tilde ranges. |
 | `msbuild-sdk`| `replace`      | MSBuild SDK references (e.g. `Aspire.AppHost.Sdk`) must stay floating - bracketed pins like `[13.2.4]` break SDK resolution. Pin update PRs are explicitly disabled for this manager. |
+| `dockerfile` / `docker-compose` | `replace` + `pinDigests` | Image tags get an immutable `@sha256:...` digest appended for supply-chain integrity. |
+| `github-actions` | `replace` + `pinDigests` | Action references (`uses: actions/checkout@v6`) get pinned to commit SHAs. |
 
 When adding a new manager, set its `rangeStrategy` explicitly in a `packageRules` entry rather than relying on a global default.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,15 +152,7 @@ dotnet tool run openapi
 
 Dependencies are managed by [Renovate](https://docs.renovatebot.com/) (config: `renovate.json`).
 
-| Manager      | Range strategy | Notes                                                                 |
-|--------------|----------------|-----------------------------------------------------------------------|
-| `nuget`      | `pin`          | NuGet `PackageVersion` entries use exact-version brackets (e.g. `[10.0.7]`) via `Directory.Packages.props`. |
-| `npm`        | `pin`          | `frontend/package.json` keeps exact versions (no `^`/`~`); Renovate auto-pins any new caret/tilde ranges. |
-| `msbuild-sdk`| `replace`      | MSBuild SDK references (e.g. `Aspire.AppHost.Sdk`) must stay floating - bracketed pins like `[13.2.4]` break SDK resolution. Pin update PRs are explicitly disabled for this manager. |
-| `dockerfile` / `docker-compose` | `replace` + `pinDigests` | Image tags get an immutable `@sha256:...` digest appended for supply-chain integrity. |
-| `github-actions` | `replace` + `pinDigests` | Action references (`uses: actions/checkout@v6`) get pinned to commit SHAs. |
-
-When adding a new manager, set its `rangeStrategy` explicitly in a `packageRules` entry rather than relying on a global default.
+The default `rangeStrategy` is `pin` - any new dependency range gets pinned to an exact version (e.g. NuGet `[10.0.7]`, npm `19.2.5`). The one exception is the `msbuild-sdk` manager: SDK references like `Aspire.AppHost.Sdk` must stay floating because bracketed pins (`[13.2.4]`) break SDK resolution. Two `packageRules` enforce this - one sets `rangeStrategy: replace` for all msbuild-sdk updates, the other disables `pin` update PRs entirely. Both rules must stay separate; merging them would only apply `replace` to pin updates and let the global `pin` strategy leak into regular version bumps.
 
 ## Architecture Decisions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,7 @@ Dependencies are managed by [Renovate](https://docs.renovatebot.com/) (config: `
 | Manager      | Range strategy | Notes                                                                 |
 |--------------|----------------|-----------------------------------------------------------------------|
 | `nuget`      | `pin`          | NuGet `PackageVersion` entries use exact-version brackets (e.g. `[10.0.7]`) via `Directory.Packages.props`. |
+| `npm`        | `pin`          | `frontend/package.json` keeps exact versions (no `^`/`~`); Renovate auto-pins any new caret/tilde ranges. |
 | `msbuild-sdk`| `replace`      | MSBuild SDK references (e.g. `Aspire.AppHost.Sdk`) must stay floating - bracketed pins like `[13.2.4]` break SDK resolution. Pin update PRs are explicitly disabled for this manager. |
 
 When adding a new manager, set its `rangeStrategy` explicitly in a `packageRules` entry rather than relying on a global default.

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,14 @@
       "matchManagers": ["msbuild-sdk"],
       "matchUpdateTypes": ["pin"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "pinDigests": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,11 @@
   "dependencyDashboard": true,
   "automerge": false,
   "labels": ["dependencies", "renovate"],
-  "rangeStrategy": "pin",
   "packageRules": [
+    {
+      "matchManagers": ["nuget"],
+      "rangeStrategy": "pin"
+    },
     {
       "matchManagers": ["msbuild-sdk"],
       "rangeStrategy": "replace"

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "schedule": ["* 6 * * *"],
   "timezone": "Europe/Berlin",
   "dependencyDashboard": true,
   "automerge": false,
   "labels": ["dependencies", "renovate"],
+  "rangeStrategy": "pin",
   "packageRules": [
-    {
-      "matchManagers": ["nuget", "npm"],
-      "rangeStrategy": "pin"
-    },
     {
       "matchManagers": ["msbuild-sdk"],
       "rangeStrategy": "replace"
@@ -21,22 +16,13 @@
       "matchManagers": ["msbuild-sdk"],
       "matchUpdateTypes": ["pin"],
       "enabled": false
-    },
-    {
-      "matchManagers": ["dockerfile", "docker-compose"],
-      "pinDigests": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "pinDigests": true
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
       "fileMatch": [
-        "^CLAUDE\\.md$",
-        "^keycloak/CLAUDE\\.md$",
+        "^(keycloak/)?CLAUDE\\.md$",
         "^docs/Architektur/src/.*\\.adoc$",
         "^docs/Architektur/images/.*\\.puml$"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "labels": ["dependencies", "renovate"],
   "packageRules": [
     {
-      "matchManagers": ["nuget"],
+      "matchManagers": ["nuget", "npm"],
       "rangeStrategy": "pin"
     },
     {


### PR DESCRIPTION
The global rangeStrategy: pin caused Renovate to keep proposing pin PRs for MSBuild SDK references (e.g. Aspire.AppHost.Sdk), overriding the per-manager replace rule. Move the pin strategy to a nuget-only packageRule so msbuild-sdk references stay floating.

Closes #127