### PR TITLE
feat: consolidated org overview with calendar view and color picker (#501, #504)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -352,7 +352,7 @@ jobs:
             done
             docker compose pull
             docker compose up -d --remove-orphans
-            docker image prune --force
+            docker image prune --force || true
           EOF
 
       - name: Capture container logs on deploy failure

--- a/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
@@ -1,0 +1,43 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Organizations.GetOrganizationCalendarEvents.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Organizations.GetOrganizationCalendarEvents.v1;
+
+internal sealed class GetOrganizationCalendarEventsEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/organizations/{organizationId:guid}/calendar-events", GetOrganizationCalendarEventsAsync)
+			.WithName("GetOrganizationCalendarEvents")
+			.Produces<IReadOnlyList<OrganizationCalendarEventDto>>()
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> GetOrganizationCalendarEventsAsync(
+		[FromRoute] Guid organizationId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? new UserId(uid)
+			: throw new DomainException("Invalid user.");
+
+		var query = new GetOrganizationCalendarEventsQuery(organizationId, userId);
+		var result = await sender.Send(query, cancellationToken);
+		return Results.Ok(result);
+	}
+}

--- a/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
+++ b/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.SearchMemberCandidates.v1;
 using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,7 @@ internal sealed class SearchMemberCandidatesEndpoint
 			.Produces<IReadOnlyList<MemberCandidateDto>>()
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
+++ b/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
@@ -1,0 +1,37 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Application.Common.Messaging;
+using Application.Organizations.SearchMemberCandidates.v1;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Organizations.SearchMemberCandidates.v1;
+
+internal sealed class SearchMemberCandidatesEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/organizations/{organizationId:guid}/members/search", SearchAsync)
+			.WithName("SearchMemberCandidates")
+			.Produces<IReadOnlyList<MemberCandidateDto>>()
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> SearchAsync(
+		[FromRoute] Guid organizationId,
+		[FromQuery] string q,
+		[FromServices] ISender sender,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(q) || q.Length < 2)
+			return Results.Ok(Array.Empty<MemberCandidateDto>());
+
+		var result = await sender.Send(
+			new SearchMemberCandidatesQuery(organizationId, q),
+			cancellationToken);
+
+		return Results.Ok(result);
+	}
+}

--- a/backend/src/Api/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorEndpoint.cs
@@ -1,0 +1,48 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities.SetOpportunityColor.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.VolunteerOpportunities.SetOpportunityColor.v1;
+
+internal sealed class SetOpportunityColorEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapPut("/volunteer-opportunities/{opportunityId:guid}/color", SetOpportunityColorAsync)
+			.WithName("SetOpportunityColor")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> SetOpportunityColorAsync(
+		[FromRoute] Guid opportunityId,
+		[FromBody] SetOpportunityColorRequest request,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? new UserId(uid)
+			: throw new DomainException("Invalid user.");
+
+		await sender.Send(
+			new SetOpportunityColorCommand(opportunityId, request.Color, userId),
+			cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorRequest.cs
@@ -1,0 +1,3 @@
+namespace Api.VolunteerOpportunities.SetOpportunityColor.v1;
+
+public sealed record SetOpportunityColorRequest(string? Color);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1767,6 +1767,58 @@
         }
       }
     },
+    "/v1/organizations/{organizationId}/members/search": {
+      "get": {
+        "tags": [
+          "SearchMemberCandidatesEndpoint"
+        ],
+        "operationId": "SearchMemberCandidates",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MemberCandidateDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organizationId}/members/{userId}": {
       "delete": {
         "tags": [
@@ -3744,6 +3796,40 @@
           }
         }
       },
+      "MemberCandidateDto": {
+        "required": [
+          "userId",
+          "username",
+          "firstName",
+          "lastName",
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "lastName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
       "MyProfileResponse": {
         "required": [
           "id",
@@ -5122,6 +5208,9 @@
     },
     {
       "name": "GetOrganizationDetailsEndpoint"
+    },
+    {
+      "name": "SearchMemberCandidatesEndpoint"
     },
     {
       "name": "RemoveMemberEndpoint"

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -500,6 +500,90 @@
         }
       }
     },
+    "/v1/volunteer-opportunities/{opportunityId}/color": {
+      "put": {
+        "tags": [
+          "SetOpportunityColorEndpoint"
+        ],
+        "operationId": "SetOpportunityColor",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetOpportunityColorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/volunteer-opportunities/{opportunityId}/publish": {
       "post": {
         "tags": [
@@ -1969,6 +2053,70 @@
         }
       }
     },
+    "/v1/organizations/{organizationId}/calendar-events": {
+      "get": {
+        "tags": [
+          "GetOrganizationCalendarEventsEndpoint"
+        ],
+        "operationId": "GetOrganizationCalendarEvents",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrganizationCalendarEventDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organizationId}/members": {
       "post": {
         "tags": [
@@ -3054,6 +3202,37 @@
           }
         }
       },
+      "CalendarTimeSlotDto": {
+        "required": [
+          "timeSlotId",
+          "startDateTime",
+          "endDateTime",
+          "maxParticipants"
+        ],
+        "type": "object",
+        "properties": {
+          "timeSlotId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "maxParticipants": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          }
+        }
+      },
       "CancelEngagementRequest": {
         "required": [
           "reason"
@@ -3785,6 +3964,36 @@
           }
         }
       },
+      "OrganizationCalendarEventDto": {
+        "required": [
+          "opportunityId",
+          "title",
+          "color",
+          "timeSlots"
+        ],
+        "type": "object",
+        "properties": {
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "color": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "timeSlots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CalendarTimeSlotDto"
+            }
+          }
+        }
+      },
       "OrganizationDashboardResponse": {
         "required": [
           "openOpportunities",
@@ -4219,6 +4428,20 @@
             "items": {
               "$ref": "#/components/schemas/AchievementSummary"
             }
+          }
+        }
+      },
+      "SetOpportunityColorRequest": {
+        "required": [
+          "color"
+        ],
+        "type": "object",
+        "properties": {
+          "color": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -4862,6 +5085,9 @@
       "name": "DeleteTimeSlotEndpoint"
     },
     {
+      "name": "SetOpportunityColorEndpoint"
+    },
+    {
       "name": "PublishVolunteerOpportunityEndpoint"
     },
     {
@@ -4911,6 +5137,9 @@
     },
     {
       "name": "GetOrganizationDashboardEndpoint"
+    },
+    {
+      "name": "GetOrganizationCalendarEventsEndpoint"
     },
     {
       "name": "AddMemberEndpoint"

--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -39,4 +39,9 @@ public interface IKeycloakOrganizationService
 	Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
 		Guid organizationId,
 		CancellationToken cancellationToken = default);
+
+	Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
+		string search,
+		int max = 20,
+		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQuery.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQuery.cs
@@ -1,0 +1,9 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.Organizations.GetOrganizationCalendarEvents.v1;
+
+public sealed record GetOrganizationCalendarEventsQuery(
+	Guid OrganizationId,
+	UserId RequestingUserId)
+	: IQuery<IReadOnlyList<OrganizationCalendarEventDto>>;

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
@@ -1,0 +1,18 @@
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities;
+
+namespace Application.Organizations.GetOrganizationCalendarEvents.v1;
+
+internal sealed class GetOrganizationCalendarEventsQueryHandler(
+	IVolunteerOpportunityReadRepository readRepository)
+	: IQueryHandler<GetOrganizationCalendarEventsQuery, IReadOnlyList<OrganizationCalendarEventDto>>
+{
+	public async ValueTask<IReadOnlyList<OrganizationCalendarEventDto>> Handle(
+		GetOrganizationCalendarEventsQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		return await readRepository.GetCalendarEventsAsync(
+			request.OrganizationId,
+			cancellationToken);
+	}
+}

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/OrganizationCalendarEventDto.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/OrganizationCalendarEventDto.cs
@@ -1,0 +1,13 @@
+namespace Application.Organizations.GetOrganizationCalendarEvents.v1;
+
+public sealed record OrganizationCalendarEventDto(
+	Guid OpportunityId,
+	string Title,
+	string? Color,
+	IReadOnlyList<CalendarTimeSlotDto> TimeSlots);
+
+public sealed record CalendarTimeSlotDto(
+	Guid TimeSlotId,
+	DateTimeOffset StartDateTime,
+	DateTimeOffset EndDateTime,
+	int MaxParticipants);

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
@@ -1,0 +1,15 @@
+using Application.Common.Messaging;
+
+namespace Application.Organizations.SearchMemberCandidates.v1;
+
+public sealed record SearchMemberCandidatesQuery(
+	Guid OrganizationId,
+	string Search)
+	: IQuery<IReadOnlyList<MemberCandidateDto>>;
+
+public sealed record MemberCandidateDto(
+	Guid UserId,
+	string Username,
+	string? FirstName,
+	string? LastName,
+	string Email);

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
@@ -1,0 +1,34 @@
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+
+namespace Application.Organizations.SearchMemberCandidates.v1;
+
+internal sealed class SearchMemberCandidatesQueryHandler(
+	IKeycloakOrganizationService keycloak)
+	: IQueryHandler<SearchMemberCandidatesQuery, IReadOnlyList<MemberCandidateDto>>
+{
+	public async ValueTask<IReadOnlyList<MemberCandidateDto>> Handle(
+		SearchMemberCandidatesQuery query,
+		CancellationToken cancellationToken)
+	{
+		var allResults = await keycloak.SearchUsersAsync(
+			query.Search,
+			cancellationToken: cancellationToken);
+
+		var currentMembers = await keycloak.GetMembersAsync(
+			query.OrganizationId,
+			cancellationToken);
+
+		var memberIds = currentMembers.Select(m => m.UserId).ToHashSet();
+
+		return allResults
+			.Where(u => !memberIds.Contains(u.UserId))
+			.Select(u => new MemberCandidateDto(
+				u.UserId,
+				u.Username,
+				u.FirstName,
+				u.LastName,
+				u.Email))
+			.ToList();
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
+++ b/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
@@ -1,4 +1,5 @@
 using Application.Common.Pagination;
+using Application.Organizations.GetOrganizationCalendarEvents.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 using Domain.VolunteerOpportunities;
@@ -22,5 +23,9 @@ public interface IVolunteerOpportunityReadRepository
 
 	ValueTask<string?> GetBannerUrlAsync(
 		Guid opportunityId,
+		CancellationToken cancellationToken = default);
+
+	ValueTask<IReadOnlyList<OrganizationCalendarEventDto>> GetCalendarEventsAsync(
+		Guid organizationId,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorCommand.cs
@@ -1,0 +1,10 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.VolunteerOpportunities.SetOpportunityColor.v1;
+
+public sealed record SetOpportunityColorCommand(
+	Guid OpportunityId,
+	string? Color,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/SetOpportunityColor/v1/SetOpportunityColorCommandHandler.cs
@@ -1,0 +1,35 @@
+using Application.Common.Authorization;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.SetOpportunityColor.v1;
+
+internal sealed class SetOpportunityColorCommandHandler(
+	IApplicationDbContext dbContext,
+	IKeycloakOrganizationService keycloakOrgService)
+	: ICommandHandler<SetOpportunityColorCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		SetOpportunityColorCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunityId = new VolunteerOpportunityId(request.OpportunityId);
+
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			opportunityId, cancellationToken)
+			?? throw new DomainException($"Volunteer opportunity '{request.OpportunityId}' not found.");
+
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrgService,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		opportunity.SetColor(request.Color);
+
+		return true;
+	}
+}

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -33,6 +33,8 @@ public sealed class VolunteerOpportunity
 
 	public string? BannerImageUrl { get; private set; }
 
+	public string? Color { get; private set; }
+
 	public string? CheckInPin { get; private set; }
 
 	public IReadOnlyCollection<TimeSlot> TimeSlots => _timeSlots.AsReadOnly();
@@ -140,6 +142,11 @@ public sealed class VolunteerOpportunity
 			throw new DomainException("Banner image URL must not be empty.");
 
 		BannerImageUrl = url;
+	}
+
+	public void SetColor(string? color)
+	{
+		Color = color;
 	}
 
 	public void Update(

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -144,6 +144,34 @@ internal sealed class KeycloakOrganizationService(
 			.ToList();
 	}
 
+	public async Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
+		string search,
+		int max = 20,
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var encoded = Uri.EscapeDataString(search);
+		var response = await httpClient.GetAsync(
+			$"/admin/realms/{_options.Realm}/users?search={encoded}&max={max}",
+			cancellationToken);
+
+		await EnsureSuccessAsync(response, cancellationToken);
+
+		var users = await response.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
+			JsonOptions, cancellationToken) ?? [];
+
+		return users
+			.Select(u => new KeycloakOrganizationMember(
+				Guid.Parse(u.Id),
+				u.Username,
+				u.FirstName,
+				u.LastName,
+				u.Email ?? string.Empty,
+				false))
+			.ToList();
+	}
+
 	public async Task RemoveMemberAsync(
 		Guid organizationId,
 		Guid userId,

--- a/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
@@ -66,6 +66,8 @@ internal sealed class VolunteerOpportunityConfiguration
 
 		builder.Property(vo => vo.BannerImageUrl);
 
+		builder.Property(vo => vo.Color);
+
 		builder.PrimitiveCollection(vo => vo.Tags)
 			.HasColumnType("text[]");
 

--- a/backend/src/Infrastructure/Persistence/Migrations/20260622120000_AddOpportunityColor.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260622120000_AddOpportunityColor.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260622120000_AddOpportunityColor")]
+	partial class AddOpportunityColor
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260622120000_AddOpportunityColor.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260622120000_AddOpportunityColor.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOpportunityColor : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "color",
+				table: "volunteer_opportunity",
+				type: "text",
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "color",
+				table: "volunteer_opportunity");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -1,4 +1,5 @@
 using Application.Common.Pagination;
