### PR TITLE
fix: add notification titles and deep-links, drop security scan push trigger

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,6 @@
 name: Dependency Security Scan
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/security.yml'
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -3143,6 +3143,8 @@
           "id",
           "kind",
           "relatedEntityId",
+          "relatedTitle",
+          "actionUrl",
           "isRead",
           "createdOn"
         ],
@@ -3158,6 +3160,18 @@
           "relatedEntityId": {
             "type": "string",
             "format": "uuid"
+          },
+          "relatedTitle": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "actionUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isRead": {
             "type": "boolean"

--- a/backend/src/Application/Notifications/NotificationSummary.cs
+++ b/backend/src/Application/Notifications/NotificationSummary.cs
@@ -4,5 +4,7 @@ public sealed record NotificationSummary(
 	Guid Id,
 	string Kind,
 	Guid RelatedEntityId,
+	string? RelatedTitle,
+	string? ActionUrl,
 	bool IsRead,
 	DateTimeOffset CreatedOn);

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -1,5 +1,7 @@
 using Application.Notifications;
+using Domain.Notifications;
 using Domain.Users;
+using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
@@ -8,17 +10,88 @@ internal sealed class NotificationReadRepository(
 	ApplicationDbContext dbContext)
 	: INotificationReadRepository
 {
+	private static readonly NotificationKind[] EngagementKinds =
+	[
+		NotificationKind.EngagementCreated,
+		NotificationKind.EngagementConfirmed,
+		NotificationKind.EngagementCancelled,
+		NotificationKind.EngagementWithdrawn,
+	];
+
 	public async ValueTask<List<NotificationSummary>> GetByRecipientAsync(
 		UserId recipientId,
-		CancellationToken cancellationToken = default) =>
-		await dbContext.NotificationsQuery
+		CancellationToken cancellationToken = default)
+	{
+		var notifications = await dbContext.NotificationsQuery
 			.Where(n => n.RecipientId == recipientId)
 			.OrderByDescending(n => n.CreatedOn)
-			.Select(n => new NotificationSummary(
+			.ToListAsync(cancellationToken);
+
+		// Collect entity IDs by type
+		var engagementIds = notifications
+			.Where(n => EngagementKinds.Contains(n.Kind))
+			.Select(n => n.RelatedEntityId)
+			.ToHashSet();
+
+		var directOpportunityIds = notifications
+			.Where(n => !EngagementKinds.Contains(n.Kind))
+			.Select(n => n.RelatedEntityId)
+			.ToHashSet();
+
+		// Batch-fetch engagements and compute opportunity IDs from them
+		Dictionary<Guid, Guid> engagementToOpportunity = [];
+		if (engagementIds.Count > 0)
+		{
+			engagementToOpportunity = await dbContext.EngagementsQuery
+				.Where(e => engagementIds.Contains(e.Id.Value))
+				.Select(e => new { EngId = e.Id.Value, OppId = e.OpportunityId.Value })
+				.ToDictionaryAsync(x => x.EngId, x => x.OppId, cancellationToken);
+		}
+
+		var opportunityIdsFromEngagements = engagementToOpportunity.Values.ToHashSet();
+		var allOpportunityIds = opportunityIdsFromEngagements.Union(directOpportunityIds).ToHashSet();
+
+		// Batch-fetch opportunity titles
+		Dictionary<Guid, string> opportunityTitles = [];
+		if (allOpportunityIds.Count > 0)
+		{
+			opportunityTitles = await dbContext.VolunteerOpportunitiesQuery
+				.Where(o => allOpportunityIds.Contains(o.Id.Value))
+				.Select(o => new { Id = o.Id.Value, o.Title })
+				.ToDictionaryAsync(x => x.Id, x => x.Title, cancellationToken);
+		}
+
+		return notifications.Select(n =>
+		{
+			string? relatedTitle = null;
+			string? actionUrl = null;
+
+			if (EngagementKinds.Contains(n.Kind) &&
+				engagementToOpportunity.TryGetValue(n.RelatedEntityId, out var opportunityId))
+			{
+				opportunityTitles.TryGetValue(opportunityId, out relatedTitle);
+
+				actionUrl = n.Kind is NotificationKind.EngagementCreated or NotificationKind.EngagementWithdrawn
+					? $"/volunteer-opportunities/{opportunityId}/engagements"
+					: "/my-engagements";
+			}
+			else if (!EngagementKinds.Contains(n.Kind))
+			{
+				opportunityTitles.TryGetValue(n.RelatedEntityId, out relatedTitle);
+
+				actionUrl = n.Kind == NotificationKind.OpportunityUpdated
+					? $"/volunteer-opportunities/{n.RelatedEntityId}"
+					: "/my-engagements";
+			}
+
+			return new NotificationSummary(
 				n.Id.Value,
 				n.Kind.ToString(),
 				n.RelatedEntityId,
+				relatedTitle,
+				actionUrl,
 				n.IsRead,
-				n.CreatedOn))
-			.ToListAsync(cancellationToken);
+				n.CreatedOn);
+		}).ToList();
+	}
 }

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -1,4 +1,5 @@
 using Application.Notifications;
