### PR TITLE
fix: evaluate milestone achievement badges when engagement is confirmed

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -45,4 +45,8 @@ public interface IApplicationDbContext
 	Task<List<Engagement>> GetEngagementsForVolunteerTrackingAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default);
+
+	Task<int> CountConfirmedEngagementsForVolunteerAsync(
+		UserId volunteerId,
+		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -1,3 +1,4 @@
+using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Email;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
@@ -12,7 +13,8 @@ namespace Application.Engagements.ConfirmEngagement.v1;
 internal sealed class ConfirmEngagementCommandHandler(
 	IApplicationDbContext dbContext,
 	IKeycloakUserService keycloakUserService,
-	IEmailService emailService)
+	IEmailService emailService,
+	ISender sender)
 	: ICommandHandler<ConfirmEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -35,6 +37,13 @@ internal sealed class ConfirmEngagementCommandHandler(
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
 		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
 		await RecordActivityStreakAsync(engagement.VolunteerId, isoYear, isoWeek, cancellationToken);
+
+		// Count from DB (not yet saved) and +1 for this confirmation
+		var confirmedCount = await dbContext.CountConfirmedEngagementsForVolunteerAsync(
+			engagement.VolunteerId,
+			cancellationToken) + 1;
+
+		await EvaluateMilestoneAchievementsAsync(engagement.VolunteerId, confirmedCount, cancellationToken);
 
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken);
 		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId.Value, cancellationToken);
@@ -63,5 +72,24 @@ internal sealed class ConfirmEngagementCommandHandler(
 			await dbContext.UserStreaks.AddAsync(streak, cancellationToken);
 		}
 		streak.RecordActivity(isoYear, isoWeek);
+	}
+
+	private async Task EvaluateMilestoneAchievementsAsync(
+		UserId volunteerId,
+		int confirmedCount,
+		CancellationToken cancellationToken)
+	{
+		string[] keysToAward = confirmedCount switch
+		{
+			1 => ["first-step"],
+			5 => ["dedicated-5"],
+			100 => ["centurion-100"],
+			_ => []
+		};
+
+		foreach (var key in keysToAward)
+		{
+			await sender.Send(new AwardAchievementCommand(volunteerId, key), cancellationToken);
+		}
 	}
 }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -108,6 +108,12 @@ internal sealed class ApplicationDbContext(
 			.Where(e => e.VolunteerId == volunteerId)
 			.ToListAsync(cancellationToken);
 
+	public async Task<int> CountConfirmedEngagementsForVolunteerAsync(
+		UserId volunteerId,
+		CancellationToken cancellationToken = default) =>
+		await Set<Engagement>()
+			.CountAsync(e => e.VolunteerId == volunteerId && e.Status == EngagementStatus.Confirmed, cancellationToken);
+
 	protected override void OnModelCreating(
 		ModelBuilder modelBuilder) =>
 			modelBuilder.ApplyConfigurationsFromAssembly(

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Email;
 using Application.Common.Keycloak;
+using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements.ConfirmEngagement.v1;
 using AwesomeAssertions;
@@ -21,6 +22,7 @@ public class ConfirmEngagementCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly ISender _sender = Substitute.For<ISender>();
 	private readonly ConfirmEngagementCommandHandler _sut;
 
 	public ConfirmEngagementCommandHandlerTests()
@@ -30,7 +32,7 @@ public class ConfirmEngagementCommandHandlerTests
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
-		_sut = new ConfirmEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService);
+		_sut = new ConfirmEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService, _sender);
 	}
 
 	[Test]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `CountConfirmedEngagementsForVolunteerAsync` to `IApplicationDbContext` and implements it in `ApplicationDbContext` to count a volunteer's confirmed engagements directly from the DB
- Injects `ISender` into `ConfirmEngagementCommandHandler` and calls `AwardAchievementCommand` after each confirmation
- Evaluates milestone thresholds (1, 5, 100 confirmed engagements) and awards the corresponding badges (`first-step`, `dedicated-5`, `centurion-100`)
- The DB count is taken before `SaveChanges` (which runs via `TransactionPipelineBehavior`), so +1 is added to account for the current confirmation

Closes #317

## Test plan

- [ ] Confirm an engagement for a volunteer with 0 prior confirmed engagements - verify the "First Step" (`first-step`) badge is awarded
- [ ] Confirm engagements until the volunteer has 4 confirmed, then confirm one more - verify the "Dedicated" (`dedicated-5`) badge is awarded at 5
- [ ] Verify that confirming an engagement at counts other than 1, 5, or 100 does not award any badge
- [ ] Verify the email and streak recording still work correctly after the change

https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MkKwvKMEA9RNwN9vRovxt)_