### PR TITLE
fix: breadcrumb on opportunity detail page links back to opportunities list (#274)

### DIFF
--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -36,7 +36,7 @@ export default function VolunteerOpportunityDetailPage() {
 
 	usePageToolbar([
 		{ label: t("breadcrumb.home"), href: "/" },
-		{ label: t("breadcrumb.volunteerOpportunities"), href: "/" },
+		{ label: t("breadcrumb.volunteerOpportunities"), href: "/#opportunities" },
 		{ label: opportunity?.title ?? "" },
 	]);
 


### PR DESCRIPTION
## Problem

The "Volunteer Opportunities" breadcrumb on the opportunity detail page linked to `"/"` (the home page root), so clicking it scrolled to the top of the page rather than jumping to the `#opportunities` anchor.

## Fix

Changed `href: "/"` to `href: "/#opportunities"` in the `usePageToolbar` call so the breadcrumb navigates directly to the opportunities section.

## Closes

Closes #274

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_