### PR TITLE
feat: add API rate limiting

### DIFF
--- a/backend/src/Api/Common/RateLimiting/RateLimitingExtensions.cs
+++ b/backend/src/Api/Common/RateLimiting/RateLimitingExtensions.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace Api.Common.RateLimiting;
+
+internal static class RateLimitingExtensions
+{
+	public static IServiceCollection AddRateLimitingPolicies(
+		this IServiceCollection services,
+		IConfiguration configuration)
+	{
+		var options = configuration
+			.GetSection("RateLimiting")
+			.Get<RateLimitingOptions>() ?? new RateLimitingOptions();
+
+		return services.AddRateLimiter(limiter =>
+		{
+			limiter.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+			var readWindow = TimeSpan.FromSeconds(options.Read.WindowSeconds);
+			var writeWindow = TimeSpan.FromSeconds(options.Write.WindowSeconds);
+
+			limiter.AddPolicy(RateLimitingPolicies.Read, httpContext =>
+			{
+				if (httpContext.User.Identity?.IsAuthenticated == true)
+				{
+					var userId = httpContext.User.FindFirstValue("sub") ?? "unknown";
+					return RateLimitPartition.GetFixedWindowLimiter(userId, _ => new FixedWindowRateLimiterOptions
+					{
+						PermitLimit = options.Read.AuthenticatedPermitLimit,
+						Window = readWindow,
+						QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+						QueueLimit = 0
+					});
+				}
+
+				var clientIp = GetClientIp(httpContext);
+				return RateLimitPartition.GetFixedWindowLimiter(clientIp, _ => new FixedWindowRateLimiterOptions
+				{
+					PermitLimit = options.Read.AnonymousPermitLimit,
+					Window = readWindow,
+					QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+					QueueLimit = 0
+				});
+			});
+
+			limiter.AddPolicy(RateLimitingPolicies.Write, httpContext =>
+			{
+				var key = httpContext.User.FindFirstValue("sub") ?? GetClientIp(httpContext);
+				return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+				{
+					PermitLimit = options.Write.PermitLimit,
+					Window = writeWindow,
+					QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+					QueueLimit = 0
+				});
+			});
+		});
+	}
+
+	private static string GetClientIp(HttpContext ctx) =>
+		ctx.Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim()
+		?? ctx.Connection.RemoteIpAddress?.ToString()
+		?? "unknown";
+}

--- a/backend/src/Api/Common/RateLimiting/RateLimitingOptions.cs
+++ b/backend/src/Api/Common/RateLimiting/RateLimitingOptions.cs
@@ -1,0 +1,20 @@
+namespace Api.Common.RateLimiting;
+
+internal sealed class RateLimitingOptions
+{
+	public ReadOptions Read { get; init; } = new();
+	public WriteOptions Write { get; init; } = new();
+
+	internal sealed class ReadOptions
+	{
+		public int AuthenticatedPermitLimit { get; init; } = 200;
+		public int AnonymousPermitLimit { get; init; } = 60;
+		public int WindowSeconds { get; init; } = 60;
+	}
+
+	internal sealed class WriteOptions
+	{
+		public int PermitLimit { get; init; } = 100;
+		public int WindowSeconds { get; init; } = 60;
+	}
+}

--- a/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
+++ b/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
@@ -1,0 +1,7 @@
+namespace Api.Common.RateLimiting;
+
+internal static class RateLimitingPolicies
+{
+    public const string Read = "rate-limit-read";
+    public const string Write = "rate-limit-write";
+}

--- a/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
+++ b/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
@@ -1,6 +1,6 @@
 namespace Api.Common.RateLimiting;
 
