### PR TITLE
feat: add dog-paw brand logo, icon, and favicon as configurable SVGs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Einsatzbereit</title>
+		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 	</head>
 	<body>
 		<div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <!--
+    COLORS: change the two stop-color values below to recolor the icon.
+    Start color (top-left): #22c55e  →  brand-500
+    End color (bottom-right): #34d399  →  accent-400
+  -->
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+  <!-- toe pads -->
+  <circle cx="10" cy="27" r="5"   fill="url(#g)"/>
+  <circle cx="19" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="29" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="38" cy="27" r="5"   fill="url(#g)"/>
+  <!-- main pad -->
+  <ellipse cx="24" cy="37" rx="11" ry="8.5" fill="url(#g)"/>
+</svg>

--- a/frontend/public/logo-icon.svg
+++ b/frontend/public/logo-icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <!--
+    COLORS: change the two stop-color values below to recolor the icon.
+    Start color (top-left): #22c55e  →  brand-500
+    End color (bottom-right): #34d399  →  accent-400
+  -->
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+  <!-- toe pads -->
+  <circle cx="10" cy="27" r="5"   fill="url(#g)"/>
+  <circle cx="19" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="29" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="38" cy="27" r="5"   fill="url(#g)"/>
+  <!-- main pad -->
+  <ellipse cx="24" cy="37" rx="11" ry="8.5" fill="url(#g)"/>
+</svg>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 48">
+  <!--
+    COLORS: change the two stop-color values below to recolor the entire logo.
+    Start color (top-left): #22c55e  →  brand-500
+    End color (bottom-right): #34d399  →  accent-400
+
+    WORDMARK COLOR: change fill="#1f2937" on the <text> element below.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+
+  <!-- paw icon (48x48) -->
+  <!-- toe pads -->
+  <circle cx="10" cy="27" r="5"   fill="url(#g)"/>
+  <circle cx="19" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="29" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="38" cy="27" r="5"   fill="url(#g)"/>
+  <!-- main pad -->
+  <ellipse cx="24" cy="37" rx="11" ry="8.5" fill="url(#g)"/>
+
+  <!-- wordmark -->
+  <text
+    x="58"
+    y="32"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+    font-size="22"
+    font-weight="600"
+    letter-spacing="-0.3"
+    fill="#1f2937"
+  >Einsatzbereit</text>
+</svg>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -73,6 +73,12 @@ export default function Header() {
 				<div className="flex items-center justify-between h-16">
 					{/* Brand */}
 					<a href="/" className="flex items-center gap-2 group">
+						<img
+							src="/logo-icon.svg"
+							alt=""
+							aria-hidden="true"
+							className="h-8 w-8"
+						/>
 						<span className="text-xl font-bold text-brand-600 group-hover:text-brand-700 transition-colors">
 							{t("brand.name")}
 						</span>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Introduces a geometric dog-paw mark as the Einsatzbereit brand icon - 4 toe-pad circles in an arc above one large ellipse main pad, filled with a diagonal gradient matching the existing header accent bar
- Adds three SVG assets to `frontend/public/`: `favicon.svg`, `logo-icon.svg` (icon only), and `logo.svg` (icon + wordmark)
- Wires the favicon into `index.html` via `<link rel="icon" type="image/svg+xml">`
- Updates `Header.tsx` to display the paw icon alongside the existing brand name text

## Color configurability

All colors are controlled by two `stop-color` values inside each SVG's `<linearGradient>`. To recolor the entire brand identity, change only these two hex values:

```xml
<stop offset="0%"   stop-color="#22c55e"/>  <!-- brand-500 -->
<stop offset="100%" stop-color="#34d399"/>  <!-- accent-400 -->
```

The wordmark color in `logo.svg` is a single `fill="#1f2937"` on the `<text>` element.

## Test plan

- [ ] Open the app in a browser - browser tab should show the paw favicon
- [ ] Header shows the green gradient paw icon to the left of "Einsatzbereit"
- [ ] Open `/logo.svg` and `/logo-icon.svg` directly in a browser to verify rendering
- [ ] Edit a `stop-color` hex in any SVG and reload to confirm color configurability

https://claude.ai/code/session_016RFdQ9x7TYPCZiKFGbGv8o
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RFdQ9x7TYPCZiKFGbGv8o)_