### PR TITLE
fix: close remaining publish-with-empty-slots gap in Waitlist opportunity creation (#542)

### DIFF
--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -97,7 +97,16 @@ public sealed class VolunteerOpportunity
 			throw new DomainException("Title must not be empty.");
 
 		if (status == OpportunityStatus.Published)
+		{
 			EnsurePublishable(description, isRemote, address);
+
+			// Time slots can only be added after the aggregate is created (see
+			// AddTimeSlot), so a Waitlist opportunity can never satisfy the
+			// "at least one time slot" rule at construction time. Callers must
+			// create it as a Draft, add slots, then call Publish().
+			if (participationType == ParticipationType.Waitlist)
+				throw new DomainException("A Waitlist opportunity must be created as a draft and published after adding at least one time slot.");
+		}
 
 		return new VolunteerOpportunity(
 			new VolunteerOpportunityId(Guid.CreateVersion7()),

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -62,8 +62,10 @@ internal sealed class ApplicationDbContextInitializer(
 				new Domain.VolunteerOpportunities.Address("Hauptstrasse", "1", "12345", "Musterstadt"),
 				Occurrence.OneTime,
 				ParticipationType.Waitlist,
-				CheckInMethod.Manual);
+				CheckInMethod.Manual,
+				status: OpportunityStatus.Draft);
 			opp1.AddTimeSlot(now.AddDays(14), now.AddDays(14).AddHours(8), 20);
+			opp1.Publish();
 
 			var opp2 = VolunteerOpportunity.Create(
 				org1Id,
@@ -83,9 +85,11 @@ internal sealed class ApplicationDbContextInitializer(
 				new Domain.VolunteerOpportunities.Address("Tiergartenweg", "5", "12345", "Musterstadt"),
 				Occurrence.Recurring,
 				ParticipationType.Waitlist,
-				CheckInMethod.QRCode);
+				CheckInMethod.QRCode,
+				status: OpportunityStatus.Draft);
 			opp3.AddTimeSlot(now.AddDays(7), now.AddDays(7).AddHours(4), 5);
 			opp3.AddTimeSlot(now.AddDays(21), now.AddDays(21).AddHours(4), 5);
+			opp3.Publish();
 
 			var opp4 = VolunteerOpportunity.Create(
 				org2Id,

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -49,7 +49,7 @@ public class CancelEngagementCommandHandlerTests
 	}
 
 	private static VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, status: OpportunityStatus.Draft);
 
 	private static Engagement CreatePendingWaitlistEngagement() =>
 		Engagement.CreateWaitlistSignUp(

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -211,7 +211,7 @@ public class ConfirmEngagementCommandHandlerTests
 	}
 
 	private static VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, status: OpportunityStatus.Draft);
 
 	private static UserStreak BuildActivityStreakOf(UserId userId, int weeks)
 	{

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -41,7 +41,8 @@ public class CreateEngagementCommandHandlerTests
 			TestAddress,
 			Occurrence.OneTime,
 			ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None,
+			status: OpportunityStatus.Draft);
 		return org;
 	}
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -36,7 +36,8 @@ public class CreateTimeSlotCommandHandlerTests
 	private static VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
 			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress,
-			Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None);
+			Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None,
+			status: OpportunityStatus.Draft);
 
 	[Test]
 	public async Task Handle_ShouldCreateSingleSlot_WhenNoRecurrence(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Application.Common.Persistence;
 using Application.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 using AwesomeAssertions;
 using Domain.Organizations;
+using Domain.Primitives;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -43,7 +44,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 			CheckInMethod.None,
 			null,
 			[],
-			OpportunityStatus.Published);
+			OpportunityStatus.Draft);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -88,6 +89,36 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldThrow_WhenPublishingWaitlistDirectlyWithNoTimeSlots(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new CreateVolunteerOpportunityCommand(
+			"Title",
+			"Description",
+			TestOrganizationId,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			null,
+			[],
+			OpportunityStatus.Published);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>()
+			.WithMessage("*Waitlist opportunity*");
+		await _dbContext
+			.VolunteerOpportunities
+			.DidNotReceive()
+			.AddAsync(Arg.Any<VolunteerOpportunity>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
 	public async Task Handle_ShouldPersistCoordinates_WhenGeocodingSucceeds(
 		CancellationToken cancellationToken)
 	{
@@ -97,7 +128,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 			.Returns(new GeoCoordinates(52.52, 13.405));
 
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Published);
+			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -117,7 +148,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 			.Returns((GeoCoordinates?)null);
 
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Published);
+			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -137,7 +168,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 			.Returns(Task.FromException<GeoCoordinates?>(new HttpRequestException("boom")));
 
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Published);
+			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -152,7 +183,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	{
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Published);
+			"Title", "Description", TestOrganizationId, true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 	}
 
 	private static VolunteerOpportunity CreateOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