+using Domain.Engagements;
 using Domain.Notifications;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
@@ -42,10 +43,12 @@ internal sealed class NotificationReadRepository(
 		Dictionary<Guid, Guid> engagementToOpportunity = [];
 		if (engagementIds.Count > 0)
 		{
-			engagementToOpportunity = await dbContext.EngagementsQuery
-				.Where(e => engagementIds.Contains(e.Id.Value))
-				.Select(e => new { EngId = e.Id.Value, OppId = e.OpportunityId.Value })
-				.ToDictionaryAsync(x => x.EngId, x => x.OppId, cancellationToken);
+			var engagementIdVOs = engagementIds.Select(id => new EngagementId(id)).ToList();
+			var engagementRows = await dbContext.EngagementsQuery
+				.Where(e => engagementIdVOs.Contains(e.Id))
+				.Select(e => new { e.Id, e.OpportunityId })
+				.ToListAsync(cancellationToken);
+			engagementToOpportunity = engagementRows.ToDictionary(x => x.Id.Value, x => x.OpportunityId.Value);
 		}
 
 		var opportunityIdsFromEngagements = engagementToOpportunity.Values.ToHashSet();
@@ -55,10 +58,12 @@ internal sealed class NotificationReadRepository(
 		Dictionary<Guid, string> opportunityTitles = [];
 		if (allOpportunityIds.Count > 0)
 		{
-			opportunityTitles = await dbContext.VolunteerOpportunitiesQuery
-				.Where(o => allOpportunityIds.Contains(o.Id.Value))
-				.Select(o => new { Id = o.Id.Value, o.Title })
-				.ToDictionaryAsync(x => x.Id, x => x.Title, cancellationToken);
+			var opportunityIdVOs = allOpportunityIds.Select(id => new VolunteerOpportunityId(id)).ToList();
+			var opportunityRows = await dbContext.VolunteerOpportunitiesQuery
+				.Where(o => opportunityIdVOs.Contains(o.Id))
+				.Select(o => new { o.Id, o.Title })
+				.ToListAsync(cancellationToken);
+			opportunityTitles = opportunityRows.ToDictionary(x => x.Id.Value, x => x.Title);
 		}
 
 		return notifications.Select(n =>

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -5163,6 +5163,12 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid RelatedEntityId { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("relatedTitle")]
+        public string? RelatedTitle { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("actionUrl")]
+        public string? ActionUrl { get; set; } = default!;
+
         [System.Text.Json.Serialization.JsonPropertyName("isRead")]
         public bool IsRead { get; set; } = default!;
 

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class NotificationTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetMyNotifications_EngagementCreated_HasRelatedTitleAndDeepLink(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Deep-Link Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+
+		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+		notification.RelatedTitle.Should().Be(opportunityTitle);
+		notification.ActionUrl.Should()
+			.StartWith($"/volunteer-opportunities/{opportunity.Id}/engagements");
+	}
+
+	[Test]
+	public async Task GetMyNotifications_EngagementConfirmed_HasRelatedTitleAndMyEngagementsUrl(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Confirm Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "Ready to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken);
+
+		var notification = veraNotifications.Single(n => n.Kind == "EngagementConfirmed");
+		notification.RelatedTitle.Should().Be(opportunityTitle);
+		notification.ActionUrl.Should().Be("/my-engagements");
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"NotifTestOrg_{Guid.NewGuid()}" },
+			cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken)
+	{
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = title,
+				Description = "Integration test opportunity for notifications",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+			},
+			cancellationToken);
+	}
+}

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task NotificationBell_IsVisible_WhenAuthenticated()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task NotificationBell_OpensPanel_WhenClicked()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await bell.ClickAsync();
+
+		var panel = Page.GetByTestId("notification-panel");
+		await Expect(panel).ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -2522,6 +2522,8 @@ export interface NotificationSummary {
     id: string;
     kind: string;
     relatedEntityId: string;
+    relatedTitle: string | undefined;
+    actionUrl: string | undefined;
     isRead: boolean;
     createdOn: Date;
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -214,7 +214,7 @@ export default function Header() {
 																		);
 																	}
 																	setNotifOpen(false);
