### PR TITLE
fix: refresh opportunity detail auth state and show real sign-up errors

### DIFF
--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Playwright;
 
@@ -6,6 +8,54 @@ namespace VisualTests;
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
+	/// <summary>
+	/// Regression for #645: useAchievementNotifier only seeded the "seen"
+	/// localStorage set when the account had zero achievements, so a fresh
+	/// browser/device/profile for an account that already has achievements
+	/// (e.g. olaf, who already has confirmed-engagement achievements from seed
+	/// data) re-announced every existing achievement as newly unlocked.
+	/// </summary>
+	[Test]
+	public async Task ExistingAchievements_DoNotReToastAsNew_OnFreshBrowserContext()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		var achievementsResponse = await http.GetAsync("/v1/me/achievements");
+		achievementsResponse.EnsureSuccessStatusCode();
+		var achievements = await achievementsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		achievements.GetArrayLength().Should().BeGreaterThan(0,
+			"olaf must already have at least one achievement for this regression test to be meaningful");
+
+		// Each VisualTests test gets a fresh, isolated browser context (see
+		// VisualTestBase) - no einsatzbereit:seen-achievements localStorage entry
+		// yet, simulating a new device/browser/profile. The notifier's first
+		// check fires on mount; give it a moment, then assert no "New badge
+		// unlocked" toast appeared for an already-earned badge.
+		await Page.WaitForTimeoutAsync(3000);
+
+		var badgeToast = Page.Locator("[role='alert']", new() { HasText = "New badge unlocked" });
+		(await badgeToast.CountAsync()).Should().Be(0,
+			"an already-earned achievement must not re-announce itself as newly unlocked on a fresh browser context");
+	}
+
 	[Test]
 	public async Task ShareButton_OpensModal_WithQrCodeAndCopyLink()
 	{

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -102,7 +102,7 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 			new FormUrlEncodedContent(new Dictionary<string, string>
 			{
 				["grant_type"] = "password",
-				["client_id"] = "frontend",
+				["client_id"] = "frontend-test",
 				["username"] = "olaf",
 				["password"] = "olaf123",
 				["scope"] = "openid",

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -1,0 +1,137 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #644: a hard/direct navigation to an opportunity's detail
+/// page could lose the volunteer's "already applied" status - the OIDC token
+/// isn't always restored from storage before the details fetch first fires,
+/// and the effect never re-ran once it was. Separately, the sign-up modal
+/// fell back to a generic "Unknown error" instead of the backend's actual
+/// conflict message on a duplicate sign-up attempt.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task DetailPage_KeepsAlreadyAppliedStatus_AfterHardNavigation()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("HardNav");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await Page.Locator("textarea").FillAsync("Applying via VisualTests regression check.");
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Sign up" }).ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Genuine hard navigation (full reload), not an SPA transition - this is
+		// exactly the race the fix addresses: the OIDC token may not be restored
+		// from storage by the time the details fetch first fires.
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByText("Your application")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }))
+			.Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task SignUpModal_ShowsBackendConflictMessage_OnDuplicateSignUp()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("DuplicateError");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await Page.Locator("textarea").FillAsync("First sign-up attempt.");
+
+		// A second page in the same browser context: the OIDC user store is
+		// localStorage (frontend/src/main.tsx), shared across pages in one
+		// context, so this page is already authenticated as vera too - it
+		// simulates a second tab racing the first to sign up for the same
+		// opportunity.
+		var page2 = await Context.NewPageAsync();
+		await page2.GotoAsync(detailUrl);
+		await page2.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await page2.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await page2.Locator("textarea").FillAsync("Second (duplicate) sign-up attempt.");
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Sign up" }).ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var secondSignUpResponseTask = page2.WaitForResponseAsync(r =>
+			r.Url.Contains($"/volunteer-opportunities/{opportunityId}/engagements") &&
+			r.Request.Method == "POST");
+		await page2.GetByRole(AriaRole.Button, new() { Name = "Sign up" }).ClickAsync();
+		var secondSignUpResponse = await secondSignUpResponseTask;
+		secondSignUpResponse.Status.Should().Be(409);
+
+		var errorText = await page2.Locator("p.text-red-600").First.TextContentAsync();
+		errorText.Should().NotBeNullOrEmpty();
+		errorText.Should().NotContain("Unknown error");
+		errorText.Should().Contain("already signed up");
+	}
+
+	private async Task<string> CreateIndividualContactOpportunityAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var tokenHttp = new HttpClient { BaseAddress = keycloak };
+		var tokenResponse = await tokenHttp.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend",
+				["username"] = "olaf",
+				["password"] = "olaf123",
+				["scope"] = "openid",
+			}));
+		tokenResponse.EnsureSuccessStatusCode();
+		var tokenBody = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var token = tokenBody.GetProperty("access_token").GetString();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var orgsResponse = await http.GetAsync("/v1/organizations");
+		orgsResponse.EnsureSuccessStatusCode();
+		var orgs = await orgsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = orgs.EnumerateArray().First().GetProperty("id").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"OpportunityApplicationState {label} {suffix}",
+			description = "Created by OpportunityApplicationStateTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+}

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatDateTime } from "../lib/format";
+import { getApiErrorMessage } from "../lib/apiError";
 import Dropdown from "./Dropdown";
 
 interface Props {
@@ -56,7 +57,7 @@ export default function SignUpModal({
 			onSuccess();
 			onClose();
 		} catch (err) {
-			setError(err instanceof Error ? err.message : t("signUp.unknownError"));
+			setError(getApiErrorMessage(err, t("signUp.unknownError")));
 		} finally {
 			setSubmitting(false);
 		}

--- a/frontend/src/hooks/useAchievementNotifier.ts
+++ b/frontend/src/hooks/useAchievementNotifier.ts
@@ -38,6 +38,15 @@ export function useAchievementNotifier() {
 			try {
 				const achievements = await api.getMyAchievements();
 				const seen = getSeenIds();
+				// Fresh browser/device/profile with no seen-tracking yet: seed the
+				// account's existing achievements as already-seen instead of
+				// announcing all of them as newly unlocked.
+				if (seen.size === 0) {
+					if (achievements.length > 0) {
+						markSeen(achievements.map((a) => a.id));
+					}
+					return;
+				}
 				const newOnes = achievements.filter((a) => !seen.has(a.id));
 				if (newOnes.length > 0) {
 					markSeen(newOnes.map((a) => a.id));
@@ -47,10 +56,6 @@ export function useAchievementNotifier() {
 							t("achievements.newBadge", { name: a.name }),
 						),
 					);
-				}
-				// Seed seen list on first run so we don't toast for old achievements
-				if (seen.size === 0 && newOnes.length === 0) {
-					markSeen(achievements.map((a) => a.id));
 				}
 			} catch {
 				// never fail silently

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -71,7 +71,7 @@ export default function VolunteerOpportunityDetailPage() {
 		if (!opportunityId) return;
 		load();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [opportunityId]);
+	}, [opportunityId, api]);
 
 	function load() {
 		if (!opportunityId) return;

--- a/scripts/smoke-test-644-645-detail-and-achievements.mjs
+++ b/scripts/smoke-test-644-645-detail-and-achievements.mjs
@@ -1,0 +1,307 @@
+// Smoke test for #644 and #645, both filed by the 2026-07-08 persona-simulation
+// cycle and fixed together in the same PR:
+//
+// #644 - VolunteerOpportunityDetailPage's details-fetch effect only depended
+// on opportunityId, so a hard/direct navigation (fresh page load) could race
+// the OIDC token restoring from storage and fetch unauthenticated, silently
+// losing the volunteer's "already applied" status for the rest of the page's
+// lifetime. Separately, SignUpModal's error handling checked
+// `err instanceof Error`, but the NSwag client throws a raw ProblemDetails
+// object on API errors, so a genuine 409 conflict always fell back to a
+// generic "Unknown error" instead of the backend's actual message.
+//
+// #645 - useAchievementNotifier only seeded the "seen" localStorage set when
+// the account had zero achievements, so a fresh browser/device/profile for an
+// account that already has achievements re-announced every existing
+// achievement as newly unlocked.
+//
+// Run: node scripts/smoke-test-644-645-detail-and-achievements.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #644.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	// --- Setup: create two fresh IndividualContact opportunities via olaf's org ---
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	const oppA = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke644 Persistence ${Date.now()}`,
+	);
+	console.log(`OK  Created opportunity A (persistence test) ${oppA.id}`);
+	const oppB = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke644 DuplicateError ${Date.now()}`,
+	);
+	console.log(`OK  Created opportunity B (duplicate-signup test) ${oppB.id}`);
+
+	// === Test 1: "already applied" status survives a hard/direct navigation ===
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			console.log("OK  Logged in as vera");
+
+			const detailUrl = `${BASE}/volunteer-opportunities/${oppA.id}`;
+			await page.goto(detailUrl, { waitUntil: "networkidle" });
+			await page
+				.getByRole("button", { name: /express interest|interesse bekunden/i })
+				.click();
+			await page.fill(
+				"textarea",
+				"Smoke test signup for #644 persistence check.",
+			);
+			const [signupRes] = await Promise.all([
+				page.waitForResponse(
+					(r) =>
+						r
+							.url()
+							.includes(`/volunteer-opportunities/${oppA.id}/engagements`) &&
+						r.request().method() === "POST",
+				),
+				page.getByRole("button", { name: /^sign up$|^anmelden$/i }).click(),
+			]);
+			if (!signupRes.ok())
+				throw new Error(`Sign-up POST failed: ${signupRes.status()}`);
+			console.log("OK  Applied to opportunity A");
+
+			// Genuine hard navigation (full reload), not an SPA transition - this is
+			// exactly the race the fix addresses: the OIDC token may not be
+			// restored from storage by the time the details fetch first fires.
+			await page.goto(detailUrl, { waitUntil: "networkidle" });
+			await page.waitForSelector("h1", { timeout: 10000 });
+
+			await page
+				.getByText(/your application|deine bewerbung/i)
+				.waitFor({ timeout: 10000 });
+			console.log(
+				'OK  "Your application" status still shown after a hard navigation',
+			);
+
+			const ctaButton = page.getByRole("button", {
+				name: /express interest|interesse bekunden/i,
+			});
+			if ((await ctaButton.count()) > 0) {
+				throw new Error(
+					"Apply button re-appeared after a hard navigation, even though vera already applied",
+				);
+			}
+			console.log(
+				"OK  Apply button not shown - already-applied state is authoritative",
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	// === Test 2: sign-up modal shows the real 409 message, not "Unknown error" ===
+	{
+		const { browser, context, page: page1 } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page1, "vera", "vera123");
+
+			const detailUrl = `${BASE}/volunteer-opportunities/${oppB.id}`;
+			await page1.goto(detailUrl, { waitUntil: "networkidle" });
+			await page1
+				.getByRole("button", { name: /express interest|interesse bekunden/i })
+				.click();
+			await page1.fill("textarea", "First sign-up attempt.");
+
+			// Second page in the same context: the OIDC user store is localStorage
+			// (see main.tsx), which is shared across pages in one context, so this
+			// page is already authenticated - simulates a second tab racing the
+			// first to sign up for the same opportunity.
+			const page2 = await context.newPage();
+			await page2.goto(detailUrl, { waitUntil: "networkidle" });
+			await page2
+				.getByRole("button", { name: /express interest|interesse bekunden/i })
+				.click();
+			await page2.fill("textarea", "Second (duplicate) sign-up attempt.");
+
+			const [firstRes] = await Promise.all([
+				page1.waitForResponse(
+					(r) =>
+						r
+							.url()
+							.includes(`/volunteer-opportunities/${oppB.id}/engagements`) &&
+						r.request().method() === "POST",
+				),
+				page1.getByRole("button", { name: /^sign up$|^anmelden$/i }).click(),
+			]);
+			if (!firstRes.ok())
+				throw new Error(`First sign-up POST failed: ${firstRes.status()}`);
+			console.log("OK  First tab's sign-up succeeded");
+
+			const [secondRes] = await Promise.all([
+				page2.waitForResponse(
+					(r) =>
+						r
+							.url()
+							.includes(`/volunteer-opportunities/${oppB.id}/engagements`) &&
+						r.request().method() === "POST",
+				),
+				page2.getByRole("button", { name: /^sign up$|^anmelden$/i }).click(),
+			]);
+			if (secondRes.status() !== 409) {
+				throw new Error(
+					`Expected the second tab's duplicate sign-up to be rejected with 409, got ${secondRes.status()}`,
+				);
+			}
+			console.log("OK  Second tab's duplicate sign-up correctly rejected (409)");
+
+			const errorText = await page2
+				.locator("p.text-red-600")
+				.first()
+				.textContent();
+			if (!errorText || /unknown error|unbekannter fehler/i.test(errorText)) {
+				throw new Error(
+					`Sign-up modal showed a generic error instead of the backend's message: "${errorText}"`,
+				);
+			}
+			if (!/already signed up/i.test(errorText)) {
+				throw new Error(
+					`Expected the modal to surface the backend's specific conflict message, got: "${errorText}"`,
+				);
+			}
+			console.log(`OK  Modal shows the real backend error: "${errorText}"`);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	// === Test 3: achievement toasts don't re-fire on a fresh browser context ===
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			// A brand new context has no einsatzbereit:seen-achievements
+			// localStorage entry, simulating a new device/browser/profile for an
+			// account (olaf) that already has achievements from prior activity.
+			await loginAsUser(page, "olaf", "olaf123");
+			console.log("OK  Logged in as olaf (fresh browser context)");
+
+			// Confirm the precondition: olaf's account actually has achievements
+			// already (otherwise this test would trivially pass for the wrong
+			// reason).
+			const achievementsRes = await fetch(`${API}/v1/me/achievements`, {
+				headers: { Authorization: `Bearer ${olafToken}` },
+			});
+			if (!achievementsRes.ok)
+				throw new Error(
+					`GET /me/achievements failed: ${achievementsRes.status}`,
+				);
+			const achievements = await achievementsRes.json();
+			if (!Array.isArray(achievements) || achievements.length === 0) {
+				throw new Error(
+					"olaf has no existing achievements - cannot verify the re-fire fix",
+				);
+			}
+			console.log(
+				`OK  Precondition: olaf already has ${achievements.length} achievement(s)`,
+			);
+
+			// The notifier's first check fires on mount; give it a moment, then
+			// assert no "New badge unlocked" toast appeared for already-earned
+			// badges.
+			await page.waitForTimeout(3000);
+			const badgeToast = page
+				.getByRole("alert")
+				.filter({ hasText: /new badge unlocked|neues abzeichen freigeschaltet/i });
+			if ((await badgeToast.count()) > 0) {
+				const text = await badgeToast.first().textContent();
+				throw new Error(
+					`Achievement toast re-fired for an already-earned badge on a fresh browser context: "${text}"`,
+				);
+			}
+			console.log(
+				"OK  No achievement toast re-fired for already-earned badges on a fresh context",
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `VolunteerOpportunityDetailPage.tsx`: the details-fetch `useEffect` only depended on `opportunityId`. On a hard navigation (direct URL, shared link, refresh) the OIDC token frequently isn't restored by the time the effect first runs, so the initial fetch goes out unauthenticated and `currentUserEngagement` stays `null` for the rest of the page's lifetime - the "already applied" status silently disappears. Added the (memoized) `api` client to the dependency array so the effect refetches once the token becomes available.
- `SignUpModal.tsx`: the submit handler's `catch` block used `err instanceof Error ? err.message : t("signUp.unknownError")`, but the NSwag-generated client throws the raw `ProblemDetails` object for API errors (not an `Error` instance), so it always fell back to the generic "Unknown error" - hiding the backend's actual message, e.g. a `409` "you're already signed up for this opportunity". Swapped in the shared `getApiErrorMessage()` helper already used elsewhere in the codebase (e.g. this same page's own `load()`).
- `useAchievementNotifier.ts`: the "seed seen list on first run" guard only fired when the account had *zero* achievements. On a fresh browser/device/profile (empty `localStorage`) for an account that already has achievements, every existing achievement was toasted as "New badge unlocked!" and marked seen. Reordered the logic so any empty seen-set seeds the full current achievement list as already-seen, without toasting, regardless of achievement count.

Addresses #644, #645

## Test plan

- [x] `pnpm check` (tsc --noEmit) - passes
- [x] `pnpm lint` - zero warnings
- [x] `pnpm format:write` - no changes needed
- [x] `/self-review` - clean diff; a11y-check subagent confirmed no markup/ARIA changes in the touched files, nothing to flag
- [x] `dotnet build` - all projects compile (VisualTests' post-build browser-install step fails in this sandbox only - a known, pre-existing local limitation unrelated to this change; CI's real runner installs browsers fine)
- [x] `Application.UnitTests` (207/207) and `ArchitectureTests` (247/247) pass locally
- [x] Added `backend/tests/VisualTests/OpportunityApplicationStateTests.cs` (2 new tests) and a new test in `AchievementsTests.cs` covering all three fixes - these run against the local Aspire stack in CI going forward
- [x] Live verification against release-candidate staging (see below)

## Live verification

Cut `v1.0.0-rc.209` from this PR's branch. `release-rc.yml` created the tag, `publish.yml` ran end-to-end (`build-and-test`, `Publish Backend`/`Frontend`/`Keycloak`, `Deploy to Staging`) - all green, including the post-deploy health gate.

- `curl https://api.maik-hasler.de/health` -> `200`
- Ran `node scripts/smoke-test-644-645-detail-and-achievements.mjs` against `https://einsatzbereit.maik-hasler.de` - all checks passed:
  - Applied to a fresh opportunity as vera, then did a genuine hard/direct navigation (full page reload, not an SPA transition) to the same detail URL - "Your application" status was still shown and the apply button did not reappear.
  - Opened the sign-up modal in two tabs (same browser context, shared localStorage-backed auth) for a second fresh opportunity; the first tab's sign-up succeeded, the second tab's duplicate sign-up correctly returned `409` and the modal displayed the backend's actual message ("Conflict: you are already signed up for this opportunity"), not "Unknown error".
  - Logged in as olaf (who already has 2 achievements) in a brand-new browser context - no "New badge unlocked" toast fired for the pre-existing achievements.

## Remaining limitations

None known for these three fixes. The achievement-notifier fix accepts the tradeoff called out in #645 itself: a genuinely new achievement earned in the very first check after a storage wipe won't toast either (it seeds silently instead) - this was the explicitly suggested minimum fix in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
