### PR TITLE
fix: raise EngagementCancelledDomainEvent and add optional cancellati…

### DIFF
--- a/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
@@ -28,14 +28,15 @@ internal sealed class CancelEngagementEndpoint
 
 	private static async Task<IResult> CancelEngagementAsync(
 		[FromRoute] Guid engagementId,
+		[FromBody] CancelEngagementRequest? body,
 		[FromServices] ISender sender,
 		CancellationToken cancellationToken)
 	{
 		try
 		{
-			var command = new CancelEngagementCommand(new EngagementId(engagementId));
+			var command = new CancelEngagementCommand(new EngagementId(engagementId), body?.Reason);
 			var engagement = await sender.Send(command, cancellationToken);
-			return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString(), engagement.ModifiedOn));
+			return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString(), engagement.ModifiedOn, engagement.CancellationReason));
 		}
 		catch (DomainException ex) when (ex.Message.Contains("not found"))
 		{

--- a/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementRequest.cs
+++ b/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementRequest.cs
@@ -1,0 +1,3 @@
+namespace Api.Engagements.CancelEngagement.v1;
+
+public sealed record CancelEngagementRequest(string? Reason);

--- a/backend/src/Api/Engagements/EngagementStatusResponse.cs
+++ b/backend/src/Api/Engagements/EngagementStatusResponse.cs
@@ -3,4 +3,5 @@ namespace Api.Engagements;
 public sealed record EngagementStatusResponse(
 	Guid Id,
 	string Status,
-	DateTimeOffset? ModifiedOn);
+	DateTimeOffset? ModifiedOn,
+	string? CancellationReason = null);

--- a/backend/src/Application/Common/IDomainEventDispatcher.cs
+++ b/backend/src/Application/Common/IDomainEventDispatcher.cs
@@ -1,0 +1,8 @@
+using Domain.Primitives;
+
+namespace Application.Common;
+
+public interface IDomainEventDispatcher
+{
+	ValueTask DispatchAsync(IEnumerable<DomainEvent> events, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommand.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommand.cs
@@ -3,5 +3,5 @@ using Domain.Engagements;
 
 namespace Application.Engagements.CancelEngagement.v1;
 
-public sealed record CancelEngagementCommand(EngagementId EngagementId)
+public sealed record CancelEngagementCommand(EngagementId EngagementId, string? Reason = null)
 	: ICommand<Engagement>;

--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -16,7 +16,7 @@ internal sealed class CancelEngagementCommandHandler(
 		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
 			?? throw new DomainException($"Engagement '{request.EngagementId.Value}' not found.");
 
-		engagement.Cancel();
+		engagement.Cancel(request.Reason);
 
 		return engagement;
 	}

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -18,6 +18,8 @@ public sealed class Engagement
 
 	public EngagementStatus Status { get; private set; }
 
+	public string? CancellationReason { get; private set; }
+
 	public DateTimeOffset CreatedOn { get; private set; }
 
 	public DateTimeOffset? ModifiedOn { get; private set; }
@@ -81,12 +83,14 @@ public sealed class Engagement
 		Status = EngagementStatus.Confirmed;
 	}
 
-	public void Cancel()
+	public void Cancel(string? reason = null)
 	{
 		if (Status is EngagementStatus.Withdrawn or EngagementStatus.Cancelled)
 			throw new DomainException("Engagement is already terminated.");
 
+		CancellationReason = reason;
 		Status = EngagementStatus.Cancelled;
+		AddEvent(new EngagementCancelledDomainEvent(Id, VolunteerId, OpportunityId, reason));
 	}
 
 	public void Withdraw()

--- a/backend/src/Domain/Engagements/EngagementCancelledDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementCancelledDomainEvent.cs
@@ -1,0 +1,12 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+public sealed record EngagementCancelledDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId,
+	string? Reason)
+	: DomainEvent;

