### PR TITLE
fix: replace native selects with accessible custom dropdown, add modal edge margin (#573)

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -234,4 +234,39 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
+
+	[Test]
+	public async Task SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations()
+	{
+		// #573: the native time slot <select> was replaced with a custom
+		// accessible combobox/listbox - assert the open dropdown itself is
+		// axe-clean, not just the page around it.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var signUpBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Select a slot" });
+		try
+		{
+			await signUpBtn.WaitForAsync(new() { Timeout = 10_000 });
+		}
+		catch (TimeoutException)
+		{
+			return; // no waitlist opportunity with open slots seeded, skip
+		}
+
+		await signUpBtn.ClickAsync();
+		await Page.WaitForSelectorAsync("[role='dialog']");
+
+		var dropdown = Page.Locator("#sign-up-time-slot");
+		if (await dropdown.CountAsync() == 0)
+			return; // opportunity has no time slots to pick from, skip
+
+		await dropdown.ClickAsync();
+		await Expect(Page.Locator("[role='option']").First).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
 }

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -104,10 +104,15 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		await signUpBtn.ClickAsync();
 		await Page.WaitForSelectorAsync("[role='dialog']");
 
-		var slotSelect = Page.Locator("select");
-		await Expect(slotSelect).ToBeVisibleAsync();
+		// #573: the time slot picker is a custom accessible dropdown (role="combobox"
+		// trigger + role="option" list), not a native <select>.
+		var slotDropdown = Page.Locator("#sign-up-time-slot");
+		await Expect(slotDropdown).ToBeVisibleAsync();
+		await slotDropdown.ClickAsync();
 
-		var options = await slotSelect.Locator("option").AllTextContentsAsync();
+		var optionLocator = Page.Locator("[role='option']");
+		await Expect(optionLocator.First).ToBeVisibleAsync();
+		var options = await optionLocator.AllTextContentsAsync();
 		options.Should().NotBeEmpty("slot options must be rendered");
 
 		var hasAvailabilityInfo = options.Any(o =>

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -58,7 +58,7 @@ export default function CheckInModal({
 	const checkInMethod = details?.checkInMethod;
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -31,7 +31,7 @@ export default function ConfirmDialog({
 	}, [onClose]);
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -41,7 +41,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 	};
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/components/CreateVolunteerOpportunityModal.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal.tsx
@@ -10,6 +10,7 @@ import type {
 import { useApiClient } from "../hooks/useApiClient";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
+import Dropdown from "./Dropdown";
 
 const TOTAL_STEPS = 4;
 const MAX_BANNER_BYTES = 2 * 1024 * 1024;
@@ -1070,39 +1071,40 @@ export default function CreateVolunteerOpportunityModal({
 								>
 									{t("createOpportunity.fieldCategory")}
 								</label>
-								<select
+								<Dropdown
 									id="create-category"
 									value={form.category ?? ""}
-									onChange={(e) =>
+									onChange={(v) =>
 										setForm((f) => ({
 											...f,
-											category: e.target.value || undefined,
+											category: v || undefined,
 										}))
 									}
 									className={selectClass}
-								>
-									<option value="">
-										{t("createOpportunity.fieldCategoryNone")}
-									</option>
-									{(
-										[
-											"Social",
-											"Environment",
-											"Sport",
-											"Education",
-											"DisasterRelief",
-											"Health",
-											"Animals",
-											"Culture",
-											"Technology",
-											"Other",
-										] as const
-									).map((c) => (
-										<option key={c} value={c}>
-											{t(`opportunities.category.${c}`)}
-										</option>
-									))}
-								</select>
+									options={[
+										{
+											value: "",
+											label: t("createOpportunity.fieldCategoryNone"),
+										},
+										...(
+											[
+												"Social",
+												"Environment",
+												"Sport",
+												"Education",
+												"DisasterRelief",
+												"Health",
+												"Animals",
+												"Culture",
+												"Technology",
+												"Other",
+											] as const
+										).map((c) => ({
+											value: c,
+											label: t(`opportunities.category.${c}`),
+										})),
+									]}
+								/>
 							</div>
 
 							<div>
@@ -1264,21 +1266,22 @@ export default function CreateVolunteerOpportunityModal({
 													>
 														{t("timeSlots.recurrenceFrequency")}
 													</label>
-													<select
+													<Dropdown
 														id="slot-recurrence-frequency"
 														value={recurrenceFrequency}
-														onChange={(e) =>
-															setRecurrenceFrequency(e.target.value)
-														}
+														onChange={setRecurrenceFrequency}
 														className={selectClass}
-													>
-														<option value="Weekly">
-															{t("timeSlots.recurrenceWeekly")}
-														</option>
-														<option value="Monthly">
-															{t("timeSlots.recurrenceMonthly")}
-														</option>
-													</select>
+														options={[
+															{
+																value: "Weekly",
+																label: t("timeSlots.recurrenceWeekly"),
+															},
+															{
+																value: "Monthly",
+																label: t("timeSlots.recurrenceMonthly"),
+															},
+														]}
+													/>
 												</div>
 												<div>
 													<label

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+export interface DropdownOption {
+	value: string;
+	label: string;
+	disabled?: boolean;
+}
+
+interface DropdownProps {
+	id: string;
+	value: string;
+	onChange: (value: string) => void;
+	options: DropdownOption[];
+	placeholder?: string;
+	disabled?: boolean;
+	className?: string;
+}
+
+function firstEnabledIndex(options: DropdownOption[]): number {
+	return options.findIndex((o) => !o.disabled);
+}
+
+function lastEnabledIndex(options: DropdownOption[]): number {
+	for (let i = options.length - 1; i >= 0; i--) {
+		if (!options[i].disabled) return i;
+	}
+	return -1;
+}
+
+/**
+ * Accessible replacement for a native <select>, styled to match the app's
+ * inputs instead of falling back to the browser/OS picker. Implements the
+ * WAI-ARIA "select-only combobox" pattern - focus stays on the trigger
+ * button and the active option is tracked via aria-activedescendant.
+ */
+export default function Dropdown({
+	id,
+	value,
+	onChange,
+	options,
+	placeholder,
+	disabled = false,
+	className = "",
+}: DropdownProps) {
+	const [open, setOpen] = useState(false);
+	const [activeIndex, setActiveIndex] = useState(-1);
+	const rootRef = useRef<HTMLDivElement>(null);
+	const listRef = useRef<HTMLUListElement>(null);
+	const typeaheadBuffer = useRef("");
+	const typeaheadTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+	const listboxId = `${id}-listbox`;
+
+	const selectedIndex = options.findIndex((o) => o.value === value);
+	const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+
+	useEffect(() => {
+		if (!open) return;
+		function handleClick(e: MouseEvent) {
+			if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		}
+		document.addEventListener("click", handleClick);
+		return () => document.removeEventListener("click", handleClick);
+	}, [open]);
+
+	useEffect(() => {
+		if (open) {
+			setActiveIndex(
+				selectedIndex >= 0 ? selectedIndex : firstEnabledIndex(options),
+			);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open]);
+
+	useEffect(() => {
+		if (!open || activeIndex < 0) return;
+		const el = listRef.current?.children[activeIndex] as
+			HTMLElement | undefined;
+		el?.scrollIntoView({ block: "nearest" });
+	}, [open, activeIndex]);
+
+	function moveActive(delta: number) {
+		if (options.every((o) => o.disabled)) return;
+		setActiveIndex((prev) => {
+			let next = prev;
+			for (let i = 0; i < options.length; i++) {
+				next = (next + delta + options.length) % options.length;
+				if (!options[next].disabled) return next;
+			}
+			return prev;
+		});
+	}
+
+	function commit(index: number) {
+		const opt = options[index];
+		if (!opt || opt.disabled) return;
+		onChange(opt.value);
+		setOpen(false);
+	}
+
+	function handleTypeahead(char: string) {
+		window.clearTimeout(typeaheadTimeout.current);
+		typeaheadBuffer.current += char.toLowerCase();
+		const buffer = typeaheadBuffer.current;
+		typeaheadTimeout.current = setTimeout(() => {
+			typeaheadBuffer.current = "";
+		}, 500);
+		const startFrom = (open ? activeIndex : selectedIndex) + 1;
+		for (let i = 0; i < options.length; i++) {
+			const idx = (startFrom + i) % options.length;
+			const opt = options[idx];
+			if (!opt.disabled && opt.label.toLowerCase().startsWith(buffer)) {
+				if (open) setActiveIndex(idx);
+				else onChange(opt.value);
+				return;
+			}
+		}
+	}
+
+	function handleKeyDown(e: ReactKeyboardEvent<HTMLButtonElement>) {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				if (!open) setOpen(true);
+				else moveActive(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				if (!open) setOpen(true);
+				else moveActive(-1);
+				break;
+			case "Home":
+				if (open) {
+					e.preventDefault();
+					setActiveIndex(firstEnabledIndex(options));
+				}
+				break;
+			case "End":
+				if (open) {
+					e.preventDefault();
+					setActiveIndex(lastEnabledIndex(options));
+				}
+				break;
+			case "Enter":
+			case " ":
+				e.preventDefault();
+				if (open) commit(activeIndex);
+				else setOpen(true);
+				break;
+			case "Escape":
+				if (open) {
+					e.preventDefault();
+					setOpen(false);
+				}
+				break;
+			case "Tab":
+				setOpen(false);
+				break;
+			default:
+				if (e.key.length === 1 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+					handleTypeahead(e.key);
+				}
+		}
+	}
+
+	return (
+		<div className="relative" ref={rootRef}>
+			<button
+				type="button"
+				id={id}
+				role="combobox"
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				aria-controls={listboxId}
+				aria-activedescendant={
+					open && activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined
+				}
+				disabled={disabled}
+				onClick={() => setOpen((o) => !o)}
+				onKeyDown={handleKeyDown}
+				className={`flex w-full items-center justify-between gap-2 text-left disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+			>
+				<span className={`truncate ${selected ? "" : "text-gray-400"}`}>
+					{selected ? selected.label : (placeholder ?? "")}
+				</span>
+				<svg
+					aria-hidden="true"
+					className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`}
+					fill="none"
+					viewBox="0 0 24 24"
+					strokeWidth="2"
+					stroke="currentColor"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="m19.5 8.25-7.5 7.5-7.5-7.5"
+					/>
+				</svg>
+			</button>
+
+			{open && (
+				<ul
+					ref={listRef}
+					id={listboxId}
+					role="listbox"
+					aria-labelledby={id}
+					className="absolute left-0 top-full z-50 mt-1 max-h-56 w-full overflow-auto rounded-lg border border-gray-200 bg-white py-1 text-sm shadow-lg"
+				>
+					{options.map((opt, index) => (
+						<li
+							key={opt.value}
+							id={`${id}-option-${index}`}
+							role="option"
+							aria-selected={opt.value === value}
+							aria-disabled={opt.disabled || undefined}
+							onMouseEnter={() => !opt.disabled && setActiveIndex(index)}
+							onMouseDown={(e) => {
+								// Keep focus on the trigger button (combobox pattern)
+								// instead of letting the option steal it.
+								e.preventDefault();
+								commit(index);
+							}}
+							className={`px-3 py-2 ${
+								opt.disabled
+									? "cursor-not-allowed text-gray-300"
+									: `cursor-pointer ${
+											index === activeIndex
+												? "bg-brand-50 text-brand-700"
+												: "text-gray-700 hover:bg-gray-50"
+										}`
+							}`}
+						>
+							{opt.label}
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -135,7 +135,7 @@ export default function QRScannerModal({
 	}, [onClose]);
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/components/ShareAchievementsModal.tsx
+++ b/frontend/src/components/ShareAchievementsModal.tsx
@@ -26,7 +26,7 @@ export default function ShareAchievementsModal({ shareUrl, onClose }: Props) {
 	}
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatDateTime } from "../lib/format";
+import Dropdown from "./Dropdown";
 
 interface Props {
 	opportunityId: string;
@@ -38,6 +39,10 @@ export default function SignUpModal({
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
+		if (isWaitlist && timeSlots.length > 0 && !selectedTimeSlotId) {
+			setError(t("signUp.selectTimeSlotRequired"));
+			return;
+		}
 		setSubmitting(true);
 		setError(null);
 
@@ -58,7 +63,7 @@ export default function SignUpModal({
 	}
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"
@@ -79,7 +84,10 @@ export default function SignUpModal({
 				<form onSubmit={handleSubmit} className="space-y-4">
 					{isWaitlist && (
 						<div>
-							<label className="mb-1 block text-sm font-medium text-gray-700">
+							<label
+								htmlFor="sign-up-time-slot"
+								className="mb-1 block text-sm font-medium text-gray-700"
+							>
 								{t("signUp.selectTimeSlot")}
 							</label>
 							{timeSlots.length === 0 ? (
@@ -87,36 +95,32 @@ export default function SignUpModal({
 									{t("signUp.noTimeSlots")}
 								</p>
 							) : (
-								<select
+								<Dropdown
+									id="sign-up-time-slot"
 									value={selectedTimeSlotId}
-									onChange={(e) => setSelectedTimeSlotId(e.target.value)}
-									required
-									className="w-full rounded border px-3 py-2 text-sm"
-								>
-									<option value="">{t("signUp.selectPlaceholder")}</option>
-									{timeSlots.map((ts) => {
+									onChange={setSelectedTimeSlotId}
+									placeholder={t("signUp.selectPlaceholder")}
+									className="rounded border px-3 py-2 text-sm"
+									options={timeSlots.map((ts) => {
 										const spotsLeft = ts.maxParticipants - ts.bookedCount;
 										const slotFull = spotsLeft <= 0;
-										return (
-											<option key={ts.id} value={ts.id} disabled={slotFull}>
-												{formatDateTime(
-													ts.startDateTime as unknown as string,
-													i18n.language,
-												)}{" "}
-												-{" "}
-												{formatDateTime(
-													ts.endDateTime as unknown as string,
-													i18n.language,
-												)}{" "}
-												{slotFull
+										return {
+											value: ts.id,
+											disabled: slotFull,
+											label: `${formatDateTime(
+												ts.startDateTime as unknown as string,
+												i18n.language,
+											)} - ${formatDateTime(
+												ts.endDateTime as unknown as string,
+												i18n.language,
+											)} ${
+												slotFull
 													? t("signUp.slotFull")
-													: t("signUp.spotsLeft", {
-															count: spotsLeft,
-														})}
-											</option>
-										);
+													: t("signUp.spotsLeft", { count: spotsLeft })
+											}`,
+										};
 									})}
-								</select>
+								/>
 							)}
 						</div>
 					)}

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -66,7 +66,7 @@ export default function SubmitFeedbackModal({
 	const displayRating = hovered || rating;
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -304,7 +304,8 @@
       "unknownError": "Unbekannter Fehler",
       "maxParticipants": "(max. {{count}})",
       "spotsLeft": "(noch {{count}})",
-      "slotFull": "(Ausgebucht)"
+      "slotFull": "(Ausgebucht)",
+      "selectTimeSlotRequired": "Bitte wähle einen Zeitslot aus."
     },
     "organization": {
       "create": "Organisation erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -304,7 +304,8 @@
       "unknownError": "Unknown error",
       "maxParticipants": "(max. {{count}})",
       "spotsLeft": "({{count}} left)",
-      "slotFull": "(Full)"
+      "slotFull": "(Full)",
+      "selectTimeSlotRequired": "Please select a time slot."
     },
     "organization": {
       "create": "Create organization",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -19,6 +19,7 @@ import BadgeGrid from "../components/BadgeGrid";
 import CheckInModal from "../components/CheckInModal";
 import ConfirmDialog from "../components/ConfirmDialog";
 import CreateOrganizationModal from "../components/CreateOrganizationModal";
+import Dropdown from "../components/Dropdown";
 import EmptyState from "../components/EmptyState";
 import ShareAchievementsModal from "../components/ShareAchievementsModal";
 import SubmitFeedbackModal from "../components/SubmitFeedbackModal";
@@ -800,24 +801,28 @@ export default function ProfileOverviewPage() {
 												label={t("profile.fieldPreferredContact")}
 												id="preferred-contact"
 											>
-												<select
+												<Dropdown
 													id="preferred-contact"
 													value={preferredContact}
-													onChange={(e) =>
-														setPreferredContact(e.target.value as ContactPref)
+													onChange={(v) =>
+														setPreferredContact(v as ContactPref)
 													}
 													className={inputClass}
-												>
-													<option value="">
-														{t("profile.preferredContactNone")}
-													</option>
-													<option value="Email">
-														{t("profile.preferredContactEmail")}
-													</option>
-													<option value="Phone">
-														{t("profile.preferredContactPhone")}
-													</option>
-												</select>
+													options={[
+														{
+															value: "",
+															label: t("profile.preferredContactNone"),
+														},
+														{
+															value: "Email",
+															label: t("profile.preferredContactEmail"),
+														},
+														{
+															value: "Phone",
+															label: t("profile.preferredContactPhone"),
+														},
+													]}
+												/>
 											</Field>
 										</div>
 									</section>


### PR DESCRIPTION
## Summary

Closes #573. Two things the earlier modal/edit-flow consistency pass (#536) didn't touch:

**Problem 1: native `<select>` breaks out of the app's look**

Replaced all 4 native `<select>` usages with a new shared `Dropdown` component (`components/Dropdown.tsx`):
- `SignUpModal.tsx` - time slot picker for waitlist sign-up
- `CreateVolunteerOpportunityModal.tsx` - category select and recurrence-frequency select
- `ProfileOverviewPage.tsx` - preferred-contact select

`Dropdown` implements the WAI-ARIA "select-only combobox" pattern: a `role="combobox"` trigger button with `aria-expanded`/`aria-controls`/`aria-activedescendant`, and a `role="listbox"`/`role="option"` popup. Supports Arrow Up/Down, Home/End, Enter/Space, Escape, typeahead-by-label, and disabled options (used for full time slots) - keyboard behavior matches what a native `<select>` gives you for free. Visual styling is passed in via `className` so it matches each call site's existing input style (the wizard's rounded-xl style vs. the plain-profile-form style) instead of introducing a third look.

Also added application-level validation in `SignUpModal` for the one case that relied on native `required` behavior (blocking submission with no slot selected) - the `Dropdown` itself has no native form-constraint validation to fall back on.

**Problem 2: modals sit flush against the screen edge on mobile**

Added `p-3 sm:p-4` to the outer wrapper of the remaining 7 modals that lacked it (`SignUpModal`, `CheckInModal`, `ConfirmDialog`, `CreateOrganizationModal`, `QRScannerModal`, `ShareAchievementsModal`, `SubmitFeedbackModal`), matching `CreateVolunteerOpportunityModal`'s existing pattern.

## Test plan

- [x] `pnpm check` / `pnpm lint` / `pnpm format:write` (frontend) - all green, zero warnings.
- [x] `dotnet build` (backend, including `VisualTests`) - green.
- [x] `dotnet test` on `ArchitectureTests` (no Docker needed) - 240/240 passed. `Application.UnitTests`/`IntegrationTests`/`VisualTests` need Postgres/Keycloak containers, unavailable in this sandbox - see Live verification.
- [x] Updated `CheckInAndSlotTests.WaitlistSignUpModal_ShowsPerSlotBookingCounts` to query the new `role="combobox"`/`role="option"` structure instead of `<select>`/`<option>`.
- [x] Added `AccessibilityTests.SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations`, which opens the new dropdown and runs axe against it directly (not just the surrounding page).
- [x] Checked for non-ASCII dashes across all changed files - none found.
- [ ] CI on this PR - pending.

## Live verification

Docker is unavailable in this sandbox, so the local Aspire stack can't run here. Per `CLAUDE.md`, this will be verified via a release-candidate deploy to staging once CI is green, exercised with a manual Playwright smoke script against `https://einsatzbereit.maik-hasler.de` covering: opening the sign-up modal's time slot dropdown (keyboard + click selection), the category/recurrence dropdowns in the opportunity wizard, the preferred-contact dropdown on the profile page, and confirming modals keep an edge margin on a narrow viewport. Results will be added here once the RC is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KUnf7FpigbQ88xvc9wyrGa)_