### PR TITLE
fix: stop org dashboard tab bar from shrinking/left-aligning on non-calendar tabs

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using AwesomeAssertions;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -122,6 +123,36 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, delete" }).ClickAsync();
 
 		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 10_000 });
+	}
+
+	[Test]
+	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
+	{
+		// Regression for #641: the header/tab-bar used to be wrapped in the same
+		// `max-w-2xl` container as the per-tab content, so switching off the
+		// Calendar tab shrank the tab bar itself (and left-aligned it, since
+		// that container had no `mx-auto`) instead of leaving it full width and
+		// only constraining the content beneath it.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual641 Alignment");
+
+		var tabBar = Page.Locator("nav").Filter(new() { HasText = "Settings" });
+		var calendarBox = await tabBar.BoundingBoxAsync();
+		calendarBox.Should().NotBeNull();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Settings" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Edit" })).ToBeVisibleAsync(
+			new() { Timeout = 10_000 });
+
+		var settingsBox = await tabBar.BoundingBoxAsync();
+		settingsBox.Should().NotBeNull();
+
+		settingsBox!.Width.Should().Be(calendarBox!.Width);
+		settingsBox.X.Should().Be(calendarBox.X);
 	}
 
 	private async Task<string> CreateOrganizationAsync(string namePrefix)

