### PR TITLE
feat: show volunteer names in engagement management and persist application state on opportunity detail

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsEndpoint.cs
@@ -3,6 +3,7 @@ using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 
@@ -22,9 +23,11 @@ internal sealed class GetVolunteerOpportunityDetailsEndpoint
 	private static async Task<IResult> GetVolunteerOpportunityDetailsAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
-		var query = new GetVolunteerOpportunityDetailsQuery(opportunityId);
+		var requestingUserId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? uid : (Guid?)null;
+		var query = new GetVolunteerOpportunityDetailsQuery(opportunityId, requestingUserId);
 		var result = await sender.Send(query, cancellationToken);
 		return result is null ? Results.NotFound() : Results.Ok(result);
 	}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4166,6 +4166,30 @@
           }
         }
       },
+      "CurrentUserEngagementInfo": {
+        "required": [
+          "id",
+          "status",
+          "timeSlotId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "timeSlotId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          }
+        }
+      },
       "DomainEvent": {
         "type": "object"
       },
@@ -4263,6 +4287,12 @@
           "createdOn": {
             "type": "string",
             "format": "date-time"
+          },
+          "volunteerName": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -5580,6 +5610,16 @@
             "type": [
               "null",
               "string"
+            ]
+          },
+          "currentUserEngagement": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CurrentUserEngagementInfo"
+              }
             ]
           }
         }

--- a/backend/src/Application/Common/Keycloak/IKeycloakUserService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakUserService.cs
@@ -13,6 +13,10 @@ public interface IKeycloakUserService
 		Guid userId,
 		CancellationToken cancellationToken = default);
 
+	Task<IReadOnlyDictionary<Guid, string>> GetDisplayNamesAsync(
+		IReadOnlyList<Guid> userIds,
+		CancellationToken cancellationToken = default);
+
 	Task UpdateUserAsync(
 		Guid userId,
 		string? firstName,

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -12,4 +12,5 @@ public sealed record EngagementSummary(
 	string Status,
 	bool IsCheckedIn,
 	bool HasFeedback,
-	DateTimeOffset CreatedOn);
+	DateTimeOffset CreatedOn,
+	string? VolunteerName = null);

