### PR TITLE
fix: close auth bypass, cancel orphaned engagements, guard slot removal, and other bug fixes

### DIFF
--- a/backend/global.json
+++ b/backend/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.300",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   },

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -74,6 +74,10 @@ public interface IApplicationDbContext
 		TimeSlotId timeSlotId,
 		CancellationToken cancellationToken = default);
 
+	Task<List<Engagement>> GetActiveEngagementsForOpportunityAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default);
+
 	Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,

--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -23,15 +23,14 @@ internal sealed class CancelEngagementCommandHandler(
 		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
 			?? throw new DomainException($"Engagement '{request.EngagementId.Value}' not found.");
 
-		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken);
-		if (opportunity is not null)
-		{
-			await OwnershipGuard.EnsureIsOrgMemberAsync(
-				keycloakOrgService,
-				opportunity.OrganizationId.Value,
-				request.RequestingUserId,
-				cancellationToken);
-		}
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken)
+			?? throw new DomainException($"Volunteer opportunity '{engagement.OpportunityId.Value}' not found.");
+
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrgService,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
 
 		engagement.Cancel(request.Reason);
 
@@ -51,7 +50,7 @@ internal sealed class CancelEngagementCommandHandler(
 			volunteer.Email,
 			"Your engagement has been cancelled",
 			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
-			$"Unfortunately your application for \"{opportunity?.Title ?? "the opportunity"}\" has been cancelled.{reasonText}\n\n" +
+			$"Unfortunately your application for \"{opportunity.Title}\" has been cancelled.{reasonText}\n\n" +
 			$"We hope to see you at another opportunity.\n\nEinsatzbereit",
 			cancellationToken);
 

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -26,15 +26,14 @@ internal sealed class ConfirmEngagementCommandHandler(
 		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
 			?? throw new DomainException($"Engagement '{request.EngagementId.Value}' not found.");
 
-		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken);
-		if (opportunity is not null)
-		{
-			await OwnershipGuard.EnsureIsOrgMemberAsync(
-				keycloakOrgService,
-				opportunity.OrganizationId.Value,
-				request.RequestingUserId,
-				cancellationToken);
-		}
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken)
+			?? throw new DomainException($"Volunteer opportunity '{engagement.OpportunityId.Value}' not found.");
+
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrgService,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
 
 		engagement.Confirm();
 
@@ -64,7 +63,7 @@ internal sealed class ConfirmEngagementCommandHandler(
 			volunteer.Email,
 			"Your engagement has been confirmed",
 			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
-			$"Your application for \"{opportunity?.Title ?? "the opportunity"}\" has been confirmed.\n\n" +
+			$"Your application for \"{opportunity.Title}\" has been confirmed.\n\n" +
 			$"We look forward to seeing you!\n\nEinsatzbereit",
 			cancellationToken);
 

--- a/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
@@ -26,7 +26,14 @@ internal sealed class DeleteTimeSlotCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		opportunity.RemoveTimeSlot(new TimeSlotId(request.TimeSlotId));
+		var timeSlotId = new TimeSlotId(request.TimeSlotId);
+
+		var activeCount = await dbContext.CountActiveEngagementsForTimeSlotAsync(timeSlotId, cancellationToken);
+		if (activeCount > 0)
+			throw new DomainException(
+				$"Cannot delete a time slot that has {activeCount} active sign-up(s). Cancel the affected engagements first.");
+
+		opportunity.RemoveTimeSlot(timeSlotId);
 
 		return true;
 	}

--- a/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
@@ -41,6 +41,14 @@ internal sealed class DeleteVolunteerOpportunityCommandHandler(
 			NotificationKind.OpportunityDeleted,
 			cancellationToken);
 
+		// Cancel active engagements so they do not outlive the opportunity (#548).
+		var activeEngagements = await dbContext.GetActiveEngagementsForOpportunityAsync(
+			opportunityId, cancellationToken);
+		foreach (var engagement in activeEngagements)
+		{
+			engagement.Cancel("Opportunity was deleted.");
+		}
+
 		dbContext.VolunteerOpportunities.Delete(opportunity);
 
 		return true;

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -138,6 +138,14 @@ internal sealed class ApplicationDbContext(
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed),
 				cancellationToken);
 
