### PR TITLE
feat: distinguish leave from remove, protect last org member, add org deletion (#580)

### DIFF
--- a/backend/src/Api/Organizations/DeleteOrganization/v1/DeleteOrganizationEndpoint.cs
+++ b/backend/src/Api/Organizations/DeleteOrganization/v1/DeleteOrganizationEndpoint.cs
@@ -1,0 +1,45 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Organizations.DeleteOrganization.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Organizations.DeleteOrganization.v1;
+
+internal sealed class DeleteOrganizationEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapDelete("/organizations/{organizationId:guid}", DeleteOrganizationAsync)
+			.WithName("DeleteOrganization")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> DeleteOrganizationAsync(
+		[FromRoute] Guid organizationId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var requestingUserId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? new UserId(uid) : throw new DomainException("Invalid user.");
+
+		var command = new DeleteOrganizationCommand(organizationId, requestingUserId);
+
+		await sender.Send(command, cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1878,6 +1878,78 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "DeleteOrganizationEndpoint"
+        ],
+        "operationId": "DeleteOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/organizations/{organizationId}/members/search": {
@@ -5893,6 +5965,9 @@
     },
     {
       "name": "GetOrganizationDetailsEndpoint"
+    },
+    {
+      "name": "DeleteOrganizationEndpoint"
     },
     {
       "name": "SearchMemberCandidatesEndpoint"

--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -28,6 +28,10 @@ public interface IKeycloakOrganizationService
 		Guid userId,
 		CancellationToken cancellationToken = default);
 
+	Task DeleteOrganizationAsync(
+		Guid organizationId,
+		CancellationToken cancellationToken = default);
+
 	Task AssignOrganizerRoleAsync(
 		Guid userId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -78,6 +78,10 @@ public interface IApplicationDbContext
 		VolunteerOpportunityId opportunityId,
 		CancellationToken cancellationToken = default);
 
+	Task<List<VolunteerOpportunity>> GetBlockingOpportunitiesForOrganizationAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default);
+
 	Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommand.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommand.cs
@@ -1,0 +1,9 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.Organizations.DeleteOrganization.v1;
+
+public sealed record DeleteOrganizationCommand(
+	Guid OrganizationId,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
@@ -1,0 +1,54 @@
+using Application.Common.Authorization;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Application.Organizations.DeleteOrganization.v1;
+
+internal sealed class DeleteOrganizationCommandHandler(
+	IApplicationDbContext dbContext,
+	IKeycloakOrganizationService keycloakOrganizationService)
+	: ICommandHandler<DeleteOrganizationCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		DeleteOrganizationCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var organizationId = new OrganizationId(request.OrganizationId);
+
+		var organization = await dbContext.Organizations.FindAsync(organizationId, cancellationToken)
+			?? throw new DomainException($"Organization '{request.OrganizationId}' not found.");
+
+		await OwnershipGuard.EnsureIsOrgMemberAsync(
+			keycloakOrganizationService,
+			request.OrganizationId,
+			request.RequestingUserId,
+			cancellationToken);
+
+		var members = await keycloakOrganizationService.GetMembersAsync(
+			request.OrganizationId, cancellationToken);
+
+		if (members.Count > 1)
+			throw new DomainException(
+				"Conflict: only the organization's sole remaining member can delete it. Remove the other members first.");
+
+		var blockingOpportunities = await dbContext.GetBlockingOpportunitiesForOrganizationAsync(
+			organizationId, cancellationToken);
+
+		if (blockingOpportunities.Count > 0)
+		{
+			var titles = string.Join(", ", blockingOpportunities.Select(o => $"'{o.Title}'"));
+			throw new DomainException(
+				$"Conflict: cannot delete organization while it has opportunities with future time slots or active engagements: {titles}. Resolve or cancel these first.");
+		}
+
+		await keycloakOrganizationService.DeleteOrganizationAsync(
+			request.OrganizationId, cancellationToken);
+
+		dbContext.Organizations.Delete(organization);
+
+		return true;
+	}
+}

--- a/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
+++ b/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Authorization;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
+using Domain.Primitives;
 
 namespace Application.Organizations.RemoveMember.v1;
 
