### PR TITLE
fix: merge duplicate checkIn translation keys so buttonLabel resolves correctly

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -264,18 +264,19 @@
       "buttonLabel": "Einchecken",
       "checkedInLabel": "Eingecheckt",
       "title": "Einchecken",
+      "message": "Zeige diesen Bildschirm dem Organisator oder scanne den QR-Code vor Ort, um deine Teilnahme zu bestätigen.",
       "qrInstruction": "Zeige diesen QR-Code dem Veranstalter zum Einchecken.",
       "pinInstruction": "Gib die PIN des Veranstalters ein.",
       "pinLabel": "PIN",
       "pinPlaceholder": "4-stellige PIN",
-      "submitPin": "Bestatigen",
+      "submitPin": "Bestätigen",
       "submitting": "…",
       "success": "Erfolgreich eingecheckt!",
       "invalidPin": "Falsche PIN. Bitte erneut versuchen.",
       "manualInstruction": "Der Veranstalter wird dich manuell einchecken.",
-      "close": "Schliessen",
+      "close": "Fertig",
       "organizerPin": "Eincheck-PIN",
-      "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen damit sie einchecken konnen.",
+      "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen, damit sie einchecken können.",
       "markCheckedIn": "Als eingecheckt markieren",
       "markingCheckedIn": "…"
     },
@@ -322,11 +323,6 @@
         "Cancelled": "Abgesagt",
         "Withdrawn": "Zurückgezogen"
       }
-    },
-    "checkIn": {
-      "title": "Einchecken",
-      "message": "Zeige diesen Bildschirm dem Organisator oder scanne den QR-Code vor Ort, um deine Teilnahme zu bestätigen.",
-      "close": "Fertig"
     },
     "datenschutz": {
       "title": "Datenschutzerklärung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -264,6 +264,7 @@
       "buttonLabel": "Check in",
       "checkedInLabel": "Checked in",
       "title": "Check in",
+      "message": "Show this screen to the organizer or scan the QR code at the venue to confirm your attendance.",
       "qrInstruction": "Show this QR code to the organizer to check in.",
       "pinInstruction": "Enter the PIN provided by the organizer.",
       "pinLabel": "PIN",
@@ -273,7 +274,7 @@
       "success": "Checked in successfully!",
       "invalidPin": "Invalid PIN. Please try again.",
       "manualInstruction": "The organizer will check you in manually.",
-      "close": "Close",
+      "close": "Done",
       "organizerPin": "Check-in PIN",
       "organizerPinHint": "Share this PIN with your volunteers so they can check in.",
       "markCheckedIn": "Mark as checked in",
@@ -322,11 +323,6 @@
         "Cancelled": "Cancelled",
         "Withdrawn": "Withdrawn"
       }
-    },
-    "checkIn": {
-      "title": "Check in",
-      "message": "Show this screen to the organizer or scan the QR code at the venue to confirm your attendance.",
-      "close": "Done"
     },
     "datenschutz": {
       "title": "Privacy Policy",


### PR DESCRIPTION
## Summary

Fixes #316.

Both `de.json` and `en.json` had **two top-level `"checkIn"` objects**. JSON parsers silently keep only the last definition when a key is duplicated, so the second (minimal) block overwrote the first (complete) block. This caused `t("checkIn.buttonLabel")` - and every other key from the first block (`checkedInLabel`, `qrInstruction`, `pinInstruction`, etc.) - to fall back to the raw key string.

**Root cause:** a duplicate object introduced when the simpler check-in info screen was added, without noticing the full modal keys already lived under the same top-level key.

**Fix:**
- Remove the redundant second `"checkIn"` block from both locale files.
- Merge its unique `"message"` key into the canonical first block.
- While here: correct two minor German typos (`"Bestatigen"` → `"Bestätigen"`, `"konnen"` → `"können"`).

## Test plan

- [ ] Navigate to `/my-engagements` as a volunteer with a confirmed engagement
- [ ] Verify the check-in button reads "Einchecken" (DE) / "Check in" (EN) instead of the raw key
- [ ] Open the check-in modal and verify all strings render correctly (QR instruction, PIN flow, success message, close button "Fertig" / "Done")
- [ ] Verify no other translation keys regressed (quick smoke of profile, account, achievements pages)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gwLqkqJmL3dUkYxPC9HDj)_