### PR TITLE
fix: generate PIN on CheckInMethod switch and add per-slot booking counts

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5168,7 +5168,8 @@
           "id",
           "startDateTime",
           "endDateTime",
-          "maxParticipants"
+          "maxParticipants",
+          "bookedCount"
         ],
         "type": "object",
         "properties": {
@@ -5185,6 +5186,14 @@
             "format": "date-time"
           },
           "maxParticipants": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "bookedCount": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
             "type": [
               "integer",

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
@@ -28,4 +28,5 @@ public sealed record TimeSlotDetail(
 	Guid Id,
 	DateTimeOffset StartDateTime,
 	DateTimeOffset EndDateTime,
-	int MaxParticipants);
+	int MaxParticipants,
+	int BookedCount);

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -183,6 +183,8 @@ public sealed class VolunteerOpportunity
 		CheckInMethod = checkInMethod;
 		Category = category;
 		Tags = tags;
+		if (checkInMethod == CheckInMethod.PINCode && CheckInPin is null)
+			CheckInPin = GeneratePin();
 	}
 
 	public TimeSlot AddTimeSlot(

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -184,7 +184,9 @@ public sealed class VolunteerOpportunity
 		Category = category;
 		Tags = tags;
 		if (checkInMethod == CheckInMethod.PINCode && CheckInPin is null)
+		{
 			CheckInPin = GeneratePin();
+		}
 	}
 
 	public TimeSlot AddTimeSlot(

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -252,7 +252,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 				ts.Id.Value,
 				ts.StartDateTime,
 				ts.EndDateTime,
-				ts.MaxParticipants))
+				ts.MaxParticipants,
+				dbContext.EngagementsQuery.Count(e =>
+					e.TimeSlotId == ts.Id &&
+					(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))))
 			.ToListAsync(cancellationToken);
 
 		var currentParticipantCount = await dbContext.EngagementsQuery

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -7979,6 +7979,11 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
         public int MaxParticipants { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("bookedCount")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int BookedCount { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3817,6 +3817,7 @@ export interface TimeSlotDetail {
     startDateTime: Date;
     endDateTime: Date;
     maxParticipants: number;
+    bookedCount: number;
 
     [key: string]: any;
 }

--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -464,6 +464,7 @@ export default function CreateVolunteerOpportunityModal({
 						startDateTime: r.startDateTime,
 						endDateTime: r.endDateTime,
 						maxParticipants: r.maxParticipants,
+						bookedCount: 0,
 					})),
 				]);
 			} catch {

--- a/frontend/src/components/EditVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/EditVolunteerOpportunityModal.tsx
@@ -106,6 +106,7 @@ export default function EditVolunteerOpportunityModal({
 					startDateTime: r.startDateTime,
 					endDateTime: r.endDateTime,
 					maxParticipants: r.maxParticipants,
+					bookedCount: 0,
 				})),
 			]);
 			setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -94,22 +94,28 @@ export default function SignUpModal({
 									className="w-full rounded border px-3 py-2 text-sm"
 								>
 									<option value="">{t("signUp.selectPlaceholder")}</option>
-									{timeSlots.map((ts) => (
-										<option key={ts.id} value={ts.id}>
-											{formatDateTime(
-												ts.startDateTime as unknown as string,
-												i18n.language,
-											)}{" "}
-											-{" "}
-											{formatDateTime(
-												ts.endDateTime as unknown as string,
-												i18n.language,
-											)}{" "}
-											{t("signUp.maxParticipants", {
-												count: ts.maxParticipants,
-											})}
-										</option>
-									))}
+									{timeSlots.map((ts) => {
+										const spotsLeft = ts.maxParticipants - ts.bookedCount;
+										const slotFull = spotsLeft <= 0;
+										return (
+											<option key={ts.id} value={ts.id} disabled={slotFull}>
+												{formatDateTime(
+													ts.startDateTime as unknown as string,
+													i18n.language,
+												)}{" "}
+												-{" "}
+												{formatDateTime(
+													ts.endDateTime as unknown as string,
+													i18n.language,
+												)}{" "}
+												{slotFull
+													? t("signUp.slotFull")
+													: t("signUp.spotsLeft", {
+															count: spotsLeft,
+														})}
+											</option>
+										);
+									})}
 								</select>
 							)}
 						</div>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -302,7 +302,9 @@
       "submit": "Anmelden",
       "cancel": "Abbrechen",
       "unknownError": "Unbekannter Fehler",