+		VolunteerOpportunity.Create(DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, status: OpportunityStatus.Draft);
 
 	[Test]
 	public async Task Handle_ShouldReturnTrue_WhenOpportunityExists(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -49,7 +49,17 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	}
 
 	private static VolunteerOpportunity CreateOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
-		VolunteerOpportunity.Create(DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None);
+		VolunteerOpportunity.Create(DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None);
+
+	private static VolunteerOpportunity CreatePublishedWaitlistOpportunity()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Altes Thema", "Alte Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None,
+			status: OpportunityStatus.Draft);
+		opportunity.AddTimeSlot(DateTimeOffset.UtcNow.AddDays(7), DateTimeOffset.UtcNow.AddDays(7).AddHours(2), 10);
+		opportunity.Publish();
+		return opportunity;
+	}
 
 	[Test]
 	public async Task Handle_ShouldUpdateFields_WhenOpportunityExists(
@@ -106,7 +116,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	{
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
-		var opportunity = CreateOpportunity();
+		var opportunity = CreatePublishedWaitlistOpportunity();
 
 		_opportunityRepo
 			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
@@ -136,7 +146,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	{
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
-		var opportunity = CreateOpportunity();
+		var opportunity = CreatePublishedWaitlistOpportunity();
 
 		_opportunityRepo
 			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
@@ -278,7 +288,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Material change: new address (city changed).
 		var newAddress = new Address("Neue Straße", "99", "20095", "Hamburg");
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -311,7 +321,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		// Cosmetic change only: title and description change, address/remote/occurrence unchanged.
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -24,7 +24,8 @@ public class VolunteerOpportunityTests
 			TestAddress,
 			Occurrence.OneTime,
 			ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None,
+			status: OpportunityStatus.Draft);
 
 		// Assert
 		opportunity.Title.Should().Be("Helpers needed");
@@ -137,6 +138,45 @@ public class VolunteerOpportunityTests
 		opportunity.ParticipationType.Should().Be(ParticipationType.IndividualContact);
 	}
 
+	[Test]
+	public void Create_ShouldThrow_WhenPublishedWaitlistHasNoTimeSlots()
+	{
+		// Act
+		var act = () => VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			status: OpportunityStatus.Published);
+
+		// Assert
+		act.Should().Throw<DomainException>()
+			.WithMessage("*Waitlist opportunity*");
+	}
+
+	[Test]
+	public void Create_ShouldAllow_PublishedIndividualContact_WithNoTimeSlots()
+	{
+		// Act
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			status: OpportunityStatus.Published);
+
+		// Assert
+		opportunity.Status.Should().Be(OpportunityStatus.Published);
+	}
+
 	// --- Update ---
 
 	[Test]
@@ -144,7 +184,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Old title", "Old desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		var newAddress = new Address("Neue Straße", "42", "10115", "Hamburg");
 
 		opportunity.Update("New title", "New desc", false, newAddress, Occurrence.Recurring, ParticipationType.IndividualContact, CheckInMethod.Manual, null, []);
@@ -162,7 +202,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		opportunity.Update("Title", "Desc", false, TestAddress, Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None, null, []);
 