-internal static class RateLimitingPolicies
+public static class RateLimitingPolicies
 {
 	public const string Read = "rate-limit-read";
 	public const string Write = "rate-limit-write";

--- a/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
+++ b/backend/src/Api/Common/RateLimiting/RateLimitingPolicies.cs
@@ -2,6 +2,6 @@ namespace Api.Common.RateLimiting;
 
 internal static class RateLimitingPolicies
 {
-    public const string Read = "rate-limit-read";
-    public const string Write = "rate-limit-write";
+	public const string Read = "rate-limit-read";
+	public const string Write = "rate-limit-write";
 }

--- a/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements.CancelEngagement.v1;
 using Domain.Engagements;
@@ -22,6 +23,7 @@ internal sealed class CancelEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> CancelEngagementAsync(

--- a/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements.ConfirmEngagement.v1;
 using Domain.Engagements;
@@ -22,6 +23,7 @@ internal sealed class ConfirmEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> ConfirmEngagementAsync(

--- a/backend/src/Api/Engagements/CreateEngagement/v1/CreateEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CreateEngagement/v1/CreateEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements.CreateEngagement.v1;
 using Domain.Users;
@@ -20,6 +21,7 @@ internal sealed class CreateEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> CreateEngagementAsync(

--- a/backend/src/Api/Engagements/GetEngagements/v1/GetEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/GetEngagements/v1/GetEngagementsEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements;
 using Application.Engagements.GetEngagements.v1;
@@ -20,6 +21,7 @@ internal sealed class GetEngagementsEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetEngagementsAsync(

--- a/backend/src/Api/Engagements/GetMyEngagements/v1/GetMyEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/GetMyEngagements/v1/GetMyEngagementsEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements;
 using Application.Engagements.GetMyEngagements.v1;
@@ -19,6 +20,7 @@ internal sealed class GetMyEngagementsEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetMyEngagementsAsync(

--- a/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Engagements.WithdrawEngagement.v1;
 using Domain.Engagements;
@@ -21,6 +22,7 @@ internal sealed class WithdrawEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> WithdrawEngagementAsync(

--- a/backend/src/Api/Organizations/AddMember/v1/AddMemberEndpoint.cs
+++ b/backend/src/Api/Organizations/AddMember/v1/AddMemberEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.AddMember.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ internal sealed class AddMemberEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationEndpoint.cs
+++ b/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.CreateOrganization.v1;
 using Domain.Organizations;
@@ -20,6 +21,7 @@ internal sealed class CreateOrganizationEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.GetOrganizationDetails.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ internal sealed class GetOrganizationDetailsEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/GetOrganizations/v1/GetOrganizationsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizations/v1/GetOrganizationsEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Organizations.GetOrganizations.v1;
@@ -19,6 +20,7 @@ internal sealed class GetOrganizationsEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
+++ b/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.RemoveMember.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ internal sealed class RemoveMemberEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/UpdateOrganization/v1/UpdateOrganizationEndpoint.cs
+++ b/backend/src/Api/Organizations/UpdateOrganization/v1/UpdateOrganizationEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.UpdateOrganization.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -19,6 +20,7 @@ internal sealed class UpdateOrganizationEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -1,10 +1,14 @@
+using System.Security.Claims;
+using System.Threading.RateLimiting;
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application;
 using Asp.Versioning;
 using Infrastructure;
 using Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
@@ -62,6 +66,60 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddEndpoints();
 
+builder.Services.AddRateLimiter(options =>
+{
+	options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+	var readWindow = TimeSpan.FromSeconds(
+		builder.Configuration.GetValue("RateLimiting:Read:WindowSeconds", 60));
+	var readAuthLimit = builder.Configuration.GetValue("RateLimiting:Read:AuthenticatedPermitLimit", 200);
+	var readAnonLimit = builder.Configuration.GetValue("RateLimiting:Read:AnonymousPermitLimit", 60);
+	var writeWindow = TimeSpan.FromSeconds(
+		builder.Configuration.GetValue("RateLimiting:Write:WindowSeconds", 60));
+	var writeLimit = builder.Configuration.GetValue("RateLimiting:Write:PermitLimit", 100);
+
+	options.AddPolicy(RateLimitingPolicies.Read, httpContext =>
+	{
+		if (httpContext.User.Identity?.IsAuthenticated == true)
+		{
+			var userId = httpContext.User.FindFirstValue("sub") ?? "unknown";
+			return RateLimitPartition.GetFixedWindowLimiter(userId, _ => new FixedWindowRateLimiterOptions
+			{
+				PermitLimit = readAuthLimit,
+				Window = readWindow,
+				QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+				QueueLimit = 0
+			});
+		}
+
+		var clientIp = GetClientIp(httpContext);
+		return RateLimitPartition.GetFixedWindowLimiter(clientIp, _ => new FixedWindowRateLimiterOptions
+		{
+			PermitLimit = readAnonLimit,
+			Window = readWindow,
+			QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+			QueueLimit = 0
+		});
+	});
+
+	options.AddPolicy(RateLimitingPolicies.Write, httpContext =>
+	{
+		var key = httpContext.User.FindFirstValue("sub") ?? GetClientIp(httpContext);
+		return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+		{
+			PermitLimit = writeLimit,
+			Window = writeWindow,
+			QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+			QueueLimit = 0
+		});
+	});
+
+	static string GetClientIp(HttpContext ctx) =>
+		ctx.Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim()
+		?? ctx.Connection.RemoteIpAddress?.ToString()
+		?? "unknown";
+});
+
 builder.Services.AddOpenApi("v1", options =>
 {
 	options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
@@ -94,6 +152,7 @@ app.MapDefaultEndpoints();
 
 app.UseCors();
 app.UseAuthentication();
+app.UseRateLimiter();
 app.UseAuthorization();
 
 app.MapEndpoints();

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -1,5 +1,3 @@
-using System.Security.Claims;
-using System.Threading.RateLimiting;
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
@@ -8,7 +6,6 @@ using Asp.Versioning;
 using Infrastructure;
 using Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
@@ -65,60 +62,7 @@ builder.Services.AddCors(options =>
 			.AllowAnyMethod()));
 
 builder.Services.AddEndpoints();
-
-builder.Services.AddRateLimiter(options =>
-{
-	options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-
-	var readWindow = TimeSpan.FromSeconds(
-		builder.Configuration.GetValue("RateLimiting:Read:WindowSeconds", 60));
-	var readAuthLimit = builder.Configuration.GetValue("RateLimiting:Read:AuthenticatedPermitLimit", 200);
-	var readAnonLimit = builder.Configuration.GetValue("RateLimiting:Read:AnonymousPermitLimit", 60);
-	var writeWindow = TimeSpan.FromSeconds(
-		builder.Configuration.GetValue("RateLimiting:Write:WindowSeconds", 60));
-	var writeLimit = builder.Configuration.GetValue("RateLimiting:Write:PermitLimit", 100);
-
-	options.AddPolicy(RateLimitingPolicies.Read, httpContext =>
-	{
-		if (httpContext.User.Identity?.IsAuthenticated == true)
-		{
-			var userId = httpContext.User.FindFirstValue("sub") ?? "unknown";
-			return RateLimitPartition.GetFixedWindowLimiter(userId, _ => new FixedWindowRateLimiterOptions
-			{
-				PermitLimit = readAuthLimit,
-				Window = readWindow,
-				QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-				QueueLimit = 0
-			});
-		}
-
-		var clientIp = GetClientIp(httpContext);
-		return RateLimitPartition.GetFixedWindowLimiter(clientIp, _ => new FixedWindowRateLimiterOptions
-		{
-			PermitLimit = readAnonLimit,
-			Window = readWindow,
-			QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-			QueueLimit = 0
-		});
-	});
-
-	options.AddPolicy(RateLimitingPolicies.Write, httpContext =>
-	{
-		var key = httpContext.User.FindFirstValue("sub") ?? GetClientIp(httpContext);
-		return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
-		{
-			PermitLimit = writeLimit,
-			Window = writeWindow,
-			QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-			QueueLimit = 0
-		});
-	});
-
-	static string GetClientIp(HttpContext ctx) =>
-		ctx.Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim()
-		?? ctx.Connection.RemoteIpAddress?.ToString()
-		?? "unknown";
-});
+builder.Services.AddRateLimitingPolicies(builder.Configuration);
 
 builder.Services.AddOpenApi("v1", options =>
 {

--- a/backend/src/Api/Users/GetUserProfile/v1/GetUserProfileEndpoint.cs
+++ b/backend/src/Api/Users/GetUserProfile/v1/GetUserProfileEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Users.GetUserProfile.v1;
 using Domain.Users;
@@ -18,6 +19,7 @@ internal sealed class GetUserProfileEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetUserProfileAsync(

--- a/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
+++ b/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Users.UpdateUserProfile.v1;
 using Domain.Users;
@@ -18,6 +19,7 @@ internal sealed class UpdateUserProfileEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> UpdateUserProfileAsync(

--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 using Domain.Organizations;
@@ -20,6 +21,7 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> CreateVolunteerOpportunityAsync(

--- a/backend/src/Api/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 using Domain.Primitives;
@@ -19,6 +20,7 @@ internal sealed class DeleteVolunteerOpportunityEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> DeleteVolunteerOpportunityAsync(

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
@@ -1,4 +1,5 @@
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
@@ -18,6 +19,7 @@ internal sealed class GetVolunteerOpportunitiesEndpoint
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsEndpoint.cs
@@ -1,4 +1,5 @@
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -15,6 +16,7 @@ internal sealed class GetVolunteerOpportunityDetailsEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetVolunteerOpportunityDetailsAsync(

--- a/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
 using Domain.VolunteerOpportunities;
@@ -20,6 +21,7 @@ internal sealed class UpdateVolunteerOpportunityEndpoint
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> UpdateVolunteerOpportunityAsync(

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -23,5 +23,16 @@
     "Realm": "einsatzbereit",
     "ClientId": "backend",
     "ClientSecret": "backend-secret"
+  },
+  "RateLimiting": {
+    "Read": {
+      "AuthenticatedPermitLimit": 200,
+      "AnonymousPermitLimit": 60,
+      "WindowSeconds": 60
+    },
+    "Write": {
+      "PermitLimit": 100,
+      "WindowSeconds": 60
+    }
   }
 }

--- a/backend/tests/ArchitectureTests/ArchitectureTests.csproj
+++ b/backend/tests/ArchitectureTests/ArchitectureTests.csproj
@@ -5,6 +5,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
 		<PackageReference Include="NetArchTest.Rules" />
 		<PackageReference Include="TUnit" />

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -1,0 +1,94 @@
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Asp.Versioning;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ArchitectureTests;
+
+public sealed class RateLimitingConventionTests
+{
+	[Test]
+	public void AllEndpoints_ShouldHaveRateLimitingPolicyApplied()
+	{
+		var app = BuildMinimalAppWithAllEndpoints();
+		var dataSource = app.Services.GetRequiredService<EndpointDataSource>();
+
+		var endpointsWithoutRateLimiting = dataSource.Endpoints
+			.OfType<RouteEndpoint>()
+			.Where(e => e.Metadata.GetMetadata<IRateLimiterMetadata>() is null)
+			.Select(e => e.RoutePattern.RawText)
+			.ToList();
+
+		endpointsWithoutRateLimiting.Should().BeEmpty(
+			"every endpoint must call RequireRateLimiting() to opt in to a rate limiting policy");
+	}
+
+	[Test]
+	public void AllEndpoints_ShouldUseOnlyKnownRateLimitingPolicies()
+	{
+		var knownPolicies = new[] { RateLimitingPolicies.Read, RateLimitingPolicies.Write };
+
+		var app = BuildMinimalAppWithAllEndpoints();
+		var dataSource = app.Services.GetRequiredService<EndpointDataSource>();
+
+		var endpointsWithUnknownPolicy = dataSource.Endpoints
+			.OfType<RouteEndpoint>()
+			.Select(e => new
+			{
+				Route = e.RoutePattern.RawText,
+				Policy = e.Metadata.GetMetadata<IRateLimiterMetadata>()?.PolicyName,
+			})
+			.Where(e => e.Policy is not null && !knownPolicies.Contains(e.Policy))
+			.Select(e => $"{e.Route} uses unknown policy '{e.Policy}'")
+			.ToList();
+
+		endpointsWithUnknownPolicy.Should().BeEmpty(
+			$"endpoints may only use the policies '{RateLimitingPolicies.Read}' or '{RateLimitingPolicies.Write}'");
+	}
+
+	private static WebApplication BuildMinimalAppWithAllEndpoints()
+	{
+		var builder = WebApplication.CreateBuilder();
+
+		builder.Services
+			.AddApiVersioning(options =>
+			{
+				options.DefaultApiVersion = new ApiVersion(1);
+				options.AssumeDefaultVersionWhenUnspecified = true;
+				options.ApiVersionReader = new UrlSegmentApiVersionReader();
+			})
+			.AddApiExplorer(options => options.GroupNameFormat = "'v'V");
+
+		builder.Services.AddAuthentication();
+		builder.Services.AddAuthorization();
+		builder.Services.AddRateLimiter(_ => { });
+
+		// AddEndpoints() uses Assembly.GetExecutingAssembly(), which would be ArchitectureTests
+		// here. Manually register all IEndpoint implementations from the Api assembly instead.
+		var endpointTypes = AssemblyAnchors.PresentationLayer.GetTypes()
+			.Where(t => t is { IsClass: true, IsAbstract: false }
+				&& typeof(IEndpoint).IsAssignableFrom(t));
+
+		foreach (var type in endpointTypes)
+			builder.Services.AddTransient(typeof(IEndpoint), type);
+
+		var app = builder.Build();
+
+		// Replicate EndpointExtensions.MapEndpoints() without the assembly assumption
+		var versionSet = app.NewApiVersionSet()
+			.HasApiVersion(new ApiVersion(1))
+			.ReportApiVersions()
+			.Build();
+
+		var group = app.MapGroup("v{version:apiVersion}").WithApiVersionSet(versionSet);
+
+		foreach (var endpoint in app.Services.GetRequiredService<IEnumerable<IEndpoint>>())
+			endpoint.MapEndpoint(group);
+
+		return app;
+	}
+}

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -3,7 +3,6 @@ using Api.Common.RateLimiting;
 using Asp.Versioning;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -42,8 +41,13 @@ public sealed class RateLimitingConventionTests
 			$"endpoints may only use the policies '{RateLimitingPolicies.Read}' or '{RateLimitingPolicies.Write}'");
 	}
 
-	private static string? GetRateLimitingPolicyName(RouteEndpoint endpoint) =>
-		endpoint.Metadata.GetMetadata<IRateLimiterMetadata>()?.PolicyName;
+	private static string? GetRateLimitingPolicyName(RouteEndpoint endpoint)
+	{
+		var attr = endpoint.Metadata
+			.FirstOrDefault(m => m.GetType().Name == "EnableRateLimitingAttribute");
+
+		return attr?.GetType().GetProperty("PolicyName")?.GetValue(attr) as string;
+	}
 
 	private static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
 		((IEndpointRouteBuilder)app).DataSources

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -15,10 +15,8 @@ public sealed class RateLimitingConventionTests
 	public void AllEndpoints_ShouldHaveRateLimitingPolicyApplied()
 	{
 		var app = BuildMinimalAppWithAllEndpoints();
-		var dataSource = app.Services.GetRequiredService<EndpointDataSource>();
 
-		var endpointsWithoutRateLimiting = dataSource.Endpoints
-			.OfType<RouteEndpoint>()
+		var endpointsWithoutRateLimiting = GetAllRouteEndpoints(app)
 			.Where(e => e.Metadata.GetMetadata<IRateLimiterMetadata>() is null)
 			.Select(e => e.RoutePattern.RawText)
 			.ToList();
@@ -33,10 +31,8 @@ public sealed class RateLimitingConventionTests
 		var knownPolicies = new[] { RateLimitingPolicies.Read, RateLimitingPolicies.Write };
 
 		var app = BuildMinimalAppWithAllEndpoints();
-		var dataSource = app.Services.GetRequiredService<EndpointDataSource>();
 
-		var endpointsWithUnknownPolicy = dataSource.Endpoints
-			.OfType<RouteEndpoint>()
+		var endpointsWithUnknownPolicy = GetAllRouteEndpoints(app)
 			.Select(e => new
 			{
 				Route = e.RoutePattern.RawText,
@@ -49,6 +45,12 @@ public sealed class RateLimitingConventionTests
 		endpointsWithUnknownPolicy.Should().BeEmpty(
 			$"endpoints may only use the policies '{RateLimitingPolicies.Read}' or '{RateLimitingPolicies.Write}'");
 	}
+
+	private static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
+		((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(ds => ds.Endpoints)
+			.OfType<RouteEndpoint>()
+			.ToList();
 
 	private static WebApplication BuildMinimalAppWithAllEndpoints()
 	{
@@ -67,8 +69,8 @@ public sealed class RateLimitingConventionTests
 		builder.Services.AddAuthorization();
 		builder.Services.AddRateLimiter(_ => { });
 
-		// AddEndpoints() uses Assembly.GetExecutingAssembly(), which would be ArchitectureTests
-		// here. Manually register all IEndpoint implementations from the Api assembly instead.
+		// AddEndpoints() uses Assembly.GetExecutingAssembly(), which is ArchitectureTests here.
+		// Manually register all IEndpoint implementations from the Api assembly instead.
 		var endpointTypes = AssemblyAnchors.PresentationLayer.GetTypes()
 			.Where(t => t is { IsClass: true, IsAbstract: false }
 				&& typeof(IEndpoint).IsAssignableFrom(t));

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -3,6 +3,7 @@ using Api.Common.RateLimiting;
 using Asp.Versioning;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -41,16 +42,8 @@ public sealed class RateLimitingConventionTests
 			$"endpoints may only use the policies '{RateLimitingPolicies.Read}' or '{RateLimitingPolicies.Write}'");
 	}
 
-	// Use type-name reflection instead of IRateLimiterMetadata to avoid a hard dependency
-	// on Microsoft.AspNetCore.RateLimiting (which is not reliably resolvable from
-	// Microsoft.NET.Sdk test projects even with a FrameworkReference).
-	private static string? GetRateLimitingPolicyName(RouteEndpoint endpoint)
-	{
-		var attr = endpoint.Metadata
-			.FirstOrDefault(m => m.GetType().Name == "EnableRateLimitingAttribute");
-
-		return attr?.GetType().GetProperty("PolicyName")?.GetValue(attr) as string;
-	}
+	private static string? GetRateLimitingPolicyName(RouteEndpoint endpoint) =>
+		endpoint.Metadata.GetMetadata<IRateLimiterMetadata>()?.PolicyName;
 
 	private static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
 		((IEndpointRouteBuilder)app).DataSources

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -3,7 +3,6 @@ using Api.Common.RateLimiting;
 using Asp.Versioning;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,7 +16,7 @@ public sealed class RateLimitingConventionTests
 		var app = BuildMinimalAppWithAllEndpoints();
 
 		var endpointsWithoutRateLimiting = GetAllRouteEndpoints(app)
-			.Where(e => e.Metadata.GetMetadata<IRateLimiterMetadata>() is null)
+			.Where(e => GetRateLimitingPolicyName(e) is null)
 			.Select(e => e.RoutePattern.RawText)
 			.ToList();
 
@@ -33,17 +32,24 @@ public sealed class RateLimitingConventionTests
 		var app = BuildMinimalAppWithAllEndpoints();
 
 		var endpointsWithUnknownPolicy = GetAllRouteEndpoints(app)
-			.Select(e => new
-			{
-				Route = e.RoutePattern.RawText,
-				Policy = e.Metadata.GetMetadata<IRateLimiterMetadata>()?.PolicyName,
-			})
+			.Select(e => new { Route = e.RoutePattern.RawText, Policy = GetRateLimitingPolicyName(e) })
 			.Where(e => e.Policy is not null && !knownPolicies.Contains(e.Policy))
 			.Select(e => $"{e.Route} uses unknown policy '{e.Policy}'")
 			.ToList();
 
 		endpointsWithUnknownPolicy.Should().BeEmpty(
 			$"endpoints may only use the policies '{RateLimitingPolicies.Read}' or '{RateLimitingPolicies.Write}'");
+	}
+
+	// Use type-name reflection instead of IRateLimiterMetadata to avoid a hard dependency
+	// on Microsoft.AspNetCore.RateLimiting (which is not reliably resolvable from
+	// Microsoft.NET.Sdk test projects even with a FrameworkReference).
+	private static string? GetRateLimitingPolicyName(RouteEndpoint endpoint)
+	{
+		var attr = endpoint.Metadata
+			.FirstOrDefault(m => m.GetType().Name == "EnableRateLimitingAttribute");
+
+		return attr?.GetType().GetProperty("PolicyName")?.GetValue(attr) as string;
 	}
 
 	private static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
@@ -80,7 +86,6 @@ public sealed class RateLimitingConventionTests
 
 		var app = builder.Build();
 
-		// Replicate EndpointExtensions.MapEndpoints() without the assembly assumption
 		var versionSet = app.NewApiVersionSet()
 			.HasApiVersion(new ApiVersion(1))
 			.ReportApiVersions()

--- a/backend/tests/IntegrationTests/RateLimitingTests.cs
+++ b/backend/tests/IntegrationTests/RateLimitingTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class RateLimitingTests(IntegrationTestFixture fixture)
+{
+	// Unique IP so this test's quota is isolated from other test classes
+	private const string TestIp = "10.0.0.99";
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturn429_WhenAnonymousRateLimitExceeded(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Add("X-Forwarded-For", TestIp);
+
+		var statusCodes = new List<HttpStatusCode>();
+
+		for (var i = 0; i < 65; i++)
+		{
+			var response = await httpClient.GetAsync(
+				"/v1/volunteer-opportunities?pageNumber=1&pageSize=1", cancellationToken);
+			statusCodes.Add(response.StatusCode);
+		}
+
+		statusCodes.Should().Contain(HttpStatusCode.TooManyRequests);
+	}
+}

--- a/docs/Architecture/src/11_technical_risks.adoc
+++ b/docs/Architecture/src/11_technical_risks.adoc
@@ -13,7 +13,7 @@ The following table lists the relevant risks and technical debts. Each risk or t
 |1
 |Rate Limiting
 |Missing rate limitation.
-|Planned
+|Resolved
 |2026-05-03
 |link:TDRs/1_rate_limiting.html[Rate Limiting]
 

--- a/docs/TDRs/1_rate_limiting.adoc
+++ b/docs/TDRs/1_rate_limiting.adoc
@@ -3,7 +3,7 @@
 - *Author:* @maik-hasler
 - *Version:* prior v1.0.0
 - *Date:* 2026-05-03
-- *Status:* Planned
+- *Status:* Resolved
 
 === Description
 
@@ -53,3 +53,37 @@ Delaying implementation is acceptable in the short term due to low traffic. Howe
 - Potential unexpected cost spikes (bandwidth / compute)
 - More complex and risky implementation later when the system is under load
 - Reduced ability to safely onboard new users or make the service public
+
+=== Resolution
+
+Resolved in issue #125 using ASP.NET Core's built-in `Microsoft.AspNetCore.RateLimiting` middleware.
+
+==== Implementation
+
+- Two named policies defined in `Api.Common.RateLimiting.RateLimitingPolicies`:
+  - `rate-limit-read` — Fixed-window limiter; authenticated requests partition by user `sub` claim (200 req/min), anonymous requests partition by client IP (60 req/min).
+  - `rate-limit-write` — Fixed-window limiter; partitioned by user `sub` claim (falls back to client IP for unauthenticated paths); 100 req/min.
+- All endpoints decorated with `.RequireRateLimiting(...)` — reads use the read policy, mutations use the write policy.
+- `app.UseRateLimiter()` placed after `UseAuthentication()` so user identity is available for per-user partitioning.
+- Limits are configurable via `appsettings.json` under the `RateLimiting` section and can be overridden per environment via standard .NET environment variables (e.g. `RateLimiting__Write__PermitLimit`).
+- Rejected requests receive HTTP `429 Too Many Requests`.
+- Client IP resolved from `X-Forwarded-For` header (first entry) when present, otherwise from the TCP connection; this supports deployments behind a reverse proxy.
+
+==== Default Limits
+
+[cols="2,1,1"]
+|===
+| Traffic type | Permit limit | Window
+
+| Authenticated reads (per user)
+| 200
+| 60 s
+
+| Anonymous reads (per IP)
+| 60
+| 60 s
+
+| Writes (per user / IP)
+| 100
+| 60 s
+|===

--- a/docs/TDRs/1_rate_limiting.adoc
+++ b/docs/TDRs/1_rate_limiting.adoc
@@ -60,9 +60,9 @@ Resolved in issue #125 using ASP.NET Core's built-in `Microsoft.AspNetCore.RateL
 
 ==== Implementation
 
-- Two named policies defined in `Api.Common.RateLimiting.RateLimitingPolicies`:
-  - `rate-limit-read` - Fixed-window limiter; authenticated requests partition by user `sub` claim (200 req/min), anonymous requests partition by client IP (60 req/min).
-  - `rate-limit-write` - Fixed-window limiter; partitioned by user `sub` claim (falls back to client IP for unauthenticated paths); 100 req/min.
+- Two named policies are defined in `Api.Common.RateLimiting.RateLimitingPolicies`.
+- `rate-limit-read`: Fixed-window limiter; authenticated requests partition by user `sub` claim (200 req/min), anonymous requests partition by client IP (60 req/min).
+- `rate-limit-write`: Fixed-window limiter; partitioned by user `sub` claim (falls back to client IP for unauthenticated paths); 100 req/min.
 - All endpoints decorated with `.RequireRateLimiting(...)` - reads use the read policy, mutations use the write policy.
 - `app.UseRateLimiter()` placed after `UseAuthentication()` so user identity is available for per-user partitioning.
 - Limits are configurable via `appsettings.json` under the `RateLimiting` section and can be overridden per environment via standard .NET environment variables (e.g. `RateLimiting__Write__PermitLimit`).

--- a/docs/TDRs/1_rate_limiting.adoc
+++ b/docs/TDRs/1_rate_limiting.adoc
@@ -61,9 +61,9 @@ Resolved in issue #125 using ASP.NET Core's built-in `Microsoft.AspNetCore.RateL
 ==== Implementation
 
 - Two named policies defined in `Api.Common.RateLimiting.RateLimitingPolicies`:
-  - `rate-limit-read` — Fixed-window limiter; authenticated requests partition by user `sub` claim (200 req/min), anonymous requests partition by client IP (60 req/min).
-  - `rate-limit-write` — Fixed-window limiter; partitioned by user `sub` claim (falls back to client IP for unauthenticated paths); 100 req/min.
-- All endpoints decorated with `.RequireRateLimiting(...)` — reads use the read policy, mutations use the write policy.
+  - `rate-limit-read` - Fixed-window limiter; authenticated requests partition by user `sub` claim (200 req/min), anonymous requests partition by client IP (60 req/min).
+  - `rate-limit-write` - Fixed-window limiter; partitioned by user `sub` claim (falls back to client IP for unauthenticated paths); 100 req/min.
+- All endpoints decorated with `.RequireRateLimiting(...)` - reads use the read policy, mutations use the write policy.
 - `app.UseRateLimiter()` placed after `UseAuthentication()` so user identity is available for per-user partitioning.
 - Limits are configurable via `appsettings.json` under the `RateLimiting` section and can be overridden per environment via standard .NET environment variables (e.g. `RateLimiting__Write__PermitLimit`).
 - Rejected requests receive HTTP `429 Too Many Requests`.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Configures ASP.NET Core's built-in fixed-window rate limiter with two named policies: `rate-limit-read` (lighter, per-user/IP) and `rate-limit-write` (stricter, per-user)
- All 20 endpoints decorated with `RequireRateLimiting()` — reads use the read policy, mutations use the write policy
- `app.UseRateLimiter()` placed after `UseAuthentication()` so authenticated user identity drives per-user partitioning
- Limits are fully configurable via `appsettings.json` and overridable per environment (e.g. `RateLimiting__Write__PermitLimit`)
- TDR-1 marked Resolved with implementation details added to the doc

## Default limits

| Traffic type | Permit limit | Window |
|---|---|---|
| Authenticated reads (per user `sub`) | 200 | 60 s |
| Anonymous reads (per IP / `X-Forwarded-For`) | 60 | 60 s |
| Writes (per user `sub`) | 100 | 60 s |

Rejected requests receive `HTTP 429 Too Many Requests`.

## Test plan

- [ ] `RateLimitingTests.GetVolunteerOpportunities_ShouldReturn429_WhenAnonymousRateLimitExceeded` — sends 65 anonymous GETs with a unique `X-Forwarded-For: 10.0.0.99` IP to isolate the quota from other test classes; asserts at least one `429` is returned
- [ ] Existing integration tests should continue to pass — all write limits (100/min) and authenticated read limits (200/min) are well above the number of requests made by the existing test suite

Closes #125

https://claude.ai/code/session_01DgpvP9D1dKTQLXgPAoe4hs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgpvP9D1dKTQLXgPAoe4hs)_