### PR TITLE
feat: move Create Opportunity button from homepage to organization dashboard

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -105,10 +105,22 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		// Create button only appears when an org is active.
-		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
-		if (await createBtn.CountAsync() == 0)
+		// Create opportunity now lives on the organization dashboard - navigate there
+		// via the org switcher. Switcher toggle has aria-label "Switch organization"
+		// (en) / "Organisation wechseln" (de).
+		var switcherBtn = Page.Locator("button[aria-expanded]");
+		if (await switcherBtn.CountAsync() == 0)
+			return; // no org membership in seed - skip
+
+		await switcherBtn.First.ClickAsync();
+		var dashboardLink = Page.GetByTestId("org-dashboard-link");
+		if (await dashboardLink.CountAsync() == 0)
 			return; // no org selected in seed - skip
+
+		await dashboardLink.First.ClickAsync();
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await createBtn.First.ClickAsync();
 
@@ -252,10 +264,22 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		// Create opportunity button is only present when an org is active.
-		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
-		if (await createBtn.CountAsync() == 0)
+		// Create opportunity lives on the organization dashboard - navigate there
+		// via the org switcher. Switcher toggle has aria-label "Switch organization"
+		// (en) / "Organisation wechseln" (de).
+		var switcherBtn = Page.Locator("button[aria-expanded]");
+		if (await switcherBtn.CountAsync() == 0)
 			return;
+
+		await switcherBtn.First.ClickAsync();
+		var dashboardLink = Page.GetByTestId("org-dashboard-link");
+		if (await dashboardLink.CountAsync() == 0)
+			return;
+
+		await dashboardLink.First.ClickAsync();
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await createBtn.First.ClickAsync();
 
@@ -284,16 +308,10 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 			.Filter(new() { HasText = uniqueTitle });
 		await Expect(draftInPublicList).Not.ToBeVisibleAsync();
 
-		// Navigate to org dashboard via the org switcher.
-		// The switcher toggle has aria-label "Switch organization" (en) / "Organisation wechseln" (de).
-		var switcherBtn = Page.Locator("button[aria-expanded]");
-		if (await switcherBtn.CountAsync() == 0)
-			return;
+		// Navigate back to the org dashboard - the draft is listed there.
+		await Page.GoBackAsync();
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await switcherBtn.First.ClickAsync();
-		await Page.GetByTestId("org-dashboard-link").ClickAsync();
-
-		// Drafts section is visible.
 		var draftsSection = Page.GetByTestId("drafts-section");
 		await Expect(draftsSection).ToBeVisibleAsync();
 
@@ -319,9 +337,22 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
-		if (await createBtn.CountAsync() == 0)
+		// Create opportunity lives on the organization dashboard - navigate there
+		// via the org switcher. Switcher toggle has aria-label "Switch organization"
+		// (en) / "Organisation wechseln" (de).
+		var switcherBtn = Page.Locator("button[aria-expanded]");
+		if (await switcherBtn.CountAsync() == 0)
+			return; // no org membership in seed - skip
+
+		await switcherBtn.First.ClickAsync();
+		var dashboardLink = Page.GetByTestId("org-dashboard-link");
+		if (await dashboardLink.CountAsync() == 0)
 			return; // no org selected in seed - skip
+
+		await dashboardLink.First.ClickAsync();
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await createBtn.First.ClickAsync();
 

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -3,16 +3,10 @@ import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
-import { getActiveOrgId } from "../lib/activeOrg";
 import { formatOccurrence } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
-import CreateVolunteerOpportunityModal from "./CreateVolunteerOpportunityModal";
 import EmptyState from "./EmptyState";
-
-interface Props {
-	canCreateOpportunity: boolean;
-}
 
 const LIST_PAGE_SIZE = 10;
 
