### PR TITLE
fix: use translated street placeholder in create opportunity modal (#288)

### DIFF
--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -190,7 +190,7 @@ export default function CreateVolunteerOpportunityModal({
 								<input
 									type="text"
 									required
-									placeholder="123 Main St"
+									placeholder={t("createOpportunity.streetPlaceholder")}
 									value={form.street}
 									onChange={(e) =>
 										setForm((f) => ({

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -111,6 +111,7 @@
       "fieldDescription": "Beschreibung",
       "fieldAddress": "Adresse",
       "fieldStreet": "Straße",
+      "streetPlaceholder": "Musterstraße 1",
       "fieldNumber": "Nr.",
       "fieldZip": "PLZ",
       "fieldCity": "Ort",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -111,6 +111,7 @@
       "fieldDescription": "Description",
       "fieldAddress": "Address",
       "fieldStreet": "Street",
+      "streetPlaceholder": "123 Main St",
       "fieldNumber": "No.",
       "fieldZip": "ZIP",
       "fieldCity": "City",


### PR DESCRIPTION
## Problem

The street address input field in the create opportunity modal had a hardcoded English placeholder `"123 Main St"` that was never translated, showing English text to German-speaking users.

## Fix

- Added `createOpportunity.streetPlaceholder` key to both `de.json` (`"Musterstraße 1"`) and `en.json` (`"123 Main St"`)
- Replaced the hardcoded string with `t("createOpportunity.streetPlaceholder")` in `CreateVolunteerOpportunityModal.tsx`

## Closes

Closes #288

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_