### PR TITLE
feat: expose avatarUrl and logoUrl on public profile pages (#503, #504)

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4495,7 +4495,8 @@
           "website",
           "address",
           "isVerified",
-          "openOpportunities"
+          "openOpportunities",
+          "logoUrl"
         ],
         "type": "object",
         "properties": {
@@ -4548,6 +4549,12 @@
             "items": {
               "$ref": "#/components/schemas/PublicOpportunitySummaryDto"
             }
+          },
+          "logoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -4555,7 +4562,8 @@
         "required": [
           "displayName",
           "engagementCount",
-          "badges"
+          "badges",
+          "avatarUrl"
         ],
         "type": "object",
         "properties": {
@@ -4575,6 +4583,12 @@
             "items": {
               "$ref": "#/components/schemas/AchievementSummary"
             }
+          },
+          "avatarUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQueryHandler.cs
@@ -59,6 +59,7 @@ internal sealed class GetPublicOrganizationProfileQueryHandler(
 			organization.Website,
 			address,
 			organization.IsVerified,
-			openOpportunities);
+			openOpportunities,
+			organization.LogoUrl);
 	}
 }

--- a/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/PublicOrganizationProfileResponse.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/PublicOrganizationProfileResponse.cs
@@ -9,7 +9,8 @@ public sealed record PublicOrganizationProfileResponse(
 	string? Website,
 	PublicAddressDto? Address,
 	bool IsVerified,
-	IReadOnlyList<PublicOpportunitySummaryDto> OpenOpportunities);
+	IReadOnlyList<PublicOpportunitySummaryDto> OpenOpportunities,
+	string? LogoUrl);
 
 public sealed record PublicAddressDto(
 	string Street,

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
@@ -39,6 +39,8 @@ internal sealed class GetPublicUserProfileQueryHandler(
 			request.UserId,
 			cancellationToken);
 
-		return new PublicUserProfileResponse(displayName, engagementCount, badges);
+		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
+
+		return new PublicUserProfileResponse(displayName, engagementCount, badges, user?.AvatarUrl);
 	}
 }

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/PublicUserProfileResponse.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/PublicUserProfileResponse.cs
@@ -5,4 +5,5 @@ namespace Application.Users.GetPublicUserProfile.v1;
 public sealed record PublicUserProfileResponse(
 	string DisplayName,
 	int EngagementCount,
-	IReadOnlyList<AchievementSummary> Badges);
+	IReadOnlyList<AchievementSummary> Badges,
+	string? AvatarUrl);

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -6962,6 +6962,9 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<PublicOpportunitySummaryDto> OpenOpportunities { get; set; } = new System.Collections.ObjectModel.Collection<PublicOpportunitySummaryDto>();
 
+        [System.Text.Json.Serialization.JsonPropertyName("logoUrl")]
+        public string? LogoUrl { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -6989,6 +6992,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("badges")]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<AchievementSummary> Badges { get; set; } = new System.Collections.ObjectModel.Collection<AchievementSummary>();
+
+        [System.Text.Json.Serialization.JsonPropertyName("avatarUrl")]
+        public string? AvatarUrl { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3337,6 +3337,7 @@ export interface PublicOrganizationProfileResponse {
     address: PublicAddressDto | undefined;
     isVerified: boolean;
     openOpportunities: PublicOpportunitySummaryDto[];
+    logoUrl: string | undefined;
 
     [key: string]: any;
 }
@@ -3345,6 +3346,7 @@ export interface PublicUserProfileResponse {
     displayName: string;
     engagementCount: number;
     badges: AchievementSummary[];
+    avatarUrl: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -42,23 +42,36 @@ export default function OrganizationProfilePage() {
 
 	return (
 		<>
-			<div className="mb-6 flex items-center gap-2">
-				<h1 className="text-2xl font-bold text-gray-900">{profile.name}</h1>
-				{profile.isVerified && (
-					<svg
-						className="h-6 w-6 text-brand-600"
-						viewBox="0 0 20 20"
-						fill="currentColor"
-						aria-label={t("orgProfile.verified")}
-						role="img"
-					>
-						<path
-							fillRule="evenodd"
-							d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
-							clipRule="evenodd"
-						/>
-					</svg>
+			<div className="mb-6 flex items-center gap-4">
+				{profile.logoUrl ? (
+					<img
+						src={profile.logoUrl}
+						alt={profile.name}
+						className="h-16 w-16 rounded-full object-cover"
+					/>
+				) : (
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-bold text-brand-700">
+						{profile.name.charAt(0).toUpperCase()}
+					</div>
 				)}
+				<div className="flex items-center gap-2">
+					<h1 className="text-2xl font-bold text-gray-900">{profile.name}</h1>
+					{profile.isVerified && (
+						<svg
+							className="h-6 w-6 text-brand-600"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+							aria-label={t("orgProfile.verified")}
+							role="img"
+						>
+							<path
+								fillRule="evenodd"
+								d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+								clipRule="evenodd"
+							/>
+						</svg>
+					)}
+				</div>
 			</div>
 
 			<div className="max-w-2xl">

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -15,6 +15,7 @@ interface PublicUserProfile {
 	displayName: string;
 	engagementCount: number;
 	badges: AchievementSummary[];
+	avatarUrl?: string;
 }
 
 export default function UserProfilePage() {
@@ -58,9 +59,17 @@ export default function UserProfilePage() {
 	return (
 		<>
 			<div className="mb-8 flex items-center gap-4">
-				<div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-bold text-brand-700">
-					{profile.displayName.charAt(0).toUpperCase()}
-				</div>
+				{profile.avatarUrl ? (
+					<img
+						src={profile.avatarUrl}
+						alt={profile.displayName}
+						className="h-16 w-16 rounded-full object-cover"
+					/>
+				) : (
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-bold text-brand-700">
+						{profile.displayName.charAt(0).toUpperCase()}
+					</div>
+				)}
 				<div>
 					<h1 className="text-2xl font-bold text-gray-900">
 						{profile.displayName}


### PR DESCRIPTION
## Summary

Fixes the display gap for issues #503 and #504. The upload endpoints and MinIO storage for user avatars and organization logos already existed, but the public-facing profile pages showed only initials because the `avatarUrl`/`logoUrl` fields were never included in the public profile API responses.

- **Backend**: Add `AvatarUrl` to `PublicUserProfileResponse` and load the `User` entity in `GetPublicUserProfileQueryHandler` to supply the value. Add `LogoUrl` to `PublicOrganizationProfileResponse` and wire `Organization.LogoUrl` in `GetPublicOrganizationProfileQueryHandler`.
- **Generated clients**: Regenerated `openapi-v1.json`, `frontend/src/client/api-client.ts`, and `backend/tests/IntegrationTests/ApiClient.cs`.
- **Frontend**: `UserProfilePage` and `OrganizationProfilePage` now render the uploaded image when present, with an initials-circle fallback when no image has been uploaded.

## Test plan

- [ ] Upload an avatar as Vera via Profile Settings → verify it appears on `/users/{id}` public profile page
- [ ] Upload a logo as Olaf via Organization Settings → verify it appears on `/organizations/{id}` public profile page
- [ ] Verify initials fallback still shows when no image uploaded
- [ ] All 183 unit tests pass (`dotnet run --project backend/tests/Application.UnitTests/`)
- [ ] `pnpm check` and `pnpm lint` pass with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xaf2hG7NozrHjdcCohkgm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xaf2hG7NozrHjdcCohkgm6)_