### PR TITLE
fix: redirect back to original URL after login from protected route

### DIFF
--- a/frontend/src/layouts/ProtectedRoute.tsx
+++ b/frontend/src/layouts/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router";
 import type { ReactNode } from "react";
 
 interface Props {
@@ -9,6 +10,7 @@ interface Props {
 export default function ProtectedRoute({ children }: Props) {
 	const auth = useAuth();
 	const { t } = useTranslation();
+	const location = useLocation();
 
 	if (auth.isLoading) {
 		return (
@@ -19,7 +21,9 @@ export default function ProtectedRoute({ children }: Props) {
 	}
 
 	if (!auth.isAuthenticated) {
-		auth.signinRedirect();
+		auth.signinRedirect({
+			state: { returnTo: location.pathname + location.search },
+		});
 		return null;
 	}
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,7 +21,7 @@ const oidcConfig = {
 	userStore: new WebStorageStateStore({ store: window.localStorage }),
 	onSigninCallback: (user: User | undefined) => {
 		const returnTo = (user?.state as { returnTo?: string })?.returnTo ?? "/";
-		window.history.replaceState({}, "", returnTo);
+		window.location.replace(returnTo);
 	},
 };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import "./i18n";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
-import { WebStorageStateStore } from "oidc-client-ts";
+import { WebStorageStateStore, type User } from "oidc-client-ts";
 import { BrowserRouter } from "react-router";
 import App from "./App";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -19,8 +19,9 @@ const oidcConfig = {
 	automaticSilentRenew: true,
 	// Use localStorage so Playwright storageState captures the session
 	userStore: new WebStorageStateStore({ store: window.localStorage }),
-	onSigninCallback: () => {
-		window.location.replace("/");
+	onSigninCallback: (user: User | undefined) => {
+		const returnTo = (user?.state as { returnTo?: string })?.returnTo ?? "/";
+		window.history.replaceState({}, "", returnTo);
 	},
 };
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #311 - after logging in from a protected route, users were always redirected to the homepage instead of the page they originally tried to visit.

## Changes

- **`ProtectedRoute.tsx`**: Pass `{ state: { returnTo: location.pathname + location.search } }` to `auth.signinRedirect()` so the current URL is stored in the OIDC state before the Keycloak redirect.
- **`main.tsx`**: Update `onSigninCallback` to read `user.state.returnTo` and use `window.history.replaceState()` to navigate to that path after login completes. Falls back to `/` if no return URL is present (e.g. direct login from header).

## How it works

1. User visits a protected route (e.g. `/organizations/abc/settings`) while unauthenticated.
2. `ProtectedRoute` calls `signinRedirect` with the current path stored in OIDC state.
3. After Keycloak login, `onSigninCallback` extracts the `returnTo` path from `user.state` and replaces the browser URL with it instead of always going to `/`.

Closes #311
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt)_