### PR TITLE
fix: remove duplicate onboarding welcome banner on HomePage

### DIFF
--- a/backend/tests/VisualTests/SmokeTests.cs
+++ b/backend/tests/VisualTests/SmokeTests.cs
@@ -24,4 +24,18 @@ public class SmokeTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 		await Expect(Page).ToHaveURLAsync($"{origin}/");
 	}
+
+	[Test]
+	public async Task OnboardingBanner_ShowsExactlyOnce_WithNoRawTranslationKey()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		var banners = Page.GetByRole(AriaRole.Region, new() { Name = "Welcome banner" });
+		await Expect(banners).ToHaveCountAsync(1);
+		await Expect(banners).ToContainTextAsync(
+			"Browse volunteer opportunities near you, sign up with one click, and earn badges as you help your community.");
+		await Expect(banners).Not.ToContainTextAsync("onboarding.message");
+	}
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -732,13 +732,6 @@
       "achievements": "Meine Errungenschaften",
       "userAchievements": "Errungenschaften"
     },
-    "onboarding": {
-      "ariaLabel": "Willkommensbanner",
-      "title": "Willkommen bei Einsatzbereit!",
-      "message": "Entdecke Freiwilligeneinsätze in deiner Nähe, melde dich mit einem Klick an und verdiene Abzeichen, während du deine Gemeinschaft unterstützt.",
-      "cta": "Einsätze entdecken",
-      "dismiss": "Schließen"
-    },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",
       "serverError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -732,13 +732,6 @@
       "achievements": "My Achievements",
       "userAchievements": "Achievements"
     },
-    "onboarding": {
-      "ariaLabel": "Welcome banner",
-      "title": "Welcome to Einsatzbereit!",
-      "message": "Browse volunteer opportunities near you, sign up with one click, and earn badges as you help your community.",
-      "cta": "Browse opportunities",
-      "dismiss": "Dismiss"
-    },
     "error": {
       "forbidden": "You do not have permission to do this.",
       "serverError": "An unexpected error occurred. Please try again later.",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -458,40 +458,6 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			{showOnboarding && (
-				<section
-					aria-label={t("onboarding.ariaLabel")}
-					className="mb-8 rounded-2xl border border-brand-200 bg-brand-50 px-6 py-5"
-				>
-					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-						<div className="min-w-0">
-							<p className="text-sm font-semibold text-brand-900">
-								{t("onboarding.title")}
-							</p>
-							<p className="mt-1 text-sm text-brand-700">
-								{t("onboarding.message")}
-							</p>
-						</div>
-						<div className="flex shrink-0 items-center gap-3">
-							<a
-								href="#opportunities"
-								className="rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
-							>
-								{t("onboarding.cta")}
-							</a>
-							<button
-								type="button"
-								onClick={handleDismissOnboarding}
-								aria-label={t("onboarding.dismiss")}
-								className="rounded-lg border border-brand-300 px-4 py-2 text-sm font-medium text-brand-700 transition-colors hover:bg-brand-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
-							>
-								{t("onboarding.dismiss")}
-							</button>
-						</div>
-					</div>
-				</section>
-			)}
-
 			<div id="opportunities">
 				{showOnboarding && (
 					<OnboardingBanner onDismiss={handleDismissOnboarding} />


### PR DESCRIPTION
## Summary

Addresses #637.

`frontend/src/pages/HomePage.tsx` contained two independent implementations of the #374 onboarding banner, both gated by the same `showOnboarding` state: a plain inline `<section>` block, and the reusable `OnboardingBanner` component. Both rendered whenever `showOnboarding` was `true`, stacking two near-identical "Welcome to Einsatzbereit!" banners.

Compounding this, both `frontend/src/locales/en.json` and `de.json` had **two** top-level `"onboarding"` JSON objects - one keyed `message`, one keyed `body`. Since `JSON.parse` silently keeps only the last duplicate key, only `onboarding.body` survived parsing; `onboarding.message` (used by the inline block) resolved to nothing, so i18next rendered the raw key path `onboarding.message` as literal text in that banner.

## Fix

- Deleted the dead inline banner block in `HomePage.tsx`, keeping the `OnboardingBanner` component (the one already used and correctly wired to `onboarding.body`).
- Deleted the dead, `message`-keyed `"onboarding"` object from both `en.json` and `de.json`, keeping the `body`-keyed one.
- Added a `VisualTests` regression test (`SmokeTests.OnboardingBanner_ShowsExactlyOnce_WithNoRawTranslationKey`) asserting exactly one "Welcome banner" region renders after first login, with real translated copy and no raw `onboarding.message` key leaking into the page.

## Test plan

- [x] `dotnet build` (backend, VisualTests project) - compiles cleanly (the only failure is the pre-existing, unrelated Playwright-browser `apt install` post-build step, which fails in this sandbox regardless of this change per `CLAUDE.md`)
- [x] `Application.UnitTests` - 207/207 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- [x] `i18n-check` subagent - en.json/de.json remain in sync (678 keys each), no other reference to the removed key
- [x] `a11y-check` subagent - no issues; surviving `OnboardingBanner`'s `role="region"` + `aria-label` is an equivalent/valid a11y-tree exposure
- [x] `/self-review` - clean, no findings
- [ ] CI (`dotnet.yml`) green on this branch, including `Test - VisualTests`

## Live verification

Will cut a release candidate once CI is green, and smoke-test the fix against `https://einsatzbereit.maik-hasler.de` with a new Playwright script (clear `localStorage`, sign in as `vera` for the first time, confirm exactly one welcome banner renders with no raw `onboarding.message` text). Will report the result here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SpmRpfmDNcCzuEMMXnB37y)_