### PR TITLE
feat: email notifications for engagement state changes via SMTP

### DIFF
--- a/backend/src/Application/Common/Email/IEmailService.cs
+++ b/backend/src/Application/Common/Email/IEmailService.cs
@@ -1,0 +1,10 @@
+namespace Application.Common.Email;
+
+public interface IEmailService
+{
+	Task SendAsync(
+		string to,
+		string subject,
+		string body,
+		CancellationToken cancellationToken = default);
+}

--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -1,3 +1,5 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
@@ -7,7 +9,9 @@ using Domain.Primitives;
 namespace Application.Engagements.CancelEngagement.v1;
 
 internal sealed class CancelEngagementCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<CancelEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -25,6 +29,21 @@ internal sealed class CancelEngagementCommandHandler(
 			engagement.Id.Value);
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
+
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken);
+		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId.Value, cancellationToken);
+
+		var reasonText = string.IsNullOrWhiteSpace(request.Reason)
+			? string.Empty
+			: $"\n\nReason: {request.Reason}";
+
+		await emailService.SendAsync(
+			volunteer.Email,
+			"Your engagement has been cancelled",
+			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
+			$"Unfortunately your application for \"{opportunity?.Title ?? "the opportunity"}\" has been cancelled.{reasonText}\n\n" +
+			$"We hope to see you at another opportunity.\n\nEinsatzbereit",
+			cancellationToken);
 
 		return engagement;
 	}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -1,3 +1,5 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
@@ -7,7 +9,9 @@ using Domain.Primitives;
 namespace Application.Engagements.ConfirmEngagement.v1;
 
 internal sealed class ConfirmEngagementCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<ConfirmEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -25,6 +29,17 @@ internal sealed class ConfirmEngagementCommandHandler(
 			engagement.Id.Value);
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
+
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken);
+		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId.Value, cancellationToken);
+
+		await emailService.SendAsync(
+			volunteer.Email,
+			"Your engagement has been confirmed",
+			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
+			$"Your application for \"{opportunity?.Title ?? "the opportunity"}\" has been confirmed.\n\n" +
+			$"We look forward to seeing you!\n\nEinsatzbereit",
+			cancellationToken);
 
 		return engagement;
 	}

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -1,0 +1,48 @@
+using System.Net.Mail;
+using Application.Common.Email;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Email;
+
+internal sealed class SmtpEmailService(
+	IOptions<SmtpOptions> options,
+	ILogger<SmtpEmailService> logger)
+	: IEmailService
+{
+	private readonly SmtpOptions _options = options.Value;
+
+	public async Task SendAsync(
+		string to,
+		string subject,
+		string body,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+#pragma warning disable SYSLIB0006
+			using var client = new SmtpClient(_options.Host, _options.Port)
+			{
+				DeliveryMethod = SmtpDeliveryMethod.Network,
+				EnableSsl = false,
+				UseDefaultCredentials = false
+			};
+#pragma warning restore SYSLIB0006
+
+			using var message = new MailMessage
+			{
+				From = new MailAddress(_options.FromAddress, _options.FromName),
+				Subject = subject,
+				Body = body,
+				IsBodyHtml = false
+			};
+			message.To.Add(to);
+
+			await client.SendMailAsync(message, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "Failed to send email to {To} with subject {Subject}", to, subject);
+		}
+	}
+}

--- a/backend/src/Infrastructure/Email/SmtpOptions.cs
+++ b/backend/src/Infrastructure/Email/SmtpOptions.cs
@@ -1,0 +1,9 @@
+namespace Infrastructure.Email;
+
+internal sealed class SmtpOptions
+{
+	public string Host { get; init; } = "localhost";
+	public int Port { get; init; } = 1025;
+	public string FromAddress { get; init; } = "noreply@einsatzbereit.local";
+	public string FromName { get; init; } = "Einsatzbereit";
+}

--- a/backend/src/Infrastructure/Email/SmtpOptionsSetup.cs
+++ b/backend/src/Infrastructure/Email/SmtpOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Email;
+
+internal sealed class SmtpOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<SmtpOptions>
+{
+	public void Configure(SmtpOptions options) =>
+		configuration.GetSection("Smtp").Bind(options);
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Application.Common;
+using Application.Common.Email;
 using Application.Common.Geocoding;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
@@ -6,6 +7,7 @@ using Application.Engagements;
 using Application.Notifications;
 using Application.Organizations;
 using Application.VolunteerOpportunities;
+using Infrastructure.Email;
 using Infrastructure.Geocoding;
 using Infrastructure.Keycloak;
 using Infrastructure.Persistence;
@@ -55,6 +57,9 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<INotificationReadRepository, NotificationReadRepository>();
 
 		services.AddScoped<IOrganizationDashboardReadRepository, OrganizationDashboardReadRepository>();
+
+		services.ConfigureOptions<SmtpOptionsSetup>();
+		services.AddScoped<IEmailService, SmtpEmailService>();
 
 		services.ConfigureOptions<GeocodingOptionsSetup>();
 		services.AddHttpClient<IGeocodingService, NominatimGeocodingService>(

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -1,3 +1,5 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements.CancelEngagement.v1;
 using AwesomeAssertions;
@@ -17,13 +19,18 @@ public class CancelEngagementCommandHandlerTests
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
 	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly CancelEngagementCommandHandler _sut;
 
 	public CancelEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
-		_sut = new CancelEngagementCommandHandler(_dbContext);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_sut = new CancelEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService);
 	}
 
 	private static Engagement CreatePendingWaitlistEngagement() =>

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -1,3 +1,5 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements.ConfirmEngagement.v1;
 using AwesomeAssertions;
@@ -17,13 +19,18 @@ public class ConfirmEngagementCommandHandlerTests
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
 	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly ConfirmEngagementCommandHandler _sut;
 
 	public ConfirmEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
-		_sut = new ConfirmEngagementCommandHandler(_dbContext);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_sut = new ConfirmEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService);
 	}
 
 	[Test]


### PR DESCRIPTION
## Summary

Closes #106

- `IEmailService` abstraction + `SmtpEmailService` implementation (errors logged, not thrown - fire-and-forget)
- `SmtpOptions` / `SmtpOptionsSetup` bound from `appsettings.json`
- `ConfirmEngagementCommandHandler` sends a confirmation email to the volunteer via the Keycloak user profile
- `CancelEngagementCommandHandler` sends a cancellation email
- Unit tests updated to inject `IKeycloakUserService` and `IEmailService` mocks

**Depends on**: #123 (Mailpit) must be running for emails to be received locally.

## Test plan

- [ ] Confirm an engagement as organizer - verify the volunteer receives a confirmation email in Mailpit (http://localhost:1080)
- [ ] Cancel an engagement - verify the cancellation email arrives in Mailpit

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3wEzmCMeLZqimwiLvCMiw)_