### PR TITLE
feat: add persona-simulation skill as issue-triage's empty-backlog fallback

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -17,6 +17,11 @@ Review all open issues and all open PRs before starting any work.
 For each open issue:
 
 - Determine whether it's still relevant and actionable.
+- Skip anything labelled `needs-decision` entirely - it's a finding that
+  needs the repo owner's own product/design call before it can be
+  implemented (see `persona-simulation`). Don't triage it, don't implement
+  it, don't comment on it beyond what's already there. It stays untouched
+  until the owner removes the label.
 - Check open PRs for related work - if one already resolves, partially
   resolves, or clearly addresses it, don't duplicate the work. Document the
   relationship in a comment and move on.
@@ -25,6 +30,11 @@ For each open issue:
 - Prefer an issue that's already been triaged as actionable across multiple
   prior cycles without being picked up, over re-triaging the same backlog
   indefinitely and always reaching for something newer/shinier.
+- If, after all of the above, no open issue is actionable (everything
+  remaining is `needs-decision`, bot-managed like Renovate's Dependency
+  Dashboard, or already covered by an open PR), run the `persona-simulation`
+  skill instead of stopping here - it's the fallback for a genuinely empty
+  backlog, not a replacement for real triage work.
 
 ## 2. Implement
 

--- a/.claude/skills/persona-simulation/SKILL.md
+++ b/.claude/skills/persona-simulation/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: persona-simulation
+description: >
+  Simulates the app's real personas (Volunteer Vera, Organizer Olaf) against
+  live staging to surface friction, bugs, and small gaps in the existing 1.0
+  feature set - for when issue-triage's Survey step finds no actionable open
+  issue. Never invents new feature areas and never touches code; it only
+  files GitHub issues, flagging anything that needs the repo owner's own
+  product call so the automated triage loop won't implement it unsupervised.
+  Use as the fallback of the recurring issue-triage routine when there is
+  nothing left to triage, or when asked to "simulate persona usage", "audit
+  the app as a user", or "find gaps for 1.0".
+---
+
+# Persona simulation
+
+## When this runs
+
+Only as the fallback of `issue-triage`'s Survey step: after confirming every
+open issue is either not actionable, already covered by an open PR, or
+bot-managed (e.g. Renovate's Dependency Dashboard). This skill never competes
+with real triage work - if there's an issue to implement, do that instead.
+
+## Ground rules
+
+- **Never touch code, never open a branch or PR.** Output is GitHub issues
+  (and comments) only - the one thing that keeps an otherwise-unsupervised
+  run safe.
+- **No new feature areas.** The 1.0 feature set is intentionally frozen -
+  calendar, opportunities, applications/engagements, achievements, profiles,
+  organizations. Look for gaps *within* those, not adjacent domains (no
+  payments, chat, etc.), even if a gap seems to "obviously" need one.
+- **Clean up after yourself.** Anything created against the live database
+  (a draft opportunity, an application) must be deleted/withdrawn again
+  before the run ends. This runs every ~5 hours, indefinitely - it must
+  never leave test data behind.
+- **Cap findings at ~3-5 per run**, prioritized by real impact on the
+  persona's task, not nitpicks. An empty-handed run ("exercised both
+  personas, nothing new to report") is a fine, common outcome.
+- **Dedup first.** `search_issues` for `label:persona-sim` plus keywords
+  from the candidate finding before filing anything - don't re-report the
+  same friction every cycle just because it's still there.
+
+## Personas
+
+Use the real seeded test accounts (root `CLAUDE.md`, "Development Setup").
+Run at least one full pass per persona per invocation - don't cherry-pick a
+single screen.
+
+**Organizer Olaf** (`olaf/olaf123`) - runs an org day to day:
+- Checks the org calendar for what's coming up (`OrganizationOverviewPage`,
+  the `react-big-calendar` view).
+- Creates a new opportunity through the full wizard
+  (`CreateVolunteerOpportunityModal`).
+- Reviews applications/engagements and accepts, waitlists, or rejects one
+  (`OrganizationEngagementsPage`, `EngagementManagementPage`).
+- Skims the org profile (`OrganizationProfilePage`) for how it presents to
+  volunteers.
+
+**Volunteer Vera** (`vera/vera123`) - looks for and works opportunities:
+- Browses/filters the opportunity list and map (`HomePage`,
+  `VolunteerOpportunitiesList`, `OpportunityMap`) with a couple of realistic
+  filters.
+- Opens a detail page and submits an application
+  (`VolunteerOpportunityDetailPage`).
+- Checks when the opportunity she applied to actually starts, via her
+  engagement list.
+- Looks at her achievements (`UserAchievementsPage`, `BadgeGrid`,
+  `ShareAchievementsModal`) and profile (`ProfileOverviewPage`,
+  `UserProfilePage`).
+
+## Method
+
+Live staging only - see root `CLAUDE.md`'s "Sandbox Limitations" for why no
+local Aspire/Docker stack is available. Drive it with Playwright the same
+way the smoke-test scripts do:
+
+```js
+import { launchLiveBrowser, loginKeycloak } from "/home/user/einsatzbereit/scripts/lib/live-browser.mjs";
+```
+
+Write the driver script into the session scratchpad, not `scripts/` - this
+is exploratory persona-driving, not a committed fix-verification smoke test.
+Sign in as each persona in turn and walk the flows above, noting anything
+that:
+
+- breaks outright (error, dead end, silent no-op),
+- would confuse a first-time user doing the realistic task (unclear state,
+  missing feedback, a control that doesn't do what it looks like it does),
+  or
+- falls short of what the persona actually needs to get the real-life job
+  done - "Olaf can't do X his role requires", not "wouldn't it be nice".
+
+## Filing findings
+
+For each finding that survives dedup, use `issue_write` (method `create`),
+matching the shape of the existing `bug_report.yml` (Affected Persona,
+Priority, Description with Actual/Expected, Steps to Reproduce, Environment,
+Additional Information) or `user_story.yml` (Persona, Priority, User Story,
+Description, Acceptance Criteria, Implementation Proposal, Additional
+Information) template - whichever fits the finding.
+
+- **Clear, unambiguous fix** (bug, broken flow, obviously-missing
+  validation): label it `bug` or `user-story` plus `persona-sim`. This is
+  fair game for next cycle's `issue-triage` to pick up and implement
+  unsupervised, same as any other issue.
+- **Needs the repo owner's own call** - a subjective/design decision, more
+  than one defensible approach, unclear whether it's in scope for 1.0, or
+  touches something already flagged as unsatisfying (e.g. achievements -
+  the icon set and unlock criteria are known to need a rethink, not a
+  patch): add the `needs-decision` label on top, and open the body with a
+  bolded **"Needs your decision before implementation"** line plus the
+  specific question(s) to answer. `issue-triage`'s Survey step skips
+  anything labelled `needs-decision`, so this can never get auto-implemented
+  out from under you.
+
+Both labels are created automatically on first use, same as any other label
+here (`dependencies`/`renovate` on issue #25 were never pre-declared either -
+no `labels.yml` in this repo).
+
+When genuinely unsure which bucket a finding belongs in, prefer
+`needs-decision` - a wrongly-deferred bug costs one extra triage cycle; a
+wrongly-automated judgment call costs a decision made without you.
+
+## Report
+
+End with a short summary of what was exercised (both personas, which flows)
+and what, if anything, was filed. That summary is the entire output of a run
+that otherwise made no changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ edit on your own initiative):
   is the recurring triage-and-implement loop for this repo's autonomous
   routine - the durable process lives here, checked in and versioned,
   rather than only in the routine's own (unowned, unversioned) prompt text.
