### PR TITLE
fix: allow geolocation in nginx Permissions-Policy for Near me feature (#372)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,7 +13,7 @@ server {
 	add_header X-Frame-Options "DENY" always;
 	add_header X-XSS-Protection "1; mode=block" always;
 	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 	add_header Strict-Transport-Security "max-age=31536000" always;
 
 	location / {
@@ -26,7 +26,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
 	}
 
@@ -37,7 +37,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
 	}
 
@@ -47,7 +47,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
 	}
 }

--- a/scripts/debug-nearme.mjs
+++ b/scripts/debug-nearme.mjs
@@ -1,0 +1,36 @@
+import { chromium } from "playwright";
+
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+const page = await ctx.newPage();
+
+await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
+
+// Find all buttons and print their text
+const buttons = await page.getByRole("button").all();
+console.log("All visible buttons before opening filter:");
+for (const btn of buttons) {
+  const text = (await btn.textContent())?.trim().slice(0, 80);
+  const ariaLabel = await btn.getAttribute("aria-label");
+  const visible = await btn.isVisible();
+  if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
+}
+
+// Click the location filter
+const locationBtn = page.getByRole("button").filter({ hasText: /location|standort/i }).first();
+await locationBtn.click();
+await page.waitForTimeout(500);
+
+console.log("\nAll visible buttons after opening Location filter:");
+const buttons2 = await page.getByRole("button").all();
+for (const btn of buttons2) {
+  const text = (await btn.textContent())?.trim().slice(0, 80);
+  const ariaLabel = await btn.getAttribute("aria-label");
+  const visible = await btn.isVisible();
+  if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
+}
+
+await page.screenshot({ path: "/home/user/einsatzbereit/scripts/debug-location-filter.png" });
+await browser.close();

--- a/scripts/debug-nearme.mjs
+++ b/scripts/debug-nearme.mjs
@@ -12,10 +12,10 @@ await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
 const buttons = await page.getByRole("button").all();
 console.log("All visible buttons before opening filter:");
 for (const btn of buttons) {
-  const text = (await btn.textContent())?.trim().slice(0, 80);
-  const ariaLabel = await btn.getAttribute("aria-label");
-  const visible = await btn.isVisible();
-  if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
+	const text = (await btn.textContent())?.trim().slice(0, 80);
+	const ariaLabel = await btn.getAttribute("aria-label");
+	const visible = await btn.isVisible();
+	if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
 }
 
 // Click the location filter
@@ -26,10 +26,10 @@ await page.waitForTimeout(500);
 console.log("\nAll visible buttons after opening Location filter:");
 const buttons2 = await page.getByRole("button").all();
 for (const btn of buttons2) {
-  const text = (await btn.textContent())?.trim().slice(0, 80);
-  const ariaLabel = await btn.getAttribute("aria-label");
-  const visible = await btn.isVisible();
-  if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
+	const text = (await btn.textContent())?.trim().slice(0, 80);
+	const ariaLabel = await btn.getAttribute("aria-label");
+	const visible = await btn.isVisible();
+	if (visible) console.log(`  text="${text}" aria-label="${ariaLabel}"`);
 }
 
 await page.screenshot({ path: "/home/user/einsatzbereit/scripts/debug-location-filter.png" });

--- a/scripts/debug-nearme2.mjs
+++ b/scripts/debug-nearme2.mjs
@@ -1,0 +1,44 @@
+import { chromium } from "playwright";
+
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+  ignoreHTTPSErrors: true,
+  geolocation: { latitude: 48.1351, longitude: 11.582 },
+  permissions: ["geolocation"],
+});
+const page = await ctx.newPage();
+
+// Log console messages
+page.on("console", (msg) => console.log(`[browser] ${msg.type()}: ${msg.text()}`));
+page.on("pageerror", (err) => console.log(`[browser error] ${err.message}`));
+
+// Inject geolocation debug
+await page.addInitScript(() => {
+  const orig = navigator.geolocation.getCurrentPosition.bind(navigator.geolocation);
+  navigator.geolocation.getCurrentPosition = (success, error, opts) => {
+    console.log("[geolocation] getCurrentPosition called");
+    return orig(
+      (pos) => { console.log(`[geolocation] success: ${pos.coords.latitude}, ${pos.coords.longitude}`); success(pos); },
+      (err) => { console.log(`[geolocation] error: ${err.code} ${err.message}`); error?.(err); },
+      opts
+    );
+  };
+});
+
+await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
+
+const locationBtn = page.getByRole("button").filter({ hasText: /location/i }).first();
+await locationBtn.click();
+await page.waitForTimeout(500);
+
+const nearMeBtn = page.getByRole("button", { name: /use my current location/i });
+console.log("Near me visible:", await nearMeBtn.isVisible());
+await nearMeBtn.click();
+console.log("Clicked near me button");
+await page.waitForTimeout(5000);
+
+console.log("URL after 5s:", page.url());
+await page.screenshot({ path: "/home/user/einsatzbereit/scripts/debug-nearme-after-click.png" });
+await browser.close();

