### PR TITLE
fix: stop flaky AccountPage username VisualTest

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakAdminTokenProvider.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakAdminTokenProvider.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Keycloak;
+
+internal sealed class KeycloakAdminTokenProvider(
+	IHttpClientFactory httpClientFactory,
+	IOptions<KeycloakOptions> options)
+{
+	public const string HttpClientName = "keycloak-admin-token";
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+	};
+
+	private readonly KeycloakOptions _options = options.Value;
+	private readonly SemaphoreSlim _lock = new(1, 1);
+
+	private string? _token;
+	private DateTimeOffset _expiresAt = DateTimeOffset.MinValue;
+
+	public async Task<string> GetTokenAsync(
+		bool forceRefresh,
+		CancellationToken cancellationToken = default)
+	{
+		if (!forceRefresh && _token is not null && DateTimeOffset.UtcNow < _expiresAt)
+		{
+			return _token;
+		}
+
+		await _lock.WaitAsync(cancellationToken);
+		try
+		{
+			if (!forceRefresh && _token is not null && DateTimeOffset.UtcNow < _expiresAt)
+			{
+				return _token;
+			}
+
+			var token = await RequestTokenAsync(cancellationToken);
+
+			_token = token.AccessToken;
+			// Refresh slightly before the real expiry so a cached token never
+			// expires mid-request.
+			var safetySeconds = Math.Min(30, token.ExpiresIn / 2);
+			_expiresAt = DateTimeOffset.UtcNow.AddSeconds(token.ExpiresIn - safetySeconds);
+
+			return _token;
+		}
+		finally
+		{
+			_lock.Release();
+		}
+	}
+
+	private async Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken)
+	{
+		var client = httpClientFactory.CreateClient(HttpClientName);
+
+		using var tokenRequest = new FormUrlEncodedContent([
+			new KeyValuePair<string, string>("grant_type", "client_credentials"),
+			new KeyValuePair<string, string>("client_id", _options.ClientId),
+			new KeyValuePair<string, string>("client_secret", _options.ClientSecret)
+		]);
+
+		using var response = await client.PostAsync(
+			$"/realms/{_options.Realm}/protocol/openid-connect/token",
+			tokenRequest,
+			cancellationToken);
+
+		if (!response.IsSuccessStatusCode)
+		{
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			throw new HttpRequestException(
+				$"Keycloak token request failed with {(int)response.StatusCode} {response.StatusCode}: {body}",
+				inner: null,
+				response.StatusCode);
+		}
+
+		return await response.Content.ReadFromJsonAsync<TokenResponse>(JsonOptions, cancellationToken)
+			?? throw new InvalidOperationException("Keycloak returned an empty token response.");
+	}
+
+	private sealed record TokenResponse(
+		[property: JsonPropertyName("access_token")] string AccessToken,
+		[property: JsonPropertyName("expires_in")] int ExpiresIn);
+}

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Application.Common.Keycloak;
 using Microsoft.Extensions.Options;
 
@@ -11,6 +11,7 @@ namespace Infrastructure.Keycloak;
 
 internal sealed class KeycloakOrganizationService(
 	HttpClient httpClient,
+	KeycloakAdminTokenProvider tokenProvider,
 	IOptions<KeycloakOptions> options)
 	: IKeycloakOrganizationService
 {
@@ -158,32 +159,10 @@ internal sealed class KeycloakOrganizationService(
 	}
 
 	private async Task EnsureAuthenticatedAsync(
-		CancellationToken cancellationToken)
-	{
-		if (httpClient.DefaultRequestHeaders.Authorization is not null)
-		{
-			return;
-		}
-
-		var tokenRequest = new FormUrlEncodedContent([
-			new KeyValuePair<string, string>("grant_type", "client_credentials"),
-			new KeyValuePair<string, string>("client_id", _options.ClientId),
-			new KeyValuePair<string, string>("client_secret", _options.ClientSecret)
-		]);
-
-		var tokenResponse = await httpClient.PostAsync(
-			$"/realms/{_options.Realm}/protocol/openid-connect/token",
-			tokenRequest,
-			cancellationToken);
-
-		await EnsureSuccessAsync(tokenResponse, cancellationToken);
-
-		var tokenResult = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(
-			JsonOptions, cancellationToken);
-
-		httpClient.DefaultRequestHeaders.Authorization =
-			new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", tokenResult!.AccessToken);
-	}
+		CancellationToken cancellationToken) =>
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+			"Bearer",
+			await tokenProvider.GetTokenAsync(forceRefresh: false, cancellationToken));
 
 	internal static string GenerateAlias(string name)
 	{
@@ -261,9 +240,6 @@ internal sealed class KeycloakOrganizationService(
 			inner: null,
 			response.StatusCode);
 	}
