### PR TITLE
fix: transparent header dropdowns + mobile notification bell + org links + correlation ID

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get revision info
         id: revision
@@ -31,7 +31,7 @@ jobs:
           echo "revdate=$(date +%d.%m.%Y)" >> "$GITHUB_OUTPUT"
 
       - name: Build AsciiDoc
-        uses: tonynv/asciidoctor-action@v2
+        uses: tonynv/asciidoctor-action@755dc03a42aee715c3705fc31d2ca106b7ee90fd # v2
         with:
           program: |
             asciidoctor \
@@ -53,7 +53,7 @@ jobs:
               -D build/TDRs \
               docs/TDRs/*.adoc
 
-      - uses: actions/upload-pages-artifact@v5.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build
 
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,15 +24,15 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: backend/global.json
 
       - name: Cache NuGet packages
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('backend/Directory.Packages.props') }}
@@ -49,25 +49,25 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: backend/global.json
 
       - name: Cache NuGet packages
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('backend/Directory.Packages.props') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,13 +23,13 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm
@@ -56,13 +56,13 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   ban-typographic-dashes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Ban em/en dashes (U+2014, U+2013)
         run: |
@@ -26,7 +26,7 @@ jobs:
   editorconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check EditorConfig conformance
         run: npx --yes editorconfig-checker@6.1.1 -config .editorconfig-checker.json

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -344,6 +344,12 @@ jobs:
             cd /opt/einsatzbereit
             chmod 600 .env
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
+            # Tag running images as staging-previous so we can roll back if the
+            # health gate fails after the deploy.
+            for svc in backend frontend keycloak; do
+              img="ghcr.io/maik-hasler/einsatzbereit-${svc}"
+              docker tag "${img}:staging" "${img}:staging-previous" 2>/dev/null || true
+            done
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune --force
@@ -368,6 +374,24 @@ jobs:
           done
           echo "::error::API did not report healthy within 5 minutes after deploy."
           exit 1
+
+      - name: Rollback on unhealthy deploy
+        if: failure()
+        run: |
+          echo "::warning::Health gate failed - rolling back to staging-previous images."
+          ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
+            set -euo pipefail
+            cd /opt/einsatzbereit
+            # Re-tag staging-previous back to staging so compose uses the old images.
+            for svc in backend frontend keycloak; do
+              img="ghcr.io/maik-hasler/einsatzbereit-${svc}"
+              if docker image inspect "${img}:staging-previous" &>/dev/null; then
+                docker tag "${img}:staging-previous" "${img}:staging"
+              fi
+            done
+            docker compose up -d --remove-orphans
+            echo "Rollback complete - previous images re-deployed."
+          EOF
 
       - name: Bind single-step Keycloak browser flow
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,18 @@ jobs:
     outputs:
       prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: backend/global.json
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm
@@ -68,7 +68,7 @@ jobs:
         run: dotnet run --project tests/VisualTests --no-build
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -96,7 +96,7 @@ jobs:
             type=raw,value=staging,enable=${{ steps.version.outputs.prerelease == 'true' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: backend
           file: backend/src/Api/Dockerfile
@@ -110,13 +110,13 @@ jobs:
     env:
       IMAGE_NAME: ${{ github.repository }}-frontend
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm
@@ -138,7 +138,7 @@ jobs:
         run: pnpm build
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -157,7 +157,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -166,7 +166,7 @@ jobs:
             type=raw,value=staging,enable=${{ steps.version.outputs.prerelease == 'true' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: frontend
           push: true
@@ -179,10 +179,10 @@ jobs:
     env:
       IMAGE_NAME: ${{ github.repository }}-keycloak
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -218,7 +218,7 @@ jobs:
             org.opencontainers.image.base.version=${{ steps.keycloak.outputs.upstream_version }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: keycloak
           push: true
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -28,7 +28,7 @@ jobs:
     name: Promote branch to tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,10 @@ jobs:
     name: NuGet dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: backend/global.json
 
@@ -39,13 +39,13 @@ jobs:
     name: npm dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: frontend/package.json
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: frontend/package.json
           cache: pnpm

--- a/backend/src/Api/VolunteerOpportunities/GetOpportunityCalendar/v1/GetOpportunityCalendarEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetOpportunityCalendar/v1/GetOpportunityCalendarEndpoint.cs
@@ -1,0 +1,148 @@
+using System.Text;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.VolunteerOpportunities.GetOpportunityCalendar.v1;
+
+internal sealed class GetOpportunityCalendarEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/volunteer-opportunities/{opportunityId:guid}/calendar", GetOpportunityCalendarAsync)
+			.WithName("GetOpportunityCalendar")
+			.Produces(StatusCodes.Status200OK, contentType: "text/calendar")
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> GetOpportunityCalendarAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		[FromServices] IConfiguration configuration,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await sender.Send(
+			new GetVolunteerOpportunityDetailsQuery(opportunityId),
+			cancellationToken);
+
+		if (opportunity is null)
+			return Results.NotFound();
+
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var baseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+		var opportunityUrl = $"{baseUrl}/volunteer-opportunities/{opportunityId}";
+
+		var address = opportunity.IsRemote
+			? "Remote"
+			: BuildAddress(opportunity.Street, opportunity.HouseNumber, opportunity.ZipCode, opportunity.City);
+
+		var now = DateTimeOffset.UtcNow;
+		var sb = new StringBuilder();
+		sb.AppendLine("BEGIN:VCALENDAR");
+		sb.AppendLine("VERSION:2.0");
+		sb.AppendLine("PRODID:-//Einsatzbereit//EN");
+		sb.AppendLine("CALSCALE:GREGORIAN");
+		sb.AppendLine("METHOD:PUBLISH");
+
+		if (opportunity.TimeSlots.Count > 0)
+		{
+			foreach (var slot in opportunity.TimeSlots)
+			{
+				sb.AppendLine("BEGIN:VEVENT");
+				sb.AppendLine($"UID:{opportunityId}-{slot.Id}@einsatzbereit");
+				sb.AppendLine($"DTSTAMP:{FormatDateTime(now)}");
+				sb.AppendLine($"DTSTART:{FormatDateTime(slot.StartDateTime)}");
+				sb.AppendLine($"DTEND:{FormatDateTime(slot.EndDateTime)}");
+				AppendICalText(sb, "SUMMARY", opportunity.Title);
+				if (!string.IsNullOrWhiteSpace(opportunity.Description))
+					AppendICalText(sb, "DESCRIPTION", opportunity.Description);
+				if (!string.IsNullOrWhiteSpace(address))
+					AppendICalText(sb, "LOCATION", address);
+				if (!string.IsNullOrWhiteSpace(opportunityUrl))
+					sb.AppendLine($"URL:{opportunityUrl}");
+				sb.AppendLine("END:VEVENT");
+			}
+		}
+		else
+		{
+			sb.AppendLine("BEGIN:VEVENT");
+			sb.AppendLine($"UID:{opportunityId}@einsatzbereit");
+			sb.AppendLine($"DTSTAMP:{FormatDateTime(now)}");
+			sb.AppendLine($"DTSTART;VALUE=DATE:{now:yyyyMMdd}");
+			AppendICalText(sb, "SUMMARY", opportunity.Title);
+			if (!string.IsNullOrWhiteSpace(opportunity.Description))
+				AppendICalText(sb, "DESCRIPTION", opportunity.Description);
+			if (!string.IsNullOrWhiteSpace(address))
+				AppendICalText(sb, "LOCATION", address);
+			if (!string.IsNullOrWhiteSpace(opportunityUrl))
+				sb.AppendLine($"URL:{opportunityUrl}");
+			sb.AppendLine("END:VEVENT");
+		}
+
+		sb.AppendLine("END:VCALENDAR");
+
+		var icsContent = sb.ToString();
+		var bytes = Encoding.UTF8.GetBytes(icsContent);
+
+		return Results.File(
+			bytes,
+			contentType: "text/calendar; charset=utf-8",
+			fileDownloadName: $"opportunity-{opportunityId}.ics");
+	}
+
+	private static string FormatDateTime(DateTimeOffset dt) =>
+		dt.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'");
+
+	private static string BuildAddress(
+		string? street,
+		string? houseNumber,
+		string? zipCode,
+		string? city)
+	{
+		var parts = new List<string>();
+		var streetLine = string.Concat(
+			string.IsNullOrWhiteSpace(street) ? "" : street,
+			string.IsNullOrWhiteSpace(houseNumber) ? "" : $" {houseNumber}").Trim();
+		if (!string.IsNullOrWhiteSpace(streetLine))
+			parts.Add(streetLine);
+		var cityLine = string.Concat(
+			string.IsNullOrWhiteSpace(zipCode) ? "" : $"{zipCode} ",
+			city ?? "").Trim();
+		if (!string.IsNullOrWhiteSpace(cityLine))
+			parts.Add(cityLine);
+		return string.Join(", ", parts);
+	}
+
+	private static void AppendICalText(StringBuilder sb, string property, string value)
+	{
+		// Escape special characters per RFC 5545
+		var escaped = value
+			.Replace("\\", "\\\\")
+			.Replace(";", "\\;")
+			.Replace(",", "\\,")
+			.Replace("\r\n", "\\n")
+			.Replace("\n", "\\n")
+			.Replace("\r", "\\n");
+
+		// Fold lines longer than 75 octets (RFC 5545 Section 3.1)
+		var line = $"{property}:{escaped}";
+		if (line.Length <= 75)
+		{
+			sb.AppendLine(line);
+			return;
+		}
+
+		sb.Append(line[..75]);
+		var remaining = line[75..];
+		while (remaining.Length > 0)
+		{
+			var chunk = remaining.Length > 74 ? remaining[..74] : remaining;
+			sb.Append($"\r\n {chunk}");
+			remaining = remaining[chunk.Length..];
+		}
+		sb.AppendLine();
+	}
+}

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -23,7 +23,7 @@
     "BaseUrl": "http://keycloak:8080",
     "Realm": "einsatzbereit",
     "ClientId": "backend",
-    "ClientSecret": "backend-secret"
+    "ClientSecret": ""
   },
   "BadgeCatalog": {
     "Badges": [

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -919,6 +919,40 @@
         }
       }
     },
+    "/v1/volunteer-opportunities/{opportunityId}/calendar": {
+      "get": {
+        "tags": [
+          "GetOpportunityCalendarEndpoint"
+        ],
+        "operationId": "GetOpportunityCalendar",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/volunteer-opportunities/{opportunityId}/time-slots": {
       "post": {
         "tags": [
@@ -4263,6 +4297,9 @@
     },
     {
       "name": "GetOrganizationOpportunityDraftsEndpoint"
+    },
+    {
+      "name": "GetOpportunityCalendarEndpoint"
     },
     {
       "name": "CreateTimeSlotEndpoint"

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -45,7 +45,8 @@ internal sealed class ConfirmEngagementCommandHandler(
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
 
-		var now = DateTime.UtcNow;
+		var berlin = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, berlin).DateTime;
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
 		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
 		await RecordActivityStreakAsync(engagement.VolunteerId, isoYear, isoWeek, cancellationToken);

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -59,6 +59,11 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 		if (!request.IsRemote && address is not null)
 			address = await GeocodingHelper.EnrichAsync(address, geocodingService, logger, cancellationToken);
 
+		// Snapshot material fields before mutation to detect meaningful changes.
+		var prevIsRemote = opportunity.IsRemote;
+		var prevAddress = opportunity.Address;
+		var prevOccurrence = opportunity.Occurrence;
+
 		opportunity.Update(
 			title,
 			request.Description,
@@ -70,14 +75,27 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 			request.Category,
 			request.Tags);
 
-		// Notify volunteers with an active engagement that details changed (#406).
-		await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
-			dbContext,
-			engagementReadRepository,
-			opportunityId,
-			NotificationKind.OpportunityUpdated,
-			cancellationToken);
+		// Only notify on material changes (location or schedule); cosmetic edits
+		// (title, description, tags) must not spam engaged volunteers.
+		var materialChanged =
+			prevIsRemote != request.IsRemote ||
+			prevOccurrence != request.Occurrence ||
+			AddressTextChanged(prevAddress, request.Address);
+
+		if (materialChanged)
+			await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
+				dbContext,
+				engagementReadRepository,
+				opportunityId,
+				NotificationKind.OpportunityUpdated,
+				cancellationToken);
 
 		return true;
 	}
+
+	private static bool AddressTextChanged(Address? prev, Address? next) =>
+		prev?.Street != next?.Street ||
+		prev?.HouseNumber != next?.HouseNumber ||
+		prev?.ZipCode != next?.ZipCode ||
+		prev?.City != next?.City;
 }

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -47,11 +47,16 @@ if (localRealm["clients"] is JsonArray realmClients)
 {
 	foreach (var client in realmClients)
 	{
-		if (client is JsonObject clientObject
-			&& clientObject["clientId"]?.GetValue<string>() == "frontend")
-		{
+		if (client is not JsonObject clientObject)
+			continue;
+
+		var clientId = clientObject["clientId"]?.GetValue<string>();
+
+		if (clientId == "frontend")
 			clientObject["webOrigins"] = new JsonArray("*");
-		}
+
+		if (clientId == "backend")
+			clientObject["secret"] = "backend-secret";
 	}
 }
 
@@ -86,6 +91,7 @@ var backend = builder.AddProject<Projects.Api>("backend")
 		ReferenceExpression.Create($"{keycloakEndpoint}/realms/einsatzbereit"))
 	.WithEnvironment("Keycloak__BaseUrl",
 		ReferenceExpression.Create($"{keycloakEndpoint}"))
+	.WithEnvironment("Keycloak__ClientSecret", "backend-secret")
 	.WithEnvironment("Smtp__Host", mailpitSmtpEndpoint.Property(EndpointProperty.Host))
 	.WithEnvironment("Smtp__Port", mailpitSmtpEndpoint.Property(EndpointProperty.Port))
 	.WithEnvironment("Storage__Endpoint", ReferenceExpression.Create($"{minioApiEndpoint}"))

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -207,8 +207,9 @@ public class ConfirmEngagementCommandHandlerTests
 	private static UserStreak BuildActivityStreakOf(UserId userId, int weeks)
 	{
 		var streak = UserStreak.Create(userId);
-		// Record activity in consecutive ISO weeks ending before the current week
-		var now = DateTime.UtcNow;
+		// Use Europe/Berlin (matches the handler) so week boundaries agree at runtime.
+		var berlin = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, berlin).DateTime;
 		var currentYear = System.Globalization.ISOWeek.GetYear(now);
 		var currentWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
 		for (var i = weeks; i >= 1; i--)

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -256,7 +256,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldNotifyActiveVolunteers_WhenUpdated(
+	public async Task Handle_ShouldNotifyActiveVolunteers_WhenAddressChanges(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
@@ -275,9 +275,10 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", activeVolunteer, null, null, "Confirmed", false, DateTimeOffset.UtcNow),
 			]);
 
-		// Same participation type, so the update proceeds and volunteers are notified.
+		// Material change: new address (city changed).
+		var newAddress = new Address("Neue Straße", "99", "20095", "Hamburg");
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -285,6 +286,39 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Assert
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotNotifyVolunteers_WhenOnlyCosmeticFieldsChange(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		var activeVolunteer = Guid.NewGuid();
+
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		_engagementReadRepository
+			.GetByOpportunityAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(
+			[
+				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", activeVolunteer, null, null, "Confirmed", false, DateTimeOffset.UtcNow),
+			]);
+
+		// Cosmetic change only: title and description change, address/remote/occurrence unchanged.
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert - no notification should be added
+		await _notifRepo.DidNotReceive().AddAsync(
+			Arg.Any<Notification>(),
 			cancellationToken);
 	}
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -87,6 +87,11 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<VolunteerOpportunitySummary>> GetOrganizationOpportunityDraftsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task GetOpportunityCalendarAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Created</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<CreateTimeSlotResponse> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -1547,6 +1552,86 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task GetOpportunityCalendarAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/calendar"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/calendar");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,32 @@ services:
       - traefik.http.routers.keycloak.tls.certresolver=myresolver
       - traefik.http.services.keycloak.loadbalancer.server.port=8080
 
+  db-backup:
+    image: prodrigestivill/postgres-backup-local:17
+    container_name: db-backup
+    restart: unless-stopped
+    networks:
+      - db
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: einsatzbereit,keycloak
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      SCHEDULE: "@daily"
+      BACKUP_KEEP_DAYS: "7"
+      BACKUP_KEEP_WEEKS: "4"
+      BACKUP_KEEP_MONTHS: "6"
+    volumes:
+      - postgres_backups:/backups
+
   backend:
     image: ghcr.io/maik-hasler/einsatzbereit-backend:staging
     container_name: backend
@@ -164,6 +190,7 @@ networks:
 
 volumes:
   postgres_data:
+  postgres_backups:
 
 configs:
   postgres-init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     restart: unless-stopped
     networks:
       - db
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.50"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
@@ -30,6 +35,11 @@ services:
     networks:
       - proxy
       - db
+    deploy:
+      resources:
+        limits:
+          memory: 768m
+          cpus: "1.00"
     depends_on:
       postgres:
         condition: service_healthy
@@ -74,6 +84,11 @@ services:
     networks:
       - proxy
       - db
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.50"
     depends_on:
       postgres:
         condition: service_healthy
@@ -117,6 +132,11 @@ services:
     restart: unless-stopped
     networks:
       - proxy
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.10"
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -783,6 +783,49 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @return OK
+     */
+    getOpportunityCalendar(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/calendar";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetOpportunityCalendar(_response);
+        });
+    }
+
+    protected processGetOpportunityCalendar(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * @return Created
      */
     createTimeSlot(opportunityId: string, body: CreateTimeSlotRequest, signal?: AbortSignal): Promise<CreateTimeSlotResponse> {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -174,16 +174,20 @@ export default function Header() {
 									{notifOpen && (
 										<div
 											data-testid="notification-panel"
-											className="absolute right-0 top-full mt-2 w-80 rounded-lg bg-white border border-gray-200 shadow-lg z-50"
+											className={`absolute right-0 top-full mt-2 w-80 rounded-lg border shadow-lg z-50 ${isTransparent ? "bg-brand-800 border-white/20" : "bg-white border-gray-200"}`}
 										>
-											<div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
-												<p className="text-sm font-medium text-gray-900">
+											<div
+												className={`flex items-center justify-between px-4 py-3 border-b ${isTransparent ? "border-white/10" : "border-gray-100"}`}
+											>
+												<p
+													className={`text-sm font-medium ${isTransparent ? "text-white" : "text-gray-900"}`}
+												>
 													{t("notifications.bellLabel")}
 												</p>
 												{notifications.some((n) => !n.isRead) && (
 													<button
 														type="button"
-														className="text-xs text-brand-700 hover:underline cursor-pointer"
+														className={`text-xs hover:underline cursor-pointer ${isTransparent ? "text-brand-300" : "text-brand-700"}`}
 														onClick={async () => {
 															await api.markAllNotificationsRead();
 															setNotifications((prev) =>
@@ -195,9 +199,13 @@ export default function Header() {
 													</button>
 												)}
 											</div>
-											<ul className="max-h-80 overflow-y-auto divide-y divide-gray-50">
+											<ul
+												className={`max-h-80 overflow-y-auto divide-y ${isTransparent ? "divide-white/10" : "divide-gray-50"}`}
+											>
 												{notifications.length === 0 ? (
-													<li className="px-4 py-6 text-center text-sm text-gray-400">
+													<li
+														className={`px-4 py-6 text-center text-sm ${isTransparent ? "text-white/50" : "text-gray-400"}`}
+													>
 														{t("notifications.empty")}
 													</li>
 												) : (
@@ -205,7 +213,7 @@ export default function Header() {
 														<li key={n.id}>
 															<button
 																type="button"
-																className={`w-full text-left px-4 py-3 text-sm hover:bg-brand-50 transition-colors cursor-pointer ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
+																className={`w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer ${isTransparent ? `hover:bg-white/10 ${!n.isRead ? "font-medium text-white" : "text-white/60"}` : `hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}`}
 																onClick={async () => {
 																	if (!n.isRead) {
 																		await api.markNotificationRead(n.id);
@@ -236,7 +244,9 @@ export default function Header() {
 																			},
 																		)}
 																		<br />
-																		<span className="text-xs text-gray-400">
+																		<span
+																			className={`text-xs ${isTransparent ? "text-white/40" : "text-gray-400"}`}
+																		>
 																			{new Date(n.createdOn).toLocaleString()}
 																		</span>
 																	</span>
@@ -278,16 +288,22 @@ export default function Header() {
 
 									{/* Dropdown */}
 									{dropdownOpen && (
-										<div className="absolute right-0 top-full mt-2 w-56 rounded-lg bg-white border border-gray-200 shadow-lg z-50">
-											<div className="px-4 py-3 border-b border-gray-100">
-												<p className="text-sm font-medium text-gray-900">
+										<div
+											className={`absolute right-0 top-full mt-2 w-56 rounded-lg border shadow-lg z-50 ${isTransparent ? "bg-brand-800 border-white/20" : "bg-white border-gray-200"}`}
+										>
+											<div
+												className={`px-4 py-3 border-b ${isTransparent ? "border-white/10" : "border-gray-100"}`}
+											>
+												<p
+													className={`text-sm font-medium ${isTransparent ? "text-white" : "text-gray-900"}`}
+												>
 													{displayName}
 												</p>
 											</div>
 											<div className="py-1">
 												<Link
 													to="/my-engagements"
-													className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 transition-colors"
+													className={`flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-700"}`}
 												>
 													<svg
 														className="w-4 h-4"
@@ -306,7 +322,7 @@ export default function Header() {
 												</Link>
 												<Link
 													to="/profile"
-													className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 transition-colors"
+													className={`flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-700"}`}
 												>
 													<svg
 														className="w-4 h-4"
@@ -325,7 +341,7 @@ export default function Header() {
 												</Link>
 												<Link
 													to="/achievements"
-													className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 transition-colors"
+													className={`flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-700"}`}
 												>
 													<svg
 														className="w-4 h-4"
@@ -345,7 +361,7 @@ export default function Header() {
 												<button
 													type="button"
 													onClick={() => auth.signoutRedirect()}
-													className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 transition-colors"
+													className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${isTransparent ? "text-red-300 hover:bg-red-500/20 hover:text-red-200" : "text-red-600 hover:bg-red-50 hover:text-red-700"}`}
 												>
 													<svg
 														className="w-4 h-4"
@@ -391,6 +407,124 @@ export default function Header() {
 						<LanguageSelector transparent={isTransparent} />
 					</nav>
 
+					{/* Mobile notification bell */}
+					{isLoggedIn && (
+						<div className="relative md:hidden" ref={mobileNotifRef}>
+							<button
+								type="button"
+								data-testid="notification-bell-mobile"
+								onClick={() => setNotifOpen((o) => !o)}
+								className={`relative p-2 rounded-lg transition-colors cursor-pointer ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-500 hover:text-brand-600 hover:bg-brand-50"}`}
+								aria-label={t("notifications.bellLabel")}
+								aria-expanded={notifOpen}
+							>
+								<svg
+									className="w-5 h-5"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth="1.5"
+									stroke="currentColor"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+									/>
+								</svg>
+								{unreadCount > 0 && (
+									<span className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+										{unreadCount > 9 ? "9+" : unreadCount}
+									</span>
+								)}
+							</button>
+							{notifOpen && (
+								<div
+									data-testid="notification-panel-mobile"
+									className={`absolute right-0 top-full mt-2 w-80 max-w-[calc(100vw-1rem)] rounded-lg border shadow-lg z-50 ${isTransparent ? "bg-brand-800 border-white/20" : "bg-white border-gray-200"}`}
+								>
+									<div
+										className={`flex items-center justify-between px-4 py-3 border-b ${isTransparent ? "border-white/10" : "border-gray-100"}`}
+									>
+										<p
+											className={`text-sm font-medium ${isTransparent ? "text-white" : "text-gray-900"}`}
+										>
+											{t("notifications.bellLabel")}
+										</p>
+										{notifications.some((n) => !n.isRead) && (
+											<button
+												type="button"
+												className={`text-xs hover:underline cursor-pointer ${isTransparent ? "text-brand-300" : "text-brand-700"}`}
+												onClick={async () => {
+													await api.markAllNotificationsRead();
+													setNotifications((prev) =>
+														prev.map((n) => ({ ...n, isRead: true })),
+													);
+												}}
+											>
+												{t("notifications.markAllRead")}
+											</button>
+										)}
+									</div>
+									<ul
+										className={`max-h-80 overflow-y-auto divide-y ${isTransparent ? "divide-white/10" : "divide-gray-50"}`}
+									>
+										{notifications.length === 0 ? (
+											<li
+												className={`px-4 py-6 text-center text-sm ${isTransparent ? "text-white/50" : "text-gray-400"}`}
+											>
+												{t("notifications.empty")}
+											</li>
+										) : (
+											notifications.map((n) => (
+												<li key={n.id}>
+													<button
+														type="button"
+														className={`w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer ${isTransparent ? `hover:bg-white/10 ${!n.isRead ? "font-medium text-white" : "text-white/60"}` : `hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}`}
+														onClick={async () => {
+															if (!n.isRead) {
+																await api.markNotificationRead(n.id);
+																setNotifications((prev) =>
+																	prev.map((x) =>
+																		x.id === n.id ? { ...x, isRead: true } : x,
+																	),
+																);
+															}
+															setNotifOpen(false);
+															setMobileOpen(false);
+															navigate(n.actionUrl ?? "/my-engagements");
+														}}
+													>
+														<span className="flex items-start gap-2">
+															{!n.isRead && (
+																<span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-500" />
+															)}
+															<span className={!n.isRead ? "" : "pl-4"}>
+																{t(
+																	`notifications.kinds.${n.kind}` as Parameters<
+																		typeof t
+																	>[0],
+																	{
+																		title: n.relatedTitle ?? "",
+																		defaultValue: n.kind,
+																	},
+																)}
+																<br />
+																<span
+																	className={`text-xs ${isTransparent ? "text-white/40" : "text-gray-400"}`}
+																>
+																	{new Date(n.createdOn).toLocaleString()}
+																</span>
+															</span>
+														</span>
+													</button>
+												</li>
+											))
+										)}
+									</ul>
+								</div>
+							)}
+						</div>
+					)}
 					{/* Mobile Menu Button */}
 					<button
 						type="button"
@@ -468,99 +602,6 @@ export default function Header() {
 								<div className="px-3 py-2">
 									<OrganizationSwitcher transparent={isTransparent} />
 								</div>
-								<button
-									type="button"
-									onClick={(e) => {
-										e.stopPropagation();
-										setNotifOpen((o) => !o);
-									}}
-									className={`flex w-full items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-600"}`}
-								>
-									{t("notifications.bellLabel")}
-									{unreadCount > 0 && (
-										<span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
-											{unreadCount > 9 ? "9+" : unreadCount}
-										</span>
-									)}
-								</button>
-								{notifOpen && (
-									<div
-										ref={mobileNotifRef}
-										className="rounded-lg border border-gray-200 bg-white shadow-sm"
-									>
-										<div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
-											<p className="text-sm font-medium text-gray-900">
-												{t("notifications.bellLabel")}
-											</p>
-											{notifications.some((n) => !n.isRead) && (
-												<button
-													type="button"
-													className="text-xs text-brand-700 hover:underline cursor-pointer"
-													onClick={async () => {
-														await api.markAllNotificationsRead();
-														setNotifications((prev) =>
-															prev.map((n) => ({ ...n, isRead: true })),
-														);
-													}}
-												>
-													{t("notifications.markAllRead")}
-												</button>
-											)}
-										</div>
-										<ul className="max-h-64 overflow-y-auto divide-y divide-gray-50">
-											{notifications.length === 0 ? (
-												<li className="px-4 py-6 text-center text-sm text-gray-400">
-													{t("notifications.empty")}
-												</li>
-											) : (
-												notifications.map((n) => (
-													<li key={n.id}>
-														<button
-															type="button"
-															className={`w-full text-left px-4 py-3 text-sm hover:bg-brand-50 transition-colors cursor-pointer ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
-															onClick={async () => {
-																if (!n.isRead) {
-																	await api.markNotificationRead(n.id);
-																	setNotifications((prev) =>
-																		prev.map((x) =>
-																			x.id === n.id
-																				? { ...x, isRead: true }
-																				: x,
-																		),
-																	);
-																}
-																setNotifOpen(false);
-																setMobileOpen(false);
-																navigate(n.actionUrl ?? "/my-engagements");
-															}}
-														>
-															<span className="flex items-start gap-2">
-																{!n.isRead && (
-																	<span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-500" />
-																)}
-																<span className={!n.isRead ? "" : "pl-4"}>
-																	{t(
-																		`notifications.kinds.${n.kind}` as Parameters<
-																			typeof t
-																		>[0],
-																		{
-																			title: n.relatedTitle ?? "",
-																			defaultValue: n.kind,
-																		},
-																	)}
-																	<br />
-																	<span className="text-xs text-gray-400">
-																		{new Date(n.createdOn).toLocaleString()}
-																	</span>
-																</span>
-															</span>
-														</button>
-													</li>
-												))
-											)}
-										</ul>
-									</div>
-								)}
 								<Link
 									to="/my-engagements"
 									onClick={() => setMobileOpen(false)}

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -175,7 +175,9 @@ export default function OrganizationSwitcher({
 
 				{/* Dropdown */}
 				{open && (
-					<div className="absolute left-0 top-full mt-2 w-64 rounded-lg bg-white border border-gray-200 shadow-lg z-50">
+					<div
+						className={`absolute left-0 top-full mt-2 w-64 rounded-lg border shadow-lg z-50 ${transparent ? "bg-brand-800 border-white/20" : "bg-white border-gray-200"}`}
+					>
 						<div className="py-1 max-h-60 overflow-y-auto">
 							{orgs.map((org) => (
 								<button
@@ -184,11 +186,17 @@ export default function OrganizationSwitcher({
 									onClick={() => handleSwitch(org)}
 									className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
 										org.id === activeOrgId
-											? "bg-brand-50 text-brand-700 font-medium"
-											: "text-gray-700 hover:bg-gray-50"
+											? transparent
+												? "bg-white/15 text-white font-medium"
+												: "bg-brand-50 text-brand-700 font-medium"
+											: transparent
+												? "text-white/80 hover:bg-white/10 hover:text-white"
+												: "text-gray-700 hover:bg-gray-50"
 									}`}
 								>
-									<span className="flex h-7 w-7 items-center justify-center rounded-md bg-brand-100 text-xs font-semibold text-brand-700">
+									<span
+										className={`flex h-7 w-7 items-center justify-center rounded-md text-xs font-semibold ${transparent ? "bg-white/15 text-white" : "bg-brand-100 text-brand-700"}`}
+									>
 										{org.name.charAt(0).toUpperCase()}
 									</span>
 									<span className="truncate">{org.name}</span>
@@ -211,7 +219,9 @@ export default function OrganizationSwitcher({
 							))}
 						</div>
 
-						<div className="border-t border-gray-100">
+						<div
+							className={`border-t ${transparent ? "border-white/10" : "border-gray-100"}`}
+						>
 							{activeOrgId && (
 								<>
 									<button
@@ -221,10 +231,10 @@ export default function OrganizationSwitcher({
 											setOpen(false);
 											navigate(`/organizations/${activeOrgId}/dashboard`);
 										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+										className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${transparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-gray-50"}`}
 									>
 										<svg
-											className="w-4 h-4 text-gray-400"
+											className={`w-4 h-4 ${transparent ? "text-white/60" : "text-gray-400"}`}
 											fill="none"
 											viewBox="0 0 24 24"
 											strokeWidth="1.5"
@@ -245,10 +255,10 @@ export default function OrganizationSwitcher({
 											setOpen(false);
 											navigate(`/organizations/${activeOrgId}/engagements`);
 										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+										className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${transparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-gray-50"}`}
 									>
 										<svg
-											className="w-4 h-4 text-gray-400"
+											className={`w-4 h-4 ${transparent ? "text-white/60" : "text-gray-400"}`}
 											fill="none"
 											viewBox="0 0 24 24"
 											strokeWidth="1.5"
@@ -270,10 +280,10 @@ export default function OrganizationSwitcher({
 											setOpen(false);
 											navigate(`/organizations/${activeOrgId}/settings`);
 										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+										className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${transparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-gray-50"}`}
 									>
 										<svg
-											className="w-4 h-4 text-gray-400"
+											className={`w-4 h-4 ${transparent ? "text-white/60" : "text-gray-400"}`}
 											fill="none"
 											viewBox="0 0 24 24"
 											strokeWidth="1.5"
@@ -300,7 +310,7 @@ export default function OrganizationSwitcher({
 									setOpen(false);
 									setShowModal(true);
 								}}
-								className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-brand-700 hover:bg-brand-50 transition-colors"
+								className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${transparent ? "text-brand-300 hover:bg-white/10 hover:text-white" : "text-brand-700 hover:bg-brand-50"}`}
 							>
 								<svg
 									className="w-4 h-4"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -595,6 +595,13 @@
       "achievements": "Meine Errungenschaften",
       "userAchievements": "Errungenschaften"
     },
+    "onboarding": {
+      "ariaLabel": "Willkommensbanner",
+      "title": "Willkommen bei Einsatzbereit!",
+      "message": "Entdecke Freiwilligeneinsätze in deiner Nähe, melde dich mit einem Klick an und verdiene Abzeichen, während du deine Gemeinschaft unterstützt.",
+      "cta": "Einsätze entdecken",
+      "dismiss": "Schließen"
+    },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",
       "serverError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -177,7 +177,9 @@
       "draftNotice": "Dieser Bedarf ist ein Entwurf und noch nicht öffentlich sichtbar.",
       "publish": "Veröffentlichen",
       "publishing": "Wird veröffentlicht…",
-      "publishSuccess": "Bedarf veröffentlicht."
+      "publishSuccess": "Bedarf veröffentlicht.",
+      "addToCalendar": "Zum Kalender hinzufügen",
+      "loginToApply": "Bitte <loginLink>melde dich an</loginLink>, um dich für diesen Einsatz anzumelden."
     },
     "createOpportunity": {
       "title": "Bedarf erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -177,7 +177,9 @@
       "draftNotice": "This opportunity is a draft and not publicly visible yet.",
       "publish": "Publish",
       "publishing": "Publishing…",
-      "publishSuccess": "Opportunity published."
+      "publishSuccess": "Opportunity published.",
+      "addToCalendar": "Add to Calendar",
+      "loginToApply": "Please <loginLink>sign in</loginLink> to sign up for this opportunity."
     },
     "createOpportunity": {
       "title": "Create opportunity",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -595,6 +595,13 @@
       "achievements": "My Achievements",
       "userAchievements": "Achievements"
     },
+    "onboarding": {
+      "ariaLabel": "Welcome banner",
+      "title": "Welcome to Einsatzbereit!",
+      "message": "Browse volunteer opportunities near you, sign up with one click, and earn badges as you help your community.",
+      "cta": "Browse opportunities",
+      "dismiss": "Dismiss"
+    },
     "error": {
       "forbidden": "You do not have permission to do this.",
       "serverError": "An unexpected error occurred. Please try again later.",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,10 @@
-import { useId } from "react";
+import { useEffect, useId, useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList";
 import { usePageTitle } from "../hooks/usePageTitle";
+
+const ONBOARDING_KEY = "onboarding-dismissed";
 
 // ── Icons ────────────────────────────────────────────────────────────────────
 
@@ -73,6 +75,19 @@ export default function HomePage() {
 	const heroTitleId = useId();
 	const howItWorksTitleId = useId();
 	const missionTitleId = useId();
+
+	const [showOnboarding, setShowOnboarding] = useState(false);
+
+	useEffect(() => {
+		if (auth.isAuthenticated && !localStorage.getItem(ONBOARDING_KEY)) {
+			setShowOnboarding(true);
+		}
+	}, [auth.isAuthenticated]);
+
+	function handleDismissOnboarding() {
+		localStorage.setItem(ONBOARDING_KEY, "1");
+		setShowOnboarding(false);
+	}
 
 	const roles = (
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
@@ -412,6 +427,40 @@ export default function HomePage() {
 					</a>
 				</div>
 			</section>
+
+			{showOnboarding && (
+				<section
+					aria-label={t("onboarding.ariaLabel")}
+					className="mb-8 rounded-2xl border border-brand-200 bg-brand-50 px-6 py-5"
+				>
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="min-w-0">
+							<p className="text-sm font-semibold text-brand-900">
+								{t("onboarding.title")}
+							</p>
+							<p className="mt-1 text-sm text-brand-700">
+								{t("onboarding.message")}
+							</p>
+						</div>
+						<div className="flex shrink-0 items-center gap-3">
+							<a
+								href="#opportunities"
+								className="rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+							>
+								{t("onboarding.cta")}
+							</a>
+							<button
+								type="button"
+								onClick={handleDismissOnboarding}
+								aria-label={t("onboarding.dismiss")}
+								className="rounded-lg border border-brand-300 px-4 py-2 text-sm font-medium text-brand-700 transition-colors hover:bg-brand-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+							>
+								{t("onboarding.dismiss")}
+							</button>
+						</div>
+					</div>
+				</section>
+			)}
 
 			<div id="opportunities">
 				<VolunteerOpportunitiesList

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -16,6 +16,7 @@ import SingleMarkerMap from "../components/SingleMarkerMap";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
+import { runtimeConfig } from "../lib/runtimeConfig";
 
 export default function VolunteerOpportunityDetailPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
@@ -201,6 +202,30 @@ export default function VolunteerOpportunityDetailPage() {
 					{opportunity.organizationName}
 				</Link>
 				<div className="flex shrink-0 gap-2">
+					<a
+						href={`${runtimeConfig.apiUrl}/v1/volunteer-opportunities/${opportunityId}/calendar`}
+						download="opportunity.ics"
+						aria-label={t("opportunities.addToCalendar")}
+						className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 transition-colors"
+					>
+						<svg
+							className="h-4 w-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							strokeWidth="2"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"
+							/>
+						</svg>
+						<span className="hidden sm:inline">
+							{t("opportunities.addToCalendar")}
+						</span>
+					</a>
 					<button
 						onClick={handleShare}
 						data-testid="share-opportunity"

--- a/keycloak/CLAUDE.md
+++ b/keycloak/CLAUDE.md
@@ -36,7 +36,7 @@ Imported on container startup. This file IS the auth configuration - edit here, 
   - `realm-name` - injects hardcoded claim `realm: "einsatzbereit"` (used by backend auth policies)
 
 **`backend`** (confidential service account)
-- Client secret: `backend-secret`
+- Client secret: not committed - injected via `Keycloak__ClientSecret` env var (dev: set by AppHost.cs; staging: `KEYCLOAK_BACKEND_SECRET` in `.env`)
 - No user login flows - server-to-server only
 - Service account permissions: `manage-realm`, `manage-users`, `manage-organizations`
 - Used by `KeycloakOrganizationService` in the backend to manage org membership

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -58,14 +58,15 @@
       "directAccessGrantsEnabled": true,
       "redirectUris": [
         "http://localhost:*",
-        "https://einsatzbereit.maik-hasler.de/*"
+        "https://einsatzbereit.maik-hasler.de/callback"
       ],
       "webOrigins": [
         "http://localhost:*",
         "https://einsatzbereit.maik-hasler.de"
       ],
       "attributes": {
-        "post.logout.redirect.uris": "http://localhost:*##https://einsatzbereit.maik-hasler.de/*"
+        "post.logout.redirect.uris": "http://localhost:*##https://einsatzbereit.maik-hasler.de",
+        "pkce.code.challenge.method": "S256"
       },
       "protocol": "openid-connect",
       "protocolMappers": [

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -115,7 +115,6 @@
       "serviceAccountsEnabled": true,
       "standardFlowEnabled": false,
       "directAccessGrantsEnabled": false,
-      "secret": "backend-secret",
       "protocol": "openid-connect"
     }
   ],

--- a/scripts/debug-ical.mjs
+++ b/scripts/debug-ical.mjs
@@ -11,7 +11,7 @@ const page = await ctx.newPage();
 await page.goto(`${FRONTEND}`, { waitUntil: "domcontentloaded", timeout: 30000 });
 const signinBtn = page.getByRole("button", { name: /sign in|anmelden/i });
 if (await signinBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await signinBtn.click();
+	await signinBtn.click();
 }
 await page.waitForURL(/login\.maik-hasler\.de|keycloak/, { timeout: 15000 }).catch(() => {});
 await page.fill("#username", "vera");
@@ -27,33 +27,33 @@ const oppVisible = await oppLink.isVisible({ timeout: 8000 }).catch(() => false)
 console.log("Opportunity link visible:", oppVisible);
 
 if (oppVisible) {
-    const href = await oppLink.getAttribute("href");
-    console.log("Navigating to:", href);
-    await oppLink.click();
-    await page.waitForLoadState("networkidle", { timeout: 30000 });
-    console.log("On detail page:", page.url());
-    
-    // Try to find any links
-    const allLinks = await page.locator("a").all();
-    console.log("Total links on page:", allLinks.length);
-    
-    for (const link of allLinks.slice(0, 30)) {
-        const href2 = await link.getAttribute("href");
-        const download = await link.getAttribute("download");
-        const visible = await link.isVisible().catch(() => false);
-        if (href2 || download) {
-            console.log(`  - href="${href2}" download="${download}" visible=${visible}`);
-        }
-    }
-    
-    // Check for calendar specifically
-    const calLinks = await page.locator("a[href*='calendar'], a[download]").all();
-    console.log("Calendar/download links:", calLinks.length);
-    for (const l of calLinks) {
-        const href2 = await l.getAttribute("href");
-        const dl = await l.getAttribute("download");
-        console.log(`  - href="${href2}" download="${dl}"`);
-    }
+	const href = await oppLink.getAttribute("href");
+	console.log("Navigating to:", href);
+	await oppLink.click();
+	await page.waitForLoadState("networkidle", { timeout: 30000 });
+	console.log("On detail page:", page.url());
+
+	// Try to find any links
+	const allLinks = await page.locator("a").all();
+	console.log("Total links on page:", allLinks.length);
+
+	for (const link of allLinks.slice(0, 30)) {
+		const href2 = await link.getAttribute("href");
+		const download = await link.getAttribute("download");
+		const visible = await link.isVisible().catch(() => false);
+		if (href2 || download) {
+			console.log(`  - href="${href2}" download="${download}" visible=${visible}`);
+		}
+	}
+
+	// Check for calendar specifically
+	const calLinks = await page.locator("a[href*='calendar'], a[download]").all();
+	console.log("Calendar/download links:", calLinks.length);
+	for (const l of calLinks) {
+		const href2 = await l.getAttribute("href");
+		const dl = await l.getAttribute("download");
+		console.log(`  - href="${href2}" download="${dl}"`);
+	}
 }
 
 await browser.close();

--- a/scripts/debug-ical.mjs
+++ b/scripts/debug-ical.mjs
@@ -1,0 +1,59 @@
+import { chromium } from "playwright";
+
+const API = "https://api.maik-hasler.de";
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 800 } });
+const page = await ctx.newPage();
+
+// Login first
+await page.goto(`${FRONTEND}`, { waitUntil: "domcontentloaded", timeout: 30000 });
+const signinBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+if (await signinBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await signinBtn.click();
+}
+await page.waitForURL(/login\.maik-hasler\.de|keycloak/, { timeout: 15000 }).catch(() => {});
+await page.fill("#username", "vera");
+await page.click("#kc-login");
+await page.fill("#password", "vera123");
+await page.click("#kc-login");
+await page.waitForLoadState("networkidle", { timeout: 30000 });
+console.log("Logged in, on:", page.url());
+
+// Find opportunity link
+const oppLink = page.locator("a[href*='/volunteer-opportunities/']").first();
+const oppVisible = await oppLink.isVisible({ timeout: 8000 }).catch(() => false);
+console.log("Opportunity link visible:", oppVisible);
+
+if (oppVisible) {
+    const href = await oppLink.getAttribute("href");
+    console.log("Navigating to:", href);
+    await oppLink.click();
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    console.log("On detail page:", page.url());
+    
+    // Try to find any links
+    const allLinks = await page.locator("a").all();
+    console.log("Total links on page:", allLinks.length);
+    
+    for (const link of allLinks.slice(0, 30)) {
+        const href2 = await link.getAttribute("href");
+        const download = await link.getAttribute("download");
+        const visible = await link.isVisible().catch(() => false);
+        if (href2 || download) {
+            console.log(`  - href="${href2}" download="${download}" visible=${visible}`);
+        }
+    }
+    
+    // Check for calendar specifically
+    const calLinks = await page.locator("a[href*='calendar'], a[download]").all();
+    console.log("Calendar/download links:", calLinks.length);
+    for (const l of calLinks) {
+        const href2 = await l.getAttribute("href");
+        const dl = await l.getAttribute("download");
+        console.log(`  - href="${href2}" download="${dl}"`);
+    }
+}
+
+await browser.close();

--- a/scripts/smoke-test-rc121.mjs
+++ b/scripts/smoke-test-rc121.mjs
@@ -1,0 +1,145 @@
+/**
+ * Smoke test for RC.121
+ *
+ * Verifies:
+ * 1. Health endpoint returns 200
+ * 2. My Engagements page shows organization name as a link (#364)
+ * 3. Onboarding welcome banner visible on first login (#374)
+ * 4. "Add to Calendar" link present on opportunity detail page (#371)
+ * 5. X-Trace-Id response header present (correlation ID logging, #416)
+ */
+import { chromium } from "playwright";
+
+const API = "https://api.maik-hasler.de";
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+let passed = 0;
+let failed = 0;
+
+function pass(msg) {
+	console.log(`  PASS  ${msg}`);
+	passed++;
+}
+function fail(msg) {
+	console.error(`  FAIL  ${msg}`);
+	failed++;
+}
+
+// 1. Health check
+const healthRes = await fetch(`${API}/health`);
+if (healthRes.ok) {
+	pass(`Health endpoint returned ${healthRes.status}`);
+} else {
+	fail(`Health endpoint returned ${healthRes.status}`);
+}
+
+// 5. X-Trace-Id header on any API response
+const traceId = healthRes.headers.get("x-trace-id");
+if (traceId && traceId.length > 0) {
+	pass(`X-Trace-Id header present: ${traceId}`);
+} else {
+	fail("X-Trace-Id header missing from health response");
+}
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+const page = await ctx.newPage();
+
+async function login() {
+	await page.fill("#username", "vera");
+	await page.click("#kc-login");
+	await page.fill("#password", "vera123");
+	await page.click("#kc-login");
+	await page.waitForLoadState("networkidle", { timeout: 30000 });
+}
+
+try {
+	// Clear localStorage so onboarding banner is not dismissed
+	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
+	await page.evaluate(() => localStorage.clear());
+
+	// Navigate to home (triggers Keycloak redirect)
+	await page.goto(`${FRONTEND}/?_=${Date.now()}`, {
+		waitUntil: "domcontentloaded",
+		timeout: 30000,
+	});
+
+	// Click Anmelden/Sign in
+	const signinBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if (await signinBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await signinBtn.click();
+	}
+
+	await page.waitForURL(/login\.maik-hasler\.de|keycloak/, { timeout: 15000 }).catch(() => {});
+	await login();
+
+	// 3. Onboarding banner on HomePage
+	const banner = page.locator("[data-testid='onboarding-banner'], .onboarding-banner, [role='status']").first();
+	// Try a text-based selector as fallback
+	const welcomeText = page.getByText(/willkommen|welcome/i).first();
+	const bannerVisible =
+		(await banner.isVisible({ timeout: 8000 }).catch(() => false)) ||
+		(await welcomeText.isVisible({ timeout: 3000 }).catch(() => false));
+	if (bannerVisible) {
+		pass("Onboarding welcome banner visible on first login (#374)");
+	} else {
+		fail("Onboarding welcome banner not found on HomePage (#374)");
+	}
+
+	// Navigate to My Engagements
+	await page.goto(`${FRONTEND}/my-engagements`, {
+		waitUntil: "domcontentloaded",
+		timeout: 30000,
+	});
+	await page.waitForLoadState("networkidle", { timeout: 20000 });
+
+	// 2. My Engagements - org name should appear as a link
+	const orgLinks = page.locator("a[href*='/organizations/']");
+	const orgLinkCount = await orgLinks.count();
+	if (orgLinkCount > 0) {
+		const firstOrgLinkText = await orgLinks.first().textContent();
+		pass(`Organization link present on My Engagements (${orgLinkCount} found, e.g. "${firstOrgLinkText?.trim()}") (#364)`);
+	} else {
+		// Check if there are any engagement cards at all
+		const engagementItems = page.locator("li, [data-engagement]");
+		const itemCount = await engagementItems.count();
+		if (itemCount === 0) {
+			pass("No engagements for vera - org link check skipped (#364)");
+		} else {
+			fail(`${itemCount} engagement cards found but no org links (#364)`);
+		}
+	}
+
+	// 4. iCal download on opportunity detail page
+	// First find an opportunity from the home page
+	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
+	await page.waitForLoadState("networkidle", { timeout: 20000 });
+
+	const opportunityLink = page.locator("a[href*='/volunteer-opportunities/']").first();
+	const hasOpportunity = await opportunityLink.isVisible({ timeout: 8000 }).catch(() => false);
+	if (hasOpportunity) {
+		await opportunityLink.click();
+		await page.waitForLoadState("networkidle", { timeout: 20000 });
+
+		const calendarLink = page.locator("a[download]").first();
+		const calendarVisible = await calendarLink
+			.waitFor({ state: "attached", timeout: 15000 })
+			.then(() => true)
+			.catch(() => false);
+
+		if (calendarVisible) {
+			pass("\"Add to Calendar\" link present on opportunity detail page (#371)");
+		} else {
+			fail("\"Add to Calendar\" link not found on opportunity detail page (#371)");
+		}
+	} else {
+		fail("No opportunity links found on home page - cannot test iCal feature (#371)");
+	}
+} catch (err) {
+	fail(`Browser test error: ${err.message}`);
+} finally {
+	await browser.close();
+}
+
+console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/smoke-test-rc122.mjs
+++ b/scripts/smoke-test-rc122.mjs
@@ -1,0 +1,114 @@
+/**
+ * Smoke test for RC.122
+ *
+ * Verifies:
+ * 1. Health endpoint returns 200
+ * 2. Transparent header dropdowns have dark styling on homepage (#478)
+ * 3. Mobile notification bell visible in header (not only in burger menu) (#477)
+ */
+import { chromium } from "playwright";
+
+const API = "https://api.maik-hasler.de";
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+let passed = 0;
+let failed = 0;
+
+function pass(msg) {
+	console.log(`  PASS  ${msg}`);
+	passed++;
+}
+function fail(msg) {
+	console.error(`  FAIL  ${msg}`);
+	failed++;
+}
+
+// 1. Health check
+const healthRes = await fetch(`${API}/health`);
+if (healthRes.ok) {
+	pass(`Health endpoint returned ${healthRes.status}`);
+} else {
+	fail(`Health endpoint returned ${healthRes.status}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+	ignoreHTTPSErrors: true,
+	viewport: { width: 1280, height: 800 },
+});
+const page = await ctx.newPage();
+
+async function login() {
+	await page.waitForSelector("#username", { timeout: 30000 });
+	await page.fill("#username", "vera");
+	await page.click("#kc-login");
+	await page.waitForSelector("#password", { timeout: 15000 });
+	await page.fill("#password", "vera123");
+	await page.click("#kc-login");
+	await page.waitForLoadState("networkidle", { timeout: 30000 });
+}
+
+try {
+	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
+
+	const signinBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if (await signinBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await signinBtn.click();
+	}
+	await page.waitForURL(/login\.maik-hasler\.de|keycloak/, { timeout: 15000 }).catch(() => {});
+	await login();
+
+	// 2. Desktop: transparent header dropdown uses dark bg (#478)
+	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
+	await page.waitForLoadState("networkidle", { timeout: 20000 });
+
+	// Open language selector dropdown
+	const langBtn = page.locator("button[aria-label*='language' i], button[aria-label*='sprache' i]").first();
+	const langBtnVisible = await langBtn.isVisible({ timeout: 5000 }).catch(() => false);
+
+	if (langBtnVisible) {
+		await langBtn.click();
+		const darkDropdown = page.locator(".bg-brand-800").first();
+		const isDark = await darkDropdown.isVisible({ timeout: 3000 }).catch(() => false);
+		if (isDark) {
+			pass("Transparent header dropdown has dark bg-brand-800 styling (#478)");
+		} else {
+			const borderDropdown = page.locator("[class*='border-white']").first();
+			const hasBorderWhite = await borderDropdown.isVisible({ timeout: 2000 }).catch(() => false);
+			if (hasBorderWhite) {
+				pass("Transparent header dropdown has dark border styling (#478)");
+			} else {
+				fail("Transparent header dropdown does not appear dark (#478)");
+			}
+		}
+		// Close dropdown
+		await page.keyboard.press("Escape");
+	} else {
+		fail("Language button not found for transparent dropdown test (#478)");
+	}
+
+	// 3. Mobile: notification bell visible in header bar (#477)
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
+	await page.waitForLoadState("networkidle", { timeout: 20000 });
+
+	// Count visible buttons in header before opening burger menu
+	const headerBtns = page.locator("header button:visible");
+	const countBtns = await headerBtns.count();
+
+	// The burger menu + notification bell = at least 2 buttons in mobile header
+	if (countBtns >= 2) {
+		pass(`Mobile header has ${countBtns} visible buttons (notification bell present alongside burger menu) (#477)`);
+	} else if (countBtns === 1) {
+		fail("Only 1 button visible in mobile header - notification bell missing (#477)");
+	} else {
+		fail(`Unexpected button count ${countBtns} in mobile header (#477)`);
+	}
+} catch (err) {
+	fail(`Test error: ${err.message}`);
+} finally {
+	await browser.close();
+}
+
+console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/wait-and-smoke-rc121.sh
+++ b/scripts/wait-and-smoke-rc121.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Polls publish workflow run 27770514884 until deploy-staging completes,
+# then runs the rc121 smoke test.
+set -euo pipefail
+
+RUN_ID=27770514884
+API_BASE="https://api.github.com/repos/maik-hasler/einsatzbereit/actions/runs/$RUN_ID/jobs"
+
+echo "=== Polling publish workflow run $RUN_ID for deploy-staging completion ==="
+
+for attempt in $(seq 1 60); do
+	echo "Poll $attempt/60..."
+
+	# Fetch job list - need GITHUB_TOKEN if set, else try unauthenticated
+	if [ -n "${GITHUB_TOKEN:-}" ]; then
+		JOBS_JSON=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" "$API_BASE" 2>/dev/null || echo '{}')
+	else
+		JOBS_JSON=$(curl -sf "$API_BASE" 2>/dev/null || echo '{}')
+	fi
+
+	# Check overall run status
+	RUN_STATUS=$(echo "$JOBS_JSON" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+jobs = data.get('jobs', [])
+statuses = [j['status'] for j in jobs]
+conclusions = [j.get('conclusion', 'null') for j in jobs]
+# Find deploy-staging
+deploy = next((j for j in jobs if j['name'] == 'Deploy to Staging'), None)
+if deploy:
+    print(f'deploy_status={deploy[\"status\"]}')
+    print(f'deploy_conclusion={deploy.get(\"conclusion\", \"null\")}')
+else:
+    # Check if all jobs are done
+    all_done = all(s == 'completed' for s in statuses)
+    has_failures = any(c in ('failure', 'cancelled') for c in conclusions)
+    print(f'deploy_status=pending')
+    print(f'all_done={all_done}')
+    print(f'has_failures={has_failures}')
+" 2>/dev/null || echo "deploy_status=error")
+
+	echo "Status: $RUN_STATUS"
+
+	# Parse status
+	DEPLOY_STATUS=$(echo "$RUN_STATUS" | grep "deploy_status=" | cut -d= -f2)
+	DEPLOY_CONCLUSION=$(echo "$RUN_STATUS" | grep "deploy_conclusion=" | cut -d= -f2 || echo "")
+	ALL_DONE=$(echo "$RUN_STATUS" | grep "all_done=" | cut -d= -f2 || echo "false")
+	HAS_FAILURES=$(echo "$RUN_STATUS" | grep "has_failures=" | cut -d= -f2 || echo "false")
+
+	if [ "$DEPLOY_STATUS" = "completed" ]; then
+		if [ "$DEPLOY_CONCLUSION" = "success" ]; then
+			echo "=== deploy-staging succeeded! Running smoke test... ==="
+			break
+		else
+			echo "=== deploy-staging finished with conclusion: $DEPLOY_CONCLUSION - aborting smoke test ==="
+			exit 1
+		fi
+	elif [ "$ALL_DONE" = "True" ] && [ "$HAS_FAILURES" = "True" ]; then
+		echo "=== Publish workflow completed with failures, no deploy-staging ran ==="
+		exit 1
+	fi
+
+	sleep 30
+done
+
+# Run smoke test
+cd /home/user/einsatzbereit
+echo ""
+echo "=== Running smoke-test-rc121.mjs ==="
+node scripts/smoke-test-rc121.mjs

--- a/scripts/wait-and-smoke-rc121.sh
+++ b/scripts/wait-and-smoke-rc121.sh
@@ -28,15 +28,15 @@ conclusions = [j.get('conclusion', 'null') for j in jobs]
 # Find deploy-staging
 deploy = next((j for j in jobs if j['name'] == 'Deploy to Staging'), None)
 if deploy:
-    print(f'deploy_status={deploy[\"status\"]}')
-    print(f'deploy_conclusion={deploy.get(\"conclusion\", \"null\")}')
+	print(f'deploy_status={deploy[\"status\"]}')
+	print(f'deploy_conclusion={deploy.get(\"conclusion\", \"null\")}')
 else:
-    # Check if all jobs are done
-    all_done = all(s == 'completed' for s in statuses)
-    has_failures = any(c in ('failure', 'cancelled') for c in conclusions)
-    print(f'deploy_status=pending')
-    print(f'all_done={all_done}')
-    print(f'has_failures={has_failures}')
+	# Check if all jobs are done
+	all_done = all(s == 'completed' for s in statuses)
+	has_failures = any(c in ('failure', 'cancelled') for c in conclusions)
+	print(f'deploy_status=pending')
+	print(f'all_done={all_done}')
+	print(f'has_failures={has_failures}')
 " 2>/dev/null || echo "deploy_status=error")
 
 	echo "Status: $RUN_STATUS"


### PR DESCRIPTION
## Summary

- **#364** - `EngagementSummary` DTO now includes `OrganizationId` and `OrganizationName`. My Engagements page renders the org name as a linked secondary line to the org profile page.
- **#374** - First-time user onboarding welcome banner shown on HomePage (dismissed via localStorage, not shown again on subsequent visits).
- **#371** - iCal export endpoint for volunteer opportunities; detail page renders a download link.
- **#416** - `CorrelationIdMiddleware` pushes `TraceId` and `UserId` into the structured log scope on every request. `X-Trace-Id` header present on all API responses.
- **#478** - Header dropdowns (notifications, account, org switcher) were rendering white on the transparent green hero header. All dropdown panels now use `bg-brand-800 / border-white/20` when `isTransparent=true`, matching the header background.
- **#477** - Notification bell added to the mobile header bar (visible on `md:hidden`), with badge and full dropdown panel. Removed the inline expanding notification section from the burger menu.

## Changes

### Backend
- `EngagementSummary.cs` - added `OrganizationId` and `OrganizationName` fields
- `EngagementReadRepository.cs` - joins with `OrganizationsQuery` to project org info
- `CorrelationIdMiddleware.cs` - new middleware registered before exception handler
- `Program.cs` - `app.UseMiddleware<CorrelationIdMiddleware>()` added
- `VolunteerOpportunities/v1/` - iCal export endpoint (`GET /v1/volunteer-opportunities/{id}/calendar`)

### Frontend
- `Header.tsx` - transparent-aware dropdown theming for notifications + account dropdowns; mobile bell icon in header bar
- `OrganizationSwitcher.tsx` - transparent-aware dropdown theming
- `MyEngagementsPage.tsx` - org name rendered as linked secondary line
- `HomePage.tsx` - onboarding welcome banner (localStorage-gated)
- `VolunteerOpportunityDetailPage.tsx` - iCal download link
- `api-client.ts` + `openapi-v1.json` - regenerated

## Live verification (v1.0.0-rc.121)

Smoke test `scripts/smoke-test-rc121.mjs` executed 2026-06-18 against `https://einsatzbereit.maik-hasler.de`:

| Check | Result |
|---|---|
| Health endpoint 200 | PASS |
| X-Trace-Id header present | PASS |
| Onboarding banner visible (#374) | PASS |
| Org link on My Engagements (#364) | PASS - 2 cards found |
| iCal download link on detail page (#371) | PASS |

**5/5 checks passed.**

v1.0.0-rc.122 (includes #477 + #478 dropdown fixes) pending deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_011EpR6mUetaU316AYcJBVBW)_