@@ -17,6 +18,13 @@ internal sealed class RemoveMemberCommandHandler(
 			request.OrganizationId,
 			request.RequestingUserId,
 			cancellationToken);
+
+		var members = await keycloakOrganizationService.GetMembersAsync(
+			request.OrganizationId, cancellationToken);
+
+		if (members.Count == 1 && members[0].UserId == request.UserId)
+			throw new DomainException(
+				"Conflict: you are the only member of this organization. Delete the organization instead of leaving it.");
 
 		await keycloakOrganizationService.RemoveMemberAsync(
 			request.OrganizationId, request.UserId, cancellationToken);

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -186,6 +186,19 @@ internal sealed class KeycloakOrganizationService(
 		await EnsureSuccessAsync(response, cancellationToken);
 	}
 
+	public async Task DeleteOrganizationAsync(
+		Guid organizationId,
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var response = await httpClient.DeleteAsync(
+			$"/admin/realms/{_options.Realm}/organizations/{organizationId}",
+			cancellationToken);
+
+		await EnsureSuccessAsync(response, cancellationToken);
+	}
+
 	private async Task EnsureAuthenticatedAsync(
 		CancellationToken cancellationToken) =>
 		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -146,6 +146,34 @@ internal sealed class ApplicationDbContext(
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 			.ToListAsync(cancellationToken);
 
+	public async Task<List<VolunteerOpportunity>> GetBlockingOpportunitiesForOrganizationAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunities = await Set<VolunteerOpportunity>()
+			.Include(vo => vo.TimeSlots)
+			.Where(vo => vo.OrganizationId == organizationId)
+			.ToListAsync(cancellationToken);
+
+		if (opportunities.Count == 0)
+			return [];
+
+		var opportunityIds = opportunities.Select(vo => vo.Id).ToList();
+		var now = DateTimeOffset.UtcNow;
+
+		var opportunityIdsWithActiveEngagements = await Set<Engagement>()
+			.Where(e => opportunityIds.Contains(e.OpportunityId)
+				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
+			.Select(e => e.OpportunityId)
+			.Distinct()
+			.ToListAsync(cancellationToken);
+
+		return opportunities
+			.Where(vo => vo.TimeSlots.Any(ts => ts.StartDateTime > now)
+				|| opportunityIdsWithActiveEngagements.Contains(vo.Id))
+			.ToList();
+	}
+
 	public async Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
@@ -1,0 +1,161 @@
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Organizations.DeleteOrganization.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.DeleteOrganization;
+
+public class DeleteOrganizationCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Organization, OrganizationId> _organizationRepo =
+		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly DeleteOrganizationCommandHandler _sut;
+
+	private static readonly UserId DefaultRequestingUserId = new(Guid.CreateVersion7());
+
+	public DeleteOrganizationCommandHandlerTests()
+	{
+		_dbContext.Organizations.Returns(_organizationRepo);
+		_dbContext
+			.GetBlockingOpportunitiesForOrganizationAsync(Arg.Any<OrganizationId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<VolunteerOpportunity>());
+		_sut = new DeleteOrganizationCommandHandler(_dbContext, _keycloakService);
+	}
+
+	private void AllowRequestingUserInOrg(Guid orgId) =>
+		_keycloakService
+			.GetUserOrganizationsAsync(DefaultRequestingUserId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganization(orgId, "Test Org")]);
+
+	private void SetMembers(Guid orgId, params Guid[] memberIds) =>
+		_keycloakService
+			.GetMembersAsync(orgId, Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)memberIds
+				.Select(id => new KeycloakOrganizationMember(id, "user", "First", "Last", "user@example.com", false))
+				.ToList());
+
+	private static Organization CreateOrganization(Guid id) =>
+		Organization.Create(new OrganizationId(id), "Test Org");
+
+	private static VolunteerOpportunity CreateOpportunityWithFutureTimeSlot(OrganizationId orgId)
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			orgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, status: OpportunityStatus.Draft);
+		opportunity.AddTimeSlot(DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 5);
+		return opportunity;
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteOrganizationAndCallKeycloak_WhenSoleMemberAndNoBlockingOpportunities(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(new OrganizationId(orgId), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		_organizationRepo.Received(1).Delete(organization);
+		await _keycloakService.Received(1).DeleteOrganizationAsync(orgId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOrganizationNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		_organizationRepo.FindAsync(new OrganizationId(orgId), cancellationToken).Returns((Organization?)null);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>()
+			.WithMessage($"*{orgId}*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(new OrganizationId(orgId), cancellationToken).Returns(organization);
+		_keycloakService
+			.GetUserOrganizationsAsync(DefaultRequestingUserId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganization(Guid.NewGuid(), "Unrelated Org")]);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>();
+		_organizationRepo.DidNotReceive().Delete(Arg.Any<Organization>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOtherMembersRemain(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(new OrganizationId(orgId), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value, Guid.NewGuid());
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>()
+			.WithMessage("*sole remaining member*");
+		_organizationRepo.DidNotReceive().Delete(Arg.Any<Organization>());
+		await _keycloakService.DidNotReceive().DeleteOrganizationAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityHasFutureTimeSlotOrActiveEngagement(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(new OrganizationId(orgId), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		var blockingOpportunity = CreateOpportunityWithFutureTimeSlot(new OrganizationId(orgId));
+		_dbContext
+			.GetBlockingOpportunitiesForOrganizationAsync(new OrganizationId(orgId), cancellationToken)
+			.Returns([blockingOpportunity]);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>()
+			.WithMessage("*Titel*");
+		_organizationRepo.DidNotReceive().Delete(Arg.Any<Organization>());
+		await _keycloakService.DidNotReceive().DeleteOrganizationAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
@@ -26,6 +26,14 @@ public class RemoveMemberCommandHandlerTests
 			.GetUserOrganizationsAsync(DefaultRequestingUserId.Value, Arg.Any<CancellationToken>())
 			.Returns([new KeycloakOrganization(orgId, "Test Org")]);
 
+	private void SetMembers(Guid orgId, params KeycloakOrganizationMember[] members) =>
+		_keycloakService
+			.GetMembersAsync(orgId, Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)members);
+
+	private static KeycloakOrganizationMember Member(Guid userId) =>
+		new(userId, "user", "First", "Last", "user@example.com", IsOrganisator: false);
+
 	[Test]
 	public async Task Handle_ShouldCallRemoveMemberOnKeycloak(
 		CancellationToken cancellationToken)
@@ -34,6 +42,7 @@ public class RemoveMemberCommandHandlerTests
 		var orgId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
 		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, Member(DefaultRequestingUserId.Value), Member(userId));
 		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
 
 		// Act
@@ -49,8 +58,10 @@ public class RemoveMemberCommandHandlerTests
 	{
 		// Arrange
 		var orgId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
 		AllowRequestingUserInOrg(orgId);
-		var command = new RemoveMemberCommand(orgId, Guid.NewGuid(), DefaultRequestingUserId);
+		SetMembers(orgId, Member(DefaultRequestingUserId.Value), Member(userId));
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -67,6 +78,7 @@ public class RemoveMemberCommandHandlerTests
 		var orgId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
 		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, Member(DefaultRequestingUserId.Value), Member(userId));
 		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
 
 		_keycloakService
@@ -99,5 +111,43 @@ public class RemoveMemberCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<DomainException>();
 		await _keycloakService.DidNotReceive().RemoveMemberAsync(orgId, userId, Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRemovingTheLastRemainingMember(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the requesting user is the org's sole member removing (leaving) themselves.
+		var orgId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, Member(DefaultRequestingUserId.Value));
+		var command = new RemoveMemberCommand(orgId, DefaultRequestingUserId.Value, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>()
+			.WithMessage("*only member*");
+		await _keycloakService.DidNotReceive().RemoveMemberAsync(orgId, DefaultRequestingUserId.Value, Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldAllowRemoval_WhenMultipleMembersRemain(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - two members left, removing one is fine.
+		var orgId = Guid.NewGuid();
+		var otherUserId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, Member(DefaultRequestingUserId.Value), Member(otherUserId));
+		var command = new RemoveMemberCommand(orgId, otherUserId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).RemoveMemberAsync(orgId, otherUserId, cancellationToken);
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -167,6 +167,11 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<OrganizationDetailsResponse> GetOrganizationDetailsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteOrganizationAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<MemberCandidateDto>> SearchMemberCandidatesAsync(System.Guid organizationId, string q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -3327,6 +3332,125 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteOrganizationAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/organizations/{organizationId}"
+                    urlBuilder_.Append("v1/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -392,6 +392,7 @@ public class OrganizationSettingsTests(
 				Occurrence = "OneTime",
 				ParticipationType = "Waitlist",
 				CheckInMethod = "None",
+				IsDraft = true,
 			},
 			cancellationToken);
 

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -298,6 +298,123 @@ public class OrganizationSettingsTests(
 		invitations.Should().NotContain(i => i.Id == invitation.InvitationId);
 	}
 
+	// ── RemoveMember (last-member protection, #580) ──────────────────────────
+
+	[Test]
+	public async Task RemoveMember_ShouldReturn409_WhenRemovingTheLastRemainingMember(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Last Member Test Org" }, cancellationToken);
+		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
+
+		var act = () => olafClient.RemoveMemberAsync(org.Id.Value, olaf.Id, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().ContainSingle(m => m.UserId == olaf.Id);
+	}
+
+	// ── DeleteOrganization (#580) ─────────────────────────────────────────────
+
+	[Test]
+	public async Task DeleteOrganization_ShouldReturn401_WhenNotAuthenticated(
+		CancellationToken cancellationToken)
+	{
+		var client = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => client.DeleteOrganizationAsync(Guid.NewGuid(), cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(401);
+	}
+
+	[Test]
+	public async Task DeleteOrganization_ShouldReturn204AndRemoveOrganization_WhenSoleMemberWithNoBlockingOpportunities(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Delete Success Test Org" }, cancellationToken);
+
+		await olafClient.DeleteOrganizationAsync(org.Id.Value, cancellationToken);
+
+		var act = () => olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task DeleteOrganization_ShouldReturn409_WhenOtherMembersRemain(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Delete 409 Members Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var act = () => olafClient.DeleteOrganizationAsync(org.Id.Value, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().HaveCount(2);
+	}
+
+	[Test]
+	public async Task DeleteOrganization_ShouldReturn409_WhenOpportunityHasFutureTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Delete 409 Opportunity Test Org" }, cancellationToken);
+
+		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Blocking Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = org.Id.Value,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "Waitlist",
+				CheckInMethod = "None",
+			},
+			cancellationToken);
+
+		await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		var act = () => olafClient.DeleteOrganizationAsync(org.Id.Value, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Id.Should().Be(org.Id.Value);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
 	{
 		var token = await fixture.GetAccessTokenAsync(username, password);

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1717,6 +1717,73 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @return No Content
+     */
+    deleteOrganization(organizationId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteOrganization(_response);
+        });
+    }
+
+    protected processDeleteOrganization(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * @return OK
      */
     searchMemberCandidates(organizationId: string, q: string, signal?: AbortSignal): Promise<MemberCandidateDto[]> {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -380,6 +380,9 @@
       "organisator": "Organisator",
       "removeMember": "Entfernen",
       "removeMemberError": "Mitglied konnte nicht entfernt werden.",
+      "leaveOrganization": "Verlassen",
+      "leaveOrganizationError": "Organisation konnte nicht verlassen werden.",
+      "leaveOrganizationLastMemberHint": "Du bist das einzige Mitglied - lösche stattdessen die Organisation, wenn du sie schließen möchtest.",
       "searching": "Suche läuft…",
       "noSearchResults": "Keine Benutzer gefunden.",
       "edit": "Bearbeiten",
@@ -394,7 +397,11 @@
       "declinedInvitations": "Abgelehnte Einladungen",
       "dismissInvitation": "Entfernen",
       "dismissError": "Einladung konnte nicht entfernt werden.",
-      "invitationSentOn": "Gesendet am {{date}}"
+      "invitationSentOn": "Gesendet am {{date}}",
+      "dangerZone": "Gefahrenzone",
+      "deleteOrganization": "Organisation löschen",
+      "deleteOrganizationHint": "Nur das letzte verbleibende Mitglied kann die Organisation löschen. Entferne zuerst die anderen Mitglieder.",
+      "deleteOrganizationError": "Organisation konnte nicht gelöscht werden."
     },
     "account": {
       "title": "Mein Konto",
@@ -580,6 +587,16 @@
         "title": "Engagement absagen?",
         "message": "Möchtest du dieses Engagement wirklich absagen? Der Freiwillige wird informiert.",
         "confirm": "Ja, absagen"
+      },
+      "leaveOrganization": {
+        "title": "Organisation verlassen?",
+        "message": "Möchtest du \"{{name}}\" wirklich verlassen? Du verlierst den Organisator-Zugriff darauf.",
+        "confirm": "Ja, verlassen"
+      },
+      "deleteOrganization": {
+        "title": "Organisation löschen?",
+        "message": "Möchtest du \"{{name}}\" wirklich dauerhaft löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, löschen"
       }
     },
     "orgProfile": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -380,6 +380,9 @@
       "organisator": "Organizer",
       "removeMember": "Remove",
       "removeMemberError": "Could not remove member.",
+      "leaveOrganization": "Leave",
+      "leaveOrganizationError": "Could not leave organization.",
+      "leaveOrganizationLastMemberHint": "You're the only member - delete the organization instead if you want to close it.",
       "searching": "Searching…",
       "noSearchResults": "No users found.",
       "edit": "Edit",
@@ -394,7 +397,11 @@
       "declinedInvitations": "Declined Invitations",
       "dismissInvitation": "Dismiss",
       "dismissError": "Could not dismiss invitation.",
-      "invitationSentOn": "Sent {{date}}"
+      "invitationSentOn": "Sent {{date}}",
+      "dangerZone": "Danger Zone",
+      "deleteOrganization": "Delete Organization",
+      "deleteOrganizationHint": "Only the organization's sole remaining member can delete it. Remove other members first.",
+      "deleteOrganizationError": "Could not delete organization."
     },
     "account": {
       "title": "My Account",
@@ -580,6 +587,16 @@
         "title": "Cancel engagement?",
         "message": "Are you sure you want to cancel this engagement? The volunteer will be informed.",
         "confirm": "Yes, cancel"
+      },
+      "leaveOrganization": {
+        "title": "Leave organization?",
+        "message": "Are you sure you want to leave \"{{name}}\"? You will lose organizer access to it.",
+        "confirm": "Yes, leave"
+      },
+      "deleteOrganization": {
+        "title": "Delete organization?",
+        "message": "Are you sure you want to permanently delete \"{{name}}\"? This cannot be undone.",
+        "confirm": "Yes, delete"
       }
     },
     "orgProfile": {

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "react-oidc-context";
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
 import type { View } from "react-big-calendar";
 import { format, parse, startOfWeek, getDay } from "date-fns";
@@ -16,7 +17,9 @@ import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { inputClass, labelClass } from "../lib/formClasses";
+import { getApiErrorMessage } from "../lib/apiError";
 import EmptyState from "../components/EmptyState";
+import ConfirmDialog from "../components/ConfirmDialog";
 import CreateVolunteerOpportunityModal from "../components/CreateVolunteerOpportunityModal";
 
 const rbcLocales = {
@@ -93,7 +96,10 @@ export default function OrganizationOverviewPage() {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
+	const auth = useAuth();
+	const navigate = useNavigate();
 	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
+	const currentUserId = auth.user?.profile?.sub;
 
 	const rawTab = searchParams.get("tab");
 	const activeTab: Tab = isTab(rawTab) ? rawTab : "calendar";
@@ -271,6 +277,11 @@ export default function OrganizationOverviewPage() {
 	const [saving, setSaving] = useState(false);
 	const [settingsError, setSettingsError] = useState<string | null>(null);
 	const [successMessage, setSuccessMessage] = useState<string | null>(null);
+	const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+	const [leaving, setLeaving] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const isSoleMember = org?.members.length === 1;
 
 	// ── Member search ────────────────────────────────────────────────────────
 	const [memberSearch, setMemberSearch] = useState("");
@@ -463,6 +474,38 @@ export default function OrganizationOverviewPage() {
 			);
 		} catch {
 			setSettingsError(t("orgSettings.removeMemberError"));
+		}
+	}
+
+	async function handleLeaveOrganization() {
+		if (!organizationId || !currentUserId) return;
+		setLeaving(true);
+		try {
+			await api.removeMember(organizationId, currentUserId);
+			navigate("/");
+		} catch (err) {
+			setShowLeaveConfirm(false);
+			setSettingsError(
+				getApiErrorMessage(err, t("orgSettings.leaveOrganizationError")),
+			);
+		} finally {
+			setLeaving(false);
+		}
+	}
+
+	async function handleDeleteOrganization() {
+		if (!organizationId) return;
+		setDeleting(true);
+		try {
+			await api.deleteOrganization(organizationId);
+			navigate("/");
+		} catch (err) {
+			setShowDeleteConfirm(false);
+			setSettingsError(
+				getApiErrorMessage(err, t("orgSettings.deleteOrganizationError")),
+			);
+		} finally {
+			setDeleting(false);
 		}
 	}
 
@@ -791,6 +834,11 @@ export default function OrganizationOverviewPage() {
 									{successMessage}
 								</div>
 							)}
+							{settingsError && (
+								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									{settingsError}
+								</div>
+							)}
 
 							{org.description && (
 								<p className="mb-5 leading-relaxed text-gray-600">
@@ -906,6 +954,23 @@ export default function OrganizationOverviewPage() {
 									)}
 								</div>
 							)}
+
+							<div className="mt-8 rounded-2xl border border-red-100 bg-red-50 px-4 py-4">
+								<h2 className="text-sm font-semibold text-red-800">
+									{t("orgSettings.dangerZone")}
+								</h2>
+								<p className="mt-1 text-xs text-red-700">
+									{t("orgSettings.deleteOrganizationHint")}
+								</p>
+								<button
+									type="button"
+									onClick={() => setShowDeleteConfirm(true)}
+									disabled={!isSoleMember}
+									className="mt-3 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400 disabled:hover:bg-white"
+								>
+									{t("orgSettings.deleteOrganization")}
+								</button>
+							</div>
 						</>
 					)}
 					{!orgLoading && org && editing && (
@@ -1307,20 +1372,67 @@ export default function OrganizationOverviewPage() {
 													</span>
 												)}
 											</div>
-											<button
-												type="button"
-												onClick={() => handleRemoveMember(member.userId)}
-												className="text-xs text-red-700 hover:text-red-800"
-											>
-												{t("orgSettings.removeMember")}
-											</button>
+											{member.userId === currentUserId ? (
+												<button
+													type="button"
+													onClick={() => setShowLeaveConfirm(true)}
+													disabled={isSoleMember}
+													title={
+														isSoleMember
+															? t("orgSettings.leaveOrganizationLastMemberHint")
+															: undefined
+													}
+													className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+												>
+													{t("orgSettings.leaveOrganization")}
+												</button>
+											) : (
+												<button
+													type="button"
+													onClick={() => handleRemoveMember(member.userId)}
+													className="text-xs text-red-700 hover:text-red-800"
+												>
+													{t("orgSettings.removeMember")}
+												</button>
+											)}
 										</li>
 									))}
 								</ul>
 							)}
+							{isSoleMember && (
+								<p className="mt-3 text-xs text-gray-500">
+									{t("orgSettings.leaveOrganizationLastMemberHint")}
+								</p>
+							)}
 						</>
 					)}
 				</div>