+	public async Task<List<Engagement>> GetActiveEngagementsForOpportunityAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default) =>
+		await Set<Engagement>()
+			.Where(e => e.OpportunityId == opportunityId
+				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
+			.ToListAsync(cancellationToken);
+
 	public async Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Engagements.CancelEngagement.v1;
 using AwesomeAssertions;
 using Domain.Engagements;
 using Domain.Notifications;
+using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
@@ -27,12 +28,17 @@ public class CancelEngagementCommandHandlerTests
 	private readonly CancelEngagementCommandHandler _sut;
 
 	private static readonly UserId DefaultRequestingUserId = new(Guid.CreateVersion7());
+	private static readonly OrganizationId DefaultOrgId = new(Guid.Empty);
+	private static readonly Address DefaultAddress = new("Teststraße", "1", "12345", "Berlin");
 
 	public CancelEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
@@ -41,6 +47,9 @@ public class CancelEngagementCommandHandlerTests
 			.Returns([new KeycloakOrganization(Guid.Empty, "any")]);
 		_sut = new CancelEngagementCommandHandler(_dbContext, _keycloakUserService, _keycloakOrgService, _emailService);
 	}
+
+	private static VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
 
 	private static Engagement CreatePendingWaitlistEngagement() =>
 		Engagement.CreateWaitlistSignUp(

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using Application.Engagements.ConfirmEngagement.v1;
 using AwesomeAssertions;
 using Domain.Engagements;
 using Domain.Notifications;
+using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
@@ -32,6 +33,8 @@ public class ConfirmEngagementCommandHandlerTests
 	private readonly ConfirmEngagementCommandHandler _sut;
 
 	private static readonly UserId DefaultRequestingUserId = new(Guid.CreateVersion7());
+	private static readonly OrganizationId DefaultOrgId = new(Guid.Empty);
+	private static readonly Address DefaultAddress = new("Teststraße", "1", "12345", "Berlin");
 
 	public ConfirmEngagementCommandHandlerTests()
 	{
@@ -39,6 +42,9 @@ public class ConfirmEngagementCommandHandlerTests
 		_dbContext.Notifications.Returns(_notifRepo);
 		_dbContext.UserStreaks.Returns(_streakRepo);
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
@@ -203,6 +209,9 @@ public class ConfirmEngagementCommandHandlerTests
 			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "weekly-hero-4"),
 			Arg.Any<CancellationToken>());
 	}
+
+	private static VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
 
 	private static UserStreak BuildActivityStreakOf(UserId userId, int weeks)
 	{

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 using AwesomeAssertions;
+using Domain.Engagements;
 using Domain.Notifications;
 using Domain.Organizations;
 using Domain.Primitives;
@@ -32,6 +33,9 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 	{
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Engagement>());
 		_engagementReadRepository
 			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns([]);


### PR DESCRIPTION
## Summary

This PR accumulates several sessions of bug fixes and features targeting the open issues. The key changes are:

**Security / data-integrity fixes (this session — #548, #539)**
- `ConfirmEngagement` and `CancelEngagement` now **fail closed**: if the opportunity cannot be found, the request is rejected (DomainException) instead of silently skipping the ownership guard and proceeding. Closes the auth bypass documented in #548.
- `DeleteVolunteerOpportunity` now **cancels all active engagements** (Pending/Confirmed) before removing the opportunity, so volunteers are not left with orphaned engagements pointing at a deleted record (#548).
- `DeleteTimeSlot` now **blocks removal** when the slot has active sign-ups, returning a clear error message. The organizer must cancel affected engagements first (#539).
- Adds `GetActiveEngagementsForOpportunityAsync` to `IApplicationDbContext` / `ApplicationDbContext` to support the bulk cancellation.
- Reverts `global.json` SDK version from 10.0.301 → 10.0.300 to match the installed SDK in the CI/cloud environment.

**Previous sessions also on this branch**
- Re-apply after withdrawal now resets `IsCheckedIn`, feedback, and reminder state (#541).
- Waitlist opportunity publish requires at least one time slot (#542).
- Time-slot capacity update is guarded against over-subscription (#540).
- Notification badge loads immediately on login (removed the 35 s test-workaround delay) (#545).
- Participation-type wording clarified in EN/DE copy (#543).
- Account deletion clears the local `User` aggregate, avatar blob, and feedback PII (#546).
- Banner image can be changed and removed in edit mode (#538).
- Badge names and descriptions are localized via i18n keys (#544).
- `AvatarUrl` and `LogoUrl` exposed on public profile endpoints (#503, #504).
- Organization invitation flow (#527).
- Calendar view branded with CSS overrides (#521).

## Test plan

- [ ] Delete an opportunity that has pending/confirmed sign-ups → all sign-ups should be cancelled (status = Cancelled) and volunteers notified.
- [ ] Try to confirm an engagement whose opportunity was deleted → expect 404/DomainException, not success.
- [ ] Try to cancel an engagement whose opportunity was deleted → expect 404/DomainException, not success.
- [ ] Try to delete a time slot that has active sign-ups → expect a clear error blocking the deletion.
- [ ] Delete a time slot with zero active sign-ups → deletion proceeds normally.
- [ ] Architecture tests pass (240/240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGiPSyjb3dQWj32RtFrafd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGiPSyjb3dQWj32RtFrafd)_