@@ -174,7 +214,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		opportunity.Update("Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, []);
 
@@ -186,7 +226,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
 
 		opportunity.Update("Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, []);
@@ -199,7 +239,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
 
 		opportunity.Update("New title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
@@ -212,7 +252,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		opportunity.Update("Remote title", "Remote desc", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
 
@@ -228,7 +268,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		Action act = () => opportunity.Update(title!, "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
 
@@ -241,9 +281,7 @@ public class VolunteerOpportunityTests
 	[Arguments(null)]
 	public void Update_ShouldThrow_WhenDescriptionIsEmpty(string? description)
 	{
-		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+		var opportunity = CreatePublishedWaitlistOpportunity();
 
 		Action act = () => opportunity.Update("Title", description!, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
 
@@ -253,13 +291,21 @@ public class VolunteerOpportunityTests
 	[Test]
 	public void Update_ShouldThrow_WhenNotRemoteAndAddressIsNull()
 	{
-		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+		var opportunity = CreatePublishedWaitlistOpportunity();
 
 		Action act = () => opportunity.Update("Title", "Desc", false, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, []);
 
 		act.Should().Throw<DomainException>().WithMessage("Address is required for non-remote opportunities.");
+	}
+
+	private VolunteerOpportunity CreatePublishedWaitlistOpportunity()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
+			CheckInMethod.None, status: OpportunityStatus.Draft);
+		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
+		opportunity.Publish();
+		return opportunity;
 	}
 
 	// --- AddTimeSlot ---
@@ -269,7 +315,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), maxParticipants: 20);
 
@@ -294,7 +340,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.Recurring, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
 		opportunity.AddTimeSlot(FutureSlotStart.AddDays(7), FutureSlotStart.AddDays(7).AddHours(2), 10);
@@ -309,7 +355,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10);
 		var slotId = opportunity.TimeSlots.First().Id;
 
@@ -323,7 +369,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		var nonExistentId = new TimeSlotId(Guid.CreateVersion7());
 
 		Action act = () => opportunity.RemoveTimeSlot(nonExistentId);
@@ -336,7 +382,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.Recurring, ParticipationType.Waitlist,
-			CheckInMethod.None);
+			CheckInMethod.None, status: OpportunityStatus.Draft);
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 5);
 		opportunity.AddTimeSlot(FutureSlotStart.AddDays(7), FutureSlotStart.AddDays(7).AddHours(2), 5);
 

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -733,6 +733,8 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	private static async Task<CreateVolunteerOpportunityResponse> CreateWaitlistOpportunityAsync(
 		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
 	{
+		// Created as a draft: a Waitlist opportunity can't be published until it has
+		// at least one time slot, and callers add slots separately after this returns.
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
@@ -746,6 +748,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 				Occurrence = "OneTime",
 				ParticipationType = "Waitlist",
 				CheckInMethod = "None",
+				IsDraft = true,
 			},
 			cancellationToken);
 	}

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -256,7 +256,9 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, string title, string description,
 		CancellationToken cancellationToken)
 	{
-		return await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		// A Waitlist opportunity can't be published until it has at least one time
+		// slot, so create it as a draft, add a slot, then publish it.
+		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
 			Title = title,
 			Description = description,
@@ -267,7 +269,23 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 			City = "Berlin",
 			Occurrence = "OneTime",
 			ParticipationType = "Waitlist",
-			CheckInMethod = "None"
+			CheckInMethod = "None",
+			IsDraft = true,
 		}, cancellationToken);
+
+		await client.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		await client.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		return opportunity;
 	}
 }

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -304,4 +304,74 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var amberBadge = draftsSection.Locator("[class*='bg-amber-100']").First;
 		await Expect(amberBadge).ToBeVisibleAsync();
 	}
