### PR TITLE
fix: repair GetOpportunityFeedback 500 and drop doubled arrow on manage-engagements links

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -225,11 +225,11 @@ internal sealed class EngagementReadRepository(
 	{
 		var items = await dbContext.EngagementsQuery
 			.Where(e => e.OpportunityId == opportunityId && e.FeedbackSubmittedAt != null)
+			.OrderByDescending(e => e.FeedbackSubmittedAt)
 			.Select(e => new FeedbackItemDto(
 				e.FeedbackRating!.Value,
 				e.FeedbackComment,
 				e.FeedbackSubmittedAt!.Value))
-			.OrderByDescending(f => f.SubmittedAt)
 			.ToListAsync(cancellationToken);
 
 		var avg = items.Count > 0 ? (double?)items.Average(f => f.Rating) : null;

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -651,6 +651,51 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		result.Status.Should().Be("Pending");
 	}
 
+	// ── GetOpportunityFeedback (#628) ─────────────────────────────────────────
+
+	[Test]
+	public async Task GetOpportunityFeedback_ShouldReturnEmptySummary_WhenNoFeedbackSubmitted(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, cancellationToken);
+
+		summary.AverageRating.Should().BeNull();
+		summary.FeedbackCount.Should().Be(0);
+		summary.Items.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task GetOpportunityFeedback_ShouldReturnSubmittedFeedback_WhenVolunteerCheckedInAndRated(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id,
+			new SubmitFeedbackRequest { Rating = 4, Comment = "Great experience" },
+			cancellationToken);
+
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, cancellationToken);
+
+		summary.AverageRating.Should().Be(4);
+		summary.FeedbackCount.Should().Be(1);
+		summary.Items.Should().ContainSingle(i => i.Rating == 4 && i.Comment == "Great experience");
+	}
+
 	// ── Cross-opportunity time slot validation (#524) ─────────────────────────
 
 	[Test]

