### PR TITLE
fix: pull Mailpit image from GHCR to fix failing CI on main

### DIFF
--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -4,7 +4,7 @@ var postgres = builder.AddPostgres("postgres")
 	.WithDataVolume()
 	.WithPgAdmin();
 
-var mailpit = builder.AddContainer("mailpit", "axllent/mailpit", "latest")
+var mailpit = builder.AddContainer("mailpit", "ghcr.io/axllent/mailpit", "latest")
 	.WithHttpEndpoint(port: 1080, targetPort: 8025, name: "webui", isProxied: false)
 	.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp", scheme: "tcp", isProxied: false);
 


### PR DESCRIPTION
## Summary

`build-and-test` is still failing on every PR (including #241) and on `main` after the most recent commits. The previous attempt to fix CI (#251) only removed `.WaitFor(mailpit)` so the backend would not block on it, but the Mailpit container itself is still declared in `AppHost.cs` and is still pulled on every Aspire run. Anonymous Docker Hub pulls from GitHub Actions runners are rate-limited, so the container never reaches `Running`, and that surfaces as test/Aspire failures further down the line (most visibly in the VisualTests step that brings up the full distributed application).

Mailpit ships the exact same image to GitHub Container Registry (`ghcr.io/axllent/mailpit`), which has no anonymous pull rate limit from Actions runners. Switching the source unblocks CI without touching anything else:

- Local dev still gets a working Mailpit container with SMTP on `1025` / web UI on `1080`
- Keycloak realm SMTP config (`smtpServer.host: mailpit`) keeps working - it still resolves to the same container name on the Aspire network
- No code change for `Smtp__Host` / `Smtp__Port` env wiring on the backend

## Test plan

- [ ] `build-and-test` CI goes green on this PR
- [ ] After merge: re-run CI on #241 (and other PRs targeting `main`) to confirm they go green
- [ ] Local: `dotnet run --project backend/src/Aspire/AppHost` still brings up Mailpit and you can reach the UI at http://localhost:1080


---
_Generated by [Claude Code](https://claude.ai/code/session_015G1SnetEuyR6j8bC5PXhAa)_