### PR TITLE
fix: show uploaded avatars/logos in nav bar and opportunity cards (#588)

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5945,6 +5945,12 @@
           "isOrganizationVerified": {
             "type": "boolean",
             "default": false
+          },
+          "organizationLogoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
@@ -23,4 +23,5 @@ public sealed record VolunteerOpportunitySummary(
 	int CurrentParticipantCount,
 	string Status,
 	string? BannerImageUrl,
-	bool IsOrganizationVerified = false);
+	bool IsOrganizationVerified = false,
+	string? OrganizationLogoUrl = null);

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -88,6 +88,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				OrganizationId = x.vo.OrganizationId.Value,
 				OrgName = x.org.Name,
 				OrgIsVerified = x.org.IsVerified,
+				OrgLogoUrl = x.org.LogoUrl,
 				Street = x.vo.Address != null ? x.vo.Address.Street : null,
 				HouseNumber = x.vo.Address != null ? x.vo.Address.HouseNumber : null,
 				ZipCode = x.vo.Address != null ? x.vo.Address.ZipCode : null,
@@ -135,7 +136,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 					x.CheckInMethod.ToString(), x.Category?.ToString(), x.Tags, x.CreatedOn,
 					maxPMap.GetValueOrDefault(x.Id, 0),
 					partCountMap.GetValueOrDefault(x.Id, 0),
-					x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified))
+					x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified, x.OrgLogoUrl))
 				.ToList();
 
 			return new PagedList<VolunteerOpportunitySummary>(summaries, matched.Count, filter.PageNumber, filter.PageSize);
@@ -161,7 +162,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				x.CheckInMethod.ToString(), x.Category?.ToString(), x.Tags, x.CreatedOn,
 				maxParticipantsMap.GetValueOrDefault(x.Id, 0),
 				participantCountMap.GetValueOrDefault(x.Id, 0),
-				x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified))
+				x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified, x.OrgLogoUrl))
 			.ToList();
 
 		return new PagedList<VolunteerOpportunitySummary>(result, total, filter.PageNumber, filter.PageSize);
@@ -340,6 +341,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				OrganizationId = x.vo.OrganizationId.Value,
 				OrgName = x.org.Name,
 				OrgIsVerified = x.org.IsVerified,
+				OrgLogoUrl = x.org.LogoUrl,
 				Street = x.vo.Address != null ? x.vo.Address.Street : null,
 				HouseNumber = x.vo.Address != null ? x.vo.Address.HouseNumber : null,
 				ZipCode = x.vo.Address != null ? x.vo.Address.ZipCode : null,
@@ -372,7 +374,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				x.CheckInMethod.ToString(), x.Category?.ToString(), x.Tags, x.CreatedOn,
 				maxParticipantsMap.GetValueOrDefault(x.Id, 0),
 				participantCountMap.GetValueOrDefault(x.Id, 0),
-				x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified))
+				x.Status.ToString(), x.BannerImageUrl, x.OrgIsVerified, x.OrgLogoUrl))
 			.ToList();
 	}
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -8605,6 +8605,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("isOrganizationVerified")]
         public bool IsOrganizationVerified { get; set; } = false;
 
