### PR TITLE
fix: preserve a volunteer's own engagement history after opportunity deletion

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4377,14 +4377,23 @@
             "format": "uuid"
           },
           "opportunityTitle": {
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "organizationId": {
-            "type": "string",
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "organizationName": {
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "volunteerId": {
             "type": "string",

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -3,9 +3,9 @@ namespace Application.Engagements;
 public sealed record EngagementSummary(
 	Guid Id,
 	Guid OpportunityId,
-	string OpportunityTitle,
-	Guid OrganizationId,
-	string OrganizationName,
+	string? OpportunityTitle,
+	Guid? OrganizationId,
+	string? OrganizationName,
 	Guid VolunteerId,
 	Guid? TimeSlotId,
 	string? Message,

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -76,55 +76,32 @@ internal sealed class EngagementReadRepository(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default)
 	{
-		var raw = await dbContext.EngagementsQuery
+		// Deliberately not an inner join against VolunteerOpportunitiesQuery: deleting an
+		// opportunity hard-deletes its row while only cancelling (not deleting) the
+		// volunteer's Engagement rows, so an inner join would silently drop those
+		// engagements from the volunteer's own history (#667). Opportunity/organization
+		// data is instead looked up separately and merged in below, falling back to
+		// null when the opportunity no longer exists.
+		var engagements = await dbContext.EngagementsQuery
 			.Where(e => e.VolunteerId == volunteerId)
-			.Join(
-				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.IsRemote, o.Address, o.OrganizationId }),
-				e => e.OpportunityId,
-				o => o.Id,
-				(e, o) => new
-				{
-					e.Id,
-					e.OpportunityId,
-					OpportunityTitle = o.Title,
-					o.IsRemote,
-					o.Address,
-					o.OrganizationId,
-					e.VolunteerId,
-					e.TimeSlotId,
-					e.Message,
-					e.Status,
-					e.IsCheckedIn,
-					e.FeedbackSubmittedAt,
-					e.CreatedOn,
-				})
-			.Join(
-				dbContext.OrganizationsQuery.Select(org => new { org.Id, org.Name }),
-				x => x.OrganizationId,
-				org => org.Id,
-				(x, org) => new
-				{
-					x.Id,
-					x.OpportunityId,
-					x.OpportunityTitle,
-					x.IsRemote,
-					x.Address,
-					OrganizationId = org.Id,
-					OrganizationName = org.Name,
-					x.VolunteerId,
-					x.TimeSlotId,
-					x.Message,
-					x.Status,
-					x.IsCheckedIn,
-					x.FeedbackSubmittedAt,
-					x.CreatedOn,
-				})
-			.OrderByDescending(x => x.CreatedOn)
+			.OrderByDescending(e => e.CreatedOn)
 			.ToListAsync(cancellationToken);
 
-		var timeSlotIds = raw
-			.Where(x => x.TimeSlotId is not null)
-			.Select(x => x.TimeSlotId!.Value)
+		var opportunityIds = engagements.Select(e => e.OpportunityId).Distinct().ToList();
+		var opportunities = await dbContext.VolunteerOpportunitiesQuery
+			.Where(o => opportunityIds.Contains(o.Id))
+			.Select(o => new { o.Id, o.Title, o.IsRemote, o.Address, o.OrganizationId })
+			.ToDictionaryAsync(o => o.Id, cancellationToken);
+
+		var organizationIds = opportunities.Values.Select(o => o.OrganizationId).Distinct().ToList();
+		var organizations = await dbContext.OrganizationsQuery
+			.Where(org => organizationIds.Contains(org.Id))
+			.Select(org => new { org.Id, org.Name })
+			.ToDictionaryAsync(org => org.Id, cancellationToken);
+
+		var timeSlotIds = engagements
+			.Where(e => e.TimeSlotId is not null)
+			.Select(e => e.TimeSlotId!.Value)
 			.Distinct()
 			.ToList();
 
@@ -136,28 +113,36 @@ internal sealed class EngagementReadRepository(
 				.ToDictionaryAsync(ts => ts.Id, cancellationToken);
 		}
 
-		return raw.Select(x =>
+		return engagements.Select(e =>
 		{
-			TimeSlot? timeSlot = x.TimeSlotId is not null
-				&& timeSlots.TryGetValue(x.TimeSlotId.Value, out var slot)
+			opportunities.TryGetValue(e.OpportunityId, out var opportunity);
+			var organization = opportunity is not null
+				&& organizations.TryGetValue(opportunity.OrganizationId, out var org)
+					? org
+					: null;
+
+			TimeSlot? timeSlot = e.TimeSlotId is not null
+				&& timeSlots.TryGetValue(e.TimeSlotId.Value, out var slot)
 					? slot
 					: null;
 
-			var location = x.IsRemote ? "Remote" : FormatAddress(x.Address);
+			var location = opportunity is null
+				? null
+				: opportunity.IsRemote ? "Remote" : FormatAddress(opportunity.Address);
 
 			return new EngagementSummary(
-				x.Id.Value,
-				x.OpportunityId.Value,
-				x.OpportunityTitle,
-				x.OrganizationId.Value,
-				x.OrganizationName,
-				x.VolunteerId.Value,
-				x.TimeSlotId?.Value,
-				x.Message,
-				x.Status.ToString(),
-				x.IsCheckedIn,
-				x.FeedbackSubmittedAt.HasValue,
-				x.CreatedOn,
+				e.Id.Value,
+				e.OpportunityId.Value,
+				opportunity?.Title,
+				organization?.Id.Value,
+				organization?.Name,
+				e.VolunteerId.Value,
+				e.TimeSlotId?.Value,
+				e.Message,
+				e.Status.ToString(),
+				e.IsCheckedIn,
+				e.FeedbackSubmittedAt.HasValue,
+				e.CreatedOn,
 				TimeSlotStartDateTime: timeSlot?.StartDateTime,
 				TimeSlotEndDateTime: timeSlot?.EndDateTime,
 				Location: location);

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -7326,16 +7326,13 @@ namespace IntegrationTests
         public System.Guid OpportunityId { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("opportunityTitle")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string OpportunityTitle { get; set; } = default!;
+        public string? OpportunityTitle { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationId")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.Guid OrganizationId { get; set; } = default!;
+        public System.Guid? OrganizationId { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationName")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string OrganizationName { get; set; } = default!;
+        public string? OrganizationName { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("volunteerId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]

--- a/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
@@ -1,0 +1,147 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #667: GetByVolunteerAsync (backing GET /v1/me/engagements,
+/// the volunteer's "My Profile -> Engagements" list) used an inner join
+/// against VolunteerOpportunitiesQuery. Deleting an opportunity hard-deletes
+/// that row while only cancelling (not deleting) affected Engagement rows,
+/// so the inner join silently dropped the volunteer's own engagement entirely
+/// once its opportunity was gone - it should still appear, marked Cancelled,
+/// with a fallback title.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task MyEngagements_StillListsEngagement_AfterItsOpportunityIsDeleted()
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistDeleted");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
+		confirmResponse.EnsureSuccessStatusCode();
+
+		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		deleteResponse.EnsureSuccessStatusCode();
+
+		var myEngagementsResponse = await veraHttp.GetAsync("/v1/me/engagements");
+		myEngagementsResponse.EnsureSuccessStatusCode();
+		var myEngagements = await myEngagementsResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+		var engagement = myEngagements.EnumerateArray()
+			.FirstOrDefault(e => e.GetProperty("id").GetString() == engagementId);
+
+		engagement.ValueKind.Should().NotBe(JsonValueKind.Undefined,
+			"the engagement must still appear in the volunteer's own history, not disappear entirely, once its opportunity is deleted");
+		engagement.GetProperty("status").GetString().Should().Be("Cancelled");
+		engagement.GetProperty("opportunityTitle").ValueKind.Should().Be(JsonValueKind.Null,
+			"the opportunity backing this engagement no longer exists, so its title can no longer be resolved");
+	}
+
+	[Test]
+	public async Task MyEngagementsPage_ShowsFallbackTitle_ForDeletedOpportunity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistDeletedUi");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		deleteResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByText("This opportunity has been removed").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	private static async Task<string> ApplyAsync(HttpClient http, string opportunityId, string message)
+	{
+		var response = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Create a fresh organization rather than reusing olaf's shared seed
+		// org - other VisualTests running concurrently in this shared Aspire
+		// session can mutate/delete shared orgs, which made GET
+		// /v1/organizations intermittently race to an empty list here.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"EngHistDeletedOpp Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain Organization
+		// aggregate (unlike GetOrganizations, which projects to a DTO), so
+		// its strongly-typed OrganizationId record struct serializes as a
+		// nested { "value": "<guid>" } object rather than a plain string.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"EngHistDeletedOpp {label} {suffix}",
+			description = "Created by EngagementHistoryForDeletedOpportunityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3663,9 +3663,9 @@ export interface EngagementStatusResponse {
 export interface EngagementSummary {
     id: string;
     opportunityId: string;
-    opportunityTitle: string;
-    organizationId: string;
-    organizationName: string;
+    opportunityTitle: string | undefined;
+    organizationId: string | undefined;
+    organizationName: string | undefined;
     volunteerId: string;
     timeSlotId: string | undefined;
     message: string | undefined;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -474,6 +474,7 @@
       "exploreNeeds": "Bedarfe erkunden",
       "viewOpportunity": "Bedarf anzeigen →",
       "registeredOn": "Angemeldet: {{date}}",
+      "deletedOpportunityTitle": "Dieser Bedarf wurde entfernt",
       "checkIn": "Einchecken",
       "withdraw": "Zurückziehen",
       "withdrawing": "…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -474,6 +474,7 @@
       "exploreNeeds": "Explore opportunities",
       "viewOpportunity": "View opportunity →",
       "registeredOn": "Signed up: {{date}}",
+      "deletedOpportunityTitle": "This opportunity has been removed",
       "checkIn": "Check in",
       "withdraw": "Withdraw",
       "withdrawing": "…",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -873,20 +873,28 @@ export default function ProfileOverviewPage() {
 									>
 										<div className="flex items-start justify-between gap-3">
 											<div className="min-w-0">
-												<Link
-													to={`/volunteer-opportunities/${e.opportunityId}`}
-													className="text-sm font-semibold text-gray-900 transition-colors hover:text-brand-700"
-												>
-													{e.opportunityTitle}
-												</Link>
-												<p className="mt-0.5 text-xs text-gray-500">
+												{e.opportunityTitle ? (
 													<Link
-														to={`/organizations/${e.organizationId}`}
-														className="hover:underline"
+														to={`/volunteer-opportunities/${e.opportunityId}`}
+														className="text-sm font-semibold text-gray-900 transition-colors hover:text-brand-700"
 													>
-														{e.organizationName}
+														{e.opportunityTitle}
 													</Link>
-												</p>
+												) : (
+													<span className="text-sm font-semibold italic text-gray-500">
+														{t("myEngagements.deletedOpportunityTitle")}
+													</span>
+												)}
+												{e.organizationName && e.organizationId && (
+													<p className="mt-0.5 text-xs text-gray-500">
+														<Link
+															to={`/organizations/${e.organizationId}`}
+															className="hover:underline"
+														>
+															{e.organizationName}
+														</Link>
+													</p>
+												)}
 												{e.message && (
 													<p className="mt-1 truncate text-sm italic text-gray-500">
 														&ldquo;{e.message}&rdquo;
@@ -950,7 +958,10 @@ export default function ProfileOverviewPage() {
 													e.timeSlotEndDateTime && (
 														<AddToCalendarMenu
 															engagementId={e.id}
-															title={e.opportunityTitle}
+															title={
+																e.opportunityTitle ??
+																t("myEngagements.deletedOpportunityTitle")
+															}
 															location={e.location}
 															start={e.timeSlotStartDateTime}
 															end={e.timeSlotEndDateTime}
@@ -1183,7 +1194,10 @@ export default function ProfileOverviewPage() {
 			{feedbackEngagement && (
 				<SubmitFeedbackModal
 					engagementId={feedbackEngagement.id}
-					opportunityTitle={feedbackEngagement.opportunityTitle}
+					opportunityTitle={
+						feedbackEngagement.opportunityTitle ??
+						t("myEngagements.deletedOpportunityTitle")
+					}
 					onSubmitted={handleFeedbackSubmitted}
 					onClose={() => setFeedbackEngagement(null)}
 				/>

--- a/scripts/smoke-test-667-engagement-history-deleted-opportunity.mjs
+++ b/scripts/smoke-test-667-engagement-history-deleted-opportunity.mjs
@@ -1,0 +1,213 @@
+// Smoke test for #667:
+//
+// GetByVolunteerAsync (backing GET /v1/me/engagements, which powers "My
+// Profile -> Engagements") used an inner join against
+// VolunteerOpportunitiesQuery. Deleting an opportunity hard-deletes that row
+// while only cancelling (not deleting) affected Engagement rows, so the
+// inner join silently dropped the volunteer's own engagement from the list
+// entirely once its opportunity was gone - no "Cancelled" entry, no
+// placeholder, nothing.
+//
+// Fix: EngagementReadRepository.GetByVolunteerAsync now looks up
+// opportunities/organizations separately and merges them in, falling back to
+// null (rendered as "This opportunity has been removed" / "Dieser Bedarf
+// wurde entfernt" in the UI) when the opportunity no longer exists, instead
+// of dropping the row.
+//
+// Run: node scripts/smoke-test-667-engagement-history-deleted-opportunity.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #667.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function applyToOpportunity(token, opportunityId, message) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}/engagements`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ message }),
+		},
+	);
+	if (!res.ok)
+		throw new Error(`Apply failed: ${res.status} ${await res.text()}`);
+	return res.json();
+}
+
+async function confirmEngagement(token, engagementId) {
+	const res = await fetch(`${API}/v1/engagements/${engagementId}/confirm`, {
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok)
+		throw new Error(`Confirm failed: ${res.status} ${await res.text()}`);
+}
+
+async function deleteOpportunity(token, opportunityId) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities/${opportunityId}`, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok)
+		throw new Error(`Delete failed: ${res.status} ${await res.text()}`);
+}
+
+async function getMyEngagements(token) {
+	const res = await fetch(`${API}/v1/me/engagements`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) throw new Error(`GET /me/engagements failed: ${res.status}`);
+	return res.json();
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	// --- Setup: olaf creates an opportunity, vera applies and gets confirmed, olaf deletes it ---
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	const opportunity = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke667 EngagementHistory ${Date.now()}`,
+	);
+	console.log(`OK  Created opportunity ${opportunity.id}`);
+
+	const veraToken = await getToken("vera", "vera123");
+	const engagement = await applyToOpportunity(
+		veraToken,
+		opportunity.id,
+		"Smoke test application for #667.",
+	);
+	console.log(`OK  vera applied - engagement ${engagement.id}`);
+
+	await confirmEngagement(olafToken, engagement.id);
+	console.log("OK  olaf confirmed vera's application");
+
+	await deleteOpportunity(olafToken, opportunity.id);
+	console.log("OK  olaf deleted the opportunity");
+
+	// === Ground-truth data check: the engagement still appears, marked Cancelled ===
+	const myEngagements = await getMyEngagements(veraToken);
+	const historyEntry = myEngagements.find((e) => e.id === engagement.id);
+	if (!historyEntry) {
+		throw new Error(
+			"Engagement for the deleted opportunity is missing entirely from GET /v1/me/engagements - it should still appear as Cancelled",
+		);
+	}
+	if (historyEntry.status !== "Cancelled") {
+		throw new Error(
+			`Expected status "Cancelled" for the deleted-opportunity engagement, got "${historyEntry.status}"`,
+		);
+	}
+	if (historyEntry.opportunityTitle !== null && historyEntry.opportunityTitle !== undefined) {
+		throw new Error(
+			`Expected opportunityTitle to be null for a deleted opportunity, got "${historyEntry.opportunityTitle}"`,
+		);
+	}
+	console.log(
+		"OK  GET /v1/me/engagements still lists the engagement, status Cancelled, opportunityTitle: null",
+	);
+
+	// === UI check: "My Profile -> Engagements" shows the fallback title, not a blank/missing card ===
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			await page.goto(`${BASE}/my-engagements`, { waitUntil: "networkidle" });
+
+			const fallbackTitle = page.getByText(
+				/this opportunity has been removed|dieser bedarf wurde entfernt/i,
+			);
+			await fallbackTitle.first().waitFor({ timeout: 15000 });
+			console.log(
+				'OK  "My Profile -> Engagements" shows the fallback title for the deleted opportunity instead of dropping the card',
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `EngagementReadRepository.GetByVolunteerAsync` (backing `GET /v1/me/engagements`, which powers "My Profile -> Engagements") used an **inner join** against `VolunteerOpportunitiesQuery`. `DeleteVolunteerOpportunityCommandHandler` hard-deletes the opportunity row while only cancelling (not deleting) affected `Engagement` rows - so once the opportunity was gone, the inner join silently dropped that engagement from the volunteer's own history entirely. No "Cancelled" entry, no placeholder - the volunteer had no way to know they ever applied to, or were confirmed for, that opportunity.
- Rewrote the query to fetch the volunteer's engagements directly, then look up referenced opportunities/organizations separately via dictionary batch-lookups (same pattern already used by `NotificationReadRepository` for the analogous #655 fix), merging them in with a `null` fallback instead of dropping the row.
- `EngagementSummary.OpportunityTitle`/`OrganizationId`/`OrganizationName` are now nullable to represent "opportunity no longer exists".
- `ProfileOverviewPage.tsx`'s engagements list now renders a "This opportunity has been removed" / "Dieser Bedarf wurde entfernt" fallback (new `myEngagements.deletedOpportunityTitle` i18n key) instead of a broken/dead link when the opportunity is gone, and omits the organization link/name in that case.
- Added an `EngagementHistoryForDeletedOpportunityTests` VisualTests suite (runs against the local Aspire stack in CI) and a `scripts/smoke-test-667-engagement-history-deleted-opportunity.mjs` live-staging Playwright script, both covering: the engagement still appears via the API with `status: "Cancelled"` and `opportunityTitle: null`, and the UI shows the fallback title instead of dropping the card.

Addresses #667

## Test plan

- [x] `dotnet build` (backend) - succeeds, NSwag regenerates `openapi-v1.json` / `api-client.ts` / `ApiClient.cs` consistently with the DTO nullability change
- [x] `dotnet test tests/Application.UnitTests` - 210/210 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc --noEmit) - passes
- [x] `pnpm lint` - zero warnings
- [x] `pnpm format:write` - no changes needed
- [x] `/self-review` - fanned out to `ef-migration-check` (no migration needed - pure query-shape/DTO change), `nswag-check` (generated clients consistent), `a11y-check` (no violations, existing `AccessibilityTests` coverage sufficient), `i18n-check` (locale files stay in sync, 675/675 keys). One P2 finding (org `<Link>` guarded only on `organizationName`, not `organizationId`) was fixed before pushing.
- [x] CI on this PR (build-and-test, lint, format-check, editorconfig, ban-typographic-dashes, PR title) - all green
- [x] Live verification against staging (release candidate) - complete, see below

## Live verification

- Cut as `v1.0.0-rc.219` from this branch. `release-rc.yml` created the tag; `publish.yml` built and pushed all three images (frontend/backend/keycloak) and ran the full backend suite as part of the build - `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, and **`VisualTests` (including the new `EngagementHistoryForDeletedOpportunityTests` regression suite)** all passed against the real Aspire/Testcontainers stack in CI. `deploy-staging` then completed successfully, health gate green.
- `curl -sf https://api.maik-hasler.de/health` returned `200` (`Healthy`).
- Ran `node scripts/smoke-test-667-engagement-history-deleted-opportunity.mjs` against `https://einsatzbereit.maik-hasler.de`: created a live opportunity as `olaf`, had `vera` apply, confirmed the application, then deleted the opportunity. Verified via the API that `GET /v1/me/engagements` still lists the engagement (`status: "Cancelled"`, `opportunityTitle: null`) instead of dropping it, and verified in the UI that "My Profile -> Engagements" shows the "This opportunity has been removed" fallback title instead of an empty/missing card. All assertions passed (`ALL CHECKS PASSED`). The throwaway opportunity/engagement created for this test were left in their final (deleted/cancelled) state as expected - no cleanup needed since deletion is the very state under test.

This PR is now ready for review. As always, this routine does not merge PRs - that remains the repository owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXxPvGZrsoJDLXWhUYqtDx)_