### PR TITLE
fix: avoid Playwright strict-mode violation in homepage VisualTests check

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -236,11 +236,14 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		// The main element must be present - a 500 would show an error page instead.
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		// Wait for the API call to resolve: opportunity cards, empty state, or error appear
+		// Wait for the API call to resolve: opportunity cards, empty state, or error appear.
+		// .First avoids a Playwright strict-mode violation when more than one
+		// opportunity card is present - this just needs to see *some* result.
 		await Expect(
 			Page.Locator("ul li:has(a[href*='/volunteer-opportunities/'])")
 				.Or(Page.GetByText(new Regex("No opportunities|Keine Eins", RegexOptions.IgnoreCase)))
 				.Or(Page.GetByTestId("opportunities-error"))
+				.First
 		).ToBeVisibleAsync(new() { Timeout = 30_000 });
 
 		// No error message should be visible in the opportunities list.


### PR DESCRIPTION
## Summary

Follow-up to #596 (merged). The release-candidate CI run for `v1.0.0-rc.194` (built from #596's merge commit) failed on `VisualTests`:

```
failed HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist (6s 416ms)
  PlaywrightException: Locator expected to be visible
  Error: strict mode violation: Locator("ul li:has(a[href*='/volunteer-opportunities/'])")
    .Or(GetByText(...)).Or(GetByTestId("opportunities-error")) resolved to 2 elements
```

`HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist` (`VolunteerOpportunityTests.cs`) asserts that *some* result (an opportunity card, the empty state, or the error state) is visible on the homepage, but its locator has no `.First`, so `ToBeVisibleAsync()` throws a Playwright strict-mode violation as soon as more than one opportunity card exists - which is the normal state of a homepage with real content, not a bug. This was a latent issue in the test's own assertion, exposed now because `#596` added one more published opportunity to the shared VisualTests database (via `AvatarAndLogoDisplayTests.OrganizationLogo_ShowsOnOpportunityCard_InsteadOfInitials`), tipping the count from 1 to 2.

## Change

Added `.First` to the locator chain so the assertion means "at least one of these three states is visible" (its actual intent, per the existing comment), not "exactly one element matches across the whole page." No other assertions in the test are affected.

## Test plan

- [x] `dotnet build tests/VisualTests` - compiles cleanly (verified up to the point where this sandbox's Playwright browser-dependency install step fails on a pre-existing, unrelated apt-repo issue - same limitation noted in prior PRs; CI's runner has a working setup).
- [ ] CI on this PR - pending, this is what unblocks it.

## Live verification

N/A - test-only change, no product behavior affected. Once CI is green here, will re-cut `v1.0.0-rc.194`-equivalent release branch to retry the #588 staging deploy/live verification that this fix unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WefrEy7UEfLvQmsD14pAMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WefrEy7UEfLvQmsD14pAMZ)_