### PR TITLE
fix: add redirects for /opportunities and /organizations routes (#271)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router";
+import { Routes, Route, Navigate } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import AppLayout from "./layouts/AppLayout";
@@ -108,6 +108,11 @@ export default function App() {
 						</ProtectedRoute>
 					}
 				/>
+				<Route
+					path="/opportunities"
+					element={<Navigate to="/#opportunities" replace />}
+				/>
+				<Route path="/organizations" element={<Navigate to="/" replace />} />
 				<Route path="*" element={<NotFoundPage />} />
 			</Route>
 		</Routes>


### PR DESCRIPTION
## Problem

Visiting `/opportunities` or `/organizations` directly returned a 404 Not Found page. These are natural URLs that users might share or type, but no routes existed for them.

## Fix

Added `Navigate` redirects in `App.tsx`:
- `/opportunities` redirects to `/#opportunities` (the opportunities section of the home page)
- `/organizations` redirects to `/` (home page)

## Closes

Closes #271

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_