### PR TITLE
fix: enforce org-membership ownership check on RemoveMember endpoint

### DIFF
--- a/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
+++ b/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
@@ -3,7 +3,10 @@ using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.RemoveMember.v1;
+using Domain.Primitives;
+using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace Api.Organizations.RemoveMember.v1;
 
@@ -16,6 +19,7 @@ internal sealed class RemoveMemberEndpoint
 			.WithName("RemoveMember")
 			.Produces(StatusCodes.Status204NoContent)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
@@ -27,9 +31,12 @@ internal sealed class RemoveMemberEndpoint
 		[FromRoute] Guid organizationId,
 		[FromRoute] Guid userId,
 		[FromServices] ISender sender,
+		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
-		var command = new RemoveMemberCommand(organizationId, userId);
+		var requestingUserId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? new UserId(uid) : throw new DomainException("Invalid user.");
+
+		var command = new RemoveMemberCommand(organizationId, userId, requestingUserId);
 
 		await sender.Send(command, cancellationToken);
 

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1972,6 +1972,16 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {

--- a/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommand.cs
+++ b/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommand.cs
@@ -1,8 +1,10 @@
 using Application.Common.Messaging;
+using Domain.Users;
 
 namespace Application.Organizations.RemoveMember.v1;
 
 public sealed record RemoveMemberCommand(
 	Guid OrganizationId,
-	Guid UserId)
+	Guid UserId,
+	UserId RequestingUserId)
 	: ICommand<bool>;

--- a/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
+++ b/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
@@ -1,3 +1,4 @@
+using Application.Common.Authorization;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 
@@ -11,6 +12,12 @@ internal sealed class RemoveMemberCommandHandler(
 		RemoveMemberCommand request,
 		CancellationToken cancellationToken = default)
 	{
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrganizationService,
+			request.OrganizationId,
+			request.RequestingUserId,
+			cancellationToken);
+
 		await keycloakOrganizationService.RemoveMemberAsync(
 			request.OrganizationId, request.UserId, cancellationToken);
 

--- a/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
@@ -1,6 +1,8 @@
 using Application.Common.Keycloak;
 using Application.Organizations.RemoveMember.v1;
 using AwesomeAssertions;
+using Domain.Primitives;
+using Domain.Users;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -12,10 +14,17 @@ public class RemoveMemberCommandHandlerTests
 	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
 	private readonly RemoveMemberCommandHandler _sut;
 
+	private static readonly UserId DefaultRequestingUserId = new(Guid.CreateVersion7());
+
 	public RemoveMemberCommandHandlerTests()
 	{
 		_sut = new RemoveMemberCommandHandler(_keycloakService);
 	}