--- a/backend/src/Infrastructure/NullDomainEventDispatcher.cs
+++ b/backend/src/Infrastructure/NullDomainEventDispatcher.cs
@@ -1,0 +1,20 @@
+using Application.Common;
+using Domain.Primitives;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure;
+
+internal sealed class NullDomainEventDispatcher(
+	ILogger<NullDomainEventDispatcher> logger)
+	: IDomainEventDispatcher
+{
+	public ValueTask DispatchAsync(IEnumerable<DomainEvent> events, CancellationToken cancellationToken = default)
+	{
+		foreach (var @event in events)
+		{
+			logger.LogDebug("Domain event raised: {EventType}", @event.GetType().Name);
+		}
+
+		return ValueTask.CompletedTask;
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -39,6 +39,8 @@ internal sealed class EngagementConfiguration
 
 		builder.Property(e => e.Message);
 
+		builder.Property(e => e.CancellationReason);
+
 		builder.Property(e => e.Status)
 			.HasConversion<string>()
 			.IsRequired();

--- a/backend/src/Infrastructure/Persistence/Interceptors/DomainEventInterceptor.cs
+++ b/backend/src/Infrastructure/Persistence/Interceptors/DomainEventInterceptor.cs
@@ -1,0 +1,34 @@
+using Application.Common;
+using Domain.Primitives;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Infrastructure.Persistence.Interceptors;
+
+internal sealed class DomainEventInterceptor(
+	IDomainEventDispatcher dispatcher)
+	: SaveChangesInterceptor
+{
+	public override async ValueTask<int> SavedChangesAsync(
+		SaveChangesCompletedEventData eventData,
+		int result,
+		CancellationToken cancellationToken = default)
+	{
+		if (eventData.Context is not null)
+		{
+			var events = eventData.Context.ChangeTracker
+				.Entries<IAggregateRoot>()
+				.SelectMany(e => e.Entity.Events)
+				.ToList();
+
+			foreach (var entry in eventData.Context.ChangeTracker.Entries<IAggregateRoot>())
+			{
+				entry.Entity.ClearEvents();
+			}
+
+			await dispatcher.DispatchAsync(events, cancellationToken);
+		}
+
+		return await base.SavedChangesAsync(eventData, result, cancellationToken);
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Migrations/20260514120000_AddEngagementCancellationReason.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260514120000_AddEngagementCancellationReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260514120000_AddEngagementCancellationReason")]
+	partial class AddEngagementCancellationReason
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260514120000_AddEngagementCancellationReason.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260514120000_AddEngagementCancellationReason.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddEngagementCancellationReason : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "cancellation_reason",
+				table: "engagement",
+				type: "text",
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "cancellation_reason",
+				table: "engagement");
+		}
+	}
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Application.Common;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -22,6 +23,8 @@ public static class ServiceCollectionExtensions
 		services.ConfigureOptions<ConnectionStringOptionsSetup>();
 
 		services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor>();
+		services.AddScoped<IDomainEventDispatcher, NullDomainEventDispatcher>();
+		services.AddScoped<ISaveChangesInterceptor, DomainEventInterceptor>();
 
 		services.AddDbContext<ApplicationDbContext>((sp, options) =>
 		{


### PR DESCRIPTION
…on reason

Engagement.Cancel() now accepts an optional reason string, persists it as CancellationReason on the aggregate, and raises EngagementCancelledDomainEvent so downstream notification handlers (email, in-app — future stories) can react.

- Add EngagementCancelledDomainEvent domain event record
- Add IDomainEventDispatcher interface + NullDomainEventDispatcher (logs events)
- Add DomainEventInterceptor (SaveChangesInterceptor) dispatching after save
- Thread Reason through CancelEngagementCommand → handler → Cancel()
- Add CancelEngagementRequest body (optional, backwards-compatible)
- Expose CancellationReason in EngagementStatusResponse
- EF Core migration: add cancellation_reason column to engagement table

Closes #118

https://claude.ai/code/session_012mJBa1BrdoZ8C5DERMrpgt