### PR TITLE
ci: consolidate dotnet test projects into single dotnet test step

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -17,9 +17,9 @@
 
 ### `dotnet.yml`
 - **Trigger:** `backend/**`, `frontend/**`, `keycloak/**` path filter or manual (frontend + keycloak included because VisualTests boots full stack via Aspire)
-- **Steps:** setup .NET + Node + pnpm → frontend `pnpm install` → `dotnet restore` → `dotnet build` → run each test project sequentially via `dotnet run --project ... --no-build`
-- **Test projects:** Application.UnitTests, ArchitectureTests, IntegrationTests, VisualTests
-- **Why `dotnet run` not `dotnet test`:** TUnit uses Microsoft.Testing.Platform; `dotnet test` on .NET 10 requires opt-in to new experience. `dotnet run` invokes the test runner directly.
+- **Steps:** setup .NET + Node + pnpm → frontend `pnpm install` → `dotnet restore` → `dotnet build` → `dotnet test --no-build`
+- **Test projects:** Application.UnitTests, ArchitectureTests, IntegrationTests, VisualTests (all discovered via solution file)
+- **Why `dotnet test` works:** `global.json` opts in to `Microsoft.Testing.Platform` runner, which TUnit requires.
 
 ### `frontend.yml`
 - **Trigger:** `frontend/**` path filter or manual

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -71,18 +71,6 @@ jobs:
         working-directory: backend
         run: dotnet build --no-restore
 
-      - name: Test - Application.UnitTests
+      - name: Test
         working-directory: backend
-        run: dotnet run --project tests/Application.UnitTests --no-build
-
-      - name: Test - ArchitectureTests
-        working-directory: backend
-        run: dotnet run --project tests/ArchitectureTests --no-build
-
-      - name: Test - IntegrationTests (Aspire + Docker)
-        working-directory: backend
-        run: dotnet run --project tests/IntegrationTests --no-build
-
-      - name: Test - VisualTests (Aspire + Docker + Playwright)
-        working-directory: backend
-        run: dotnet run --project tests/VisualTests --no-build
+        run: dotnet test --no-build


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces four separate `dotnet run --project` steps with a single `dotnet test --no-build`
- `global.json` already has the `Microsoft.Testing.Platform` opt-in, so `dotnet test` discovers all four test projects via the solution file
- Updates `.github/CLAUDE.md` to remove the now-inaccurate note explaining why `dotnet run` was used

## Time savings

Marginal - eliminates 3 GitHub Actions step-initialization overheads. Test execution remains sequential since IntegrationTests and VisualTests both boot Aspire/Docker and would conflict if parallelized. Main win is simpler workflow.

https://claude.ai/code/session_01EpKzAf7fEgXZkFbJWFcjSg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpKzAf7fEgXZkFbJWFcjSg)_