--- a/frontend/src/pages/OrganizationOverviewPage.tsx
+++ b/frontend/src/pages/OrganizationOverviewPage.tsx
@@ -538,7 +538,7 @@ export default function OrganizationOverviewPage() {
 	];
 
 	return (
-		<div className={activeTab !== "calendar" ? "max-w-2xl" : ""}>
+		<div>
 			<div className="mb-6 flex items-center justify-between gap-3">
 				<h1 className="text-2xl font-bold text-gray-900">
 					{org?.name ?? t("orgDashboard.title")}
@@ -576,772 +576,795 @@ export default function OrganizationOverviewPage() {
 				</nav>
 			</div>
 
-			{/* ── Calendar tab ──────────────────────────────────────────────────── */}
-			{activeTab === "calendar" && (
-				<div>
-					{drafts.length > 0 && (
-						<section className="mb-8" data-testid="drafts-section">
-							<h2 className="text-lg font-semibold text-gray-900">
-								{t("orgDashboard.draftsTitle")}
-							</h2>
-							<p className="mt-1 text-sm text-gray-500">
-								{t("orgDashboard.draftsDesc")}
-							</p>
-							<ul className="mt-4 space-y-3">
-								{drafts.map((draft) => (
-									<li
-										key={draft.id}
-										className="relative rounded-2xl border border-gray-100 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md"
-									>
-										<Link
-											to={`/volunteer-opportunities/${draft.id}`}
-											className="absolute inset-0"
-											aria-label={draft.title || t("orgDashboard.unnamedDraft")}
-										/>
-										<div className="flex items-center justify-between gap-3">
-											<div className="min-w-0">
-												<p className="truncate text-sm font-semibold text-gray-900">
-													{draft.title || t("orgDashboard.unnamedDraft")}
-												</p>
-												{draft.description && (
-													<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">
-														{draft.description}
+			<div
+				className={
+					activeTab !== "calendar"
+						? "mx-auto max-w-2xl lg:min-h-[600px]"
+						: "lg:min-h-[600px]"
+				}
+			>
+				{/* ── Calendar tab ──────────────────────────────────────────────────── */}
+				{activeTab === "calendar" && (
+					<div>
+						{drafts.length > 0 && (
+							<section className="mb-8" data-testid="drafts-section">
+								<h2 className="text-lg font-semibold text-gray-900">
+									{t("orgDashboard.draftsTitle")}
+								</h2>
+								<p className="mt-1 text-sm text-gray-500">
+									{t("orgDashboard.draftsDesc")}
+								</p>
+								<ul className="mt-4 space-y-3">
+									{drafts.map((draft) => (
+										<li
+											key={draft.id}
+											className="relative rounded-2xl border border-gray-100 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md"
+										>
+											<Link
+												to={`/volunteer-opportunities/${draft.id}`}
+												className="absolute inset-0"
+												aria-label={
+													draft.title || t("orgDashboard.unnamedDraft")
+												}
+											/>
+											<div className="flex items-center justify-between gap-3">
+												<div className="min-w-0">
+													<p className="truncate text-sm font-semibold text-gray-900">
+														{draft.title || t("orgDashboard.unnamedDraft")}
 													</p>
-												)}
+													{draft.description && (
+														<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">
+															{draft.description}
+														</p>
+													)}
+												</div>
+												<span className="shrink-0 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800">
+													{t("opportunities.draftBadge")}
+												</span>
 											</div>
-											<span className="shrink-0 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800">
-												{t("opportunities.draftBadge")}
-											</span>
-										</div>
-									</li>
-								))}
-							</ul>
-						</section>
-					)}
+										</li>
+									))}
+								</ul>
+							</section>
+						)}
 
-					{calLoading && (
-						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">
-								{t("orgOverview.calendarLoading")}
-							</span>
-						</div>
-					)}
-					{calError && (
-						<p className="text-red-600">
-							{t("orgOverview.calendarError", { message: calError })}
-						</p>
-					)}
-					{!calLoading && !calError && (
-						<div className="rbc-container">
-							<Calendar
-								localizer={localizer}
-								events={calEvents}
-								view={calView}
-								onView={(v: View) => setCalView(v)}
-								date={calDate}
-								onNavigate={(d: Date) => setCalDate(d)}
-								views={["month", "week", "work_week", "day"]}
-								style={{ height: 600 }}
-								components={{ event: CalEventChip }}
-								eventPropGetter={(event: object) => {
-									const e = event as CalEvent;
-									const bg = e.color ?? DEFAULT_EVENT_COLOR;
-									return {
-										style: {
-											backgroundColor: bg,
-											borderColor: bg,
-											color: "#ffffff",
-										},
-									};
-								}}
-								onSelectEvent={(event: object) =>
-									handleSelectEvent(event as CalEvent)
-								}
-								messages={{
-									today: t("orgOverview.calendarToday"),
-									previous: t("orgOverview.calendarBack"),
-									next: t("orgOverview.calendarNext"),
-									month: t("orgOverview.calendarMonth"),
-									week: t("orgOverview.calendarWeek"),
-									work_week: t("orgOverview.calendarWorkWeek"),
-									day: t("orgOverview.calendarDay"),
-									noEventsInRange: t("orgOverview.calendarNoEvents"),
-								}}
-							/>
-						</div>
-					)}
-
-					{/* Color picker modal */}
-					{selectedEvent && (
-						<div className="fixed inset-0 z-[2000] flex items-center justify-center">
-							<button
-								type="button"
-								aria-hidden="true"
-								tabIndex={-1}
-								className="absolute inset-0 bg-black/50"
-								onClick={() => setSelectedEvent(null)}
-							/>
-							<div
-								role="dialog"
-								aria-modal="true"
-								aria-labelledby="color-dialog-title"
-								className="relative z-10 w-80 rounded-xl bg-white p-6 shadow-xl"
-							>
-								<h2
-									id="color-dialog-title"
-									className="mb-4 text-lg font-semibold text-gray-900"
-								>
-									{selectedEvent.title}
-								</h2>
-								<div className="space-y-4">
-									{selectedEvent.maxParticipants > 0 && (
-										<p className="text-sm text-gray-600">
-											{t("orgOverview.eventFillState", {
-												booked: selectedEvent.bookedCount,
-												max: selectedEvent.maxParticipants,
-											})}
-										</p>
-									)}
-									<div>
-										<label
-											htmlFor="event-color-picker"
-											className="block text-sm font-medium text-gray-700"
-										>
-											{t("orgOverview.eventColorLabel")}
-										</label>
-										<div className="mt-1 flex items-center gap-3">
-											<input
-												id="event-color-picker"
-												type="color"
-												value={pickerColor}
-												onChange={(e) => setPickerColor(e.target.value)}
-												className="h-9 w-16 cursor-pointer rounded border border-gray-300"
-											/>
-											<span className="text-sm text-gray-500">
-												{pickerColor}
-											</span>
-										</div>
-									</div>
-									{colorSaveError && (
-										<p className="text-sm text-red-600">{colorSaveError}</p>
-									)}
-									<div className="flex flex-col gap-2">
-										<div className="flex gap-4">
-											<Link
-												to={`/volunteer-opportunities/${selectedEvent.opportunityId}`}
-												className="text-sm text-brand-700 hover:underline"
-												onClick={() => setSelectedEvent(null)}
-											>
-												{t("orgOverview.eventNavigate")}
-											</Link>
-											<Link
-												to={`/volunteer-opportunities/${selectedEvent.opportunityId}/engagements`}
-												className="text-sm text-brand-700 hover:underline"
-												onClick={() => setSelectedEvent(null)}
-											>
-												{t("orgOverview.eventManageApplications")}
-											</Link>
-										</div>
-										<div className="flex justify-end gap-2">
-											<button
-												type="button"
-												onClick={() => setSelectedEvent(null)}
-												className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-											>
-												{t("createOpportunity.cancel")}
-											</button>
-											<button
-												type="button"
-												disabled={savingColor}
-												onClick={handleColorSave}
-												className="rounded-md bg-brand-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-											>
-												{savingColor
-													? t("orgOverview.eventColorSaving")
-													: t("orgOverview.eventColorSave")}
-											</button>
-										</div>
-									</div>
-								</div>
+						{calLoading && (
+							<div className="flex items-center justify-center py-16">
+								<span className="text-gray-500">
+									{t("orgOverview.calendarLoading")}
+								</span>
 							</div>
-						</div>
-					)}
-				</div>
-			)}
+						)}
+						{calError && (
+							<p className="text-red-600">
+								{t("orgOverview.calendarError", { message: calError })}
+							</p>
+						)}
+						{!calLoading && !calError && (
+							<div className="rbc-container">
+								<Calendar
+									localizer={localizer}
+									events={calEvents}
+									view={calView}
+									onView={(v: View) => setCalView(v)}
+									date={calDate}
+									onNavigate={(d: Date) => setCalDate(d)}
+									views={["month", "week", "work_week", "day"]}
+									style={{ height: 600 }}
+									components={{ event: CalEventChip }}
+									eventPropGetter={(event: object) => {
+										const e = event as CalEvent;
+										const bg = e.color ?? DEFAULT_EVENT_COLOR;
+										return {
+											style: {
+												backgroundColor: bg,
+												borderColor: bg,
+												color: "#ffffff",
+											},
+										};
+									}}
+									onSelectEvent={(event: object) =>
+										handleSelectEvent(event as CalEvent)
+									}
+									messages={{
+										today: t("orgOverview.calendarToday"),
+										previous: t("orgOverview.calendarBack"),
+										next: t("orgOverview.calendarNext"),
+										month: t("orgOverview.calendarMonth"),
+										week: t("orgOverview.calendarWeek"),
+										work_week: t("orgOverview.calendarWorkWeek"),
+										day: t("orgOverview.calendarDay"),
+										noEventsInRange: t("orgOverview.calendarNoEvents"),
+									}}
+								/>
+							</div>
+						)}
 
-			{/* ── Engagements tab ───────────────────────────────────────────────── */}
-			{activeTab === "engagements" && (
-				<div>
-					{engLoading && (
-						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">
-								{t("orgEngagements.loading")}
-							</span>
-						</div>
-					)}
-					{engError && (
-						<p className="text-red-600">
-							{t("orgEngagements.error", { message: engError })}
-						</p>
-					)}
-					{!engLoading && !engError && engOpps.length === 0 && (
-						<EmptyState
-							title={t("orgEngagements.noOpportunities")}
-							message={t("orgEngagements.noOpportunitiesHint")}
-						/>
-					)}
-					{!engLoading && !engError && engOpps.length > 0 && (
-						<ul className="space-y-3">
-							{engOpps.map((opp) => (
-								<li
-									key={opp.id}
-									className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+						{/* Color picker modal */}
+						{selectedEvent && (
+							<div className="fixed inset-0 z-[2000] flex items-center justify-center">
+								<button
+									type="button"
+									aria-hidden="true"
+									tabIndex={-1}
+									className="absolute inset-0 bg-black/50"
+									onClick={() => setSelectedEvent(null)}
+								/>
+								<div
+									role="dialog"
+									aria-modal="true"
+									aria-labelledby="color-dialog-title"
+									className="relative z-10 w-80 rounded-xl bg-white p-6 shadow-xl"
 								>
-									<p className="text-sm font-semibold text-gray-900">
-										{opp.title}
-									</p>
-									{opp.description && (
-										<p className="mt-1 line-clamp-2 text-sm text-gray-500">
-											{opp.description}
-										</p>
-									)}
-									<Link
-										to={`/volunteer-opportunities/${opp.id}/engagements`}
-										className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
+									<h2
+										id="color-dialog-title"
+										className="mb-4 text-lg font-semibold text-gray-900"
 									>
-										{t("orgEngagements.manageEngagements")}
-										<svg
-											className="h-3.5 w-3.5"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth="2"
-											stroke="currentColor"
-											aria-hidden="true"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-											/>
-										</svg>
-									</Link>
-								</li>
-							))}
-						</ul>
-					)}
-				</div>
-			)}
-
-			{/* ── Settings tab ──────────────────────────────────────────────────── */}
-			{activeTab === "settings" && (
-				<div>
-					{orgLoading && (
-						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">{t("orgSettings.loading")}</span>
-						</div>
-					)}
-					{!orgLoading && !org && (
-						<div className="py-8 text-center text-red-600">
-							{t("orgSettings.notFound")}
-						</div>
-					)}
-					{!orgLoading && org && !editing && (
-						<OrganizationProfileView
-							name={org.name}
-							logoUrl={logoUrl}
-							description={org.description}
-							contactEmail={org.contactEmail}
-							contactPhone={org.contactPhone}
-							website={org.website}
-							address={org.address}
-							subtitle={
-								<p className="text-xs text-gray-400">
-									{t("orgSettings.createdOn", {
-										date: new Date(org.createdOn).toLocaleDateString(locale, {
-											day: "2-digit",
-											month: "long",
-											year: "numeric",
-										}),
-									})}
-								</p>
-							}
-							actions={
-								<button
-									type="button"
-									onClick={() => setEditing(true)}
-									className="shrink-0 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-								>
-									{t("orgSettings.edit")}
-								</button>
-							}
-							beforeContent={
-								<>
-									{successMessage && (
-										<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
-											{successMessage}
-										</div>
-									)}
-									{settingsError && (
-										<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-											{settingsError}
-										</div>
-									)}
-								</>
-							}
-						>
-							<div className="mt-8 rounded-2xl border border-red-100 bg-red-50 px-4 py-4">
-								<h2 className="text-sm font-semibold text-red-800">
-									{t("orgSettings.dangerZone")}
-								</h2>
-								<p className="mt-1 text-xs text-red-700">
-									{t("orgSettings.deleteOrganizationHint")}
-								</p>
-								<button
-									type="button"
-									onClick={() => setShowDeleteConfirm(true)}
-									disabled={!isSoleMember}
-									className="mt-3 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400 disabled:hover:bg-white"
-								>
-									{t("orgSettings.deleteOrganization")}
-								</button>
-							</div>
-						</OrganizationProfileView>
-					)}
-					{!orgLoading && org && editing && (
-						<>
-							{settingsError && (
-								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-									{settingsError}
-								</div>
-							)}
-
-							<form onSubmit={handleSave} className="space-y-5">
-								<div>
-									<p className="mb-1 block text-sm font-medium text-gray-700">
-										{t("orgSettings.fieldLogo")}
-									</p>
-									<div className="flex items-center gap-4">
-										{logoUrl ? (
-											<img
-												src={logoUrl}
-												alt=""
-												className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
-											/>
-										) : (
-											<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
-												{org.name.charAt(0).toUpperCase()}
-											</span>
+										{selectedEvent.title}
+									</h2>
+									<div className="space-y-4">
+										{selectedEvent.maxParticipants > 0 && (
+											<p className="text-sm text-gray-600">
+												{t("orgOverview.eventFillState", {
+													booked: selectedEvent.bookedCount,
+													max: selectedEvent.maxParticipants,
+												})}
+											</p>
 										)}
 										<div>
 											<label
-												htmlFor="logo-upload"
-												className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
+												htmlFor="event-color-picker"
+												className="block text-sm font-medium text-gray-700"
 											>
-												{uploadingLogo
-													? t("orgSettings.logoUploading")
-													: t("orgSettings.logoUpload")}
+												{t("orgOverview.eventColorLabel")}
 											</label>
-											<input
-												ref={logoInputRef}
-												id="logo-upload"
-												type="file"
-												accept="image/jpeg,image/png,image/webp"
-												className="sr-only"
-												onChange={handleLogoChange}
-												disabled={uploadingLogo}
-											/>
-											<p className="mt-1 text-xs text-gray-500">
-												{t("orgSettings.logoHint")}
-											</p>
-											{logoError && (
-												<p className="mt-1 text-xs text-red-600">{logoError}</p>
-											)}
+											<div className="mt-1 flex items-center gap-3">
+												<input
+													id="event-color-picker"
+													type="color"
+													value={pickerColor}
+													onChange={(e) => setPickerColor(e.target.value)}
+													className="h-9 w-16 cursor-pointer rounded border border-gray-300"
+												/>
+												<span className="text-sm text-gray-500">
+													{pickerColor}
+												</span>
+											</div>
 										</div>
-									</div>
-								</div>
-
-								<Field label={t("orgSettings.fieldName")} id="org-name">
-									<input
-										id="org-name"
-										required
-										value={form.name}
-										onChange={(e) =>
-											setForm((f) => ({ ...f, name: e.target.value }))
-										}
-										className={inputClass}
-									/>
-								</Field>
-
-								<Field
-									label={t("orgSettings.fieldDescription")}
-									id="org-description"
-								>
-									<textarea
-										id="org-description"
-										rows={3}
-										value={form.description}
-										onChange={(e) =>
-											setForm((f) => ({
-												...f,
-												description: e.target.value,
-											}))
-										}
-										className={inputClass}
-									/>
-								</Field>
-
-								<Field
-									label={t("orgSettings.fieldContactEmail")}
-									id="org-contact-email"
-								>
-									<input
-										id="org-contact-email"
-										type="email"
-										value={form.contactEmail}
-										onChange={(e) =>
-											setForm((f) => ({
-												...f,
-												contactEmail: e.target.value,
-											}))
-										}
-										className={inputClass}
-									/>
-								</Field>
-
-								<Field label={t("orgSettings.fieldPhone")} id="org-phone">
-									<input
-										id="org-phone"
-										type="tel"
-										value={form.contactPhone}
-										onChange={(e) =>
-											setForm((f) => ({
-												...f,
-												contactPhone: e.target.value,
-											}))
-										}
-										className={inputClass}
-									/>
-								</Field>
-
-								<Field label={t("orgSettings.fieldWebsite")} id="org-website">
-									<input
-										id="org-website"
-										type="url"
-										value={form.website}
-										onChange={(e) =>
-											setForm((f) => ({
-												...f,
-												website: e.target.value,
-											}))
-										}
-										placeholder="https://"
-										className={inputClass}
-									/>
-								</Field>
-
-								<fieldset className="rounded-md border border-gray-200 p-4">
-									<legend className="px-1 text-sm font-medium text-gray-700">
-										{t("orgSettings.fieldAddress")}
-									</legend>
-									<div className="mt-3 grid grid-cols-3 gap-3">
-										<div className="col-span-2">
-											<label htmlFor="org-street" className={labelClass}>
-												{t("orgSettings.fieldStreet")}
-											</label>
-											<input
-												id="org-street"
-												value={form.street}
-												onChange={(e) =>
-													setForm((f) => ({
-														...f,
-														street: e.target.value,
-													}))
-												}
-												className={inputClass}
-											/>
-										</div>
-										<div>
-											<label htmlFor="org-house-number" className={labelClass}>
-												{t("orgSettings.fieldHouseNumber")}
-											</label>
-											<input
-												id="org-house-number"
-												value={form.houseNumber}
-												onChange={(e) =>
-													setForm((f) => ({
-														...f,
-														houseNumber: e.target.value,
-													}))
-												}
-												className={inputClass}
-											/>
-										</div>
-										<div>
-											<label htmlFor="org-zip" className={labelClass}>
-												{t("orgSettings.fieldZip")}
-											</label>
-											<input
-												id="org-zip"
-												maxLength={5}
-												value={form.zipCode}
-												onChange={(e) =>
-													setForm((f) => ({
-														...f,
-														zipCode: e.target.value,
-													}))
-												}
-												className={inputClass}
-											/>
-										</div>
-										<div className="col-span-2">
-											<label htmlFor="org-city" className={labelClass}>
-												{t("orgSettings.fieldCity")}
-											</label>
-											<input
-												id="org-city"
-												value={form.city}
-												onChange={(e) =>
-													setForm((f) => ({
-														...f,
-														city: e.target.value,
-													}))
-												}
-												className={inputClass}
-											/>
-										</div>
-									</div>
-								</fieldset>
-
-								<div className="flex justify-end gap-3">
-									<button
-										type="button"
-										onClick={handleCancelEdit}
-										className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-									>
-										{t("orgSettings.cancel")}
-									</button>
-									<button
-										type="submit"
-										disabled={saving}
-										className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-									>
-										{saving ? t("orgSettings.saving") : t("orgSettings.save")}
-									</button>
-								</div>
-							</form>
-						</>
-					)}
-				</div>
-			)}
-
-			{/* ── Members tab ───────────────────────────────────────────────────── */}
-			{activeTab === "members" && (
-				<div>
-					{orgLoading && (
-						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">{t("orgSettings.loading")}</span>
-						</div>
-					)}
-					{!orgLoading && org && (
-						<>
-							{successMessage && (
-								<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
-									{successMessage}
-								</div>
-							)}
-							{settingsError && (
-								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-									{settingsError}
-								</div>
-							)}
-
-							{/* Invite member search */}
-							<div className="mb-6">
-								<label
-									htmlFor="member-search"
-									className="block text-sm font-medium text-gray-700"
-								>
-									{t("orgSettings.inviteLabel")}
-								</label>
-								<input
-									id="member-search"
-									type="search"
-									value={memberSearch}
-									onChange={(e) => handleMemberSearchChange(e.target.value)}
-									placeholder={t("orgSettings.invitePlaceholder")}
-									className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none"
-								/>
-								{memberSearchLoading && (
-									<p className="mt-1 text-xs text-gray-500">
-										{t("orgSettings.searching")}
-									</p>
-								)}
-								{memberCandidates.length > 0 && (
-									<ul className="mt-1 divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
-										{memberCandidates.map((candidate) => (
-											<li
-												key={candidate.userId}
-												className="flex items-center justify-between px-3 py-2"
-											>
-												<div className="min-w-0">
-													<p className="truncate text-sm font-medium text-gray-900">
-														{candidate.firstName && candidate.lastName
-															? `${candidate.firstName} ${candidate.lastName}`
-															: candidate.username}
-													</p>
-													<p className="truncate text-xs text-gray-500">
-														{candidate.email}
-													</p>
-												</div>
+										{colorSaveError && (
+											<p className="text-sm text-red-600">{colorSaveError}</p>
+										)}
+										<div className="flex flex-col gap-2">
+											<div className="flex gap-4">
+												<Link
+													to={`/volunteer-opportunities/${selectedEvent.opportunityId}`}
+													className="text-sm text-brand-700 hover:underline"
+													onClick={() => setSelectedEvent(null)}
+												>
+													{t("orgOverview.eventNavigate")}
+												</Link>
+												<Link
+													to={`/volunteer-opportunities/${selectedEvent.opportunityId}/engagements`}
+													className="text-sm text-brand-700 hover:underline"
+													onClick={() => setSelectedEvent(null)}
+												>
+													{t("orgOverview.eventManageApplications")}
+												</Link>
+											</div>
+											<div className="flex justify-end gap-2">
 												<button
 													type="button"
-													onClick={() => handleInviteMember(candidate.userId)}
-													className="ml-3 shrink-0 rounded-md bg-brand-700 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-800"
+													onClick={() => setSelectedEvent(null)}
+													className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
 												>
-													{t("orgSettings.invite")}
+													{t("createOpportunity.cancel")}
 												</button>
-											</li>
-										))}
-									</ul>
+												<button
+													type="button"
+													disabled={savingColor}
+													onClick={handleColorSave}
+													className="rounded-md bg-brand-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+												>
+													{savingColor
+														? t("orgOverview.eventColorSaving")
+														: t("orgOverview.eventColorSave")}
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+
+				{/* ── Engagements tab ───────────────────────────────────────────────── */}
+				{activeTab === "engagements" && (
+					<div>
+						{engLoading && (
+							<div className="flex items-center justify-center py-16">
+								<span className="text-gray-500">
+									{t("orgEngagements.loading")}
+								</span>
+							</div>
+						)}
+						{engError && (
+							<p className="text-red-600">
+								{t("orgEngagements.error", { message: engError })}
+							</p>
+						)}
+						{!engLoading && !engError && engOpps.length === 0 && (
+							<EmptyState
+								title={t("orgEngagements.noOpportunities")}
+								message={t("orgEngagements.noOpportunitiesHint")}
+							/>
+						)}
+						{!engLoading && !engError && engOpps.length > 0 && (
+							<ul className="space-y-3">
+								{engOpps.map((opp) => (
+									<li
+										key={opp.id}
+										className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+									>
+										<p className="text-sm font-semibold text-gray-900">
+											{opp.title}
+										</p>
+										{opp.description && (
+											<p className="mt-1 line-clamp-2 text-sm text-gray-500">
+												{opp.description}
+											</p>
+										)}
+										<Link
+											to={`/volunteer-opportunities/${opp.id}/engagements`}
+											className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
+										>
+											{t("orgEngagements.manageEngagements")}
+											<svg
+												className="h-3.5 w-3.5"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="2"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+												/>
+											</svg>
+										</Link>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				)}
+
+				{/* ── Settings tab ──────────────────────────────────────────────────── */}
+				{activeTab === "settings" && (
+					<div>
+						{orgLoading && (
+							<div className="flex items-center justify-center py-16">
+								<span className="text-gray-500">
+									{t("orgSettings.loading")}
+								</span>
+							</div>
+						)}
+						{!orgLoading && !org && (
+							<div className="py-8 text-center text-red-600">
+								{t("orgSettings.notFound")}
+							</div>
+						)}
+						{!orgLoading && org && !editing && (
+							<OrganizationProfileView
+								name={org.name}
+								logoUrl={logoUrl}
+								description={org.description}
+								contactEmail={org.contactEmail}
+								contactPhone={org.contactPhone}
+								website={org.website}
+								address={org.address}
+								subtitle={
+									<p className="text-xs text-gray-400">
+										{t("orgSettings.createdOn", {
+											date: new Date(org.createdOn).toLocaleDateString(locale, {
+												day: "2-digit",
+												month: "long",
+												year: "numeric",
+											}),
+										})}
+									</p>
+								}
+								actions={
+									<button
+										type="button"
+										onClick={() => setEditing(true)}
+										className="shrink-0 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+									>
+										{t("orgSettings.edit")}
+									</button>
+								}
+								beforeContent={
+									<>
+										{successMessage && (
+											<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+												{successMessage}
+											</div>
+										)}
+										{settingsError && (
+											<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+												{settingsError}
+											</div>
+										)}
+									</>
+								}
+							>
+								<div className="mt-8 rounded-2xl border border-red-100 bg-red-50 px-4 py-4">
+									<h2 className="text-sm font-semibold text-red-800">
+										{t("orgSettings.dangerZone")}
+									</h2>
+									<p className="mt-1 text-xs text-red-700">
+										{t("orgSettings.deleteOrganizationHint")}
+									</p>
+									<button
+										type="button"
+										onClick={() => setShowDeleteConfirm(true)}
+										disabled={!isSoleMember}
+										className="mt-3 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400 disabled:hover:bg-white"
+									>
+										{t("orgSettings.deleteOrganization")}
+									</button>
+								</div>
+							</OrganizationProfileView>
+						)}
+						{!orgLoading && org && editing && (
+							<>
+								{settingsError && (
+									<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+										{settingsError}
+									</div>
 								)}
-								{memberSearch.length >= 2 &&
-									!memberSearchLoading &&
-									memberCandidates.length === 0 && (
+
+								<form onSubmit={handleSave} className="space-y-5">
+									<div>
+										<p className="mb-1 block text-sm font-medium text-gray-700">
+											{t("orgSettings.fieldLogo")}
+										</p>
+										<div className="flex items-center gap-4">
+											{logoUrl ? (
+												<img
+													src={logoUrl}
+													alt=""
+													className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
+												/>
+											) : (
+												<span className="flex h-16 w-16 items-center justify-center rounded-lg bg-brand-100 text-2xl font-semibold text-brand-700">
+													{org.name.charAt(0).toUpperCase()}
+												</span>
+											)}
+											<div>
+												<label
+													htmlFor="logo-upload"
+													className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
+												>
+													{uploadingLogo
+														? t("orgSettings.logoUploading")
+														: t("orgSettings.logoUpload")}
+												</label>
+												<input
+													ref={logoInputRef}
+													id="logo-upload"
+													type="file"
+													accept="image/jpeg,image/png,image/webp"
+													className="sr-only"
+													onChange={handleLogoChange}
+													disabled={uploadingLogo}
+												/>
+												<p className="mt-1 text-xs text-gray-500">
+													{t("orgSettings.logoHint")}
+												</p>
+												{logoError && (
+													<p className="mt-1 text-xs text-red-600">
+														{logoError}
+													</p>
+												)}
+											</div>
+										</div>
+									</div>
+
+									<Field label={t("orgSettings.fieldName")} id="org-name">
+										<input
+											id="org-name"
+											required
+											value={form.name}
+											onChange={(e) =>
+												setForm((f) => ({ ...f, name: e.target.value }))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field
+										label={t("orgSettings.fieldDescription")}
+										id="org-description"
+									>
+										<textarea
+											id="org-description"
+											rows={3}
+											value={form.description}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													description: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field
+										label={t("orgSettings.fieldContactEmail")}
+										id="org-contact-email"
+									>
+										<input
+											id="org-contact-email"
+											type="email"
+											value={form.contactEmail}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													contactEmail: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field label={t("orgSettings.fieldPhone")} id="org-phone">
+										<input
+											id="org-phone"
+											type="tel"
+											value={form.contactPhone}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													contactPhone: e.target.value,
+												}))
+											}
+											className={inputClass}
+										/>
+									</Field>
+
+									<Field label={t("orgSettings.fieldWebsite")} id="org-website">
+										<input
+											id="org-website"
+											type="url"
+											value={form.website}
+											onChange={(e) =>
+												setForm((f) => ({
+													...f,
+													website: e.target.value,
+												}))
+											}
+											placeholder="https://"
+											className={inputClass}
+										/>
+									</Field>
+
+									<fieldset className="rounded-md border border-gray-200 p-4">
+										<legend className="px-1 text-sm font-medium text-gray-700">
+											{t("orgSettings.fieldAddress")}
+										</legend>
+										<div className="mt-3 grid grid-cols-3 gap-3">
+											<div className="col-span-2">
+												<label htmlFor="org-street" className={labelClass}>
+													{t("orgSettings.fieldStreet")}
+												</label>
+												<input
+													id="org-street"
+													value={form.street}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															street: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div>
+												<label
+													htmlFor="org-house-number"
+													className={labelClass}
+												>
+													{t("orgSettings.fieldHouseNumber")}
+												</label>
+												<input
+													id="org-house-number"
+													value={form.houseNumber}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															houseNumber: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div>
+												<label htmlFor="org-zip" className={labelClass}>
+													{t("orgSettings.fieldZip")}
+												</label>
+												<input
+													id="org-zip"
+													maxLength={5}
+													value={form.zipCode}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															zipCode: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+											<div className="col-span-2">
+												<label htmlFor="org-city" className={labelClass}>
+													{t("orgSettings.fieldCity")}
+												</label>
+												<input
+													id="org-city"
+													value={form.city}
+													onChange={(e) =>
+														setForm((f) => ({
+															...f,
+															city: e.target.value,
+														}))
+													}
+													className={inputClass}
+												/>
+											</div>
+										</div>
+									</fieldset>
+
+									<div className="flex justify-end gap-3">
+										<button
+											type="button"
+											onClick={handleCancelEdit}
+											className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+										>
+											{t("orgSettings.cancel")}
+										</button>
+										<button
+											type="submit"
+											disabled={saving}
+											className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+										>
+											{saving ? t("orgSettings.saving") : t("orgSettings.save")}
+										</button>
+									</div>
+								</form>
+							</>
+						)}
+					</div>
+				)}
+
+				{/* ── Members tab ───────────────────────────────────────────────────── */}
+				{activeTab === "members" && (
+					<div>
+						{orgLoading && (
+							<div className="flex items-center justify-center py-16">
+								<span className="text-gray-500">
+									{t("orgSettings.loading")}
+								</span>
+							</div>
+						)}
+						{!orgLoading && org && (
+							<>
+								{successMessage && (
+									<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+										{successMessage}
+									</div>
+								)}
+								{settingsError && (
+									<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+										{settingsError}
+									</div>
+								)}
+
+								{/* Invite member search */}
+								<div className="mb-6">
+									<label
+										htmlFor="member-search"
+										className="block text-sm font-medium text-gray-700"
+									>
+										{t("orgSettings.inviteLabel")}
+									</label>
+									<input
+										id="member-search"
+										type="search"
+										value={memberSearch}
+										onChange={(e) => handleMemberSearchChange(e.target.value)}
+										placeholder={t("orgSettings.invitePlaceholder")}
+										className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none"
+									/>
+									{memberSearchLoading && (
 										<p className="mt-1 text-xs text-gray-500">
-											{t("orgSettings.noSearchResults")}
+											{t("orgSettings.searching")}
 										</p>
 									)}
-							</div>
-
-							{invitations.some((i) => i.status === "Pending") && (
-								<div className="mb-6">
-									<h2 className="mb-2 text-sm font-medium text-gray-700">
-										{t("orgSettings.pendingInvitations")}
-									</h2>
-									<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
-										{invitations
-											.filter((i) => i.status === "Pending")
-											.map((invitation) => (
+									{memberCandidates.length > 0 && (
+										<ul className="mt-1 divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+											{memberCandidates.map((candidate) => (
 												<li
-													key={invitation.id}
+													key={candidate.userId}
 													className="flex items-center justify-between px-3 py-2"
 												>
 													<div className="min-w-0">
 														<p className="truncate text-sm font-medium text-gray-900">
-															{invitation.inviteeName}
+															{candidate.firstName && candidate.lastName
+																? `${candidate.firstName} ${candidate.lastName}`
+																: candidate.username}
 														</p>
 														<p className="truncate text-xs text-gray-500">
-															{t("orgSettings.invitationSentOn", {
-																date: new Date(
-																	invitation.createdOn,
-																).toLocaleDateString(locale, {
-																	day: "2-digit",
-																	month: "long",
-																	year: "numeric",
-																}),
-															})}
-														</p>
-													</div>
-												</li>
-											))}
-									</ul>
-								</div>
-							)}
-
-							{invitations.some((i) => i.status === "Declined") && (
-								<div className="mb-6">
-									<h2 className="mb-2 text-sm font-medium text-gray-700">
-										{t("orgSettings.declinedInvitations")}
-									</h2>
-									<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
-										{invitations
-											.filter((i) => i.status === "Declined")
-											.map((invitation) => (
-												<li
-													key={invitation.id}
-													className="flex items-center justify-between px-3 py-2"
-												>
-													<div className="min-w-0">
-														<p className="truncate text-sm font-medium text-gray-900">
-															{invitation.inviteeName}
+															{candidate.email}
 														</p>
 													</div>
 													<button
 														type="button"
-														onClick={() =>
-															handleDismissInvitation(invitation.id)
-														}
-														className="ml-3 shrink-0 text-xs text-red-700 hover:text-red-800"
+														onClick={() => handleInviteMember(candidate.userId)}
+														className="ml-3 shrink-0 rounded-md bg-brand-700 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-800"
 													>
-														{t("orgSettings.dismissInvitation")}
+														{t("orgSettings.invite")}
 													</button>
 												</li>
 											))}
-									</ul>
+										</ul>
+									)}
+									{memberSearch.length >= 2 &&
+										!memberSearchLoading &&
+										memberCandidates.length === 0 && (
+											<p className="mt-1 text-xs text-gray-500">
+												{t("orgSettings.noSearchResults")}
+											</p>
+										)}
 								</div>
-							)}
 
-							{org.members.length === 0 ? (
-								<EmptyState
-									title={t("orgSettings.noMembers")}
-									message={t("orgSettings.noMembersHint")}
-								/>
-							) : (
-								<ul className="divide-y divide-gray-100">
-									{org.members.map((member) => (
-										<li
-											key={member.userId}
-											className="flex items-center justify-between py-3"
-										>
-											<div>
-												<p className="text-sm font-medium text-gray-900">
-													{member.firstName && member.lastName
-														? `${member.firstName} ${member.lastName}`
-														: member.username}
-												</p>
-												<p className="text-xs text-gray-500">{member.email}</p>
-												{member.isOrganisator && (
-													<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
-														{t("orgSettings.organisator")}
-													</span>
+								{invitations.some((i) => i.status === "Pending") && (
+									<div className="mb-6">
+										<h2 className="mb-2 text-sm font-medium text-gray-700">
+											{t("orgSettings.pendingInvitations")}
+										</h2>
+										<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+											{invitations
+												.filter((i) => i.status === "Pending")
+												.map((invitation) => (
+													<li
+														key={invitation.id}
+														className="flex items-center justify-between px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="truncate text-sm font-medium text-gray-900">
+																{invitation.inviteeName}
+															</p>
+															<p className="truncate text-xs text-gray-500">
+																{t("orgSettings.invitationSentOn", {
+																	date: new Date(
+																		invitation.createdOn,
+																	).toLocaleDateString(locale, {
+																		day: "2-digit",
+																		month: "long",
+																		year: "numeric",
+																	}),
+																})}
+															</p>
+														</div>
+													</li>
+												))}
+										</ul>
+									</div>
+								)}
+
+								{invitations.some((i) => i.status === "Declined") && (
+									<div className="mb-6">
+										<h2 className="mb-2 text-sm font-medium text-gray-700">
+											{t("orgSettings.declinedInvitations")}
+										</h2>
+										<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+											{invitations
+												.filter((i) => i.status === "Declined")
+												.map((invitation) => (
+													<li
+														key={invitation.id}
+														className="flex items-center justify-between px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="truncate text-sm font-medium text-gray-900">
+																{invitation.inviteeName}
+															</p>
+														</div>
+														<button
+															type="button"
+															onClick={() =>
+																handleDismissInvitation(invitation.id)
+															}
+															className="ml-3 shrink-0 text-xs text-red-700 hover:text-red-800"
+														>
+															{t("orgSettings.dismissInvitation")}
+														</button>
+													</li>
+												))}
+										</ul>
+									</div>
+								)}
+
+								{org.members.length === 0 ? (
+									<EmptyState
+										title={t("orgSettings.noMembers")}
+										message={t("orgSettings.noMembersHint")}
+									/>
+								) : (
+									<ul className="divide-y divide-gray-100">
+										{org.members.map((member) => (
+											<li
+												key={member.userId}
+												className="flex items-center justify-between py-3"
+											>
+												<div>
+													<p className="text-sm font-medium text-gray-900">
+														{member.firstName && member.lastName
+															? `${member.firstName} ${member.lastName}`
+															: member.username}
+													</p>
+													<p className="text-xs text-gray-500">
+														{member.email}
+													</p>
+													{member.isOrganisator && (
+														<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+															{t("orgSettings.organisator")}
+														</span>
+													)}
+												</div>
+												{member.userId === currentUserId ? (
+													<button
+														type="button"
+														onClick={() => setShowLeaveConfirm(true)}
+														disabled={isSoleMember}
+														title={
+															isSoleMember
+																? t(
+																		"orgSettings.leaveOrganizationLastMemberHint",
+																	)
+																: undefined
+														}
+														className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+													>
+														{t("orgSettings.leaveOrganization")}
+													</button>
+												) : (
+													<button
+														type="button"
+														onClick={() => handleRemoveMember(member.userId)}
+														className="text-xs text-red-700 hover:text-red-800"
+													>
+														{t("orgSettings.removeMember")}
+													</button>
 												)}
-											</div>
-											{member.userId === currentUserId ? (
-												<button
-													type="button"
-													onClick={() => setShowLeaveConfirm(true)}
-													disabled={isSoleMember}
-													title={
-														isSoleMember
-															? t("orgSettings.leaveOrganizationLastMemberHint")
-															: undefined
-													}
-													className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
-												>
-													{t("orgSettings.leaveOrganization")}
-												</button>
-											) : (
-												<button
-													type="button"
-													onClick={() => handleRemoveMember(member.userId)}
-													className="text-xs text-red-700 hover:text-red-800"
-												>
-													{t("orgSettings.removeMember")}
-												</button>
-											)}
-										</li>
-									))}
-								</ul>
-							)}
-							{isSoleMember && (
-								<p className="mt-3 text-xs text-gray-500">
-									{t("orgSettings.leaveOrganizationLastMemberHint")}
-								</p>
-							)}
-						</>
-					)}
-				</div>
-			)}
+											</li>
+										))}
+									</ul>
+								)}
+								{isSoleMember && (
+									<p className="mt-3 text-xs text-gray-500">
+										{t("orgSettings.leaveOrganizationLastMemberHint")}
+									</p>
+								)}
+							</>
+						)}
+					</div>
+				)}
+			</div>
 
 			{showLeaveConfirm && org && (
 				<ConfirmDialog

--- a/scripts/smoke-test-641-org-tabs-alignment.mjs
+++ b/scripts/smoke-test-641-org-tabs-alignment.mjs
@@ -1,0 +1,91 @@
+// Smoke test for #641: the organization dashboard's outer wrapper applied
+// `max-w-2xl` (with no `mx-auto`) to the header, tab bar, AND tab content
+// together whenever a non-calendar tab was active. That shrank and
+// left-hugged the tab bar itself, so the Calendar tab rendered full width
+// while Engagements/Members/Settings rendered narrow and left-aligned, with
+// a visible layout jump when switching tabs. The fix moves the width
+// constraint to only wrap the per-tab content, centering it with `mx-auto`,
+// leaving the header/tab bar full width and consistently positioned across
+// all tabs.
+//
+// Verifies the tab bar's bounding box (position + width) is identical on
+// the Calendar tab and the Settings tab.
+//
+// No throwaway data is created (an existing org from seed data is used), so
+// there is nothing to clean up (see #630).
+// Run: node scripts/smoke-test-641-org-tabs-alignment.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.click("text=/sign in|anmelden/i");
+		await page.waitForURL(/\/realms\//, { timeout: 30000 });
+		await loginKeycloak(page, "olaf", "olaf123");
+
+		await page.goto(BASE, { waitUntil: "networkidle" });
+
+		const switcherBtn = page.getByRole("button", { name: "Switch organization" });
+		if ((await switcherBtn.count()) === 0) {
+			throw new Error("No org switcher found - olaf has no organizations in seed data");
+		}
+		await switcherBtn.first().click();
+
+		const dashboardLink = page.getByTestId("org-dashboard-link");
+		if ((await dashboardLink.count()) === 0) {
+			throw new Error("No org-dashboard-link found in switcher dropdown");
+		}
+		await dashboardLink.first().click();
+
+		await page.waitForURL(/\/organizations\/.+\/dashboard/, { timeout: 15000 });
+		console.log("OK  Navigated to org dashboard");
+
+		const tabBar = page.locator("nav").filter({ hasText: "Settings" });
+		await tabBar.waitFor({ state: "visible", timeout: 15000 });
+
+		const calendarBox = await tabBar.boundingBox();
+		if (!calendarBox) throw new Error("Could not measure tab bar bounding box on Calendar tab");
+		console.log(
+			`OK  Calendar tab bar box: x=${calendarBox.x}, width=${calendarBox.width}`,
+		);
+
+		await page.getByRole("button", { name: "Settings" }).click();
+		await page.getByRole("button", { name: "Edit" }).waitFor({ timeout: 10000 });
+
+		const settingsBox = await tabBar.boundingBox();
+		if (!settingsBox) throw new Error("Could not measure tab bar bounding box on Settings tab");
+		console.log(
+			`OK  Settings tab bar box: x=${settingsBox.x}, width=${settingsBox.width}`,
+		);
+
+		if (Math.abs(settingsBox.x - calendarBox.x) > 1) {
+			throw new Error(
+				`Tab bar shifted horizontally between tabs: calendar x=${calendarBox.x}, settings x=${settingsBox.x}`,
+			);
+		}
+		if (Math.abs(settingsBox.width - calendarBox.width) > 1) {
+			throw new Error(
+				`Tab bar width changed between tabs: calendar width=${calendarBox.width}, settings width=${settingsBox.width}`,
+			);
+		}
+		console.log("OK  Tab bar position and width are identical across Calendar and Settings tabs");
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `OrganizationOverviewPage`'s outer wrapper applied `max-w-2xl` (with no `mx-auto`) to the header, tab bar, *and* tab content together whenever a non-calendar tab was active. That shrank and left-hugged the tab bar itself, so the Calendar tab rendered full width while Engagements/Members/Settings rendered narrow and left-aligned - plus a visible layout width jump every time the active tab changed.
- Moved the width constraint so it only wraps the per-tab *content*, added `mx-auto` so constrained content is centered instead of left-hugging, and added `lg:min-h-[600px]` on the content wrapper so tab height doesn't jump as sharply between the fixed-height calendar and the shorter tabs on desktop.
- Header and tab bar are now always full width and consistently positioned across all four tabs.

Addresses #641

## Test plan

- [x] `pnpm check` (tsc --noEmit) - passes
- [x] `pnpm lint` - zero warnings
- [x] `dotnet build` - compiles clean (Playwright browser install step fails in this sandbox due to an apt repo issue unrelated to the change - a known sandbox limitation, not a code problem)
- [x] `Application.UnitTests` (207/207) and `ArchitectureTests` (247/247) - both pass
- [x] Added `OrganizationTests.TabBar_StaysFullWidth_AcrossTabSwitches` - regression test asserting the tab bar's bounding box (width/x-position) is identical when switching from the Calendar tab to the Settings tab
- [x] CI green on this PR (all 7 checks, including `build-and-test` which runs `Test - VisualTests`)

## Live verification

- Cut `v1.0.0-rc.205` from this branch. Full `Publish` pipeline succeeded end-to-end: `Test - VisualTests` passed, `Deploy to Staging` succeeded (health gate green).
- `curl -sf https://api.maik-hasler.de/health` -> `200`
- Ran `scripts/smoke-test-641-org-tabs-alignment.mjs` against `https://einsatzbereit.maik-hasler.de` (logged in as `olaf`, navigated to an org dashboard, measured the tab bar's bounding box on the Calendar tab vs. the Settings tab): position and width are now identical (`x=32, width=1216` on both), confirming the fix on live staging. All checks passed.
- Added an automated regression test (`OrganizationTests.TabBar_StaysFullWidth_AcrossTabSwitches`) in `backend/tests/VisualTests/`, which will run against the local Aspire stack in CI going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNqGk6mxRPp7kgdnpnZUnd