--- a/scripts/debug-nearme2.mjs
+++ b/scripts/debug-nearme2.mjs
@@ -4,9 +4,9 @@ const FRONTEND = "https://einsatzbereit.maik-hasler.de";
 
 const browser = await chromium.launch({ headless: true });
 const ctx = await browser.newContext({
-  ignoreHTTPSErrors: true,
-  geolocation: { latitude: 48.1351, longitude: 11.582 },
-  permissions: ["geolocation"],
+	ignoreHTTPSErrors: true,
+	geolocation: { latitude: 48.1351, longitude: 11.582 },
+	permissions: ["geolocation"],
 });
 const page = await ctx.newPage();
 
@@ -16,15 +16,15 @@ page.on("pageerror", (err) => console.log(`[browser error] ${err.message}`));
 
 // Inject geolocation debug
 await page.addInitScript(() => {
-  const orig = navigator.geolocation.getCurrentPosition.bind(navigator.geolocation);
-  navigator.geolocation.getCurrentPosition = (success, error, opts) => {
-    console.log("[geolocation] getCurrentPosition called");
-    return orig(
-      (pos) => { console.log(`[geolocation] success: ${pos.coords.latitude}, ${pos.coords.longitude}`); success(pos); },
-      (err) => { console.log(`[geolocation] error: ${err.code} ${err.message}`); error?.(err); },
-      opts
-    );
-  };
+	const orig = navigator.geolocation.getCurrentPosition.bind(navigator.geolocation);
+	navigator.geolocation.getCurrentPosition = (success, error, opts) => {
+		console.log("[geolocation] getCurrentPosition called");
+		return orig(
+			(pos) => { console.log(`[geolocation] success: ${pos.coords.latitude}, ${pos.coords.longitude}`); success(pos); },
+			(err) => { console.log(`[geolocation] error: ${err.code} ${err.message}`); error?.(err); },
+			opts
+		);
+	};
 });
 
 await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });

--- a/scripts/smoke-test-rc134.mjs
+++ b/scripts/smoke-test-rc134.mjs
@@ -17,94 +17,94 @@ let passed = 0;
 let failed = 0;
 
 function pass(msg) {
-  console.log(`  PASS  ${msg}`);
-  passed++;
+	console.log(`  PASS  ${msg}`);
+	passed++;
 }
 function fail(msg) {
-  console.error(`  FAIL  ${msg}`);
-  failed++;
+	console.error(`  FAIL  ${msg}`);
+	failed++;
 }
 
 // 1. Health check
 const healthRes = await fetch(`${API}/health`);
 if (healthRes.ok) {
-  pass(`Health endpoint returned ${healthRes.status}`);
+	pass(`Health endpoint returned ${healthRes.status}`);
 } else {
-  fail(`Health endpoint returned ${healthRes.status}`);
+	fail(`Health endpoint returned ${healthRes.status}`);
 }
 
 // 2. Browser checks - grant geolocation with Munich coordinates
 const browser = await chromium.launch({ headless: true });
 const ctx = await browser.newContext({
-  ignoreHTTPSErrors: true,
-  geolocation: { latitude: 48.1351, longitude: 11.582 },
-  permissions: ["geolocation"],
+	ignoreHTTPSErrors: true,
+	geolocation: { latitude: 48.1351, longitude: 11.582 },
+	permissions: ["geolocation"],
 });
 const page = await ctx.newPage();
 
 try {
-  await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
+	await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
 
-  // Find the Location filter button using loose text match (same as debug script)
-  const locationFilterBtn = page
-    .getByRole("button")
-    .filter({ hasText: /location/i })
-    .first();
-  const isVisible = await locationFilterBtn.isVisible({ timeout: 5000 });
-  if (isVisible) {
-    pass("Location filter button is visible");
-  } else {
-    fail("Location filter button not found");
-    await browser.close();
-    process.exit(1);
-  }
+	// Find the Location filter button using loose text match (same as debug script)
+	const locationFilterBtn = page
+		.getByRole("button")
+		.filter({ hasText: /location/i })
+		.first();
+	const isVisible = await locationFilterBtn.isVisible({ timeout: 5000 });
+	if (isVisible) {
+		pass("Location filter button is visible");
+	} else {
+		fail("Location filter button not found");
+		await browser.close();
+		process.exit(1);
+	}
 
-  // Open the dropdown and wait for it to render
-  await locationFilterBtn.click();
-  await page.waitForTimeout(600);
+	// Open the dropdown and wait for it to render
+	await locationFilterBtn.click();
+	await page.waitForTimeout(600);
 
-  // Verify the Near me button exists in the open dropdown
-  // aria-label is "Use my current location to filter opportunities"
-  const nearMeBtn = page.getByRole("button", {
-    name: /use my current location/i,
-  });
-  const nearMeVisible = await nearMeBtn.isVisible({ timeout: 5000 });
-  if (nearMeVisible) {
-    pass('"Use my location" button is visible in location filter');
-  } else {
-    fail('"Use my location" button not found in location filter dropdown');
-    await page.screenshot({
-      path: "/home/user/einsatzbereit/scripts/debug-nearme-fail.png",
-    });
-    await browser.close();
-    process.exit(1);
-  }
+	// Verify the Near me button exists in the open dropdown
+	// aria-label is "Use my current location to filter opportunities"
+	const nearMeBtn = page.getByRole("button", {
+		name: /use my current location/i,
+	});
+	const nearMeVisible = await nearMeBtn.isVisible({ timeout: 5000 });
+	if (nearMeVisible) {
+		pass('"Use my location" button is visible in location filter');
+	} else {
+		fail('"Use my location" button not found in location filter dropdown');
+		await page.screenshot({
+			path: "/home/user/einsatzbereit/scripts/debug-nearme-fail.png",
+		});
+		await browser.close();
+		process.exit(1);
+	}
 
-  // Check aria-label
-  const ariaLabel = await nearMeBtn.getAttribute("aria-label");
-  if (ariaLabel && ariaLabel.length > 0) {
-    pass(`Button has aria-label: "${ariaLabel}"`);
-  } else {
-    fail("Button is missing aria-label");
-  }
+	// Check aria-label
+	const ariaLabel = await nearMeBtn.getAttribute("aria-label");
+	if (ariaLabel && ariaLabel.length > 0) {
+		pass(`Button has aria-label: "${ariaLabel}"`);
+	} else {
+		fail("Button is missing aria-label");
+	}
 
-  // Click - geolocation is mocked with Munich coordinates
-  await nearMeBtn.click();
+	// Click - geolocation is mocked with Munich coordinates
+	await nearMeBtn.click();
 
-  // Wait for URL to update with lat/lng params (geolocation callback sets them)
-  try {
-    await page.waitForURL((url) => url.searchParams.has("lat"), { timeout: 8000 });
-    const url = new URL(page.url());
-    pass(
-      `URL params set: lat=${url.searchParams.get("lat")}, lng=${url.searchParams.get("lng")}, radius=${url.searchParams.get("radius")}`,
-    );
-  } catch {
-    fail("lat/lng not set in URL params after geolocation click (timed out 8s)");
-  }
+	// Wait for URL to update with lat/lng params (geolocation callback sets them)
+	try {
+		await page.waitForURL((url) => url.searchParams.has("lat"), { timeout: 8000 });
+		const url = new URL(page.url());
+		pass(
+			`URL params set: lat=${url.searchParams.get("lat")}, lng=${url.searchParams.get("lng")}, radius=${url.searchParams.get("radius")}`,
+		);
+	} catch {
+		fail("lat/lng not set in URL params after geolocation click (timed out 8s)");
+	}
 } catch (err) {
-  fail(`Unexpected error: ${err.message}`);
+	fail(`Unexpected error: ${err.message}`);
 } finally {
-  await browser.close();
+	await browser.close();
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/scripts/smoke-test-rc134.mjs
+++ b/scripts/smoke-test-rc134.mjs
@@ -1,0 +1,111 @@
+/**
+ * Smoke test for RC.134 - "Near me" geolocation button in location filter (#372).
+ *
+ * Verifies:
+ * 1. Health endpoint returns 200
+ * 2. Homepage loads with the location filter dropdown
+ * 3. Opening the Location filter reveals the "Use my location" button
+ * 4. The button has an aria-label for accessibility
+ * 5. Clicking with a mocked geolocation sets lat/lng URL params
+ */
+import { chromium } from "playwright";
+
+const API = "https://api.maik-hasler.de";
+const FRONTEND = "https://einsatzbereit.maik-hasler.de";
+
+let passed = 0;
+let failed = 0;
+
+function pass(msg) {
+  console.log(`  PASS  ${msg}`);
+  passed++;
+}
+function fail(msg) {
+  console.error(`  FAIL  ${msg}`);
+  failed++;
+}
+
+// 1. Health check
+const healthRes = await fetch(`${API}/health`);
+if (healthRes.ok) {
+  pass(`Health endpoint returned ${healthRes.status}`);
+} else {
+  fail(`Health endpoint returned ${healthRes.status}`);
+}
+
+// 2. Browser checks - grant geolocation with Munich coordinates
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+  ignoreHTTPSErrors: true,
+  geolocation: { latitude: 48.1351, longitude: 11.582 },
+  permissions: ["geolocation"],
+});
+const page = await ctx.newPage();
+
+try {
+  await page.goto(FRONTEND, { waitUntil: "networkidle", timeout: 30000 });
+
+  // Find the Location filter button using loose text match (same as debug script)
+  const locationFilterBtn = page
+    .getByRole("button")
+    .filter({ hasText: /location/i })
+    .first();
+  const isVisible = await locationFilterBtn.isVisible({ timeout: 5000 });
+  if (isVisible) {
+    pass("Location filter button is visible");
+  } else {
+    fail("Location filter button not found");
+    await browser.close();
+    process.exit(1);
+  }
+
+  // Open the dropdown and wait for it to render
+  await locationFilterBtn.click();
+  await page.waitForTimeout(600);
+
+  // Verify the Near me button exists in the open dropdown
+  // aria-label is "Use my current location to filter opportunities"
+  const nearMeBtn = page.getByRole("button", {
+    name: /use my current location/i,
+  });
+  const nearMeVisible = await nearMeBtn.isVisible({ timeout: 5000 });
+  if (nearMeVisible) {
+    pass('"Use my location" button is visible in location filter');
+  } else {
+    fail('"Use my location" button not found in location filter dropdown');
+    await page.screenshot({
+      path: "/home/user/einsatzbereit/scripts/debug-nearme-fail.png",
+    });
+    await browser.close();
+    process.exit(1);
+  }
+
+  // Check aria-label
+  const ariaLabel = await nearMeBtn.getAttribute("aria-label");
+  if (ariaLabel && ariaLabel.length > 0) {
+    pass(`Button has aria-label: "${ariaLabel}"`);
+  } else {
+    fail("Button is missing aria-label");
+  }
+
+  // Click - geolocation is mocked with Munich coordinates
+  await nearMeBtn.click();
+
+  // Wait for URL to update with lat/lng params (geolocation callback sets them)
+  try {
+    await page.waitForURL((url) => url.searchParams.has("lat"), { timeout: 8000 });
+    const url = new URL(page.url());
+    pass(
+      `URL params set: lat=${url.searchParams.get("lat")}, lng=${url.searchParams.get("lng")}, radius=${url.searchParams.get("radius")}`,
+    );
+  } catch {
+    fail("lat/lng not set in URL params after geolocation click (timed out 8s)");
+  }
+} catch (err) {
+  fail(`Unexpected error: ${err.message}`);
+} finally {
+  await browser.close();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Changes `geolocation=()` to `geolocation=(self)` in all four `Permissions-Policy` header definitions in `frontend/nginx.conf`
- The "Near me" button (landed in #485) calls `navigator.geolocation.getCurrentPosition()` which is blocked by the current `geolocation=()` policy
- `geolocation=(self)` allows geolocation on the same origin while still blocking it from third-party iframes

## Live verification

Discovered during smoke testing of RC.134: staging returned HTTP error "Permissions policy violation: Geolocation access has been blocked because of a permissions policy applied to the current document." The button UI is rendered correctly but the geolocation callback never fires.

## Test plan

- [ ] `curl -sI https://einsatzbereit.maik-hasler.de | grep -i permissions-policy` shows `geolocation=(self)`
- [ ] Open location filter, click "Use my location", browser permission dialog appears
- [ ] Allowing grants location and sets `?lat=...&lng=...` in the URL
- [ ] Denying shows an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AydBNANoYPTtukeA3qHMN

---
_Generated by [Claude Code](https://claude.ai/code/session_019AydBNANoYPTtukeA3qHMN)_