### PR TITLE
fix: remove WaitFor(mailpit) to unblock backend startup in CI

### DIFF
--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -31,7 +31,6 @@ var backend = builder.AddProject<Projects.Api>("backend")
 	.WithReference(database)
 	.WaitFor(database)
 	.WaitFor(keycloak)
-	.WaitFor(mailpit)
 	.WithEnvironment("Authentication__Authority",
 		ReferenceExpression.Create($"{keycloakEndpoint}/realms/einsatzbereit"))
 	.WithEnvironment("Authentication__ValidIssuers__0",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes `.WaitFor(mailpit)` from the backend resource definition in `AppHost.cs`
- Docker Hub rate-limits `axllent/mailpit` pulls on GitHub Actions runners, causing the Mailpit container to fail/timeout before starting
- With `WaitFor(mailpit)` in place the backend never reached `Running` state, so `IntegrationTestFixture` timed out after 180 s and the entire `build-and-test` CI job failed for every PR targeting main
- No email service (`IEmailService` / `SmtpEmailService`) is registered yet - the backend does not connect to SMTP at startup, so removing the wait is safe

## Test plan

- [ ] `build-and-test` CI passes on this PR
- [ ] After merging, re-run CI on PRs #238 and #239 to confirm they go green

https://claude.ai/code/session_01X3wEzmCMeLZqimwiLvCMiw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3wEzmCMeLZqimwiLvCMiw)_