### PR TITLE
feat: add QR code scanner for organizer check-in (#554)

### DIFF
--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { EngagementSummary } from "../client/api-client";
+import { useApiClient } from "../hooks/useApiClient";
+
+declare global {
+	class BarcodeDetector {
+		constructor(options?: { formats: string[] });
+		detect(
+			source: HTMLVideoElement | HTMLCanvasElement | ImageBitmap,
+		): Promise<Array<{ rawValue: string; format: string }>>;
+		static getSupportedFormats(): Promise<string[]>;
+	}
+}
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface QRScannerModalProps {
+	engagements: EngagementSummary[];
+	onCheckedIn: (engagementId: string) => void;
+	onClose: () => void;
+}
+
+export default function QRScannerModal({
+	engagements,
+	onCheckedIn,
+	onClose,
+}: QRScannerModalProps) {
+	const api = useApiClient();
+	const { t } = useTranslation();
+	const videoRef = useRef<HTMLVideoElement>(null);
+	const streamRef = useRef<MediaStream | null>(null);
+	const engagementsRef = useRef(engagements);
+	const [supported, setSupported] = useState<boolean | null>(null);
+	const [cameraError, setCameraError] = useState<string | null>(null);
+	const [scanError, setScanError] = useState<string | null>(null);
+	const [success, setSuccess] = useState(false);
+
+	// Keep ref in sync so the scan loop always sees the latest engagements
+	useEffect(() => {
+		engagementsRef.current = engagements;
+	}, [engagements]);
+
+	// Check browser support
+	useEffect(() => {
+		const ok =
+			typeof BarcodeDetector !== "undefined" &&
+			!!navigator.mediaDevices?.getUserMedia;
+		setSupported(ok);
+	}, []);
+
+	// Start camera once support is confirmed
+	useEffect(() => {
+		if (supported !== true) return;
+		let alive = true;
+		navigator.mediaDevices
+			.getUserMedia({ video: { facingMode: "environment" } })
+			.then((stream) => {
+				if (!alive) {
+					stream.getTracks().forEach((tr) => tr.stop());
+					return;
+				}
+				streamRef.current = stream;
+				if (videoRef.current) videoRef.current.srcObject = stream;
+			})
+			.catch(() => {
+				if (alive) setCameraError(t("checkIn.qrCameraError"));
+			});
+		return () => {
+			alive = false;
+			streamRef.current?.getTracks().forEach((tr) => tr.stop());
+			streamRef.current = null;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [supported]);
+
+	// Scan loop
+	useEffect(() => {
+		if (supported !== true) return;
+		let alive = true;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const loop = async () => {
+			if (!alive) return;
+			const video = videoRef.current;
+			if (video && video.readyState >= video.HAVE_ENOUGH_DATA) {
+				try {
+					const detector = new BarcodeDetector({ formats: ["qr_code"] });
+					const barcodes = await detector.detect(video);
+					for (const barcode of barcodes) {
+						const raw = barcode.rawValue.trim();
+						if (!UUID_RE.test(raw)) continue;
+						const match = engagementsRef.current.find(
+							(e) => e.id === raw && e.status === "Confirmed" && !e.isCheckedIn,
+						);
+						if (!match) {
+							setScanError(t("checkIn.qrNotFound"));
+							continue;
+						}
+						alive = false;
+						try {
+							await api.checkInEngagement(raw);
+							setSuccess(true);
+							onCheckedIn(raw);
+						} catch {
+							setScanError(t("checkIn.qrCheckInError"));
+							alive = true;
+						}
+						return;
+					}
+					setScanError(null);
+				} catch {
+					// detection failure - retry on next tick
+				}
+			}
+			if (alive) timer = setTimeout(() => void loop(), 500);
+		};
+
+		// Give camera stream a moment to initialize
+		timer = setTimeout(() => void loop(), 1000);
+		return () => {
+			alive = false;
+			if (timer !== null) clearTimeout(timer);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [supported]);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", onKey);
+		return () => document.removeEventListener("keydown", onKey);
+	}, [onClose]);
+
+	return (
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+			<button
+				type="button"
+				className="absolute inset-0 bg-black/50"
+				onClick={onClose}
+				tabIndex={-1}
+				aria-hidden="true"
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="qr-scanner-title"
+				className="relative z-10 w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+			>
+				<h2
+					id="qr-scanner-title"
+					className="mb-4 text-lg font-semibold text-gray-900"
+				>
+					{t("checkIn.qrScanTitle")}
+				</h2>
+
+				{supported === null && (
+					<p className="text-sm text-gray-500">{t("opportunities.loading")}</p>
+				)}
+
+				{supported === false && (
+					<p className="text-sm text-red-600">{t("checkIn.qrNotSupported")}</p>
+				)}
+
+				{supported === true && !success && (
+					<>
+						{cameraError ? (
+							<p className="text-sm text-red-600">{cameraError}</p>
+						) : (
+							<div className="relative overflow-hidden rounded-lg bg-black">
+								<video
+									ref={videoRef}
+									autoPlay
+									muted
+									playsInline
+									className="h-64 w-full object-cover"
+									aria-label={t("checkIn.qrVideoLabel")}
+								/>
+								<div
+									aria-hidden="true"
+									className="pointer-events-none absolute inset-0 flex items-center justify-center"
+								>
+									<div className="h-40 w-40 rounded-xl border-2 border-white opacity-60" />
+								</div>
+							</div>
+						)}
+						{scanError && (
+							<p className="mt-2 text-sm text-red-600" role="alert">
+								{scanError}
+							</p>
+						)}
+						{!cameraError && !scanError && (
+							<p className="mt-3 text-sm text-gray-500">
+								{t("checkIn.qrScanHint")}
+							</p>
+						)}
+					</>
+				)}
+
+				{success && (
+					<p className="text-sm font-medium text-green-700">
+						{t("checkIn.qrSuccess")}
+					</p>
+				)}
+
+				<button
+					type="button"
+					onClick={onClose}
+					className="mt-5 w-full rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+				>
+					{t("checkIn.close")}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -455,7 +455,16 @@
       "organizerPin": "Eincheck-PIN",
       "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen, damit sie einchecken können.",
       "markCheckedIn": "Als eingecheckt markieren",
-      "markingCheckedIn": "…"
+      "markingCheckedIn": "…",
+      "qrScanButton": "QR-Code scannen",
+      "qrScanTitle": "Freiwilligen-QR-Code scannen",
+      "qrScanHint": "Halte die Kamera auf den QR-Code des Freiwilligen.",
+      "qrVideoLabel": "Kamerabild zum Scannen von QR-Codes",
+      "qrNotSupported": "QR-Scanning wird in diesem Browser nicht unterstützt. Bitte Chrome oder Edge verwenden oder zur manuellen Eincheck-Methode wechseln.",
+      "qrCameraError": "Kamerazugriff verweigert. Bitte Kamerazugriff erlauben und erneut versuchen.",
+      "qrNotFound": "QR-Code nicht erkannt. Der Freiwillige ist möglicherweise noch nicht bestätigt.",
+      "qrCheckInError": "Einchecken fehlgeschlagen. Bitte erneut versuchen.",
+      "qrSuccess": "Freiwilliger erfolgreich eingecheckt!"
     },
     "myEngagements": {
       "title": "Meine Engagements",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -455,7 +455,16 @@
       "organizerPin": "Check-in PIN",
       "organizerPinHint": "Share this PIN with your volunteers so they can check in.",
       "markCheckedIn": "Mark as checked in",
-      "markingCheckedIn": "…"
+      "markingCheckedIn": "…",
+      "qrScanButton": "Scan QR code",
+      "qrScanTitle": "Scan volunteer QR code",
+      "qrScanHint": "Point the camera at the volunteer's QR code.",
+      "qrVideoLabel": "Camera view for QR code scanning",
+      "qrNotSupported": "QR scanning is not supported in this browser. Please use Chrome or Edge, or switch to a manual check-in method.",
+      "qrCameraError": "Camera access denied. Please allow camera access and try again.",
+      "qrNotFound": "QR code not recognised. The volunteer may not be confirmed yet.",
+      "qrCheckInError": "Check-in failed. Please try again.",
+      "qrSuccess": "Volunteer checked in successfully!"
     },
     "myEngagements": {
       "title": "My Engagements",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -9,6 +9,7 @@ import type {
 import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
+import QRScannerModal from "../components/QRScannerModal";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { dispatchToast } from "../lib/toastBus";
@@ -55,6 +56,7 @@ export default function EngagementManagementPage() {
 	const [cancelling, setCancelling] = useState(false);
 	const [cancelError, setCancelError] = useState<string | null>(null);
 	const [checkingIn, setCheckingIn] = useState<string | null>(null);
+	const [qrScannerOpen, setQrScannerOpen] = useState(false);
 
 	useEffect(() => {
 		if (!opportunityId) return;
@@ -149,8 +151,8 @@ export default function EngagementManagementPage() {
 	}
 
 	const checkInMethod = opportunity?.checkInMethod;
-	const showManualCheckIn =
-		checkInMethod === "Manual" || checkInMethod === "QRCode";
+	const showManualCheckIn = checkInMethod === "Manual";
+	const showQrScanner = checkInMethod === "QRCode";
 
 	return (
 		<>
@@ -195,6 +197,37 @@ export default function EngagementManagementPage() {
 					<p className="mt-1 text-xs text-blue-600">
 						{t("checkIn.organizerPinHint")}
 					</p>
+				</div>
+			)}
+
+			{showQrScanner && (
+				<div className="mb-6">
+					<button
+						type="button"
+						onClick={() => setQrScannerOpen(true)}
+						className="inline-flex items-center gap-2 rounded-lg bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800"
+					>
+						<svg
+							className="h-4 w-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							strokeWidth="1.5"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z"
+							/>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M6.75 6.75h.75v.75h-.75v-.75ZM6.75 16.5h.75v.75h-.75v-.75ZM16.5 6.75h.75v.75h-.75v-.75ZM13.5 13.5h.75v.75h-.75v-.75ZM13.5 19.5h.75v.75h-.75v-.75ZM19.5 13.5h.75v.75h-.75v-.75ZM19.5 19.5h.75v.75h-.75v-.75ZM16.5 16.5h.75v.75h-.75v-.75Z"
+							/>
+						</svg>
+						{t("checkIn.qrScanButton")}
+					</button>
 				</div>
 			)}
 
@@ -329,6 +362,20 @@ export default function EngagementManagementPage() {
 						</li>
 					))}
 				</ul>
+			)}
+
+			{qrScannerOpen && (
+				<QRScannerModal
+					engagements={engagements}
+					onCheckedIn={(engagementId) => {
+						setEngagements((prev) =>
+							prev.map((e) =>
+								e.id === engagementId ? { ...e, isCheckedIn: true } : e,
+							),
+						);
+					}}
+					onClose={() => setQrScannerOpen(false)}
+				/>
 			)}
 
 			{confirmCancelId && (


### PR DESCRIPTION
## Summary

- Adds `QRScannerModal` component using the browser-native `BarcodeDetector` API and `getUserMedia` to scan volunteer QR codes from the rear camera
- On `EngagementManagementPage`, separates QRCode and Manual check-in methods: QRCode now shows a "Scan QR code" button that opens the scanner instead of falling through to the manual form
- Scans every 500 ms; on finding a UUID that matches a confirmed, unchecked-in engagement it calls `api.checkInEngagement` and updates the local list
- Gracefully handles unsupported browsers (no `BarcodeDetector`) and camera permission denial with clear error messages
- Adds 9 i18n keys under `checkIn.qr*` in both `en.json` and `de.json`

## Test plan

- [ ] Open an opportunity with check-in method = "QRCode" as an organizer
- [ ] Verify the "Scan QR code" button appears (manual check-in form should NOT appear)
- [ ] Click the button, allow camera, hold a volunteer's QR code in view - volunteer should be marked as checked in
- [ ] Test in an unsupported browser (Firefox without flag) - should see the "not supported" message
- [ ] Deny camera permission - should see the camera error message
- [ ] Open an opportunity with check-in method = "Manual" - QR button should NOT appear, manual form should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVUkjsPARh3vvDeLGthHbM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVUkjsPARh3vvDeLGthHbM)_