+
+	[Test]
+	public async Task PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne()
+	{
+		// Regression for #542: a Waitlist opportunity could be published with
+		// zero time slots via the direct-create-as-Published path, since
+		// VolunteerOpportunity.Create() had no equivalent guard to Publish().
+		// Verifies the UI still blocks publishing with no slots, and that the
+		// supported draft -> add-slot -> publish flow succeeds.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var uniqueTitle = $"Waitlist Publish Gap Test {Guid.NewGuid().ToString("N")[..8]}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		if (await createBtn.CountAsync() == 0)
+			return; // no org selected in seed - skip
+
+		await createBtn.First.ClickAsync();
+
+		try
+		{
+			await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+		}
+		catch
+		{
+			return; // modal did not open - skip remaining assertions
+		}
+
+		// Step 1: title/description.
+		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
+		await Page.Locator("#opportunity-description").FillAsync(
+			"Regression test for the Waitlist publish-with-no-slots gap.");
+
+		// Step 2: remote, to skip address fields.
+		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
+		await Page.Locator("#opportunity-remote").CheckAsync();
+
+		// Step 3: Waitlist participation type.
+		await Page.GetByTestId("wizard-stepper-3").ClickAsync();
+		await Page.Locator("input[name='participationType'][value='Waitlist']").CheckAsync();
+
+		// Step 4: publishing with no time slots must still be blocked client-side.
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+		await Page.GetByTestId("modal-submit").ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("wizard-step-4")).ToBeVisibleAsync();
+
+		// Add a time slot, then publishing must succeed.
+		var start = DateTimeOffset.UtcNow.AddDays(7);
+		var end = start.AddHours(2);
+		var step4 = Page.GetByTestId("wizard-step-4");
+		await step4.Locator("#slot-start").FillAsync(start.ToString("yyyy-MM-ddTHH:mm"));
+		await step4.Locator("#slot-end").FillAsync(end.ToString("yyyy-MM-ddTHH:mm"));
+		var addSlotBtn = step4.GetByRole(AriaRole.Button, new() { Name = "Add", Exact = true });
+		await addSlotBtn.ClickAsync();
+		await Expect(addSlotBtn).ToBeEnabledAsync(new() { Timeout = 5000 });
+
+		await Page.GetByTestId("modal-submit").ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The newly published opportunity is visible in the public list.
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var listedCard = Page
+			.Locator("a[href*='/volunteer-opportunities/']")
+			.Filter(new() { HasText = uniqueTitle });
+		await Expect(listedCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
 }

