### PR TITLE
test: cover engagement cancellation on opportunity deletion (#548)

### DIFF
--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -119,6 +119,38 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldCancelActiveEngagements_WhenOpportunityDeleted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		var timeSlotId = new TimeSlotId(Guid.CreateVersion7());
+		var pendingEngagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(opportunityId), new UserId(Guid.CreateVersion7()), timeSlotId);
+		var confirmedEngagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(opportunityId), new UserId(Guid.CreateVersion7()), timeSlotId);
+		confirmedEngagement.Confirm();
+
+		_opportunityRepo
+			.FindAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns(opportunity);
+
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(new VolunteerOpportunityId(opportunityId), cancellationToken)
+			.Returns([pendingEngagement, confirmedEngagement]);
+
+		// Act
+		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert - active engagements are cancelled, not left dangling after the opportunity is gone.
+		pendingEngagement.Status.Should().Be(EngagementStatus.Cancelled);
+		pendingEngagement.CancellationReason.Should().Be("Opportunity was deleted.");
+		confirmedEngagement.Status.Should().Be(EngagementStatus.Cancelled);
+		confirmedEngagement.CancellationReason.Should().Be("Opportunity was deleted.");
+	}
+
+	[Test]
 	public async Task Handle_ShouldNotNotify_WhenNoActiveEngagements(
 		CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
## Summary

Standing "review open issues / open PRs" routine. Independently re-verified all 20 open issues against current `main` via four parallel deep-dive investigations (reading current code, not just prior triage comments):

- 17 of 20 are already fully resolved by previously merged PRs, with accurate, current (2026-07-03) triage comments already in place - no duplicate comments added.
- #542, #547, and #536's last remaining item are already covered by the currently-open PRs #569, #566, and #570 respectively - all three were spot-checked (diff read, CI green, issue comments accurate) and are legitimate, sufficient, non-duplicative work. No action taken on these.
- #25 (Renovate's self-managed Dependency Dashboard) needs no action.

One issue had a real, actionable gap: **#548** ("Deleting an opportunity orphans its engagements and bypasses the ownership check on confirm/cancel"). The underlying bug is genuinely fixed - `DeleteVolunteerOpportunityCommandHandler` correctly cancels all active engagements before deleting the opportunity, and `ConfirmEngagementCommandHandler`/`CancelEngagementCommandHandler` fail closed (`?? throw`) rather than silently skipping the ownership guard. However, a prior triage comment on the issue claimed a test named `Handle_ShouldCancelActiveEngagements_WhenOpportunityDeleted` already existed - it does not. Every existing `DeleteVolunteerOpportunityCommandHandler` test only ever supplies an empty engagement list, so the handler's `engagement.Cancel(...)` call was never actually exercised by the suite.

## Changes

- Added `Handle_ShouldCancelActiveEngagements_WhenOpportunityDeleted` to `backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs`: creates a Pending and a Confirmed `Engagement`, has `GetActiveEngagementsForOpportunityAsync` return both, and asserts both end up `Cancelled` with `CancellationReason == "Opportunity was deleted."` after the handler runs.
- No production code changed - the fix itself was already correct and already deployed via a previously merged PR.

## Test plan

- [x] `dotnet test tests/Application.UnitTests` - 186/186 passing (new test included, verified individually via `--output Detailed`).
- [x] `dotnet format --verify-no-changes` - clean.

## Live verification

Not applicable - this is a test-only change with no production code modified and no observable runtime behavior change (the underlying fix is already live in production from a previously merged PR). Per the same reasoning already used for docs-only PR #566, the mandatory deploy/RC/smoke-test flow doesn't apply here since there is nothing new to observe in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJJtXJL8H8rLHrrfaG4guf

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJtXJL8H8rLHrrfaG4guf)_