### PR TITLE
fix: show opportunity title on engagement cards instead of generic link text

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -2658,6 +2658,7 @@
         "required": [
           "id",
           "opportunityId",
+          "opportunityTitle",
           "volunteerId",
           "timeSlotId",
           "message",
@@ -2674,6 +2675,9 @@
           "opportunityId": {
             "type": "string",
             "format": "uuid"
+          },
+          "opportunityTitle": {
+            "type": "string"
           },
           "volunteerId": {
             "type": "string",

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -3,6 +3,7 @@ namespace Application.Engagements;
 public sealed record EngagementSummary(
 	Guid Id,
 	Guid OpportunityId,
+	string OpportunityTitle,
 	Guid VolunteerId,
 	Guid? TimeSlotId,
 	string? Message,

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -14,16 +14,21 @@ internal sealed class EngagementReadRepository(
 		CancellationToken cancellationToken = default) =>
 		await dbContext.EngagementsQuery
 			.Where(e => e.OpportunityId == opportunityId)
+			.Join(
+				dbContext.VolunteerOpportunitiesQuery,
+				e => e.OpportunityId,
+				o => o.Id,
+				(e, o) => new EngagementSummary(
+					e.Id.Value,
+					e.OpportunityId.Value,
+					o.Title,
+					e.VolunteerId.Value,
+					e.TimeSlotId != null ? e.TimeSlotId.Value.Value : (Guid?)null,
+					e.Message,
+					e.Status.ToString(),
+					e.IsCheckedIn,
+					e.CreatedOn))
 			.OrderByDescending(e => e.CreatedOn)
-			.Select(e => new EngagementSummary(
-				e.Id.Value,
-				e.OpportunityId.Value,
-				e.VolunteerId.Value,
-				e.TimeSlotId != null ? e.TimeSlotId.Value.Value : (Guid?)null,
-				e.Message,
-				e.Status.ToString(),
-				e.IsCheckedIn,
-				e.CreatedOn))
 			.ToListAsync(cancellationToken);
 
 	public async ValueTask<List<EngagementSummary>> GetByVolunteerAsync(
@@ -31,15 +36,20 @@ internal sealed class EngagementReadRepository(
 		CancellationToken cancellationToken = default) =>
 		await dbContext.EngagementsQuery
 			.Where(e => e.VolunteerId == volunteerId)
+			.Join(
+				dbContext.VolunteerOpportunitiesQuery,
+				e => e.OpportunityId,
+				o => o.Id,
+				(e, o) => new EngagementSummary(
+					e.Id.Value,
+					e.OpportunityId.Value,
+					o.Title,
+					e.VolunteerId.Value,
+					e.TimeSlotId != null ? e.TimeSlotId.Value.Value : (Guid?)null,
+					e.Message,
+					e.Status.ToString(),
+					e.IsCheckedIn,
+					e.CreatedOn))
 			.OrderByDescending(e => e.CreatedOn)
-			.Select(e => new EngagementSummary(
-				e.Id.Value,
-				e.OpportunityId.Value,
-				e.VolunteerId.Value,
-				e.TimeSlotId != null ? e.TimeSlotId.Value.Value : (Guid?)null,
-				e.Message,
-				e.Status.ToString(),
-				e.IsCheckedIn,
-				e.CreatedOn))
 			.ToListAsync(cancellationToken);
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -104,7 +104,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.GetByOpportunityAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
 			.Returns(
 			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, Guid.NewGuid(), null, null, "Pending", false, DateTimeOffset.UtcNow)
+				new EngagementSummary(Guid.NewGuid(), opportunityId, "Test Opportunity", Guid.NewGuid(), null, null, "Pending", false, DateTimeOffset.UtcNow)
 			]);
 
 		var command = new UpdateVolunteerOpportunityCommand(
@@ -134,7 +134,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.GetByOpportunityAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
 			.Returns(
 			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, Guid.NewGuid(), null, null, "Cancelled", false, DateTimeOffset.UtcNow)
+				new EngagementSummary(Guid.NewGuid(), opportunityId, "Test Opportunity", Guid.NewGuid(), null, null, "Cancelled", false, DateTimeOffset.UtcNow)
 			]);
 
 		var command = new UpdateVolunteerOpportunityCommand(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -4513,6 +4513,10 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid OpportunityId { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("opportunityTitle")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string OpportunityTitle { get; set; } = default!;
+
         [System.Text.Json.Serialization.JsonPropertyName("volunteerId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid VolunteerId { get; set; } = default!;

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -2212,6 +2212,7 @@ export interface EngagementStatusResponse {
 export interface EngagementSummary {
     id: string;
     opportunityId: string;
+    opportunityTitle: string;
     volunteerId: string;
     timeSlotId: string | undefined;
     message: string | undefined;

--- a/frontend/src/pages/MyEngagementsPage.tsx
+++ b/frontend/src/pages/MyEngagementsPage.tsx
@@ -119,7 +119,7 @@ export default function MyEngagementsPage() {
 										}
 										className="text-left text-sm font-medium text-gray-900 hover:underline"
 									>
-										{t("myEngagements.viewOpportunity")}
+										{e.opportunityTitle}
 									</button>
 									{e.message && (
 										<p className="mt-1 truncate text-sm text-gray-500">


### PR DESCRIPTION
## Summary

Fixes #318.

`EngagementSummary` previously had no `OpportunityTitle` field, so the "My Engagements" page used the static translation key `myEngagements.viewOpportunity` ("Bedarf anzeigen →") as the card heading, giving volunteers no context about which opportunity each engagement is for.

**Changes:**
- `EngagementSummary` record gains an `OpportunityTitle` property.
- Both repository queries (`GetByVolunteer`, `GetByOpportunity`) join with `VolunteerOpportunity` to populate the title.
- NSwag-regenerated OpenAPI spec, C# integration-test client, and TypeScript API client all updated.
- `MyEngagementsPage.tsx` renders `e.opportunityTitle` as the card heading instead of the static string.

## Test plan

- [ ] Log in as `vera / vera123` and navigate to `/my-engagements`
- [ ] Verify each engagement card shows the actual opportunity title (e.g. "Wir suchen Tierkuschler:innen!") as a clickable heading
- [ ] Clicking the title navigates to the correct opportunity detail page
- [ ] Organizer view (`/volunteer-opportunities/:id/engagements`) still loads without errors

---
_Generated by [Claude Code](https://claude.ai/code/session_016gwLqkqJmL3dUkYxPC9HDj)_