### PR TITLE
fix: harden VisualTests reliability and restore drafts UI

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -403,8 +403,13 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(step4.GetByText("No time slots added yet.")).Not.ToBeVisibleAsync(
 			new() { Timeout = 5000 });
 
+		// Closing the dialog waits on 3 sequential API calls (create opportunity,
+		// create time slot, publish) - under the shared, contended CI stack this can
+		// exceed 15s even when nothing is actually wrong, so use the same 30s window
+		// already established in this file for other network-heavy waits (see
+		// HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist above).
 		await Page.GetByTestId("modal-submit").ClickAsync();
-		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 30_000 });
 
 		// The newly published opportunity is visible in the public list.
 		await Page.GotoAsync(frontend.ToString());

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -12,6 +12,7 @@ import type {
 	OrganizationDetailsResponse,
 	OrgInvitationDto,
 	PublicOpportunitySummaryDto,
+	VolunteerOpportunitySummary,
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -169,8 +170,25 @@ export default function OrganizationOverviewPage() {
 
 	function handleOpportunityCreated() {
 		loadCalendarEvents();
+		loadDrafts();
 		setEngInitialized(false);
 	}
+
+	// ── Drafts (unpublished opportunities, not shown in public listings) ────
+	const [drafts, setDrafts] = useState<VolunteerOpportunitySummary[]>([]);
+
+	function loadDrafts() {
+		if (!organizationId) return;
+		api
+			.getOrganizationOpportunityDrafts(organizationId)
+			.then(setDrafts)
+			.catch(() => {});
+	}
+
+	useEffect(() => {
+		loadDrafts();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [organizationId]);
 
 	// ── Calendar tab ────────────────────────────────────────────────────────
 	const [calData, setCalData] = useState<OrganizationCalendarEventDto[]>([]);
@@ -561,6 +579,46 @@ export default function OrganizationOverviewPage() {
 			{/* ── Calendar tab ──────────────────────────────────────────────────── */}
 			{activeTab === "calendar" && (
 				<div>
+					{drafts.length > 0 && (
+						<section className="mb-8" data-testid="drafts-section">
+							<h2 className="text-lg font-semibold text-gray-900">
+								{t("orgDashboard.draftsTitle")}
+							</h2>
+							<p className="mt-1 text-sm text-gray-500">
+								{t("orgDashboard.draftsDesc")}
+							</p>
+							<ul className="mt-4 space-y-3">
+								{drafts.map((draft) => (
+									<li
+										key={draft.id}
+										className="relative rounded-2xl border border-gray-100 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md"
+									>
+										<Link
+											to={`/volunteer-opportunities/${draft.id}`}
+											className="absolute inset-0"
+											aria-label={draft.title || t("orgDashboard.unnamedDraft")}
+										/>
+										<div className="flex items-center justify-between gap-3">
+											<div className="min-w-0">
+												<p className="truncate text-sm font-semibold text-gray-900">
+													{draft.title || t("orgDashboard.unnamedDraft")}
+												</p>
+												{draft.description && (
+													<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">
+														{draft.description}
+													</p>
+												)}
+											</div>
+											<span className="shrink-0 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800">
+												{t("opportunities.draftBadge")}
+											</span>
+										</div>
+									</li>
+								))}
+							</ul>
+						</section>
+					)}
+
 					{calLoading && (
 						<div className="flex items-center justify-center py-16">
 							<span className="text-gray-500">


### PR DESCRIPTION
## Summary

Relates to #623 - the ongoing `VisualTests` reliability problem blocking staging deploys. This PR fixes two distinct, unrelated causes of `Test - VisualTests` failures found while working the issue:

**1. Publish-flow dialog-close timeout (`PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne`)**

The latest failure on `main` (run [28838541369](https://github.com/maik-hasler/einsatzbereit/actions/runs/28838541369)) times out waiting for the create-opportunity dialog to close after publish:

```
PlaywrightException: Locator expected not to be visible
Call log:
  - Expect "ToBeVisibleAsync" with timeout 15000ms
  - waiting for Locator("[role='dialog']")
    19 x locator resolved to <div role="dialog" ... create-opportunity-dialog-title ...>
       - unexpected value "visible"
```

Root cause: `CreateVolunteerOpportunityModal.submit()` only calls `onClose()` after 3 sequential, awaited API calls succeed (create opportunity, create time slot, publish) - `frontend/src/components/CreateVolunteerOpportunityModal.tsx:568-618`. The "19 x locator resolved ... unexpected value visible" is Playwright's standard poll-retry log for a single element that never disappeared (~1 poll/second over the 15s timeout), not 19 stale/leaked dialogs - verified the modal is only ever mounted once, gated by a single boolean in the parent. Under the shared, contended `SharedType.PerTestSession` CI stack, those 3 round-trips can exceed a 15s budget even when nothing is actually wrong.

Fix: bump this assertion's timeout from 15s to 30s, matching the precedent already established in this same file for another network-heavy wait (`HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist`, line 247).

**2. Missing drafts UI (`CreateDraft_DoesNotAppearInPublicList_AppearOnDashboardWithAmberBadge`) - filed as #633**

While re-running CI for fix #1, a *different* test failed on the same run: waiting for `GetByTestId("drafts-section")`, element not found at all (not just hidden). Investigation showed this isn't flakiness - it's a real regression. PR #561 deleted `OrganizationDashboardPage.tsx` as "dead code" since it wasn't wired into `App.tsx`, but that page contained the *only* UI rendering an organization's draft opportunities. The backend endpoint (`getOrganizationOpportunityDrafts`), NSwag client method, and locale strings all still exist; the UI referencing them was simply never ported to `OrganizationOverviewPage.tsx`, which superseded it. So organizers could save a draft but never see it again anywhere in the app.

This test only reaches the failing assertion when an earlier, unrelated early-return guard in the same test doesn't trigger (depends on how many orgs have accumulated for `olaf` earlier in the same shared CI session) - which is why it looked like more evidence of #623's flakiness pattern at first, rather than a deterministic, unrelated regression.

Fix: restored the drafts section into `OrganizationOverviewPage.tsx`'s default "Calendar" tab, reusing the exact same markup/testid/locale keys the deleted page (and the existing VisualTests test) already expect, backed by the still-live endpoint. Filed as #633 for a clear paper trail on the regression itself.

**Not changed:** per this issue's own findings from the last cycle, making `deploy-staging` more resilient to flaky `VisualTests` (retry-on-failure, or not gating the deploy on this suite), and any redesign of the `SharedType.PerTestSession` isolation model, are both CI-policy/architecture tradeoffs left for your decision.

## Test plan

- [x] `dotnet build` (backend) - compiles cleanly (the only failure is the pre-existing, unrelated Playwright-browser `apt install` post-build step for `VisualTests`, which fails in this sandbox regardless of this change per `CLAUDE.md`)
- [x] `Application.UnitTests` - 207/207 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- [x] `a11y-check` subagent - no issues in the new drafts section (stretched-link pattern, matching accessible name, correctly applied)
- [x] `/self-review` - clean, no findings
- [ ] CI (`dotnet.yml`) green on this branch, including `Test - VisualTests`

## Live verification

Change #1 is test-infrastructure-only (no app behavior change) - validated via `Test - VisualTests` passing in CI/on a release-candidate build. Change #2 is a real UI fix - will additionally smoke-test the restored drafts section against staging with Playwright. Will cut a release candidate once CI is green and report both results here.
