### PR TITLE
fix: use SelectMany via navigation property for time slot query

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -93,8 +93,9 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (result is null)
 			return null;
 
-		var timeSlots = await dbContext.TimeSlotsQuery
-			.Where(ts => EF.Property<Guid>(ts, "volunteer_opportunity_id") == opportunityId)
+		var timeSlots = await dbContext.VolunteerOpportunitiesQuery
+			.Where(vo => vo.Id == opportunityId_)
+			.SelectMany(vo => vo.TimeSlots)
 			.OrderBy(ts => ts.StartDateTime)
 			.Select(ts => new TimeSlotDetail(
 				ts.Id.Value,


### PR DESCRIPTION
EF.Property<Guid> used the wrong CLR type for the shadow FK volunteer_opportunity_id — the property is typed as VolunteerOpportunityId (the principal PK type), not Guid. This caused a runtime exception on the detail endpoint, returning a non-JSON 500 response that the frontend could not parse.

Replaced the shadow property filter with SelectMany through the TimeSlots navigation property, which EF Core translates correctly.

Fixes #188