### PR TITLE
ci: validate PR titles against Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            chore
+            build
+            ci
+            perf
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" must start lowercase and not end with a period.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ Rules:
 - Max 72 characters in the subject line
 - Reference the Issue number in the PR description, not the commit
 
+PR titles are validated against Conventional Commits in CI by the [`PR Title`](.github/workflows/pr-title.yml) workflow. Non-conforming titles fail the check.
+
 ## Pull Request Process
 
 1. Keep PRs focused - one logical change per PR


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that validates PR titles against the Conventional Commits spec using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request). Non-conforming titles fail the check, which keeps the squash-merge commit history clean for future automated changelog/version tooling.

- New workflow `.github/workflows/pr-title.yml` (runs on `opened`, `edited`, `synchronize`, `reopened`)
- Allowed types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `style`, `revert`
- Subject must start lowercase and not end with a period
- `CONTRIBUTING.md` notes the policy and links to the workflow

Skipped the optional commit-level commitlint enforcement — PR-title validation alone is enough given the squash-merge flow, and a per-commit hook adds friction without a corresponding payoff right now. Easy to add later if needed.

Closes #121

## Test plan

- [ ] Open a PR with a non-conforming title (e.g. `Update stuff`) and confirm the check fails
- [ ] Edit the title to a conforming one (e.g. `chore: update stuff`) and confirm the check re-runs and passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf2SwM2UKhTpgYGhvNgmN8)_