### PR TITLE
fix: guard opportunity detail fetch against out-of-order responses

### DIFF
--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -11,7 +11,10 @@ namespace VisualTests;
 /// isn't always restored from storage before the details fetch first fires,
 /// and the effect never re-ran once it was. Separately, the sign-up modal
 /// fell back to a generic "Unknown error" instead of the backend's actual
-/// conflict message on a duplicate sign-up attempt.
+/// conflict message on a duplicate sign-up attempt. A follow-up pass found
+/// that re-firing the details fetch as the OIDC token resolves could still
+/// race: an earlier-sent, unauthenticated request resolving after a later,
+/// authenticated one could silently overwrite the correct data.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -38,6 +41,48 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 		// Genuine hard navigation (full reload), not an SPA transition - this is
 		// exactly the race the fix addresses: the OIDC token may not be restored
 		// from storage by the time the details fetch first fires.
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByText("Your application")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }))
+			.Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task DetailPage_KeepsAlreadyAppliedStatus_WhenEarlierUnauthenticatedResponseResolvesLast()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("RaceGuard");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await Page.Locator("textarea").FillAsync("Applying via race-guard regression check.");
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Sign up" }).ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Delay any unauthenticated GET to the details endpoint so it resolves
+		// *after* a later authenticated GET - reproducing the out-of-order
+		// response race the request-id guard defends against: an earlier-sent
+		// request must not overwrite the result of a later-sent one just
+		// because it resolves later.
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", async route =>
+		{
+			if (route.Request.Method == "GET" && !route.Request.Headers.ContainsKey("authorization"))
+			{
+				await Task.Delay(1500);
+			}
+
+			await route.ContinueAsync();
+		});
+
 		await Page.GotoAsync(detailUrl);
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation, Trans } from "react-i18next";
@@ -67,6 +67,8 @@ export default function VolunteerOpportunityDetailPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isOrganisator]);
 
