### PR TITLE
fix: recover from a deleted opportunity in notifications and applications view

### DIFF
--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -79,7 +79,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 
 	private static async Task<JsonElement> GetEngagementCreatedNotificationAsync(HttpClient http, string opportunityId)
 	{
-		var response = await http.GetAsync("/v1/me/notifications");
+		var response = await http.GetAsync("/v1/notifications");
 		response.EnsureSuccessStatusCode();
 		var notifications = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return notifications.EnumerateArray()

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -1,0 +1,145 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #655: once a volunteer opportunity is deleted, the
+/// EngagementCreated notification that was already generated for it resolves
+/// its title via a live lookup of the (now-gone) opportunity, so
+/// relatedTitle stays null forever, and its actionUrl 404s. Covers both the
+/// frontend fallback title text and EngagementManagementPage rendering the
+/// existing NotFoundPage instead of a raw error string on that 404.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Notification_KeepsNullRelatedTitle_AfterOpportunityDeleted()
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedTitle");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		deleteResponse.EnsureSuccessStatusCode();
+
+		var notification = await GetEngagementCreatedNotificationAsync(olafHttp, opportunityId);
+
+		notification.TryGetProperty("relatedTitle", out var relatedTitle).Should().BeTrue();
+		(relatedTitle.ValueKind is JsonValueKind.Null).Should().BeTrue(
+			"the opportunity backing this notification no longer exists, so its title can no longer be resolved");
+		notification.GetProperty("actionUrl").GetString().Should().Be(
+			$"/volunteer-opportunities/{opportunityId}/engagements");
+	}
+
+	[Test]
+	public async Task EngagementManagementPage_RendersNotFoundPage_ForDeletedOpportunity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedUi");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		deleteResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Page not found" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	private static async Task<string> ApplyAsync(HttpClient http, string opportunityId, string message)
+	{
+		var response = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<JsonElement> GetEngagementCreatedNotificationAsync(HttpClient http, string opportunityId)
+	{
+		var response = await http.GetAsync("/v1/me/notifications");
+		response.EnsureSuccessStatusCode();
+		var notifications = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return notifications.EnumerateArray()
+			.First(n => n.GetProperty("kind").GetString() == "EngagementCreated"
+				&& n.GetProperty("actionUrl").GetString() == $"/volunteer-opportunities/{opportunityId}/engagements");
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Create a fresh organization rather than reusing olaf's shared seed
+		// org - other VisualTests running concurrently in this shared Aspire
+		// session can mutate/delete shared orgs, which made GET
+		// /v1/organizations intermittently race to an empty list here.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"NotifDeletedOpp Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain Organization
+		// aggregate (unlike GetOrganizations, which projects to a DTO), so
+		// its strongly-typed OrganizationId record struct serializes as a
+		// nested { "value": "<guid>" } object rather than a plain string.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"NotifDeletedOpp {label} {suffix}",
+			description = "Created by NotificationForDeletedOpportunityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -245,7 +245,11 @@ export default function Header() {
 																				typeof t
 																			>[0],
 																			{
-																				title: n.relatedTitle ?? "",
+																				title:
+																					n.relatedTitle ??
+																					t(
+																						"notifications.deletedOpportunityPlaceholder",
+																					),
 																				defaultValue: n.kind,
 																			},
 																		)}
@@ -467,7 +471,11 @@ export default function Header() {
 																			typeof t
 																		>[0],
 																		{
-																			title: n.relatedTitle ?? "",
+																			title:
+																				n.relatedTitle ??
+																				t(
+																					"notifications.deletedOpportunityPlaceholder",
+																				),
 																			defaultValue: n.kind,
 																		},
 																	)}

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -15,3 +15,18 @@ export function getApiErrorMessage(err: unknown, fallback: string): string {
 	}
 	return fallback;
 }
