### PR TITLE
fix(ci): detect RC tags via bash glob instead of leading-dash grep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-          if echo "$TAG" | grep -qE '-rc\.'; then
+          if [[ "$TAG" == *-rc.* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
@@ -149,7 +149,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-          if echo "$TAG" | grep -qE '-rc\.'; then
+          if [[ "$TAG" == *-rc.* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
@@ -193,7 +193,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-          if echo "$TAG" | grep -qE '-rc\.'; then
+          if [[ "$TAG" == *-rc.* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`prerelease=true` was never being set for RC tags because the version step's regex started with `-`, which grep parses as a flag (even on GNU grep without `--`). Every RC tag silently got `prerelease=false`, which:

- **broke the new `:staging` tagging** added in #260 - no image was tagged, so `docker compose pull` on the host had nothing to pull
- **caused `deploy-staging` to skip** via `if: needs.publish-backend.outputs.prerelease == 'true'`
- **incorrectly applied `:latest` to RC builds** - the opposite branch ran

Reproduction:
```
$ TAG=1.0.0-rc.2
$ echo "$TAG" | grep -qE '-rc\.'
grep: invalid option -- '.'    # exit 2 → if/else flips
```

Fix: replace the three identical version steps' regex with a bash glob (`[[ "$TAG" == *-rc.* ]]`) which is the default Actions shell, handles the leading dash natively, and is easier to read.

Verified locally:
```
1.0.0       → prerelease=false
1.0.0-rc.2  → prerelease=true
2.5.10-rc.1 → prerelease=true
```

## Test plan

- [x] YAML parses
- [x] Bash glob covers RC and non-RC tags correctly
- [ ] Push `v1.0.0-rc.3` after merge - expect `:staging` tag on all three GHCR images and `deploy-staging` to run

https://claude.ai/code/session_012zQMHZNFQT2T1WcFb1KBYH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zQMHZNFQT2T1WcFb1KBYH)_