### PR TITLE
fix: restore missing umlaut in German breadcrumb for volunteer opportunities (#273)

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -453,7 +453,7 @@
     },
     "breadcrumb": {
       "home": "Startseite",
-      "volunteerOpportunities": "Einsatzmoglichkeiten",
+      "volunteerOpportunities": "Einsatzmöglichkeiten",
       "engagements": "Bewerbungen",
       "settings": "Einstellungen",
       "account": "Konto",


### PR DESCRIPTION
## Problem

The German breadcrumb label for the volunteer opportunities list was spelled `"Einsatzmoglichkeiten"` - missing the umlaut over the `o`.

## Fix

Corrected to `"Einsatzmöglichkeiten"` in `de.json`.

## Closes

Closes #273

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_