### PR TITLE
fix: propagate X-Timezone header into activity-streak ISO-week calculation (#404)

### DIFF
--- a/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
@@ -32,10 +32,12 @@ internal sealed class ConfirmEngagementEndpoint
 		[FromRoute] Guid engagementId,
 		[FromServices] ISender sender,
 		ClaimsPrincipal user,
+		HttpRequest request,
 		CancellationToken cancellationToken)
 	{
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? new UserId(uid) : throw new DomainException("Invalid user.");
-		var command = new ConfirmEngagementCommand(new EngagementId(engagementId), userId);
+		var timezone = request.Headers["X-Timezone"].FirstOrDefault();
+		var command = new ConfirmEngagementCommand(new EngagementId(engagementId), userId, timezone);
 		var engagement = await sender.Send(command, cancellationToken);
 		return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString(), engagement.ModifiedOn));
 	}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommand.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommand.cs
@@ -4,5 +4,5 @@ using Domain.Users;
 
 namespace Application.Engagements.ConfirmEngagement.v1;
 
-public sealed record ConfirmEngagementCommand(EngagementId EngagementId, UserId RequestingUserId)
+public sealed record ConfirmEngagementCommand(EngagementId EngagementId, UserId RequestingUserId, string? Timezone = null)
 	: ICommand<Engagement>;

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -45,8 +45,8 @@ internal sealed class ConfirmEngagementCommandHandler(
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
 
-		var berlin = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, berlin).DateTime;
+		var tz = ResolveTimeZone(request.Timezone);
+		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
 		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
 		await RecordActivityStreakAsync(engagement.VolunteerId, isoYear, isoWeek, cancellationToken);
@@ -69,6 +69,20 @@ internal sealed class ConfirmEngagementCommandHandler(
 			cancellationToken);
 
 		return engagement;
+	}
+
+	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
+	{
+		if (string.IsNullOrWhiteSpace(ianaId))
+			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		try
+		{
+			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+		}
+		catch
+		{
+			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		}
 	}
 
 	private async Task RecordActivityStreakAsync(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -6583,9 +6583,6 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string OrganizationName { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("organizationIsVerified")]
-        public bool OrganizationIsVerified { get; set; } = default!;
-
         [System.Text.Json.Serialization.JsonPropertyName("street")]
         public string? Street { get; set; } = default!;
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3063,7 +3063,6 @@ export interface VolunteerOpportunitySummary {
     description: string | undefined;
     organizationId: string;
     organizationName: string;
-    organizationIsVerified: boolean;
     street: string | undefined;
     houseNumber: string | undefined;
     zipCode: string | undefined;


### PR DESCRIPTION
## Summary

Closes the remaining gap from #404: the login streak already used the `X-Timezone` IANA header for per-user timezone conversion, but the activity streak in `ConfirmEngagementCommandHandler` was hardcoded to `Europe/Berlin`.

- Added optional `string? Timezone = null` to `ConfirmEngagementCommand`
- `ConfirmEngagementEndpoint` reads the `X-Timezone` request header and passes it through
- `ConfirmEngagementCommandHandler` resolves the IANA timezone ID (defaults to `Europe/Berlin` on missing/invalid value) before computing the ISO year/week for the weekly activity streak
- Also includes NSwag-regenerated client files that clean up a stale `organizationIsVerified` property renamed to `isOrganizationVerified` in main

## Test plan

- [ ] All 177 unit tests pass - existing `ConfirmEngagementCommandHandlerTests` use no timezone (defaults to Europe/Berlin), still green
- [ ] A user in UTC+5 confirming an engagement just after their local midnight now records the streak in the correct local week, not the previous UTC week

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7nj6RtHukPm1RRQACeMmu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7nj6RtHukPm1RRQACeMmu)_