### PR TITLE
fix: replace Impressum placeholder text with real operator information

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -331,7 +331,7 @@
     "datenschutz": {
       "title": "Datenschutzerklärung",
       "section1Title": "Verantwortliche Stelle",
-      "section1Body": "[Vor- und Nachname / Organisation]\n[Straße und Hausnummer]\n[PLZ und Ort]\nE-Mail: [deine@email.de]",
+      "section1Body": "Maik Hasler\nAdresse auf Anfrage\nE-Mail: maikhslr@gmail.com",
       "section2Title": "Erhebung und Speicherung personenbezogener Daten",
       "section2Body1": "Beim Besuch dieser Website werden automatisch Informationen allgemeiner Natur erfasst (z. B. IP-Adresse, Browsertyp, Uhrzeit des Zugriffs). Diese Daten lassen keine Rückschlüsse auf Ihre Person zu und werden zur Sicherstellung des Betriebs ausgewertet.",
       "section2Body2": "Bei der Registrierung und Anmeldung über unseren Authentifizierungsdienst (Keycloak) werden die von Ihnen eingegebenen Daten (z. B. Name, E-Mail-Adresse) gespeichert, um Ihnen die Nutzung der Plattform zu ermöglichen.",
@@ -345,11 +345,11 @@
     "impressum": {
       "title": "Impressum",
       "section1Title": "Angaben gemäß § 5 TMG",
-      "section1Body": "[Vor- und Nachname / Organisation]\n[Straße und Hausnummer]\n[PLZ und Ort]",
+      "section1Body": "Maik Hasler\nAdresse auf Anfrage",
       "section2Title": "Kontakt",
-      "section2Body": "E-Mail: [deine@email.de]",
+      "section2Body": "E-Mail: maikhslr@gmail.com\nWebsite: https://einsatzbereit.maik-hasler.de",
       "section3Title": "Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV",
-      "section3Body": "[Vor- und Nachname]\n[Adresse wie oben]",
+      "section3Body": "Maik Hasler\nAdresse auf Anfrage",
       "section4Title": "Haftungsausschluss",
       "section4aTitle": "Haftung für Inhalte",
       "section4aBody": "Die Inhalte dieser Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -331,7 +331,7 @@
     "datenschutz": {
       "title": "Privacy Policy",
       "section1Title": "Responsible party",
-      "section1Body": "[First and last name / Organization]\n[Street and house number]\n[ZIP and city]\nEmail: [your@email.de]",
+      "section1Body": "Maik Hasler\nAddress available on request\nEmail: maikhslr@gmail.com",
       "section2Title": "Collection and storage of personal data",
       "section2Body1": "When visiting this website, general information is automatically collected (e.g. IP address, browser type, time of access). This data does not allow conclusions about your person and is evaluated to ensure operation.",
       "section2Body2": "When registering and logging in via our authentication service (Keycloak), the data you enter (e.g. name, email address) is stored to enable you to use the platform.",
@@ -345,11 +345,11 @@
     "impressum": {
       "title": "Imprint",
       "section1Title": "Information according to § 5 TMG",
-      "section1Body": "[First and last name / Organization]\n[Street and house number]\n[ZIP and city]",
+      "section1Body": "Maik Hasler\nAddress available on request",
       "section2Title": "Contact",
-      "section2Body": "Email: [your@email.de]",
+      "section2Body": "Email: maikhslr@gmail.com\nWebsite: https://einsatzbereit.maik-hasler.de",
       "section3Title": "Responsible for content according to § 55 para. 2 RStV",
-      "section3Body": "[First and last name]\n[Address as above]",
+      "section3Body": "Maik Hasler\nAddress available on request",
       "section4Title": "Disclaimer",
       "section4aTitle": "Liability for content",
       "section4aBody": "The contents of these pages have been created with the greatest care. However, we cannot guarantee the accuracy, completeness and timeliness of the content.",


### PR DESCRIPTION
Fixes #285

Replaces all template placeholders on the `/impressum` and `/datenschutz` pages with real operator contact information to comply with TMG §5.

## Changes

- `frontend/src/locales/de.json`: Replaced `[Vor- und Nachname / Organisation]`, `[Straße und Hausnummer]`, `[PLZ und Ort]`, `[deine@email.de]` with real data in both `impressum` and `datenschutz` sections
- `frontend/src/locales/en.json`: Same replacements in English locale

## Operator info used

- Name: Maik Hasler
- Email: maikhslr@gmail.com
- Website: https://einsatzbereit.maik-hasler.de
- Address: "Adresse auf Anfrage" / "Address available on request" (no physical address found in codebase)

https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg)_