### PR TITLE
fix: add concurrent-instance tripwire to issue-triage survey step

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -14,6 +14,19 @@ description: >
 
 ## 1. Survey
 
+Before anything else, check for a sign that another instance of this
+routine might already be running: look for a PR or branch matching this
+repo's `claude/*` naming convention that was opened in roughly the last 15
+minutes. If one already exists, stop immediately and do nothing this cycle
+- no comments, no new branches, no PRs - since the likely cause is a
+duplicate/overlapping scheduled trigger (this has happened before: two
+triggers on the same cron schedule both firing). Two instances racing on
+the same backlog risks duplicate fixes and colliding pushes. A PR that's
+simply been sitting open for a while awaiting the repository owner's review
+is normal and not a sign of this - the window is short specifically so it
+only catches near-simultaneous starts, not the everyday case of a PR
+waiting to be merged.
+
 Review all open issues and all open PRs before starting any work.
 
 For each open issue:


### PR DESCRIPTION
## Summary

Follow-up to #626. The earlier "no repo attached" / duplicate-firing incident this session hit was caused by two scheduled triggers existing on the same cron schedule at once, both able to act on the repo simultaneously. Adds a cheap guard to `.claude/skills/issue-triage/SKILL.md`'s Survey step: before doing anything else, check for a `claude/*` PR or branch opened in roughly the last 15 minutes. If one exists, stop immediately and do nothing this cycle rather than risk two instances racing on the same backlog (duplicate fixes, colliding pushes).

The 15-minute window is deliberately short: a PR that's simply been open for hours awaiting your review (the normal resting state now that the routine never merges its own PRs, per #626) is not mistaken for a concurrent instance - only a near-simultaneous second start would trip it.

## Test plan

- [x] Self-review: clean - `.claude/` skill doc only, no runtime/product code.
- [x] No Unicode em/en dashes, no stray tabs (checked manually).
- [ ] No runtime/product code changed - same as the precedent `.claude/` config PRs (#591, #624, #626), the "Mandatory: Deploy and verify" release-and-live-smoke-test workflow doesn't apply here.


---
_Generated by [Claude Code](https://claude.ai/code/session_019LqNoN5gni3X7tGn3DcDb8)_