### PR TITLE
feat: add ConfirmDialog before destructive engagement actions

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+	title: string;
+	message: string;
+	confirmLabel: string;
+	onConfirm: () => void;
+	onClose: () => void;
+	loading?: boolean;
+	error?: string | null;
+}
+
+export default function ConfirmDialog({
+	title,
+	message,
+	confirmLabel,
+	onConfirm,
+	onClose,
+	loading = false,
+	error = null,
+}: Props) {
+	const { t } = useTranslation();
+
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") onClose();
+		}
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onClose]);
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			onClick={onClose}
+		>
+			<div
+				className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+				<p className="mt-2 text-sm text-gray-600">{message}</p>
+
+				{error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+				<div className="mt-5 flex justify-end gap-3">
+					<button
+						onClick={onClose}
+						disabled={loading}
+						className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+					>
+						{t("confirmDialog.keep")}
+					</button>
+					<button
+						onClick={onConfirm}
+						disabled={loading}
+						className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+					>
+						{loading ? "…" : confirmLabel}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -238,6 +238,19 @@
       "description": "Die Seite existiert nicht oder wurde verschoben. Vielleicht hat der Hund sie gefressen…",
       "backHome": "Zur Startseite"
     },
+    "confirmDialog": {
+      "keep": "Behalten",
+      "withdraw": {
+        "title": "Bewerbung zurückziehen?",
+        "message": "Möchtest du deine Bewerbung wirklich zurückziehen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, zurückziehen"
+      },
+      "cancel": {
+        "title": "Engagement absagen?",
+        "message": "Möchtest du dieses Engagement wirklich absagen? Der Freiwillige wird informiert.",
+        "confirm": "Ja, absagen"
+      }
+    },
     "orgProfile": {
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -238,6 +238,19 @@
       "description": "This page doesn't exist or has been moved. Maybe the dog ate it…",
       "backHome": "Back to home"
     },
+    "confirmDialog": {
+      "keep": "Keep",
+      "withdraw": {
+        "title": "Withdraw application?",
+        "message": "Are you sure you want to withdraw your application? This cannot be undone.",
+        "confirm": "Yes, withdraw"
+      },
+      "cancel": {
+        "title": "Cancel engagement?",
+        "message": "Are you sure you want to cancel this engagement? The volunteer will be informed.",
+        "confirm": "Yes, cancel"
+      }
+    },
     "orgProfile": {
       "loading": "Loading…",
       "error": "Error: {{message}}",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import ConfirmDialog from "../components/ConfirmDialog";
 
 const STATUS_COLORS: Record<string, string> = {
 	Pending: "bg-yellow-50 text-yellow-700",
@@ -29,7 +30,10 @@ export default function EngagementManagementPage() {
 	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [processing, setProcessing] = useState<string | null>(null);
+	const [confirming, setConfirming] = useState<string | null>(null);
+	const [confirmCancelId, setConfirmCancelId] = useState<string | null>(null);
+	const [cancelling, setCancelling] = useState(false);
+	const [cancelError, setCancelError] = useState<string | null>(null);
 
 	useEffect(() => {
 		if (!opportunityId) return;
@@ -42,7 +46,7 @@ export default function EngagementManagementPage() {
 	}, [opportunityId]);
 
 	async function handleConfirm(engagementId: string) {
-		setProcessing(engagementId + "-confirm");
+		setConfirming(engagementId);
 		try {
 			const updated = await api.confirmEngagement(engagementId);
 			setEngagements((prev) =>
@@ -57,28 +61,37 @@ export default function EngagementManagementPage() {
 					: t("engagementManagement.confirmError"),
 			);
 		} finally {
-			setProcessing(null);
+			setConfirming(null);
 		}
 	}
 
-	async function handleCancel(engagementId: string) {
-		setProcessing(engagementId + "-cancel");
+	async function handleCancelConfirm() {
+		if (!confirmCancelId) return;
+		setCancelling(true);
+		setCancelError(null);
 		try {
-			const updated = await api.cancelEngagement(engagementId);
+			const updated = await api.cancelEngagement(confirmCancelId);
 			setEngagements((prev) =>
 				prev.map((e) =>
-					e.id === engagementId ? { ...e, status: updated.status } : e,
+					e.id === confirmCancelId ? { ...e, status: updated.status } : e,
 				),
 			);
+			setConfirmCancelId(null);
 		} catch (err) {
-			alert(
+			setCancelError(
 				err instanceof Error
 					? err.message
 					: t("engagementManagement.cancelError"),
 			);
 		} finally {
-			setProcessing(null);
+			setCancelling(false);
 		}
+	}
+
+	function handleCancelClose() {
+		if (cancelling) return;
+		setConfirmCancelId(null);
+		setCancelError(null);
 	}
 
 	return (
@@ -144,33 +157,27 @@ export default function EngagementManagementPage() {
 										<div className="flex gap-2">
 											<button
 												onClick={() => handleConfirm(e.id)}
-												disabled={processing === e.id + "-confirm"}
+												disabled={confirming === e.id}
 												className="text-xs rounded bg-green-600 px-2 py-1 text-white hover:bg-green-700 disabled:opacity-50"
 											>
-												{processing === e.id + "-confirm"
+												{confirming === e.id
 													? t("engagementManagement.processing")
 													: t("engagementManagement.confirm")}
 											</button>
 											<button
-												onClick={() => handleCancel(e.id)}
-												disabled={processing === e.id + "-cancel"}
-												className="text-xs rounded bg-red-600 px-2 py-1 text-white hover:bg-red-700 disabled:opacity-50"
+												onClick={() => setConfirmCancelId(e.id)}
+												className="text-xs rounded bg-red-600 px-2 py-1 text-white hover:bg-red-700"
 											>
-												{processing === e.id + "-cancel"
-													? t("engagementManagement.processing")
-													: t("engagementManagement.cancel")}
+												{t("engagementManagement.cancel")}
 											</button>
 										</div>
 									)}
 									{e.status === "Confirmed" && (
 										<button
-											onClick={() => handleCancel(e.id)}
-											disabled={processing === e.id + "-cancel"}
-											className="text-xs text-red-600 hover:underline disabled:opacity-50"
+											onClick={() => setConfirmCancelId(e.id)}
+											className="text-xs text-red-600 hover:underline"
 										>
-											{processing === e.id + "-cancel"
-												? t("engagementManagement.processing")
-												: t("engagementManagement.revoke")}
+											{t("engagementManagement.revoke")}
 										</button>
 									)}
 								</div>
@@ -178,6 +185,18 @@ export default function EngagementManagementPage() {
 						</li>
 					))}
 				</ul>
+			)}
+
+			{confirmCancelId && (
+				<ConfirmDialog
+					title={t("confirmDialog.cancel.title")}
+					message={t("confirmDialog.cancel.message")}
+					confirmLabel={t("confirmDialog.cancel.confirm")}
+					onConfirm={handleCancelConfirm}
+					onClose={handleCancelClose}
+					loading={cancelling}
+					error={cancelError}
+				/>
 			)}
 		</>
 	);

--- a/frontend/src/pages/MyEngagementsPage.tsx
+++ b/frontend/src/pages/MyEngagementsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import ConfirmDialog from "../components/ConfirmDialog";
 
 const STATUS_COLORS: Record<string, string> = {
 	Pending: "bg-yellow-50 text-yellow-700",
@@ -18,7 +19,9 @@ export default function MyEngagementsPage() {
 	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [withdrawing, setWithdrawing] = useState<string | null>(null);
+	const [confirmWithdrawId, setConfirmWithdrawId] = useState<string | null>(null);
+	const [withdrawing, setWithdrawing] = useState(false);
+	const [withdrawError, setWithdrawError] = useState<string | null>(null);
 
 	const STATUS_LABELS: Record<string, string> = {
 		Pending: t("myEngagements.status.Pending"),
@@ -38,22 +41,31 @@ export default function MyEngagementsPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	async function handleWithdraw(engagementId: string) {
-		setWithdrawing(engagementId);
+	async function handleWithdrawConfirm() {
+		if (!confirmWithdrawId) return;
+		setWithdrawing(true);
+		setWithdrawError(null);
 		try {
-			const updated = await api.withdrawEngagement(engagementId);
+			const updated = await api.withdrawEngagement(confirmWithdrawId);
 			setEngagements((prev) =>
 				prev.map((e) =>
-					e.id === engagementId ? { ...e, status: updated.status } : e,
+					e.id === confirmWithdrawId ? { ...e, status: updated.status } : e,
 				),
 			);
+			setConfirmWithdrawId(null);
 		} catch (err) {
-			alert(
+			setWithdrawError(
 				err instanceof Error ? err.message : t("myEngagements.withdrawError"),
 			);
 		} finally {
-			setWithdrawing(null);
+			setWithdrawing(false);
 		}
+	}
+
+	function handleWithdrawClose() {
+		if (withdrawing) return;
+		setConfirmWithdrawId(null);
+		setWithdrawError(null);
 	}
 
 	return (
@@ -116,13 +128,10 @@ export default function MyEngagementsPage() {
 									</span>
 									{(e.status === "Pending" || e.status === "Confirmed") && (
 										<button
-											onClick={() => handleWithdraw(e.id)}
-											disabled={withdrawing === e.id}
-											className="text-xs text-red-600 hover:underline disabled:opacity-50"
+											onClick={() => setConfirmWithdrawId(e.id)}
+											className="text-xs text-red-600 hover:underline"
 										>
-											{withdrawing === e.id
-												? t("myEngagements.withdrawing")
-												: t("myEngagements.withdraw")}
+											{t("myEngagements.withdraw")}
 										</button>
 									)}
 								</div>
@@ -130,6 +139,18 @@ export default function MyEngagementsPage() {
 						</li>
 					))}
 				</ul>
+			)}
+
+			{confirmWithdrawId && (
+				<ConfirmDialog
+					title={t("confirmDialog.withdraw.title")}
+					message={t("confirmDialog.withdraw.message")}
+					confirmLabel={t("confirmDialog.withdraw.confirm")}
+					onConfirm={handleWithdrawConfirm}
+					onClose={handleWithdrawClose}
+					loading={withdrawing}
+					error={withdrawError}
+				/>
 			)}
 		</>
 	);

--- a/frontend/src/pages/MyEngagementsPage.tsx
+++ b/frontend/src/pages/MyEngagementsPage.tsx
@@ -19,7 +19,9 @@ export default function MyEngagementsPage() {
 	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [confirmWithdrawId, setConfirmWithdrawId] = useState<string | null>(null);
+	const [confirmWithdrawId, setConfirmWithdrawId] = useState<string | null>(
+		null,
+	);
 	const [withdrawing, setWithdrawing] = useState(false);
 	const [withdrawError, setWithdrawError] = useState<string | null>(null);
 


### PR DESCRIPTION
Volunteers must now confirm before withdrawing an application, and organizers must confirm before cancelling or revoking an engagement. Prevents accidental data loss from a single misclick.

- New reusable ConfirmDialog component (Escape + backdrop dismiss, inline error display, loading state on confirm button)
- MyEngagementsPage: Withdraw shows dialog before API call
- EngagementManagementPage: Cancel and Revoke both show dialog; errors surface inline in the dialog rather than alert()
- i18n keys added in en.json and de.json

Closes #111

https://claude.ai/code/session_012mJBa1BrdoZ8C5DERMrpgt