### PR TITLE
fix(deps): update react-i18next to 17.0.8 and i18next to 26.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,13 +17,13 @@
     "i18n:check": "node scripts/check-i18n-keys.js"
   },
   "dependencies": {
-    "i18next": "26.1.0",
+    "i18next": "26.2.0",
     "i18next-browser-languagedetector": "8.2.1",
     "leaflet": "1.9.4",
     "oidc-client-ts": "3.5.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-i18next": "17.0.7",
+    "react-i18next": "17.0.8",
     "react-leaflet": "5.0.0",
     "react-oidc-context": "3.3.1",
     "react-router": "7.15.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       i18next:
-        specifier: 26.1.0
-        version: 26.1.0(typescript@6.0.3)
+        specifier: 26.2.0
+        version: 26.2.0(typescript@6.0.3)
       i18next-browser-languagedetector:
         specifier: 8.2.1
         version: 8.2.1
@@ -27,8 +27,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       react-i18next:
-        specifier: 17.0.7
-        version: 17.0.7(i18next@26.1.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        specifier: 17.0.8
+        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       react-leaflet:
         specifier: 5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1057,8 +1057,8 @@ packages:
   i18next-browser-languagedetector@8.2.1:
     resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
 
-  i18next@26.1.0:
-    resolution: {integrity: sha512-dIU6td04DvQuIqVst5S9g0GviTmhZ0DYD4b9ociVGJmuCa5vZ2de/t+Enf4olvj87mF8Y2lwjNQBwC9QZsvzKQ==}
+  i18next@26.2.0:
+    resolution: {integrity: sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==}
     peerDependencies:
       typescript: ^5 || ^6
     peerDependenciesMeta:
@@ -1458,10 +1458,10 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
-  react-i18next@17.0.7:
-    resolution: {integrity: sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==}
+  react-i18next@17.0.8:
+    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
     peerDependencies:
-      i18next: '>= 26.0.10'
+      i18next: '>= 26.2.0'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
@@ -2824,7 +2824,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
 
-  i18next@26.1.0(typescript@6.0.3):
+  i18next@26.2.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
@@ -3185,11 +3185,11 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-i18next@17.0.7(i18next@26.1.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  react-i18next@17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 26.1.0(typescript@6.0.3)
+      i18next: 26.2.0(typescript@6.0.3)
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Updates `react-i18next` from `17.0.7` to `17.0.8` (resolves #234)
- Updates `i18next` from `26.1.0` to `26.2.0` to satisfy the new peer dependency requirement introduced by `react-i18next@17.0.8` (`>= 26.2.0`)

## Problem

PR #234 (Renovate) bumped `react-i18next` to `17.0.8`, which raised its minimum peer dependency on `i18next` from `>= 26.0.10` to `>= 26.2.0`. Merging the PR as-is would leave `i18next@26.1.0` installed, causing the `build-and-test` CI check to fail due to the unmet peer dependency.

## Solution

Both packages are bumped together so the peer dependency is satisfied and CI passes cleanly. TypeScript check (`pnpm check`) and lint (`pnpm lint`) both pass with the updated versions.

https://claude.ai/code/session_01CtEbytGZC6g8RDdVeMRF4U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtEbytGZC6g8RDdVeMRF4U)_