### PR TITLE
fix: make AddOrganizationIsVerified migration idempotent (staging deploy rollback)

### DIFF
--- a/.github/workflows/keycloak-realm-import.yml
+++ b/.github/workflows/keycloak-realm-import.yml
@@ -1,0 +1,84 @@
+name: Keycloak Realm Import Check
+
+# Imports the committed realm on the SAME Keycloak version that ships to
+# production (read from keycloak/Dockerfile) and fails if the realm is not
+# served afterwards. The backend's readiness probe and the integration-test
+# fixture both depend on GET /realms/einsatzbereit/.well-known/openid-configuration
+# being reachable; if a realm change is rejected by the production Keycloak
+# version, Keycloak crashes on `--import-realm` and every staging deploy rolls
+# back. This guard catches that before it reaches staging, and prints the full
+# Keycloak logs (the exact ModelValidationException / rejected element) on
+# failure.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'keycloak/**'
+      - '.github/workflows/keycloak-realm-import.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'keycloak/**'
+      - '.github/workflows/keycloak-realm-import.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  import-check:
+    name: Import realm on production Keycloak version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Resolve production Keycloak version
+        id: kc
+        run: |
+          KC_VERSION=$(grep -m1 'FROM quay.io/keycloak/keycloak:' keycloak/Dockerfile \
+            | sed 's/.*keycloak:\([^ ]*\).*/\1/')
+          echo "version=$KC_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Testing realm import on quay.io/keycloak/keycloak:$KC_VERSION"
+
+      - name: Import realm and verify it is served
+        env:
+          KC_VERSION: ${{ steps.kc.outputs.version }}
+        run: |
+          set -u
+          IMPORT_DIR="$RUNNER_TEMP/kc-import"
+          mkdir -p "$IMPORT_DIR"
+          cp keycloak/realms/*-realm.json "$IMPORT_DIR/"
+
+          docker run -d --name kc-import-check -p 8080:8080 \
+            -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+            -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+            -v "$IMPORT_DIR:/opt/keycloak/data/import:ro" \
+            "quay.io/keycloak/keycloak:$KC_VERSION" \
+            start-dev --import-realm
+
+          WELL_KNOWN="http://localhost:8080/realms/einsatzbereit/.well-known/openid-configuration"
+          ready=0
+          for i in $(seq 1 60); do
+            if curl -fsS "$WELL_KNOWN" >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            # Fail fast if the container has already exited (import crash).
+            if [ "$(docker inspect -f '{{.State.Running}}' kc-import-check 2>/dev/null)" != "true" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          echo "::group::Keycloak container logs"
+          docker logs kc-import-check || true
+          echo "::endgroup::"
+
+          docker rm -f kc-import-check >/dev/null 2>&1 || true
+
+          if [ "$ready" != "1" ]; then
+            echo "::error::Keycloak $KC_VERSION did not serve the 'einsatzbereit' realm after --import-realm (see logs above)."
+            exit 1
+          fi
+          echo "Realm 'einsatzbereit' imported and served successfully on Keycloak $KC_VERSION."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check EditorConfig conformance
+        # editorconfig-checker downloads its binary from GitHub releases on first
+        # run; without a token the unauthenticated GitHub API rate limit (shared
+        # across the runner's IP) intermittently returns 403 and fails the job.
+        # GITHUB_TOKEN authenticates the download and raises the limit.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx --yes editorconfig-checker@6.1.1 -config .editorconfig-checker.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -355,6 +355,24 @@ jobs:
             docker image prune --force
           EOF
 
+      - name: Capture container logs on deploy failure
+        if: failure()
+        run: |
+          # The deploy fails inside `docker compose up` when the backend never
+          # becomes healthy; the failed containers are then recreated by the
+          # rollback step, losing their logs. Dump them here first so the root
+          # cause (a backend startup exception / migration error) is visible in
+          # the workflow log instead of an opaque "container is unhealthy".
+          ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
+            set +e
+            cd /opt/einsatzbereit
+            for svc in backend keycloak postgres; do
+              echo "::group::docker logs ${svc} (tail 150)"
+              docker logs --tail 150 "${svc}" 2>&1 || true
+              echo "::endgroup::"
+            done
+          EOF
+
       - name: Post-deploy health gate
         run: |
           set -uo pipefail

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -367,8 +367,11 @@ jobs:
             set +e
             cd /opt/einsatzbereit
             for svc in backend keycloak postgres; do
-              echo "::group::docker logs ${svc} (tail 150)"
-              docker logs --tail 150 "${svc}" 2>&1 || true
+              echo "::group::docker inspect ${svc} (state)"
+              docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Health={{if .State.Health}}{{.State.Health.Status}}{{end}}' "${svc}" 2>&1 || true
+              echo "::endgroup::"
+              echo "::group::docker logs ${svc} (tail 200)"
+              docker logs --tail 200 "${svc}" 2>&1 || true
               echo "::endgroup::"
             done
           EOF

--- a/backend/src/Infrastructure/Persistence/Migrations/20260619062516_AddOrganizationIsVerified.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260619062516_AddOrganizationIsVerified.cs
@@ -10,20 +10,22 @@ namespace Infrastructure.Persistence.Migrations
 		/// <inheritdoc />
 		protected override void Up(MigrationBuilder migrationBuilder)
 		{
-			migrationBuilder.AddColumn<bool>(
-				name: "is_verified",
-				table: "organization",
-				type: "boolean",
-				nullable: false,
-				defaultValue: false);
+			// Idempotent on purpose: on staging the is_verified column already
+			// exists (created by a duplicate migration that was later removed,
+			// leaving no __EFMigrationsHistory row for this id), so a plain
+			// AddColumn crashes the backend on startup with "column is_verified
+			// already exists" and the deploy rolls back. IF NOT EXISTS makes the
+			// re-apply a no-op there while still creating the column on fresh
+			// databases (CI, a clean local stack, a first-time deploy).
+			migrationBuilder.Sql(
+				"ALTER TABLE organization ADD COLUMN IF NOT EXISTS is_verified boolean NOT NULL DEFAULT FALSE;");
 		}
 
 		/// <inheritdoc />
 		protected override void Down(MigrationBuilder migrationBuilder)
 		{
-			migrationBuilder.DropColumn(
-				name: "is_verified",
-				table: "organization");
+			migrationBuilder.Sql(
+				"ALTER TABLE organization DROP COLUMN IF EXISTS is_verified;");
 		}
 	}
 }


### PR DESCRIPTION
## Root cause (confirmed from staging logs)

Every staging deploy failed and rolled back because the **backend container never became healthy**. The deploy's failure-time log capture (added in this PR) shows the postgres logs, repeated on every backend restart:

```
ERROR:  column "is_verified" of relation "organization" already exists
STATEMENT:  ALTER TABLE organization ADD is_verified boolean NOT NULL DEFAULT FALSE
```

On startup the backend runs `MigrateAsync()`. It tries to apply `20260619062516_AddOrganizationIsVerified`, but on staging the `is_verified` column **already exists** while there is **no `__EFMigrationsHistory` row** for that migration id (it was created by a duplicate migration that was later removed). Postgres rejects the `ALTER TABLE ... ADD`, the migration throws, the backend process exits, its container never reaches `healthy`, and `docker compose up` aborts (`frontend`/`keycloak` depend on `backend` being `service_healthy`) -> rollback. Every release since **rc.135**.

Fresh CI databases don't have the column, so the migration applied normally there and **CI stayed green**, hiding the failure (Keycloak, the realm, and the 26.6.1/26.6.3 version split were all ruled out - Keycloak comes up healthy and the realm imports cleanly on 26.6.3).

## Fix

`20260619062516_AddOrganizationIsVerified` now uses idempotent SQL:

```csharp
migrationBuilder.Sql("ALTER TABLE organization ADD COLUMN IF NOT EXISTS is_verified boolean NOT NULL DEFAULT FALSE;");
```

- On **staging**: the column already exists -> no-op, EF records the history row, and the rest of the migration chain (`AddEngagementReminderSentAt`, `AddEngagementFeedback`) applies normally -> backend starts -> deploy succeeds.
- On **fresh DBs** (CI, clean local, first deploy): the column is created as before.

## Supporting changes (diagnosis + guard rails)

- `publish.yml` - **capture `backend`/`keycloak`/`postgres` state + logs on deploy failure** before rollback (this is what surfaced the root cause; previously only "container is unhealthy" was visible).
- `.github/workflows/keycloak-realm-import.yml` - guard that imports the committed realm on the production Keycloak version and fails (with logs) if rejected. Currently green.
- `lint.yml` - authenticate the `editorconfig-checker` binary download with `GITHUB_TOKEN` to stop the intermittent rate-limit (403) failures.

## Live verification

Verified on the live staging environment with the fix (release `v1.0.0-rc.145`):

- `publish.yml` run for **`v1.0.0-rc.145`**: **success** - the first successful deploy since rc.134. `deploy-staging` and the post-deploy health gate passed; the rollback step did **not** fire.
- `curl https://api.maik-hasler.de/health` -> **HTTP 200** (readiness probe: database + Keycloak reachable, backend up).
- `https://einsatzbereit.maik-hasler.de` -> **HTTP 200**.

rc.135 through rc.144 (without this fix) all failed and rolled back; rc.145 (with it) succeeded - directly confirming the root cause and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)