### PR TITLE
fix: show formatted time slot and shortened volunteer id instead of raw UUIDs (#280)

### DIFF
--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -9,6 +9,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import { usePageToolbar } from "../contexts/ToolbarContext";
+import { formatDateTime } from "../lib/format";
 
 const STATUS_COLORS: Record<string, string> = {
 	Pending: "bg-yellow-50 text-yellow-700",
@@ -188,18 +189,28 @@ export default function EngagementManagementPage() {
 							<div className="flex items-start justify-between gap-2">
 								<div className="min-w-0">
 									<p className="font-mono text-xs text-gray-500">
-										{t("engagementManagement.volunteer", { id: e.volunteerId })}
+										{t("engagementManagement.volunteer", {
+											id: e.volunteerId.slice(0, 8) + "...",
+										})}
 									</p>
 									{e.message && (
 										<p className="mt-1 text-sm text-gray-700">
 											&ldquo;{e.message}&rdquo;
 										</p>
 									)}
-									{e.timeSlotId && (
-										<p className="mt-1 text-xs text-gray-400">
-											{t("engagementManagement.timeSlot", { id: e.timeSlotId })}
-										</p>
-									)}
+									{e.timeSlotId &&
+										(() => {
+											const slot = opportunity?.timeSlots.find(
+												(s) => s.id === e.timeSlotId,
+											);
+											return (
+												<p className="mt-1 text-xs text-gray-400">
+													{slot
+														? `${formatDateTime(slot.startDateTime as unknown as string, i18n.language)} - ${formatDateTime(slot.endDateTime as unknown as string, i18n.language)}`
+														: e.timeSlotId.slice(0, 8) + "..."}
+												</p>
+											);
+										})()}
 									<p className="mt-1 text-xs text-gray-400">
 										{t("engagementManagement.receivedOn", {
 											date: new Date(e.createdOn).toLocaleDateString(locale),


### PR DESCRIPTION
Closes #280

## Changes

- Import `formatDateTime` from `../lib/format` into `EngagementManagementPage`
- Volunteer ID is now displayed as the first 8 characters followed by `...` instead of the full UUID
- Time slot is resolved from the already-fetched `opportunity.timeSlots` list and shown as a formatted `start - end` datetime string; falls back to a shortened UUID if the slot cannot be matched

## Root cause

The page rendered `volunteerId` and `timeSlotId` verbatim from the API response. The opportunity details (including its `timeSlots` array) are already fetched in the same `Promise.all`, so resolving the slot client-side requires no additional network call.

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_