-
-	private sealed record TokenResponse(
-		[property: JsonPropertyName("access_token")] string AccessToken);
 
 	private sealed record KeycloakRole(
 		string Id,

--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -1,6 +1,7 @@
+using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Application.Common.Keycloak;
 using Microsoft.Extensions.Options;
 
@@ -8,6 +9,7 @@ namespace Infrastructure.Keycloak;
 
 internal sealed class KeycloakUserService(
 	HttpClient httpClient,
+	KeycloakAdminTokenProvider tokenProvider,
 	IOptions<KeycloakOptions> options)
 	: IKeycloakUserService
 {
@@ -22,10 +24,10 @@ internal sealed class KeycloakUserService(
 		Guid userId,
 		CancellationToken cancellationToken = default)
 	{
-		await EnsureAuthenticatedAsync(cancellationToken);
-
-		var response = await httpClient.GetAsync(
-			$"/admin/realms/{_options.Realm}/users/{userId}",
+		var response = await SendAuthorizedAsync(
+			() => httpClient.GetAsync(
+				$"/admin/realms/{_options.Realm}/users/{userId}",
+				cancellationToken),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -48,8 +50,6 @@ internal sealed class KeycloakUserService(
 		string? lastName,
 		CancellationToken cancellationToken = default)
 	{
-		await EnsureAuthenticatedAsync(cancellationToken);
-
 		// Keycloak's admin API merges PUT bodies and skips null fields, so to
 		// clear firstName/lastName we must send an empty string instead of null.
 		var body = new
@@ -58,42 +58,43 @@ internal sealed class KeycloakUserService(
 			lastName = lastName ?? string.Empty,
 		};
 
-		var putResponse = await httpClient.PutAsJsonAsync(
-			$"/admin/realms/{_options.Realm}/users/{userId}",
-			body,
-			JsonOptions,
+		var response = await SendAuthorizedAsync(
+			() => httpClient.PutAsJsonAsync(
+				$"/admin/realms/{_options.Realm}/users/{userId}",
+				body,
+				JsonOptions,
+				cancellationToken),
 			cancellationToken);
 
-		await EnsureSuccessAsync(putResponse, cancellationToken);
+		await EnsureSuccessAsync(response, cancellationToken);
 	}
 
-	private async Task EnsureAuthenticatedAsync(
+	private async Task<HttpResponseMessage> SendAuthorizedAsync(
+		Func<Task<HttpResponseMessage>> send,
 		CancellationToken cancellationToken)
 	{
-		if (httpClient.DefaultRequestHeaders.Authorization is not null)
+		await SetBearerAsync(forceRefresh: false, cancellationToken);
+
+		var response = await send();
+		if (response.StatusCode != HttpStatusCode.Unauthorized)
 		{
-			return;
+			return response;
 		}
 
-		var tokenRequest = new FormUrlEncodedContent([
-			new KeyValuePair<string, string>("grant_type", "client_credentials"),
-			new KeyValuePair<string, string>("client_id", _options.ClientId),
-			new KeyValuePair<string, string>("client_secret", _options.ClientSecret)
-		]);
-
-		var tokenResponse = await httpClient.PostAsync(
-			$"/realms/{_options.Realm}/protocol/openid-connect/token",
-			tokenRequest,
-			cancellationToken);
-
-		await EnsureSuccessAsync(tokenResponse, cancellationToken);
-
-		var tokenResult = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>(
-			JsonOptions, cancellationToken);
-
-		httpClient.DefaultRequestHeaders.Authorization =
-			new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", tokenResult!.AccessToken);
+		// The cached admin token was rejected (e.g. Keycloak cold start or key
+		// rotation). Refresh once and retry so a transient 401 self-heals
+		// instead of bubbling up as a 500.
+		response.Dispose();
+		await SetBearerAsync(forceRefresh: true, cancellationToken);
+		return await send();
 	}
+
+	private async Task SetBearerAsync(
+		bool forceRefresh,
+		CancellationToken cancellationToken) =>
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+			"Bearer",
+			await tokenProvider.GetTokenAsync(forceRefresh, cancellationToken));
 
 	private static string? NullIfEmpty(string? value) =>
 		string.IsNullOrEmpty(value) ? null : value;
@@ -116,14 +117,10 @@ internal sealed class KeycloakUserService(
 			response.StatusCode);
 	}
 
-	private sealed record TokenResponse(
-		[property: JsonPropertyName("access_token")] string AccessToken);
-
 	private sealed record KeycloakUserResponse(
 		string Id,
 		string Username,
 		string? FirstName,
 		string? LastName,
 		string? Email);
-
 }

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -67,6 +67,14 @@ public static class ServiceCollectionExtensions
 			});
 
 		services.ConfigureOptions<KeycloakOptionsSetup>();
+
+		services.AddSingleton<KeycloakAdminTokenProvider>();
+		services.AddHttpClient(KeycloakAdminTokenProvider.HttpClientName, (sp, client) =>
+		{
+			var keycloakOptions = sp.GetRequiredService<IOptions<KeycloakOptions>>().Value;
+			client.BaseAddress = new Uri(keycloakOptions.BaseUrl);
+		});
+
 		services.AddHttpClient<IKeycloakOrganizationService, KeycloakOrganizationService>(
 			(sp, client) =>
 			{

--- a/backend/tests/VisualTests/AccountTests.cs
+++ b/backend/tests/VisualTests/AccountTests.cs
@@ -27,7 +27,13 @@ public class AccountTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
 
-		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/account");
+		// Wait for a successful /users/me load (tolerating an earlier attempt the
+		// frontend retries) before asserting, so a backend hiccup surfaces as a
+		// real status code instead of a silent empty-value timeout.
+		await Page.RunAndWaitForResponseAsync(
+			() => Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/account"),
+			response => response.Url.Contains("/users/me") && response.Ok,
+			new() { Timeout = 30_000 });
 
 		await Expect(Page.GetByLabel("Username")).ToHaveValueAsync("vera",
 			new() { Timeout = 30_000 });

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -26,18 +26,44 @@ export default function AccountPage() {
 	});
 
 	useEffect(() => {
-		setLoading(true);
-		api
-			.getUserProfile()
-			.then((data) => {
-				setProfile(data);
-				setForm({
-					firstName: data.firstName ?? "",
-					lastName: data.lastName ?? "",
-				});
-			})
-			.catch(() => setError(t("account.loadError")))
-			.finally(() => setLoading(false));
+		let cancelled = false;
+		// Retry transient failures (e.g. the backend's /users/me briefly failing
+		// while Keycloak warms up) instead of leaving the page blank forever.
+		const retryDelaysMs = [500, 1000, 2000];
+
+		async function loadProfile() {
+			setLoading(true);
+			for (let attempt = 0; ; attempt++) {
+				try {
+					const data = await api.getUserProfile();
+					if (cancelled) return;
+					setProfile(data);
+					setForm({
+						firstName: data.firstName ?? "",
+						lastName: data.lastName ?? "",
+					});
+					setError(null);
+					return;
+				} catch {
+					if (cancelled) return;
+					if (attempt >= retryDelaysMs.length) {
+						setError(t("account.loadError"));
+						return;
+					}
+					await new Promise<void>((resolve) =>
+						setTimeout(resolve, retryDelaysMs[attempt]),
+					);
+				}
+			}
+		}
+
+		loadProfile().finally(() => {
+			if (!cancelled) setLoading(false);
+		});
+
+		return () => {
+			cancelled = true;
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 


### PR DESCRIPTION
## Summary

`AccountPage_DisplaysUsername_AfterLogin` failed intermittently across feature branches, PRs, and `main` (the "Username" input stayed empty for the full 30s assertion timeout). This was a genuine load/timing flake, which is why prior fixes went green on merge then red again later.

**Root cause:** the username comes from `GET /v1/users/me`, not the OIDC token. That endpoint makes a per-request Keycloak Admin API call (token + user lookup). When Keycloak is cold/slow in CI the call transiently fails, and **nothing retried**: the frontend fetched the profile exactly once and left the field blank for the rest of the page's life. A global `AddStandardResilienceHandler` already exists (via `AddServiceDefaults`), but it shares the test's 30s budget and does not retry 4xx, so a cold-start 401 surfaced as a 500 with no recovery. (So "add a resilience handler" / "add a `WaitForLoadState`" would not have fixed it - the assertion already polls 30s.)

## Changes

- **Frontend (primary fix)** - `AccountPage.tsx`: retry the profile load (4 attempts, 0.5s/1s/2s backoff) with an unmount guard before surfacing an error, instead of giving up after a single failed `/users/me`.
- **Backend** - new `KeycloakAdminTokenProvider` (singleton, caches the admin token honoring `expires_in`); `KeycloakUserService` uses it and refreshes-on-401-then-retries-once so a cold-start/stale token self-heals instead of returning 500; `/users/me` now makes one admin call instead of two. `KeycloakOrganizationService` shares the same cache.
- **Test** - the flaky test waits for a successful `/users/me` response before asserting, so any future regression surfaces a real status code instead of a silent empty-value timeout.

No API contract change (the NSwag-generated `api-client.ts` is unchanged).

## Test plan

- [x] `dotnet build` succeeds (0 warnings, 0 errors)
- [x] Frontend `pnpm lint` and `pnpm check` pass
- [ ] VisualTests `AccountTests` pass repeatedly (running locally to confirm the flake is gone)
- [ ] CI build-and-test green

https://claude.ai/code/session_011EnoSDHtospbFQxMFPBqLq

---
_Generated by [Claude Code](https://claude.ai/code/session_011EnoSDHtospbFQxMFPBqLq)_