### PR TITLE
feat: split header into Actionbar and optional Toolbar with breadcrumbs

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router";
+import type { BreadcrumbItem } from "../contexts/ToolbarContext";
+
+export default function Breadcrumb({ items }: { items: BreadcrumbItem[] }) {
+	return (
+		<nav
+			aria-label="Breadcrumb"
+			className="flex items-center gap-1 text-sm text-gray-500 min-w-0 overflow-hidden"
+		>
+			{items.map((item, index) => (
+				<span key={index} className="flex items-center gap-1 min-w-0 shrink-0">
+					{index > 0 && (
+						<span className="text-gray-300 shrink-0" aria-hidden="true">
+							›
+						</span>
+					)}
+					{item.href !== undefined ? (
+						<Link
+							to={item.href}
+							className="hover:text-gray-800 transition-colors truncate shrink"
+						>
+							{item.label}
+						</Link>
+					) : (
+						<span className="font-medium text-gray-900 truncate shrink">
+							{item.label}
+						</span>
+					)}
+				</span>
+			))}
+		</nav>
+	);
+}

--- a/frontend/src/contexts/ToolbarContext.tsx
+++ b/frontend/src/contexts/ToolbarContext.tsx
@@ -1,0 +1,56 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+	type ReactNode,
+} from "react";
+
+export type BreadcrumbItem = {
+	label: string;
+	href?: string;
+};
+
+type ToolbarConfig = {
+	breadcrumbs: BreadcrumbItem[];
+};
+
+type ToolbarContextValue = {
+	config: ToolbarConfig | null;
+	setConfig: (config: ToolbarConfig | null) => void;
+};
+
+const ToolbarContext = createContext<ToolbarContextValue | null>(null);
+
+export function ToolbarProvider({ children }: { children: ReactNode }) {
+	const [config, setConfigState] = useState<ToolbarConfig | null>(null);
+	const setConfig = useCallback((c: ToolbarConfig | null) => {
+		setConfigState(c);
+	}, []);
+	return (
+		<ToolbarContext.Provider value={{ config, setConfig }}>
+			{children}
+		</ToolbarContext.Provider>
+	);
+}
+
+function useToolbarCtx() {
+	const ctx = useContext(ToolbarContext);
+	if (!ctx)
+		throw new Error("usePageToolbar must be used within ToolbarProvider");
+	return ctx;
+}
+
+export function useToolbarConfig() {
+	return useToolbarCtx().config;
+}
+
+export function usePageToolbar(breadcrumbs: BreadcrumbItem[]) {
+	const { setConfig } = useToolbarCtx();
+	const key = JSON.stringify(breadcrumbs);
+	useEffect(() => {
+		setConfig({ breadcrumbs: JSON.parse(key) as BreadcrumbItem[] });
+		return () => setConfig(null);
+	}, [key, setConfig]);
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,15 +1,40 @@
 import { Outlet } from "react-router";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import Breadcrumb from "../components/Breadcrumb";
+import { ToolbarProvider, useToolbarConfig } from "../contexts/ToolbarContext";
 
-export default function AppLayout() {
+function ToolbarStrip() {
+	const config = useToolbarConfig();
+	if (!config) return null;
+	return (
+		<div className="border-b border-gray-100 bg-white">
+			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+				<div className="flex items-center h-10 min-w-0">
+					<Breadcrumb items={config.breadcrumbs} />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function AppLayoutInner() {
 	return (
 		<div className="min-h-screen flex flex-col">
 			<Header />
+			<ToolbarStrip />
 			<main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8 flex-1 w-full">
 				<Outlet />
 			</main>
 			<Footer />
 		</div>
+	);
+}
+
+export default function AppLayout() {
+	return (
+		<ToolbarProvider>
+			<AppLayoutInner />
+		</ToolbarProvider>
 	);
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -273,6 +273,13 @@
       "address": "Adresse:",
       "currentNeeds": "Aktuelle Bedarfe",
       "noOpportunities": "Keine aktuellen Bedarfe vorhanden."
+    },
+    "breadcrumb": {
+      "home": "Startseite",
+      "volunteerOpportunities": "Einsatzmoglichkeiten",
+      "engagements": "Bewerbungen",
+      "settings": "Einstellungen",
+      "account": "Konto"
     }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -273,6 +273,13 @@
       "address": "Address:",
       "currentNeeds": "Current Opportunities",
       "noOpportunities": "No current opportunities available."
+    },
+    "breadcrumb": {
+      "home": "Home",
+      "volunteerOpportunities": "Volunteer Opportunities",
+      "engagements": "Engagements",
+      "settings": "Settings",
+      "account": "Account"
     }
   }
 }

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -3,11 +3,17 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import type { MyProfileResponse } from "../client/api-client";
+import { usePageToolbar } from "../contexts/ToolbarContext";
 
 export default function AccountPage() {
 	const auth = useAuth();
 	const api = useApiClient();
 	const { t } = useTranslation();
+
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{ label: t("breadcrumb.account") },
+	]);
 	const [profile, setProfile] = useState<MyProfileResponse | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router";
