### PR TITLE
fix: clear feedback PII on account deletion, add banner edit, localize badge names

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerEndpoint.cs
@@ -1,0 +1,42 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities.DeleteOpportunityBanner.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.VolunteerOpportunities.DeleteOpportunityBanner.v1;
+
+internal sealed class DeleteOpportunityBannerEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapDelete("/volunteer-opportunities/{opportunityId:guid}/banner", DeleteOpportunityBannerAsync)
+			.WithName("DeleteOpportunityBanner")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> DeleteOpportunityBannerAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? new UserId(uid)
+			: throw new DomainException("Invalid user.");
+
+		await sender.Send(
+			new DeleteOpportunityBannerCommand(opportunityId, userId),
+			cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -139,6 +139,58 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "DeleteOpportunityBannerEndpoint"
+        ],
+        "operationId": "DeleteOpportunityBanner",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/volunteer-opportunities/{opportunityId}": {
@@ -5222,6 +5274,9 @@
     },
     {
       "name": "GetOpportunityBannerEndpoint"
+    },
+    {
+      "name": "DeleteOpportunityBannerEndpoint"
     },
     {
       "name": "UpdateVolunteerOpportunityEndpoint"

--- a/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
+++ b/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
@@ -1,15 +1,19 @@
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Domain.Users;
 
 namespace Application.Users.DeleteMyAccount.v1;
 
 internal sealed class DeleteMyAccountCommandHandler(
 	IApplicationDbContext dbContext,
-	IKeycloakUserService keycloakUserService)
+	IKeycloakUserService keycloakUserService,
+	IFileStorageService fileStorage)
 	: ICommandHandler<DeleteMyAccountCommand, bool>
 {
+	private static readonly string[] AvatarExtensions = [".jpg", ".png", ".webp"];
+
 	public async ValueTask<bool> Handle(
 		DeleteMyAccountCommand request,
 		CancellationToken cancellationToken = default)
@@ -21,6 +25,24 @@ internal sealed class DeleteMyAccountCommandHandler(
 			engagement.Anonymize();
 
 		await dbContext.DeleteNotificationsForRecipientAsync(request.UserId, cancellationToken);
+
+		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
+		if (user is not null)
+		{
+			foreach (var ext in AvatarExtensions)
+			{
+				try
+				{
+					await fileStorage.DeleteAsync($"user-avatars/{request.UserId.Value}{ext}", cancellationToken);
+				}
+				catch
+				{
+					// Object may not exist for this extension; continue
+				}
+			}
+
+			dbContext.Users.Delete(user);
+		}
 
 		await keycloakUserService.DeleteUserAsync(request.UserId.Value, cancellationToken);
 

--- a/backend/src/Application/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerCommand.cs
@@ -1,0 +1,9 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.VolunteerOpportunities.DeleteOpportunityBanner.v1;
+
+public sealed record DeleteOpportunityBannerCommand(
+	Guid OpportunityId,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerCommandHandler.cs
@@ -1,0 +1,49 @@
+using Application.Common.Authorization;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Domain.Primitives;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.DeleteOpportunityBanner.v1;
+
+internal sealed class DeleteOpportunityBannerCommandHandler(
+	IApplicationDbContext dbContext,
+	IKeycloakOrganizationService keycloakOrgService,
+	IFileStorageService fileStorage)
+	: ICommandHandler<DeleteOpportunityBannerCommand, bool>
+{
+	private static readonly string[] BannerExtensions = [".jpg", ".png", ".webp"];
+
+	public async ValueTask<bool> Handle(
+		DeleteOpportunityBannerCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			new VolunteerOpportunityId(request.OpportunityId), cancellationToken)
+			?? throw new DomainException($"Volunteer opportunity '{request.OpportunityId}' not found.");
+
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrgService,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		foreach (var ext in BannerExtensions)
+		{
+			try
+			{
+				await fileStorage.DeleteAsync($"opportunity-banners/{request.OpportunityId}{ext}", cancellationToken);
+			}
+			catch
+			{
+				// Object may not exist for this extension; continue
+			}
+		}
+
+		opportunity.ClearBannerImageUrl();
+
+		return true;
+	}
+}

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -161,5 +161,8 @@ public sealed class Engagement
 	{
 		VolunteerId = new UserId(Guid.Empty);
 		Message = null;
+		FeedbackComment = null;
+		FeedbackRating = null;
+		FeedbackSubmittedAt = null;
 	}
 }

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -144,6 +144,11 @@ public sealed class VolunteerOpportunity
 		BannerImageUrl = url;
 	}
 
