### PR TITLE
feat: add Mailpit to Aspire AppHost for local email testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Aspire AppHost provisions Postgres, Keycloak, backend API, and the Vite frontend
 | Keycloak admin | http://localhost:8080 | admin / admin |
 | pgAdmin | http://localhost:5050 | admin@admin.com / admin |
 | PostgreSQL | localhost:5432 | postgres / postgres |
+| Mailpit (email) | http://localhost:1080 | - (no auth required) |
 
 Test users: `vera/vera123` (user), `olaf/olaf123` (user + organisator), `admin/admin123` (admin)
 

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -24,6 +24,12 @@
     "ClientId": "backend",
     "ClientSecret": "backend-secret"
   },
+  "Smtp": {
+    "Host": "localhost",
+    "Port": 1025,
+    "FromAddress": "noreply@einsatzbereit.local",
+    "FromName": "Einsatzbereit"
+  },
   "RateLimiting": {
     "Read": {
       "AuthenticatedPermitLimit": 200,

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -4,6 +4,10 @@ var postgres = builder.AddPostgres("postgres")
 	.WithDataVolume()
 	.WithPgAdmin();
 
+var mailpit = builder.AddContainer("mailpit", "axllent/mailpit", "latest")
+	.WithHttpEndpoint(port: 1080, targetPort: 8025, name: "webui", isProxied: false)
+	.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp", scheme: "tcp", isProxied: false);
+
 var database = postgres.AddDatabase("einsatzbereit");
 
 var keycloakRealmPath = Path.GetFullPath(
@@ -21,16 +25,21 @@ var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26
 
 var keycloakEndpoint = keycloak.GetEndpoint("http");
 
+var mailpitSmtpEndpoint = mailpit.GetEndpoint("smtp");
+
 var backend = builder.AddProject<Projects.Api>("backend")
 	.WithReference(database)
 	.WaitFor(database)
 	.WaitFor(keycloak)
+	.WaitFor(mailpit)
 	.WithEnvironment("Authentication__Authority",
 		ReferenceExpression.Create($"{keycloakEndpoint}/realms/einsatzbereit"))
 	.WithEnvironment("Authentication__ValidIssuers__0",
 		ReferenceExpression.Create($"{keycloakEndpoint}/realms/einsatzbereit"))
 	.WithEnvironment("Keycloak__BaseUrl",
-		ReferenceExpression.Create($"{keycloakEndpoint}"));
+		ReferenceExpression.Create($"{keycloakEndpoint}"))
+	.WithEnvironment("Smtp__Host", mailpitSmtpEndpoint.Property(EndpointProperty.Host))
+	.WithEnvironment("Smtp__Port", mailpitSmtpEndpoint.Property(EndpointProperty.Port));
 
 var frontend = builder.AddViteApp("frontend", "../../../../frontend")
 	.WithPnpm()


### PR DESCRIPTION
## Summary

Closes #123

- Mailpit container added to Aspire AppHost (port 1080 web UI, port 1025 SMTP)
- SMTP environment variables wired into the API service
- `appsettings.json` `Smtp` section added with Mailpit defaults
- CLAUDE.md updated with Mailpit service entry (http://localhost:1080)

## Test plan

- [ ] Run `dotnet run --project backend/src/Aspire/AppHost` and verify Mailpit appears in the Aspire dashboard
- [ ] Navigate to http://localhost:1080 and confirm the Mailpit web UI loads

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3wEzmCMeLZqimwiLvCMiw)_