### PR TITLE
chore(renovate): group coupled package families into single PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,40 +24,6 @@
       "matchPackageNames": ["TUnit{/,}**"],
       "groupName": "TUnit",
       "groupSlug": "tunit"
-    },
-    {
-      "matchManagers": ["nuget"],
-      "matchPackageNames": [
-        "Microsoft.EntityFrameworkCore{/,}**",
-        "Npgsql.EntityFrameworkCore.PostgreSQL",
-        "EFCore.NamingConventions"
-      ],
-      "groupName": "Entity Framework Core",
-      "groupSlug": "efcore"
-    },
-    {
-      "matchManagers": ["nuget"],
-      "matchPackageNames": ["OpenTelemetry{/,}**"],
-      "groupName": "OpenTelemetry",
-      "groupSlug": "opentelemetry"
-    },
-    {
-      "matchManagers": ["nuget"],
-      "matchPackageNames": ["Aspire.Hosting{/,}**"],
-      "groupName": "Aspire.Hosting",
-      "groupSlug": "aspire-hosting"
-    },
-    {
-      "matchManagers": ["nuget"],
-      "matchPackageNames": ["Asp.Versioning{/,}**"],
-      "groupName": "Asp.Versioning",
-      "groupSlug": "asp-versioning"
-    },
-    {
-      "matchManagers": ["nuget"],
-      "matchPackageNames": ["Microsoft.Extensions{/,}**"],
-      "groupName": "Microsoft.Extensions",
-      "groupSlug": "microsoft-extensions"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,46 @@
       "matchDepNames": ["Aspire.AppHost.Sdk"],
       "matchUpdateTypes": ["pin"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["TUnit{/,}**"],
+      "groupName": "TUnit",
+      "groupSlug": "tunit"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": [
+        "Microsoft.EntityFrameworkCore{/,}**",
+        "Npgsql.EntityFrameworkCore.PostgreSQL",
+        "EFCore.NamingConventions"
+      ],
+      "groupName": "Entity Framework Core",
+      "groupSlug": "efcore"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["OpenTelemetry{/,}**"],
+      "groupName": "OpenTelemetry",
+      "groupSlug": "opentelemetry"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Aspire.Hosting{/,}**"],
+      "groupName": "Aspire.Hosting",
+      "groupSlug": "aspire-hosting"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Asp.Versioning{/,}**"],
+      "groupName": "Asp.Versioning",
+      "groupSlug": "asp-versioning"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Microsoft.Extensions{/,}**"],
+      "groupName": "Microsoft.Extensions",
+      "groupSlug": "microsoft-extensions"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Closes #131.

Adds `packageRules` to `renovate.json` so coupled NuGet package families are bumped atomically in a single PR rather than split across multiple PRs (e.g. `TUnit` + `TUnit.Playwright`).

Grouped families:
- `TUnit*`
- `Microsoft.EntityFrameworkCore*` + `Npgsql.EntityFrameworkCore.PostgreSQL` + `EFCore.NamingConventions`
- `OpenTelemetry.*`
- `Aspire.Hosting.*`
- `Asp.Versioning.*`
- `Microsoft.Extensions.*`

Uses `matchPackageNames` with the `{/,}**` glob pattern (the modern replacement for the deprecated `matchPackagePatterns`).

## Test plan

- [ ] Renovate dry-run / dependency dashboard shows a single grouped PR per family on next scheduled run
- [ ] Verify no regression in the existing `Aspire.AppHost.Sdk` `rangeStrategy` rule


---
_Generated by [Claude Code](https://claude.ai/code/session_01LxsELUt28XFKZ13EUSLoNK)_