### PR TITLE
fix: repair flaky VisualTests assertions blocking staging deploys

### DIFF
--- a/backend/tests/VisualTests/AccountTests.cs
+++ b/backend/tests/VisualTests/AccountTests.cs
@@ -14,7 +14,9 @@ public class AccountTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/account");
 
-		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" });
+		// /account redirects to /profile - .First matches the guard already
+		// applied to this same "Edit" button in ProfileOverviewTests.cs.
+		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" }).First;
 		await Expect(editButton).ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await editButton.ClickAsync();
 
@@ -32,7 +34,9 @@ public class AccountTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/account");
 
-		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" });
+		// /account redirects to /profile - .First matches the guard already
+		// applied to this same "Edit" button in ProfileOverviewTests.cs.
+		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" }).First;
 		await Expect(editButton).ToBeVisibleAsync(new() { Timeout = 30_000 });
 		await editButton.ClickAsync();
 
@@ -49,7 +53,9 @@ public class AccountTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/account");
 
-		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" });
+		// /account redirects to /profile - .First matches the guard already
+		// applied to this same "Edit" button in ProfileOverviewTests.cs.
+		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" }).First;
 		await Expect(editButton).ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await editButton.ClickAsync();
 

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -33,8 +33,10 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var orgLinks = Page.Locator("a[href^='/organizations/']");
 		await Expect(orgLinks.First).ToBeVisibleAsync();
 
-		// Both seed org names must appear somewhere on the page.
-		await Expect(Page.GetByText("Rotes Kreuz Musterstadt")).ToBeVisibleAsync();
-		await Expect(Page.GetByText("Tierschutzverein Musterstadt")).ToBeVisibleAsync();
+		// Both seed org names must appear somewhere on the page. .First avoids a
+		// Playwright strict-mode violation once Vera has more than one engagement
+		// with the same org (seed data grows release over release).
+		await Expect(Page.GetByText("Rotes Kreuz Musterstadt").First).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Tierschutzverein Musterstadt").First).ToBeVisibleAsync();
 	}
 }

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -129,7 +129,11 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Page.GotoAsync($"{origin}/users/{userId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		// This page's data comes from a fresh fetch that fans out to Keycloak (user
+		// lookup) plus several DB queries (engagement count, badges, profile), so it
+		// is slower than a typical page load - give it the same headroom already
+		// used elsewhere in this file for API-heavy pages rather than the default.
+		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await Expect(Page.GetByText(skill)).ToBeVisibleAsync();
 		await Expect(Page.GetByText("Preferred contact channel")).ToBeVisibleAsync();
 	}

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -395,7 +395,13 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await step4.Locator("#slot-end").FillAsync(end.ToString("yyyy-MM-ddTHH:mm"));
 		var addSlotBtn = step4.GetByRole(AriaRole.Button, new() { Name = "Add", Exact = true });
 		await addSlotBtn.ClickAsync();
-		await Expect(addSlotBtn).ToBeEnabledAsync(new() { Timeout = 5000 });
+
+		// The Add button clears start/end and goes disabled again by design once a
+		// slot is added (ready for the next entry), so waiting for it to re-enable
+		// is not a valid completion signal here - that previously made this
+		// assertion flaky/incorrect. Wait for the slot to actually appear instead.
+		await Expect(step4.GetByText("No time slots added yet.")).Not.ToBeVisibleAsync(
+			new() { Timeout = 5000 });
 
 		await Page.GetByTestId("modal-submit").ClickAsync();
 		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });


### PR DESCRIPTION
## Summary

Fixes #623 - the last 4 release-candidate attempts each failed `Test - VisualTests` on a different test, blocking `deploy-staging`. Investigated the two previously-unexplained failures plus did a broader audit for the same underlying pattern.

- **`VolunteerOpportunityTests.PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne`**: asserted the time-slot "Add" button re-enables after being clicked. `handleAddSlot()` in `CreateVolunteerOpportunityModal.tsx` synchronously clears `startDateTime`/`endDateTime` after adding a slot, which correctly disables the button again (ready for the next entry) - this is by-design UI behavior, not a bug. The assertion was checking the wrong signal, not racing a real timing issue. Fixed to wait for the "No time slots added yet." placeholder to disappear instead - the real signal that the slot was added.
- **`ProfileOverviewTests.PublicUserProfile_ShowsBioSkillsLanguagesAndPreferredContact`**: timed out at 10s waiting for a just-saved bio to appear on the public profile page after navigation. Traced the read path (`GetPublicUserProfileQueryHandler`) - it's read-after-write consistent (fresh `DbContext.Users.FindAsync`, no cache), but it also blocks on a live Keycloak Admin API call plus two more DB queries before responding, making this specific page reliably slower than a typical load under the shared `SharedType.PerTestSession` stack's concurrent-test load. Bumped the timeout to 20s, matching the convention already used elsewhere in this same file for similarly API-heavy pages.
- **`AccountTests`** (3 tests) and **`MyEngagementsTests.MyEngagementsPage_ShowsOrganizationNameLinks_ForVerasEngagements`**: found via a broader audit for the same "assumes exactly one match" pattern that caused the two prior fixes in #621/#622. `/account` redirects to `/profile`, the same page `ProfileOverviewTests.cs` already had to guard with `.First`; the org-name assertions in `MyEngagementsTests.cs` will hit the same Playwright strict-mode violation once Vera has more than one engagement with the same org, which grows more likely release over release.

Also reviewed (per the issue's suggestion) `SharedType.PerTestSession`/seed-data-growth as the systemic root cause, and a few lower-risk unguarded locators in `OrganizationTests.cs`/`CheckInAndSlotTests.cs` that are currently scoped tightly enough (freshly-created orgs, single-opportunity detail pages, search-filtered lists) not to warrant a speculative change right now.

Left the issue's suggestion to change the deploy-gating policy (retry-on-failure or don't gate `deploy-staging` on this suite) untouched - that's a CI-policy tradeoff for the repo owner, separate from actually fixing the flaky tests.

## Test plan

- [x] `dotnet build backend/tests/VisualTests/VisualTests.csproj` - compiles cleanly (the only failure is the pre-existing, unrelated Playwright-browser `apt install` post-build step, which fails in this sandbox regardless of this change - Playwright is provided separately per `CLAUDE.md`)
- [x] `/self-review` - no findings
- [ ] CI's `dotnet.yml`/`publish.yml` `Test - VisualTests` job (this sandbox cannot run Aspire/Docker locally)
- [ ] Cut a release candidate and confirm `Test - VisualTests` passes end-to-end, then smoke-test staging

## Live verification

Docker/Aspire is not available in this sandbox, so these tests could not be executed locally. Verification is via CI on this PR, followed by a release-candidate cut once merged (per repo policy) to confirm `Test - VisualTests` passes and `deploy-staging` proceeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTLtkgRfFUUiAkUyb88peR)_