### PR TITLE
fix(frontend): chmod 644 on config.js after envsubst so nginx can read it

### DIFF
--- a/frontend/docker-entrypoint.d/99-runtime-config.sh
+++ b/frontend/docker-entrypoint.d/99-runtime-config.sh
@@ -9,4 +9,7 @@ if [ -f "$config" ]; then
 	tmp="$(mktemp)"
 	envsubst '${VITE_KEYCLOAK_AUTHORITY_URL} ${VITE_KEYCLOAK_CLIENT_ID} ${VITE_API_URL}' < "$config" > "$tmp"
 	mv "$tmp" "$config"
+	# mktemp creates files mode 600; nginx runs as a non-root user and would
+	# return 403 without world-readable perms.
+	chmod 644 "$config"
 fi


### PR DESCRIPTION
## Summary

`https://einsatzbereit.maik-hasler.de/config.js` returned **HTTP 403** on the first working RC->staging deploy (rc.6). Root cause: `mktemp` in the runtime-config entrypoint creates the file with mode 600. After `mv "$tmp" "$config"` the runtime-rendered `config.js` is owned root:root mode 600, but the nginx process runs as a non-root user and can't read it - hence 403.

Consequence if not fixed: the SPA's `<script src="/config.js">` 403s, `window.__APP_CONFIG__` stays undefined, the runtime resolver falls back to the build-time `import.meta.env.VITE_*` defaults (which are `localhost` URLs baked into the image), and users see a broken app.

Fix: `chmod 644 "$config"` after the move. The entrypoint runs as root (nginx official image's docker-entrypoint runs `/docker-entrypoint.d/*.sh` before dropping privileges), so chmod is allowed.

## Test plan

Verified manually against rc.6 deploy that backend, frontend root (`/index.html`), and keycloak all work end-to-end - only `/config.js` returns 403. After this merge:

- [ ] Push `release/v1.0.0-rc.7`
- [ ] Expect `curl https://einsatzbereit.maik-hasler.de/config.js` → 200 with substituted values (`KEYCLOAK_AUTHORITY_URL: "https://login.maik-hasler.de/..."` etc., no `${...}` placeholders)
- [ ] Expect the SPA to load Keycloak login round-trip

https://claude.ai/code/session_012zQMHZNFQT2T1WcFb1KBYH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zQMHZNFQT2T1WcFb1KBYH)_