### PR TITLE
docs: scaffold domain storytelling AS-IS story and bounded-context map (#547)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,10 @@ jobs:
               -b html5 \
               -D build/TDRs \
               docs/TDRs/*.adoc
+            asciidoctor \
+              -b html5 \
+              -D build/domain-stories \
+              docs/Architecture/domain-stories/*.adoc
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/docs/ADRs/5_bounded_contexts_and_event_driven_integration.adoc
+++ b/docs/ADRs/5_bounded_contexts_and_event_driven_integration.adoc
@@ -1,0 +1,153 @@
+== 5. Bounded Contexts and Event-Driven Integration
+
+=== Status
+Proposed
+
+=== Date
+2026-07-01
+
+=== Context
+Issue #547 asks us to make the domain explicit before 1.0 hardens the
+current structure: capture how Einsatzbereit actually works as a Domain
+Story, derive bounded contexts and a context map from it, and define a path
+toward self-contained systems (SCS). A first, code-derived AS-IS domain
+story lives at
+link:../domain-stories/as-is-core-flow.html[domain-stories/as-is-core-flow.adoc]
+and the candidate context map at
+link:../images/context-map.puml[context-map.puml].
+
+The current `Domain/` folder is already organized by concept
+(`Users`, `Organizations`, `VolunteerOpportunities`, `Engagements`,
+`Achievements`, `Notifications`), but the modules are not decoupled:
+
+* `CreateEngagementCommandHandler` reaches directly into
+  `opportunity.TimeSlots` for capacity checks (shared-model coupling between
+  Engagement and Opportunity).
+* `ConfirmEngagementCommandHandler` directly issues `AwardAchievementCommand`
+  and records streaks - Gamification is called synchronously from the core
+  participation flow instead of reacting to it.
+* Every engagement/opportunity handler creates a `Notification` row
+  directly, instead of Notifications being a downstream consumer.
+* `EngagementCancelledDomainEvent` is raised in `Engagement.Cancel()` but has
+  **no registered handler** - concrete evidence that event-driven
+  integration between contexts was intended at some point but never wired
+  up.
+* Organization membership is split between Keycloak (roles) and the local
+  `Organizations` module, with no explicit anti-corruption boundary.
+
+None of this is a functional bug today; it is friction that will make future
+changes (per-context ownership, independent deployability, the SCS goal in
+#547) increasingly expensive if left alone.
+
+=== Decision
+Adopt the following bounded-context catalog as the working model until a
+Domain Storytelling workshop with domain experts revises it:
+
+[cols="1,3,2" options="header"]
+|===
+|Context |Responsibility |Today lives in
+
+|Identity & Access
+|Users, roles, org membership
+|Keycloak + `Domain/Users` (partial)
+
+|Organization Management
+|Org profile, members, verification
+|`Domain/Organizations`
+
+|Opportunity Management (core)
+|Opportunities, time slots, publish, banner
+|`Domain/VolunteerOpportunities`
+
+|Participation / Engagement (core)
+|Apply, waitlist, confirm, cancel, withdraw, check-in
+|`Domain/Engagements`
+
+|Feedback
+|Ratings & comments
+|currently embedded in `Engagement`
+
+|Recognition / Gamification
+|Achievements, badges, streaks
+|`Domain/Achievements`, `Domain/Users/UserStreak`
+
+|Notifications
+|In-app + email
+|`Domain/Notifications`
+|===
+
+Going forward, cross-context integration should prefer **domain events**
+over direct calls or shared-model reach-through:
+
+* Introduce explicit domain events for the seams identified above -
+  `EngagementConfirmed`, `EngagementCheckedIn`, `FeedbackSubmitted` - and move
+  Recognition and Notifications to react to them instead of being called
+  inline from `Engagement`/`VolunteerOpportunity` command handlers.
+* Wire (or remove) the currently dead `EngagementCancelledDomainEvent`
+  handler as the first concrete step, since it already demonstrates the
+  intended pattern.
+* Keep Engagement <-> Opportunity/TimeSlot as a deliberate Shared Kernel for
+  now (capacity is a genuine cross-context invariant); revisit only if the
+  coupling grows further.
+* Treat Identity & Access as requiring an explicit Anti-Corruption Layer
+  between Keycloak-held roles and the locally-owned `Organizations`
+  membership data.
+
+Recognition and Notifications are the first candidates for an eventual SCS
+carve-out, since they are naturally downstream/async consumers once the
+event model above is in place. Actually splitting into separately deployed
+systems remains out of scope for this ADR.
+
+=== Rationale
+* The dead `EngagementCancelledDomainEvent` handler shows the codebase
+  already has the primitives (a domain event dispatcher) for this pattern;
+  the gap is discipline, not infrastructure.
+* Moving Gamification and Notifications to react to events removes them from
+  the core participation transaction, so a failure to award a badge or send
+  a notification can no longer affect whether a confirm/cancel succeeds.
+* Naming the bounded-context catalog now gives the NetArchTest suite
+  (already used in this repo for Clean Architecture layering) a vocabulary
+  to eventually enforce module boundaries per context, closing the loop
+  requested in #547's roadmap.
+
+=== Considered Alternatives
+
+==== Do nothing until the full Domain Storytelling workshop happens
+Wait for a dedicated workshop with organizers and volunteers before writing
+anything down.
+
+* Pros
+** Avoids codifying an AS-IS model that might be wrong before domain experts
+   weigh in.
+* Cons
+** #547 has been open across many sessions with no workshop scheduled; a
+   code-derived starting point lowers the cost of that future workshop
+   rather than replacing it.
+** The dead-event-handler and inline-coupling findings are concrete and
+   worth recording regardless of workshop timing.
+
+==== Split into separate deployable services now
+Jump straight to physically separating Notifications/Recognition as their
+own services.
+
+* Pros
+** Forces the decoupling immediately.
+* Cons
+** Premature at current scale; the in-process event-driven step above is a
+   prerequisite (a strangler-fig sequence), not something to skip.
+** Adds operational complexity (deployment, service discovery, distributed
+   transactions) not justified yet.
+
+=== Consequences
+* This ADR is **Proposed**, not Accepted - it should move to Accepted (or be
+  revised) after the Domain Storytelling workshop described in
+  link:../domain-stories/as-is-core-flow.html[the AS-IS domain
+  story] happens.
+* No code changes ship with this ADR. It records the target integration
+  pattern so that the next concrete step (wiring or removing
+  `EngagementCancelledDomainEvent`, and introducing `EngagementConfirmed`)
+  can be scoped as its own focused PR against issue #547.
+* Until the event-driven integration lands, `ConfirmEngagementCommandHandler`
+  remains the single place where Engagement, Recognition, and Notifications
+  intersect - anyone changing confirmation behavior needs to be aware all
+  three are affected together.

--- a/docs/ADRs/5_bounded_contexts_and_event_driven_integration.adoc
+++ b/docs/ADRs/5_bounded_contexts_and_event_driven_integration.adoc
@@ -7,41 +7,20 @@ Proposed
 2026-07-01
 
 === Context
-Issue #547 asks us to make the domain explicit before 1.0 hardens the
-current structure: capture how Einsatzbereit actually works as a Domain
-Story, derive bounded contexts and a context map from it, and define a path
-toward self-contained systems (SCS). A first, code-derived AS-IS domain
-story lives at
-link:../domain-stories/as-is-core-flow.html[domain-stories/as-is-core-flow.adoc]
-and the candidate context map at
-link:../images/context-map.puml[context-map.puml].
+Issue #547 asks us to make the domain explicit before 1.0 hardens the current structure: capture how Einsatzbereit actually works as a Domain Story, derive bounded contexts and a context map from it, and define a path toward self-contained systems (SCS). A first, code-derived AS-IS domain story lives at link:../domain-stories/as-is-core-flow.html[domain-stories/as-is-core-flow.adoc] and the candidate context map at link:../images/context-map.puml[context-map.puml].
 
-The current `Domain/` folder is already organized by concept
-(`Users`, `Organizations`, `VolunteerOpportunities`, `Engagements`,
-`Achievements`, `Notifications`), but the modules are not decoupled:
+The current `Domain/` folder is already organized by concept (`Users`, `Organizations`, `VolunteerOpportunities`, `Engagements`, `Achievements`, `Notifications`), but the modules are not decoupled:
 
-* `CreateEngagementCommandHandler` reaches directly into
-  `opportunity.TimeSlots` for capacity checks (shared-model coupling between
-  Engagement and Opportunity).
-* `ConfirmEngagementCommandHandler` directly issues `AwardAchievementCommand`
-  and records streaks - Gamification is called synchronously from the core
-  participation flow instead of reacting to it.
-* Every engagement/opportunity handler creates a `Notification` row
-  directly, instead of Notifications being a downstream consumer.
-* `EngagementCancelledDomainEvent` is raised in `Engagement.Cancel()` but has
-  **no registered handler** - concrete evidence that event-driven
-  integration between contexts was intended at some point but never wired
-  up.
-* Organization membership is split between Keycloak (roles) and the local
-  `Organizations` module, with no explicit anti-corruption boundary.
+* `CreateEngagementCommandHandler` reaches directly into `opportunity.TimeSlots` for capacity checks (shared-model coupling between Engagement and Opportunity).
+* `ConfirmEngagementCommandHandler` directly issues `AwardAchievementCommand` and records streaks - Gamification is called synchronously from the core participation flow instead of reacting to it.
+* Every engagement/opportunity handler creates a `Notification` row directly, instead of Notifications being a downstream consumer.
+* `EngagementCancelledDomainEvent` is raised in `Engagement.Cancel()` but has **no registered handler** - concrete evidence that event-driven integration between contexts was intended at some point but never wired up.
+* Organization membership is split between Keycloak (roles) and the local `Organizations` module, with no explicit anti-corruption boundary.
 
-None of this is a functional bug today; it is friction that will make future
-changes (per-context ownership, independent deployability, the SCS goal in
-#547) increasingly expensive if left alone.
+None of this is a functional bug today; it is friction that will make future changes (per-context ownership, independent deployability, the SCS goal in #547) increasingly expensive if left alone.
 
 === Decision
-Adopt the following bounded-context catalog as the working model until a
-Domain Storytelling workshop with domain experts revises it:
+Adopt the following bounded-context catalog as the working model until a Domain Storytelling workshop with domain experts revises it:
 
 [cols="1,3,2" options="header"]
 |===
@@ -76,78 +55,41 @@ Domain Storytelling workshop with domain experts revises it:
 |`Domain/Notifications`
 |===
 
-Going forward, cross-context integration should prefer **domain events**
-over direct calls or shared-model reach-through:
+Going forward, cross-context integration should prefer **domain events** over direct calls or shared-model reach-through:
 
-* Introduce explicit domain events for the seams identified above -
-  `EngagementConfirmed`, `EngagementCheckedIn`, `FeedbackSubmitted` - and move
-  Recognition and Notifications to react to them instead of being called
-  inline from `Engagement`/`VolunteerOpportunity` command handlers.
-* Wire (or remove) the currently dead `EngagementCancelledDomainEvent`
-  handler as the first concrete step, since it already demonstrates the
-  intended pattern.
-* Keep Engagement <-> Opportunity/TimeSlot as a deliberate Shared Kernel for
-  now (capacity is a genuine cross-context invariant); revisit only if the
-  coupling grows further.
-* Treat Identity & Access as requiring an explicit Anti-Corruption Layer
-  between Keycloak-held roles and the locally-owned `Organizations`
-  membership data.
+* Introduce explicit domain events for the seams identified above - `EngagementConfirmed`, `EngagementCheckedIn`, `FeedbackSubmitted` - and move Recognition and Notifications to react to them instead of being called inline from `Engagement`/`VolunteerOpportunity` command handlers.
+* Wire (or remove) the currently dead `EngagementCancelledDomainEvent` handler as the first concrete step, since it already demonstrates the intended pattern.
+* Keep Engagement <-> Opportunity/TimeSlot as a deliberate Shared Kernel for now (capacity is a genuine cross-context invariant); revisit only if the coupling grows further.
+* Treat Identity & Access as requiring an explicit Anti-Corruption Layer between Keycloak-held roles and the locally-owned `Organizations` membership data.
 
-Recognition and Notifications are the first candidates for an eventual SCS
-carve-out, since they are naturally downstream/async consumers once the
-event model above is in place. Actually splitting into separately deployed
-systems remains out of scope for this ADR.
+Recognition and Notifications are the first candidates for an eventual SCS carve-out, since they are naturally downstream/async consumers once the event model above is in place. Actually splitting into separately deployed systems remains out of scope for this ADR.
 
 === Rationale
-* The dead `EngagementCancelledDomainEvent` handler shows the codebase
-  already has the primitives (a domain event dispatcher) for this pattern;
-  the gap is discipline, not infrastructure.
-* Moving Gamification and Notifications to react to events removes them from
-  the core participation transaction, so a failure to award a badge or send
-  a notification can no longer affect whether a confirm/cancel succeeds.
-* Naming the bounded-context catalog now gives the NetArchTest suite
-  (already used in this repo for Clean Architecture layering) a vocabulary
-  to eventually enforce module boundaries per context, closing the loop
-  requested in #547's roadmap.
+* The dead `EngagementCancelledDomainEvent` handler shows the codebase already has the primitives (a domain event dispatcher) for this pattern; the gap is discipline, not infrastructure.
+* Moving Gamification and Notifications to react to events removes them from the core participation transaction, so a failure to award a badge or send a notification can no longer affect whether a confirm/cancel succeeds.
+* Naming the bounded-context catalog now gives the NetArchTest suite (already used in this repo for Clean Architecture layering) a vocabulary to eventually enforce module boundaries per context, closing the loop requested in #547's roadmap.
 
 === Considered Alternatives
 
 ==== Do nothing until the full Domain Storytelling workshop happens
-Wait for a dedicated workshop with organizers and volunteers before writing
-anything down.
+Wait for a dedicated workshop with organizers and volunteers before writing anything down.
 
 * Pros
-** Avoids codifying an AS-IS model that might be wrong before domain experts
-   weigh in.
+** Avoids codifying an AS-IS model that might be wrong before domain experts weigh in.
 * Cons
-** #547 has been open across many sessions with no workshop scheduled; a
-   code-derived starting point lowers the cost of that future workshop
-   rather than replacing it.
-** The dead-event-handler and inline-coupling findings are concrete and
-   worth recording regardless of workshop timing.
+** #547 has been open across many sessions with no workshop scheduled; a code-derived starting point lowers the cost of that future workshop rather than replacing it.
+** The dead-event-handler and inline-coupling findings are concrete and worth recording regardless of workshop timing.
 
 ==== Split into separate deployable services now
-Jump straight to physically separating Notifications/Recognition as their
-own services.
+Jump straight to physically separating Notifications/Recognition as their own services.
 
 * Pros
 ** Forces the decoupling immediately.
 * Cons
-** Premature at current scale; the in-process event-driven step above is a
-   prerequisite (a strangler-fig sequence), not something to skip.
-** Adds operational complexity (deployment, service discovery, distributed
-   transactions) not justified yet.
+** Premature at current scale; the in-process event-driven step above is a prerequisite (a strangler-fig sequence), not something to skip.
+** Adds operational complexity (deployment, service discovery, distributed transactions) not justified yet.
 
 === Consequences
-* This ADR is **Proposed**, not Accepted - it should move to Accepted (or be
-  revised) after the Domain Storytelling workshop described in
-  link:../domain-stories/as-is-core-flow.html[the AS-IS domain
-  story] happens.
-* No code changes ship with this ADR. It records the target integration
-  pattern so that the next concrete step (wiring or removing
-  `EngagementCancelledDomainEvent`, and introducing `EngagementConfirmed`)
-  can be scoped as its own focused PR against issue #547.
-* Until the event-driven integration lands, `ConfirmEngagementCommandHandler`
-  remains the single place where Engagement, Recognition, and Notifications
-  intersect - anyone changing confirmation behavior needs to be aware all
-  three are affected together.
+* This ADR is **Proposed**, not Accepted - it should move to Accepted (or be revised) after the Domain Storytelling workshop described in link:../domain-stories/as-is-core-flow.html[the AS-IS domain story] happens.
+* No code changes ship with this ADR. It records the target integration pattern so that the next concrete step (wiring or removing `EngagementCancelledDomainEvent`, and introducing `EngagementConfirmed`) can be scoped as its own focused PR against issue #547.
+* Until the event-driven integration lands, `ConfirmEngagementCommandHandler` remains the single place where Engagement, Recognition, and Notifications intersect - anyone changing confirmation behavior needs to be aware all three are affected together.

--- a/docs/Architecture/domain-stories/as-is-core-flow.adoc
+++ b/docs/Architecture/domain-stories/as-is-core-flow.adoc
@@ -40,8 +40,7 @@ because they touch bounded-context boundaries the core flow above does not:
 
 * Organization onboarding & verification (admin)
 * Member management (joining/leaving an organization)
-* Withdraw / cancel and its consequences (orphaned slots, notifications - see
-  issues #539, #548)
+* Withdraw / cancel and its consequences (orphaned slots, notifications - see issues #539, #548)
 * Account deletion / "forget me" (right to erasure - see issue #546)
 * Reminders (scheduled, not actor-triggered)
 

--- a/docs/Architecture/domain-stories/as-is-core-flow.adoc
+++ b/docs/Architecture/domain-stories/as-is-core-flow.adoc
@@ -1,0 +1,66 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+[[domain-story-as-is-core-flow]]
+= Domain Story: AS-IS Core Flow
+
+== Status
+
+Scaffold - code-derived starting point for issue #547.
+
+CAUTION: Domain Storytelling is a *collaborative* modeling technique (see Hofer &
+Schwentner, _Domain Storytelling_, WPS; tool: https://egon.io[egon.io]). The
+story below was reconstructed from the current codebase by an automated
+session, not captured in a workshop with the actual domain experts
+(organizers and volunteers). Treat it as a draft to correct and refine in a
+real session, not as ground truth.
+
+== AS-IS story - core flow
+
+Sentence form: `Actor -> activity -> work object [-> recipient]`
+
+1. Volunteer *searches* the _opportunity list_ for needs nearby.
+2. Organizer *creates* an _opportunity_ with _time slots_.
+3. Organizer *publishes* the _opportunity_.
+4. Volunteer *applies to* the _opportunity_ (a _message_, or a _time slot_).
+5. System *notifies* the Organizer of the new _application_.
+6. Organizer *reviews* the _applications_.
+7. Organizer *confirms* an _application_.
+8. System *notifies* the Volunteer of the _confirmation_.
+9. Volunteer *checks in* with a _PIN/QR code_ at the _event_.
+10. Volunteer *submits* _feedback_ for the _engagement_.
+11. System *awards* a _badge_ to the Volunteer.
+
+A visual (egon.io) version of this story should be produced in the workshop
+and exported as `.egn` + PNG into this folder.
+
+== Secondary stories (not yet told)
+
+These are worth capturing as their own domain stories in the workshop,
+because they touch bounded-context boundaries the core flow above does not:
+
+* Organization onboarding & verification (admin)
+* Member management (joining/leaving an organization)
+* Withdraw / cancel and its consequences (orphaned slots, notifications - see
+  issues #539, #548)
+* Account deletion / "forget me" (right to erasure - see issue #546)
+* Reminders (scheduled, not actor-triggered)
+
+== How this feeds the context map
+
+Each activity above is annotated in link:{imagesdir}/context-map.puml[the
+candidate context map] with the bounded context that currently owns it. The
+seams between contexts in that diagram are exactly the points where this
+story crosses from one actor/system responsibility to another (e.g. step 7
+"confirms" today directly triggers Recognition and Notifications side
+effects instead of only emitting `EngagementConfirmed`).
+
+See link:../ADRs/5_bounded_contexts_and_event_driven_integration.html[ADR
+5] for the proposed bounded-context catalog and integration pattern that
+follows from this story.
+
+== Next steps (from issue #547's roadmap)
+
+* [ ] Run the actual Domain Storytelling workshop with organizers + volunteers.
+* [ ] Replace this text version with the egon.io export.
+* [ ] Extend to the secondary stories above.
+* [ ] Enforce the resulting module boundaries with NetArchTest rules per context.

--- a/docs/Architecture/images/context-map.puml
+++ b/docs/Architecture/images/context-map.puml
@@ -1,0 +1,39 @@
+@startuml Context Map (Candidate, AS-IS)
+
+title Candidate Bounded Context Map - AS-IS coupling (see ADR 5)
+
+skinparam rectangle {
+	BackgroundColor White
+	BorderColor Black
+}
+
+rectangle "Identity & Access\n(Keycloak + Domain/Users, partial)" as identity
+rectangle "Organization Management\n(Domain/Organizations)" as orgs
+rectangle "Opportunity Management\n(Domain/VolunteerOpportunities)" as opportunities
+rectangle "Participation / Engagement\n(Domain/Engagements)" as engagements
+rectangle "Feedback\n(embedded in Engagement)" as feedback
+rectangle "Recognition / Gamification\n(Domain/Achievements, UserStreak)" as recognition
+rectangle "Notifications\n(Domain/Notifications)" as notifications
+
+engagements -right-> opportunities : "Shared Kernel (today)\nreaches into opportunity.TimeSlots\nfor capacity checks"
+engagements -down-> recognition : "Customer/Supplier (today, synchronous)\ndirect AwardAchievementCommand +\nstreak recording from ConfirmEngagementCommandHandler\n--> should become async, reacting to EngagementConfirmed"
+engagements .down.> notifications : "Published Language (today, inline)\nevery handler creates Notification directly\n--> should become a downstream consumer of domain events"
+feedback -up-> engagements : "embedded, not yet split out"
+orgs -up-> identity : "Anti-Corruption Layer needed\norg membership split between Keycloak and local store"
+opportunities -up-> orgs : "owned by"
+
+note bottom of engagements
+  Dead integration point: **EngagementCancelledDomainEvent**
+  is raised in Engagement.Cancel() but has no handler -
+  evidence event-driven integration was intended but never wired.
+end note
+
+legend right
+  |= Style |= Meaning |
+  | solid arrow | direct/synchronous call (tight coupling today) |
+  | dotted arrow | inline side-effect (should become event-driven) |
+  This is a code-derived AS-IS view for the Domain Storytelling
+  workshop proposed in issue #547, not a final TO-BE design.
+endlegend
+
+@enduml

--- a/docs/Architecture/images/context-map.puml
+++ b/docs/Architecture/images/context-map.puml
@@ -23,17 +23,17 @@ orgs -up-> identity : "Anti-Corruption Layer needed\norg membership split betwee
 opportunities -up-> orgs : "owned by"
 
 note bottom of engagements
-  Dead integration point: **EngagementCancelledDomainEvent**
-  is raised in Engagement.Cancel() but has no handler -
-  evidence event-driven integration was intended but never wired.
+Dead integration point: **EngagementCancelledDomainEvent**
+is raised in Engagement.Cancel() but has no handler -
+evidence event-driven integration was intended but never wired.
 end note
 
 legend right
-  |= Style |= Meaning |
-  | solid arrow | direct/synchronous call (tight coupling today) |
-  | dotted arrow | inline side-effect (should become event-driven) |
-  This is a code-derived AS-IS view for the Domain Storytelling
-  workshop proposed in issue #547, not a final TO-BE design.
+|= Style |= Meaning |
+| solid arrow | direct/synchronous call (tight coupling today) |
+| dotted arrow | inline side-effect (should become event-driven) |
+This is a code-derived AS-IS view for the Domain Storytelling
+workshop proposed in issue #547, not a final TO-BE design.
 endlegend
 
 @enduml

--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -93,3 +93,22 @@ Key logged events:
 * Startup configuration summary
 
 No external observability service (Datadog, Grafana, etc.) is currently integrated - this is a deliberate trade-off to keep operational complexity minimal.
+
+=== Domain Storytelling and Bounded Contexts
+
+As a step toward the Domain Storytelling / bounded-contexts / self-contained
+systems track (issue #547), the domain has a code-derived AS-IS story and a
+candidate context map:
+
+* link:domain-stories/as-is-core-flow.html[AS-IS domain story - core flow]
+* link:ADRs/5_bounded_contexts_and_event_driven_integration.html[ADR 5 -
+  Bounded Contexts and Event-Driven Integration]
+
+.Candidate Context Map
+[plantuml, "context-map", png]
+....
+include::../images/context-map.puml[]
+....
+
+These are a starting point for a Domain Storytelling workshop with domain
+experts, not a finalized design - see the caveats in the linked documents.

--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -101,8 +101,7 @@ systems track (issue #547), the domain has a code-derived AS-IS story and a
 candidate context map:
 
 * link:domain-stories/as-is-core-flow.html[AS-IS domain story - core flow]
-* link:ADRs/5_bounded_contexts_and_event_driven_integration.html[ADR 5 -
-  Bounded Contexts and Event-Driven Integration]
+* link:ADRs/5_bounded_contexts_and_event_driven_integration.html[ADR 5 - Bounded Contexts and Event-Driven Integration]
 
 .Candidate Context Map
 [plantuml, "context-map", png]

--- a/docs/Architecture/src/09_architecture_decisions.adoc
+++ b/docs/Architecture/src/09_architecture_decisions.adoc
@@ -31,4 +31,18 @@ The following table lists the relevant architecture decisions. Each decision lin
 |2026-03-25
 |link:ADRs/3_keycloak.html[Keycloak]
 
+|4
+|Geocoding
+|Geocode addresses at write time; bounding-box + Haversine spatial search, no PostGIS.
+|Accepted
+|2026-05-13
+|link:ADRs/4_geocoding_and_geo_search.html[Geocoding and Geo Search]
+
+|5
+|Bounded Contexts
+|Candidate bounded-context catalog and event-driven integration pattern between contexts.
+|Proposed
+|2026-07-01
+|link:ADRs/5_bounded_contexts_and_event_driven_integration.html[Bounded Contexts and Event-Driven Integration]
+
 |===


### PR DESCRIPTION
## Summary

Follow-up to the standing "review open issues / open PRs" routine. Nearly
every open bug/enhancement issue (#521, #532, #534, #536, #537, #538, #539,
#540, #541, #542, #543, #544, #545, #546, #548, #554) was verified against
current `main` and is already fixed by previously merged PRs, or already
covered by the currently-open PR #565 (the remaining time-slot-clearing gap
in #539) - no duplicate work was done for those, and no new comments were
added since this exact triage had already run minutes earlier in this
session cycle.

The one genuinely new, actionable item this session: the repo owner
commented directly on the architecture epic #547
(https://github.com/maik-hasler/einsatzbereit/issues/547#issuecomment-4855103170)
authorizing the scaffold that issue itself proposes - "You can tackle this
aswell. Use plantuml to render to images." This PR implements exactly that
scaffold:

- `docs/Architecture/domain-stories/as-is-core-flow.adoc` - a code-derived
  AS-IS domain story (actor -> activity -> work object sentence form) for the
  core flow, plus a list of secondary stories worth capturing in a real
  workshop. Explicitly marked as a scaffold/starting point, not a
  replacement for the collaborative Domain Storytelling session with
  organizers and volunteers that the issue calls for.
- `docs/Architecture/images/context-map.puml` - a candidate bounded-context
  map (PlantUML, per the owner's request) covering the 7 contexts named in
  #547, annotated with the concrete coupling seams already identified in the
  issue (Engagement -> Opportunity shared kernel, inline Gamification calls,
  inline Notifications, the dead `EngagementCancelledDomainEvent` handler).
- `docs/ADRs/5_bounded_contexts_and_event_driven_integration.adoc` - a
  **Proposed** ADR recording the candidate context catalog and the
  event-driven integration pattern to move toward, to be promoted to
  Accepted (or revised) after the actual workshop.
- Cross-linked from `08_concepts.adoc` (new "Domain Storytelling and Bounded
  Contexts" subsection, with the context map rendered inline) and the
  ADR index table in `09_architecture_decisions.adoc`.
- `.github/workflows/docs.yml`: added a build step for the new
  `domain-stories` folder, mirroring the existing ADRs/TDRs steps exactly,
  so the new page is published to GitHub Pages alongside the rest of the
  docs site.

No application code changed; this is documentation/architecture scaffolding
only, as explicitly authorized by the issue owner.

## Test plan

- [x] Built the full `Architecture.adoc` locally with `asciidoctor` (same
      invocation as `docs.yml`) - the new `context-map.puml` fails only for
      the same environment reason every pre-existing C4 diagram in this repo
      fails locally (no network access to fetch the C4-PlantUML stdlib) -
      not a regression.
- [x] Rendered `context-map.puml` standalone with the `plantuml` CLI (no C4
      include) - renders cleanly to SVG with no syntax errors.
- [x] Built `docs/ADRs/*.adoc` and `docs/Architecture/domain-stories/*.adoc`
      standalone with `asciidoctor` (same invocation `docs.yml` uses for
      ADRs/TDRs) - both build with zero errors.
- [x] Verified the cross-document relative links (`08_concepts.adoc` <->
      `ADRs/5_....adoc` <-> `domain-stories/as-is-core-flow.adoc` <->
      `images/context-map.puml`) resolve correctly against the `build/`
      output layout produced by `docs.yml` (checked generated `href`
      attributes).
- [x] Checked for non-ASCII dashes (repo's `ban-typographic-dashes` CI gate)
      across all changed/added files - none found.
- [ ] CI on this PR (build/lint/format/docs) - pending.

## Live verification

Not applicable - documentation-only change with no runtime behavior; the
CLAUDE.md-mandated release/staging-smoke-test flow applies to bug
fixes/features, not to architecture docs. The rendered pages will be
visible on GitHub Pages once this merges and `docs.yml` runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014aczwNEyThwytiErsDabUA)_