### PR TITLE
fix: share achievements URL uses public per-user route (#291)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import NotFoundPage from "./pages/NotFoundPage";
 import OrganizationProfilePage from "./pages/OrganizationProfilePage";
 import OrganizationDashboardPage from "./pages/OrganizationDashboardPage";
 import AchievementsPage from "./pages/AchievementsPage";
+import UserAchievementsPage from "./pages/UserAchievementsPage";
 
 function CallbackPage() {
 	const auth = useAuth();
@@ -107,6 +108,10 @@ export default function App() {
 							<AchievementsPage />
 						</ProtectedRoute>
 					}
+				/>
+				<Route
+					path="/users/:userId/achievements"
+					element={<UserAchievementsPage />}
 				/>
 				<Route
 					path="/opportunities"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -440,6 +440,7 @@
     },
     "achievements": {
       "title": "Meine Errungenschaften",
+      "publicTitle": "Errungenschaften",
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",
       "noAchievements": "Noch keine Errungenschaften. Beginne mit dem Ehrenamt, um Abzeichen zu verdienen!",
@@ -470,7 +471,8 @@
       "settings": "Einstellungen",
       "account": "Konto",
       "profile": "Profil",
-      "achievements": "Meine Errungenschaften"
+      "achievements": "Meine Errungenschaften",
+      "userAchievements": "Errungenschaften"
     },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -440,6 +440,7 @@
     },
     "achievements": {
       "title": "My Achievements",
+      "publicTitle": "Achievements",
       "loading": "Loading…",
       "error": "Error: {{message}}",
       "noAchievements": "No achievements yet. Start volunteering to earn badges!",
@@ -470,7 +471,8 @@
       "settings": "Settings",
       "account": "Account",
       "profile": "Profile",
-      "achievements": "My Achievements"
+      "achievements": "My Achievements",
+      "userAchievements": "Achievements"
     },
     "error": {
       "forbidden": "You do not have permission to do this.",

--- a/frontend/src/pages/AchievementsPage.tsx
+++ b/frontend/src/pages/AchievementsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import type {
@@ -12,6 +13,7 @@ import ShareAchievementsModal from "../components/ShareAchievementsModal";
 
 export default function AchievementsPage() {
 	const api = useApiClient();
+	const auth = useAuth();
 	const { t } = useTranslation();
 
 	usePageToolbar([
@@ -129,7 +131,14 @@ export default function AchievementsPage() {
 
 			{shareModalOpen && (
 				<ShareAchievementsModal
-					shareUrl={window.location.origin + "/achievements"}
+					shareUrl={
+						auth.user?.profile?.sub
+							? window.location.origin +
+								"/users/" +
+								auth.user.profile.sub +
+								"/achievements"
+							: window.location.origin + "/achievements"
+					}
 					onClose={() => setShareModalOpen(false)}
 				/>
 			)}

--- a/frontend/src/pages/UserAchievementsPage.tsx
+++ b/frontend/src/pages/UserAchievementsPage.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
+import { useTranslation } from "react-i18next";
+import { createApiClient } from "../client/api-instance";
+import type {
+	AchievementSummary,
+	BadgeCatalogEntry,
+} from "../client/api-client";
+import { usePageToolbar } from "../contexts/ToolbarContext";
+import BadgeGrid from "../components/BadgeGrid";
+
+export default function UserAchievementsPage() {
+	const { userId } = useParams<{ userId: string }>();
+	const { t } = useTranslation();
+
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{ label: t("breadcrumb.userAchievements") },
+	]);
+
+	const [achievements, setAchievements] = useState<AchievementSummary[]>([]);
+	const [catalog, setCatalog] = useState<BadgeCatalogEntry[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!userId) return;
+		const api = createApiClient();
+		Promise.all([api.getUserAchievements(userId), api.getBadgeCatalog()])
+			.then(([ach, cat]) => {
+				setAchievements(ach);
+				setCatalog(cat);
+			})
+			.catch((err: unknown) =>
+				setError(err instanceof Error ? err.message : String(err)),
+			)
+			.finally(() => setLoading(false));
+	}, [userId]);
+
+	if (error) {
+		return (
+			<p className="text-sm text-red-600">
+				{t("achievements.error", { message: error })}
+			</p>
+		);
+	}
+
+	return (
+		<div className="space-y-8">
+			<h1 className="text-2xl font-bold text-gray-900">
+				{t("achievements.publicTitle")}
+			</h1>
+			<section>
+				<h2 className="mb-3 text-base font-semibold text-gray-700">
+					{t("achievements.badgesTitle")}
+				</h2>
+				<BadgeGrid earned={achievements} catalog={catalog} loading={loading} />
+			</section>
+		</div>
+	);
+}


### PR DESCRIPTION
Closes #291

## Root cause

`AchievementsPage` passed `window.location.origin + "/achievements"` as the share URL to `ShareAchievementsModal`. That route is protected by `ProtectedRoute` and always shows the authenticated user's own achievements, not the sharer's.

## Changes

- **`AchievementsPage.tsx`**: reads `auth.user?.profile?.sub` (Keycloak UUID) and builds the share URL as `/users/{sub}/achievements`
- **`UserAchievementsPage.tsx`** (new): public page at `/users/:userId/achievements` - calls the existing unauthenticated `GET /v1/users/{userId}/achievements` endpoint and renders `BadgeGrid` in read-only mode without requiring login
- **`App.tsx`**: registers `/users/:userId/achievements` as a plain (non-protected) route
- **`en.json` / `de.json`**: adds `achievements.publicTitle` and `breadcrumb.userAchievements` keys

## Acceptance criteria verified

- Shared URL now contains the user's UUID
- `/users/:userId/achievements` is publicly accessible (no `ProtectedRoute` wrapper)
- Own `/achievements` page is unchanged

https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sY1R5ggSG5PyU4exZ2L9)_