### PR TITLE
fix: dashboard KPI cards link to org profile instead of settings (#283)

### DIFF
--- a/frontend/src/pages/OrganizationDashboardPage.tsx
+++ b/frontend/src/pages/OrganizationDashboardPage.tsx
@@ -133,7 +133,7 @@ export default function OrganizationDashboardPage() {
 					description={t("orgDashboard.pendingEngagementsDesc")}
 					value={data?.pendingEngagements}
 					loading={loading}
-					to={`/organizations/${organizationId}/settings`}
+					to={`/organizations/${organizationId}`}
 					color="yellow"
 				/>
 				<KpiCard
@@ -141,7 +141,7 @@ export default function OrganizationDashboardPage() {
 					description={t("orgDashboard.confirmedNext7DaysDesc")}
 					value={data?.confirmedEngagementsNext7Days}
 					loading={loading}
-					to={`/organizations/${organizationId}/settings`}
+					to={`/organizations/${organizationId}`}
 					color="green"
 				/>
 				<KpiCard
@@ -149,7 +149,7 @@ export default function OrganizationDashboardPage() {
 					description={t("orgDashboard.cancelledEngagementsDesc")}
 					value={data?.cancelledEngagements}
 					loading={loading}
-					to={`/organizations/${organizationId}/settings`}
+					to={`/organizations/${organizationId}`}
 					color="red"
 				/>
 			</div>


### PR DESCRIPTION
## Problem

Three KPI cards on the organisation dashboard (pending engagements, confirmed in the next 7 days, cancelled) all linked to `/organizations/:id/settings`. That route is restricted to organisators, so clicking a card produced an error or blank page for regular users.

## Fix

Changed the `to` prop on the three affected `KpiCard` components to link to `/organizations/:id` (the public organization profile page).

## Closes

Closes #283

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_