### PR TITLE
fix: skip pnpm TTY confirmation in non-interactive environments

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+confirm-module-purge=false


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `frontend/.npmrc` with `confirm-module-purge=false`
- pnpm v8+ requires a TTY to confirm `node_modules` removal; Aspire spawns `pnpm install` as a non-TTY subprocess, causing `frontend-installer` to exit with code 1
- This setting suppresses the interactive prompt so the installer completes successfully

## Test plan

- [ ] Delete `frontend/node_modules` locally
- [ ] Run `pnpm install` in `frontend/` - should complete without prompting
- [ ] Start Aspire: `dotnet run --project backend/src/Aspire/AppHost` - `frontend-installer` should finish with exit code 0 and `frontend` should start

https://claude.ai/code/session_01RmKKLRKKwZJajfPtA3pjvp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmKKLRKKwZJajfPtA3pjvp)_