--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -565,6 +565,12 @@ export default function CreateVolunteerOpportunityModal({
 					}
 				}
 			} else {
+				// A Waitlist opportunity can't be published until it has at least
+				// one time slot, and slots can only be added after the opportunity
+				// exists. Always create it as a draft, add slots and banner, then
+				// publish - this also keeps it invisible in listings if any step
+				// in between fails, instead of leaving a published dead-end.
+				const publishWaitlistAfterCreate = !asDraft && isWaitlist;
 				const opportunity = await api.createVolunteerOpportunity({
 					title: form.title,
 					description: form.description,
@@ -579,7 +585,7 @@ export default function CreateVolunteerOpportunityModal({
 					checkInMethod: form.checkInMethod,
 					category: form.category,
 					tags: form.tags,
-					isDraft: asDraft,
+					isDraft: asDraft || publishWaitlistAfterCreate,
 				});
 				if (bannerFile) {
 					try {
@@ -599,6 +605,9 @@ export default function CreateVolunteerOpportunityModal({
 						recurrenceFrequency: undefined,
 						recurrenceCount: 1,
 					});
+				}
+				if (publishWaitlistAfterCreate) {
+					await api.publishVolunteerOpportunity(opportunity.id);
 				}
 				if (asDraft) {
 					dispatchToast("success", t("createOpportunity.draftSavedToast"));

--- a/scripts/smoke-test-542-waitlist-publish-gap.mjs
+++ b/scripts/smoke-test-542-waitlist-publish-gap.mjs
@@ -1,0 +1,143 @@
+// Smoke test for #542 follow-up (PR #569): a Waitlist opportunity could still
+// be published with zero time slots via the direct-create-as-Published API
+// path, bypassing the Publish()-time guard entirely. Verifies:
+//   1. Direct API create with isDraft:false + ParticipationType:Waitlist is
+//      now rejected (400), instead of silently creating a dead-end listing.
+//   2. The supported flow (create as draft -> add a time slot -> publish)
+//      still works end-to-end and the opportunity becomes visible/Published.
+// Run: node scripts/smoke-test-542-waitlist-publish-gap.mjs
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const token = await getToken("olaf", "olaf123");
+	console.log("OK  Got access token for olaf (organisator)");
+	const authHeaders = {
+		Authorization: `Bearer ${token}`,
+		"Content-Type": "application/json",
+	};
+
+	// Find (or reuse) an organization olaf belongs to.
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: authHeaders,
+	});
+	if (!orgsRes.ok) throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+	console.log(`OK  Using organization ${orgId}`);
+
+	const basePayload = {
+		title: `Smoke Test 542 ${Date.now()}`,
+		description: "Automated smoke test for the Waitlist publish-gap fix.",
+		organizationId: orgId,
+		isRemote: true,
+		occurrence: "OneTime",
+		participationType: "Waitlist",
+		checkInMethod: "None",
+	};
+
+	// --- 1. Direct create as Published with no slots must now be rejected ---
+	const rejectedRes = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: authHeaders,
+		body: JSON.stringify({ ...basePayload, isDraft: false }),
+	});
+	if (rejectedRes.status !== 400) {
+		const body = await rejectedRes.text();
+		throw new Error(
+			`Expected 400 when creating a Published Waitlist opportunity with no slots, got ${rejectedRes.status}: ${body}`,
+		);
+	}
+	console.log(
+		"OK  Direct create-as-Published Waitlist-with-no-slots rejected (400)",
+	);
+
+	// --- 2. Supported flow: draft -> add slot -> publish ---
+	const draftRes = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: authHeaders,
+		body: JSON.stringify({ ...basePayload, isDraft: true }),
+	});
+	if (!draftRes.ok)
+		throw new Error(`Draft create failed: ${draftRes.status} ${await draftRes.text()}`);
+	const draft = await draftRes.json();
+	if (draft.status !== "Draft")
+		throw new Error(`Expected Draft status, got ${draft.status}`);
+	console.log(`OK  Created draft opportunity ${draft.id}`);
+
+	const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+	const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+	const slotRes = await fetch(
+		`${API}/v1/volunteer-opportunities/${draft.id}/time-slots`,
+		{
+			method: "POST",
+			headers: authHeaders,
+			body: JSON.stringify({
+				startDateTime: start.toISOString(),
+				endDateTime: end.toISOString(),
+				maxParticipants: 5,
+				recurrenceCount: 1,
+			}),
+		},
+	);
+	if (!slotRes.ok)
+		throw new Error(`Time slot create failed: ${slotRes.status} ${await slotRes.text()}`);
+	console.log("OK  Added a time slot to the draft");
+
+	const publishRes = await fetch(
+		`${API}/v1/volunteer-opportunities/${draft.id}/publish`,
+		{ method: "POST", headers: authHeaders },
+	);
+	if (!publishRes.ok)
+		throw new Error(`Publish failed: ${publishRes.status} ${await publishRes.text()}`);
+	console.log("OK  Published the draft after adding a time slot");
+
+	// Verify it's now visible/Published via the public listing.
+	const listRes = await fetch(
+		`${API}/v1/volunteer-opportunities?pageNumber=1&pageSize=50`,
+	);
+	if (!listRes.ok) throw new Error(`GET /volunteer-opportunities failed: ${listRes.status}`);
+	const list = await listRes.json();
+	const found = (list.items ?? []).find((i) => i.id === draft.id);
+	if (!found)
+		throw new Error("Published opportunity not visible in public listing");
+	console.log("OK  Published opportunity visible in public listing");
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Standing "review open issues / open PRs" routine. Independently re-verified all 20 open issues against current `main` (not just PR titles/prior triage comments) via a dedicated verification pass. 19 of 20 were confirmed genuinely fixed by already-merged PRs, or are docs-only/meta issues correctly left open (#547 epic, tracked by the still-open PR #566; #25 is Renovate's self-managed dashboard). Full per-issue findings were left as comments on each of the 20 issues.

One real gap survived six previous rounds of "verified fixed" triage on **#542** ("A Waitlist opportunity can be published with no time slots, creating an apply dead-end"):

- `VolunteerOpportunity.Publish()` already guarded against publishing a Waitlist opportunity with zero time slots (`backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs`).
- `VolunteerOpportunity.Create()` had **no equivalent guard** - and structurally couldn't reuse `Publish()`'s check, since time slots are only ever added *after* the aggregate exists (`AddTimeSlot`), so `_timeSlots` is always empty at construction time.
- The direct-create-as-Published path (`isDraft:false`) therefore bypassed the invariant entirely. The frontend made this worse: `CreateVolunteerOpportunityModal.tsx` persisted the opportunity as **Published** before running its slot-creation loop, so a failed/interrupted request between those two steps left a live, permanently-broken dead-end opportunity - exactly the bug the issue reports.

## Changes

- `VolunteerOpportunity.Create()` now throws a `DomainException` when asked to create a Waitlist opportunity directly as `Published`. Callers must create it as `Draft`, add slots, then call `Publish()`.
- `CreateVolunteerOpportunityModal.tsx`: when publishing a new Waitlist opportunity, it's now created as a draft, slots (and banner) are added, and only then is `publishVolunteerOpportunity` called - so a failure mid-flow leaves an invisible draft instead of a broken published listing.
- `ApplicationDbContextInitializer` (dev seed data) updated to the draft -> add-slots -> publish sequence for its two Waitlist seed opportunities.
- Unit tests: added a domain-level test (`Create_ShouldThrow_WhenPublishedWaitlistHasNoTimeSlots`) and a handler-level test (`Handle_ShouldThrow_WhenPublishingWaitlistDirectlyWithNoTimeSlots`); updated ~10 existing tests that relied on directly `Create()`-ing Published Waitlist opportunities.
- Integration test helpers (`GetVolunteerOpportunitiesTests.cs`, `EngagementTests.cs`) updated to the draft -> add-slot -> publish sequence so they keep exercising a genuinely Published Waitlist opportunity.
- Added `scripts/smoke-test-542-waitlist-publish-gap.mjs` (live staging smoke test) and a TUnit VisualTests regression test (`PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne`).

## Test plan

- [x] `dotnet test tests/Application.UnitTests` - 188/188 passing.
- [x] `dotnet test tests/ArchitectureTests` - 240/240 passing, no layering/convention regressions.
- [x] `dotnet build` (Api/Domain/Application/Infrastructure/VisualTests) - 0 warnings, 0 errors; NSwag client regenerated cleanly.
- [x] `dotnet format --verify-no-changes` - clean.
- [x] Frontend: `pnpm check` (tsc), `pnpm lint` (0 warnings), `pnpm build` - all clean.
- [x] CI on this PR (build, lint, format-check, build-and-test, editorconfig, ban-typographic-dashes, PR title) - all green.
- [ ] `tests/VisualTests` execution - could not run in this sandbox (Playwright browser-download step is network-blocked here); compiles cleanly and will execute against the local Aspire stack in CI.

## Live verification

Deployed release candidate **v1.0.0-rc.182** (tag pushed via `release/v1.0.0-rc.182`, built and deployed to staging by `publish.yml` / `deploy-staging`, both green).

- `curl https://api.maik-hasler.de/health` -> `200 Healthy`.
- Ran `node scripts/smoke-test-542-waitlist-publish-gap.mjs` against the live staging API (`https://api.maik-hasler.de`, organizer `olaf`):
  - Direct `POST /v1/volunteer-opportunities` with `isDraft:false` + `participationType:Waitlist` + no slots now returns **400** (previously would have silently created a broken published listing).
  - The supported flow - create as draft, `POST .../time-slots`, then `POST .../publish` - succeeds, and the opportunity becomes `Published` and visible via `GET /v1/volunteer-opportunities`.
  - `ALL CHECKS PASSED`, script exits 0.
- Note: full browser-driven Playwright automation against the live site could not be run from this sandbox - headless Chromium's outbound network is blocked here entirely (even to unrelated hosts like example.com), independent of this change. The API-level script above exercises the exact same request sequence the frontend now issues (create-draft -> add-slot -> publish) and directly validates the domain invariant that was the actual bug. The equivalent flow is additionally covered by the new automated TUnit VisualTests test, which will run against the local Aspire stack in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ucbuhsk9AoMCofBa3MUBDF