+	const latestRequestRef = useRef(0);
+
 	useEffect(() => {
 		if (!opportunityId) return;
 		load();
@@ -75,12 +77,22 @@ export default function VolunteerOpportunityDetailPage() {
 
 	function load() {
 		if (!opportunityId) return;
+		const requestId = ++latestRequestRef.current;
 		setLoading(true);
 		api
 			.getVolunteerOpportunityDetails(opportunityId)
-			.then(setOpportunity)
-			.catch((err) => setError(getApiErrorMessage(err, t("error.serverError"))))
-			.finally(() => setLoading(false));
+			.then((details) => {
+				if (requestId !== latestRequestRef.current) return;
+				setOpportunity(details);
+			})
+			.catch((err) => {
+				if (requestId !== latestRequestRef.current) return;
+				setError(getApiErrorMessage(err, t("error.serverError")));
+			})
+			.finally(() => {
+				if (requestId !== latestRequestRef.current) return;
+				setLoading(false);
+			});
 	}
 
 	async function handleShare() {

--- a/scripts/smoke-test-644-followup-race-condition.mjs
+++ b/scripts/smoke-test-644-followup-race-condition.mjs
@@ -1,0 +1,235 @@
+// Smoke test for the #644 follow-up found during the 2026-07-08
+// persona-simulation cycle after PR #646 shipped: VolunteerOpportunityDetailPage's
+// load() re-fires as the OIDC token resolves after a hard/direct navigation,
+// but had no request-ordering guard. An earlier-sent, unauthenticated GET
+// could resolve *after* a later, authenticated GET and silently overwrite the
+// correct currentUserEngagement with null via setOpportunity - making the
+// "already applied" status intermittently revert to "Express interest".
+//
+// Fixed in PR #647 with a latestRequestRef counter: any .then()/.catch()/
+// .finally() callback whose request id no longer matches the latest issued
+// request is dropped, so only the most-recently-*sent* request's result is
+// ever applied, regardless of resolution order.
+//
+// This script verifies the fix two ways:
+//   1. Deterministically, by delaying unauthenticated GET responses to the
+//      details endpoint via Playwright route interception, forcing the exact
+//      out-of-order race described above.
+//   2. As a black-box repro of the original persona-sim finding: several
+//      consecutive hard navigations to the same URL, same as the manual repro
+//      that caught this on rc.210.
+//
+// Run: node scripts/smoke-test-644-followup-race-condition.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #644 follow-up.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function applyToOpportunity(page, opportunityId, message) {
+	const detailUrl = `${BASE}/volunteer-opportunities/${opportunityId}`;
+	await page.goto(detailUrl, { waitUntil: "networkidle" });
+	await page
+		.getByRole("button", { name: /express interest|interesse bekunden/i })
+		.click();
+	await page.fill("textarea", message);
+	const [signupRes] = await Promise.all([
+		page.waitForResponse(
+			(r) =>
+				r
+					.url()
+					.includes(`/volunteer-opportunities/${opportunityId}/engagements`) &&
+				r.request().method() === "POST",
+		),
+		page.getByRole("button", { name: /^sign up$|^anmelden$/i }).click(),
+	]);
+	if (!signupRes.ok())
+		throw new Error(`Sign-up POST failed: ${signupRes.status()}`);
+	return detailUrl;
+}
+
+async function assertAlreadyAppliedState(page, detailUrl, label) {
+	await page.goto(detailUrl, { waitUntil: "networkidle" });
+	await page.waitForSelector("h1", { timeout: 10000 });
+	await page
+		.getByText(/your application|deine bewerbung/i)
+		.waitFor({ timeout: 10000 });
+	const ctaButton = page.getByRole("button", {
+		name: /express interest|interesse bekunden/i,
+	});
+	if ((await ctaButton.count()) > 0) {
+		throw new Error(
+			`${label}: apply button re-appeared even though the volunteer already applied`,
+		);
+	}
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	// === Test 1: deterministic race - delay unauthenticated GET responses so
+	// they resolve after a later, authenticated GET ===
+	{
+		const oppRace = await createOpportunity(
+			olafToken,
+			orgId,
+			`Smoke644Followup RaceGuard ${Date.now()}`,
+		);
+		console.log(`OK  Created opportunity for race-guard test ${oppRace.id}`);
+
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			console.log("OK  Logged in as vera");
+
+			const detailUrl = await applyToOpportunity(
+				page,
+				oppRace.id,
+				"Applying via race-guard smoke check.",
+			);
+			console.log("OK  Applied to race-guard opportunity");
+
+			await page.route(
+				`**/v1/volunteer-opportunities/${oppRace.id}`,
+				async (route) => {
+					const headers = route.request().headers();
+					if (route.request().method() === "GET" && !headers.authorization) {
+						await new Promise((resolve) => setTimeout(resolve, 1500));
+					}
+					await route.continue();
+				},
+			);
+
+			await assertAlreadyAppliedState(
+				page,
+				detailUrl,
+				"Deterministic race guard",
+			);
+			console.log(
+				"OK  Already-applied state survives an out-of-order unauthenticated response",
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	// === Test 2: black-box repro - several consecutive hard navigations, same
+	// as the manual repro that caught this on rc.210 ===
+	{
+		const oppRepeat = await createOpportunity(
+			olafToken,
+			orgId,
+			`Smoke644Followup RepeatedNav ${Date.now()}`,
+		);
+		console.log(
+			`OK  Created opportunity for repeated-navigation test ${oppRepeat.id}`,
+		);
+
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+
+			const detailUrl = await applyToOpportunity(
+				page,
+				oppRepeat.id,
+				"Applying via repeated-navigation smoke check.",
+			);
+			console.log("OK  Applied to repeated-navigation opportunity");
+
+			const attempts = 5;
+			for (let i = 1; i <= attempts; i++) {
+				await assertAlreadyAppliedState(
+					page,
+					detailUrl,
+					`Hard navigation attempt ${i}/${attempts}`,
+				);
+			}
+			console.log(
+				`OK  Already-applied state survived ${attempts} consecutive hard navigations`,
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Follow-up to PR #646 for #644: a persona-simulation pass on the deployed fix found that `VolunteerOpportunityDetailPage.tsx`'s `load()` had no request-ordering guard. As the OIDC token resolves after a hard/direct navigation, `load()` can fire more than once in overlapping flight (observed: two unauthenticated GETs followed by one authenticated GET). Whichever response *resolved* last was applied via `setOpportunity`/`setError`, not whichever request was *sent* last - so an earlier, unauthenticated response (with `currentUserEngagement: null`) could silently overwrite the correct, later-sent authenticated response, making the "already applied" status intermittently revert to "Express interest".
- Fix: track the most-recently-issued request via a `latestRequestRef` counter and drop any `.then()/.catch()/.finally()` callback whose request id no longer matches the latest - a "latest request wins by send order" guard. All existing `load()` callers (initial fetch, withdraw, publish, sign-up success, edit success) benefit automatically since they all go through the same function.
- Added a regression test that deterministically reproduces the race by delaying unauthenticated GET responses to the details endpoint via Playwright route interception, so the authenticated response resolves first even though it was sent second.

## Test plan

- [x] `pnpm check` / `pnpm lint` - clean
- [x] `pnpm format:write` - no changes needed
- [x] `dotnet build` - clean (0 warnings, 0 errors)
- [x] `Application.UnitTests` - 207/207 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] `/self-review` (incl. `a11y-check` since a `.tsx` page changed - no JSX/markup changed, confirmed no a11y impact)
- [x] Added `OpportunityApplicationStateTests.DetailPage_KeepsAlreadyAppliedStatus_WhenEarlierUnauthenticatedResponseResolvesLast` to `backend/tests/VisualTests/` - passed in CI (`Test - VisualTests` green on this PR)
- [x] All PR CI checks green (lint, format-check, editorconfig, ban-typographic-dashes, build, build-and-test, PR title)
- [x] Live verification - see below

## Live verification

Cut `v1.0.0-rc.211` from this PR's branch. `publish.yml` succeeded end-to-end: build, `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, `Test - VisualTests` (including the new regression test), image publish for frontend/backend/keycloak, and `Deploy to Staging` with the post-deploy health gate green. `curl https://api.maik-hasler.de/health` -> `200`.

Ran `scripts/smoke-test-644-followup-race-condition.mjs` against `https://einsatzbereit.maik-hasler.de` as `vera`:
- **Deterministic race repro**: applied to a fresh opportunity, then intercepted the details-fetch route to delay any unauthenticated GET response by 1.5s (forcing it to resolve after a later authenticated GET, exactly matching the network trace from the original persona-sim finding) - the "already applied" status correctly survived and the apply button did not reappear.
- **Black-box repro**: applied to a second fresh opportunity, then did 5 consecutive hard navigations (`page.goto` + full reload) to the same detail URL - the "already applied" status survived every single one (the original bug reverted on attempts 2 and 3 out of 3 on rc.210).

Script exited 0, "ALL CHECKS PASSED".

Relates to #644 (not a closing keyword - the routine that owns this PR never merges or closes issues itself).