+  `.claude/skills/persona-simulation/` is that routine's fallback for a
+  genuinely empty backlog - it drives the live app as Volunteer Vera/Organizer
+  Olaf to find real gaps in the existing feature set, filing GitHub issues
+  only (never code) and labelling anything needing the repo owner's own
+  product call as `needs-decision`, which `issue-triage` then leaves alone.
 - **Hooks** - `.claude/hooks/protect-generated-clients.sh` blocks Edit/Write
   on the three NSwag-generated files (see "API client" row above).
   `.claude/hooks/pre-stop-verify.sh` (`Stop` hook) runs `dotnet build`/`pnpm lint`+`check`


### PR DESCRIPTION
## Summary

The recurring issue-triage routine currently has nothing to do whenever the backlog runs dry (right now: one real bug plus Renovate's Dependency Dashboard). Instead of idling, it now falls back to a new `persona-simulation` skill that drives the live app as the two real-usage personas and files findings as issues - closing the loop the repo owner described: they don't have time to manually keep discovering 1.0 gaps, but also don't want speculative product decisions made without them.

### `.claude/skills/persona-simulation/SKILL.md` (new)

- Drives `https://einsatzbereit.maik-hasler.de` with Playwright (reusing `scripts/lib/live-browser.mjs`) as **Organizer Olaf** (`olaf/olaf123`: calendar, creating an opportunity, reviewing applications, org profile) and **Volunteer Vera** (`vera/vera123`: browsing/filtering, applying, checking when her engagement starts, achievements, profile).
- Chosen as a skill rather than a subagent: it's a primary recurring workflow with a multi-step process (like `issue-triage`), not a narrow report-only checker fanned out from `/self-review` (like the `.claude/agents/*`).
- Hard constraints baked in: never touches code/branches/PRs (issues only), no new feature areas (stays inside the existing 1.0 pillars), always cleans up any data it creates against the live database, caps findings per run, and dedups against issues already labelled `persona-sim` before filing.
- Every finding is filed as a normal issue (`bug`/`user-story` + `persona-sim`), **except** anything that's actually the repo owner's product/design call (subjective, ambiguous scope, or touching something already known to need a rethink, e.g. achievements) - those get `needs-decision` added and open with an explicit "needs your decision" line.

### `.claude/skills/issue-triage/SKILL.md`

- Survey step now skips any issue labelled `needs-decision` outright - it stays untouched until the owner removes the label, so nothing requiring your judgment call gets auto-implemented.
- When nothing else is actionable, it now runs `persona-simulation` instead of just stopping.

### `CLAUDE.md`

- Documents the new skill alongside the existing `.claude/` configuration summary.

## Why not touch the recurring trigger's prompt text directly

The trigger's own prompt is intentionally treated as unowned/unversioned (see the original `issue-triage` PR #591) - the durable process lives in the checked-in skill, which is what actually gets invoked when the routine's prompt matches. The Survey-step fallback added here is sufficient on its own; I didn't want to touch the live trigger's session binding without checking first, since `update_trigger` can't edit prompt text (only name/cron/enabled) and recreating it risks rebinding it away from its existing session history.

## Test plan

- [x] Self-review (`/self-review`): clean, no P1-P4 findings - this is `.claude/` skill config + docs, no runtime/product code.
- [x] No Unicode em/en dashes introduced (checked manually).
- [x] `.md` files use space indentation per `.editorconfig`; no stray tabs/trailing whitespace.
- [ ] No runtime/product code changed - same as the precedent `.claude/` config PR (#591), the "Mandatory: Deploy and verify" release-and-live-smoke-test workflow doesn't apply here (nothing user-facing to verify on staging).


---
_Generated by [Claude Code](https://claude.ai/code/session_019LqNoN5gni3X7tGn3DcDb8)_