### PR TITLE
feat: add recurring time slots to volunteer opportunities (#378)

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
@@ -15,7 +15,7 @@ internal sealed class CreateTimeSlotEndpoint : IEndpoint
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
 		app.MapPost("/volunteer-opportunities/{opportunityId:guid}/time-slots", CreateTimeSlotAsync)
 			.WithName("CreateTimeSlot")
-			.Produces<CreateTimeSlotResponse>(StatusCodes.Status201Created)
+			.Produces<IReadOnlyList<CreateTimeSlotResponse>>(StatusCodes.Status201Created)
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
@@ -33,9 +33,35 @@ internal sealed class CreateTimeSlotEndpoint : IEndpoint
 		CancellationToken cancellationToken)
 	{
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? new UserId(uid) : throw new DomainException("Invalid user.");
-		var command = new CreateTimeSlotCommand(opportunityId, request.StartDateTime, request.EndDateTime, request.MaxParticipants, userId);
-		var timeSlotId = await sender.Send(command, cancellationToken);
-		var response = new CreateTimeSlotResponse(timeSlotId, request.StartDateTime, request.EndDateTime, request.MaxParticipants);
-		return Results.Created($"/v1/volunteer-opportunities/{opportunityId}/time-slots/{timeSlotId}", response);
+
+		var recurrenceCount = request.RecurrenceCount <= 0 ? 1 : request.RecurrenceCount;
+		if (recurrenceCount > 52)
+			return Results.Problem("RecurrenceCount must be between 1 and 52.", statusCode: StatusCodes.Status400BadRequest);
+
+		if (request.RecurrenceFrequency is not null &&
+			!request.RecurrenceFrequency.Equals("Weekly", StringComparison.OrdinalIgnoreCase) &&
+			!request.RecurrenceFrequency.Equals("Monthly", StringComparison.OrdinalIgnoreCase))
+		{
+			return Results.Problem(
+				"Invalid RecurrenceFrequency. Allowed values: Weekly, Monthly.",
+				statusCode: StatusCodes.Status400BadRequest);
+		}
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId,
+			request.StartDateTime,
+			request.EndDateTime,
+			request.MaxParticipants,
+			userId,
+			request.RecurrenceFrequency,
+			recurrenceCount);
+
+		var timeSlots = await sender.Send(command, cancellationToken);
+
+		var responses = timeSlots
+			.Select(ts => new CreateTimeSlotResponse(ts.Id.Value, ts.StartDateTime, ts.EndDateTime, ts.MaxParticipants))
+			.ToList();
+
+		return Results.Created($"/v1/volunteer-opportunities/{opportunityId}/time-slots", responses);
 	}
 }

--- a/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotRequest.cs
@@ -3,4 +3,6 @@ namespace Api.VolunteerOpportunities.CreateTimeSlot.v1;
 public sealed record CreateTimeSlotRequest(
 	DateTimeOffset StartDateTime,
 	DateTimeOffset EndDateTime,
-	int MaxParticipants);
+	int MaxParticipants,
+	string? RecurrenceFrequency,
+	int RecurrenceCount);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1037,7 +1037,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateTimeSlotResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CreateTimeSlotResponse"
+                  }
                 }
               }
             }
@@ -2988,7 +2991,9 @@
         "required": [
           "startDateTime",
           "endDateTime",
-          "maxParticipants"
+          "maxParticipants",
+          "recurrenceFrequency",
+          "recurrenceCount"
         ],
         "type": "object",
         "properties": {
@@ -3001,6 +3006,20 @@
             "format": "date-time"
           },
           "maxParticipants": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "recurrenceFrequency": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "recurrenceCount": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
             "type": [
               "integer",

--- a/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommand.cs
@@ -1,5 +1,6 @@
 using Application.Common.Messaging;
 using Domain.Users;
+using Domain.VolunteerOpportunities;
 
 namespace Application.VolunteerOpportunities.CreateTimeSlot.v1;
 
@@ -8,5 +9,7 @@ public sealed record CreateTimeSlotCommand(
 	DateTimeOffset StartDateTime,
 	DateTimeOffset EndDateTime,
 	int MaxParticipants,
-	UserId RequestingUserId)
-	: ICommand<Guid>;
+	UserId RequestingUserId,
+	string? RecurrenceFrequency = null,
+	int RecurrenceCount = 1)
+	: ICommand<IReadOnlyList<TimeSlot>>;