-																	navigate("/my-engagements");
+																	navigate(n.actionUrl ?? "/my-engagements");
 																}}
 															>
 																<span className="flex items-start gap-2">
@@ -226,7 +226,10 @@ export default function Header() {
 																			`notifications.kinds.${n.kind}` as Parameters<
 																				typeof t
 																			>[0],
-																			{ defaultValue: n.kind },
+																			{
+																				title: n.relatedTitle ?? "",
+																				defaultValue: n.kind,
+																			},
 																		)}
 																		<br />
 																		<span className="text-xs text-gray-400">
@@ -524,7 +527,7 @@ export default function Header() {
 																}
 																setNotifOpen(false);
 																setMobileOpen(false);
-																navigate("/my-engagements");
+																navigate(n.actionUrl ?? "/my-engagements");
 															}}
 														>
 															<span className="flex items-start gap-2">
@@ -536,7 +539,10 @@ export default function Header() {
 																		`notifications.kinds.${n.kind}` as Parameters<
 																			typeof t
 																		>[0],
-																		{ defaultValue: n.kind },
+																		{
+																			title: n.relatedTitle ?? "",
+																			defaultValue: n.kind,
+																		},
 																	)}
 																	<br />
 																	<span className="text-xs text-gray-400">

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -144,6 +144,7 @@ export default function Header() {
 								<div className="relative" ref={notifRef}>
 									<button
 										type="button"
+										data-testid="notification-bell"
 										onClick={() => setNotifOpen((o) => !o)}
 										className={`relative p-2 rounded-lg transition-colors cursor-pointer ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-500 hover:text-brand-600 hover:bg-brand-50"}`}
 										aria-label={t("notifications.bellLabel")}
@@ -171,7 +172,10 @@ export default function Header() {
 
 									{/* Notification dropdown */}
 									{notifOpen && (
-										<div className="absolute right-0 top-full mt-2 w-80 rounded-lg bg-white border border-gray-200 shadow-lg z-50">
+										<div
+											data-testid="notification-panel"
+											className="absolute right-0 top-full mt-2 w-80 rounded-lg bg-white border border-gray-200 shadow-lg z-50"
+										>
 											<div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
 												<p className="text-sm font-medium text-gray-900">
 													{t("notifications.bellLabel")}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -479,11 +479,11 @@
       "markAllRead": "Alle als gelesen markieren",
       "empty": "Keine Benachrichtigungen.",
       "kinds": {
-        "EngagementCreated": "Neue Bewerbung eingegangen",
-        "EngagementConfirmed": "Deine Bewerbung wurde bestätigt",
-        "EngagementCancelled": "Deine Bewerbung wurde abgesagt",
-        "EngagementWithdrawn": "Eine Bewerbung wurde zurückgezogen",
-        "OpportunityUpdated": "Ein Bedarf, für den du dich angemeldet hast, wurde aktualisiert",
+        "EngagementCreated": "Neue Bewerbung eingegangen fur {{title}}",
+        "EngagementConfirmed": "Deine Bewerbung fur {{title}} wurde bestätigt",
+        "EngagementCancelled": "Deine Bewerbung fur {{title}} wurde abgesagt",
+        "EngagementWithdrawn": "Eine Bewerbung fur {{title}} wurde zurückgezogen",
+        "OpportunityUpdated": "{{title}} wurde aktualisiert",
         "OpportunityDeleted": "Ein Bedarf, für den du dich angemeldet hast, wurde entfernt"
       }
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -479,11 +479,11 @@
       "markAllRead": "Mark all as read",
       "empty": "No notifications.",
       "kinds": {
-        "EngagementCreated": "New application received",
-        "EngagementConfirmed": "Your application was confirmed",
-        "EngagementCancelled": "Your application was cancelled",
-        "EngagementWithdrawn": "An application was withdrawn",
-        "OpportunityUpdated": "An opportunity you signed up for was updated",
+        "EngagementCreated": "New application received for {{title}}",
+        "EngagementConfirmed": "Your application for {{title}} was confirmed",
+        "EngagementCancelled": "Your application for {{title}} was cancelled",
+        "EngagementWithdrawn": "An application for {{title}} was withdrawn",
+        "OpportunityUpdated": "{{title}} was updated",
         "OpportunityDeleted": "An opportunity you signed up for was removed"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "editorconfig-checker": "6.1.1",
-        "playwright": "1.61.0"
+        "playwright": "^1.61.0"
       }
     },
     "node_modules/editorconfig-checker": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "editorconfig-checker": "6.1.1",
-    "playwright": "1.61.0"
+    "playwright": "^1.61.0"
   }
 }

--- a/scripts/smoke-test-notifications.mjs
+++ b/scripts/smoke-test-notifications.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for notification deep-links and enriched titles (issues #367, #462).
+ *
+ * Verifies:
+ *   1. API health check passes
+ *   2. GET /v1/notifications returns relatedTitle and actionUrl fields (when auth)
+ *   3. Notification bell is visible after login in browser
+ *   4. Clicking the bell opens the notification panel
+ *
+ * Run: node scripts/smoke-test-notifications.mjs
+ */
+
+import { chromium } from "playwright";
+
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const REALM = "einsatzbereit";
+const CLIENT_ID = "frontend";
+
+let passed = 0;
+let failed = 0;
+
+function ok(label) {
+	console.log(`  PASS  ${label}`);
+	passed++;
+}
+
+function fail(label, detail) {
+	console.error(`  FAIL  ${label}: ${detail}`);
+	failed++;
+}
+
+// --- API health ---
+async function checkHealth() {
+	console.log("\n[Health]");
+	const res = await fetch(`${API}/health`);
+	if (res.ok) {
+		ok(`GET /health -> ${res.status}`);
+	} else {
+		fail("GET /health", `got ${res.status}`);
+	}
+}
+
+// --- Get Keycloak token for vera ---
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) {
+		throw new Error(`Token fetch failed: ${res.status}`);
+	}
+	const { access_token } = await res.json();
+	return access_token;
+}
+
+// --- API: check notification schema ---
+async function checkNotificationSchema() {
+	console.log("\n[Notification API schema]");
+
+	let token;
+	try {
+		token = await getToken("vera", "vera123");
+		ok("Keycloak token acquired for vera");
+	} catch (e) {
+		fail("Keycloak token", e.message);
+		return;
+	}
+
+	const res = await fetch(`${API}/v1/notifications`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+
+	if (!res.ok) {
+		fail("GET /v1/notifications", `status ${res.status}`);
+		return;
+	}
+
+	ok("GET /v1/notifications -> 200");
+
+	const notifications = await res.json();
+
+	// Even if empty, the response must be an array
+	if (!Array.isArray(notifications)) {
+		fail("GET /v1/notifications response shape", "expected array");
+		return;
+	}
+
+	ok(`Response is an array (${notifications.length} items)`);
+
+	// Verify schema fields exist on any notification that's present
+	for (const n of notifications) {
+		if (!("relatedTitle" in n)) {
+			fail("notification.relatedTitle", "field missing from response");
+			return;
+		}
+		if (!("actionUrl" in n)) {
+			fail("notification.actionUrl", "field missing from response");
+			return;
+		}
+		// Check actionUrl routing logic
+		if (n.kind === "EngagementCreated" || n.kind === "EngagementWithdrawn") {
+			if (n.actionUrl && !n.actionUrl.includes("/volunteer-opportunities/")) {
+				fail(
+					`${n.kind} actionUrl`,
+					`expected /volunteer-opportunities/... got ${n.actionUrl}`,
+				);
+				return;
+			}
+		}
+		if (n.kind === "EngagementConfirmed" || n.kind === "EngagementCancelled") {
+			if (n.actionUrl && n.actionUrl !== "/my-engagements") {
+				fail(
+					`${n.kind} actionUrl`,
+					`expected /my-engagements got ${n.actionUrl}`,
+				);
+				return;
+			}
+		}
+	}
+
+	if (notifications.length > 0) {
+		const sample = notifications[0];
+		ok(
+			`First notification: kind=${sample.kind}, title="${sample.relatedTitle ?? "(none)"}", url=${sample.actionUrl ?? "(none)"}`,
+		);
+	} else {
+		ok("No notifications for vera (empty list is valid, schema fields present)");
+	}
+}
+
+// --- Browser: verify notification bell ---
+async function checkNotificationBell() {
+	console.log("\n[Browser: notification bell]");
+
+	const browser = await chromium.launch({ headless: true });
+	const context = await browser.newContext({ ignoreHTTPSErrors: true });
+	const page = await context.newPage();
+
+	try {
+		await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30_000 });
+
+		// Two-step Keycloak login on live
+		await page.getByRole("button", { name: /sign in|anmelden/i }).first().click();
+		await page.waitForURL(`**/${REALM}/**`, { timeout: 15_000 });
+		await page.locator("#username").fill("vera");
+		await page.locator("#kc-login").click();
+		await page.locator("#password").fill("vera123");
+		await page.locator("#kc-login").click();
+
+		await page.waitForURL(`${FRONTEND}/`, { timeout: 30_000 });
+		ok("Login as vera succeeded");
+
+		// Bell button
+		const bell = page.getByTestId("notification-bell");
+		await bell.waitFor({ state: "visible", timeout: 10_000 });
+		ok("Notification bell is visible");
+
+		// Open panel
+		await bell.click();
+		const panel = page.getByTestId("notification-panel");
+		await panel.waitFor({ state: "visible", timeout: 5_000 });
+		ok("Notification panel opens after clicking bell");
+
+		// Close panel (click outside)
+		await page.keyboard.press("Escape");
+	} catch (e) {
+		fail("Browser notification bell check", e.message);
+	} finally {
+		await browser.close();
+	}
+}
+
+async function main() {
+	console.log("=== Smoke test: notification deep-links (issues #367, #462) ===");
+
+	await checkHealth();
+	await checkNotificationSchema();
+	await checkNotificationBell();
+
+	console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);
+	if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => {
+	console.error("Unexpected error:", e);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Fixes #367** - Notifications now show the opportunity title and deep-link to the relevant page instead of always navigating to `/my-engagements`
- **Fixes #462** - Security scan no longer runs on push to `main`, removing the circular dependency where a CVE in main blocks all PRs

## Changes

### #367 - Rich notification messages with deep-links

**Backend:**
- Added `RelatedTitle string?` and `ActionUrl string?` to `NotificationSummary`
- `NotificationReadRepository` now batch-fetches engagements and opportunities to populate these fields using value-object instances in `Contains()` to ensure correct EF Core LINQ translation
- Engagement notifications (Created/Confirmed/Cancelled/Withdrawn): look up opportunity title via engagement -> opportunity join
- Opportunity notifications (Updated/Deleted): look up title directly

**ActionUrl routing:**
| Kind | Recipient | ActionUrl |
|---|---|---|
| `EngagementCreated` | organisator | `/volunteer-opportunities/{id}/engagements` |
| `EngagementWithdrawn` | organisator | `/volunteer-opportunities/{id}/engagements` |
| `EngagementConfirmed` | volunteer | `/my-engagements` |
| `EngagementCancelled` | volunteer | `/my-engagements` |
| `OpportunityUpdated` | volunteer | `/volunteer-opportunities/{id}` |
| `OpportunityDeleted` | volunteer | `/my-engagements` |

**Frontend:**
- `Header.tsx` uses `n.actionUrl ?? "/my-engagements"` for click navigation (both desktop and mobile)
- i18n strings updated to include `{{title}}` placeholder (en + de)
- NSwag-generated client updated automatically

### #462 - Security scan no longer blocks PRs

Removed the `push: branches: [main]` trigger from `security.yml`. The scan still runs:
- Weekly on Monday at 6 AM UTC (scheduled)
- On-demand via `workflow_dispatch`

This breaks the circular dependency: a CVE in `main` no longer blocks the PR that would fix it.

## Test plan

- [x] CI passes (dotnet build + frontend lint + IntegrationTests + VisualTests)
- [x] Smoke test on staging after RC deploy
- [x] `GET /v1/notifications` returns 200 with `relatedTitle` and `actionUrl` fields
- [x] Notification bell visible and panel opens after clicking

## Live verification

Deployed as **v1.0.0-rc.115** - all publish jobs and deploy-staging succeeded (2026-06-18 10:43 UTC).

Smoke test against `https://einsatzbereit.maik-hasler.de` (8/8 passed):

```
=== Smoke test: notification deep-links (issues #367, #462) ===

[Health]
  PASS  GET /health -> 200

[Notification API schema]
  PASS  Keycloak token acquired for vera
  PASS  GET /v1/notifications -> 200
  PASS  Response is an array (3 items)
  PASS  First notification: kind=OpportunityDeleted, title="(none)", url=/my-engagements

[Browser: notification bell]
  PASS  Login as vera succeeded
  PASS  Notification bell is visible
  PASS  Notification panel opens after clicking bell

=== Results: 8 passed, 0 failed ===
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014owT5Y4vfRivSb2CRMX9bL)_