@@ -815,9 +809,7 @@ function FilterDropdown({
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function VolunteerOpportunitiesList({
-	canCreateOpportunity,
-}: Props) {
+export default function VolunteerOpportunitiesList() {
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -856,8 +848,6 @@ export default function VolunteerOpportunitiesList({
 	const [loading, setLoading] = useState(true);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [refreshKey, setRefreshKey] = useState(0);
-	const [showModal, setShowModal] = useState(false);
 
 	useEffect(() => {
 		function handleOutside(e: MouseEvent) {
@@ -931,7 +921,6 @@ export default function VolunteerOpportunitiesList({
 		dateTo,
 		categories: categoriesParam,
 		tag,
-		refreshKey,
 	});
 
 	useEffect(() => {
@@ -946,8 +935,7 @@ export default function VolunteerOpportunitiesList({
 			prev.dateFrom !== dateFrom ||
 			prev.dateTo !== dateTo ||
 			prev.categories !== categoriesParam ||
-			prev.tag !== tag ||
-			prev.refreshKey !== refreshKey;
+			prev.tag !== tag;
 
 		prevFiltersRef.current = {
 			lat,
@@ -960,7 +948,6 @@ export default function VolunteerOpportunitiesList({
 			dateTo,
 			categories: categoriesParam,
 			tag,
-			refreshKey,
 		};
 
 		if (filterChanged) {
@@ -1040,10 +1027,7 @@ export default function VolunteerOpportunitiesList({
 		dateTo,
 		categoriesParam,
 		tag,
-		refreshKey,
 	]);
-
-	const activeOrgId = getActiveOrgId();
 
 	function updateFilter(key: string, value: string) {
 		const next = new URLSearchParams(window.location.search);
@@ -1205,16 +1189,6 @@ export default function VolunteerOpportunitiesList({
 				<p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-gray-500 sm:text-base">
 					{t("opportunities.subtitle")}
 				</p>
-				{canCreateOpportunity && (
-					<button
-						type="button"
-						onClick={() => setShowModal(true)}
-						data-testid="create-opportunity-btn"
-						className="mt-5 inline-flex items-center gap-1.5 rounded-xl bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none"
-					>
-						{t("opportunities.createNeed")}
-					</button>
-				)}
 			</div>
 
 			{/* Filter bar */}
@@ -1752,14 +1726,6 @@ export default function VolunteerOpportunitiesList({
 						</div>
 					)}
 				</>
-			)}
-
-			{showModal && activeOrgId && (
-				<CreateVolunteerOpportunityModal
-					organizationId={activeOrgId}
-					onClose={() => setShowModal(false)}
-					onSuccess={() => setRefreshKey((k) => k + 1)}
-				/>
 			)}
 		</div>
 	);

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -82,7 +82,6 @@
     "opportunities": {
       "currentNeeds": "Aktuelle Einsätze",
       "subtitle": "Finde eine Aufgabe in deiner Nähe und pack mit an - die meisten dauern nur wenige Stunden.",
-      "createNeed": "+ Einsatz erstellen",
       "searchPlaceholder": "Suche…",
       "cityPlaceholder": "Stadt…",
       "allFrequencies": "Alle Häufigkeiten",
@@ -784,7 +783,8 @@
       "calendarWorkWeek": "Arbeitswoche",
       "calendarDay": "Tag",
       "eventFillState": "{{booked}} / {{max}} gebucht",
-      "eventManageApplications": "Bewerbungen verwalten"
+      "eventManageApplications": "Bewerbungen verwalten",
+      "createOpportunity": "+ Einsatz erstellen"
     }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -82,7 +82,6 @@
     "opportunities": {
       "currentNeeds": "Current Opportunities",
       "subtitle": "Find a cause near you and lend a hand - most take just a few hours.",
-      "createNeed": "+ Create opportunity",
       "searchPlaceholder": "Search…",
       "cityPlaceholder": "City…",
       "allFrequencies": "All frequencies",
@@ -784,7 +783,8 @@
       "calendarWorkWeek": "Work week",
       "calendarDay": "Day",
       "eventFillState": "{{booked}} / {{max}} booked",
-      "eventManageApplications": "Manage applications"
+      "eventManageApplications": "Manage applications",
+      "createOpportunity": "+ Create opportunity"
     }
   }
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -125,12 +125,6 @@ export default function HomePage() {
 		setShowOnboarding(false);
 	}
 
-	const roles = (
-		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
-	) as string[];
-	const canCreateOpportunity =
-		auth.isAuthenticated && roles.includes("organisator");
-
 	const steps = [
 		{
 			step: 1,
@@ -502,9 +496,7 @@ export default function HomePage() {
 				{showOnboarding && (
 					<OnboardingBanner onDismiss={handleDismissOnboarding} />
 				)}
-				<VolunteerOpportunitiesList
-					canCreateOpportunity={canCreateOpportunity}
-				/>
+				<VolunteerOpportunitiesList />
 			</div>
 		</>
 	);

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -15,6 +15,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { inputClass, labelClass } from "../lib/formClasses";
 import EmptyState from "../components/EmptyState";
+import CreateVolunteerOpportunityModal from "../components/CreateVolunteerOpportunityModal";
 
 const rbcLocales = {
 	"en-US": enUS,
@@ -146,6 +147,14 @@ export default function OrganizationOverviewPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [organizationId]);
 
+	// ── Create opportunity ───────────────────────────────────────────────────
+	const [showCreateModal, setShowCreateModal] = useState(false);
+
+	function handleOpportunityCreated() {
+		loadCalendarEvents();
+		setEngInitialized(false);
+	}
+
 	// ── Calendar tab ────────────────────────────────────────────────────────
 	const [calData, setCalData] = useState<OrganizationCalendarEventDto[]>([]);
 	const [calLoading, setCalLoading] = useState(true);
@@ -166,7 +175,7 @@ export default function OrganizationOverviewPage() {
 		return () => document.removeEventListener("keydown", handleKey);
 	}, [selectedEvent]);
 
-	useEffect(() => {
+	function loadCalendarEvents() {
 		if (!organizationId) return;
 		setCalLoading(true);
 		setCalError(null);
@@ -177,6 +186,10 @@ export default function OrganizationOverviewPage() {
 				setCalError(e instanceof Error ? e.message : String(e)),
 			)
 			.finally(() => setCalLoading(false));
+	}
+
+	useEffect(() => {
+		loadCalendarEvents();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [organizationId]);
 
@@ -433,9 +446,21 @@ export default function OrganizationOverviewPage() {
 
 	return (
 		<div className={activeTab !== "calendar" ? "max-w-2xl" : ""}>
-			<h1 className="mb-6 text-2xl font-bold text-gray-900">
-				{org?.name ?? t("orgDashboard.title")}
-			</h1>
+			<div className="mb-6 flex items-center justify-between gap-3">
+				<h1 className="text-2xl font-bold text-gray-900">
+					{org?.name ?? t("orgDashboard.title")}
+				</h1>
+				{organizationId && (
+					<button
+						type="button"
+						onClick={() => setShowCreateModal(true)}
+						data-testid="create-opportunity-btn"
+						className="inline-flex shrink-0 items-center gap-1.5 rounded-xl bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none"
+					>
+						{t("orgOverview.createOpportunity")}
+					</button>
+				)}
+			</div>
 
 			{/* Tab bar */}
 			<div className="mb-6 border-b border-gray-200">
@@ -1192,6 +1217,14 @@ export default function OrganizationOverviewPage() {
 						</>
 					)}
 				</div>
+			)}
+
+			{showCreateModal && organizationId && (
+				<CreateVolunteerOpportunityModal
+					organizationId={organizationId}
+					onClose={() => setShowCreateModal(false)}
+					onSuccess={handleOpportunityCreated}
+				/>
 			)}
 		</div>
 	);

--- a/scripts/smoke-test-575-move-create-opportunity.mjs
+++ b/scripts/smoke-test-575-move-create-opportunity.mjs
@@ -1,0 +1,129 @@
+/**
+ * Smoke test for #575: "Create Opportunity" moved from the homepage to the
+ * organization dashboard.
+ * Verifies: the homepage no longer shows a create button (for anyone), and
+ * an organizer can find + use the create action on their org dashboard,
+ * scoped by the dashboard's own organizationId.
+ * Run: node scripts/smoke-test-575-move-create-opportunity.mjs
+ *
+ * Requires a logged-in organisator account (olaf/olaf123) and an existing org.
+ */
+
+import { chromium } from "playwright";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const apiRes = await fetch(`${API}/health`);
+	if (!apiRes.ok) throw new Error(`Health check failed: ${apiRes.status}`);
+	console.log("OK  API health check passed");
+
+	// The sandbox's egress proxy re-terminates TLS; Chromium's default
+	// ClientHello (HTTP/2, QUIC, PQ-Kyber/ECH) resets against it, so pin an
+	// older negotiation profile. Not needed outside this sandboxed runner.
+	const browser = await chromium.launch({
+		executablePath: "/opt/pw-browsers/chromium",
+		proxy: { server: process.env.HTTPS_PROXY ?? "http://127.0.0.1:42149" },
+		args: [
+			"--no-sandbox",
+			"--disable-setuid-sandbox",
+			"--disable-http2",
+			"--disable-quic",
+			"--ssl-version-max=tls1.2",
+			"--disable-features=PostQuantumKyber,EncryptedClientHello",
+		],
+	});
+	const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+	const page = await ctx.newPage();
+
+	try {
+		// --- Login as organisator ---
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		if ((await signInBtn.count()) > 0) {
+			await signInBtn.first().click();
+			await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+
+			await page.fill("#username", "olaf");
+			await page.click("#kc-login");
+			await page.fill("#password", "olaf123");
+			await page.click("#kc-login");
+			await page.waitForURL(BASE + "/**", { timeout: 15000 });
+			console.log("OK  Logged in as olaf (organisator)");
+		}
+
+		await page.waitForSelector("main", { timeout: 10000 });
+
+		// --- Homepage must NOT show a create-opportunity button anymore ---
+		const homeCreateBtn = page.getByTestId("create-opportunity-btn");
+		if ((await homeCreateBtn.count()) > 0) {
+			throw new Error(
+				"Create-opportunity button still present on the homepage",
+			);
+		}
+		console.log("OK  Homepage shows no create-opportunity button");
+
+		// --- Navigate to the org dashboard via the org switcher ---
+		const switcherBtn = page.getByRole("button", {
+			name: /switch organization|organisation wechseln/i,
+		});
+		try {
+			await switcherBtn.first().waitFor({ state: "visible", timeout: 8000 });
+		} catch {
+			console.log(
+				"WARN  Org switcher not visible (olaf has no org membership) - skipping dashboard checks",
+			);
+			return;
+		}
+		await switcherBtn.first().click();
+
+		const dashboardLink = page.getByTestId("org-dashboard-link");
+		try {
+			await dashboardLink.first().waitFor({ state: "visible", timeout: 5000 });
+		} catch {
+			console.log(
+				"WARN  org-dashboard-link not found - skipping dashboard checks",
+			);
+			return;
+		}
+		await dashboardLink.first().click();
+		await page.waitForURL(/\/organizations\/.+\/dashboard/, {
+			timeout: 10000,
+		});
+		console.log("OK  Navigated to organization dashboard");
+
+		// --- Create-opportunity button present on the dashboard, on every tab ---
+		const dashCreateBtn = page.getByTestId("create-opportunity-btn");
+		await dashCreateBtn.waitFor({ state: "visible", timeout: 8000 });
+		console.log("OK  Create-opportunity button present on org dashboard (calendar tab)");
+
+		for (const tab of ["engagements", "members", "settings"]) {
+			await page.getByRole("button", { name: new RegExp(tab, "i") }).click();
+			await dashCreateBtn.waitFor({ state: "visible", timeout: 5000 });
+		}
+		console.log("OK  Create-opportunity button remains visible across all tabs");
+
+		// --- Clicking it opens the create wizard, scoped to this org ---
+		await dashCreateBtn.click();
+		await page.waitForSelector('[role="dialog"]', { timeout: 8000 });
+		console.log("OK  Create-opportunity dialog opens from the dashboard");
+
+		await page.keyboard.press("Escape");
+		await page.waitForSelector('[role="dialog"]', {
+			state: "hidden",
+			timeout: 5000,
+		});
+		console.log("OK  Escape key closes dialog");
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Resolves #575.

- Removes the "+ Create opportunity" button and its `canCreateOpportunity` gating entirely from `HomePage.tsx` / `VolunteerOpportunitiesList.tsx`, so the homepage is a purely volunteer-facing browse page again. Also drops the now-dead `getActiveOrgId()`/`activeOrgId`/`showModal`/`refreshKey` plumbing that existed solely to support that button.
- Adds a "Create Opportunity" action to the organization dashboard header (`OrganizationOverviewPage.tsx`, visible on every tab), wired to the route's `organizationId` directly - no reliance on the `active-org` cookie, so an organizer managing multiple organizations can no longer create an opportunity under the wrong one by mistake.
- On success, the dashboard refetches the calendar tab's events and resets the engagements tab so the new opportunity shows up without a manual reload.
- Added `orgOverview.createOpportunity` translation key (en/de) and removed the now-unused `opportunities.createNeed` key.

## Test plan

- [x] `pnpm check` (tsc) - clean
- [x] `pnpm lint` (zero warnings) - clean
- [x] `pnpm format:write` - no changes needed
- [x] `dotnet build` (backend + NSwag regen) - clean
- [x] Updated the 3 Playwright/TUnit tests in `backend/tests/VisualTests/VolunteerOpportunityTests.cs` that opened the create wizard from the homepage right after login - they now navigate to the org dashboard via the org switcher (`org-dashboard-link`) first, matching the new entry point.
- [x] Ran the full `VolunteerOpportunityTests` suite locally against the Aspire stack (Postgres + Keycloak + Playwright, Docker): **10/10 passed**, including the 3 updated tests.

## Live verification

Ran the full `VolunteerOpportunityTests` suite (`dotnet run --project tests/VisualTests`) against a local Aspire-orchestrated stack - all 10 tests passed, confirming the create-opportunity flow works end-to-end from the org dashboard for an organizer (`olaf`) with an active organization, including the draft-visibility and Waitlist-publish-gap regression tests that exercise the wizard.

A release-candidate branch will be cut from this branch to deploy to `https://einsatzbereit.maik-hasler.de` staging for an additional live smoke check, per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01XB5dnyzMEmH2BacLNwpUpY)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB5dnyzMEmH2BacLNwpUpY)_