### PR TITLE
feat: filter URL params and Load More button for volunteer opportunities

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -14,5 +15,126 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Expect(Page.Locator("main")).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task SearchFilter_UpdatesUrlWithSearchParam()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByPlaceholder("Search…").FillAsync("volunteer");
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*search=volunteer"));
+	}
+
+	[Test]
+	public async Task CityFilter_UpdatesUrlWithCityParam()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByPlaceholder("City…").FillAsync("Berlin");
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*city=Berlin"));
+	}
+
+	[Test]
+	public async Task OccurrenceFilter_UpdatesUrlWithOccurrenceParam()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Combobox).First.SelectOptionAsync("OneTime");
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*occurrence=OneTime"));
+	}
+
+	[Test]
+	public async Task ParticipationTypeFilter_UpdatesUrlWithParticipationTypeParam()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Combobox).Nth(1).SelectOptionAsync("Waitlist");
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*participationType=Waitlist"));
+	}
+
+	[Test]
+	public async Task UrlSearchParam_PreFillsSearchInput()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/?search=testquery");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByPlaceholder("Search…")).ToHaveValueAsync("testquery");
+	}
+
+	[Test]
+	public async Task UrlCityParam_PreFillsCityInput()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/?city=Hamburg");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByPlaceholder("City…")).ToHaveValueAsync("Hamburg");
+	}
+
+	[Test]
+	public async Task SearchFilter_WithNoResults_HidesLoadMoreButton()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByPlaceholder("Search…").FillAsync("zzz_no_match_xyz_abc_999");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(
+			Page.GetByRole(AriaRole.Button, new() { Name = "Load more" })
+		).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task MultipleFilters_AllReflectedInUrl()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByPlaceholder("Search…").FillAsync("help");
+		await Page.GetByPlaceholder("City…").FillAsync("Munich");
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*search=help"));
+		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*city=Munich"));
+	}
+
+	[Test]
+	public async Task ClearingSearchFilter_RemovesParamFromUrl()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/?search=hello");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByPlaceholder("Search…").ClearAsync();
+
+		await Expect(Page).Not.ToHaveURLAsync(new Regex(@"\?.*search="));
 	}
 }

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState } from "react";
-import { useNavigate, Link } from "react-router";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import type {
-	PagedListOfVolunteerOpportunitySummary,
-	VolunteerOpportunitySummary,
-} from "../client/api-client";
+import type { VolunteerOpportunitySummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { getActiveOrgId } from "../lib/activeOrg";
 import { formatOccurrence, formatParticipationType } from "../lib/format";
@@ -20,23 +17,59 @@ export default function VolunteerOpportunitiesList({
 	const api = useApiClient();
 	const navigate = useNavigate();
 	const { t } = useTranslation();
-	const [data, setData] =
-		useState<PagedListOfVolunteerOpportunitySummary | null>(null);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
+	const [searchParams, setSearchParams] = useSearchParams();
+	const search = searchParams.get("search") ?? "";
+	const city = searchParams.get("city") ?? "";
+	const occurrence = searchParams.get("occurrence") ?? "";
+	const participationType = searchParams.get("participationType") ?? "";
+
+	const [items, setItems] = useState<VolunteerOpportunitySummary[]>([]);
 	const [page, setPage] = useState(1);
+	const [pageCount, setPageCount] = useState(1);
+	const [loading, setLoading] = useState(true);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 	const [refreshKey, setRefreshKey] = useState(0);
 	const [showModal, setShowModal] = useState(false);
 
-	const [search, setSearch] = useState("");
-	const [city, setCity] = useState("");
-	const [occurrence, setOccurrence] = useState("");
-	const [participationType, setParticipationType] = useState("");
+	const prevFiltersRef = useRef({
+		search,
+		city,
+		occurrence,
+		participationType,
+		refreshKey,
+	});
 
 	useEffect(() => {
-		setLoading(true);
+		const prev = prevFiltersRef.current;
+		const filterChanged =
+			prev.search !== search ||
+			prev.city !== city ||
+			prev.occurrence !== occurrence ||
+			prev.participationType !== participationType ||
+			prev.refreshKey !== refreshKey;
+
+		prevFiltersRef.current = {
+			search,
+			city,
+			occurrence,
+			participationType,
+			refreshKey,
+		};
+
+		if (filterChanged) {
+			setItems([]);
+			if (page !== 1) {
+				setPage(1);
+				return;
+			}
+		}
+
+		if (page > 1) setLoadingMore(true);
+		else setLoading(true);
 		setError(null);
 
+		let cancelled = false;
 		api
 			.getVolunteerOpportunities(
 				page,
@@ -46,16 +79,39 @@ export default function VolunteerOpportunitiesList({
 				occurrence || undefined,
 				participationType || undefined,
 			)
-			.then((json: PagedListOfVolunteerOpportunitySummary) => setData(json))
-			.catch((err: Error) => setError(err.message))
-			.finally(() => setLoading(false));
+			.then((result) => {
+				if (cancelled) return;
+				if (page === 1) setItems(result.items);
+				else setItems((prev) => [...prev, ...result.items]);
+				setPageCount(result.pageCount ?? 1);
+				setLoading(false);
+				setLoadingMore(false);
+			})
+			.catch((err: Error) => {
+				if (cancelled) return;
+				setError(err.message);
+				setLoading(false);
+				setLoadingMore(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [page, refreshKey, search, city, occurrence, participationType]);
+	}, [page, search, city, occurrence, participationType, refreshKey]);
 
 	const activeOrgId = getActiveOrgId();
 
-	function handleFilterChange() {
-		setPage(1);
+	function updateFilter(key: string, value: string) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (value) next.set(key, value);
+				else next.delete(key);
+				return next;
+			},
+			{ replace: true },
+		);
 	}
 
 	return (
@@ -80,28 +136,19 @@ export default function VolunteerOpportunitiesList({
 					type="text"
 					placeholder={t("opportunities.searchPlaceholder")}
 					value={search}
-					onChange={(e) => {
-						setSearch(e.target.value);
-						handleFilterChange();
-					}}
+					onChange={(e) => updateFilter("search", e.target.value)}
 					className="rounded border px-3 py-1.5 text-sm"
 				/>
 				<input
 					type="text"
 					placeholder={t("opportunities.cityPlaceholder")}
 					value={city}
-					onChange={(e) => {
-						setCity(e.target.value);
-						handleFilterChange();
-					}}
+					onChange={(e) => updateFilter("city", e.target.value)}
 					className="rounded border px-3 py-1.5 text-sm"
 				/>
 				<select
 					value={occurrence}
-					onChange={(e) => {
-						setOccurrence(e.target.value);
-						handleFilterChange();
-					}}
+					onChange={(e) => updateFilter("occurrence", e.target.value)}
 					className="rounded border px-3 py-1.5 text-sm text-gray-700"
 				>
 					<option value="">{t("opportunities.allFrequencies")}</option>
@@ -110,10 +157,7 @@ export default function VolunteerOpportunitiesList({
 				</select>
 				<select
 					value={participationType}
-					onChange={(e) => {
-						setParticipationType(e.target.value);
-						handleFilterChange();
-					}}
+					onChange={(e) => updateFilter("participationType", e.target.value)}
 					className="rounded border px-3 py-1.5 text-sm text-gray-700"
 				>
 					<option value="">{t("opportunities.allTypes")}</option>
@@ -131,13 +175,13 @@ export default function VolunteerOpportunitiesList({
 				</p>
 			)}
 
-			{!loading && !error && data && (
+			{!loading && !error && (
 				<>
-					{data.items.length === 0 ? (
+					{items.length === 0 ? (
 						<p className="text-gray-500">{t("opportunities.noResults")}</p>
 					) : (
 						<ul className="space-y-3">
-							{data.items.map((item: VolunteerOpportunitySummary) => (
+							{items.map((item: VolunteerOpportunitySummary) => (
 								<li
 									key={item.id}
 									className="cursor-pointer rounded border p-4 hover:bg-gray-50 transition-colors"
@@ -185,27 +229,16 @@ export default function VolunteerOpportunitiesList({
 						</ul>
 					)}
 
-					{(data.pageCount ?? 1) > 1 && (
-						<div className="mt-4 flex items-center gap-3">
-							<button
-								onClick={() => setPage((p) => p - 1)}
-								disabled={page <= 1}
-								className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-40"
-							>
-								{t("opportunities.previous")}
-							</button>
-							<span className="text-sm text-gray-500">
-								{t("opportunities.page", {
-									current: page,
-									total: data.pageCount,
-								})}
-							</span>
+					{items.length > 0 && page < pageCount && (
+						<div className="mt-4 flex justify-center">
 							<button
 								onClick={() => setPage((p) => p + 1)}
-								disabled={page >= (data.pageCount ?? 1)}
-								className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-40"
+								disabled={loadingMore}
+								className="rounded px-4 py-2 text-sm hover:bg-gray-100 disabled:opacity-40"
 							>
-								{t("opportunities.next")}
+								{loadingMore
+									? t("opportunities.loading")
+									: t("opportunities.loadMore")}
 							</button>
 						</div>
 					)}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -42,6 +42,7 @@
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",
       "noResults": "Keine Bedarfe gefunden.",
+      "loadMore": "Mehr laden",
       "previous": "← Zurück",
       "next": "Weiter →",
       "page": "{{current}} / {{total}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -42,6 +42,7 @@
       "loading": "Loading…",
       "error": "Error: {{message}}",
       "noResults": "No opportunities found.",
+      "loadMore": "Load more",
       "previous": "← Back",
       "next": "Next →",
       "page": "{{current}} / {{total}}",


### PR DESCRIPTION
## Summary

- Replaces prev/next pagination with a **Load More** button that appends the next page of results below the current list - fits volunteer-browsing behavior better than classic pagination
- Syncs filter state (`search`, `city`, `occurrence`, `participationType`) to the URL as query params so filtered views are **shareable and bookmarkable**
- Uses a `prevFiltersRef` pattern to safely handle the race condition where filters change while the user is on page > 1 (resets to page 1 before fetching with new filters)
- Adds `loadMore` translation key in `en.json` and `de.json`

Closes #103

## Test plan

- [ ] Open `/` - first 10 items load; "Load More" button is visible when there are more than 10 results
- [ ] Click "Load More" - next 10 items append below the existing list; button disappears when all pages are loaded
- [ ] Type in the search field - URL updates to `?search=...`, list resets to the first page of filtered results
- [ ] Change city, occurrence, or participation type filters - URL params update accordingly
- [ ] Copy the URL with active filters and open it in a new tab - same filtered results appear
- [ ] Create an opportunity (as organisator) - list refreshes and shows the new item

---
_Generated by [Claude Code](https://claude.ai/code/session_018maAtcUYAKY8nxWZMfL953)_