--- a/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
+++ b/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrganizationEngagementsTabTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	/// <summary>
+	/// Regression for #628 and #629. On the org dashboard's "Engagements" tab:
+	/// - GetOpportunityFeedback must not 500 (previously an EF Core query
+	///   ordered results after projecting into a DTO, which failed
+	///   translation on every call, regardless of engagement data).
+	/// - The "Manage engagements" link must show exactly one arrow (the SVG
+	///   icon), not a doubled arrow from a literal "→" baked into the
+	///   translation string plus the adjacent icon.
+	/// </summary>
+	[Test]
+	public async Task EngagementsTab_ShowsSingleArrowAndNoFeedbackError_ForFreshOpportunity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualEngTab {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"VisualEngTab Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by OrganizationEngagementsTabTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var feedbackResponse = await http.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/feedback");
+		feedbackResponse.EnsureSuccessStatusCode();
+		var feedback = await feedbackResponse.Content.ReadFromJsonAsync<JsonElement>();
+		feedback.GetProperty("feedbackCount").GetInt32().Should().Be(0);
+		feedback.GetProperty("items").GetArrayLength().Should().Be(0);
+
+		await Page.GotoAsync($"{origin}/organizations/{organizationId}/dashboard?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var manageLink = row.GetByRole(AriaRole.Link, new() { Name = "Manage engagements" });
+		await Expect(manageLink).ToBeVisibleAsync();
+
+		var linkText = (await manageLink.InnerTextAsync()).Trim();
+		linkText.Should().NotContain("→");
+
+		var svgCount = await manageLink.Locator("svg").CountAsync();
+		svgCount.Should().Be(1);
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -325,7 +325,7 @@
       "error": "Fehler: {{message}}",
       "noOpportunities": "Keine offenen Einsatzmöglichkeiten",
       "noOpportunitiesHint": "Erstelle eine Einsatzmöglichkeit, um Bewerbungen zu erhalten.",
-      "manageEngagements": "Bewerbungen verwalten →"
+      "manageEngagements": "Bewerbungen verwalten"
     },
     "orgDashboard": {
       "title": "Organisations-Dashboard",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -325,7 +325,7 @@
       "error": "Error: {{message}}",
       "noOpportunities": "No open opportunities",
       "noOpportunitiesHint": "Create a volunteer opportunity to start receiving applications.",
-      "manageEngagements": "Manage engagements →"
+      "manageEngagements": "Manage engagements"
     },
     "orgDashboard": {
       "title": "Organization Dashboard",

--- a/scripts/smoke-test-628-629-feedback-and-arrow.mjs
+++ b/scripts/smoke-test-628-629-feedback-and-arrow.mjs
@@ -1,0 +1,156 @@
+// Smoke test for #628 (GetOpportunityFeedback 500s on every "Manage
+// applications" page) and #629 ("Manage engagements" link shows a doubled
+// arrow). Verifies:
+//   1. GET /v1/volunteer-opportunities/{id}/feedback returns 200 with an
+//      empty summary for a fresh opportunity with no engagements, instead
+//      of the 500 reported in #628.
+//   2. The org dashboard's "Engagements" tab renders exactly one arrow
+//      indicator (the SVG icon) next to "Manage engagements", not two.
+// Creates a throwaway organization + opportunity and deletes both at the
+// end so this script doesn't leave junk data on the live site (see #630).
+// Run: node scripts/smoke-test-628-629-feedback-and-arrow.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const token = await getToken("olaf", "olaf123");
+	const authHeaders = {
+		Authorization: `Bearer ${token}`,
+		"Content-Type": "application/json",
+	};
+	console.log("OK  Got access token for olaf (organisator)");
+
+	const orgRes = await fetch(`${API}/v1/organizations`, {
+		method: "POST",
+		headers: authHeaders,
+		body: JSON.stringify({ name: `Smoke628629 Org ${Date.now()}` }),
+	});
+	if (!orgRes.ok)
+		throw new Error(`Create organization failed: ${orgRes.status} ${await orgRes.text()}`);
+	const org = await orgRes.json();
+	const orgId = org.id.value;
+	console.log(`OK  Created throwaway organization ${orgId}`);
+
+	let opportunityId;
+	try {
+		const oppRes = await fetch(`${API}/v1/volunteer-opportunities`, {
+			method: "POST",
+			headers: authHeaders,
+			body: JSON.stringify({
+				title: `Smoke628629 Opportunity ${Date.now()}`,
+				description: "Automated smoke test for #628/#629.",
+				organizationId: orgId,
+				isRemote: true,
+				occurrence: "OneTime",
+				participationType: "IndividualContact",
+				checkInMethod: "None",
+				isDraft: false,
+			}),
+		});
+		if (!oppRes.ok)
+			throw new Error(`Create opportunity failed: ${oppRes.status} ${await oppRes.text()}`);
+		const opportunity = await oppRes.json();
+		opportunityId = opportunity.id;
+		console.log(`OK  Created published opportunity ${opportunityId} with zero engagements`);
+
+		// --- 1. #628: feedback endpoint must return 200 + empty summary ---
+		const feedbackRes = await fetch(
+			`${API}/v1/volunteer-opportunities/${opportunityId}/feedback`,
+			{ headers: authHeaders },
+		);
+		if (!feedbackRes.ok) {
+			throw new Error(
+				`Expected 200 from GetOpportunityFeedback, got ${feedbackRes.status}: ${await feedbackRes.text()}`,
+			);
+		}
+		const feedback = await feedbackRes.json();
+		if (feedback.feedbackCount !== 0 || feedback.averageRating !== null || feedback.items.length !== 0) {
+			throw new Error(`Expected empty feedback summary, got ${JSON.stringify(feedback)}`);
+		}
+		console.log("OK  GetOpportunityFeedback returns 200 with an empty summary (#628 fixed)");
+
+		// --- 2. #629: exactly one arrow indicator on the manage-engagements link ---
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await page.goto(BASE, { waitUntil: "networkidle" });
+			await page.click("text=/sign in|anmelden/i");
+			await page.waitForURL(/\/realms\//, { timeout: 30000 });
+			await loginKeycloak(page, "olaf", "olaf123");
+
+			await page.goto(`${BASE}/organizations/${orgId}/dashboard?tab=engagements`, {
+				waitUntil: "networkidle",
+			});
+
+			const link = page
+				.locator("li", { hasText: "Smoke628629 Opportunity" })
+				.getByRole("link", { name: /manage engagements/i });
+			await link.waitFor({ state: "visible", timeout: 15000 });
+
+			const linkText = (await link.innerText()).trim();
+			if (linkText.includes("→") || linkText.includes("->")) {
+				throw new Error(
+					`Expected the link text to have no literal arrow (SVG icon supplies it), got "${linkText}"`,
+				);
+			}
+			const svgCount = await link.locator("svg").count();
+			if (svgCount !== 1) {
+				throw new Error(`Expected exactly one SVG arrow icon on the link, found ${svgCount}`);
+			}
+			console.log(
+				`OK  "Manage engagements" link renders exactly one arrow (text: "${linkText}", svg icons: ${svgCount}) (#629 fixed)`,
+			);
+		} finally {
+			await browser.close();
+		}
+	} finally {
+		if (opportunityId) {
+			await fetch(`${API}/v1/volunteer-opportunities/${opportunityId}`, {
+				method: "DELETE",
+				headers: authHeaders,
+			});
+		}
+		await fetch(`${API}/v1/organizations/${orgId}`, {
+			method: "DELETE",
+			headers: authHeaders,
+		});
+		console.log("OK  Cleaned up throwaway opportunity and organization");
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #628 and #629, both filed by this cycle's persona-simulation run.

**#628 - Feedback endpoint 500s on every "Manage applications" page (High)**

`EngagementReadRepository.GetFeedbackByOpportunityAsync` was the only read-repository query in the codebase that calls `.OrderByDescending()` *after* `.Select()`-projecting into a custom DTO record (`FeedbackItemDto`), combined with null-forgiving `!.Value` accessors on the nullable columns being ordered on. Every other query in this repository (and the rest of `Infrastructure/Persistence/Repositories/`) orders on the raw entity property *before* projecting - this is the one place that didn't follow that pattern. That mismatch is consistent with an EF Core query-translation failure that throws at query-compile time, which explains why the bug reproduced 100% of the time, even for opportunities with zero engagements (the exception happens before the query ever executes against data).

Fix: reorder so `.OrderByDescending(e => e.FeedbackSubmittedAt)` runs on the entity property before the `.Select()` projection, matching the established convention used everywhere else in this file (see `GetByOpportunityAsync`, `GetByVolunteerAsync`).

**#629 - Doubled arrow on "Manage engagements" links (Low)**

`orgEngagements.manageEngagements` in both `en.json`/`de.json` had a literal trailing `" →"` baked into the translation string, rendered immediately next to an SVG chevron icon in `OrganizationEngagementsPage.tsx` and `OrganizationOverviewPage.tsx`, producing "Manage engagements → →". Dropped the trailing arrow from both locale strings, keeping the SVG icon (consistent with the pattern used elsewhere in the app). Left the unrelated `opportunities.manageApplications` key untouched - it's a plain-text link with no adjacent icon, so its arrow is intentional.

## Test plan

- [x] `dotnet build` (backend) - compiles cleanly (the only failure is the pre-existing, unrelated Playwright-browser `apt install` post-build step for `VisualTests`, which fails in this sandbox regardless of this change per `CLAUDE.md`)
- [x] `Application.UnitTests` - 207/207 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] Added `IntegrationTests`: `GetOpportunityFeedback_ShouldReturnEmptySummary_WhenNoFeedbackSubmitted`, `GetOpportunityFeedback_ShouldReturnSubmittedFeedback_WhenVolunteerCheckedInAndRated`
- [x] Added `VisualTests`: `OrganizationEngagementsTabTests.EngagementsTab_ShowsSingleArrowAndNoFeedbackError_ForFreshOpportunity` - exercises both fixes together against the Aspire-hosted stack
- [x] Frontend `pnpm lint` / `pnpm format:check` / `pnpm check` - all clean
- [x] CI (`dotnet.yml`) green on this branch, including `Test - VisualTests`
- [x] `/self-review` - findings addressed (caught and reverted a collateral edit to the unrelated `manageApplications` locale key before committing); `i18n-check` and `ef-migration-check` subagents both report clean

## Live verification

Cut release candidate `v1.0.0-rc.198` from this branch; `publish.yml` succeeded end-to-end including `deploy-staging`.

- `curl https://api.maik-hasler.de/health` -> `200`
- `node scripts/smoke-test-628-629-feedback-and-arrow.mjs` against `https://einsatzbereit.maik-hasler.de` - all checks passed:
  - `GetOpportunityFeedback` returns `200` with an empty summary for a fresh opportunity with zero engagements (previously `500` on every call)
  - The "Manage engagements" link on the org dashboard's Engagements tab renders exactly one arrow (link text has no literal `→`, exactly one `<svg>` icon)
  - The script creates a throwaway organization + opportunity for the test and deletes both afterwards, so it doesn't leave junk data on the live site (see #630)

Automated coverage for both fixes also added to `backend/tests/VisualTests/OrganizationEngagementsTabTests.cs`, which runs against the Aspire-hosted stack in CI.
