### PR TITLE
fix: only fetch check-in PIN when checkInMethod is PINCode

### DIFF
--- a/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
@@ -1,0 +1,125 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #665: EngagementManagementPage ("Manage applications")
+/// unconditionally called GET .../check-in-pin on every load, regardless of
+/// the opportunity's checkInMethod. The backend returns 404 whenever the PIN
+/// is null, i.e. for every checkInMethod other than "PINCode" - so the
+/// request was a guaranteed, silently-swallowed 404 for 3 of the 4 possible
+/// values. The fix gates the fetch on checkInMethod === "PINCode", the same
+/// condition already used to render the PIN block.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementManagementCheckInPinTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task ManageApplicationsPage_DoesNotRequestCheckInPin_WhenCheckInMethodIsNone()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CheckInPinNone", "None");
+
+		var pinRequested = false;
+		await Page.RouteAsync("**/*check-in-pin*", async route =>
+		{
+			pinRequested = true;
+			await route.ContinueAsync();
+		});
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		pinRequested.Should().BeFalse(
+			"checkInMethod is \"None\", so the PIN endpoint would always 404 and must not be called");
+	}
+
+	[Test]
+	public async Task ManageApplicationsPage_RequestsCheckInPin_WhenCheckInMethodIsPINCode()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CheckInPinPin", "PINCode");
+
+		var pinResponseStatuses = new List<int>();
+		Page.Response += (_, response) =>
+		{
+			if (response.Url.Contains("check-in-pin", StringComparison.Ordinal))
+				pinResponseStatuses.Add(response.Status);
+		};
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		pinResponseStatuses.Should().ContainSingle().Which.Should().Be(200);
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<string> CreateIndividualContactOpportunityAsync(
+		Uri keycloak, Uri backend, string label, string checkInMethod)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Create a fresh organization rather than reusing olaf's shared seed
+		// org - other VisualTests running concurrently in this shared Aspire
+		// session can mutate/delete shared orgs, which made GET
+		// /v1/organizations intermittently race to an empty list here.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"CheckInPin Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain Organization
+		// aggregate (unlike GetOrganizations, which projects to a DTO), so
+		// its strongly-typed OrganizationId record struct serializes as a
+		// nested { "value": "<guid>" } object rather than a plain string.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"CheckInPin {label} {suffix}",
+			description = "Created by EngagementManagementCheckInPinTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod,
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+}

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -84,10 +84,6 @@ export default function EngagementManagementPage() {
 				.getOpportunityFeedback(opportunityId)
 				.then(setFeedback)
 				.catch(() => undefined),
-			api
-				.getOpportunityCheckInPin(opportunityId)
-				.then(setCheckInPin)
-				.catch(() => undefined),
 		])
 			.then(([e]) => setEngagements(e))
 			.catch((err) => {
@@ -100,6 +96,15 @@ export default function EngagementManagementPage() {
 			.finally(() => setLoading(false));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [opportunityId]);
+
+	useEffect(() => {
+		if (!opportunityId || opportunity?.checkInMethod !== "PINCode") return;
+		api
+			.getOpportunityCheckInPin(opportunityId)
+			.then(setCheckInPin)
+			.catch(() => undefined);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [opportunityId, opportunity?.checkInMethod]);
 
 	async function handleConfirm(engagementId: string) {
 		setConfirming(engagementId);

--- a/scripts/smoke-test-665-checkin-pin-request.mjs
+++ b/scripts/smoke-test-665-checkin-pin-request.mjs
@@ -1,0 +1,197 @@
+// Smoke test for #665:
+//
+// EngagementManagementPage ("Manage applications") unconditionally called
+// GET /v1/volunteer-opportunities/{id}/check-in-pin on every page load,
+// regardless of the opportunity's checkInMethod. The backend returns 404
+// whenever the PIN is null, i.e. for every checkInMethod other than
+// "PINCode" - so 3 of the 4 possible values guaranteed a wasted, silently
+// swallowed 404 request on every view.
+//
+// Fix: the PIN fetch now lives in its own effect gated on
+// opportunity?.checkInMethod === "PINCode", the same condition already
+// used to render the PIN block.
+//
+// This script checks both sides: no check-in-pin request for a "None"
+// opportunity, and the request still succeeds (200) for a "PINCode" one.
+//
+// Run: node scripts/smoke-test-665-checkin-pin-request.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title, checkInMethod) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #665.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod,
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function deleteOpportunity(token, opportunityId) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}`,
+		{ method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+	);
+	if (!res.ok)
+		throw new Error(`Delete failed: ${res.status} ${await res.text()}`);
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function visitManageApplications(opportunityId) {
+	const { browser, page } = await launchLiveBrowser();
+	const pinRequests = [];
+	page.on("response", (r) => {
+		if (r.url().includes("/check-in-pin")) {
+			pinRequests.push({ url: r.url(), status: r.status() });
+		}
+	});
+	try {
+		await loginAsUser(page, "olaf", "olaf123");
+		await page.goto(
+			`${BASE}/volunteer-opportunities/${opportunityId}/engagements`,
+			{ waitUntil: "networkidle" },
+		);
+		await page.waitForSelector("main", { timeout: 10000 });
+		// give any stray requests a moment to land after networkidle
+		await page.waitForTimeout(1000);
+	} finally {
+		await browser.close();
+	}
+	return pinRequests;
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	let noneOpportunity;
+	let pinOpportunity;
+	try {
+		// === Case 1: checkInMethod "None" - no check-in-pin request expected ===
+		noneOpportunity = await createOpportunity(
+			olafToken,
+			orgId,
+			`Smoke665 NoneCheckIn ${Date.now()}`,
+			"None",
+		);
+		console.log(
+			`OK  Created "None" check-in opportunity ${noneOpportunity.id}`,
+		);
+
+		const noneRequests = await visitManageApplications(noneOpportunity.id);
+		if (noneRequests.length > 0) {
+			throw new Error(
+				`Expected no check-in-pin request for a "None" opportunity, got: ${JSON.stringify(noneRequests)}`,
+			);
+		}
+		console.log(
+			'OK  No GET .../check-in-pin request fired for a "None" check-in opportunity',
+		);
+
+		// === Case 2: checkInMethod "PINCode" - request still fires and succeeds ===
+		pinOpportunity = await createOpportunity(
+			olafToken,
+			orgId,
+			`Smoke665 PINCodeCheckIn ${Date.now()}`,
+			"PINCode",
+		);
+		console.log(`OK  Created "PINCode" check-in opportunity ${pinOpportunity.id}`);
+
+		const pinRequests = await visitManageApplications(pinOpportunity.id);
+		if (pinRequests.length !== 1) {
+			throw new Error(
+				`Expected exactly one check-in-pin request for a "PINCode" opportunity, got: ${JSON.stringify(pinRequests)}`,
+			);
+		}
+		if (pinRequests[0].status !== 200) {
+			throw new Error(
+				`Expected check-in-pin request to return 200, got ${pinRequests[0].status}`,
+			);
+		}
+		console.log(
+			'OK  GET .../check-in-pin request fired and returned 200 for a "PINCode" check-in opportunity',
+		);
+	} finally {
+		if (noneOpportunity) {
+			await deleteOpportunity(olafToken, noneOpportunity.id);
+			console.log(`OK  Cleaned up opportunity ${noneOpportunity.id}`);
+		}
+		if (pinOpportunity) {
+			await deleteOpportunity(olafToken, pinOpportunity.id);
+			console.log(`OK  Cleaned up opportunity ${pinOpportunity.id}`);
+		}
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `EngagementManagementPage` (Manage applications) unconditionally called `getOpportunityCheckInPin` on every load, regardless of the opportunity's `checkInMethod`. The backend endpoint returns `404` whenever the PIN is `null`, i.e. for every check-in method other than `PINCode` - so 3 of the 4 possible values guaranteed a wasted, silently-swallowed 404 request on every page view.
- Split the PIN fetch out of the main data-fetching effect into its own `useEffect`, gated on `opportunity?.checkInMethod === "PINCode"` - the same condition already used to render the PIN block - so the request is only made when it can actually succeed.
- Added a `EngagementManagementCheckInPinTests` VisualTests suite (runs against the local Aspire stack in CI) and a `scripts/smoke-test-665-checkin-pin-request.mjs` live-staging Playwright script, both asserting no PIN request fires for a `None` opportunity and the PIN request still fires and returns `200` for a `PINCode` one.

Addresses #665

## Test plan

- [x] `pnpm check` (tsc --noEmit) - passes
- [x] `pnpm lint` - zero warnings
- [x] `pnpm format:write` - no changes needed
- [x] `/self-review` - clean, `a11y-check` subagent confirmed no regression (no JSX/markup changed)
- [x] `dotnet build` / `ArchitectureTests` (Docker-free subset) - pass
- [x] Live verification against staging (release candidate) - complete, see below

## Live verification

- Cut as `v1.0.0-rc.218` from this branch; `publish.yml` build + `deploy-staging` completed successfully.
- `curl -sf https://api.maik-hasler.de/health` returned `200`.
- Ran `node scripts/smoke-test-665-checkin-pin-request.mjs` against `https://einsatzbereit.maik-hasler.de`: created a live "None" check-in opportunity as `olaf`, opened its "Manage applications" page, and confirmed no `GET .../check-in-pin` request fired at all. Created a second "PINCode" opportunity and confirmed the request still fires and returns `200`. Both test opportunities were deleted afterwards. All assertions passed (`ALL CHECKS PASSED`).
- Added the same assertions as an automated `EngagementManagementCheckInPinTests` TUnit suite under `backend/tests/VisualTests/` for CI coverage against the local Aspire stack (not runnable in this sandbox per root `CLAUDE.md`; the C# compiles cleanly, full run relies on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KZT8r7m2EWanGDKBHTt1vG)_