+        [System.Text.Json.Serialization.JsonPropertyName("organizationLogoUrl")]
+        public string? OrganizationLogoUrl { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -1,0 +1,135 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #588: an uploaded user avatar / organization logo used to
+/// only render on that user's/organization's own profile page - the nav bar
+/// and opportunity card badges always showed initials, even with an image on
+/// file, because neither read the field that already carried the URL.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// 1x1 transparent PNG.
+	private static readonly byte[] TinyPng = Convert.FromBase64String(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+
+	[Test]
+	public async Task UploadedAvatar_ShowsInNavBar_InsteadOfInitials()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await GetAccessTokenAsync();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		using var content = new MultipartFormDataContent();
+		using var fileContent = new ByteArrayContent(TinyPng);
+		fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+		content.Add(fileContent, "file", "avatar.png");
+
+		var response = await http.PutAsync("/v1/users/me/avatar", content);
+		response.EnsureSuccessStatusCode();
+
+		// Header only fetches the profile once on mount, so a full navigation
+		// is needed to pick up the freshly uploaded avatar.
+		await Page.GotoAsync(origin);
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var userMenu = Page.GetByRole(AriaRole.Button, new() { Name = "User menu" });
+		await Expect(userMenu.Locator("img")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
+	public async Task OrganizationLogo_ShowsOnOpportunityCard_InsteadOfInitials()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await GetAccessTokenAsync();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualLogo {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		using var content = new MultipartFormDataContent();
+		using var fileContent = new ByteArrayContent(TinyPng);
+		fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+		content.Add(fileContent, "file", "logo.png");
+
+		(await http.PutAsync($"/v1/organizations/{organizationId}/logo", content)).EnsureSuccessStatusCode();
+
+		var tag = $"visual588-{suffix}";
+		var oppTitle = $"VisualLogo Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by AvatarAndLogoDisplayTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "Waitlist",
+			checkInMethod = "None",
+			isDraft = true,
+			tags = new[] { tag },
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(3);
+		var end = start.AddHours(2);
+		(await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 }))
+			.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/?tag={tag}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var card = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var orgLink = card.Locator($"a[href='/organizations/{organizationId}']");
+		await Expect(orgLink.Locator("img")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	private async Task<string> GetAccessTokenAsync()
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		return token!;
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -4045,6 +4045,7 @@ export interface VolunteerOpportunitySummary {
     status: string;
     bannerImageUrl: string | undefined;
     isOrganizationVerified?: boolean;
+    organizationLogoUrl?: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,6 +25,7 @@ export default function Header() {
 		user?.preferred_username ??
 		"User") as string;
 	const initials = isLoggedIn ? getInitials(displayName) : "";
+	const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [notifOpen, setNotifOpen] = useState(false);
@@ -80,6 +81,24 @@ export default function Header() {
 			controller.abort();
 			clearInterval(id);
 		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isLoggedIn]);
+
+	useEffect(() => {
+		if (!isLoggedIn) {
+			setAvatarUrl(null);
+			return;
+		}
+		const controller = new AbortController();
+		void (async () => {
+			try {
+				const profile = await api.getUserProfile(controller.signal);
+				setAvatarUrl(profile.avatarUrl ?? null);
+			} catch {
+				// silently ignore (includes AbortError on cleanup)
+			}
+		})();
+		return () => controller.abort();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isLoggedIn]);
 
@@ -253,9 +272,17 @@ export default function Header() {
 										aria-label={t("nav.userMenu")}
 										aria-expanded={dropdownOpen}
 									>
-										<span className="w-9 h-9 rounded-full bg-brand-700 text-white flex items-center justify-center text-sm font-semibold">
-											{initials}
-										</span>
+										{avatarUrl ? (
+											<img
+												src={avatarUrl}
+												alt=""
+												className="w-9 h-9 rounded-full object-cover"
+											/>
+										) : (
+											<span className="w-9 h-9 rounded-full bg-brand-700 text-white flex items-center justify-center text-sm font-semibold">
+												{initials}
+											</span>
+										)}
 										<svg
 											className={`w-4 h-4 ${isTransparent ? "text-white/70" : "text-gray-400"}`}
 											fill="none"
@@ -522,9 +549,17 @@ export default function Header() {
 						{isLoggedIn ? (
 							<div className="space-y-1">
 								<div className="flex items-center gap-3 px-3 py-2">
-									<div className="w-9 h-9 rounded-full bg-brand-700 text-white flex items-center justify-center text-sm font-semibold">
-										{initials}
-									</div>
+									{avatarUrl ? (
+										<img
+											src={avatarUrl}
+											alt=""
+											className="w-9 h-9 rounded-full object-cover"
+										/>
+									) : (
+										<div className="w-9 h-9 rounded-full bg-brand-700 text-white flex items-center justify-center text-sm font-semibold">
+											{initials}
+										</div>
+									)}
 									<span
 										className={`text-sm font-medium ${isTransparent ? "text-white/90" : "text-gray-700"}`}
 									>

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -1663,12 +1663,20 @@ export default function VolunteerOpportunitiesList() {
 														to={`/organizations/${item.organizationId}`}
 														className="group/org relative z-20 inline-flex items-center gap-2"
 													>
-														<span
-															aria-hidden="true"
-															className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand-100 text-[11px] font-bold text-brand-700"
-														>
-															{orgInitials(item.organizationName)}
-														</span>
+														{item.organizationLogoUrl ? (
+															<img
+																src={item.organizationLogoUrl}
+																alt=""
+																className="h-7 w-7 shrink-0 rounded-full object-cover"
+															/>
+														) : (
+															<span
+																aria-hidden="true"
+																className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand-100 text-[11px] font-bold text-brand-700"
+															>
+																{orgInitials(item.organizationName)}
+															</span>
+														)}
 														<span className="text-sm font-medium text-gray-600 transition-colors group-hover/org:text-brand-700 group-hover/org:underline">
 															{item.organizationName}
 														</span>


### PR DESCRIPTION
## Summary

Closes #588. Two separate gaps, both stemming from the initials-fallback UI never having a real image to render:

- **Nav bar (`Header.tsx`)**: the header only read `auth.user?.profile` (Keycloak id_token claims, no `avatarUrl`), so `getInitials()` was used unconditionally regardless of whether the user had uploaded a profile picture.
- **Opportunity cards (`VolunteerOpportunitiesList.tsx`)**: the backend DTO `VolunteerOpportunitySummary` didn't include the organization's `LogoUrl` at all, so the frontend had no logo URL to render regardless of UI changes.

## Changes

- `Header.tsx` now fetches the authenticated user's own profile (`api.getUserProfile()`, the same endpoint `ProfileOverviewPage` already uses) once on login and renders the real `avatarUrl` as an `<img>` in both the desktop dropdown and the mobile menu, falling back to the existing initials span when unset.
- `VolunteerOpportunitySummary` gains a new `OrganizationLogoUrl` field, populated in `VolunteerOpportunityReadRepository` from the existing `Organization.LogoUrl` column (no migration needed - the column already exists) across all three query paths (paged list, radius search, per-organization list).
- `VolunteerOpportunitiesList.tsx` renders the organization's logo on each opportunity card's organizer badge when present, falling back to initials otherwise.

## Test plan

- [x] `dotnet build` - 0 warnings, 0 errors; NSwag regenerated `api-client.ts`/`openapi-v1.json`/`IntegrationTests/ApiClient.cs` with the new `organizationLogoUrl` field, verified consistent across all three.
- [x] `dotnet test tests/Application.UnitTests` - 207/207 passed.
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed.
- [x] `pnpm check` / `pnpm lint` / `pnpm format:check` / `pnpm build` - all clean.
- [x] Self-review via `nswag-check`, `a11y-check`, `ef-migration-check` subagents - all reported clean (generated clients in sync, `alt=""` decorative-image treatment correct given adjacent accessible names/text, no EF migration required since `Organization.LogoUrl` already exists from a prior migration).
- [x] Added `backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs` (`UploadedAvatar_ShowsInNavBar_InsteadOfInitials`, `OrganizationLogo_ShowsOnOpportunityCard_InsteadOfInitials`) - uploads a real avatar/logo via the API then verifies via Playwright that the nav bar / opportunity card render an `<img>` instead of initials. Compiles cleanly; `VisualTests`/Aspire needs real container networking, unavailable in this sandbox - will run in CI.
- [ ] `IntegrationTests`/`VisualTests` execution - not runnable in this sandbox (no reliable Docker/Aspire); will run in CI.

## Live verification

Pending: will cut a release candidate once CI is green and verify against staging with a Playwright smoke script, confirming an uploaded avatar shows in the nav bar and an uploaded organization logo shows on opportunity cards. Will update this section once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WefrEy7UEfLvQmsD14pAMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WefrEy7UEfLvQmsD14pAMZ)_