### PR TITLE
fix: time slot past-date check, composite indexes, JSON skills, security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,12 +7,6 @@ on:
       - 'backend/**'
       - 'frontend/**'
       - '.github/workflows/security.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/security.yml'
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/backend/src/Domain/VolunteerOpportunities/TimeSlot.cs
+++ b/backend/src/Domain/VolunteerOpportunities/TimeSlot.cs
@@ -49,6 +49,9 @@ public sealed class TimeSlot : Entity<TimeSlotId>
 
 	public void Update(DateTimeOffset startDateTime, DateTimeOffset endDateTime, int maxParticipants)
 	{
+		if (startDateTime <= DateTimeOffset.UtcNow)
+			throw new DomainException("Start date must be in the future.");
+
 		if (endDateTime <= startDateTime)
 			throw new DomainException("End date must be after start date.");
 

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -57,6 +57,10 @@ internal sealed class EngagementConfiguration
 
 		builder.HasIndex(e => e.VolunteerId);
 
+		builder.HasIndex(e => new { e.OpportunityId, e.Status });
+
+		builder.HasIndex(e => new { e.VolunteerId, e.Status });
+
 		builder.HasOne<TimeSlot>()
 			.WithMany()
 			.HasForeignKey(e => e.TimeSlotId)

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -42,5 +42,9 @@ internal sealed class NotificationConfiguration
 		builder.Ignore(n => n.Events);
 
 		builder.HasIndex(n => n.RecipientId);
+
+		builder.HasIndex(n => new { n.RecipientId, n.IsRead });
+
+		builder.HasIndex(n => new { n.RecipientId, n.CreatedOn });
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Persistence.Configurations;
 
@@ -20,17 +22,24 @@ internal sealed class UserConfiguration
 
 		builder.Property(u => u.Bio);
 
+		var listComparer = new ValueComparer<IReadOnlyList<string>>(
+			(a, b) => a != null && b != null && a.SequenceEqual(b),
+			v => v.Aggregate(0, (h, s) => HashCode.Combine(h, s.GetHashCode())),
+			v => v.ToList());
+
 		builder.Property(u => u.Skills)
 			.HasConversion(
-				list => string.Join('|', list),
-				raw => (IReadOnlyList<string>)(raw == "" ? Array.Empty<string>() : raw.Split('|', StringSplitOptions.RemoveEmptyEntries)))
-			.HasColumnType("text");
+				list => JsonSerializer.Serialize(list, JsonSerializerOptions.Default),
+				json => JsonSerializer.Deserialize<IReadOnlyList<string>>(json, JsonSerializerOptions.Default) ?? Array.Empty<string>())
+			.HasColumnType("text")
+			.Metadata.SetValueComparer(listComparer);
 
 		builder.Property(u => u.Languages)
 			.HasConversion(
-				list => string.Join('|', list),
-				raw => (IReadOnlyList<string>)(raw == "" ? Array.Empty<string>() : raw.Split('|', StringSplitOptions.RemoveEmptyEntries)))
-			.HasColumnType("text");
+				list => JsonSerializer.Serialize(list, JsonSerializerOptions.Default),
+				json => JsonSerializer.Deserialize<IReadOnlyList<string>>(json, JsonSerializerOptions.Default) ?? Array.Empty<string>())
+			.HasColumnType("text")
+			.Metadata.SetValueComparer(listComparer);
 
 		builder.Property(u => u.PreferredContact)
 			.HasConversion<string>();

--- a/backend/src/Infrastructure/Persistence/Migrations/20260617201211_AddCompositeIndexesAndJsonSkills.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260617201211_AddCompositeIndexesAndJsonSkills.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617201211_AddCompositeIndexesAndJsonSkills")]
+    partial class AddCompositeIndexesAndJsonSkills
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260617201211_AddCompositeIndexesAndJsonSkills.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260617201211_AddCompositeIndexesAndJsonSkills.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompositeIndexesAndJsonSkills : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Convert pipe-delimited skills/languages to JSON arrays.
+            // The LIKE '[%' guard makes this idempotent if run more than once.
+            migrationBuilder.Sql("""
+                UPDATE "user"
+                SET skills = CASE
+                    WHEN skills IS NULL OR skills = '' THEN '[]'
+                    WHEN skills LIKE '[%' THEN skills
+                    ELSE array_to_json(string_to_array(skills, '|'))::text
+                END,
+                languages = CASE
+                    WHEN languages IS NULL OR languages = '' THEN '[]'
+                    WHEN languages LIKE '[%' THEN languages
+                    ELSE array_to_json(string_to_array(languages, '|'))::text
+                END;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notification_recipient_id_created_on",
+                table: "notification",
+                columns: new[] { "recipient_id", "created_on" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notification_recipient_id_is_read",
+                table: "notification",
+                columns: new[] { "recipient_id", "is_read" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_engagement_opportunity_id_status",
+                table: "engagement",
+                columns: new[] { "opportunity_id", "status" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_engagement_volunteer_id_status",
+                table: "engagement",
+                columns: new[] { "volunteer_id", "status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_notification_recipient_id_created_on",
+                table: "notification");
+
+            migrationBuilder.DropIndex(
+                name: "ix_notification_recipient_id_is_read",
+                table: "notification");
+
+            migrationBuilder.DropIndex(
+                name: "ix_engagement_opportunity_id_status",
+                table: "engagement");
+
+            migrationBuilder.DropIndex(
+                name: "ix_engagement_volunteer_id_status",
+                table: "engagement");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four open issues in one commit:

- **#462** - Removed `pull_request` trigger from `security.yml` so CVEs already present in `main` no longer block dependency-update PRs. The scan still runs on push to `main` and on the weekly schedule.
- **#409** - Added past-date guard to `TimeSlot.Update()`. The guard already existed in `Create()` but was missing from the update path, allowing organisators to edit a time slot to a past start time.
- **#417** - Migrated `Skills` and `Languages` storage from pipe-delimited text to JSON. Includes a data migration (`array_to_json(string_to_array(skills, '|'))`) to convert existing rows. A `ValueComparer` is set so EF change tracking works correctly for the collection.
- **#407** - Added four missing composite indexes: `(opportunity_id, status)` and `(volunteer_id, status)` on `engagement`, and `(recipient_id, is_read)` and `(recipient_id, created_on)` on `notification`.

## Test plan

- [ ] CI build passes (dotnet + frontend workflows)
- [ ] `TimeSlot.Update()` with a past start date returns 400
- [ ] User profile skills/languages round-trip correctly after migration
- [ ] New indexes appear in `\d engagement` and `\d notification` in psql
- [ ] Security scan no longer runs on PRs (only push to main + schedule)

## Live verification

Will be verified on staging after `v1.0.0-rc.106` is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNGQc9A1GU2AJkj53SbFFg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNGQc9A1GU2AJkj53SbFFg)_