### PR TITLE
fix: repair broken main CI (lockfile dedup + editorconfig)

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1638,14 +1638,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3417,16 +3409,6 @@ snapshots:
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:

--- a/scripts/smoke-test-pr459.mjs
+++ b/scripts/smoke-test-pr459.mjs
@@ -14,112 +14,112 @@ let pass = 0;
 let fail = 0;
 
 function ok(msg) {
-  console.log(`  PASS  ${msg}`);
-  pass++;
+	console.log(`  PASS  ${msg}`);
+	pass++;
 }
 function ko(msg) {
-  console.error(`  FAIL  ${msg}`);
-  fail++;
+	console.error(`  FAIL  ${msg}`);
+	fail++;
 }
 
 // ── 1. API: no opportunity in the listing should have all time slots in the past ─────
 async function testExpiredFilter() {
-  console.log("\n[#442] Expired opportunities excluded from listing");
-  const url = `${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=100`;
-  const res = await fetch(url);
-  if (!res.ok) { ko(`GET /v1/volunteer-opportunities returned ${res.status}`); return; }
-  const body = await res.json();
-  const now = new Date();
-  let allGood = true;
-  for (const item of body.items ?? []) {
-    // If the API returns time-slot info, verify none are fully in the past.
-    // The listing summary may not include time slots - we just check the
-    // opportunities are present and rely on the filter; if the known past
-    // listing "Wir suchen Tierkuschler:innen" (end date 31 May) is gone, fix works.
-    if (item.title && item.title.toLowerCase().includes("tierkuschler")) {
-      ko(`Past opportunity still visible: "${item.title}"`);
-      allGood = false;
-    }
-  }
-  if (allGood) ok(`No known expired opportunities found in ${body.items?.length ?? 0} results`);
+	console.log("\n[#442] Expired opportunities excluded from listing");
+	const url = `${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=100`;
+	const res = await fetch(url);
+	if (!res.ok) { ko(`GET /v1/volunteer-opportunities returned ${res.status}`); return; }
+	const body = await res.json();
+	const now = new Date();
+	let allGood = true;
+	for (const item of body.items ?? []) {
+		// If the API returns time-slot info, verify none are fully in the past.
+		// The listing summary may not include time slots - we just check the
+		// opportunities are present and rely on the filter; if the known past
+		// listing "Wir suchen Tierkuschler:innen" (end date 31 May) is gone, fix works.
+		if (item.title && item.title.toLowerCase().includes("tierkuschler")) {
+			ko(`Past opportunity still visible: "${item.title}"`);
+			allGood = false;
+		}
+	}
+	if (allGood) ok(`No known expired opportunities found in ${body.items?.length ?? 0} results`);
 }
 
 // ── 2. UI: category + tags on detail page ────────────────────────────────────────────
 async function testCategoryTagsOnDetail(browser) {
-  console.log("\n[#351] Category and tags on opportunity detail page");
-  // Find the first opportunity that has a category via the API
-  const listRes = await fetch(`${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=20`);
-  if (!listRes.ok) { ko("Could not fetch opportunities"); return; }
-  const list = await listRes.json();
-  const opp = (list.items ?? []).find((i) => i.category);
-  if (!opp) { ok("No opportunities with a category found - skipping UI check"); return; }
+	console.log("\n[#351] Category and tags on opportunity detail page");
+	// Find the first opportunity that has a category via the API
+	const listRes = await fetch(`${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=20`);
+	if (!listRes.ok) { ko("Could not fetch opportunities"); return; }
+	const list = await listRes.json();
+	const opp = (list.items ?? []).find((i) => i.category);
+	if (!opp) { ok("No opportunities with a category found - skipping UI check"); return; }
 
-  const page = await browser.newPage();
-  await page.context().setExtraHTTPHeaders({});
-  try {
-    await page.goto(`${BASE}/volunteer-opportunities/${opp.id}`, { waitUntil: "networkidle", timeout: 20000 });
-    // Look for a badge containing the category name (e.g. "Animals", "Social")
-    const categoryText = opp.category;
-    const found = await page.locator(`text=${categoryText}`).count();
-    if (found > 0) {
-      ok(`Category badge "${categoryText}" visible on detail page for "${opp.title}"`);
-    } else {
-      ko(`Category badge "${categoryText}" NOT found on detail page for "${opp.title}"`);
-    }
-  } finally {
-    await page.close();
-  }
+	const page = await browser.newPage();
+	await page.context().setExtraHTTPHeaders({});
+	try {
+		await page.goto(`${BASE}/volunteer-opportunities/${opp.id}`, { waitUntil: "networkidle", timeout: 20000 });
+		// Look for a badge containing the category name (e.g. "Animals", "Social")
+		const categoryText = opp.category;
+		const found = await page.locator(`text=${categoryText}`).count();
+		if (found > 0) {
+			ok(`Category badge "${categoryText}" visible on detail page for "${opp.title}"`);
+		} else {
+			ko(`Category badge "${categoryText}" NOT found on detail page for "${opp.title}"`);
+		}
+	} finally {
+		await page.close();
+	}
 }
 
 // ── 3. UI: organisator of another org sees sign-up button ─────────────────────────────
 async function testOrganisatorSignUp(browser) {
-  console.log("\n[#348] Organisator of other org can see sign-up button");
-  // Log in as olaf (organisator role)
-  const page = await browser.newPage();
-  try {
-    // Navigate to login
-    await page.goto(BASE, { waitUntil: "networkidle", timeout: 20000 });
-    const signInBtn = page.locator("button").filter({ hasText: /sign in|anmelden/i }).first();
-    await signInBtn.click();
-    // Two-step Keycloak login
-    await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
-    await page.fill("#username", "olaf");
-    await page.click("#kc-login");
-    await page.fill("#password", "olaf123");
-    await page.click("#kc-login");
-    await page.waitForURL(BASE + "**", { timeout: 15000 });
+	console.log("\n[#348] Organisator of other org can see sign-up button");
+	// Log in as olaf (organisator role)
+	const page = await browser.newPage();
+	try {
+		// Navigate to login
+		await page.goto(BASE, { waitUntil: "networkidle", timeout: 20000 });
+		const signInBtn = page.locator("button").filter({ hasText: /sign in|anmelden/i }).first();
+		await signInBtn.click();
+		// Two-step Keycloak login
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await page.fill("#username", "olaf");
+		await page.click("#kc-login");
+		await page.fill("#password", "olaf123");
+		await page.click("#kc-login");
+		await page.waitForURL(BASE + "**", { timeout: 15000 });
 
-    // Find an opportunity from a different org (not owned by olaf's org)
-    const listRes = await fetch(`${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=50`);
-    const list = await listRes.json();
-    // olaf's org id - we just need any published opportunity
-    const opp = (list.items ?? []).find((i) => i.id);
-    if (!opp) { ok("No opportunities to test against"); return; }
+		// Find an opportunity from a different org (not owned by olaf's org)
+		const listRes = await fetch(`${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=50`);
+		const list = await listRes.json();
+		// olaf's org id - we just need any published opportunity
+		const opp = (list.items ?? []).find((i) => i.id);
+		if (!opp) { ok("No opportunities to test against"); return; }
 
-    await page.goto(`${BASE}/volunteer-opportunities/${opp.id}`, { waitUntil: "networkidle", timeout: 20000 });
+		await page.goto(`${BASE}/volunteer-opportunities/${opp.id}`, { waitUntil: "networkidle", timeout: 20000 });
 
-    // The sign-up button should be visible if this opp belongs to a different org
-    // Look for "Join waitlist" or "Express interest" buttons
-    const signUpBtn = page.locator("button").filter({ hasText: /join waitlist|express interest|warteliste|interesse/i });
-    const manageBtn = page.locator("button, a").filter({ hasText: /manage applications|bewerbungen/i });
+		// The sign-up button should be visible if this opp belongs to a different org
+		// Look for "Join waitlist" or "Express interest" buttons
+		const signUpBtn = page.locator("button").filter({ hasText: /join waitlist|express interest|warteliste|interesse/i });
+		const manageBtn = page.locator("button, a").filter({ hasText: /manage applications|bewerbungen/i });
 
-    const isOwner = await manageBtn.count() > 0;
-    if (isOwner) {
-      // This is olaf's own opportunity - still a useful check
-      ok(`Viewing own opportunity - sign-up correctly hidden, manage button shown for "${opp.title}"`);
-    } else {
-      const visible = await signUpBtn.count() > 0;
-      if (visible) {
-        ok(`Sign-up button visible for organisator on "${opp.title}" (cross-org)`);
-      } else {
-        ko(`Sign-up button NOT visible for organisator on "${opp.title}"`);
-      }
-    }
-  } catch (err) {
-    ko(`Login/navigation error: ${err.message}`);
-  } finally {
-    await page.close();
-  }
+		const isOwner = await manageBtn.count() > 0;
+		if (isOwner) {
+			// This is olaf's own opportunity - still a useful check
+			ok(`Viewing own opportunity - sign-up correctly hidden, manage button shown for "${opp.title}"`);
+		} else {
+			const visible = await signUpBtn.count() > 0;
+			if (visible) {
+				ok(`Sign-up button visible for organisator on "${opp.title}" (cross-org)`);
+			} else {
+				ko(`Sign-up button NOT visible for organisator on "${opp.title}"`);
+			}
+		}
+	} catch (err) {
+		ko(`Login/navigation error: ${err.message}`);
+	} finally {
+		await page.close();
+	}
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────────────
@@ -127,12 +127,12 @@ const browser = await chromium.launch({ headless: true });
 const context = await browser.newContext({ ignoreHTTPSErrors: true });
 
 try {
-  await testExpiredFilter();
-  await testCategoryTagsOnDetail(context);
-  await testOrganisatorSignUp(context);
+	await testExpiredFilter();
+	await testCategoryTagsOnDetail(context);
+	await testOrganisatorSignUp(context);
 } finally {
-  await context.close();
-  await browser.close();
+	await context.close();
+	await browser.close();
 }
 
 console.log(`\nResults: ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Repairs the two CI jobs that were red on `main`.

## 1. Broken pnpm lockfile (the reported failure)

The **npm dependency audit** job in `security.yml` failed:

```
[ERR_PNPM_BROKEN_LOCKFILE] The lockfile at ".../frontend/pnpm-lock.yaml" is broken:
duplicated mapping key (1641:3)
 1641 |   tinyglobby@0.2.17:
```

`frontend/pnpm-lock.yaml` had `tinyglobby@0.2.17` **triplicated** in both the
`packages:` and `snapshots:` sections - a bad-merge artifact that accumulated:

| commit | top-level `tinyglobby@0.2.17:` lines |
|---|---|
| `5d3d8f9` (#458) | 2 (correct) |
| `a88c0c2` (#459) | 4 (doubled) |
| `c0e5f36` (#461) | 6 (tripled) |

Duplicate YAML mapping keys make the file unparseable, so `pnpm install --frozen-lockfile`
aborts. All three copies were **byte-for-byte identical**, so collapsing them to one
changes **zero** dependency resolution (18 deletions, no other lines touched).

## 2. EditorConfig violation (pre-existing, blocking too)

The **editorconfig** job in `lint.yml` was *also* red on `main`: `scripts/smoke-test-pr459.mjs`
(added in `c4a426a`) used 2-space indentation, but `.editorconfig` enforces
`indent_style = tab` repo-wide (`.mjs` doesn't match the `*.{js,ts,jsx,tsx,css}` group,
so it falls under `[*]` = tabs). Converted leading indentation to tabs; internal
template-string spacing preserved, no behavioural change.

> This had to be fixed in the same PR: the file lives in the merge base, so the PR's
> own `editorconfig` check couldn't go green otherwise.

## Live verification

Both are CI-only fixes with no runtime/behavioral change (identical resolved dependency
tree; script behaviour unchanged), so a staging RC deploy isn't applicable - built images
would be byte-identical to current `main`. Verified by running the exact failing CI
commands locally:

- `pnpm install --frozen-lockfile` -> exit 0 (`Lockfile is up to date, resolution step is skipped`)
- `pnpm audit --audit-level=high` -> exit 0 (1 low + 1 moderate; none high/critical)
- `scripts/smoke-test-pr459.mjs`: `node --check` passes; manual check confirms tab-only
  indentation, no trailing whitespace, final newline present (the editorconfig-checker
  binary couldn't run in-sandbox due to a GitHub API rate limit, so conformance was
  verified against the exact rules it enforces).

## Note on #462

#462 is about the audit blocking PRs when a **CVE** lands in `main`. That's a separate
concern - this failure was **not** a CVE (the audit step passes). The breakage was the
corrupted lockfile + the editorconfig violation, both repaired here. Happy to tackle
#462's workflow ergonomics separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L53fZPcQGW4iF9t411bkYo