### PR TITLE
fix: darken low-contrast text on My Engagements to meet WCAG AA

### DIFF
--- a/backend/tests/VisualTests/EngagementStatusContrastTests.cs
+++ b/backend/tests/VisualTests/EngagementStatusContrastTests.cs
@@ -1,0 +1,116 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Deque.AxeCore.Commons;
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #659: the "Signed up: {date}" line (text-gray-400 on white)
+/// and the Withdrawn status badge (text-gray-500 on bg-gray-100) failed WCAG
+/// AA color-contrast. MyEngagementsPage_AsVera_HasNoSeriousA11yViolations in
+/// AccessibilityTests.cs only caught this when a dated/Withdrawn engagement
+/// happened to already be present for vera at scan time - seed/timing
+/// dependent under the shared AspireFixture session. This test deterministically
+/// creates a Withdrawn engagement first, so the violation is always exercised.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementStatusContrastTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task MyEngagementsPage_WithWithdrawnEngagement_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend);
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+
+		var applyResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "EngagementStatusContrastTests application." });
+		applyResponse.EnsureSuccessStatusCode();
+		var applied = await applyResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = applied.GetProperty("id").GetString()!;
+
+		var withdrawResponse = await http.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
+		withdrawResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Confirm the Withdrawn badge this fix targets is actually on the page
+		// before scanning - otherwise a pass proves nothing.
+		await Expect(Page.GetByText("Withdrawn").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		var violations = result.Violations
+			.Where(v => v.Impact is "serious" or "critical")
+			.ToList();
+
+		if (violations.Count > 0)
+		{
+			var summary = string.Join("\n", violations.Select(v =>
+				$"[{v.Impact}] {v.Id}: {v.Description}\n" +
+				string.Join("\n", v.Nodes.Select(n => $"  - {n.Html}"))));
+			throw new Exception($"Axe found {violations.Count} serious/critical a11y violation(s):\n{summary}");
+		}
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Create a fresh organization rather than reusing olaf's shared seed
+		// org - other VisualTests running concurrently in this shared Aspire
+		// session can mutate/delete shared orgs (see EngagementReactivationTests).
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"EngagementStatusContrast Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"EngagementStatusContrast {suffix}",
+			description = "Created by EngagementStatusContrastTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+}

--- a/frontend/src/lib/engagementStatus.ts
+++ b/frontend/src/lib/engagementStatus.ts
@@ -2,5 +2,5 @@ export const ENGAGEMENT_STATUS_COLORS: Record<string, string> = {
 	Pending: "bg-yellow-50 text-yellow-700 border-yellow-100",
 	Confirmed: "bg-green-50 text-green-700 border-green-100",
 	Cancelled: "bg-red-50 text-red-700 border-red-100",
-	Withdrawn: "bg-gray-100 text-gray-500 border-gray-200",
+	Withdrawn: "bg-gray-100 text-gray-700 border-gray-200",
 };

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -892,7 +892,7 @@ export default function ProfileOverviewPage() {
 														&ldquo;{e.message}&rdquo;
 													</p>
 												)}
-												<p className="mt-1.5 text-xs text-gray-400">
+												<p className="mt-1.5 text-xs text-gray-500">
 													{t("myEngagements.registeredOn", {
 														date: new Date(e.createdOn).toLocaleDateString(
 															locale,


### PR DESCRIPTION
## Summary

Addresses #659. Axe-core flagged two static Tailwind class combinations on "My Profile -> Engagements" as `serious` WCAG AA color-contrast violations:

- `frontend/src/pages/ProfileOverviewPage.tsx`: the "Signed up: {date}" line used `text-gray-400` directly on the white card background (~2.87:1 contrast, below the 4.5:1 AA minimum for normal text). Changed to `text-gray-500` (~4.83:1), matching the shade already used by every other muted-text element on the same card.
- `frontend/src/lib/engagementStatus.ts`: the `Withdrawn` engagement-status badge used `bg-gray-100 text-gray-500 border-gray-200` (~4.39:1 against its own background, narrowly failing 4.5:1). Changed the text shade to `text-gray-700` (~9.4:1), which also aligns it with the other three status entries (`Pending`/`Confirmed`/`Cancelled`), all of which already use a `-700` text shade against a lighter background.

Both classes are static (not conditional on data), so the violation was deterministic whenever this markup rendered - it was only caught intermittently in CI because it depends on a `Withdrawn` (or otherwise dated) engagement existing for vera at scan time under the shared `AspireFixture` session.

No backend change needed - this is a pure Tailwind class swap on already-rendered text content, no ARIA/markup changes required (confirmed via `a11y-check`).

## Test plan

- [x] `pnpm format:write` / `pnpm lint` (zero warnings) / `pnpm check` (tsc --noEmit) - clean
- [x] `/self-review` - fanned out to `a11y-check` since the diff touches `.tsx`/status-color logic. It confirmed the fix is color-only and adequate, but flagged that the existing `MyEngagementsPage_AsVera_HasNoSeriousA11yViolations` test doesn't reliably exercise a Withdrawn-status card (seed/timing dependent, per #659's own description) - so it wouldn't reliably regression-guard this fix.
- [x] Added `backend/tests/VisualTests/EngagementStatusContrastTests.cs`: creates a throwaway opportunity, applies and withdraws as vera (producing a real `Withdrawn` engagement), navigates to "My Profile -> Engagements", asserts the `Withdrawn` badge is actually visible, then runs an axe scan and asserts zero serious/critical violations - deterministic coverage instead of relying on whatever engagement state happens to already exist.
- [x] Compile-verified locally (`dotnet build tests/VisualTests/VisualTests.csproj` succeeds through `VisualTests.dll`; the sandbox's Playwright browser-install post-build step fails for unrelated apt-repo reasons - Docker/Aspire isn't available in this sandbox per root `CLAUDE.md`). Will run for real in CI's `dotnet.yml`.
- [ ] Live verification against staging (release candidate) - in progress, will update this PR once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Me5CviU4VBswFJC53MsL7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Me5CviU4VBswFJC53MsL7A)_