+			)}
+
+			{showLeaveConfirm && org && (
+				<ConfirmDialog
+					title={t("confirmDialog.leaveOrganization.title")}
+					message={t("confirmDialog.leaveOrganization.message", {
+						name: org.name,
+					})}
+					confirmLabel={t("confirmDialog.leaveOrganization.confirm")}
+					onConfirm={handleLeaveOrganization}
+					onClose={() => setShowLeaveConfirm(false)}
+					loading={leaving}
+				/>
+			)}
+
+			{showDeleteConfirm && org && (
+				<ConfirmDialog
+					title={t("confirmDialog.deleteOrganization.title")}
+					message={t("confirmDialog.deleteOrganization.message", {
+						name: org.name,
+					})}
+					confirmLabel={t("confirmDialog.deleteOrganization.confirm")}
+					onConfirm={handleDeleteOrganization}
+					onClose={() => setShowDeleteConfirm(false)}
+					loading={deleting}
+				/>
 			)}
 
 			{showCreateModal && organizationId && (


### PR DESCRIPTION
## Summary

Closes the safety gap described in #580: every member row in the Organization Dashboard's Members tab showed the same generic "Remove" action, nothing stopped the org's last remaining member from removing themselves (orphaning the org), and there was no way to delete an organization at all.

- **Leave vs. Remove:** the current user's own row in the Members tab now shows a distinct "Leave" action; other members' rows still show "Remove" (unchanged).
- **Last-member protection:** `RemoveMemberCommandHandler` now rejects removing the organization's sole remaining member with a `409 Conflict`. The "Leave" button is disabled (with an explanatory hint) when the user is the only member, and the same hint is shown in the UI as a fallback.
- **New "Delete Organization" action** (Settings tab, "Danger Zone"): only enabled when the requesting user is the org's sole member, gated behind a confirmation dialog.
  - New `DELETE /v1/organizations/{organizationId}` endpoint (organizer-only), backed by a new `DeleteOrganizationCommand`/`Handler`.
  - Deletion is blocked with `409 Conflict` if the org has other members, or if any of its opportunities have a future time slot or an active/confirmed engagement (new `IApplicationDbContext.GetBlockingOpportunitiesForOrganizationAsync`), protecting volunteers who already committed.
  - New `IKeycloakOrganizationService.DeleteOrganizationAsync` calls Keycloak's organization DELETE admin API.

## Test plan

- [x] `dotnet build` (Api, Application, Infrastructure, Domain) - 0 warnings, 0 errors.
- [x] `ArchitectureTests` - 244/244 passed (layer/naming conventions unaffected).
- [x] `Application.UnitTests` - 203/203 passed, including new tests for the last-member guard (`RemoveMemberCommandHandlerTests`) and the new `DeleteOrganizationCommandHandlerTests` (sole-member success, not-found, not-a-member, other-members-remain, blocking-opportunity cases).
- [x] Added `IntegrationTests` in `OrganizationSettingsTests.cs` covering `DeleteOrganization` (401/204/409 for other members/409 for a future time slot) and `RemoveMember`'s new 409 last-member case.
- [x] Frontend: `pnpm check` (tsc), `pnpm lint` (0 warnings), `pnpm format:check`, `pnpm build` - all green.
- [x] CI green on this PR, including `IntegrationTests` and `VisualTests` (build-and-test job).

## Live verification

Deployed as `v1.0.0-rc.190` (release branch cut from this PR's merge commit `6591cb4`) and verified against the live staging environment:

- `curl -sf https://api.maik-hasler.de/health` → `200 OK`.
- Ran `scripts/smoke-test-580-org-deletion.mjs` against `https://einsatzbereit.maik-hasler.de` (added in follow-up #589, since this PR had already merged by the time verification ran): logged in as `vera`, created a fresh organization, and verified end-to-end:
  ```
  OK  Logged in as vera
  OK  Created organization "Smoke580 1783250147720"
  OK  Own row shows a disabled "Leave" action (sole member)
  OK  Own row does not show "Remove"
  OK  "Delete Organization" is enabled for the sole member
  OK  Confirmation dialog shown, mentions the organization name
  OK  Deleting redirected to the home page
  OK  Deleted organization no longer resolves

  ALL CHECKS PASSED
  ```
- The corresponding automated TUnit `VisualTests` (`SoleMember_MembersTab_ShowsDisabledLeaveInsteadOfRemove`, `SoleMember_CanDeleteOrganization_FromSettingsTab`) were added in follow-up #589, since this PR merged (via auto-merge) before that step of the mandatory verification flow completed.

**Remaining limitations:** none for the scope of #580's acceptance criteria. The richer Owner/Moderator/Member role hierarchy mentioned in the issue as out-of-scope was not built here, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