+import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
+import { usePageToolbar } from "../contexts/ToolbarContext";
 
 const STATUS_COLORS: Record<string, string> = {
 	Pending: "bg-yellow-50 text-yellow-700",
@@ -14,7 +15,6 @@ const STATUS_COLORS: Record<string, string> = {
 
 export default function EngagementManagementPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
-	const navigate = useNavigate();
 	const api = useApiClient();
 	const { t, i18n } = useTranslation();
 
@@ -28,6 +28,7 @@ export default function EngagementManagementPage() {
 	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
 
 	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
+	const [opportunityTitle, setOpportunityTitle] = useState<string>("");
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [confirming, setConfirming] = useState<string | null>(null);
@@ -35,11 +36,25 @@ export default function EngagementManagementPage() {
 	const [cancelling, setCancelling] = useState(false);
 	const [cancelError, setCancelError] = useState<string | null>(null);
 
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{
+			label: opportunityTitle || t("breadcrumb.volunteerOpportunities"),
+			href: opportunityId ? `/volunteer-opportunities/${opportunityId}` : "/",
+		},
+		{ label: t("breadcrumb.engagements") },
+	]);
+
 	useEffect(() => {
 		if (!opportunityId) return;
-		api
-			.getEngagements(opportunityId)
-			.then(setEngagements)
+		Promise.all([
+			api.getEngagements(opportunityId),
+			api
+				.getVolunteerOpportunityDetails(opportunityId)
+				.then((d) => setOpportunityTitle(d.title))
+				.catch(() => undefined),
+		])
+			.then(([e]) => setEngagements(e))
 			.catch((err) => setError(err.message))
 			.finally(() => setLoading(false));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,13 +111,6 @@ export default function EngagementManagementPage() {
 
 	return (
 		<>
-			<button
-				onClick={() => navigate(-1)}
-				className="mb-4 text-sm text-gray-500 hover:text-gray-800"
-			>
-				{t("engagementManagement.back")}
-			</button>
-
 			<h1 className="mb-6 text-2xl font-bold text-gray-900">
 				{t("engagementManagement.title")}
 			</h1>

--- a/frontend/src/pages/OrganizationSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettingsPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import type { OrganizationDetailsResponse } from "../client/api-client";
+import { usePageToolbar } from "../contexts/ToolbarContext";
 
 type Tab = "general" | "members";
 
@@ -30,6 +31,15 @@ export default function OrganizationSettingsPage() {
 	});
 
 	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
+
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{
+			label: org?.name ?? "",
+			href: organizationId ? `/organizations/${organizationId}` : "/",
+		},
+		{ label: t("breadcrumb.settings") },
+	]);
 
 	useEffect(() => {
 		if (!organizationId) return;

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/format";
 import SignUpModal from "../components/SignUpModal";
 import EditVolunteerOpportunityModal from "../components/EditVolunteerOpportunityModal";
+import { usePageToolbar } from "../contexts/ToolbarContext";
 
 export default function VolunteerOpportunityDetailPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
@@ -32,6 +33,12 @@ export default function VolunteerOpportunityDetailPage() {
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
 	const isOrganisator = roles.includes("organisator");
+
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{ label: t("breadcrumb.volunteerOpportunities"), href: "/" },
+		{ label: opportunity?.title ?? "" },
+	]);
 
 	useEffect(() => {
 		if (!opportunityId) return;
@@ -78,13 +85,6 @@ export default function VolunteerOpportunityDetailPage() {
 
 	return (
 		<div className="max-w-2xl">
-			<button
-				onClick={() => navigate(-1)}
-				className="mb-4 text-sm text-gray-500 hover:text-gray-800"
-			>
-				{t("opportunities.back")}
-			</button>
-
 			<div className="mb-1 flex items-start justify-between gap-4">
 				<h1 className="text-2xl font-bold text-gray-900">
 					{opportunity.title}


### PR DESCRIPTION
## Summary

- Keeps the existing `Header.tsx` as the always-visible **Actionbar** (logo, org switcher, language selector, user menu - unchanged)
- Adds a **ToolbarStrip** rendered below the Header in `AppLayout` - only visible when a page opts in, zero height otherwise
- New `ToolbarContext` + `usePageToolbar` hook lets page components declare their breadcrumbs without prop-drilling through `AppLayout`
- New `Breadcrumb` component renders linked ancestor items and an unlinked current-page item with mobile-safe truncation

**Pages that opt in (per issue spec):**

| Page | Breadcrumb trail |
|---|---|
| `VolunteerOpportunityDetailPage` | Home > Volunteer Opportunities > {title} |
| `EngagementManagementPage` | Home > {opportunity title} > Engagements |
| `OrganizationSettingsPage` | Home > {org name} > Settings |
| `AccountPage` | Home > Account |

Ad-hoc "Back" buttons removed from pages that now have breadcrumbs. `EngagementManagementPage` fetches the opportunity title so the breadcrumb middle item shows the real name. Breadcrumb translation keys added to `en.json` and `de.json`.

Closes #197

## Test plan

- [ ] Navigate to a volunteer opportunity detail page - Toolbar strip appears below header with "Home > Volunteer Opportunities > {title}" breadcrumbs; clicking "Home" or "Volunteer Opportunities" navigates to `/`
- [ ] Navigate to the engagements management page - breadcrumb shows "Home > {opportunity title} > Engagements"; middle item links back to the detail page
- [ ] Navigate to organization settings - breadcrumb shows "Home > {org name} > Settings"; org name links to `/organizations/:id`
- [ ] Navigate to account page - breadcrumb shows "Home > Account"
- [ ] Navigate to home page - no Toolbar strip visible and no empty space reserved
- [ ] Verify no "Back" button exists on the four opted-in pages
- [ ] Switch language to German - breadcrumb labels update to German translations

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSmTbMkskBca8cNhTUrKdm)_