+
+/**
+ * Detects a 404 from a rejected API call.
+ *
+ * Both shapes the NSwag client can throw - the raw ProblemDetails object
+ * (when the response has a JSON body) or an ApiException instance (when it
+ * doesn't) - carry a numeric `.status` field, so this works for either.
+ */
+export function isApiNotFoundError(err: unknown): boolean {
+	return (
+		!!err &&
+		typeof err === "object" &&
+		(err as { status?: unknown }).status === 404
+	);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -545,6 +545,7 @@
       "bellLabel": "Benachrichtigungen",
       "markAllRead": "Alle als gelesen markieren",
       "empty": "Keine Benachrichtigungen.",
+      "deletedOpportunityPlaceholder": "einen gelöschten Bedarf",
       "kinds": {
         "EngagementCreated": "Neue Bewerbung eingegangen fur {{title}}",
         "EngagementConfirmed": "Deine Bewerbung fur {{title}} wurde bestätigt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -545,6 +545,7 @@
       "bellLabel": "Notifications",
       "markAllRead": "Mark all as read",
       "empty": "No notifications.",
+      "deletedOpportunityPlaceholder": "a deleted opportunity",
       "kinds": {
         "EngagementCreated": "New application received for {{title}}",
         "EngagementConfirmed": "Your application for {{title}} was confirmed",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
-import {
-	ApiException,
-	type EngagementSummary,
-	type OpportunityFeedbackSummary,
-	type VolunteerOpportunityDetails,
+import type {
+	EngagementSummary,
+	OpportunityFeedbackSummary,
+	VolunteerOpportunityDetails,
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
@@ -16,7 +15,7 @@ import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
-import { getApiErrorMessage } from "../lib/apiError";
+import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
@@ -92,7 +91,7 @@ export default function EngagementManagementPage() {
 		])
 			.then(([e]) => setEngagements(e))
 			.catch((err) => {
-				if (err instanceof ApiException && err.status === 404) {
+				if (isApiNotFoundError(err)) {
 					setNotFound(true);
 				} else {
 					setError(getApiErrorMessage(err, t("error.serverError")));

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
-import type {
-	EngagementSummary,
-	OpportunityFeedbackSummary,
-	VolunteerOpportunityDetails,
+import {
+	ApiException,
+	type EngagementSummary,
+	type OpportunityFeedbackSummary,
+	type VolunteerOpportunityDetails,
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import QRScannerModal from "../components/QRScannerModal";
+import NotFoundPage from "./NotFoundPage";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
@@ -63,6 +65,7 @@ export default function EngagementManagementPage() {
 	const [checkInPin, setCheckInPin] = useState<string | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [notFound, setNotFound] = useState(false);
 	const [confirming, setConfirming] = useState<string | null>(null);
 	const [confirmCancelId, setConfirmCancelId] = useState<string | null>(null);
 	const [cancelling, setCancelling] = useState(false);
@@ -88,7 +91,13 @@ export default function EngagementManagementPage() {
 				.catch(() => undefined),
 		])
 			.then(([e]) => setEngagements(e))
-			.catch((err) => setError(getApiErrorMessage(err, t("error.serverError"))))
+			.catch((err) => {
+				if (err instanceof ApiException && err.status === 404) {
+					setNotFound(true);
+				} else {
+					setError(getApiErrorMessage(err, t("error.serverError")));
+				}
+			})
 			.finally(() => setLoading(false));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [opportunityId]);
@@ -160,6 +169,10 @@ export default function EngagementManagementPage() {
 		if (cancelling) return;
 		setConfirmCancelId(null);
 		setCancelError(null);
+	}
+
+	if (notFound) {
+		return <NotFoundPage />;
 	}
 
 	const checkInMethod = opportunity?.checkInMethod;


### PR DESCRIPTION
## Summary

Addresses #655. Once a volunteer opportunity is deleted, notifications generated for it before the deletion (`EngagementCreated`/withdrawal notifications) keep pointing at the now-gone opportunity, and this produced two dead ends for the recipient (usually Organizer Olaf):

- The notification bell (`Header.tsx`) interpolated `relatedTitle` (which resolves via a live lookup that now misses) straight into the notification text, rendering a bare, meaningless string like "New application received for" with nothing after "for". `Header.tsx` now falls back to a translated placeholder ("a deleted opportunity" / "einen gelöschten Bedarf") whenever `relatedTitle` is null, in both the desktop and mobile notification dropdowns.
- Clicking through to the opportunity's "Manage applications" page (`EngagementManagementPage`) rendered the backend's raw `ProblemDetails` message ("Volunteer opportunity '{guid}' not found.") as inline page text instead of the app's existing friendly `NotFoundPage`. The page's engagements fetch is the only call in that page's `Promise.all` without its own catch, so a 404 there is now detected (`err instanceof ApiException && err.status === 404`) and renders `NotFoundPage` instead.

No backend change was needed - `relatedTitle` being `null` for a since-deleted opportunity is expected/correct behavior; the fix is entirely about the frontend degrading gracefully instead of showing a raw error.

## Test plan

- [x] `Application.UnitTests` - 210/210 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc --noEmit) - clean
- [x] `pnpm lint` (zero warnings) - clean
- [x] `/self-review` - clean; fanned out to `a11y-check` (no new a11y test needed - `NotFoundPage_HasNoSeriousA11yViolations` in `AccessibilityTests.cs` already exercises the same `NotFoundPage` component) and `i18n-check` (en/de locale keys confirmed in sync)
- [x] Added `backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs`:
  - `Notification_KeepsNullRelatedTitle_AfterOpportunityDeleted` - creates an opportunity, has a volunteer apply, deletes the opportunity as the organizer, and asserts the resulting `EngagementCreated` notification has `relatedTitle: null` and its `actionUrl` still points at the deleted opportunity's engagements page.
  - `EngagementManagementPage_RendersNotFoundPage_ForDeletedOpportunity` - deletes an opportunity, navigates to its (now-404) "Manage applications" page as the organizer, and asserts the friendly `NotFoundPage` heading renders instead of a raw error.
  - Docker/Aspire isn't available in this sandbox, so these compile-verified locally but will run for real in CI's `dotnet.yml`.
- [ ] Live verification against staging (release candidate) - in progress, will update this PR once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UXaZBwqSWZi3dCMCWgdQZ


---
_Generated by [Claude Code](https://claude.ai/code/session_012UXaZBwqSWZi3dCMCWgdQZ)_