### PR TITLE
fix: populate mobile hamburger menu with navigation items

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -453,24 +453,28 @@ export default function Header() {
 								</button>
 								<a
 									href="/my-engagements"
+									onClick={() => setMobileOpen(false)}
 									className="block px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-600 transition-colors"
 								>
 									{t("nav.myEngagements")}
 								</a>
 								<a
 									href="/profile"
+									onClick={() => setMobileOpen(false)}
 									className="block px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-600 transition-colors"
 								>
 									{t("nav.myProfile")}
 								</a>
 								<a
 									href="/achievements"
+									onClick={() => setMobileOpen(false)}
 									className="block px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-600 transition-colors"
 								>
 									{t("nav.myAchievements")}
 								</a>
 								<a
 									href="/account"
+									onClick={() => setMobileOpen(false)}
 									className="block px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-600 transition-colors"
 								>
 									{t("nav.profileSettings")}


### PR DESCRIPTION
Fixes #275

## Summary

- The mobile hamburger menu drawer already renders the correct navigation items for both auth states (Anmelden/Registrieren for logged-out users; My Engagements, Profile, Achievements, Account Settings, and Sign Out for logged-in users) along with the language switcher.
- The missing behaviour was that tapping a nav link inside the drawer did not close the drawer - it stayed open on top of the destination page.
- Added `onClick={() => setMobileOpen(false)}` to each of the four nav anchor elements (My Engagements, Profile, Achievements, Account Settings) in the mobile menu, mirroring what the notification button already did.

## Test plan

- [ ] Open the site at a 390px-wide mobile viewport (e.g. iPhone 14 Pro in DevTools)
- [ ] Tap the hamburger icon (top-right corner)
- [ ] Confirm the drawer opens and shows navigation links
- [ ] Logged out: verify "Anmelden" and "Registrieren" buttons appear
- [ ] Logged in: verify "My Engagements", "Profile", "Achievements", "Account Settings", and "Sign Out" links appear
- [ ] Tap any nav link and confirm the drawer closes after navigation

https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg)_