+
+	private void AllowRequestingUserInOrg(Guid orgId) =>
+		_keycloakService
+			.GetUserOrganizationsAsync(DefaultRequestingUserId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganization(orgId, "Test Org")]);
 
 	[Test]
 	public async Task Handle_ShouldCallRemoveMemberOnKeycloak(
@@ -24,7 +33,8 @@ public class RemoveMemberCommandHandlerTests
 		// Arrange
 		var orgId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new RemoveMemberCommand(orgId, userId);
+		AllowRequestingUserInOrg(orgId);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -38,7 +48,9 @@ public class RemoveMemberCommandHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var command = new RemoveMemberCommand(Guid.NewGuid(), Guid.NewGuid());
+		var orgId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		var command = new RemoveMemberCommand(orgId, Guid.NewGuid(), DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -54,7 +66,8 @@ public class RemoveMemberCommandHandlerTests
 		// Arrange
 		var orgId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new RemoveMemberCommand(orgId, userId);
+		AllowRequestingUserInOrg(orgId);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
 
 		_keycloakService
 			.RemoveMemberAsync(orgId, userId, cancellationToken)
@@ -66,5 +79,25 @@ public class RemoveMemberCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<HttpRequestException>()
 			.WithMessage("*404*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMemberOfTheOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		_keycloakService
+			.GetUserOrganizationsAsync(DefaultRequestingUserId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganization(Guid.NewGuid(), "Unrelated Org")]);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>();
+		await _keycloakService.DidNotReceive().RemoveMemberAsync(orgId, userId, Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -3515,6 +3515,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -164,10 +164,13 @@ public class OrganizationSettingsTests(
 	public async Task RemoveMember_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{
-		// vera creates her own organization and becomes its sole member/organizer.
+		// vera creates her own organization and becomes its sole member/organizer. Her original
+		// access token predates that role grant, so a fresh token is needed to call organizer-only
+		// endpoints against her own org afterwards.
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var veraOrg = await veraClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Vera's Unrelated Org" }, cancellationToken);
+		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var veraOrgDetails = await veraClient.GetOrganizationDetailsAsync(veraOrg.Id.Value, cancellationToken);
 		var veraUserId = veraOrgDetails.Members.Single().UserId;
 

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -160,6 +160,29 @@ public class OrganizationSettingsTests(
 		ex.Which.StatusCode.Should().Be(401);
 	}
 
+	[Test]
+	public async Task RemoveMember_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization(
+		CancellationToken cancellationToken)
+	{
+		// vera creates her own organization and becomes its sole member/organizer.
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var veraOrg = await veraClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Vera's Unrelated Org" }, cancellationToken);
+		var veraOrgDetails = await veraClient.GetOrganizationDetailsAsync(veraOrg.Id.Value, cancellationToken);
+		var veraUserId = veraOrgDetails.Members.Single().UserId;
+
+		// olaf is an organizer of other organizations, but not a member of vera's.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+
+		var act = () => olafClient.RemoveMemberAsync(veraOrg.Id.Value, veraUserId, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
+
+		var stillThere = await veraClient.GetOrganizationDetailsAsync(veraOrg.Id.Value, cancellationToken);
+		stillThere.Members.Should().ContainSingle(m => m.UserId == veraUserId);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
 	{
 		var token = await fixture.GetAccessTokenAsync(username, password);

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1804,6 +1804,12 @@ export class EinsatzbereitApi {
             result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Unauthorized", status, _responseText, _headers, result401);
             });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
         } else if (status === 404) {
             return response.text().then((_responseText) => {
             let result404: any = null;


### PR DESCRIPTION
## Summary

Resolves #578.

`RemoveMemberCommandHandler` called straight through to
`IKeycloakOrganizationService.RemoveMemberAsync` with no check that the
requesting user actually belongs to the target organization. The endpoint
is only gated by the platform-wide `organisator` role
(`RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)`),
which is not scoped to a specific organization - so any user holding that
role for *any* organization could remove any member (including other
organizers) from *any* organization, fully orphaning it.

Fix follows the exact pattern already used by
`UpdateOrganizationCommandHandler`/`GetOrganizationDetailsQueryHandler`:

- `RemoveMemberCommand` gains a `RequestingUserId` (`UserId`) parameter.
- `RemoveMemberEndpoint` populates it from the JWT `sub` claim (same as
  `UpdateOrganizationEndpoint`).
- `RemoveMemberCommandHandler` calls `OwnershipGuard.EnsureIsOrgMemberAsync`
  before removing the member, throwing a `DomainException` ("... permission
  ...") that the existing `DomainExceptionHandler` maps to `403 Forbidden`.

No route/request-body/frontend changes needed - the requesting user comes
from the JWT, not the request payload, so the NSwag-generated API client
only picked up the new documented `403` response.

## Test plan

- [x] `dotnet build` (backend + NSwag regen) - clean, 0 warnings/errors
- [x] `dotnet test tests/Application.UnitTests` - 190/190 passed, including
      updated `RemoveMemberCommandHandlerTests` (added a case asserting the
      handler throws and never calls Keycloak when the requester isn't an
      org member)
- [x] `dotnet test tests/ArchitectureTests` - 240/240 passed (no layering
      violations introduced)
- [x] `pnpm check` (tsc) - clean
- [x] `pnpm lint` - clean
- [x] Added `RemoveMember_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization`
      to `backend/tests/IntegrationTests/OrganizationSettingsTests.cs`,
      reproducing the exact exploit from the issue (`vera` creates her own
      org; `olaf`, an organizer of unrelated orgs, is rejected with `403`
      when trying to remove vera from her org, and she's still a member
      afterwards). Integration tests require Testcontainers/Docker, which
      isn't available in this sandbox, so this test will run in CI.

## Live verification

A release-candidate branch will be cut from this branch per `CLAUDE.md` to
deploy to `https://einsatzbereit.maik-hasler.de` staging and verify the fix
end-to-end (confirm a cross-org removal attempt now returns 403, and that a
legitimate same-org removal still succeeds), before this task is considered
complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W31MMJ7aET2ojfzim7HTek

---
_Generated by [Claude Code](https://claude.ai/code/session_01W31MMJ7aET2ojfzim7HTek)_