### PR TITLE
fix: retry flaky VisualTests before failing CI

### DIFF
--- a/backend/tests/VisualTests/AssemblyRetryPolicy.cs
+++ b/backend/tests/VisualTests/AssemblyRetryPolicy.cs
@@ -1,0 +1,10 @@
+// Regression for #623: ~61 VisualTests classes share one Aspire-hosted stack
+// per test session (SharedType.PerTestSession). Under a contended CI runner,
+// individual tests intermittently time out waiting on UI state that is slow
+// to settle (dialog close, save-then-navigate reads) rather than failing due
+// to an actual app defect - a different test flakes this way each release,
+// which has repeatedly blocked Deploy to Staging on a transient failure.
+// Retrying a failed test re-runs only that test method against the same
+// shared stack; a genuine regression still fails on every attempt and still
+// fails the suite, but a one-off timing flake gets a chance to pass.
+[assembly: Retry(2)]


### PR DESCRIPTION
## Summary

Relates to #623 - the recurring "staging deploys blocked by a different flaky `VisualTests` failure each release" problem. Four consecutive release-candidate attempts (rc.193-rc.196) each failed on a different test; two of those were fixed as real test bugs (#621/#622), a third fix landed in #625, and yet another `VisualTests` test flaked again immediately afterward on `main` (see the issue's own reopening comments). Every one of these flakes has been a UI-state timing wait (dialog close, save-then-navigate read) under the shared, contended `SharedType.PerTestSession` CI stack, not a real app defect.

Point-fixing individual assertions has not converged - a new test flakes each cycle. The issue itself proposes retry-on-failure as an option ("Decide whether to make Deploy to Staging more resilient to individual flaky VisualTests failures (e.g. retry-on-failure, or don't gate deploy on this specific suite)"). This PR implements the narrower of those two: retry at the individual-test level rather than skipping the gate entirely.

## Changes

- `backend/tests/VisualTests/AssemblyRetryPolicy.cs` (new): `[assembly: Retry(2)]` (TUnit's built-in retry attribute) gives every `VisualTests` test up to two additional attempts before it's reported as failed. A test that fails on every attempt (a genuine regression, e.g. a missing UI element or wrong assertion) still fails the suite - this only absorbs one-off timing flakiness, it doesn't mask deterministic failures.

**Not changed:** the issue's other two suggestions - auditing the suite for order-/count-dependent locator assumptions, and reconsidering whether `SharedType.PerTestSession` is still the right isolation model at ~61 tests - are both larger, separate efforts (the first is an ongoing incremental audit already touched in prior cycles; the second is an architecture call) and out of scope for this bounded resilience fix.

## Test plan

- [x] `dotnet build backend/src/Api/Api.csproj` - compiles cleanly, 0 warnings/errors
- [x] `dotnet build backend/tests/VisualTests/VisualTests.csproj` - compiles cleanly (the only failure is the pre-existing, unrelated Playwright-browser `apt install` post-build step, which fails in this sandbox regardless of this change per `CLAUDE.md`)
- [x] `Application.UnitTests` - 207/207 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] `/self-review` equivalent - diff only touches a new test-infrastructure file outside all domain-specific-check paths (no endpoint/DTO, EF, layer, `.tsx`, or locale changes), so none of the specialized subagents apply; reviewed manually against the priority checklist, no findings

## Live verification

This change only affects `VisualTests` retry behavior in CI/CD (`dotnet.yml`'s `Test - VisualTests` step and the release pipeline's equivalent gate) - there is no live-application behavior to smoke-test with Playwright against staging. Verification is: cut a release candidate from this branch and confirm `Test - VisualTests` (and therefore `Deploy to Staging`) is no longer single-shot-fragile to one flaky test. Will report the RC result here once cut.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBPb3aNn6Yt15kmSEVfBaJ)_