### PR TITLE
fix: clear orphaned time slots when opportunity switches away from Waitlist

### DIFF
--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -179,6 +179,12 @@ public sealed class VolunteerOpportunity
 		IsRemote = isRemote;
 		Address = address;
 		Occurrence = occurrence;
+		// Time slots are only meaningful for Waitlist opportunities (see AddTimeSlot).
+		// Clearing them when switching away prevents orphaned slots from lingering
+		// once the opportunity no longer surfaces them. Callers must ensure no
+		// active engagements reference these slots before switching away.
+		if (participationType != ParticipationType.Waitlist && ParticipationType == ParticipationType.Waitlist)
+			_timeSlots.Clear();
 		ParticipationType = participationType;
 		CheckInMethod = checkInMethod;
 		Category = category;

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -182,6 +182,32 @@ public class VolunteerOpportunityTests
 	}
 
 	[Test]
+	public void Update_ShouldClearTimeSlots_WhenSwitchingAwayFromWaitlist()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
+			CheckInMethod.None);
+		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
+
+		opportunity.Update("Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, []);
+
+		opportunity.TimeSlots.Should().BeEmpty();
+	}
+
+	[Test]
+	public void Update_ShouldKeepTimeSlots_WhenStayingWaitlist()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
+			CheckInMethod.None);
+		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
+
+		opportunity.Update("New title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
+
+		opportunity.TimeSlots.Should().HaveCount(1);
+	}
+
+	[Test]
 	public void Update_ShouldAllowRemote_WithNullAddress()
 	{
 		var opportunity = VolunteerOpportunity.Create(

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -48,7 +48,7 @@ public class IntegrationTestFixture
 
 		_keycloakClient = _app.CreateHttpClient("keycloak");
 
-		var backendClient = _app.CreateHttpClient("backend");
+		var backendClient = _app.CreateHttpClient("backend", "http");
 		await WaitForBackendReadyAsync(backendClient);
 
 		await WaitForRealmReadyAsync();
@@ -75,7 +75,7 @@ public class IntegrationTestFixture
 		await _app.DisposeAsync();
 
 	public HttpClient CreateHttpClient() =>
-		_app.CreateHttpClient("backend");
+		_app.CreateHttpClient("backend", "http");
 
 	public async Task<string> GetAccessTokenAsync(string username, string password)
 	{


### PR DESCRIPTION
## Summary

Closes the remaining part of #539.

Investigation showed most of #539's acceptance criteria were already met by prior work:
- `DeleteTimeSlotCommandHandler` already blocks deleting a time slot that has active (Pending/Confirmed) engagements.
- `UpdateVolunteerOpportunityCommandHandler` already blocks switching `ParticipationType` while active engagements exist.

The one remaining gap: `VolunteerOpportunity.Update()` changed `ParticipationType` freely without clearing `_timeSlots`, so a Waitlist opportunity with slots that have **no active engagements** (e.g. all withdrawn, or never signed up) could switch to `IndividualContact` while leaving orphaned time slots in the aggregate - even though `AddTimeSlot` only ever adds slots for `Waitlist` opportunities, and the UI no longer surfaces them for a non-Waitlist type.

- **Domain**: `VolunteerOpportunity.Update()` now clears `_timeSlots` when `ParticipationType` changes away from `Waitlist`. Since the handler already blocks the change whenever active engagements exist, this only ever discards slots that have no active sign-ups.
- **Tests**: Added `Update_ShouldClearTimeSlots_WhenSwitchingAwayFromWaitlist` and `Update_ShouldKeepTimeSlots_WhenStayingWaitlist` to `VolunteerOpportunityTests.cs`.

## Unrelated CI fix bundled in

While cutting this PR, `build-and-test` failed on the exact same `main` commit this branch is based on (confirmed via CI runs on `main` at the same SHA `dfa0068`), so it's a pre-existing, repo-wide break rather than something introduced here. Root cause: `chore(deps): update aspire monorepo to v13.4.6 (#457)` landed on `main` today. Per Aspire's own 13.4 changelog, `CreateHttpClient()`/`GetEndpointUriString()` now **prefer the https endpoint** when no endpoint name is given (previously http was preferred). `IntegrationTestFixture.cs` calls `_app.CreateHttpClient("backend")` unqualified, so it started hitting the backend's HTTPS Kestrel endpoint, whose self-signed ASP.NET Core dev cert isn't trusted in CI - every request failed with `AuthenticationException: ... UntrustedRoot` and the fixture timed out waiting for the backend, taking down all 62 dependent integration tests.

`VisualTests/AspireFixture.cs` already defends against this by defaulting to the `"http"` endpoint name. Applied the same fix to `IntegrationTestFixture.cs` (`_app.CreateHttpClient("backend", "http")` in both call sites) so this PR - and `main` once merged - build green again.

## Test plan

- [x] `dotnet run` in `backend/tests/Application.UnitTests/` - all 185 tests pass
- [x] `dotnet run` in `backend/tests/ArchitectureTests/` - all 240 tests pass
- [x] `dotnet build` on `Api`, `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests` - no errors
- [ ] `IntegrationTests` full run against CI (no local Docker daemon available in this sandbox to verify directly) - awaiting CI result after the endpoint-name fix

## Live verification

_Pending - will be updated after CI is green and the release-candidate deploy/staging smoke test complete._

🤖 Generated with [Claude Code](https://claude.com/claude-code)