+	public void ClearBannerImageUrl()
+	{
+		BannerImageUrl = null;
+	}
+
 	public void SetColor(string? color)
 	{
 		Color = color;

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -44,6 +44,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteOpportunityBannerAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task UpdateVolunteerOpportunityAsync(System.Guid opportunityId, UpdateVolunteerOpportunityRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -521,6 +526,106 @@ namespace IntegrationTests
                         {
 
                             return;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteOpportunityBannerAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/banner"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/banner");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -141,6 +141,61 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    deleteOpportunityBanner(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/banner";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteOpportunityBanner(_response);
+        });
+    }
+
+    protected processDeleteOpportunityBanner(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     updateVolunteerOpportunity(opportunityId: string, body: UpdateVolunteerOpportunityRequest, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}";
         if (opportunityId === undefined || opportunityId === null)

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -58,7 +58,11 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 					isEarned ? "text-gray-900" : "text-gray-400"
 				}`}
 			>
-				{isHidden ? t("achievements.lockedBadge") : catalog.name}
+				{isHidden
+					? t("achievements.lockedBadge")
+					: t(`achievements.badges.${catalog.key}.name`, {
+							defaultValue: catalog.name,
+						})}
 			</p>
 			{isEarned && (
 				<p className="mt-1 text-xs text-gray-500">
@@ -68,7 +72,11 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 				</p>
 			)}
 			{!isEarned && !isHidden && (
-				<p className="mt-1 text-xs text-gray-400">{catalog.description}</p>
+				<p className="mt-1 text-xs text-gray-400">
+					{t(`achievements.badges.${catalog.key}.description`, {
+						defaultValue: catalog.description,
+					})}
+				</p>
 			)}
 			{!isHidden && (
 				<div
@@ -76,8 +84,16 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 					role="tooltip"
 					className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block"
 				>
-					<p className="font-semibold">{catalog.name}</p>
-					<p className="mt-0.5 text-gray-300">{catalog.description}</p>
+					<p className="font-semibold">
+						{t(`achievements.badges.${catalog.key}.name`, {
+							defaultValue: catalog.name,
+						})}
+					</p>
+					<p className="mt-0.5 text-gray-300">
+						{t(`achievements.badges.${catalog.key}.description`, {
+							defaultValue: catalog.description,
+						})}
+					</p>
 					{isEarned && (
 						<p className="mt-1 text-brand-300">
 							{t("achievements.types." + typeName)}

--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -301,10 +301,13 @@ export default function CreateVolunteerOpportunityModal({
 	);
 	const [orgAddress, setOrgAddress] = useState<AddressDto | null>(null);
 
-	// Banner (create mode only)
+	// Banner
 	const [bannerFile, setBannerFile] = useState<File | null>(null);
-	const [bannerPreview, setBannerPreview] = useState<string | null>(null);
+	const [bannerPreview, setBannerPreview] = useState<string | null>(
+		initialOpportunity?.bannerImageUrl ?? null,
+	);
 	const [bannerError, setBannerError] = useState<string | null>(null);
+	const [bannerRemoved, setBannerRemoved] = useState(false);
 
 	// Time slots: pending = not yet persisted (create mode); existing = already saved (edit mode)
 	const [pendingSlots, setPendingSlots] = useState<PendingTimeSlot[]>([]);
@@ -425,6 +428,9 @@ export default function CreateVolunteerOpportunityModal({
 	}
 
 	function removeBanner() {
+		if (isEditMode && bannerFile === null) {
+			setBannerRemoved(true);
+		}
 		setBannerFile(null);
 		setBannerPreview(null);
 		setBannerError(null);
@@ -533,6 +539,22 @@ export default function CreateVolunteerOpportunityModal({
 					category: form.category || undefined,
 					tags: form.tags,
 				});
+				if (bannerFile) {
+					try {
+						await api.uploadOpportunityBanner(initialOpportunity.id, {
+							data: bannerFile,
+							fileName: bannerFile.name,
+						});
+					} catch {
+						dispatchToast("error", t("editOpportunity.bannerUploadFailed"));
+					}
+				} else if (bannerRemoved) {
+					try {
+						await api.deleteOpportunityBanner(initialOpportunity.id);
+					} catch {
+						dispatchToast("error", t("editOpportunity.bannerRemoveFailed"));
+					}
+				}
 			} else {
 				const opportunity = await api.createVolunteerOpportunity({
 					title: form.title,
@@ -723,67 +745,65 @@ export default function CreateVolunteerOpportunityModal({
 								showCount
 							/>
 
-							{!isEditMode && (
-								<div>
-									<p className="mb-1.5 text-sm font-semibold text-gray-800">
-										{t("createOpportunity.fieldBanner")}
-									</p>
-									{bannerPreview ? (
-										<div className="relative overflow-hidden rounded-xl">
-											<img
-												src={bannerPreview}
-												alt={t("createOpportunity.fieldBanner")}
-												className="h-36 w-full object-cover"
-											/>
-											<button
-												type="button"
-												onClick={removeBanner}
-												className="absolute right-2 top-2 rounded-lg bg-black/60 px-2.5 py-1 text-xs font-semibold text-white backdrop-blur transition hover:bg-black/80"
-											>
-												{t("createOpportunity.bannerRemove")}
-											</button>
-										</div>
-									) : (
-										<label
-											htmlFor="opportunity-banner"
-											className="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center transition hover:border-brand-300 hover:bg-brand-50"
+							<div>
+								<p className="mb-1.5 text-sm font-semibold text-gray-800">
+									{t("createOpportunity.fieldBanner")}
+								</p>
+								{bannerPreview ? (
+									<div className="relative overflow-hidden rounded-xl">
+										<img
+											src={bannerPreview}
+											alt={t("createOpportunity.fieldBanner")}
+											className="h-36 w-full object-cover"
+										/>
+										<button
+											type="button"
+											onClick={removeBanner}
+											className="absolute right-2 top-2 rounded-lg bg-black/60 px-2.5 py-1 text-xs font-semibold text-white backdrop-blur transition hover:bg-black/80"
 										>
-											<svg
-												aria-hidden="true"
-												className="h-6 w-6 text-gray-400"
-												fill="none"
-												stroke="currentColor"
-												strokeWidth={1.5}
-												viewBox="0 0 24 24"
-											>
-												<path
-													strokeLinecap="round"
-													strokeLinejoin="round"
-													d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
-												/>
-											</svg>
-											<span className="text-sm font-medium text-gray-700">
-												{t("createOpportunity.bannerUpload")}
-											</span>
-											<span className="text-xs text-gray-400">
-												{t("createOpportunity.bannerHint")}
-											</span>
-											<input
-												id="opportunity-banner"
-												type="file"
-												accept="image/jpeg,image/png,image/webp"
-												className="sr-only"
-												onChange={handleBannerChange}
+											{t("createOpportunity.bannerRemove")}
+										</button>
+									</div>
+								) : (
+									<label
+										htmlFor="opportunity-banner"
+										className="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center transition hover:border-brand-300 hover:bg-brand-50"
+									>
+										<svg
+											aria-hidden="true"
+											className="h-6 w-6 text-gray-400"
+											fill="none"
+											stroke="currentColor"
+											strokeWidth={1.5}
+											viewBox="0 0 24 24"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
 											/>
-										</label>
-									)}
-									{bannerError && (
-										<p className="mt-1 text-xs text-red-600" role="alert">
-											{bannerError}
-										</p>
-									)}
-								</div>
-							)}
+										</svg>
+										<span className="text-sm font-medium text-gray-700">
+											{t("createOpportunity.bannerUpload")}
+										</span>
+										<span className="text-xs text-gray-400">
+											{t("createOpportunity.bannerHint")}
+										</span>
+										<input
+											id="opportunity-banner"
+											type="file"
+											accept="image/jpeg,image/png,image/webp"
+											className="sr-only"
+											onChange={handleBannerChange}
+										/>
+									</label>
+								)}
+								{bannerError && (
+									<p className="mt-1 text-xs text-red-600" role="alert">
+										{bannerError}
+									</p>
+								)}
+							</div>
 						</div>
 					)}
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -266,7 +266,9 @@
       "saving": "Wird gespeichert…",
       "save": "Speichern",
       "cancel": "Abbrechen",
-      "unknownError": "Unbekannter Fehler"
+      "unknownError": "Unbekannter Fehler",
+      "bannerUploadFailed": "Der Bedarf wurde gespeichert, aber das Bannerbild konnte nicht hochgeladen werden.",
+      "bannerRemoveFailed": "Das Banner konnte nicht entfernt werden."
     },
     "timeSlots": {
       "sectionTitle": "Zeitslots",
@@ -639,6 +641,32 @@
         "Streak": "Serie",
         "Social": "Sozial",
         "Hidden": "Besonders"
+      },
+      "badges": {
+        "first-step": {
+          "name": "Erster Schritt",
+          "description": "Verdient bei deinem ersten bestaetigen Einsatz."
+        },
+        "dedicated-5": {
+          "name": "Engagiert",
+          "description": "Verdient nach 5 bestaetigten Einsaetzen."
+        },
+        "centurion-100": {
+          "name": "Jahrhundert",
+          "description": "Verdient nach 100 bestaetigten Einsaetzen."
+        },
+        "on-a-roll-7": {
+          "name": "Auf Kurs",
+          "description": "Verdient fuer eine 7-taegige Login-Serie."
+        },
+        "weekly-hero-4": {
+          "name": "Wochenheld",
+          "description": "Verdient fuer 4 aufeinanderfolgende Aktivitaetswochen."
+        },
+        "early-adopter": {
+          "name": "Frueheinsteiger",
+          "description": "Einer der ersten Freiwilligen auf der Plattform."
+        }
       }
     },
     "breadcrumb": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -266,7 +266,9 @@
       "saving": "Saving…",
       "save": "Save",
       "cancel": "Cancel",
-      "unknownError": "Unknown error"
+      "unknownError": "Unknown error",
+      "bannerUploadFailed": "The opportunity was saved, but the banner image could not be uploaded.",
+      "bannerRemoveFailed": "The banner could not be removed."
     },
     "timeSlots": {
       "sectionTitle": "Time slots",
@@ -639,6 +641,32 @@
         "Streak": "Streak",
         "Social": "Social",
         "Hidden": "Special"
+      },
+      "badges": {
+        "first-step": {
+          "name": "First Step",
+          "description": "Earned on your first confirmed engagement."
+        },
+        "dedicated-5": {
+          "name": "Dedicated",
+          "description": "Earned after 5 confirmed engagements."
+        },
+        "centurion-100": {
+          "name": "Century",
+          "description": "Earned after 100 confirmed engagements."
+        },
+        "on-a-roll-7": {
+          "name": "On a Roll",
+          "description": "Earned for a 7-day login streak."
+        },
+        "weekly-hero-4": {
+          "name": "Weekly Hero",
+          "description": "Earned for 4 consecutive weeks of activity."
+        },
+        "early-adopter": {
+          "name": "Early Adopter",
+          "description": "One of the first volunteers on the platform."
+        }
       }
     },
     "breadcrumb": {


### PR DESCRIPTION
## Summary

- **#546 GDPR account deletion**: `Anonymize()` on `Engagement` now clears `FeedbackComment`, `FeedbackRating`, and `FeedbackSubmittedAt` (free-text PII that was previously retained). `DeleteMyAccountCommandHandler` now also deletes the `User` aggregate and all avatar blobs (`.jpg`, `.png`, `.webp` tried via try/catch) before removing the Keycloak account.
- **#538 Banner edit**: Added `DELETE /v1/volunteer-opportunities/{opportunityId}/banner` endpoint + command/handler to remove a banner. In the `CreateVolunteerOpportunityModal`, the banner section is now shown in both create and edit modes. In edit mode the existing banner URL pre-populates the preview, a new file upload replaces it, and clicking Remove calls the new delete endpoint.
- **#544 Badge i18n**: `BadgeGrid` now looks up badge names and descriptions via `t("achievements.badges.<key>.name")` with the server value as a fallback. English and German translations added for all six catalog badges.

## Changes

### Backend
- `Domain/Engagements/Engagement.cs` - `Anonymize()` clears feedback fields
- `Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs` - deletes User aggregate + avatar blobs
- `Domain/VolunteerOpportunities/VolunteerOpportunity.cs` - adds `ClearBannerImageUrl()` method
- `Application/VolunteerOpportunities/DeleteOpportunityBanner/v1/` - new command + handler
- `Api/VolunteerOpportunities/DeleteOpportunityBanner/v1/` - new `DELETE .../banner` endpoint (requires `organisator` role)
- `openapi-v1.json` + `IntegrationTests/ApiClient.cs` - regenerated by NSwag build

### Frontend
- `client/api-client.ts` - regenerated, includes `deleteOpportunityBanner`
- `components/CreateVolunteerOpportunityModal.tsx` - banner section visible in edit mode; `bannerPreview` initialized from existing URL; `bannerRemoved` state drives delete call on save
- `components/BadgeGrid.tsx` - badge names/descriptions use i18n with server fallback
- `locales/en.json` + `locales/de.json` - `achievements.badges.*` translations + `editOpportunity.bannerUploadFailed`/`bannerRemoveFailed`

## Test plan

- [ ] Account deletion anonymizes engagement feedback fields (no PII retained)
- [ ] Account deletion removes the User record and avatar blob
- [ ] `DELETE /v1/volunteer-opportunities/{id}/banner` returns 204, clears `BannerImageUrl`
- [ ] Edit opportunity modal shows existing banner preview; new upload replaces it
- [ ] Clicking Remove on the existing banner calls the delete endpoint on save
- [ ] Badge names and descriptions render in German when locale is `de`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uaGm4QApzBN6GC1KcnK7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_013uaGm4QApzBN6GC1KcnK7Q)_