### PR TITLE
fix: add organization management routes for organizator role

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ProfilePage from "./pages/ProfilePage";
 import NotFoundPage from "./pages/NotFoundPage";
 import OrganizationProfilePage from "./pages/OrganizationProfilePage";
 import OrganizationDashboardPage from "./pages/OrganizationDashboardPage";
+import OrganizationEngagementsPage from "./pages/OrganizationEngagementsPage";
 import AchievementsPage from "./pages/AchievementsPage";
 import UserAchievementsPage from "./pages/UserAchievementsPage";
 
@@ -98,6 +99,14 @@ export default function App() {
 					element={
 						<ProtectedRoute>
 							<OrganizationDashboardPage />
+						</ProtectedRoute>
+					}
+				/>
+				<Route
+					path="/organizations/:organizationId/engagements"
+					element={
+						<ProtectedRoute>
+							<OrganizationEngagementsPage />
 						</ProtectedRoute>
 					}
 				/>

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -232,6 +232,31 @@ export default function OrganizationSwitcher() {
 									</button>
 									<button
 										type="button"
+										data-testid="org-engagements-link"
+										onClick={() => {
+											setOpen(false);
+											navigate(`/organizations/${activeOrgId}/engagements`);
+										}}
+										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+									>
+										<svg
+											className="w-4 h-4 text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+											/>
+										</svg>
+										{t("organization.engagements")}
+									</button>
+									<button
+										type="button"
 										data-testid="org-settings-link"
 										onClick={() => {
 											setOpen(false);

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -192,12 +192,21 @@
       "selectPlaceholder": "Organisation wählen",
       "settings": "Einstellungen",
       "dashboard": "Dashboard",
+      "engagements": "Bewerbungen verwalten",
       "nameLabel": "Name",
       "namePlaceholder": "z.B. Freiwillige Feuerwehr Musterstadt",
       "creating": "Wird erstellt…",
       "submit": "Erstellen",
       "cancel": "Abbrechen",
       "unknownError": "Unbekannter Fehler"
+    },
+    "orgEngagements": {
+      "title": "Bewerbungen",
+      "loading": "Wird geladen…",
+      "error": "Fehler: {{message}}",
+      "noOpportunities": "Keine offenen Einsatzmöglichkeiten",
+      "noOpportunitiesHint": "Erstelle eine Einsatzmöglichkeit, um Bewerbungen zu erhalten.",
+      "manageEngagements": "Bewerbungen verwalten →"
     },
     "orgDashboard": {
       "title": "Organisations-Dashboard",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -192,12 +192,21 @@
       "selectPlaceholder": "Select organization",
       "settings": "Settings",
       "dashboard": "Dashboard",
+      "engagements": "Manage Engagements",
       "nameLabel": "Name",
       "namePlaceholder": "e.g. Volunteer Fire Department",
       "creating": "Creating…",
       "submit": "Create",
       "cancel": "Cancel",
       "unknownError": "Unknown error"
+    },
+    "orgEngagements": {
+      "title": "Engagement Overview",
+      "loading": "Loading…",
+      "error": "Error: {{message}}",
+      "noOpportunities": "No open opportunities",
+      "noOpportunitiesHint": "Create a volunteer opportunity to start receiving applications.",
+      "manageEngagements": "Manage engagements →"
     },
     "orgDashboard": {
       "title": "Organization Dashboard",

--- a/frontend/src/pages/OrganizationEngagementsPage.tsx
+++ b/frontend/src/pages/OrganizationEngagementsPage.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import type { PublicOpportunitySummaryDto } from "../client/api-client";
+import { useApiClient } from "../hooks/useApiClient";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { usePageToolbar } from "../contexts/ToolbarContext";
+import EmptyState from "../components/EmptyState";
+
+export default function OrganizationEngagementsPage() {
+	const { organizationId } = useParams<{ organizationId: string }>();
+	const api = useApiClient();
+	const { t } = useTranslation();
+
+	const [orgName, setOrgName] = useState<string>("");
+	const [opportunities, setOpportunities] = useState<
+		PublicOpportunitySummaryDto[]
+	>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	usePageTitle(
+		orgName
+			? `${orgName} - ${t("orgEngagements.title")}`
+			: t("orgEngagements.title"),
+	);
+
+	usePageToolbar([
+		{ label: t("breadcrumb.home"), href: "/" },
+		{
+			label: orgName,
+			href: organizationId ? `/organizations/${organizationId}` : "/",
+		},
+		{ label: t("orgEngagements.title") },
+	]);
+
+	useEffect(() => {
+		if (!organizationId) return;
+		setLoading(true);
+		setError(null);
+		api
+			.getPublicOrganizationProfile(organizationId)
+			.then((profile) => {
+				setOrgName(profile.name);
+				setOpportunities(profile.openOpportunities);
+			})
+			.catch((e: unknown) =>
+				setError(e instanceof Error ? e.message : String(e)),
+			)
+			.finally(() => setLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [organizationId]);
+
+	if (loading) {
+		return (
+			<div className="flex items-center justify-center py-16">
+				<span className="text-gray-500">{t("orgEngagements.loading")}</span>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="mx-auto max-w-2xl px-4 py-8">
+				<p className="text-red-600">
+					{t("orgEngagements.error", { message: error })}
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto max-w-2xl">
+			<h1 className="mb-6 text-2xl font-bold text-gray-900">
+				{t("orgEngagements.title")}
+			</h1>
+
+			{opportunities.length === 0 ? (
+				<EmptyState
+					title={t("orgEngagements.noOpportunities")}
+					message={t("orgEngagements.noOpportunitiesHint")}
+				/>
+			) : (
+				<ul className="divide-y divide-gray-100">
+					{opportunities.map((opp) => (
+						<li key={opp.id} className="relative py-4">
+							<p className="font-medium text-gray-900">{opp.title}</p>
+							{opp.description && (
+								<p className="mt-1 text-sm text-gray-500 line-clamp-2">
+									{opp.description}
+								</p>
+							)}
+							<Link
+								to={`/volunteer-opportunities/${opp.id}/engagements`}
+								className="mt-2 inline-block text-sm font-medium text-brand-700 hover:underline"
+							>
+								{t("orgEngagements.manageEngagements")}
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
$(cat <<'EOF'
Fixes #272

## Summary

- Adds the missing `/organizations/:organizationId/engagements` route to `App.tsx`, protected by `ProtectedRoute`
- Creates `OrganizationEngagementsPage.tsx` that lists the organization's open volunteer opportunities, each with a "Manage engagements" link to the per-opportunity engagement management page (`/volunteer-opportunities/:id/engagements`)
- Adds a third "Manage Engagements" button to the `OrganizationSwitcher` dropdown (between Dashboard and Settings) so organizators can navigate to engagement management without knowing the URL
- Adds `organization.engagements` and `orgEngagements` translation keys to both `en.json` and `de.json`

The existing `/organizations/:organizationId/dashboard` and `/organizations/:organizationId/settings` routes were already registered - only the engagements route and the switcher dropdown entry were missing.

## Test plan

- [ ] Log in as `olaf` / `olaf123`
- [ ] Verify the organization name button in the header opens a dropdown with three management links: Dashboard, Manage Engagements, Settings
- [ ] Navigate to `/organizations/<id>/engagements` - confirm the page renders (not 404) and lists opportunities with engagement links
- [ ] Navigate to `/organizations/<id>/dashboard` - confirm page renders
- [ ] Navigate to `/organizations/<id>/settings` - confirm page renders
- [ ] Confirm all three routes redirect to Keycloak when not logged in

https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgGYNW87n2sKFCkgU1iSRg)_