--- a/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
@@ -3,6 +3,7 @@ using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Primitives;
+using Domain.Users;
 using Domain.VolunteerOpportunities;
 
 namespace Application.VolunteerOpportunities.CreateTimeSlot.v1;
@@ -10,9 +11,11 @@ namespace Application.VolunteerOpportunities.CreateTimeSlot.v1;
 internal sealed class CreateTimeSlotCommandHandler(
 	IApplicationDbContext dbContext,
 	IKeycloakOrganizationService keycloakOrgService)
-	: ICommandHandler<CreateTimeSlotCommand, Guid>
+	: ICommandHandler<CreateTimeSlotCommand, IReadOnlyList<TimeSlot>>
 {
-	public async ValueTask<Guid> Handle(
+	private const int MaxRecurrenceCount = 52;
+
+	public async ValueTask<IReadOnlyList<TimeSlot>> Handle(
 		CreateTimeSlotCommand request,
 		CancellationToken cancellationToken = default)
 	{
@@ -26,8 +29,25 @@ internal sealed class CreateTimeSlotCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var timeSlot = opportunity.AddTimeSlot(request.StartDateTime, request.EndDateTime, request.MaxParticipants);
+		var count = Math.Clamp(request.RecurrenceCount, 1, MaxRecurrenceCount);
+		var duration = request.EndDateTime - request.StartDateTime;
+		var slots = new List<TimeSlot>(count);
 
-		return timeSlot.Id.Value;
+		for (var i = 0; i < count; i++)
+		{
+			var start = Advance(request.StartDateTime, request.RecurrenceFrequency, i);
+			var end = start + duration;
+			slots.Add(opportunity.AddTimeSlot(start, end, request.MaxParticipants));
+		}
+
+		return slots;
 	}
+
+	private static DateTimeOffset Advance(DateTimeOffset origin, string? frequency, int steps) =>
+		frequency?.ToUpperInvariant() switch
+		{
+			"WEEKLY" => origin.AddDays(7 * steps),
+			"MONTHLY" => origin.AddMonths(steps),
+			_ => origin
+		};
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -1,0 +1,159 @@
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.CreateTimeSlot.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.CreateTimeSlot;
+
+public class CreateTimeSlotCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IKeycloakOrganizationService _keycloakOrgService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly CreateTimeSlotCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = new(Guid.CreateVersion7());
+	private static readonly UserId DefaultRequestingUserId = new(Guid.CreateVersion7());
+	private static readonly Address DefaultAddress = new("Hauptstrasse", "1", "12345", "Berlin");
+	private static readonly DateTimeOffset BaseStart = DateTimeOffset.UtcNow.AddDays(7);
+	private static readonly DateTimeOffset BaseEnd = DateTimeOffset.UtcNow.AddDays(7).AddHours(2);
+
+	public CreateTimeSlotCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_keycloakOrgService
+			.GetUserOrganizationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganization(DefaultOrgId.Value, "Test Org")]);
+		_sut = new CreateTimeSlotCommandHandler(_dbContext, _keycloakOrgService);
+	}
+
+	private static VolunteerOpportunity CreateOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress,
+			Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None);
+
+	[Test]
+	public async Task Handle_ShouldCreateSingleSlot_WhenNoRecurrence(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 10, DefaultRequestingUserId);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.Should().HaveCount(1);
+		result[0].StartDateTime.Should().Be(BaseStart);
+		result[0].EndDateTime.Should().Be(BaseEnd);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreate8WeeklySlots_WithWeeklyFrequency(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 5, DefaultRequestingUserId,
+			RecurrenceFrequency: "Weekly", RecurrenceCount: 8);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.Should().HaveCount(8);
+		for (var i = 0; i < 8; i++)
+			result[i].StartDateTime.Should().Be(BaseStart.AddDays(7 * i));
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreate3MonthlySlots_WithMonthlyFrequency(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 20, DefaultRequestingUserId,
+			RecurrenceFrequency: "Monthly", RecurrenceCount: 3);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.Should().HaveCount(3);
+		result[0].StartDateTime.Should().Be(BaseStart);
+		result[1].StartDateTime.Should().Be(BaseStart.AddMonths(1));
+		result[2].StartDateTime.Should().Be(BaseStart.AddMonths(2));
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampCountTo52_WhenCountExceeds52(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 5, DefaultRequestingUserId,
+			RecurrenceFrequency: "Weekly", RecurrenceCount: 100);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.Should().HaveCount(52);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPreserveDuration_ForAllRecurringSlots(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		var expectedDuration = BaseEnd - BaseStart;
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 10, DefaultRequestingUserId,
+			RecurrenceFrequency: "Weekly", RecurrenceCount: 4);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		foreach (var slot in result)
+			(slot.EndDateTime - slot.StartDateTime).Should().Be(expectedDuration);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns((VolunteerOpportunity?)null);
+
+		Func<Task> act = async () => await _sut.Handle(
+			new CreateTimeSlotCommand(opportunityId, BaseStart, BaseEnd, 10, DefaultRequestingUserId),
+			cancellationToken);
+
+		await act.Should().ThrowAsync<DomainException>().WithMessage($"*{opportunityId}*");
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -99,7 +99,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Created</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<CreateTimeSlotResponse> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<CreateTimeSlotResponse>> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
@@ -1772,7 +1772,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Created</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<CreateTimeSlotResponse> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<CreateTimeSlotResponse>> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (opportunityId == null)
                 throw new System.ArgumentNullException("opportunityId");
