### PR TITLE
fix: replace auth redirect button with link to opportunities in footer (#287)

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,9 +1,7 @@
 import { Link } from "react-router";
-import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 
 export default function Footer() {
-	const auth = useAuth();
 	const { t } = useTranslation();
 	const currentYear = new Date().getFullYear();
 
@@ -31,12 +29,12 @@ export default function Footer() {
 								</Link>
 							</li>
 							<li>
-								<button
-									onClick={() => auth.signinRedirect()}
+								<Link
+									to="/#opportunities"
 									className="hover:text-white transition-colors"
 								>
 									{t("footer.participate")}
-								</button>
+								</Link>
 							</li>
 						</ul>
 


### PR DESCRIPTION
## Problem

Clicking "Mitmachen" in the footer triggered a Keycloak login redirect rather than navigating to the opportunities list. Unauthenticated visitors who want to get involved were immediately pushed to a login screen instead of being shown the available opportunities.

## Fix

- Remove the unused `useAuth` dependency from Footer
- Replace `<button onClick={() => auth.signinRedirect()}>` with `<Link to="/#opportunities">` so the link navigates to the opportunities section of the home page

## Closes

Closes #287

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_