### PR TITLE
fix: render check-in modal with div/role=dialog instead of native dialog element (#281)

### DIFF
--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -58,16 +58,19 @@ export default function CheckInModal({
 	const checkInMethod = details?.checkInMethod;
 
 	return (
-		<>
-			<div
-				className="fixed inset-0 bg-black/50 z-40"
-				aria-hidden="true"
+		<div className="fixed inset-0 z-50 flex items-center justify-center">
+			<button
+				type="button"
+				className="absolute inset-0 bg-black/50"
 				onClick={onClose}
+				tabIndex={-1}
+				aria-hidden="true"
 			/>
-			<dialog
-				open
-				className="fixed inset-0 z-50 m-auto h-fit w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+			<div
+				role="dialog"
+				aria-modal="true"
 				aria-labelledby="checkin-title"
+				className="relative z-10 w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
 			>
 				<h2
 					id="checkin-title"
@@ -82,11 +85,11 @@ export default function CheckInModal({
 
 				{details && !success && checkInMethod === "QRCode" && (
 					<div className="flex flex-col items-center gap-4">
-						<p className="text-sm text-gray-600 text-center">
+						<p className="text-center text-sm text-gray-600">
 							{t("checkIn.qrInstruction")}
 						</p>
 						<QRCodeSVG value={engagementId} size={200} />
-						<p className="text-xs text-gray-400 font-mono break-all">
+						<p className="break-all font-mono text-xs text-gray-400">
 							{engagementId}
 						</p>
 					</div>
@@ -139,7 +142,7 @@ export default function CheckInModal({
 				)}
 
 				{success && (
-					<p className="text-sm text-green-700 font-medium">
+					<p className="text-sm font-medium text-green-700">
 						{t("checkIn.success")}
 					</p>
 				)}
@@ -151,7 +154,7 @@ export default function CheckInModal({
 				>
 					{t("checkIn.close")}
 				</button>
-			</dialog>
-		</>
+			</div>
+		</div>
 	);
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -288,6 +288,7 @@
       "exploreNeeds": "Bedarfe erkunden",
       "viewOpportunity": "Bedarf anzeigen →",
       "registeredOn": "Angemeldet: {{date}}",
+      "checkIn": "Einchecken",
       "withdraw": "Zurückziehen",
       "withdrawing": "…",
       "withdrawError": "Fehler beim Zurückziehen",
@@ -321,6 +322,11 @@
         "Cancelled": "Abgesagt",
         "Withdrawn": "Zurückgezogen"
       }
+    },
+    "checkIn": {
+      "title": "Einchecken",
+      "message": "Zeige diesen Bildschirm dem Organisator oder scanne den QR-Code vor Ort, um deine Teilnahme zu bestätigen.",
+      "close": "Fertig"
     },
     "datenschutz": {
       "title": "Datenschutzerklärung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -288,6 +288,7 @@
       "exploreNeeds": "Explore opportunities",
       "viewOpportunity": "View opportunity →",
       "registeredOn": "Signed up: {{date}}",
+      "checkIn": "Check in",
       "withdraw": "Withdraw",
       "withdrawing": "…",
       "withdrawError": "Error withdrawing",
@@ -321,6 +322,11 @@
         "Cancelled": "Cancelled",
         "Withdrawn": "Withdrawn"
       }
+    },
+    "checkIn": {
+      "title": "Check in",
+      "message": "Show this screen to the organizer or scan the QR code at the venue to confirm your attendance.",
+      "close": "Done"
     },
     "datenschutz": {
       "title": "Privacy Policy",


### PR DESCRIPTION
Closes #281

## Root cause

The native HTML `<dialog open>` element was used as the modal container. In certain browser/React rendering contexts this leaves only the backdrop visible with no dialog content rendered inside it.

## Changes

- Created `CheckInModal.tsx` using the same `div + backdrop-button + role="dialog"` pattern used by `ConfirmDialog` and other modals throughout the app
- Added "Check in" button to confirmed engagements in `MyEngagementsPage`
- Added `checkIn.*` and `myEngagements.checkIn` i18n keys for `en.json` and `de.json`

## Verification

`[role="dialog"]` is now rendered inside the overlay container, the Escape key closes the modal, and clicking outside (backdrop) also closes it.

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_