### PR TITLE
fix: show unlock criteria on locked badge cards

### DIFF
--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -66,9 +66,7 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 				</p>
 			)}
 			{!isEarned && !isHidden && (
-				<p className="mt-1 text-xs text-gray-400">
-					{t("achievements.lockedDescription")}
-				</p>
+				<p className="mt-1 text-xs text-gray-400">{catalog.description}</p>
 			)}
 			{!isHidden && (
 				<div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block">


### PR DESCRIPTION
## Summary

- Locked badge cards on the achievements page now display the actual unlock condition from `catalog.description` instead of the generic "Bleib dabei, um es freizuschalten!" message.
- `catalog.description` is already returned by the API - no backend changes needed.
- The hover tooltip still shows the same description, so its behavior is unchanged.

## Test plan

- [ ] Navigate to the achievements page while logged in as a user with some locked badges.
- [ ] Confirm that each locked (non-hidden) badge card shows its specific unlock condition text (e.g. "Earned on your first confirmed engagement.") beneath the badge name.
- [ ] Confirm that fully hidden badges still show no description.
- [ ] Confirm that earned badges still show the unlock date.
- [ ] Confirm that the hover tooltip still works as before.

Closes #320

https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt

---
_Generated by [Claude Code](https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt)_