--- a/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
@@ -9,7 +9,8 @@ namespace Application.Engagements.GetEngagements.v1;
 internal sealed class GetEngagementsQueryHandler(
 	IEngagementReadRepository readRepository,
 	IApplicationDbContext dbContext,
-	IKeycloakOrganizationService keycloakOrgService)
+	IKeycloakOrganizationService keycloakOrgService,
+	IKeycloakUserService keycloakUserService)
 	: IQueryHandler<GetEngagementsQuery, List<EngagementSummary>>
 {
 	public async ValueTask<List<EngagementSummary>> Handle(
@@ -25,6 +26,13 @@ internal sealed class GetEngagementsQueryHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		return await readRepository.GetByOpportunityAsync(request.OpportunityId, cancellationToken);
+		var engagements = await readRepository.GetByOpportunityAsync(request.OpportunityId, cancellationToken);
+
+		var volunteerIds = engagements.Select(e => e.VolunteerId).Distinct().ToList();
+		var nameMap = await keycloakUserService.GetDisplayNamesAsync(volunteerIds, cancellationToken);
+
+		return engagements
+			.Select(e => e with { VolunteerName = nameMap.GetValueOrDefault(e.VolunteerId) })
+			.ToList();
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsQuery.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsQuery.cs
@@ -2,5 +2,5 @@ using Application.Common.Messaging;
 
 namespace Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 
-public sealed record GetVolunteerOpportunityDetailsQuery(Guid OpportunityId)
+public sealed record GetVolunteerOpportunityDetailsQuery(Guid OpportunityId, Guid? RequestingUserId = null)
 	: IQuery<VolunteerOpportunityDetails?>;

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/GetVolunteerOpportunityDetailsQueryHandler.cs
@@ -9,5 +9,5 @@ internal sealed class GetVolunteerOpportunityDetailsQueryHandler(
 	public async ValueTask<VolunteerOpportunityDetails?> Handle(
 		GetVolunteerOpportunityDetailsQuery request,
 		CancellationToken cancellationToken = default) =>
-			await readRepository.GetDetailsAsync(request.OpportunityId, cancellationToken);
+			await readRepository.GetDetailsAsync(request.OpportunityId, request.RequestingUserId, cancellationToken);
 }

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
@@ -22,7 +22,8 @@ public sealed record VolunteerOpportunityDetails(
 	DateTimeOffset CreatedOn,
 	int CurrentParticipantCount,
 	string Status,
-	string? BannerImageUrl);
+	string? BannerImageUrl,
+	CurrentUserEngagementInfo? CurrentUserEngagement = null);
 
 public sealed record TimeSlotDetail(
 	Guid Id,
@@ -30,3 +31,8 @@ public sealed record TimeSlotDetail(
 	DateTimeOffset EndDateTime,
 	int MaxParticipants,
 	int BookedCount);
+
+public sealed record CurrentUserEngagementInfo(
+	Guid Id,
+	string Status,
+	Guid? TimeSlotId);

--- a/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
+++ b/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
@@ -14,6 +14,7 @@ public interface IVolunteerOpportunityReadRepository
 
 	ValueTask<VolunteerOpportunityDetails?> GetDetailsAsync(
 		Guid opportunityId,
+		Guid? requestingUserId = null,
 		CancellationToken cancellationToken = default);
 
 	ValueTask<IReadOnlyList<VolunteerOpportunitySummary>> GetSummariesByOrganizationAsync(

--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -44,6 +44,29 @@ internal sealed class KeycloakUserService(
 			user.Email ?? string.Empty);
 	}
 
+	public async Task<IReadOnlyDictionary<Guid, string>> GetDisplayNamesAsync(
+		IReadOnlyList<Guid> userIds,
+		CancellationToken cancellationToken = default)
+	{
+		var result = new Dictionary<Guid, string>(userIds.Count);
+		foreach (var userId in userIds.Distinct())
+		{
+			try
+			{
+				var profile = await GetUserAsync(userId, cancellationToken);
+				var name = profile.FirstName is not null || profile.LastName is not null
+					? $"{profile.FirstName} {profile.LastName}".Trim()
+					: profile.Username;
+				result[userId] = name;
+			}
+			catch
+			{
+				// ignore individual lookup failures
+			}
+		}
+		return result;
+	}
+
 	public async Task UpdateUserAsync(
 		Guid userId,
 		string? firstName,

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -5,6 +5,7 @@ using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 using Domain.Engagements;
 using Domain.Organizations;
+using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Infrastructure.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -210,6 +211,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 	public async ValueTask<VolunteerOpportunityDetails?> GetDetailsAsync(
 		Guid opportunityId,
+		Guid? requestingUserId = null,
 		CancellationToken cancellationToken = default)
 	{
 		var opportunityId_ = new VolunteerOpportunityId(opportunityId);
@@ -264,6 +266,26 @@ internal sealed class VolunteerOpportunityReadRepository(
 				(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed),
 				cancellationToken);
 
+		CurrentUserEngagementInfo? currentUserEngagement = null;
+		if (requestingUserId is Guid uid)
+		{
+			var userId_ = new UserId(uid);
+			var engagement = await dbContext.EngagementsQuery
+				.Where(e =>
+					e.OpportunityId == opportunityId_ &&
+					e.VolunteerId == userId_ &&
+					(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
+				.OrderByDescending(e => e.CreatedOn)
+				.Select(e => new { e.Id, e.Status, e.TimeSlotId })
+				.FirstOrDefaultAsync(cancellationToken);
+
+			if (engagement is not null)
+				currentUserEngagement = new CurrentUserEngagementInfo(
+					engagement.Id.Value,
+					engagement.Status.ToString(),
+					engagement.TimeSlotId?.Value);
+		}
+
 		return new VolunteerOpportunityDetails(
 			result.Id.Value,
 			result.Title,
@@ -286,7 +308,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 			result.CreatedOn,
 			currentParticipantCount,
 			result.Status.ToString(),
-			result.BannerImageUrl);
+			result.BannerImageUrl,
+			currentUserEngagement);
 	}
 
 	public async ValueTask<IReadOnlyList<VolunteerOpportunitySummary>> GetSummariesByOrganizationAsync(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -7072,6 +7072,32 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CurrentUserEngagementInfo
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid Id { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Status { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("timeSlotId")]
+        public System.Guid? TimeSlotId { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class DomainEvent
     {
 
@@ -7162,6 +7188,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("createdOn")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.DateTimeOffset CreatedOn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("volunteerName")]
+        public string? VolunteerName { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
@@ -8277,6 +8306,9 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("bannerImageUrl")]
         public string? BannerImageUrl { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("currentUserEngagement")]
+        public CurrentUserEngagementInfo? CurrentUserEngagement { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3545,6 +3545,14 @@ export interface CreateVolunteerOpportunityResponse {
     [key: string]: any;
 }
 
+export interface CurrentUserEngagementInfo {
+    id: string;
+    status: string;
+    timeSlotId: string | undefined;
+
+    [key: string]: any;
+}
+
 export interface DomainEvent {
 
     [key: string]: any;
@@ -3572,6 +3580,7 @@ export interface EngagementSummary {
     isCheckedIn: boolean;
     hasFeedback: boolean;
     createdOn: Date;
+    volunteerName?: string | undefined;
 
     [key: string]: any;
 }
@@ -3907,6 +3916,7 @@ export interface VolunteerOpportunityDetails {
     currentParticipantCount: number;
     status: string;
     bannerImageUrl: string | undefined;
+    currentUserEngagement?: CurrentUserEngagementInfo | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -182,7 +182,8 @@
       "publishing": "Wird veröffentlicht…",
       "publishSuccess": "Bedarf veröffentlicht.",
       "addToCalendar": "Zum Kalender hinzufügen",
-      "loginToApply": "Bitte <loginLink>melde dich an</loginLink>, um dich für diesen Einsatz anzumelden."
+      "loginToApply": "Bitte <loginLink>melde dich an</loginLink>, um dich für diesen Einsatz anzumelden.",
+      "yourApplication": "Deine Bewerbung"
     },
     "createOpportunity": {
       "title": "Bedarf erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -182,7 +182,8 @@
       "publishing": "Publishing…",
       "publishSuccess": "Opportunity published.",
       "addToCalendar": "Add to Calendar",
-      "loginToApply": "Please <loginLink>sign in</loginLink> to sign up for this opportunity."
+      "loginToApply": "Please <loginLink>sign in</loginLink> to sign up for this opportunity.",
+      "yourApplication": "Your application"
     },
     "createOpportunity": {
       "title": "Create opportunity",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -232,10 +232,21 @@ export default function EngagementManagementPage() {
 						>
 							<div className="flex items-start justify-between gap-2">
 								<div className="min-w-0">
-									<p className="font-mono text-xs text-gray-400">
-										{t("engagementManagement.volunteer", {
-											id: e.volunteerId.slice(0, 8) + "...",
-										})}
+									<p className="text-sm font-medium text-gray-800">
+										{e.volunteerName ? (
+											<Link
+												to={`/users/${e.volunteerId}`}
+												className="hover:underline"
+											>
+												{e.volunteerName}
+											</Link>
+										) : (
+											<span className="font-mono text-xs text-gray-400">
+												{t("engagementManagement.volunteer", {
+													id: e.volunteerId.slice(0, 8) + "...",
+												})}
+											</span>
+										)}
 									</p>
 									{e.message && (
 										<p className="mt-1 text-sm italic text-gray-700">

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -31,7 +31,9 @@ export default function VolunteerOpportunityDetailPage() {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [showSignUp, setShowSignUp] = useState(false);
-	const [signedUp, setSignedUp] = useState(false);
+	const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
+	const [withdrawing, setWithdrawing] = useState(false);
+	const [withdrawError, setWithdrawError] = useState<string | null>(null);
 	const [showEdit, setShowEdit] = useState(false);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 	const [deleting, setDeleting] = useState(false);
@@ -86,6 +88,23 @@ export default function VolunteerOpportunityDetailPage() {
 		}
 	}
 
+	async function handleWithdrawConfirm() {
+		if (!opportunity?.currentUserEngagement) return;
+		setWithdrawing(true);
+		setWithdrawError(null);
+		try {
+			await api.withdrawEngagement(opportunity.currentUserEngagement.id);
+			setShowWithdrawConfirm(false);
+			load();
+		} catch (err) {
+			setWithdrawError(
+				err instanceof Error ? err.message : t("myEngagements.withdrawError"),
+			);
+		} finally {
+			setWithdrawing(false);
+		}
+	}
+
 	async function handleDeleteConfirm() {
 		if (!opportunityId) return;
 		setDeleting(true);
@@ -130,6 +149,8 @@ export default function VolunteerOpportunityDetailPage() {
 			setPublishing(false);
 		}
 	}
+
+	const cue = opportunity.currentUserEngagement;
 
 	const totalMax = opportunity.timeSlots.reduce(
 		(sum, ts) => sum + ts.maxParticipants,
@@ -457,8 +478,37 @@ export default function VolunteerOpportunityDetailPage() {
 				</div>
 			)}
 
+			{/* Your application status */}
+			{isAuthenticated && !isOwner && cue && !isDraft && (
+				<div className="rounded-xl border border-gray-100 bg-white px-4 py-3 shadow-sm">
+					<div className="flex items-center justify-between gap-4">
+						<div>
+							<p className="mb-1 text-xs text-gray-500">
+								{t("opportunities.yourApplication")}
+							</p>
+							<span
+								className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+									cue.status === "Confirmed"
+										? "bg-green-50 text-green-700 border-green-100"
+										: "bg-yellow-50 text-yellow-700 border-yellow-100"
+								}`}
+							>
+								{t(`myEngagements.status.${cue.status}`)}
+							</span>
+						</div>
+						<button
+							onClick={() => setShowWithdrawConfirm(true)}
+							disabled={withdrawing}
+							className="shrink-0 text-xs text-red-600 hover:underline disabled:opacity-50"
+						>
+							{t("myEngagements.withdraw")}
+						</button>
+					</div>
+				</div>
+			)}
+
 			{/* Sign-up CTA */}
-			{isAuthenticated && !isOwner && !signedUp && !isDraft && (
+			{isAuthenticated && !isOwner && !cue && !isDraft && (
 				<div className="space-y-3">
 					{totalMax > 0 && (
 						<p
@@ -506,20 +556,16 @@ export default function VolunteerOpportunityDetailPage() {
 				</p>
 			)}
 
-			{/* Signed up confirmation */}
-			{signedUp && (
-				<p className="rounded-xl border border-green-100 bg-green-50 px-4 py-3 text-sm text-green-700">
-					{t("opportunities.signupSuccess")}
-				</p>
-			)}
-
 			{showSignUp && (
 				<SignUpModal
 					opportunityId={opportunity.id}
 					participationType={opportunity.participationType}
 					timeSlots={opportunity.timeSlots}
 					onClose={() => setShowSignUp(false)}
-					onSuccess={() => setSignedUp(true)}
+					onSuccess={() => {
+						setShowSignUp(false);
+						load();
+					}}
 				/>
 			)}
 
@@ -544,6 +590,22 @@ export default function VolunteerOpportunityDetailPage() {
 					}}
 					loading={deleting}
 					error={deleteError}
+				/>
+			)}
+
+			{showWithdrawConfirm && (
+				<ConfirmDialog
+					title={t("confirmDialog.withdraw.title")}
+					message={t("confirmDialog.withdraw.message")}
+					confirmLabel={t("confirmDialog.withdraw.confirm")}
+					onConfirm={handleWithdrawConfirm}
+					onClose={() => {
+						if (withdrawing) return;
+						setShowWithdrawConfirm(false);
+						setWithdrawError(null);
+					}}
+					loading={withdrawing}
+					error={withdrawError}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
## Summary

- **Issue #534** - Organizers on the Engagement Management page now see volunteer display names (first + last from Keycloak) as a clickable profile link instead of a truncated UUID. A new `GetDisplayNamesAsync` batch method on `IKeycloakUserService` fetches names sequentially (avoiding `HttpClient.DefaultRequestHeaders` race conditions) and enriches each `EngagementSummary` with a nullable `VolunteerName` field.
- **Issue #532** - The Volunteer Opportunity Detail page no longer uses an ephemeral `signedUp` local state that resets on reload. The backend `GetVolunteerOpportunityDetails` endpoint now accepts the requesting user's ID (extracted from JWT `sub` claim on the `AllowAnonymous` endpoint) and returns a `CurrentUserEngagementInfo` record when the user has an active Pending or Confirmed engagement. The frontend reads this server-provided state to show an application status badge and a Withdraw button (backed by a `ConfirmDialog`). After sign-up or withdrawal, the page reloads from the server.

## Changes

### Backend
- `IKeycloakUserService` - added `GetDisplayNamesAsync(IReadOnlyList<Guid>, CancellationToken)` returning a `Dictionary<Guid, string>`
- `KeycloakUserService` - implements `GetDisplayNamesAsync` using sequential `foreach` with silent per-user error handling
- `EngagementSummary` - added optional `string? VolunteerName = null` positional parameter
- `GetEngagementsQueryHandler` - injects `IKeycloakUserService`; enriches returned summaries with display names
- `VolunteerOpportunityDetails` - added optional `CurrentUserEngagementInfo? CurrentUserEngagement = null` positional parameter; new `CurrentUserEngagementInfo` record
- `GetVolunteerOpportunityDetailsQuery` - added optional `Guid? RequestingUserId = null`
- `GetVolunteerOpportunityDetailsEndpoint` - extracts optional `sub` claim from `ClaimsPrincipal` and passes it to the query
- `VolunteerOpportunityReadRepository.GetDetailsAsync` - queries for the requesting user's active engagement and includes it in the response

### Frontend
- `EngagementManagementPage` - renders volunteer name as `<Link to="/users/{id}">` when available, falls back to truncated UUID
- `VolunteerOpportunityDetailPage` - replaces `signedUp` state with server `currentUserEngagement`; shows status badge + Withdraw button when applied; `SignUpModal.onSuccess` now calls `load()` instead of setting local state
- `en.json` / `de.json` - added `opportunities.yourApplication` translation key
- `api-client.ts` / `ApiClient.cs` - auto-regenerated by NSwag

## Test plan

- [ ] As an authenticated volunteer, navigate to a published opportunity you have not applied for - sign-up CTA should be visible
- [ ] Apply for the opportunity - after modal closes the page should reload and show "Your application - Pending" badge with a Withdraw button
- [ ] Reload the page - badge should still be present (server state persists)
- [ ] Click Withdraw, confirm - page should reload showing the sign-up CTA again
- [ ] As an organizer, open the Engagement Management page - volunteer names should appear as clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GGTZgaQywa2fj41Xij78f

---
_Generated by [Claude Code](https://claude.ai/code/session_017GGTZgaQywa2fj41Xij78f)_