-      "maxParticipants": "(max. {{count}})"
+      "maxParticipants": "(max. {{count}})",
+      "spotsLeft": "(noch {{count}})",
+      "slotFull": "(Ausgebucht)"
     },
     "organization": {
       "create": "Organisation erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -302,7 +302,9 @@
       "submit": "Sign up",
       "cancel": "Cancel",
       "unknownError": "Unknown error",
-      "maxParticipants": "(max. {{count}})"
+      "maxParticipants": "(max. {{count}})",
+      "spotsLeft": "({{count}} left)",
+      "slotFull": "(Full)"
     },
     "organization": {
       "create": "Create organization",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -135,9 +135,14 @@ export default function VolunteerOpportunityDetailPage() {
 		(sum, ts) => sum + ts.maxParticipants,
 		0,
 	);
-	const spotsLeft =
-		totalMax > 0 ? totalMax - opportunity.currentParticipantCount : Infinity;
-	const isFull = totalMax > 0 && spotsLeft <= 0;
+	const totalBooked = opportunity.timeSlots.reduce(
+		(sum, ts) => sum + ts.bookedCount,
+		0,
+	);
+	const spotsLeft = totalMax > 0 ? totalMax - totalBooked : Infinity;
+	const isFull =
+		opportunity.timeSlots.length > 0 &&
+		opportunity.timeSlots.every((ts) => ts.bookedCount >= ts.maxParticipants);
 
 	return (
 		<div className="max-w-2xl">


### PR DESCRIPTION
## Summary

- **fix #549**: `VolunteerOpportunity.Update()` now generates a PIN when `CheckInMethod` is switched to `PINCode` and no PIN exists yet
- **fix #533**: Added `BookedCount` to `TimeSlotDetail` DTO populated via EF Core correlated subquery; fixed `isFull` logic to check per-slot capacity; updated `SignUpModal` slot picker to show remaining spots and disable full slots

## Changes

### Backend
- `VolunteerOpportunity.cs` - added PIN generation guard in `Update()` when switching to `PINCode` with no existing PIN
- `VolunteerOpportunityDetails.cs` - added `BookedCount` property to `TimeSlotDetail` record
- `VolunteerOpportunityReadRepository.cs` - populates `BookedCount` via correlated subquery counting `Pending`/`Confirmed` engagements per slot
- `openapi-v1.json` + `ApiClient.cs` - regenerated by NSwag to include `bookedCount`

### Frontend
- `VolunteerOpportunityDetailPage.tsx` - `isFull` now checks `every(ts => ts.bookedCount >= ts.maxParticipants)`; `spotsLeft` computed from per-slot totals
- `SignUpModal.tsx` - slot picker shows `(N left)` or `(Full)` per option; full slots are disabled
- `CreateVolunteerOpportunityModal.tsx` + `EditVolunteerOpportunityModal.tsx` - added `bookedCount: 0` to locally-constructed slot objects to satisfy TypeScript
- `en.json` / `de.json` - added `signUp.spotsLeft` and `signUp.slotFull` translation keys

## Test plan

- [ ] Create an opportunity with `Waitlist` participation type and multiple time slots
- [ ] Partially book a slot - verify "(N left)" shows correct remaining count
- [ ] Fill a slot to capacity - verify it shows "(Full)" and is disabled in the slot picker
- [ ] Edit an opportunity and switch `CheckInMethod` to `PINCode` - verify a PIN is generated automatically
- [ ] Verify `isFull` banner appears only when all slots are at capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYKzEUqnPo58mSGMe7xnxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYKzEUqnPo58mSGMe7xnxh)_