### PR TITLE
fix: pin Microsoft.OpenApi to patched version to unblock CI

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -35,6 +35,8 @@
 		<!-- Transitive pinning: override vulnerable transitive deps -->
 		<PackageVersion Include="MessagePack" Version="2.5.302" />
 		<PackageVersion Include="MessagePack.Annotations" Version="2.5.302" />
+		<!-- GHSA-v5pm-xwqc-g5wc: Microsoft.OpenApi 2.0.0 (pulled in by Microsoft.AspNetCore.OpenApi) has a high severity DoS vulnerability -->
+		<PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
 		<!-- Aspire: AppHost + Tests -->
 		<PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="[13.4.6]" />
 		<PackageVersion Include="Aspire.Hosting.JavaScript" Version="[13.4.6]" />


### PR DESCRIPTION
## Summary

- The `Build and Test Backend` workflow on `main` has been failing since 2026-07-01 because `dotnet restore` treats NuGet's built-in vulnerability audit (`NU1903`) as an error (`TreatWarningsAsErrors=true` in `backend/Directory.Build.props`).
- The specific finding: `Microsoft.OpenApi 2.0.0`, pulled in transitively via `Microsoft.AspNetCore.OpenApi 10.0.9`, has a known high-severity DoS vulnerability ([GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) / CVE-2026-49451, stack overflow via circular schema references). Fixed in `2.7.5`+.
- Pinned `Microsoft.OpenApi` to `2.9.0` (latest patched 2.x release) via the repo's existing transitive-pinning pattern in `backend/Directory.Packages.props` (same pattern already used for `MessagePack`), rather than disabling the audit check. This keeps the CVE gate intact for future findings instead of suppressing it.

## Verification

- `dotnet restore` now succeeds with no `NU1903` errors.
- `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages across all projects.
- `dotnet build` on `Api` and `ArchitectureTests` (the two projects that failed restore) succeeds cleanly, including the NSwag OpenAPI/TS client regeneration step - no unintended diff to the generated client.
- Full `dotnet build` otherwise only fails in this sandbox due to a Playwright Chromium download being blocked by network restrictions (`VisualTests` project), unrelated to this change.

## Test plan

- [x] `dotnet restore` succeeds locally
- [x] `dotnet list package --vulnerable --include-transitive` shows zero vulnerabilities
- [x] `dotnet build` succeeds for `Api` and `ArchitectureTests`
- [ ] CI `Build and Test Backend` workflow passes on this PR (pending)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mibzf5VHT3j1GFB4NJqCCt)_