### PR TITLE
test: add live-verification smoke script for #637 onboarding banner fix

### DIFF
--- a/scripts/smoke-test-637-onboarding-banner.mjs
+++ b/scripts/smoke-test-637-onboarding-banner.mjs
@@ -1,0 +1,64 @@
+// Smoke test for #637 (PR #638): HomePage.tsx rendered two independent
+// implementations of the #374 onboarding banner whenever showOnboarding was
+// true - a plain inline block and the reusable OnboardingBanner component -
+// stacking two "Welcome to Einsatzbereit!" boxes, with the inline one
+// showing the raw untranslated key "onboarding.message" instead of real
+// copy (a duplicate top-level "onboarding" JSON key in en.json/de.json
+// meant JSON.parse silently dropped the "message"-keyed one). PR #638
+// deleted the dead inline block and the dead locale key. Verifies exactly
+// one banner renders with real copy and no raw key text.
+//
+// No throwaway data is created (the banner is gated purely by the
+// "onboarding-dismissed" localStorage key, not server state), so there is
+// nothing to clean up (see #630).
+// Run: node scripts/smoke-test-637-onboarding-banner.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.click("text=/sign in|anmelden/i");
+		await page.waitForURL(/\/realms\//, { timeout: 30000 });
+		await loginKeycloak(page, "vera", "vera123");
+
+		await page.goto(BASE, { waitUntil: "networkidle" });
+
+		const banners = page.getByRole("region", { name: "Welcome banner" });
+		const count = await banners.count();
+		if (count !== 1) {
+			throw new Error(`Expected exactly 1 "Welcome banner" region, found ${count}`);
+		}
+		console.log('OK  Exactly one "Welcome banner" region rendered');
+
+		const bannerText = await banners.innerText();
+		const expectedBody =
+			"Browse volunteer opportunities near you, sign up with one click, and earn badges as you help your community.";
+		if (!bannerText.includes(expectedBody)) {
+			throw new Error(`Banner text missing expected real copy. Got: ${bannerText}`);
+		}
+		console.log("OK  Banner shows real translated body copy");
+
+		if (bannerText.includes("onboarding.message")) {
+			throw new Error('Banner text still contains the raw "onboarding.message" key');
+		}
+		console.log('OK  No raw "onboarding.message" translation key leaked into the page');
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Relates to #637. PR #638 fixed the duplicate onboarding welcome banner on `HomePage.tsx` and merged to `main`, but merged before the mandatory release-candidate live-verification step ran (its own PR body said "Will cut a release candidate once CI is green... Will report the result here" - that follow-up hadn't happened yet).

This PR adds the missing persisted Playwright script and completes that verification.

## What changed

- Added `scripts/smoke-test-637-onboarding-banner.mjs`, following the existing `scripts/lib/live-browser.mjs` helper pattern used by other smoke scripts in this directory. It signs in as `vera` with a fresh (no localStorage) browser context and asserts exactly one `"Welcome banner"` region renders, with the real translated body copy and no raw `onboarding.message` key text.
- No app/product code changes - the #637 fix itself (in #638) was already correct; this only adds the reviewable, committed verification artifact required by root `CLAUDE.md`'s "Mandatory: Deploy and verify" section.

## Test plan

- [x] Cut `v1.0.0-rc.204` from `main` (includes the #638 fix): `Test - VisualTests` passed, `Deploy to Staging` succeeded (health gate green).
- [x] Ran `node scripts/smoke-test-637-onboarding-banner.mjs` against `https://einsatzbereit.maik-hasler.de` - all checks passed.

## Live verification

Documented on #637: https://github.com/maik-hasler/einsatzbereit/issues/637#issuecomment-4909128502

Exactly one "Welcome banner" region renders on first login as `vera`, with real translated copy and no raw `onboarding.message` text leaking into the page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MqTu2sxNuPwMzDZy5eEd7L)_