@@ -1825,7 +1825,7 @@ namespace IntegrationTests
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 201)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<CreateTimeSlotResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<CreateTimeSlotResponse>>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -5321,6 +5321,14 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
         public int MaxParticipants { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("recurrenceFrequency")]
+        public string? RecurrenceFrequency { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("recurrenceCount")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int RecurrenceCount { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -6582,9 +6590,6 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("organizationName")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string OrganizationName { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("organizationIsVerified")]
-        public bool OrganizationIsVerified { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("street")]
         public string? Street { get; set; } = default!;

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -880,7 +880,7 @@ export class EinsatzbereitApi {
     /**
      * @return Created
      */
-    createTimeSlot(opportunityId: string, body: CreateTimeSlotRequest, signal?: AbortSignal): Promise<CreateTimeSlotResponse> {
+    createTimeSlot(opportunityId: string, body: CreateTimeSlotRequest, signal?: AbortSignal): Promise<CreateTimeSlotResponse[]> {
         let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/time-slots";
         if (opportunityId === undefined || opportunityId === null)
             throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
@@ -904,13 +904,13 @@ export class EinsatzbereitApi {
         });
     }
 
-    protected processCreateTimeSlot(response: Response): Promise<CreateTimeSlotResponse> {
+    protected processCreateTimeSlot(response: Response): Promise<CreateTimeSlotResponse[]> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 201) {
             return response.text().then((_responseText) => {
             let result201: any = null;
-            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as CreateTimeSlotResponse;
+            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as CreateTimeSlotResponse[];
             return result201;
             });
         } else if (status === 400) {
@@ -948,7 +948,7 @@ export class EinsatzbereitApi {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<CreateTimeSlotResponse>(null as any);
+        return Promise.resolve<CreateTimeSlotResponse[]>(null as any);
     }
 
     /**
@@ -2685,6 +2685,8 @@ export interface CreateTimeSlotRequest {
     startDateTime: Date;
     endDateTime: Date;
     maxParticipants: number;
+    recurrenceFrequency: string | undefined;
+    recurrenceCount: number;
 
     [key: string]: any;
 }
@@ -3063,7 +3065,6 @@ export interface VolunteerOpportunitySummary {
     description: string | undefined;
     organizationId: string;
     organizationName: string;
-    organizationIsVerified: boolean;
     street: string | undefined;
     houseNumber: string | undefined;
     zipCode: string | undefined;

--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -15,6 +15,20 @@ const TOTAL_STEPS = 4;
 const MAX_BANNER_BYTES = 2 * 1024 * 1024;
 const BANNER_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
+function advanceDate(
+	origin: Date,
+	frequency: string | undefined,
+	steps: number,
+): Date {
+	const d = new Date(origin);
+	if (frequency === "Weekly") {
+		d.setDate(d.getDate() + 7 * steps);
+	} else if (frequency === "Monthly") {
+		d.setMonth(d.getMonth() + steps);
+	}
+	return d;
+}
+
 interface Props {
 	organizationId: string;
 	onClose: () => void;
@@ -305,6 +319,8 @@ export default function CreateVolunteerOpportunityModal({
 	const [slotError, setSlotError] = useState<string | null>(null);
 	const [removingSlotId, setRemovingSlotId] = useState<string | null>(null);
 	const [addingSlot, setAddingSlot] = useState(false);
+	const [recurrenceFrequency, setRecurrenceFrequency] = useState("Weekly");
+	const [recurrenceCount, setRecurrenceCount] = useState(1);
 
 	useEffect(() => {
 		if (isEditMode) return;
@@ -424,22 +440,25 @@ export default function CreateVolunteerOpportunityModal({
 			return;
 		}
 
+		const isRecurring = form.occurrence === "Recurring";
 		if (isEditMode && initialOpportunity) {
 			setAddingSlot(true);
 			try {
-				const response = await api.createTimeSlot(initialOpportunity.id, {
+				const responses = await api.createTimeSlot(initialOpportunity.id, {
 					startDateTime: start,
 					endDateTime: end,
 					maxParticipants: newSlot.maxParticipants,
+					recurrenceFrequency: isRecurring ? recurrenceFrequency : undefined,
+					recurrenceCount: isRecurring ? recurrenceCount : 1,
 				});
 				setExistingSlots((prev) => [
 					...prev,
-					{
-						id: response.id,
-						startDateTime: response.startDateTime,
-						endDateTime: response.endDateTime,
-						maxParticipants: response.maxParticipants,
-					},
+					...responses.map((r) => ({
+						id: r.id,
+						startDateTime: r.startDateTime,
+						endDateTime: r.endDateTime,
+						maxParticipants: r.maxParticipants,
+					})),
 				]);
 			} catch {
 				setSlotError(t("timeSlots.addError"));
@@ -447,15 +466,25 @@ export default function CreateVolunteerOpportunityModal({
 				setAddingSlot(false);
 			}
 		} else {
-			setPendingSlots((prev) => [
-				...prev,
-				{
-					id: crypto.randomUUID(),
-					startDateTime: newSlot.startDateTime,
-					endDateTime: newSlot.endDateTime,
-					maxParticipants: newSlot.maxParticipants,
+			const duration = end.getTime() - start.getTime();
+			const count = isRecurring
+				? Math.max(1, Math.min(52, recurrenceCount))
+				: 1;
+			const freq = isRecurring ? recurrenceFrequency : undefined;
+			const newSlots: PendingTimeSlot[] = Array.from(
+				{ length: count },
+				(_, i) => {
+					const slotStart = advanceDate(start, freq, i);
+					const slotEnd = new Date(slotStart.getTime() + duration);
+					return {
+						id: crypto.randomUUID(),
+						startDateTime: slotStart.toISOString(),
+						endDateTime: slotEnd.toISOString(),
+						maxParticipants: newSlot.maxParticipants,
+					};
 				},
-			]);
+			);
+			setPendingSlots((prev) => [...prev, ...newSlots]);
 		}
 		setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });
 	}
@@ -536,6 +565,8 @@ export default function CreateVolunteerOpportunityModal({
 						startDateTime: new Date(slot.startDateTime),
 						endDateTime: new Date(slot.endDateTime),
 						maxParticipants: slot.maxParticipants,
+						recurrenceFrequency: undefined,
+						recurrenceCount: 1,
 					});
 				}
 				if (asDraft) {
@@ -1186,6 +1217,60 @@ export default function CreateVolunteerOpportunityModal({
 												className="w-24 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
 											/>
 										</div>
+										{form.occurrence === "Recurring" && (
+											<div className="grid grid-cols-2 gap-3">
+												<div>
+													<label
+														htmlFor="slot-recurrence-frequency"
+														className="mb-1 block text-xs font-medium text-gray-600"
+													>
+														{t("timeSlots.recurrenceFrequency")}
+													</label>
+													<select
+														id="slot-recurrence-frequency"
+														value={recurrenceFrequency}
+														onChange={(e) =>
+															setRecurrenceFrequency(e.target.value)
+														}
+														className={selectClass}
+													>
+														<option value="Weekly">
+															{t("timeSlots.recurrenceWeekly")}
+														</option>
+														<option value="Monthly">
+															{t("timeSlots.recurrenceMonthly")}
+														</option>
+													</select>
+												</div>
+												<div>
+													<label
+														htmlFor="slot-recurrence-count"
+														className="mb-1 block text-xs font-medium text-gray-600"
+													>
+														{t("timeSlots.recurrenceCount")}
+													</label>
+													<input
+														id="slot-recurrence-count"
+														type="number"
+														min={1}
+														max={52}
+														value={recurrenceCount}
+														onChange={(e) =>
+															setRecurrenceCount(
+																Math.max(
+																	1,
+																	Math.min(
+																		52,
+																		parseInt(e.target.value, 10) || 1,
+																	),
+																),
+															)
+														}
+														className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+													/>
+												</div>
+											</div>
+										)}
 										{slotError && (
 											<p className="text-xs text-red-600">{slotError}</p>
 										)}

--- a/frontend/src/components/EditVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/EditVolunteerOpportunityModal.tsx
@@ -92,19 +92,21 @@ export default function EditVolunteerOpportunityModal({
 		setAddingSlot(true);
 		setSlotError(null);
 		try {
-			const response = await api.createTimeSlot(opportunity.id, {
+			const responses = await api.createTimeSlot(opportunity.id, {
 				startDateTime: new Date(newSlot.startDateTime),
 				endDateTime: new Date(newSlot.endDateTime),
 				maxParticipants: newSlot.maxParticipants,
+				recurrenceFrequency: undefined,
+				recurrenceCount: 1,
 			});
 			setTimeSlots((prev) => [
 				...prev,
-				{
-					id: response.id,
-					startDateTime: response.startDateTime,
-					endDateTime: response.endDateTime,
-					maxParticipants: response.maxParticipants,
-				},
+				...responses.map((r) => ({
+					id: r.id,
+					startDateTime: r.startDateTime,
+					endDateTime: r.endDateTime,
+					maxParticipants: r.maxParticipants,
+				})),
 			]);
 			setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });
 		} catch {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -281,7 +281,11 @@
       "removing": "…",
       "noSlots": "Noch keine Zeitslots hinzugefügt.",
       "addError": "Zeitslot konnte nicht hinzugefügt werden.",
-      "removeError": "Zeitslot konnte nicht entfernt werden."
+      "removeError": "Zeitslot konnte nicht entfernt werden.",
+      "recurrenceFrequency": "Wiederholungsrhythmus",
+      "recurrenceWeekly": "Wöchentlich",
+      "recurrenceMonthly": "Monatlich",
+      "recurrenceCount": "Anzahl Termine"
     },
     "signUp": {
       "titleWaitlist": "Auf Warteliste eintragen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -281,7 +281,11 @@
       "removing": "…",
       "noSlots": "No time slots added yet.",
       "addError": "Could not add time slot.",
-      "removeError": "Could not remove time slot."
+      "removeError": "Could not remove time slot.",
+      "recurrenceFrequency": "Frequency",
+      "recurrenceWeekly": "Weekly",
+      "recurrenceMonthly": "Monthly",
+      "recurrenceCount": "Number of sessions"
     },
     "signUp": {
       "titleWaitlist": "Join waitlist",


### PR DESCRIPTION
## Summary

- Extends `CreateTimeSlotCommand`/`CommandHandler` to accept `RecurrenceFrequency` (`Weekly`/`Monthly`) and `RecurrenceCount` (1-52), generating N expanded `TimeSlot` rows using simple date math (no external library, no new migration)
- `CreateTimeSlotEndpoint` now returns `IReadOnlyList<CreateTimeSlotResponse>` (201 Created) and validates recurrence inputs (unknown frequency => 400, count > 52 => 400)
- Frontend `CreateVolunteerOpportunityModal` and `EditVolunteerOpportunityModal` updated to handle the new array response; recurrence frequency + count UI appears in Step 4 when the opportunity is set to `Recurring`
- Recurrence i18n keys added for both English and German
- 6 new `CreateTimeSlotCommandHandler` unit tests (single slot, 8 weekly, 3 monthly, clamping at 52, duration preservation, not-found error)

## Test plan

- [ ] All 183 unit tests pass (`dotnet run --project backend/tests/Application.UnitTests`)
- [ ] TypeScript compiles cleanly (`pnpm check`)
- [ ] ESLint passes with zero warnings (`pnpm lint`)
- [ ] Create a `Recurring` opportunity, go to Step 4 - recurrence frequency/count fields appear
- [ ] Add a slot with Frequency=Weekly, Count=4 - 4 slots appear in the preview (7 days apart)
- [ ] Publish the opportunity and verify all 4 time slots are persisted
- [ ] In edit mode, add a recurring slot - all N slots are added immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdvrLFkmiY8bx54w31LiPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdvrLFkmiY8bx54w31LiPx)_