### PR TITLE
fix: debounce search and city filters consistently and add clear buttons

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -49,7 +49,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Page.GetByPlaceholder("Search…").FillAsync("volunteer");
-		await Page.GetByPlaceholder("Search…").PressAsync("Enter");
 
 		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*search=volunteer"));
 	}
@@ -126,7 +125,9 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Page.GetByPlaceholder("Search…").FillAsync("zzz_no_match_xyz_abc_999");
-		await Page.GetByPlaceholder("Search…").PressAsync("Enter");
+
+		// Wait for the debounce (400 ms) to fire and network to settle before asserting.
+		await Page.WaitForURLAsync(new Regex(@"\?.*search=zzz"), new() { Timeout = 5_000 });
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Expect(
@@ -143,7 +144,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Page.GetByPlaceholder("Search…").FillAsync("help");
-		await Page.GetByPlaceholder("Search…").PressAsync("Enter");
 		await Page.GetByPlaceholder("City…").FillAsync("Munich");
 
 		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*search=help"));
@@ -160,7 +160,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Page.GetByPlaceholder("Search…").ClearAsync();
-		await Page.GetByPlaceholder("Search…").PressAsync("Enter");
 
 		await Expect(Page).Not.ToHaveURLAsync(new Regex(@"\?.*search="));
 	}

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -37,6 +37,10 @@ export default function VolunteerOpportunitiesList({
 	const tag = searchParams.get("tag") ?? "";
 
 	const [searchInput, setSearchInput] = useState(search);
+	const [cityInput, setCityInput] = useState(city);
+
+	const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const cityDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const { view, bounds, setView, setBounds } = useOpportunityViewFilters();
 	const isMap = view === "map";
@@ -53,6 +57,10 @@ export default function VolunteerOpportunitiesList({
 	useEffect(() => {
 		setSearchInput(search);
 	}, [search]);
+
+	useEffect(() => {
+		setCityInput(city);
+	}, [city]);
 
 	const prevFiltersRef = useRef({
 		search,
@@ -206,10 +214,6 @@ export default function VolunteerOpportunitiesList({
 		);
 	}
 
-	function commitSearch() {
-		updateFilter("search", searchInput);
-	}
-
 	function clearFilters() {
 		setSearchParams(
 			(prev) => {
@@ -294,26 +298,68 @@ export default function VolunteerOpportunitiesList({
 			</div>
 
 			<div className="mb-4 flex flex-wrap gap-2">
-				<input
-					type="text"
-					aria-label={t("opportunities.searchPlaceholder")}
-					placeholder={t("opportunities.searchPlaceholder")}
-					value={searchInput}
-					onChange={(e) => setSearchInput(e.target.value)}
-					onBlur={commitSearch}
-					onKeyDown={(e) => {
-						if (e.key === "Enter") commitSearch();
-					}}
-					className="rounded border px-3 py-1.5 text-sm"
-				/>
-				<input
-					type="text"
-					aria-label={t("opportunities.cityPlaceholder")}
-					placeholder={t("opportunities.cityPlaceholder")}
-					value={city}
-					onChange={(e) => updateFilter("city", e.target.value)}
-					className="rounded border px-3 py-1.5 text-sm"
-				/>
+				<div className="relative">
+					<input
+						type="text"
+						aria-label={t("opportunities.searchPlaceholder")}
+						placeholder={t("opportunities.searchPlaceholder")}
+						value={searchInput}
+						onChange={(e) => {
+							const val = e.target.value;
+							setSearchInput(val);
+							if (searchDebounceRef.current)
+								clearTimeout(searchDebounceRef.current);
+							searchDebounceRef.current = setTimeout(() => {
+								updateFilter("search", val);
+							}, 400);
+						}}
+						className="rounded border px-3 py-1.5 pr-7 text-sm"
+					/>
+					{searchInput && (
+						<button
+							type="button"
+							onClick={() => {
+								setSearchInput("");
+								updateFilter("search", "");
+							}}
+							aria-label={t("opportunities.clearSearch")}
+							className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+						>
+							&times;
+						</button>
+					)}
+				</div>
+				<div className="relative">
+					<input
+						type="text"
+						aria-label={t("opportunities.cityPlaceholder")}
+						placeholder={t("opportunities.cityPlaceholder")}
+						value={cityInput}
+						onChange={(e) => {
+							const val = e.target.value;
+							setCityInput(val);
+							if (cityDebounceRef.current)
+								clearTimeout(cityDebounceRef.current);
+							cityDebounceRef.current = setTimeout(() => {
+								updateFilter("city", val);
+							}, 400);
+						}}
+						className="rounded border px-3 py-1.5 pr-7 text-sm"
+					/>
+					{cityInput && (
+						<button
+							type="button"
+							onClick={() => {
+								setCityInput("");
+								updateFilter("city", "");
+							}}
+							aria-label={t("opportunities.clearCity")}
+							className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+						>
+							&times;
+						</button>
+					)}
+				</div>
 				<select
 					aria-label={t("opportunities.allFrequencies")}
 					value={occurrence}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -73,6 +73,8 @@
       "dateFromLabel": "Von Datum",
       "dateToLabel": "Bis Datum",
       "clearFilters": "Filter zurücksetzen",
+      "clearSearch": "Suche löschen",
+      "clearCity": "Stadtfilter löschen",
       "allCategories": "Alle Kategorien",
       "category": {
         "Social": "Soziales",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -73,6 +73,8 @@
       "dateFromLabel": "From date",
       "dateToLabel": "To date",
       "clearFilters": "Clear filters",
+      "clearSearch": "Clear search",
+      "clearCity": "Clear city filter",
       "allCategories": "All categories",
       "category": {
         "Social": "Social",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#310**: Search input previously only committed to the URL on `Enter`/blur while city updated on every keystroke. Both inputs now use a 400ms debounced `onChange` handler - consistent behavior across both filters.
- **#314**: Added individual X clear buttons on both the search and city text inputs. Each button appears only when the input has a value and immediately clears both the local state and the URL param.

## Changes

- `VolunteerOpportunitiesList.tsx`:
  - Added `cityInput` local state (mirrors `city` URL param, same pattern as existing `searchInput`)
  - Added `useEffect` to sync `cityInput` when `city` URL param changes externally
  - Added `searchDebounceRef` and `cityDebounceRef` refs for debounce timers
  - Removed `commitSearch` function and `onBlur`/`onKeyDown` from search input
  - Both inputs now debounce URL updates at 400ms via `onChange`
  - Each input is wrapped in a `relative` div with an absolutely-positioned `x` clear button (shown only when input has a value)
- `locales/en.json`: Added `opportunities.clearSearch` and `opportunities.clearCity`
- `locales/de.json`: Added `opportunities.clearSearch` and `opportunities.clearCity`

## Test plan

- [ ] Type in the search box - URL should update after ~400ms pause (not on every keystroke, not only on Enter)
- [ ] Type in the city box - URL should update after ~400ms pause (same behavior as search)
- [ ] Both inputs show an X button when they have a value; clicking X clears the input and removes the URL param immediately
- [ ] Clearing via the global "Clear filters" button still works and syncs both local states
- [ ] Navigating back/forward with browser history correctly syncs input values

Closes #310
Closes #314

https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt)_