### PR TITLE
fix: use exact aria-label match for org switcher in smoke test

### DIFF
--- a/scripts/smoke-test-rc148.mjs
+++ b/scripts/smoke-test-rc148.mjs
@@ -104,12 +104,12 @@ try {
 	await page.goto(FRONTEND, { waitUntil: "domcontentloaded", timeout: 30000 });
 	await page.waitForTimeout(500);
 
-	// Open org switcher (the building-icon button in the nav)
+	// Open org switcher - wait up to 10s for the API fetch to finish (loading skeleton hides the button)
+	// The button has aria-label="Switch organization" / "Organisation wechseln"
 	const orgBtn = page
-		.locator("nav")
-		.getByRole("button", { name: /organization|organisation/i })
+		.getByRole("button", { name: /switch organization|organisation wechseln/i })
 		.first();
-	const orgBtnVisible = await orgBtn.isVisible({ timeout: 5000 }).catch(() => false);
+	const orgBtnVisible = await orgBtn.isVisible({ timeout: 10000 }).catch(() => false);
 
 	if (orgBtnVisible) {
 		await orgBtn.click();
@@ -181,8 +181,7 @@ try {
 	//    and check that focus produces a non-black border color.
 	//    (Navigation to org dashboard first so we have access to create-opportunity button.)
 	const orgSwitcherBtn = page
-		.locator("nav")
-		.getByRole("button", { name: /organization|organisation/i })
+		.getByRole("button", { name: /switch organization|organisation wechseln/i })
 		.first();
 	const switcherVis = await orgSwitcherBtn
 		.isVisible({ timeout: 3000 })


### PR DESCRIPTION
## Summary

- Fixes the org-switcher Playwright selector in `scripts/smoke-test-rc148.mjs` that was failing because the previous regex (`/organization|organisation/i` scoped to `nav`) didn't account for the loading skeleton: while `fetchOrgs()` is in flight the component renders a `<div>` placeholder, not a `<button>`, so `getByRole('button', ...)` found nothing.
- Changed to match the exact aria-label values (`/switch organization|organisation wechseln/i`) and increased the timeout from 5 s to 10 s to wait for the API call to finish.

## Live verification (v1.0.0-rc.151 on staging)

Deploy to Staging succeeded at **06:55:59 UTC** (run [27934780481](https://github.com/maik-hasler/einsatzbereit/actions/runs/27934780481), job 82654822151). All steps green:

- Pull and restart: SUCCESS (06:54:45 - 06:55:50 UTC)
- Post-deploy health gate: SUCCESS
- Bind Keycloak browser flow: SUCCESS

Staging CSS fingerprint: `assets/index-DZxoAVMH.css` (changed from pre-fix `index-B4FC9b2D.css`).

Smoke test result (`node scripts/smoke-test-rc148.mjs`):

```
PASS  Health endpoint returned 200
PASS  Frontend loaded (title: "Einsatzbereit")
PASS  --color-brand-300 is defined: #80cba6
PASS  --color-brand-400 is defined: #5bbf8c
PASS  --color-brand-900 is defined: #0e251a
PASS  Logged in as olaf
      "Create organization" computed color: rgb(34, 105, 71)
PASS  "Create organization" text is NOT black (rgb(34, 105, 71)) - color token correctly applied
      brand-900 hero text computed color: rgb(14, 37, 26)
PASS  brand-900 hero text has correct color: rgb(14, 37, 26)

8 passed, 0 failed
```

All previously-broken brand color tokens (`--color-brand-300`, `--color-brand-400`, `--color-brand-900`) are now defined on staging and the "Create organization" dropdown item renders with the correct green text (`rgb(34, 105, 71)` = `brand-700`) instead of black.

## Test plan

- [x] `node scripts/smoke-test-rc148.mjs` exits 0 (8/8 checks pass against live staging)
- [x] `--color-brand-300/400/900` defined in deployed CSS
- [x] Org switcher dropdown renders with white background (not transparent)
- [x] "Create organization" text is green, not black

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QE5d8BtzGfXrjfqidMjFXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE5d8BtzGfXrjfqidMjFXN)_