### PR TITLE
feat: hide org switcher for volunteers with no org; fix mobile dropdown clipping

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -509,19 +509,16 @@ export default function Header() {
 			{/* Mobile Menu - absolute overlay so it doesn't push content down */}
 			{mobileOpen && (
 				<div
-					className={`absolute left-0 right-0 top-full border-t md:hidden shadow-lg overflow-hidden ${isTransparent ? "border-white/20 bg-brand-800" : "border-gray-100 bg-white"}`}
+					className={`absolute left-0 right-0 top-full border-t md:hidden shadow-lg ${isTransparent ? "border-white/20 bg-brand-800" : "border-gray-100 bg-white"}`}
 				>
 					{isTransparent && (
-						<>
-							<div
-								className="pointer-events-none absolute -left-20 -top-10 h-64 w-64 rounded-full bg-brand-700 opacity-60 blur-3xl"
-								aria-hidden="true"
-							/>
-							<div
-								className="pointer-events-none absolute -right-16 -top-8 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl"
-								aria-hidden="true"
-							/>
-						</>
+						<div
+							className="pointer-events-none absolute inset-0 overflow-hidden"
+							aria-hidden="true"
+						>
+							<div className="absolute -left-20 -top-10 h-64 w-64 rounded-full bg-brand-700 opacity-60 blur-3xl" />
+							<div className="absolute -right-16 -top-8 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl" />
+						</div>
 					)}
 					<div className="relative px-4 py-4 space-y-2">
 						<div className="pb-2">

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -92,40 +92,10 @@ export default function OrganizationSwitcher({
 		);
 	}
 
-	// No orgs - show direct "create" button instead of dropdown
+	// No orgs - hide the switcher from the header entirely.
+	// Users can create an org from their profile page instead.
 	if (orgs.length === 0) {
-		return (
-			<>
-				<button
-					type="button"
-					onClick={() => setShowModal(true)}
-					data-testid="create-org-btn"
-					className={`flex items-center gap-2 rounded-lg border border-dashed px-3 py-1.5 text-sm font-medium transition-colors ${transparent ? "border-white/40 bg-white/10 text-white hover:bg-white/20" : "border-brand-300 bg-brand-50 text-brand-700 hover:bg-brand-100"}`}
-				>
-					<svg
-						className={`w-4 h-4 ${transparent ? "text-white/80" : ""}`}
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth="1.5"
-						stroke="currentColor"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M12 4.5v15m7.5-7.5h-15"
-						/>
-					</svg>
-					{t("organization.create")}
-				</button>
-
-				{showModal && (
-					<CreateOrganizationModal
-						onClose={() => setShowModal(false)}
-						onSuccess={handleOrgCreated}
-					/>
-				)}
-			</>
-		);
+		return null;
 	}
 
 	return (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -601,7 +601,9 @@
       "saveError": "Speichern fehlgeschlagen.",
       "loadError": "Profil konnte nicht geladen werden.",
       "loading": "Wird geladen…",
-      "removeChip": "Entfernen"
+      "removeChip": "Entfernen",
+      "sectionOrganization": "Organisationen",
+      "createOrgHint": "Moechtest du Freiwilligeneinsaetze organisieren? Erstelle eine Organisation, um loszulegen."
     },
     "achievements": {
       "title": "Meine Errungenschaften",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -601,7 +601,9 @@
       "saveError": "Failed to save profile.",
       "loadError": "Could not load profile.",
       "loading": "Loading…",
-      "removeChip": "Remove"
+      "removeChip": "Remove",
+      "sectionOrganization": "Organizations",
+      "createOrgHint": "Want to organize volunteer opportunities? Create an organization to get started."
     },
     "achievements": {
       "title": "My Achievements",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -15,6 +15,7 @@ import { getApiErrorMessage } from "../lib/apiError";
 import BadgeGrid from "../components/BadgeGrid";
 import CheckInModal from "../components/CheckInModal";
 import ConfirmDialog from "../components/ConfirmDialog";
+import CreateOrganizationModal from "../components/CreateOrganizationModal";
 import EmptyState from "../components/EmptyState";
 import ShareAchievementsModal from "../components/ShareAchievementsModal";
 import SubmitFeedbackModal from "../components/SubmitFeedbackModal";
@@ -171,6 +172,7 @@ export default function ProfileOverviewPage() {
 	const [uploadingAvatar, setUploadingAvatar] = useState(false);
 	const [avatarError, setAvatarError] = useState<string | null>(null);
 	const avatarInputRef = useRef<HTMLInputElement>(null);
+	const [showCreateOrgModal, setShowCreateOrgModal] = useState(false);
 
 	// --- Engagements tab state ---
 	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
@@ -655,7 +657,24 @@ export default function ProfileOverviewPage() {
 								</div>
 							</form>
 
-							<div className="mt-12 rounded-lg border border-red-200 bg-red-50 p-6">
+							<div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6">
+								<h2 className="mb-1 text-base font-semibold text-gray-900">
+									{t("profile.sectionOrganization")}
+								</h2>
+								<p className="mb-4 text-sm text-gray-600">
+									{t("profile.createOrgHint")}
+								</p>
+								<button
+									type="button"
+									onClick={() => setShowCreateOrgModal(true)}
+									data-testid="create-org-btn"
+									className="rounded-md border border-brand-700 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-50"
+								>
+									{t("organization.create")}
+								</button>
+							</div>
+
+							<div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-6">
 								<h2 className="mb-1 text-base font-semibold text-red-800">
 									{t("account.dangerZoneTitle")}
 								</h2>
@@ -887,6 +906,13 @@ export default function ProfileOverviewPage() {
 			)}
 
 			{/* Dialogs / Modals */}
+			{showCreateOrgModal && (
+				<CreateOrganizationModal
+					onClose={() => setShowCreateOrgModal(false)}
+					onSuccess={() => setShowCreateOrgModal(false)}
+				/>
+			)}
+
 			{showDeleteDialog && (
 				<ConfirmDialog
 					title={t("account.deleteConfirmTitle")}


### PR DESCRIPTION
## Summary

- **#511 - Volunteer org switcher visibility**: `OrganizationSwitcher` now returns `null` when the user has no organizations, hiding the clutter from the header for pure volunteers. A new "Organizations" card on the Profile page (profile tab) gives every user a discoverable path to create an organization.
- **#510 - Mobile dropdown not scrollable**: The mobile menu had `overflow-hidden` on its outer container which clipped the absolutely-positioned org-switcher dropdown, making settings/engagements/dashboard links unreachable. Fixed by moving `overflow-hidden` to a wrapper that contains only the decorative background blobs - the dropdown is now unclipped and fully scrollable.

## Changes

| File | Change |
|---|---|
| `OrganizationSwitcher.tsx` | Return `null` instead of "Create org" button when `orgs.length === 0` |
| `Header.tsx` | Scope `overflow-hidden` to blob wrapper only; remove it from the mobile menu root |
| `ProfileOverviewPage.tsx` | Add "Organizations" section with "Create organization" button and `CreateOrganizationModal` |
| `en.json` / `de.json` | New keys: `profile.sectionOrganization`, `profile.createOrgHint` |

## Test plan

- [ ] Log in as `vera/vera123` (pure volunteer, no org) - org switcher is not visible in the header (desktop and mobile)
- [ ] Visit `/profile` as vera - "Organizations" card is visible with a "Create organization" button that opens the modal
- [ ] Log in as `olaf/olaf123` (has an org) - org switcher is visible in the header as before
- [ ] On mobile (375px), open hamburger menu as olaf, expand org switcher - dropdown is scrollable and all links (Dashboard, Manage Engagements, Settings) are reachable

## Live verification

Pending release candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss4x4CtVvSZBSYW8ZC2Jkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss4x4CtVvSZBSYW8ZC2Jkk)_