### PR TITLE
fix: persist language selection to localStorage on change (#284)

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -28,6 +28,7 @@ void i18next
 
 i18next.on("languageChanged", (lang: string) => {
 	document.documentElement.lang = lang;
+	localStorage.setItem("i18nextLng", lang);
 });
 document.documentElement.lang = i18next.language;
 


### PR DESCRIPTION
## Problem

Changing the UI language via the language selector did not persist across page reloads. The `i18next-browser-languagedetector` `caches: ['localStorage']` config only writes on initialisation, not when `changeLanguage()` is called at runtime.

## Fix

Explicitly call `localStorage.setItem("i18nextLng", lang)` inside the `languageChanged` event handler so the selected language is saved immediately on every change.

## Closes

Closes #284

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_