### PR TITLE
chore: improve Claude Code session reliability

### DIFF
--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 # Install .NET 10 SDK if dotnet is not on PATH
 if ! command -v dotnet &>/dev/null; then
-  echo "[SessionStart] dotnet not found — installing .NET SDK 10.0.300..."
-  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
-  chmod +x /tmp/dotnet-install.sh
-  /tmp/dotnet-install.sh --version 10.0.300 --install-dir "$HOME/.dotnet"
-  export PATH="$HOME/.dotnet:$PATH"
-  echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
+	echo "[SessionStart] dotnet not found - installing .NET SDK 10.0.300..."
+	curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+	chmod +x /tmp/dotnet-install.sh
+	/tmp/dotnet-install.sh --version 10.0.300 --install-dir "$HOME/.dotnet"
+	export PATH="$HOME/.dotnet:$PATH"
+	echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
 fi
 
 # Regenerate openapi-v1.json + api-client.ts + ApiClient.cs via NSwag post-build

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install .NET 10 SDK if dotnet is not on PATH
+if ! command -v dotnet &>/dev/null; then
+  echo "[SessionStart] dotnet not found — installing .NET SDK 10.0.300..."
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  chmod +x /tmp/dotnet-install.sh
+  /tmp/dotnet-install.sh --version 10.0.300 --install-dir "$HOME/.dotnet"
+  export PATH="$HOME/.dotnet:$PATH"
+  echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
+fi
+
+# Regenerate openapi-v1.json + api-client.ts + ApiClient.cs via NSwag post-build
+echo "[SessionStart] Building backend (NSwag regeneration)..."
+dotnet build backend/src/Api/Api.csproj --configuration Debug --verbosity quiet
+
+# Apply Prettier formatting so no violations are committed
+echo "[SessionStart] Formatting frontend..."
+cd frontend && pnpm format:write

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,22 @@
   "permissions": {
     "allow": [
       "Bash(dotnet build:*)",
-      "Bash(dotnet test:*)"
+      "Bash(dotnet test:*)",
+      "Bash(bash .claude/scripts/session-start.sh)",
+      "Bash(curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh)",
+      "Bash(pnpm format:write)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/session-start.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,5 @@ Test users: `vera/vera123` (user), `olaf/olaf123` (user + organisator), `admin/a
 - Commands/queries/DTOs: C# records
 - Commits: Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore:`, `test:`)
 - No `.Result`/`.Wait()` - async all the way
+- **Never use Unicode dashes** (U+2013 en dash, U+2014 em dash) in any file - write plain ASCII hyphens (`-`) instead; CI rejects non-ASCII dashes
+- **Shell scripts use tab indentation** - the EditorConfig rule for `.sh` files requires tabs, not spaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ einsatzbereit/
 
 | | |
 |---|---|
-| Backend | .NET 10, EF Core 9, PostgreSQL 18 |
+| Backend | .NET 10 (SDK 10.0.300, see `backend/global.json`), EF Core 9, PostgreSQL 18 |
 | Auth | Keycloak 26.6.1 (OIDC, JWT) |
 | Frontend | Vite SPA, React 19, React Router v7, Tailwind CSS 4 |
 | API client | NSwag-generated - **never hand-edit** `api-client.ts` |
@@ -26,6 +26,8 @@ einsatzbereit/
 | CI/CD | GitHub Actions → GHCR |
 
 ## Development Setup
+
+Required: .NET SDK **10.0.300** (enforced via `backend/global.json`). In Claude Code web/cloud sessions, the `SessionStart` hook installs it automatically via `dotnet-install.sh` if `dotnet` is not already on `PATH`.
 
 ```bash
 dotnet run --project backend/src/Aspire/AppHost

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -114,7 +114,7 @@ pnpm build         # build to dist/ (static files)
 pnpm preview       # preview production build
 pnpm check         # tsc --noEmit
 pnpm lint          # eslint, zero warnings allowed
-pnpm format:write  # apply Prettier formatting — run before every commit
+pnpm format:write  # apply Prettier formatting - run before every commit
 pnpm format:check  # check Prettier formatting (used by CI)
 ```
 
@@ -131,7 +131,7 @@ pnpm format:check  # check Prettier formatting (used by CI)
 
 ## Linting
 
-Always run `pnpm format:write` before committing. The CI `lint` job runs `format:check` and will fail if any Prettier violations exist — causing `build` to be skipped and a follow-up fix commit.
+Always run `pnpm format:write` before committing. The CI `lint` job runs `format:check` and will fail if any Prettier violations exist - causing `build` to be skipped and a follow-up fix commit.
 
 Run lint before every commit. All errors must be fixed - zero warnings allowed (`--max-warnings 0`).
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -109,11 +109,13 @@ Current protected routes:
 ## Scripts
 
 ```bash
-pnpm dev      # dev server on :4321
-pnpm build    # build to dist/ (static files)
-pnpm preview  # preview production build
-pnpm check    # tsc --noEmit
-pnpm lint     # eslint, zero warnings allowed
+pnpm dev           # dev server on :4321
+pnpm build         # build to dist/ (static files)
+pnpm preview       # preview production build
+pnpm check         # tsc --noEmit
+pnpm lint          # eslint, zero warnings allowed
+pnpm format:write  # apply Prettier formatting — run before every commit
+pnpm format:check  # check Prettier formatting (used by CI)
 ```
 
 ## Key Dependencies
@@ -128,6 +130,8 @@ pnpm lint     # eslint, zero warnings allowed
 | `@tailwindcss/vite`  | Tailwind CSS 4 via Vite              |
 
 ## Linting
+
+Always run `pnpm format:write` before committing. The CI `lint` job runs `format:check` and will fail if any Prettier violations exist — causing `build` to be skipped and a follow-up fix commit.
 
 Run lint before every commit. All errors must be fixed - zero warnings allowed (`--max-warnings 0`).
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "check": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
+    "format:write": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
     "i18n:check": "node scripts/check-i18n-keys.js"
   },
   "dependencies": {


### PR DESCRIPTION
… hygiene)

- Add .claude/scripts/session-start.sh: installs .NET SDK 10.0.300 on demand, runs dotnet build to regenerate NSwag-generated files, and applies Prettier
- Add SessionStart hook in .claude/settings.json referencing the script
- Add format:write script to frontend/package.json
- Document required .NET SDK version (10.0.300) in CLAUDE.md
- Add formatter pre-commit reminder in frontend/CLAUDE.md

Closes #202

https://claude.ai/code/session_01LKfRbzbs2rc6XyFzhcBNPo