+using Application.Organizations.GetOrganizationCalendarEvents.v1;
 using Application.VolunteerOpportunities;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
@@ -361,5 +362,40 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Where(vo => vo.Id == opportunityId_)
 			.Select(vo => vo.BannerImageUrl)
 			.FirstOrDefaultAsync(cancellationToken);
+	}
+
+	public async ValueTask<IReadOnlyList<OrganizationCalendarEventDto>> GetCalendarEventsAsync(
+		Guid organizationId,
+		CancellationToken cancellationToken = default)
+	{
+		var orgId = new OrganizationId(organizationId);
+
+		var rows = await dbContext.VolunteerOpportunitiesQuery
+			.Where(vo => vo.OrganizationId == orgId)
+			.Where(vo => vo.TimeSlots.Any())
+			.OrderBy(vo => vo.TimeSlots.Min(ts => ts.StartDateTime))
+			.Select(vo => new
+			{
+				Id = vo.Id.Value,
+				vo.Title,
+				vo.Color,
+				TimeSlots = vo.TimeSlots
+					.OrderBy(ts => ts.StartDateTime)
+					.Select(ts => new CalendarTimeSlotDto(
+						ts.Id.Value,
+						ts.StartDateTime,
+						ts.EndDateTime,
+						ts.MaxParticipants))
+					.ToList(),
+			})
+			.ToListAsync(cancellationToken);
+
+		return rows
+			.Select(r => new OrganizationCalendarEventDto(
+				r.Id,
+				r.Title,
+				r.Color,
+				r.TimeSlots))
+			.ToList();
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -69,6 +69,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task SetOpportunityColorAsync(System.Guid opportunityId, SetOpportunityColorRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task PublishVolunteerOpportunityAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -175,6 +180,11 @@ namespace IntegrationTests
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<OrganizationDashboardResponse> GetOrganizationDashboardAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
@@ -1036,6 +1046,133 @@ namespace IntegrationTests
                         if (status_ == 204)
                         {
                             return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task SetOpportunityColorAsync(System.Guid opportunityId, SetOpportunityColorRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/color"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/color");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 401)
@@ -3486,6 +3623,112 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/organizations/{organizationId}/calendar-events"
+                    urlBuilder_.Append("v1/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/calendar-events");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task AddMemberAsync(System.Guid organizationId, AddMemberRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -5448,6 +5691,38 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CalendarTimeSlotDto
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("timeSlotId")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid TimeSlotId { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("startDateTime")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.DateTimeOffset StartDateTime { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("endDateTime")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.DateTimeOffset EndDateTime { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("maxParticipants")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int MaxParticipants { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CancelEngagementRequest
     {
 
@@ -6092,6 +6367,36 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class OrganizationCalendarEventDto
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("opportunityId")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid OpportunityId { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Title { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("color")]
+        public string? Color { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("timeSlots")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<CalendarTimeSlotDto> TimeSlots { get; set; } = new System.Collections.ObjectModel.Collection<CalendarTimeSlotDto>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class OrganizationDashboardResponse
     {
 
@@ -6443,6 +6748,24 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("badges")]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<AchievementSummary> Badges { get; set; } = new System.Collections.ObjectModel.Collection<AchievementSummary>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class SetOpportunityColorRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("color")]
+        public string? Color { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -157,6 +157,11 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<OrganizationDetailsResponse> GetOrganizationDetailsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<MemberCandidateDto>> SearchMemberCandidatesAsync(System.Guid organizationId, string q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task RemoveMemberAsync(System.Guid organizationId, System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -3086,6 +3091,98 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<MemberCandidateDto>> SearchMemberCandidatesAsync(System.Guid organizationId, string q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            if (q == null)
+                throw new System.ArgumentNullException("q");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/organizations/{organizationId}/members/search"
+                    urlBuilder_.Append("v1/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/members/search");
+                    urlBuilder_.Append('?');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("q")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(q, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<MemberCandidateDto>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -6185,6 +6282,39 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("name")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Name { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MemberCandidateDto
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("userId")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid UserId { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("username")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Username { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("firstName")]
+        public string? FirstName { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("lastName")]
+        public string? LastName { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("email")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Email { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,8 +116,8 @@ services:
           memory: 512m
           cpus: "0.50"
     environment:
-      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:?set MINIO_ACCESS_KEY in .env}
-      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:?set MINIO_SECRET_KEY in .env}
+      MINIO_ROOT_USER: einsatzbereit-minio
+      MINIO_ROOT_PASSWORD: einsatzbereit-minio-secret
     volumes:
       - minio_data:/data
     healthcheck:
@@ -173,8 +173,8 @@ services:
       Keycloak__ClientSecret: ${KEYCLOAK_BACKEND_SECRET:?set KEYCLOAK_BACKEND_SECRET in .env}
       Cors__Origins__0: https://einsatzbereit.maik-hasler.de
       Storage__Endpoint: http://minio:9000
-      Storage__AccessKey: ${MINIO_ACCESS_KEY:?set MINIO_ACCESS_KEY in .env}
-      Storage__SecretKey: ${MINIO_SECRET_KEY:?set MINIO_SECRET_KEY in .env}
+      Storage__AccessKey: einsatzbereit-minio
+      Storage__SecretKey: einsatzbereit-minio-secret
       Storage__BucketName: einsatzbereit
       Storage__PublicEndpoint: https://storage.maik-hasler.de
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,38 @@ services:
     volumes:
       - postgres_backups:/backups
 
+  minio:
+    image: quay.io/minio/minio:latest
+    container_name: minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    networks:
+      - proxy
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.50"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:?set MINIO_ACCESS_KEY in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:?set MINIO_SECRET_KEY in .env}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.minio.rule=Host(`storage.maik-hasler.de`)
+      - traefik.http.routers.minio.entrypoints=websecure
+      - traefik.http.routers.minio.tls=true
+      - traefik.http.routers.minio.tls.certresolver=myresolver
+      - traefik.http.services.minio.loadbalancer.server.port=9000
+
   backend:
     image: ghcr.io/maik-hasler/einsatzbereit-backend:staging
     container_name: backend
@@ -119,6 +151,8 @@ services:
       postgres:
         condition: service_healthy
       keycloak:
+        condition: service_healthy
+      minio:
         condition: service_healthy
     # curl is installed in the Dockerfile (as root before switching to $APP_UID).
     # /alive (not /health) is used so the container is gated on the app being up,
@@ -138,6 +172,11 @@ services:
       Keycloak__BaseUrl: http://keycloak:8080
       Keycloak__ClientSecret: ${KEYCLOAK_BACKEND_SECRET:?set KEYCLOAK_BACKEND_SECRET in .env}
       Cors__Origins__0: https://einsatzbereit.maik-hasler.de
+      Storage__Endpoint: http://minio:9000
+      Storage__AccessKey: ${MINIO_ACCESS_KEY:?set MINIO_ACCESS_KEY in .env}
+      Storage__SecretKey: ${MINIO_SECRET_KEY:?set MINIO_SECRET_KEY in .env}
+      Storage__BucketName: einsatzbereit
+      Storage__PublicEndpoint: https://storage.maik-hasler.de
     labels:
       - traefik.enable=true
       - traefik.docker.network=proxy
@@ -186,6 +225,7 @@ networks:
 volumes:
   postgres_data:
   postgres_backups:
+  minio_data:
 
 configs:
   postgres-init:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,12 +17,14 @@
     "i18n:check": "node scripts/check-i18n-keys.js"
   },
   "dependencies": {
+    "date-fns": "^4.4.0",
     "i18next": "26.3.1",
     "i18next-browser-languagedetector": "8.2.1",
     "leaflet": "1.9.4",
     "oidc-client-ts": "3.5.0",
     "qrcode.react": "4.2.0",
     "react": "19.2.6",
+    "react-big-calendar": "^1.20.0",
     "react-dom": "19.2.6",
     "react-i18next": "17.0.8",
     "react-leaflet": "5.0.0",
@@ -35,6 +37,7 @@
     "@types/leaflet": "1.9.21",
     "@types/node": "25.9.3",
     "@types/react": "19.2.15",
+    "@types/react-big-calendar": "^1.16.3",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "eslint": "10.4.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       i18next:
         specifier: 26.3.1
         version: 26.3.1(typescript@6.0.3)
@@ -26,6 +29,9 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
+      react-big-calendar:
+        specifier: ^1.20.0
+        version: 1.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -57,6 +63,9 @@ importers:
       '@types/react':
         specifier: 19.2.15
         version: 19.2.15
+      '@types/react-big-calendar':
+        specifier: ^1.16.3
+        version: 1.16.3
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
@@ -644,6 +653,10 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -768,12 +781,20 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@react-leaflet/core@3.0.0':
     resolution: {integrity: sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==}
     peerDependencies:
       leaflet: ^1.9.0
       react: ^19.0.0
       react-dom: ^19.0.0
+
+  '@restart/hooks@0.4.16':
+    resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1232,6 +1253,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/date-arithmetic@4.1.4':
+    resolution: {integrity: sha512-p9eZ2X9B80iKiTW4ukVj8B4K6q9/+xFtQ5MGYA5HWToY9nL4EkhV9+6ftT2VHpVMEZb5Tv00Iel516bVdO+yRw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1250,6 +1274,12 @@ packages:
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-big-calendar@1.16.3':
+    resolution: {integrity: sha512-CR+5BKMhlr/wPgsp+sXOeNKNkoU1h/+6H1XoWuL7xnurvzGRQv/EnM8jPS9yxxBvXI8pjQBaJcI7RTSGiewG/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1263,6 +1293,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/warning@3.0.4':
+    resolution: {integrity: sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==}
 
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
@@ -1473,6 +1506,13 @@ packages:
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
+  cldrjs@0.5.5:
+    resolution: {integrity: sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1528,6 +1568,15 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-arithmetic@4.1.0:
+    resolution: {integrity: sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1552,9 +1601,19 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dom-helpers@6.0.1:
+    resolution: {integrity: sha512-IKySryuFwseGkrCA/pIqlwUPOD50w1Lj/B2Yief3vBOP18k5y4t+hTqKh55gULDVeJMRitcozve+g/wVFf4sFQ==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -1791,6 +1850,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  globalize@1.7.1:
+    resolution: {integrity: sha512-PFymRL0PtitFOlSniuwwwNfkooi3cLQJo9Uke1+j1DsGfUkkHkwneImqVtGcqKI0TuzhAlHt7hAcgK324902HA==}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -1867,6 +1929,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2150,6 +2215,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -2158,6 +2226,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -2169,12 +2241,19 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2190,6 +2269,12 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  moment-timezone@0.5.48:
+    resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
+
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2207,6 +2292,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2310,6 +2399,9 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2318,6 +2410,12 @@ packages:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-big-calendar@1.20.0:
+    resolution: {integrity: sha512-Lp1mvG34l/9xtb/2LsBb4UAF3iPcUkmDqbmpsvDHzp/n8GA5gtn3+nf8BsULWw08opKDgv38nQi75dQlOOqzkg==}
+    peerDependencies:
+      react: ^16.14.0 || ^17 || ^18 || ^19
+      react-dom: ^16.14.0 || ^17 || ^18 || ^19
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -2340,6 +2438,9 @@ packages:
       typescript:
         optional: true
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-leaflet@5.0.0:
     resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
     peerDependencies:
@@ -2347,12 +2448,21 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
   react-oidc-context@3.3.1:
     resolution: {integrity: sha512-/Azvm9W4DhhOtSDBE73kFInh1b6zZRRfILKbgmk2syExMF0PCYJOn/dGdOOi2BFX8x0rCeUe45NXHU+/+xDcrQ==}
     engines: {node: '>=18'}
     peerDependencies:
       oidc-client-ts: ^3.1.0
       react: '>=16.14.0'
+
+  react-overlays@5.2.1:
+    resolution: {integrity: sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==}
+    peerDependencies:
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
 
   react-router@7.16.0:
     resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
@@ -2630,6 +2740,11 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncontrollable@7.2.1:
+    resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
+    peerDependencies:
+      react: '>=15.0.0'
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -2738,6 +2853,9 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -3535,6 +3653,8 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3682,11 +3802,18 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@popperjs/core@2.11.8': {}
+
   '@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       leaflet: 1.9.4
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@restart/hooks@0.4.16(react@19.2.6)':
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.6
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -4009,6 +4136,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/date-arithmetic@4.1.4': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -4025,6 +4154,14 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-big-calendar@1.16.3':
+    dependencies:
+      '@types/date-arithmetic': 4.1.4
+      '@types/prop-types': 15.7.15
+      '@types/react': 19.2.15
+
   '@types/react-dom@19.2.3(@types/react@19.2.15)':
     dependencies:
       '@types/react': 19.2.15
@@ -4036,6 +4173,8 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/warning@3.0.4': {}
 
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -4289,6 +4428,10 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
+  cldrjs@0.5.5: {}
+
+  clsx@2.1.1: {}
+
   commander@2.20.3: {}
 
   common-tags@1.8.2: {}
@@ -4342,6 +4485,12 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-arithmetic@4.1.0: {}
+
+  date-fns@4.4.0: {}
+
+  dayjs@1.11.21: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4362,7 +4511,19 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
+
+  dom-helpers@6.0.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dot-case@3.0.4:
     dependencies:
@@ -4696,6 +4857,10 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  globalize@1.7.1:
+    dependencies:
+      cldrjs: 0.5.5
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -4761,6 +4926,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5005,11 +5174,17 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.sortby@4.7.0: {}
 
   lodash@4.18.1: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lower-case@2.0.2:
     dependencies:
@@ -5021,11 +5196,15 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  luxon@3.7.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  memoize-one@6.0.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -5041,6 +5220,12 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  moment-timezone@0.5.48:
+    dependencies:
+      moment: 2.30.1
+
+  moment@2.30.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -5053,6 +5238,8 @@ snapshots:
       tslib: 2.8.1
 
   node-releases@2.0.38: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -5154,11 +5341,38 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   qrcode.react@4.2.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  react-big-calendar@1.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      clsx: 2.1.1
+      date-arithmetic: 4.1.0
+      dayjs: 1.11.21
+      dom-helpers: 6.0.1
+      globalize: 1.7.1
+      invariant: 2.2.4
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      luxon: 3.7.2
+      memoize-one: 6.0.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-overlays: 5.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      uncontrollable: 7.2.1(react@19.2.6)
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -5176,6 +5390,8 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       typescript: 6.0.3
 
+  react-is@16.13.1: {}
+
   react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@react-leaflet/core': 3.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -5183,10 +5399,25 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  react-lifecycles-compat@3.0.4: {}
+
   react-oidc-context@3.3.1(oidc-client-ts@3.5.0)(react@19.2.6):
     dependencies:
       oidc-client-ts: 3.5.0
       react: 19.2.6
+
+  react-overlays@5.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@popperjs/core': 2.11.8
+      '@restart/hooks': 0.4.16(react@19.2.6)
+      '@types/warning': 3.0.4
+      dom-helpers: 5.2.1
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      uncontrollable: 7.2.1(react@19.2.6)
+      warning: 4.0.3
 
   react-router@7.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -5567,6 +5798,14 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  uncontrollable@7.2.1(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/react': 19.2.15
+      invariant: 2.2.4
+      react: 19.2.6
+      react-lifecycles-compat: 3.0.4
+
   undici-types@7.24.6: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -5639,6 +5878,10 @@ snapshots:
 
   void-elements@3.1.0: {}
 
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
+
   webidl-conversions@4.0.2: {}
 
   whatwg-url@7.1.0:
@@ -5708,7 +5951,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.7(ajv@8.20.0)
       '@babel/core': 7.29.0
       '@babel/preset-env': 7.29.7(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(rollup@4.62.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from "react-router";
+import { Routes, Route, Navigate, useParams } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import AppLayout from "./layouts/AppLayout";
@@ -6,17 +6,25 @@ import ProtectedRoute from "./layouts/ProtectedRoute";
 import HomePage from "./pages/HomePage";
 import DatenschutzPage from "./pages/DatenschutzPage";
 import ImpressumPage from "./pages/ImpressumPage";
-import OrganizationSettingsPage from "./pages/OrganizationSettingsPage";
 import VolunteerOpportunityDetailPage from "./pages/VolunteerOpportunityDetailPage";
 import EngagementManagementPage from "./pages/EngagementManagementPage";
 import ProfileOverviewPage from "./pages/ProfileOverviewPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import OrganizationProfilePage from "./pages/OrganizationProfilePage";
-import OrganizationDashboardPage from "./pages/OrganizationDashboardPage";
-import OrganizationEngagementsPage from "./pages/OrganizationEngagementsPage";
+import OrganizationOverviewPage from "./pages/OrganizationOverviewPage";
 import UserAchievementsPage from "./pages/UserAchievementsPage";
 import AdminOrganizationsPage from "./pages/AdminOrganizationsPage";
 import UserProfilePage from "./pages/UserProfilePage";
+
+function OrgTabRedirect({ tab }: { tab: string }) {
+	const { organizationId } = useParams<{ organizationId: string }>();
+	return (
+		<Navigate
+			to={`/organizations/${organizationId}/dashboard?tab=${tab}`}
+			replace
+		/>
+	);
+}
 
 function CallbackPage() {
 	const auth = useAuth();
@@ -76,27 +84,19 @@ export default function App() {
 				/>
 				<Route
 					path="/organizations/:organizationId/settings"
-					element={
-						<ProtectedRoute>
-							<OrganizationSettingsPage />
-						</ProtectedRoute>
-					}
+					element={<OrgTabRedirect tab="settings" />}
 				/>
 				<Route
 					path="/organizations/:organizationId/dashboard"
 					element={
 						<ProtectedRoute>
-							<OrganizationDashboardPage />
+							<OrganizationOverviewPage />
 						</ProtectedRoute>
 					}
 				/>
 				<Route
 					path="/organizations/:organizationId/engagements"
-					element={
-						<ProtectedRoute>
-							<OrganizationEngagementsPage />
-						</ProtectedRoute>
-					}
+					element={<OrgTabRedirect tab="engagements" />}
 				/>
 				<Route
 					path="/achievements"

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1604,6 +1604,56 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @return OK
+     */
+    searchMemberCandidates(organizationId: string, q: string, signal?: AbortSignal): Promise<MemberCandidateDto[]> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/members/search?";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        if (q === undefined || q === null)
+            throw new globalThis.Error("The parameter 'q' must be defined and cannot be null.");
+        else
+            url_ += "q=" + encodeURIComponent("" + q) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSearchMemberCandidates(_response);
+        });
+    }
+
+    protected processSearchMemberCandidates(response: Response): Promise<MemberCandidateDto[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as MemberCandidateDto[];
+            return result200;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<MemberCandidateDto[]>(null as any);
+    }
+
+    /**
      * @return No Content
      */
     removeMember(organizationId: string, userId: string, signal?: AbortSignal): Promise<void> {
@@ -3057,6 +3107,16 @@ export interface FeedbackItemDto {
 export interface KeycloakOrganization {
     id: string;
     name: string;
+
+    [key: string]: any;
+}
+
+export interface MemberCandidateDto {
+    userId: string;
+    username: string;
+    firstName: string | undefined;
+    lastName: string | undefined;
+    email: string;
 
     [key: string]: any;
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -463,6 +463,77 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    setOpportunityColor(opportunityId: string, body: SetOpportunityColorRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/color";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            signal,
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetOpportunityColor(_response);
+        });
+    }
+
+    protected processSetOpportunityColor(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     publishVolunteerOpportunity(opportunityId: string, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/publish";
         if (opportunityId === undefined || opportunityId === null)
@@ -1815,6 +1886,64 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @return OK
+     */
+    getOrganizationCalendarEvents(organizationId: string, signal?: AbortSignal): Promise<OrganizationCalendarEventDto[]> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/calendar-events";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetOrganizationCalendarEvents(_response);
+        });
+    }
+
+    protected processGetOrganizationCalendarEvents(response: Response): Promise<OrganizationCalendarEventDto[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as OrganizationCalendarEventDto[];
+            return result200;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<OrganizationCalendarEventDto[]>(null as any);
+    }
+
+    /**
      * @return No Content
      */
     addMember(organizationId: string, body: AddMemberRequest, signal?: AbortSignal): Promise<void> {
@@ -2781,6 +2910,15 @@ export interface BadgeCatalogEntry {
     [key: string]: any;
 }
 
+export interface CalendarTimeSlotDto {
+    timeSlotId: string;
+    startDateTime: Date;
+    endDateTime: Date;
+    maxParticipants: number;
+
+    [key: string]: any;
+}
+
 export interface CancelEngagementRequest {
     reason: string | undefined;
 
@@ -2975,6 +3113,15 @@ export interface Organization {
     [key: string]: any;
 }
 
+export interface OrganizationCalendarEventDto {
+    opportunityId: string;
+    title: string;
+    color: string | undefined;
+    timeSlots: CalendarTimeSlotDto[];
+
+    [key: string]: any;
+}
+
 export interface OrganizationDashboardResponse {
     openOpportunities: number;
     pendingEngagements: number;
@@ -3080,6 +3227,12 @@ export interface PublicUserProfileResponse {
     displayName: string;
     engagementCount: number;
     badges: AchievementSummary[];
+
+    [key: string]: any;
+}
+
+export interface SetOpportunityColorRequest {
+    color: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -29,7 +29,6 @@ export default function OrganizationSwitcher({
 			.getOrganizations()
 			.then((data: KeycloakOrganization[]) => {
 				setOrgs(data);
-				// Auto-select first org if none is active
 				if (!getActiveOrgId() && data.length > 0) {
 					setActiveOrgCookie(data[0].id);
 					setActiveOrgId(data[0].id);
@@ -61,7 +60,6 @@ export default function OrganizationSwitcher({
 	const handleSwitch = (org: KeycloakOrganization) => {
 		setActiveOrgCookie(org.id);
 		setActiveOrgId(org.id);
-		setOpen(false);
 	};
 
 	const handleOrgCreated = () => {
@@ -115,6 +113,7 @@ export default function OrganizationSwitcher({
 						viewBox="0 0 24 24"
 						strokeWidth="1.5"
 						stroke="currentColor"
+						aria-hidden="true"
 					>
 						<path
 							strokeLinecap="round"
@@ -134,6 +133,7 @@ export default function OrganizationSwitcher({
 						viewBox="0 0 24 24"
 						strokeWidth="2"
 						stroke="currentColor"
+						aria-hidden="true"
 					>
 						<path
 							strokeLinecap="round"
@@ -145,82 +145,37 @@ export default function OrganizationSwitcher({
 
 				{/* Dropdown */}
 				{open && (
-					<div className="absolute left-0 top-full mt-2 w-64 rounded-lg border shadow-lg z-50 bg-white border-gray-200">
-						<div className="py-1 max-h-60 overflow-y-auto">
+					<div className="absolute left-0 top-full mt-2 w-56 rounded-lg border shadow-lg z-50 bg-white border-gray-200">
+						<ul className="py-1 max-h-60 overflow-y-auto">
 							{orgs.map((org) => (
-								<button
+								<li
 									key={org.id}
-									type="button"
-									onClick={() => handleSwitch(org)}
-									className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
-										org.id === activeOrgId
-											? "bg-brand-50 text-brand-700 font-medium"
-											: "text-gray-700 hover:bg-gray-50"
-									}`}
+									className={`flex items-center gap-2 px-3 py-2 ${org.id === activeOrgId ? "bg-brand-50" : ""}`}
 								>
-									<span className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-semibold bg-brand-100 text-brand-700">
-										{org.name.charAt(0).toUpperCase()}
-									</span>
-									<span className="truncate">{org.name}</span>
-									{org.id === activeOrgId && (
-										<svg
-											className="ml-auto w-4 h-4 text-brand-500"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth="2"
-											stroke="currentColor"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="m4.5 12.75 6 6 9-13.5"
-											/>
-										</svg>
-									)}
-								</button>
-							))}
-						</div>
-
-						<div className="border-t border-gray-100">
-							{activeOrgId && (
-								<>
 									<button
 										type="button"
-										data-testid="org-dashboard-link"
-										onClick={() => {
-											setOpen(false);
-											navigate(`/organizations/${activeOrgId}/dashboard`);
-										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-gray-50"
+										onClick={() => handleSwitch(org)}
+										className={`flex flex-1 items-center gap-2 min-w-0 text-sm ${org.id === activeOrgId ? "text-brand-700 font-medium" : "text-gray-700 hover:text-gray-900"}`}
 									>
-										<svg
-											className="w-4 h-4 text-gray-400"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth="1.5"
-											stroke="currentColor"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"
-											/>
-										</svg>
-										{t("organization.dashboard")}
+										<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-xs font-semibold bg-brand-100 text-brand-700">
+											{org.name.charAt(0).toUpperCase()}
+										</span>
+										<span className="truncate">{org.name}</span>
 									</button>
 									<button
 										type="button"
-										data-testid="org-engagements-link"
+										data-testid="org-dashboard-link"
+										aria-label={t("organization.dashboard")}
 										onClick={() => {
+											setActiveOrgCookie(org.id);
+											setActiveOrgId(org.id);
 											setOpen(false);
-											navigate(
-												`/organizations/${activeOrgId}/dashboard?tab=engagements`,
-											);
+											navigate(`/organizations/${org.id}/dashboard`);
 										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-gray-50"
+										className="shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-brand-700"
 									>
 										<svg
-											className="w-4 h-4 text-gray-400"
+											className="w-4 h-4"
 											fill="none"
 											viewBox="0 0 24 24"
 											strokeWidth="1.5"
@@ -230,44 +185,15 @@ export default function OrganizationSwitcher({
 											<path
 												strokeLinecap="round"
 												strokeLinejoin="round"
-												d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+												d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
 											/>
 										</svg>
-										{t("organization.engagements")}
 									</button>
-									<button
-										type="button"
-										data-testid="org-settings-link"
-										onClick={() => {
-											setOpen(false);
-											navigate(
-												`/organizations/${activeOrgId}/dashboard?tab=settings`,
-											);
-										}}
-										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-gray-50"
-									>
-										<svg
-											className="w-4 h-4 text-gray-400"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth="1.5"
-											stroke="currentColor"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
-											/>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-											/>
-										</svg>
-										{t("organization.settings")}
-									</button>
-								</>
-							)}
+								</li>
+							))}
+						</ul>
+
+						<div className="border-t border-gray-100">
 							<button
 								type="button"
 								onClick={() => {
@@ -282,6 +208,7 @@ export default function OrganizationSwitcher({
 									viewBox="0 0 24 24"
 									strokeWidth="1.5"
 									stroke="currentColor"
+									aria-hidden="true"
 								>
 									<path
 										strokeLinecap="round"

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -213,7 +213,9 @@ export default function OrganizationSwitcher({
 										data-testid="org-engagements-link"
 										onClick={() => {
 											setOpen(false);
-											navigate(`/organizations/${activeOrgId}/engagements`);
+											navigate(
+												`/organizations/${activeOrgId}/dashboard?tab=engagements`,
+											);
 										}}
 										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-gray-50"
 									>
@@ -238,7 +240,9 @@ export default function OrganizationSwitcher({
 										data-testid="org-settings-link"
 										onClick={() => {
 											setOpen(false);
-											navigate(`/organizations/${activeOrgId}/settings`);
+											navigate(
+												`/organizations/${activeOrgId}/dashboard?tab=settings`,
+											);
 										}}
 										className="flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-gray-50"
 									>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -374,6 +374,12 @@
       "organisator": "Organisator",
       "removeMember": "Entfernen",
       "removeMemberError": "Mitglied konnte nicht entfernt werden.",
+      "addMemberLabel": "Mitglied hinzufügen",
+      "addMemberPlaceholder": "Nach Name oder E-Mail suchen…",
+      "addMember": "Hinzufügen",
+      "addMemberError": "Mitglied konnte nicht hinzugefügt werden.",
+      "searching": "Suche läuft…",
+      "noSearchResults": "Keine Benutzer gefunden.",
       "edit": "Bearbeiten",
       "cancel": "Abbrechen",
       "loading": "Wird geladen…"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -691,6 +691,7 @@
     "orgOverview": {
       "tabCalendar": "Kalender",
       "tabEngagements": "Bewerbungen",
+      "tabMembers": "Mitglieder",
       "tabSettings": "Einstellungen",
       "calendarLoading": "Kalender wird geladen...",
       "calendarError": "Kalendereintraege konnten nicht geladen werden.",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -687,6 +687,26 @@
       "noOrgs": "Keine Organisationen gefunden.",
       "verify": "Verifizieren",
       "unverify": "Verifizierung aufheben"
+    },
+    "orgOverview": {
+      "tabCalendar": "Kalender",
+      "tabEngagements": "Bewerbungen",
+      "tabSettings": "Einstellungen",
+      "calendarLoading": "Kalender wird geladen...",
+      "calendarError": "Kalendereintraege konnten nicht geladen werden.",
+      "calendarNoEvents": "Keine Eintraege in diesem Zeitraum.",
+      "eventColorLabel": "Farbe des Eintrags",
+      "eventColorSave": "Speichern",
+      "eventColorSaving": "Wird gespeichert...",
+      "colorSaveError": "Farbe konnte nicht gespeichert werden.",
+      "eventNavigate": "Einsatzmoglichkeit verwalten",
+      "calendarToday": "Heute",
+      "calendarBack": "Zuruck",
+      "calendarNext": "Weiter",
+      "calendarMonth": "Monat",
+      "calendarWeek": "Woche",
+      "calendarWorkWeek": "Arbeitswoche",
+      "calendarDay": "Tag"
     }
   }
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -374,6 +374,8 @@
       "organisator": "Organisator",
       "removeMember": "Entfernen",
       "removeMemberError": "Mitglied konnte nicht entfernt werden.",
+      "edit": "Bearbeiten",
+      "cancel": "Abbrechen",
       "loading": "Wird geladen…"
     },
     "account": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -691,6 +691,7 @@
     "orgOverview": {
       "tabCalendar": "Calendar",
       "tabEngagements": "Engagements",
+      "tabMembers": "Members",
       "tabSettings": "Settings",
       "calendarLoading": "Loading calendar...",
       "calendarError": "Failed to load calendar events.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -687,6 +687,26 @@
       "noOrgs": "No organizations found.",
       "verify": "Verify",
       "unverify": "Unverify"
+    },
+    "orgOverview": {
+      "tabCalendar": "Calendar",
+      "tabEngagements": "Engagements",
+      "tabSettings": "Settings",
+      "calendarLoading": "Loading calendar...",
+      "calendarError": "Failed to load calendar events.",
+      "calendarNoEvents": "No events in this range.",
+      "eventColorLabel": "Event color",
+      "eventColorSave": "Save",
+      "eventColorSaving": "Saving...",
+      "colorSaveError": "Failed to save color.",
+      "eventNavigate": "Manage opportunity",
+      "calendarToday": "Today",
+      "calendarBack": "Back",
+      "calendarNext": "Next",
+      "calendarMonth": "Month",
+      "calendarWeek": "Week",
+      "calendarWorkWeek": "Work week",
+      "calendarDay": "Day"
     }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -374,6 +374,8 @@
       "organisator": "Organizer",
       "removeMember": "Remove",
       "removeMemberError": "Could not remove member.",
+      "edit": "Edit",
+      "cancel": "Cancel",
       "loading": "Loading…"
     },
     "account": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -374,6 +374,12 @@
       "organisator": "Organizer",
       "removeMember": "Remove",
       "removeMemberError": "Could not remove member.",
+      "addMemberLabel": "Add member",
+      "addMemberPlaceholder": "Search by name or email…",
+      "addMember": "Add",
+      "addMemberError": "Could not add member.",
+      "searching": "Searching…",
+      "noSearchResults": "No users found.",
       "edit": "Edit",
       "cancel": "Cancel",
       "loading": "Loading…"

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -38,10 +38,9 @@ interface CalEvent {
 	color: string | undefined;
 }
 
-type Tab = "calendar" | "engagements" | "settings";
-type SettingsTab = "general" | "members";
+type Tab = "calendar" | "engagements" | "members" | "settings";
 
-const VALID_TABS: Tab[] = ["calendar", "engagements", "settings"];
+const VALID_TABS: Tab[] = ["calendar", "engagements", "members", "settings"];
 
 function isTab(v: string | null): v is Tab {
 	return VALID_TABS.includes(v as Tab);
@@ -229,8 +228,7 @@ export default function OrganizationOverviewPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [activeTab, engInitialized, organizationId]);
 
-	// ── Settings tab ────────────────────────────────────────────────────────
-	const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
+	// ── Settings / Members tabs ─────────────────────────────────────────────
 	const [saving, setSaving] = useState(false);
 	const [settingsError, setSettingsError] = useState<string | null>(null);
 	const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -337,6 +335,7 @@ export default function OrganizationOverviewPage() {
 	const tabs: { key: Tab; label: string }[] = [
 		{ key: "calendar", label: t("orgOverview.tabCalendar") },
 		{ key: "engagements", label: t("orgOverview.tabEngagements") },
+		{ key: "members", label: t("orgOverview.tabMembers") },
 		{ key: "settings", label: t("orgOverview.tabSettings") },
 	];
 
@@ -590,27 +589,6 @@ export default function OrganizationOverviewPage() {
 								})}
 							</p>
 
-							<div className="mb-6 flex gap-4 border-b border-gray-200">
-								{(["general", "members"] as SettingsTab[]).map((tab) => (
-									<button
-										key={tab}
-										type="button"
-										onClick={() => setSettingsTab(tab)}
-										className={`pb-2 text-sm font-medium transition-colors ${
-											settingsTab === tab
-												? "border-b-2 border-brand-700 text-brand-700"
-												: "text-gray-500 hover:text-gray-700"
-										}`}
-									>
-										{tab === "general"
-											? t("orgSettings.tabGeneral")
-											: t("orgSettings.tabMembers", {
-													count: org.members.length,
-												})}
-									</button>
-								))}
-							</div>
-
 							{settingsError && (
 								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
 									{settingsError}
@@ -622,262 +600,268 @@ export default function OrganizationOverviewPage() {
 								</div>
 							)}
 
-							{settingsTab === "general" && (
-								<form onSubmit={handleSave} className="space-y-5">
-									<div>
-										<p className="mb-1 block text-sm font-medium text-gray-700">
-											{t("orgSettings.fieldLogo")}
-										</p>
-										<div className="flex items-center gap-4">
-											{logoUrl ? (
-												<img
-													src={logoUrl}
-													alt=""
-													className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
-												/>
-											) : (
-												<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
-													{org.name.charAt(0).toUpperCase()}
-												</span>
+							<form onSubmit={handleSave} className="space-y-5">
+								<div>
+									<p className="mb-1 block text-sm font-medium text-gray-700">
+										{t("orgSettings.fieldLogo")}
+									</p>
+									<div className="flex items-center gap-4">
+										{logoUrl ? (
+											<img
+												src={logoUrl}
+												alt=""
+												className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
+											/>
+										) : (
+											<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
+												{org.name.charAt(0).toUpperCase()}
+											</span>
+										)}
+										<div>
+											<label
+												htmlFor="logo-upload"
+												className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
+											>
+												{uploadingLogo
+													? t("orgSettings.logoUploading")
+													: t("orgSettings.logoUpload")}
+											</label>
+											<input
+												ref={logoInputRef}
+												id="logo-upload"
+												type="file"
+												accept="image/jpeg,image/png,image/webp"
+												className="sr-only"
+												onChange={handleLogoChange}
+												disabled={uploadingLogo}
+											/>
+											<p className="mt-1 text-xs text-gray-500">
+												{t("orgSettings.logoHint")}
+											</p>
+											{logoError && (
+												<p className="mt-1 text-xs text-red-600">{logoError}</p>
 											)}
+										</div>
+									</div>
+								</div>
+
+								<Field label={t("orgSettings.fieldName")} id="org-name">
+									<input
+										id="org-name"
+										required
+										value={form.name}
+										onChange={(e) =>
+											setForm((f) => ({ ...f, name: e.target.value }))
+										}
+										className={inputClass}
+									/>
+								</Field>
+
+								<Field
+									label={t("orgSettings.fieldDescription")}
+									id="org-description"
+								>
+									<textarea
+										id="org-description"
+										rows={3}
+										value={form.description}
+										onChange={(e) =>
+											setForm((f) => ({
+												...f,
+												description: e.target.value,
+											}))
+										}
+										className={inputClass}
+									/>
+								</Field>
+
+								<Field
+									label={t("orgSettings.fieldContactEmail")}
+									id="org-contact-email"
+								>
+									<input
+										id="org-contact-email"
+										type="email"
+										value={form.contactEmail}
+										onChange={(e) =>
+											setForm((f) => ({
+												...f,
+												contactEmail: e.target.value,
+											}))
+										}
+										className={inputClass}
+									/>
+								</Field>
+
+								<Field label={t("orgSettings.fieldPhone")} id="org-phone">
+									<input
+										id="org-phone"
+										type="tel"
+										value={form.contactPhone}
+										onChange={(e) =>
+											setForm((f) => ({
+												...f,
+												contactPhone: e.target.value,
+											}))
+										}
+										className={inputClass}
+									/>
+								</Field>
+
+								<Field label={t("orgSettings.fieldWebsite")} id="org-website">
+									<input
+										id="org-website"
+										type="url"
+										value={form.website}
+										onChange={(e) =>
+											setForm((f) => ({
+												...f,
+												website: e.target.value,
+											}))
+										}
+										placeholder="https://"
+										className={inputClass}
+									/>
+								</Field>
+
+								<fieldset className="rounded-md border border-gray-200 p-4">
+									<legend className="px-1 text-sm font-medium text-gray-700">
+										{t("orgSettings.fieldAddress")}
+									</legend>
+									<div className="mt-3 grid grid-cols-3 gap-3">
+										<div className="col-span-2">
+											<label htmlFor="org-street" className={labelClass}>
+												{t("orgSettings.fieldStreet")}
+											</label>
+											<input
+												id="org-street"
+												value={form.street}
+												onChange={(e) =>
+													setForm((f) => ({
+														...f,
+														street: e.target.value,
+													}))
+												}
+												className={inputClass}
+											/>
+										</div>
+										<div>
+											<label htmlFor="org-house-number" className={labelClass}>
+												{t("orgSettings.fieldHouseNumber")}
+											</label>
+											<input
+												id="org-house-number"
+												value={form.houseNumber}
+												onChange={(e) =>
+													setForm((f) => ({
+														...f,
+														houseNumber: e.target.value,
+													}))
+												}
+												className={inputClass}
+											/>
+										</div>
+										<div>
+											<label htmlFor="org-zip" className={labelClass}>
+												{t("orgSettings.fieldZip")}
+											</label>
+											<input
+												id="org-zip"
+												maxLength={5}
+												value={form.zipCode}
+												onChange={(e) =>
+													setForm((f) => ({
+														...f,
+														zipCode: e.target.value,
+													}))
+												}
+												className={inputClass}
+											/>
+										</div>
+										<div className="col-span-2">
+											<label htmlFor="org-city" className={labelClass}>
+												{t("orgSettings.fieldCity")}
+											</label>
+											<input
+												id="org-city"
+												value={form.city}
+												onChange={(e) =>
+													setForm((f) => ({
+														...f,
+														city: e.target.value,
+													}))
+												}
+												className={inputClass}
+											/>
+										</div>
+									</div>
+								</fieldset>
+
+								<div className="flex justify-end">
+									<button
+										type="submit"
+										disabled={saving}
+										className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+									>
+										{saving ? t("orgSettings.saving") : t("orgSettings.save")}
+									</button>
+								</div>
+							</form>
+						</>
+					)}
+				</div>
+			)}
+
+			{/* ── Members tab ───────────────────────────────────────────────────── */}
+			{activeTab === "members" && (
+				<div className="mx-auto max-w-2xl">
+					{orgLoading && (
+						<div className="flex items-center justify-center py-16">
+							<span className="text-gray-500">{t("orgSettings.loading")}</span>
+						</div>
+					)}
+					{!orgLoading && org && (
+						<>
+							{settingsError && (
+								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									{settingsError}
+								</div>
+							)}
+							{org.members.length === 0 ? (
+								<EmptyState
+									title={t("orgSettings.noMembers")}
+									message={t("orgSettings.noMembersHint")}
+								/>
+							) : (
+								<ul className="divide-y divide-gray-100">
+									{org.members.map((member) => (
+										<li
+											key={member.userId}
+											className="flex items-center justify-between py-3"
+										>
 											<div>
-												<label
-													htmlFor="logo-upload"
-													className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
-												>
-													{uploadingLogo
-														? t("orgSettings.logoUploading")
-														: t("orgSettings.logoUpload")}
-												</label>
-												<input
-													ref={logoInputRef}
-													id="logo-upload"
-													type="file"
-													accept="image/jpeg,image/png,image/webp"
-													className="sr-only"
-													onChange={handleLogoChange}
-													disabled={uploadingLogo}
-												/>
-												<p className="mt-1 text-xs text-gray-500">
-													{t("orgSettings.logoHint")}
+												<p className="text-sm font-medium text-gray-900">
+													{member.firstName && member.lastName
+														? `${member.firstName} ${member.lastName}`
+														: member.username}
 												</p>
-												{logoError && (
-													<p className="mt-1 text-xs text-red-600">
-														{logoError}
-													</p>
+												<p className="text-xs text-gray-500">{member.email}</p>
+												{member.isOrganisator && (
+													<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+														{t("orgSettings.organisator")}
+													</span>
 												)}
 											</div>
-										</div>
-									</div>
-
-									<Field label={t("orgSettings.fieldName")} id="org-name">
-										<input
-											id="org-name"
-											required
-											value={form.name}
-											onChange={(e) =>
-												setForm((f) => ({ ...f, name: e.target.value }))
-											}
-											className={inputClass}
-										/>
-									</Field>
-
-									<Field
-										label={t("orgSettings.fieldDescription")}
-										id="org-description"
-									>
-										<textarea
-											id="org-description"
-											rows={3}
-											value={form.description}
-											onChange={(e) =>
-												setForm((f) => ({
-													...f,
-													description: e.target.value,
-												}))
-											}
-											className={inputClass}
-										/>
-									</Field>
-
-									<Field
-										label={t("orgSettings.fieldContactEmail")}
-										id="org-contact-email"
-									>
-										<input
-											id="org-contact-email"
-											type="email"
-											value={form.contactEmail}
-											onChange={(e) =>
-												setForm((f) => ({
-													...f,
-													contactEmail: e.target.value,
-												}))
-											}
-											className={inputClass}
-										/>
-									</Field>
-
-									<Field label={t("orgSettings.fieldPhone")} id="org-phone">
-										<input
-											id="org-phone"
-											type="tel"
-											value={form.contactPhone}
-											onChange={(e) =>
-												setForm((f) => ({
-													...f,
-													contactPhone: e.target.value,
-												}))
-											}
-											className={inputClass}
-										/>
-									</Field>
-
-									<Field label={t("orgSettings.fieldWebsite")} id="org-website">
-										<input
-											id="org-website"
-											type="url"
-											value={form.website}
-											onChange={(e) =>
-												setForm((f) => ({
-													...f,
-													website: e.target.value,
-												}))
-											}
-											placeholder="https://"
-											className={inputClass}
-										/>
-									</Field>
-
-									<fieldset className="rounded-md border border-gray-200 p-4">
-										<legend className="px-1 text-sm font-medium text-gray-700">
-											{t("orgSettings.fieldAddress")}
-										</legend>
-										<div className="mt-3 grid grid-cols-3 gap-3">
-											<div className="col-span-2">
-												<label htmlFor="org-street" className={labelClass}>
-													{t("orgSettings.fieldStreet")}
-												</label>
-												<input
-													id="org-street"
-													value={form.street}
-													onChange={(e) =>
-														setForm((f) => ({
-															...f,
-															street: e.target.value,
-														}))
-													}
-													className={inputClass}
-												/>
-											</div>
-											<div>
-												<label
-													htmlFor="org-house-number"
-													className={labelClass}
-												>
-													{t("orgSettings.fieldHouseNumber")}
-												</label>
-												<input
-													id="org-house-number"
-													value={form.houseNumber}
-													onChange={(e) =>
-														setForm((f) => ({
-															...f,
-															houseNumber: e.target.value,
-														}))
-													}
-													className={inputClass}
-												/>
-											</div>
-											<div>
-												<label htmlFor="org-zip" className={labelClass}>
-													{t("orgSettings.fieldZip")}
-												</label>
-												<input
-													id="org-zip"
-													maxLength={5}
-													value={form.zipCode}
-													onChange={(e) =>
-														setForm((f) => ({
-															...f,
-															zipCode: e.target.value,
-														}))
-													}
-													className={inputClass}
-												/>
-											</div>
-											<div className="col-span-2">
-												<label htmlFor="org-city" className={labelClass}>
-													{t("orgSettings.fieldCity")}
-												</label>
-												<input
-													id="org-city"
-													value={form.city}
-													onChange={(e) =>
-														setForm((f) => ({
-															...f,
-															city: e.target.value,
-														}))
-													}
-													className={inputClass}
-												/>
-											</div>
-										</div>
-									</fieldset>
-
-									<div className="flex justify-end">
-										<button
-											type="submit"
-											disabled={saving}
-											className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-										>
-											{saving ? t("orgSettings.saving") : t("orgSettings.save")}
-										</button>
-									</div>
-								</form>
-							)}
-
-							{settingsTab === "members" && (
-								<>
-									{org.members.length === 0 ? (
-										<EmptyState
-											title={t("orgSettings.noMembers")}
-											message={t("orgSettings.noMembersHint")}
-										/>
-									) : (
-										<ul className="divide-y divide-gray-100">
-											{org.members.map((member) => (
-												<li
-													key={member.userId}
-													className="flex items-center justify-between py-3"
-												>
-													<div>
-														<p className="text-sm font-medium text-gray-900">
-															{member.firstName && member.lastName
-																? `${member.firstName} ${member.lastName}`
-																: member.username}
-														</p>
-														<p className="text-xs text-gray-500">
-															{member.email}
-														</p>
-														{member.isOrganisator && (
-															<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
-																{t("orgSettings.organisator")}
-															</span>
-														)}
-													</div>
-													<button
-														type="button"
-														onClick={() => handleRemoveMember(member.userId)}
-														className="text-xs text-red-700 hover:text-red-800"
-													>
-														{t("orgSettings.removeMember")}
-													</button>
-												</li>
-											))}
-										</ul>
-									)}
-								</>
+											<button
+												type="button"
+												onClick={() => handleRemoveMember(member.userId)}
+												className="text-xs text-red-700 hover:text-red-800"
+											>
+												{t("orgSettings.removeMember")}
+											</button>
+										</li>
+									))}
+								</ul>
 							)}
 						</>
 					)}

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -234,6 +234,63 @@ export default function OrganizationOverviewPage() {
 	const [settingsError, setSettingsError] = useState<string | null>(null);
 	const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+	// ── Member search ────────────────────────────────────────────────────────
+	const [memberSearch, setMemberSearch] = useState("");
+	const [memberCandidates, setMemberCandidates] = useState<
+		import("../client/api-client").MemberCandidateDto[]
+	>([]);
+	const [memberSearchLoading, setMemberSearchLoading] = useState(false);
+	const memberSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	function handleMemberSearchChange(value: string) {
+		setMemberSearch(value);
+		if (memberSearchTimer.current) clearTimeout(memberSearchTimer.current);
+		if (value.length < 2) {
+			setMemberCandidates([]);
+			return;
+		}
+		memberSearchTimer.current = setTimeout(() => {
+			if (!organizationId) return;
+			setMemberSearchLoading(true);
+			api
+				.searchMemberCandidates(organizationId, value)
+				.then(setMemberCandidates)
+				.catch(() => setMemberCandidates([]))
+				.finally(() => setMemberSearchLoading(false));
+		}, 300);
+	}
+
+	async function handleAddMember(userId: string) {
+		if (!organizationId) return;
+		try {
+			await api.addMember(organizationId, { userId });
+			const added = memberCandidates.find((c) => c.userId === userId);
+			if (added) {
+				setOrg((prev) =>
+					prev
+						? {
+								...prev,
+								members: [
+									...prev.members,
+									{
+										userId: added.userId,
+										username: added.username,
+										firstName: added.firstName,
+										lastName: added.lastName,
+										email: added.email,
+										isOrganisator: false,
+									},
+								],
+							}
+						: prev,
+				);
+				setMemberCandidates((prev) => prev.filter((c) => c.userId !== userId));
+			}
+		} catch {
+			setSettingsError(t("orgSettings.addMemberError"));
+		}
+	}
+
 	function handleCancelEdit() {
 		if (!org) return;
 		setForm({
@@ -1004,6 +1061,65 @@ export default function OrganizationOverviewPage() {
 									{settingsError}
 								</div>
 							)}
+
+							{/* Add member search */}
+							<div className="mb-6">
+								<label
+									htmlFor="member-search"
+									className="block text-sm font-medium text-gray-700"
+								>
+									{t("orgSettings.addMemberLabel")}
+								</label>
+								<input
+									id="member-search"
+									type="search"
+									value={memberSearch}
+									onChange={(e) => handleMemberSearchChange(e.target.value)}
+									placeholder={t("orgSettings.addMemberPlaceholder")}
+									className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none"
+								/>
+								{memberSearchLoading && (
+									<p className="mt-1 text-xs text-gray-500">
+										{t("orgSettings.searching")}
+									</p>
+								)}
+								{memberCandidates.length > 0 && (
+									<ul className="mt-1 divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+										{memberCandidates.map((candidate) => (
+											<li
+												key={candidate.userId}
+												className="flex items-center justify-between px-3 py-2"
+											>
+												<div className="min-w-0">
+													<p className="truncate text-sm font-medium text-gray-900">
+														{candidate.firstName && candidate.lastName
+															? `${candidate.firstName} ${candidate.lastName}`
+															: candidate.username}
+													</p>
+													<p className="truncate text-xs text-gray-500">
+														{candidate.email}
+													</p>
+												</div>
+												<button
+													type="button"
+													onClick={() => handleAddMember(candidate.userId)}
+													className="ml-3 shrink-0 rounded-md bg-brand-700 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-800"
+												>
+													{t("orgSettings.addMember")}
+												</button>
+											</li>
+										))}
+									</ul>
+								)}
+								{memberSearch.length >= 2 &&
+									!memberSearchLoading &&
+									memberCandidates.length === 0 && (
+										<p className="mt-1 text-xs text-gray-500">
+											{t("orgSettings.noSearchResults")}
+										</p>
+									)}
+							</div>
+
 							{org.members.length === 0 ? (
 								<EmptyState
 									title={t("orgSettings.noMembers")}

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -360,7 +360,7 @@ export default function OrganizationOverviewPage() {
 	];
 
 	return (
-		<>
+		<div className={activeTab !== "calendar" ? "max-w-2xl" : ""}>
 			<h1 className="mb-6 text-2xl font-bold text-gray-900">
 				{org?.name ?? t("orgDashboard.title")}
 			</h1>
@@ -523,7 +523,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Engagements tab ───────────────────────────────────────────────── */}
 			{activeTab === "engagements" && (
-				<div className="max-w-2xl">
+				<div>
 					{engLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">
@@ -586,7 +586,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Settings tab ──────────────────────────────────────────────────── */}
 			{activeTab === "settings" && (
-				<div className="max-w-2xl">
+				<div>
 					{orgLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">{t("orgSettings.loading")}</span>
@@ -991,7 +991,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Members tab ───────────────────────────────────────────────────── */}
 			{activeTab === "members" && (
-				<div className="max-w-2xl">
+				<div>
 					{orgLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">{t("orgSettings.loading")}</span>
@@ -1044,6 +1044,6 @@ export default function OrganizationOverviewPage() {
 					)}
 				</div>
 			)}
-		</>
+		</div>
 	);
 }

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -1,0 +1,888 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router";
+import { useTranslation } from "react-i18next";
+import { Calendar, dateFnsLocalizer } from "react-big-calendar";
+import type { View } from "react-big-calendar";
+import { format, parse, startOfWeek, getDay } from "date-fns";
+import { enUS, de } from "date-fns/locale";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import type {
+	OrganizationCalendarEventDto,
+	OrganizationDetailsResponse,
+	PublicOpportunitySummaryDto,
+} from "../client/api-client";
+import { useApiClient } from "../hooks/useApiClient";
+import { usePageTitle } from "../hooks/usePageTitle";
+import EmptyState from "../components/EmptyState";
+
+const rbcLocales = {
+	"en-US": enUS,
+	de,
+};
+const localizer = dateFnsLocalizer({
+	format,
+	parse,
+	startOfWeek,
+	getDay,
+	locales: rbcLocales,
+});
+
+const DEFAULT_EVENT_COLOR = "#226947";
+
+interface CalEvent {
+	id: string;
+	title: string;
+	start: Date;
+	end: Date;
+	opportunityId: string;
+	color: string | undefined;
+}
+
+type Tab = "calendar" | "engagements" | "settings";
+type SettingsTab = "general" | "members";
+
+const VALID_TABS: Tab[] = ["calendar", "engagements", "settings"];
+
+function isTab(v: string | null): v is Tab {
+	return VALID_TABS.includes(v as Tab);
+}
+
+const inputClass =
+	"mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none";
+const labelClass = "block text-xs text-gray-600";
+
+function Field({
+	label,
+	id,
+	children,
+}: {
+	label: string;
+	id?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div>
+			<label htmlFor={id} className="block text-sm font-medium text-gray-700">
+				{label}
+			</label>
+			{children}
+		</div>
+	);
+}
+
+const MAX_LOGO_BYTES = 2 * 1024 * 1024;
+const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export default function OrganizationOverviewPage() {
+	const { organizationId } = useParams<{ organizationId: string }>();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const { t, i18n } = useTranslation();
+	const api = useApiClient();
+	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
+
+	const rawTab = searchParams.get("tab");
+	const activeTab: Tab = isTab(rawTab) ? rawTab : "calendar";
+
+	function switchTab(tab: Tab) {
+		setSearchParams(tab === "calendar" ? {} : { tab }, { replace: true });
+	}
+
+	// ── Org details (loaded immediately for header + settings) ──────────────
+	const [org, setOrg] = useState<OrganizationDetailsResponse | null>(null);
+	const [orgLoading, setOrgLoading] = useState(true);
+
+	const [form, setForm] = useState({
+		name: "",
+		description: "",
+		contactEmail: "",
+		contactPhone: "",
+		website: "",
+		street: "",
+		houseNumber: "",
+		zipCode: "",
+		city: "",
+	});
+	const [logoUrl, setLogoUrl] = useState<string | null>(null);
+	const [uploadingLogo, setUploadingLogo] = useState(false);
+	const [logoError, setLogoError] = useState<string | null>(null);
+	const logoInputRef = useRef<HTMLInputElement>(null);
+
+	usePageTitle(org?.name ?? t("orgDashboard.title"));
+
+	useEffect(() => {
+		if (!organizationId) return;
+		setOrgLoading(true);
+		api
+			.getOrganizationDetails(organizationId)
+			.then((data) => {
+				setOrg(data);
+				setLogoUrl(data.logoUrl ?? null);
+				setForm({
+					name: data.name,
+					description: data.description ?? "",
+					contactEmail: data.contactEmail ?? "",
+					contactPhone: data.contactPhone ?? "",
+					website: data.website ?? "",
+					street: data.address?.street ?? "",
+					houseNumber: data.address?.houseNumber ?? "",
+					zipCode: data.address?.zipCode ?? "",
+					city: data.address?.city ?? "",
+				});
+			})
+			.catch(() => {})
+			.finally(() => setOrgLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [organizationId]);
+
+	// ── Calendar tab ────────────────────────────────────────────────────────
+	const [calData, setCalData] = useState<OrganizationCalendarEventDto[]>([]);
+	const [calLoading, setCalLoading] = useState(true);
+	const [calError, setCalError] = useState<string | null>(null);
+	const [calView, setCalView] = useState<View>("month");
+	const [calDate, setCalDate] = useState(new Date());
+	const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
+	const [pickerColor, setPickerColor] = useState(DEFAULT_EVENT_COLOR);
+	const [savingColor, setSavingColor] = useState(false);
+	const [colorSaveError, setColorSaveError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!selectedEvent) return;
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setSelectedEvent(null);
+		};
+		document.addEventListener("keydown", handleKey);
+		return () => document.removeEventListener("keydown", handleKey);
+	}, [selectedEvent]);
+
+	useEffect(() => {
+		if (!organizationId) return;
+		setCalLoading(true);
+		setCalError(null);
+		api
+			.getOrganizationCalendarEvents(organizationId)
+			.then(setCalData)
+			.catch((e: unknown) =>
+				setCalError(e instanceof Error ? e.message : String(e)),
+			)
+			.finally(() => setCalLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [organizationId]);
+
+	const calEvents: CalEvent[] = calData.flatMap((opp) =>
+		opp.timeSlots.map((slot) => ({
+			id: slot.timeSlotId,
+			title: opp.title,
+			start: new Date(slot.startDateTime),
+			end: new Date(slot.endDateTime),
+			opportunityId: opp.opportunityId,
+			color: opp.color,
+		})),
+	);
+
+	function handleSelectEvent(event: CalEvent) {
+		setSelectedEvent(event);
+		setPickerColor(event.color ?? DEFAULT_EVENT_COLOR);
+		setColorSaveError(null);
+	}
+
+	async function handleColorSave() {
+		if (!selectedEvent) return;
+		setSavingColor(true);
+		setColorSaveError(null);
+		try {
+			await api.setOpportunityColor(selectedEvent.opportunityId, {
+				color: pickerColor || undefined,
+			});
+			setCalData((prev) =>
+				prev.map((opp) =>
+					opp.opportunityId === selectedEvent.opportunityId
+						? { ...opp, color: pickerColor || undefined }
+						: opp,
+				),
+			);
+			setSelectedEvent(null);
+		} catch {
+			setColorSaveError(t("orgOverview.colorSaveError"));
+		} finally {
+			setSavingColor(false);
+		}
+	}
+
+	// ── Engagements tab ─────────────────────────────────────────────────────
+	const [engOpps, setEngOpps] = useState<PublicOpportunitySummaryDto[]>([]);
+	const [engLoading, setEngLoading] = useState(false);
+	const [engError, setEngError] = useState<string | null>(null);
+	const [engInitialized, setEngInitialized] = useState(false);
+
+	useEffect(() => {
+		if (activeTab !== "engagements" || engInitialized || !organizationId)
+			return;
+		setEngInitialized(true);
+		setEngLoading(true);
+		api
+			.getPublicOrganizationProfile(organizationId)
+			.then((profile) => setEngOpps(profile.openOpportunities))
+			.catch((e: unknown) =>
+				setEngError(e instanceof Error ? e.message : String(e)),
+			)
+			.finally(() => setEngLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [activeTab, engInitialized, organizationId]);
+
+	// ── Settings tab ────────────────────────────────────────────────────────
+	const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
+	const [saving, setSaving] = useState(false);
+	const [settingsError, setSettingsError] = useState<string | null>(null);
+	const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+	const hasAddress =
+		form.street || form.houseNumber || form.zipCode || form.city;
+
+	async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+		const file = e.target.files?.[0];
+		if (!file || !organizationId) return;
+		if (!LOGO_TYPES.includes(file.type)) {
+			setLogoError(t("orgSettings.logoHint"));
+			return;
+		}
+		if (file.size > MAX_LOGO_BYTES) {
+			setLogoError(t("orgSettings.logoHint"));
+			return;
+		}
+		setUploadingLogo(true);
+		setLogoError(null);
+		try {
+			await api.uploadOrganizationLogo(organizationId, {
+				data: file,
+				fileName: file.name,
+			});
+			setLogoUrl(URL.createObjectURL(file));
+		} catch {
+			setLogoError(t("orgSettings.logoUploadError"));
+		} finally {
+			setUploadingLogo(false);
+			if (logoInputRef.current) logoInputRef.current.value = "";
+		}
+	}
+
+	async function handleSave(e: React.FormEvent) {
+		e.preventDefault();
+		if (!organizationId) return;
+		setSaving(true);
+		setSettingsError(null);
+		setSuccessMessage(null);
+		try {
+			await api.updateOrganization(organizationId, {
+				name: form.name,
+				description: form.description || undefined,
+				contactEmail: form.contactEmail || undefined,
+				contactPhone: form.contactPhone || undefined,
+				website: form.website || undefined,
+				address: hasAddress
+					? {
+							street: form.street,
+							houseNumber: form.houseNumber,
+							zipCode: form.zipCode,
+							city: form.city,
+						}
+					: undefined,
+			});
+			setSuccessMessage(t("orgSettings.savedSuccess"));
+			setOrg((prev) =>
+				prev
+					? {
+							...prev,
+							name: form.name,
+							description: form.description || undefined,
+							contactEmail: form.contactEmail || undefined,
+							contactPhone: form.contactPhone || undefined,
+							website: form.website || undefined,
+							address: hasAddress
+								? {
+										street: form.street,
+										houseNumber: form.houseNumber,
+										zipCode: form.zipCode,
+										city: form.city,
+									}
+								: undefined,
+						}
+					: prev,
+			);
+		} catch {
+			setSettingsError(t("orgSettings.saveError"));
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleRemoveMember(userId: string) {
+		if (!organizationId) return;
+		try {
+			await api.removeMember(organizationId, userId);
+			setOrg((prev) =>
+				prev
+					? {
+							...prev,
+							members: prev.members.filter((m) => m.userId !== userId),
+						}
+					: prev,
+			);
+		} catch {
+			setSettingsError(t("orgSettings.removeMemberError"));
+		}
+	}
+
+	// ── Render ───────────────────────────────────────────────────────────────
+
+	const tabs: { key: Tab; label: string }[] = [
+		{ key: "calendar", label: t("orgOverview.tabCalendar") },
+		{ key: "engagements", label: t("orgOverview.tabEngagements") },
+		{ key: "settings", label: t("orgOverview.tabSettings") },
+	];
+
+	return (
+		<>
+			<h1 className="mb-6 text-2xl font-bold text-gray-900">
+				{org?.name ?? t("orgDashboard.title")}
+			</h1>
+
+			{/* Tab bar */}
+			<div className="mb-6 border-b border-gray-200">
+				<nav className="-mb-px flex gap-6" aria-label={t("orgDashboard.title")}>
+					{tabs.map(({ key, label }) => (
+						<button
+							key={key}
+							type="button"
+							onClick={() => switchTab(key)}
+							className={`pb-3 text-sm font-medium transition-colors border-b-2 ${
+								activeTab === key
+									? "border-brand-700 text-brand-700"
+									: "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+							}`}
+							aria-current={activeTab === key ? "page" : undefined}
+						>
+							{label}
+						</button>
+					))}
+				</nav>
+			</div>
+
+			{/* ── Calendar tab ──────────────────────────────────────────────────── */}
+			{activeTab === "calendar" && (
+				<div>
+					{calLoading && (
+						<div className="flex items-center justify-center py-16">
+							<span className="text-gray-500">
+								{t("orgOverview.calendarLoading")}
+							</span>
+						</div>
+					)}
+					{calError && (
+						<p className="text-red-600">
+							{t("orgOverview.calendarError", { message: calError })}
+						</p>
+					)}
+					{!calLoading && !calError && (
+						<div className="rbc-container">
+							<Calendar
+								localizer={localizer}
+								events={calEvents}
+								view={calView}
+								onView={(v: View) => setCalView(v)}
+								date={calDate}
+								onNavigate={(d: Date) => setCalDate(d)}
+								views={["month", "week", "work_week", "day"]}
+								style={{ height: 600 }}
+								eventPropGetter={(event: object) => {
+									const e = event as CalEvent;
+									const bg = e.color ?? DEFAULT_EVENT_COLOR;
+									return {
+										style: {
+											backgroundColor: bg,
+											borderColor: bg,
+											color: "#ffffff",
+										},
+									};
+								}}
+								onSelectEvent={(event: object) =>
+									handleSelectEvent(event as CalEvent)
+								}
+								messages={{
+									today: t("orgOverview.calendarToday"),
+									previous: t("orgOverview.calendarBack"),
+									next: t("orgOverview.calendarNext"),
+									month: t("orgOverview.calendarMonth"),
+									week: t("orgOverview.calendarWeek"),
+									work_week: t("orgOverview.calendarWorkWeek"),
+									day: t("orgOverview.calendarDay"),
+									noEventsInRange: t("orgOverview.calendarNoEvents"),
+								}}
+							/>
+						</div>
+					)}
+
+					{/* Color picker modal */}
+					{selectedEvent && (
+						<div className="fixed inset-0 z-50 flex items-center justify-center">
+							<button
+								type="button"
+								aria-hidden="true"
+								tabIndex={-1}
+								className="absolute inset-0 bg-black/40"
+								onClick={() => setSelectedEvent(null)}
+							/>
+							<div
+								role="dialog"
+								aria-modal="true"
+								aria-labelledby="color-dialog-title"
+								className="relative z-10 w-80 rounded-xl bg-white p-6 shadow-xl"
+							>
+								<h2
+									id="color-dialog-title"
+									className="mb-4 text-base font-semibold text-gray-900"
+								>
+									{selectedEvent.title}
+								</h2>
+								<div className="space-y-4">
+									<div>
+										<label
+											htmlFor="event-color-picker"
+											className="block text-sm font-medium text-gray-700"
+										>
+											{t("orgOverview.eventColorLabel")}
+										</label>
+										<div className="mt-1 flex items-center gap-3">
+											<input
+												id="event-color-picker"
+												type="color"
+												value={pickerColor}
+												onChange={(e) => setPickerColor(e.target.value)}
+												className="h-9 w-16 cursor-pointer rounded border border-gray-300"
+											/>
+											<span className="text-sm text-gray-500">
+												{pickerColor}
+											</span>
+										</div>
+									</div>
+									{colorSaveError && (
+										<p className="text-sm text-red-600">{colorSaveError}</p>
+									)}
+									<div className="flex justify-between gap-3">
+										<Link
+											to={`/volunteer-opportunities/${selectedEvent.opportunityId}`}
+											className="text-sm text-brand-700 hover:underline"
+											onClick={() => setSelectedEvent(null)}
+										>
+											{t("orgOverview.eventNavigate")}
+										</Link>
+										<div className="flex gap-2">
+											<button
+												type="button"
+												onClick={() => setSelectedEvent(null)}
+												className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+											>
+												{t("createOpportunity.cancel")}
+											</button>
+											<button
+												type="button"
+												disabled={savingColor}
+												onClick={handleColorSave}
+												className="rounded-md bg-brand-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+											>
+												{savingColor
+													? t("orgOverview.eventColorSaving")
+													: t("orgOverview.eventColorSave")}
+											</button>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* ── Engagements tab ───────────────────────────────────────────────── */}
+			{activeTab === "engagements" && (
+				<div className="mx-auto max-w-2xl">
+					{engLoading && (
+						<div className="flex items-center justify-center py-16">
+							<span className="text-gray-500">
+								{t("orgEngagements.loading")}
+							</span>
+						</div>
+					)}
+					{engError && (
+						<p className="text-red-600">
+							{t("orgEngagements.error", { message: engError })}
+						</p>
+					)}
+					{!engLoading && !engError && engOpps.length === 0 && (
+						<EmptyState
+							title={t("orgEngagements.noOpportunities")}
+							message={t("orgEngagements.noOpportunitiesHint")}
+						/>
+					)}
+					{!engLoading && !engError && engOpps.length > 0 && (
+						<ul className="space-y-3">
+							{engOpps.map((opp) => (
+								<li
+									key={opp.id}
+									className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+								>
+									<p className="text-sm font-semibold text-gray-900">
+										{opp.title}
+									</p>
+									{opp.description && (
+										<p className="mt-1 line-clamp-2 text-sm text-gray-500">
+											{opp.description}
+										</p>
+									)}
+									<Link
+										to={`/volunteer-opportunities/${opp.id}/engagements`}
+										className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
+									>
+										{t("orgEngagements.manageEngagements")}
+										<svg
+											className="h-3.5 w-3.5"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="2"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+											/>
+										</svg>
+									</Link>
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			)}
+
+			{/* ── Settings tab ──────────────────────────────────────────────────── */}
+			{activeTab === "settings" && (
+				<div className="mx-auto max-w-2xl">
+					{orgLoading && (
+						<div className="flex items-center justify-center py-16">
+							<span className="text-gray-500">{t("orgSettings.loading")}</span>
+						</div>
+					)}
+					{!orgLoading && !org && (
+						<div className="py-8 text-center text-red-600">
+							{t("orgSettings.notFound")}
+						</div>
+					)}
+					{!orgLoading && org && (
+						<>
+							<p className="mb-6 text-sm text-gray-500">
+								{t("orgSettings.createdOn", {
+									date: new Date(org.createdOn).toLocaleDateString(locale, {
+										day: "2-digit",
+										month: "long",
+										year: "numeric",
+									}),
+								})}
+							</p>
+
+							<div className="mb-6 flex gap-4 border-b border-gray-200">
+								{(["general", "members"] as SettingsTab[]).map((tab) => (
+									<button
+										key={tab}
+										type="button"
+										onClick={() => setSettingsTab(tab)}
+										className={`pb-2 text-sm font-medium transition-colors ${
+											settingsTab === tab
+												? "border-b-2 border-brand-700 text-brand-700"
+												: "text-gray-500 hover:text-gray-700"
+										}`}
+									>
+										{tab === "general"
+											? t("orgSettings.tabGeneral")
+											: t("orgSettings.tabMembers", {
+													count: org.members.length,
+												})}
+									</button>
+								))}
+							</div>
+
+							{settingsError && (
+								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									{settingsError}
+								</div>
+							)}
+							{successMessage && (
+								<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+									{successMessage}
+								</div>
+							)}
+
+							{settingsTab === "general" && (
+								<form onSubmit={handleSave} className="space-y-5">
+									<div>
+										<p className="mb-1 block text-sm font-medium text-gray-700">
+											{t("orgSettings.fieldLogo")}
+										</p>
+										<div className="flex items-center gap-4">
+											{logoUrl ? (
+												<img
+													src={logoUrl}
+													alt=""
+													className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
+												/>
+											) : (
+												<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
+													{org.name.charAt(0).toUpperCase()}
+												</span>
+											)}
+											<div>
+												<label
+													htmlFor="logo-upload"
+													className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
+												>
+													{uploadingLogo
+														? t("orgSettings.logoUploading")
+														: t("orgSettings.logoUpload")}
+												</label>
+												<input
+													ref={logoInputRef}
+													id="logo-upload"
+													type="file"
+													accept="image/jpeg,image/png,image/webp"
+													className="sr-only"
+													onChange={handleLogoChange}
+													disabled={uploadingLogo}
+												/>
+												<p className="mt-1 text-xs text-gray-500">
+													{t("orgSettings.logoHint")}
+												</p>
+												{logoError && (
+													<p className="mt-1 text-xs text-red-600">
+														{logoError}
+													</p>
+												)}
+											</div>
+										</div>
+									</div>
+
+									<Field label={t("orgSettings.fieldName")} id="org-name">
+										<input
+											id="org-name"
+											required
+											value={form.name}
+											onChange={(e) =>
+												setForm((f) => ({ ...f, name: e.target.value }))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field
+										label={t("orgSettings.fieldDescription")}
+										id="org-description"
+									>
+										<textarea
+											id="org-description"
+											rows={3}
+											value={form.description}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													description: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field
+										label={t("orgSettings.fieldContactEmail")}
+										id="org-contact-email"
+									>
+										<input
+											id="org-contact-email"
+											type="email"
+											value={form.contactEmail}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													contactEmail: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field label={t("orgSettings.fieldPhone")} id="org-phone">
+										<input
+											id="org-phone"
+											type="tel"
+											value={form.contactPhone}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													contactPhone: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field label={t("orgSettings.fieldWebsite")} id="org-website">
+										<input
+											id="org-website"
+											type="url"
+											value={form.website}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													website: e.target.value,
+												}))
+											}
+											placeholder="https://"
+											className={inputClass}
+										/>
+									</Field>
+
+									<fieldset className="rounded-md border border-gray-200 p-4">
+										<legend className="px-1 text-sm font-medium text-gray-700">
+											{t("orgSettings.fieldAddress")}
+										</legend>
+										<div className="mt-3 grid grid-cols-3 gap-3">
+											<div className="col-span-2">
+												<label htmlFor="org-street" className={labelClass}>
+													{t("orgSettings.fieldStreet")}
+												</label>
+												<input
+													id="org-street"
+													value={form.street}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															street: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div>
+												<label
+													htmlFor="org-house-number"
+													className={labelClass}
+												>
+													{t("orgSettings.fieldHouseNumber")}
+												</label>
+												<input
+													id="org-house-number"
+													value={form.houseNumber}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															houseNumber: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div>
+												<label htmlFor="org-zip" className={labelClass}>
+													{t("orgSettings.fieldZip")}
+												</label>
+												<input
+													id="org-zip"
+													maxLength={5}
+													value={form.zipCode}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															zipCode: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div className="col-span-2">
+												<label htmlFor="org-city" className={labelClass}>
+													{t("orgSettings.fieldCity")}
+												</label>
+												<input
+													id="org-city"
+													value={form.city}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															city: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+										</div>
+									</fieldset>
+
+									<div className="flex justify-end">
+										<button
+											type="submit"
+											disabled={saving}
+											className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+										>
+											{saving ? t("orgSettings.saving") : t("orgSettings.save")}
+										</button>
+									</div>
+								</form>
+							)}
+
+							{settingsTab === "members" && (
+								<>
+									{org.members.length === 0 ? (
+										<EmptyState
+											title={t("orgSettings.noMembers")}
+											message={t("orgSettings.noMembersHint")}
+										/>
+									) : (
+										<ul className="divide-y divide-gray-100">
+											{org.members.map((member) => (
+												<li
+													key={member.userId}
+													className="flex items-center justify-between py-3"
+												>
+													<div>
+														<p className="text-sm font-medium text-gray-900">
+															{member.firstName && member.lastName
+																? `${member.firstName} ${member.lastName}`
+																: member.username}
+														</p>
+														<p className="text-xs text-gray-500">
+															{member.email}
+														</p>
+														{member.isOrganisator && (
+															<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+																{t("orgSettings.organisator")}
+															</span>
+														)}
+													</div>
+													<button
+														type="button"
+														onClick={() => handleRemoveMember(member.userId)}
+														className="text-xs text-red-700 hover:text-red-800"
+													>
+														{t("orgSettings.removeMember")}
+													</button>
+												</li>
+											))}
+										</ul>
+									)}
+								</>
+							)}
+						</>
+					)}
+				</div>
+			)}
+		</>
+	);
+}

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -229,9 +229,28 @@ export default function OrganizationOverviewPage() {
 	}, [activeTab, engInitialized, organizationId]);
 
 	// ── Settings / Members tabs ─────────────────────────────────────────────
+	const [editing, setEditing] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [settingsError, setSettingsError] = useState<string | null>(null);
 	const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+	function handleCancelEdit() {
+		if (!org) return;
+		setForm({
+			name: org.name,
+			description: org.description ?? "",
+			contactEmail: org.contactEmail ?? "",
+			contactPhone: org.contactPhone ?? "",
+			website: org.website ?? "",
+			street: org.address?.street ?? "",
+			houseNumber: org.address?.houseNumber ?? "",
+			zipCode: org.address?.zipCode ?? "",
+			city: org.address?.city ?? "",
+		});
+		setLogoError(null);
+		setSettingsError(null);
+		setEditing(false);
+	}
 
 	const hasAddress =
 		form.street || form.houseNumber || form.zipCode || form.city;
@@ -285,6 +304,7 @@ export default function OrganizationOverviewPage() {
 						}
 					: undefined,
 			});
+			setEditing(false);
 			setSuccessMessage(t("orgSettings.savedSuccess"));
 			setOrg((prev) =>
 				prev
@@ -503,7 +523,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Engagements tab ───────────────────────────────────────────────── */}
 			{activeTab === "engagements" && (
-				<div className="mx-auto max-w-2xl">
+				<div className="max-w-2xl">
 					{engLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">
@@ -566,7 +586,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Settings tab ──────────────────────────────────────────────────── */}
 			{activeTab === "settings" && (
-				<div className="mx-auto max-w-2xl">
+				<div className="max-w-2xl">
 					{orgLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">{t("orgSettings.loading")}</span>
@@ -577,26 +597,176 @@ export default function OrganizationOverviewPage() {
 							{t("orgSettings.notFound")}
 						</div>
 					)}
-					{!orgLoading && org && (
+					{!orgLoading && org && !editing && (
 						<>
-							<p className="mb-6 text-sm text-gray-500">
-								{t("orgSettings.createdOn", {
-									date: new Date(org.createdOn).toLocaleDateString(locale, {
-										day: "2-digit",
-										month: "long",
-										year: "numeric",
-									}),
-								})}
-							</p>
-
-							{settingsError && (
-								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-									{settingsError}
+							{/* View mode — mirrors the public org profile */}
+							<div className="mb-6 flex items-start justify-between gap-4">
+								<div className="flex items-center gap-4">
+									{logoUrl ? (
+										<img
+											src={logoUrl}
+											alt=""
+											className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
+										/>
+									) : (
+										<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
+											{org.name.charAt(0).toUpperCase()}
+										</span>
+									)}
+									<div>
+										<p className="text-base font-semibold text-gray-900">
+											{org.name}
+										</p>
+										<p className="text-xs text-gray-400">
+											{t("orgSettings.createdOn", {
+												date: new Date(org.createdOn).toLocaleDateString(
+													locale,
+													{
+														day: "2-digit",
+														month: "long",
+														year: "numeric",
+													},
+												),
+											})}
+										</p>
+									</div>
 								</div>
-							)}
+								<button
+									type="button"
+									onClick={() => setEditing(true)}
+									className="shrink-0 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+								>
+									{t("orgSettings.edit")}
+								</button>
+							</div>
+
 							{successMessage && (
 								<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
 									{successMessage}
+								</div>
+							)}
+
+							{org.description && (
+								<p className="mb-5 leading-relaxed text-gray-600">
+									{org.description}
+								</p>
+							)}
+
+							{(org.contactEmail ||
+								org.contactPhone ||
+								org.website ||
+								org.address) && (
+								<div className="space-y-2.5 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+									{org.contactEmail && (
+										<div className="flex items-center gap-3">
+											<svg
+												className="h-4 w-4 shrink-0 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="1.5"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
+												/>
+											</svg>
+											<a
+												href={`mailto:${org.contactEmail}`}
+												className="text-brand-700 hover:underline"
+											>
+												{org.contactEmail}
+											</a>
+										</div>
+									)}
+									{org.contactPhone && (
+										<div className="flex items-center gap-3">
+											<svg
+												className="h-4 w-4 shrink-0 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="1.5"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z"
+												/>
+											</svg>
+											<a
+												href={`tel:${org.contactPhone}`}
+												className="text-brand-700 hover:underline"
+											>
+												{org.contactPhone}
+											</a>
+										</div>
+									)}
+									{org.website && (
+										<div className="flex items-center gap-3">
+											<svg
+												className="h-4 w-4 shrink-0 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="1.5"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418"
+												/>
+											</svg>
+											<a
+												href={org.website}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-brand-700 hover:underline"
+											>
+												{org.website}
+											</a>
+										</div>
+									)}
+									{org.address && (
+										<div className="flex items-center gap-3">
+											<svg
+												className="h-4 w-4 shrink-0 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="1.5"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+												/>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+												/>
+											</svg>
+											<span>
+												{org.address.street} {org.address.houseNumber},{" "}
+												{org.address.zipCode} {org.address.city}
+											</span>
+										</div>
+									)}
+								</div>
+							)}
+						</>
+					)}
+					{!orgLoading && org && editing && (
+						<>
+							{settingsError && (
+								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									{settingsError}
 								</div>
 							)}
 
@@ -797,7 +967,14 @@ export default function OrganizationOverviewPage() {
 									</div>
 								</fieldset>
 
-								<div className="flex justify-end">
+								<div className="flex justify-end gap-3">
+									<button
+										type="button"
+										onClick={handleCancelEdit}
+										className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+									>
+										{t("orgSettings.cancel")}
+									</button>
 									<button
 										type="submit"
 										disabled={saving}
@@ -814,7 +991,7 @@ export default function OrganizationOverviewPage() {
 
 			{/* ── Members tab ───────────────────────────────────────────────────── */}
 			{activeTab === "members" && (
-				<div className="mx-auto max-w-2xl">
+				<div className="max-w-2xl">
 					{orgLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">{t("orgSettings.loading")}</span>

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -599,7 +599,7 @@ export default function OrganizationOverviewPage() {
 					)}
 					{!orgLoading && org && !editing && (
 						<>
-							{/* View mode — mirrors the public org profile */}
+							{/* View mode - mirrors the public org profile */}
 							<div className="mb-6 flex items-start justify-between gap-4">
 								<div className="flex items-center gap-4">
 									{logoUrl ? (


### PR DESCRIPTION
## Summary

- **Calendar view** on the organization dashboard with month / week / work-week / day modes (react-big-calendar + date-fns v4)
- **Per-opportunity color picker** - org managers can click any calendar event and assign a hex color; saved via new `PATCH /v1/volunteer-opportunities/{id}/color` endpoint
- **Consolidated org management page** - Dashboard, Engagements, and Settings merged into a single tabbed `OrganizationOverviewPage` (URL: `/organizations/:id/dashboard?tab=calendar|engagements|settings`), mirroring the existing ProfileOverviewPage pattern
- **KPIs removed** from dashboard in favor of calendar-first layout (closes acceptance criteria from #501)
- **MinIO added to docker-compose.yml** - file uploads were broken because the MinIO service was missing (#504)

### Backend changes
- `VolunteerOpportunity` domain entity - `Color` property + `SetColor()` method
- EF Core migration `20260622120000_AddOpportunityColor` - adds nullable `color` column
- `GetOrganizationCalendarEvents` query + endpoint - flattens all opportunity timeslots into calendar events with color
- `SetOpportunityColor` command + endpoint - PATCH with `{ color: string | null }`

### Frontend changes
- `OrganizationOverviewPage.tsx` - three tabs (Calendar / Engagements / Settings), color picker modal using backdrop-button a11y pattern
- `App.tsx` - new routing; old `/settings` and `/engagements` sub-paths redirect to `?tab=` params
- `OrganizationSwitcher.tsx` - dropdown links updated to new URL scheme
- `en.json` / `de.json` - `orgOverview.*` i18n keys
- `package.json` / `pnpm-lock.yaml` - react-big-calendar + date-fns deps

## Test plan

- [ ] Organization dashboard shows calendar with existing opportunities
- [ ] Switching between month / week / work-week / day views works
- [ ] Clicking an event opens the color picker modal; saving updates the event color
- [ ] Pressing Escape or clicking backdrop closes the color picker without saving
- [ ] Engagements tab loads volunteer sign-ups for the org
- [ ] Settings tab (General + Members sub-tabs) functions as before
- [ ] `/organizations/:id/settings` and `/organizations/:id/engagements` redirect correctly
- [ ] `docker-compose.yml` starts MinIO; file uploads succeed

## Live verification

Pending RC deploy and smoke test.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNnBb5Uxh1inudanLoP64L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNnBb5Uxh1inudanLoP64L)_