### PR TITLE
fix: track lifetime confirmation count for milestone achievements

### DIFF
--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -48,14 +48,10 @@ internal sealed class ConfirmEngagementCommandHandler(
 		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
 		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
-		await RecordActivityStreakAsync(engagement.VolunteerId, isoYear, isoWeek, cancellationToken);
+		var totalConfirmedEngagements = await RecordActivityStreakAndConfirmationAsync(
+			engagement.VolunteerId, isoYear, isoWeek, cancellationToken);
 
-		// Count from DB (not yet saved) and +1 for this confirmation
-		var confirmedCount = await dbContext.CountConfirmedEngagementsForVolunteerAsync(
-			engagement.VolunteerId,
-			cancellationToken) + 1;
-
-		await EvaluateMilestoneAchievementsAsync(engagement.VolunteerId, confirmedCount, cancellationToken);
+		await EvaluateMilestoneAchievementsAsync(engagement.VolunteerId, totalConfirmedEngagements, cancellationToken);
 
 		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId.Value, cancellationToken);
 
@@ -84,7 +80,7 @@ internal sealed class ConfirmEngagementCommandHandler(
 		}
 	}
 
-	private async Task RecordActivityStreakAsync(
+	private async Task<int> RecordActivityStreakAndConfirmationAsync(
 		UserId volunteerId,
 		int isoYear,
 		int isoWeek,
@@ -97,29 +93,38 @@ internal sealed class ConfirmEngagementCommandHandler(
 			await dbContext.UserStreaks.AddAsync(streak, cancellationToken);
 		}
 		streak.RecordActivity(isoYear, isoWeek);
+		streak.RecordConfirmedEngagement();
 
 		if (streak.ActivityStreak >= 4)
 		{
 			await sender.Send(new AwardAchievementCommand(volunteerId, "weekly-hero-4"), cancellationToken);
 		}
+
+		return streak.TotalConfirmedEngagements;
 	}
+
+	// Milestones are keyed by a monotonically-increasing lifetime confirmation
+	// count (never decremented by later cancellations/deletions elsewhere), and
+	// evaluated with >= rather than an exact match, so a threshold can never be
+	// skipped over or made permanently unreachable.
+	private static readonly (int Threshold, string Key)[] MilestoneThresholds =
+	[
+		(1, "first-step"),
+		(5, "dedicated-5"),
+		(100, "centurion-100"),
+	];
 
 	private async Task EvaluateMilestoneAchievementsAsync(
 		UserId volunteerId,
-		int confirmedCount,
+		int totalConfirmedEngagements,
 		CancellationToken cancellationToken)
 	{
-		string[] keysToAward = confirmedCount switch
+		foreach (var (threshold, key) in MilestoneThresholds)
 		{
-			1 => ["first-step"],
-			5 => ["dedicated-5"],
-			100 => ["centurion-100"],
-			_ => []
-		};
-
-		foreach (var key in keysToAward)
-		{
-			await sender.Send(new AwardAchievementCommand(volunteerId, key), cancellationToken);
+			if (totalConfirmedEngagements >= threshold)
+			{
+				await sender.Send(new AwardAchievementCommand(volunteerId, key), cancellationToken);
+			}
 		}
 	}
 }

--- a/backend/src/Domain/Users/UserStreak.cs
+++ b/backend/src/Domain/Users/UserStreak.cs
@@ -18,6 +18,8 @@ public sealed class UserStreak
 
 	public int? LastActiveIsoYear { get; private set; }
 
+	public int TotalConfirmedEngagements { get; private set; }
+
 	public DateTimeOffset CreatedOn { get; private set; }
 
 	public DateTimeOffset? ModifiedOn { get; private set; }
@@ -62,6 +64,11 @@ public sealed class UserStreak
 		ActivityStreak = isConsecutive ? ActivityStreak + 1 : 1;
 		LastActiveIsoYear = isoYear;
 		LastActiveIsoWeek = isoWeek;
+	}
+
+	public void RecordConfirmedEngagement()
+	{
+		TotalConfirmedEngagements++;
 	}
 
 	private static bool IsPreviousWeek(

--- a/backend/src/Infrastructure/Persistence/Configurations/UserStreakConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/UserStreakConfiguration.cs
@@ -38,6 +38,10 @@ internal sealed class UserStreakConfiguration
 
 		builder.Property(s => s.LastActiveIsoYear);
 
+		builder.Property(s => s.TotalConfirmedEngagements)
+			.HasDefaultValue(0)
+			.IsRequired();
+
 		builder.Property(s => s.CreatedOn);
 
 		builder.Property(s => s.ModifiedOn);

--- a/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260711001019_AddUserStreakTotalConfirmedEngagements")]
+	partial class AddUserStreakTotalConfirmedEngagements
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.cs
@@ -33,7 +33,7 @@ namespace Infrastructure.Persistence.Migrations
 					GROUP BY volunteer_id
 				) sub
 				WHERE us.user_id = sub.volunteer_id
-				  AND sub.confirmed_count > us.total_confirmed_engagements;
+				AND sub.confirmed_count > us.total_confirmed_engagements;
 				""");
 		}
 

--- a/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260711001019_AddUserStreakTotalConfirmedEngagements.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddUserStreakTotalConfirmedEngagements : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<int>(
+				name: "total_confirmed_engagements",
+				table: "user_streak",
+				type: "integer",
+				nullable: false,
+				defaultValue: 0);
+
+			// Backfill: seed the new monotonic counter from each volunteer's current
+			// live-confirmed count, so anyone already close to (or past) a milestone
+			// threshold under the old buggy exact-match logic isn't set back to zero.
+			// A user_streak row exists for every volunteer with a confirmed engagement,
+			// since confirming always creates one if missing (see
+			// ConfirmEngagementCommandHandler).
+			migrationBuilder.Sql("""
+				UPDATE user_streak us
+				SET total_confirmed_engagements = sub.confirmed_count
+				FROM (
+					SELECT volunteer_id, COUNT(*) AS confirmed_count
+					FROM engagement
+					WHERE status = 'Confirmed'
+					GROUP BY volunteer_id
+				) sub
+				WHERE us.user_id = sub.volunteer_id
+				  AND sub.confirmed_count > us.total_confirmed_engagements;
+				""");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "total_confirmed_engagements",
+				table: "user_streak");
+		}
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -210,8 +210,113 @@ public class ConfirmEngagementCommandHandlerTests
 			Arg.Any<CancellationToken>());
 	}
 
+	[Test]
+	public async Task Handle_ShouldAwardFirstStepBadge_WhenVolunteerHasNoPriorStreak(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = new EngagementId(Guid.CreateVersion7());
+		var volunteerId = new UserId(Guid.CreateVersion7());
+		var engagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(Guid.CreateVersion7()),
+			volunteerId,
+			new TimeSlotId(Guid.CreateVersion7()));
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_dbContext.GetUserStreakAsync(volunteerId, cancellationToken).Returns((UserStreak?)null);
+
+		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+
+		await _sender.Received(1).Send(
+			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "first-step" && c.UserId == volunteerId),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldAwardDedicatedBadge_WhenLifetimeConfirmationsReach5_EvenIfLiveConfirmedCountIsLower(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #668: a volunteer's live "currently confirmed" count can be
+		// pulled back down by an unrelated opportunity deletion/cancellation elsewhere.
+		// Milestone eligibility must key off the monotonic lifetime counter on the
+		// volunteer's UserStreak, not that live count.
+		var engagementId = new EngagementId(Guid.CreateVersion7());
+		var volunteerId = new UserId(Guid.CreateVersion7());
+		var engagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(Guid.CreateVersion7()),
+			volunteerId,
+			new TimeSlotId(Guid.CreateVersion7()));
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var streak = BuildStreakWithTotalConfirmedEngagementsOf(volunteerId, 4);
+		_dbContext.GetUserStreakAsync(volunteerId, cancellationToken).Returns(streak);
+		// Live confirmed count deliberately stubbed lower than the lifetime counter,
+		// to prove milestone evaluation no longer depends on it at all.
+		_dbContext.CountConfirmedEngagementsForVolunteerAsync(volunteerId, cancellationToken).Returns(1);
+
+		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+
+		await _sender.Received(1).Send(
+			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "dedicated-5" && c.UserId == volunteerId),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAwardDedicatedBadge_WhenLifetimeConfirmationsAreBelow5(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = new EngagementId(Guid.CreateVersion7());
+		var volunteerId = new UserId(Guid.CreateVersion7());
+		var engagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(Guid.CreateVersion7()),
+			volunteerId,
+			new TimeSlotId(Guid.CreateVersion7()));
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var streak = BuildStreakWithTotalConfirmedEngagementsOf(volunteerId, 2);
+		_dbContext.GetUserStreakAsync(volunteerId, cancellationToken).Returns(streak);
+
+		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+
+		await _sender.DidNotReceive().Send(
+			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "dedicated-5"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldAwardCenturionBadge_WhenLifetimeConfirmationsReach100(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = new EngagementId(Guid.CreateVersion7());
+		var volunteerId = new UserId(Guid.CreateVersion7());
+		var engagement = Engagement.CreateWaitlistSignUp(
+			new VolunteerOpportunityId(Guid.CreateVersion7()),
+			volunteerId,
+			new TimeSlotId(Guid.CreateVersion7()));
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var streak = BuildStreakWithTotalConfirmedEngagementsOf(volunteerId, 99);
+		_dbContext.GetUserStreakAsync(volunteerId, cancellationToken).Returns(streak);
+
+		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+
+		await _sender.Received(1).Send(
+			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "centurion-100" && c.UserId == volunteerId),
+			Arg.Any<CancellationToken>());
+	}
+
 	private static VolunteerOpportunity CreateDefaultOpportunity() =>
 		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, status: OpportunityStatus.Draft);
+
+	private static UserStreak BuildStreakWithTotalConfirmedEngagementsOf(UserId userId, int count)
+	{
+		var streak = UserStreak.Create(userId);
+		for (var i = 0; i < count; i++)
+			streak.RecordConfirmedEngagement();
+		return streak;
+	}
 
 	private static UserStreak BuildActivityStreakOf(UserId userId, int weeks)
 	{

--- a/backend/tests/Application.UnitTests/Users/UserStreakTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UserStreakTests.cs
@@ -93,4 +93,38 @@ public class UserStreakTests
 
 		streak.LoginStreak.Should().Be(1);
 	}
+
+	[Test]
+	public void RecordConfirmedEngagement_ShouldStartAtZero_BeforeAnyConfirmation()
+	{
+		var streak = UserStreak.Create(new UserId(Guid.CreateVersion7()));
+
+		streak.TotalConfirmedEngagements.Should().Be(0);
+	}
+
+	[Test]
+	public void RecordConfirmedEngagement_ShouldIncrementByOne_PerCall()
+	{
+		var streak = UserStreak.Create(new UserId(Guid.CreateVersion7()));
+
+		streak.RecordConfirmedEngagement();
+		streak.RecordConfirmedEngagement();
+		streak.RecordConfirmedEngagement();
+
+		streak.TotalConfirmedEngagements.Should().Be(3);
+	}
+
+	[Test]
+	public void RecordConfirmedEngagement_ShouldNeverDecrease_RegardlessOfOtherState()
+	{
+		// The counter has no "undo" - it must stay monotonic even if unrelated
+		// engagements are later cancelled or their opportunities deleted, since
+		// those transitions never call this method.
+		var streak = UserStreak.Create(new UserId(Guid.CreateVersion7()));
+
+		for (var i = 0; i < 5; i++)
+			streak.RecordConfirmedEngagement();
+
+		streak.TotalConfirmedEngagements.Should().Be(5);
+	}
 }

--- a/backend/tests/VisualTests/MilestoneAchievementTests.cs
+++ b/backend/tests/VisualTests/MilestoneAchievementTests.cs
@@ -1,0 +1,211 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #668: milestone achievements ("First Step" / "Dedicated" /
+/// "Century") were awarded by matching a volunteer's live "currently confirmed"
+/// engagement count against an exact threshold. That count is not monotonic -
+/// it drops whenever a confirmed engagement is cancelled, including when an
+/// organizer deletes the opportunity behind it (a normal, supported action).
+/// A volunteer whose live count gets pulled back down this way could permanently
+/// skip past a threshold and never land on it again.
+///
+/// The fix tracks a separate, monotonically-increasing lifetime confirmation
+/// counter (<c>UserStreak.TotalConfirmedEngagements</c>, incremented on every
+/// confirmation and never decremented) and evaluates milestones with
+/// <c>&gt;=</c> against it instead of an exact match on the live count.
+///
+/// Verifying this needs a volunteer account with a guaranteed-clean history so
+/// a 4-to-5 crossing can be isolated - the seeded vera/olaf accounts accumulate
+/// real usage over time and are not reliable for this (see #668's own note on
+/// why a live repro against them wasn't practical). A disposable Keycloak user
+/// is provisioned for the duration of this test and deleted afterwards.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const string Realm = "einsatzbereit";
+	private const string BackendClientId = "backend";
+	private const string BackendClientSecret = "backend-secret";
+	private const string FrontendClientId = "frontend-test";
+
+	[Test]
+	public async Task DedicatedBadge_IsAwarded_OnFifthConfirmation_EvenAfterAnEarlierConfirmedOpportunityWasDeleted()
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		var (volunteerUsername, volunteerPassword, volunteerUserId) = await CreateDisposableVolunteerAsync(keycloak);
+		try
+		{
+			using var olafHttp = new HttpClient { BaseAddress = backend };
+			olafHttp.DefaultRequestHeaders.Authorization =
+				new AuthenticationHeaderValue("Bearer", await GetTokenAsync(keycloak, "olaf", "olaf123"));
+
+			using var volunteerHttp = new HttpClient { BaseAddress = backend };
+			volunteerHttp.DefaultRequestHeaders.Authorization =
+				new AuthenticationHeaderValue("Bearer", await GetTokenAsync(keycloak, volunteerUsername, volunteerPassword));
+
+			var engagementIds = new List<string>();
+			var opportunityIds = new List<string>();
+			for (var i = 0; i < 5; i++)
+			{
+				var opportunityId = await CreateIndividualContactOpportunityAsync(olafHttp, $"Milestone668-{i}");
+				opportunityIds.Add(opportunityId);
+				engagementIds.Add(await ApplyAsync(volunteerHttp, opportunityId, "Please let me help."));
+			}
+
+			// Confirm the first 4 - lifetime counter reaches 4, no badge yet.
+			for (var i = 0; i < 4; i++)
+				await ConfirmAsync(olafHttp, engagementIds[i]);
+
+			// Delete one of the already-confirmed opportunities. This cancels its
+			// Engagement (DeleteVolunteerOpportunityCommandHandler), pulling the
+			// volunteer's *live* confirmed count back down to 3 - but must not
+			// affect the lifetime counter.
+			var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityIds[0]}");
+			deleteResponse.EnsureSuccessStatusCode();
+
+			// Confirm the 5th - live confirmed count is now only 4 (3 remaining +
+			// this one), but the lifetime counter reaches 5 and must award "Dedicated".
+			await ConfirmAsync(olafHttp, engagementIds[4]);
+
+			var achievementsResponse = await volunteerHttp.GetAsync("/v1/me/achievements");
+			achievementsResponse.EnsureSuccessStatusCode();
+			var achievements = await achievementsResponse.Content.ReadFromJsonAsync<JsonElement>();
+			achievements.EnumerateArray()
+				.Any(a => a.GetProperty("name").GetString() == "Dedicated")
+				.Should().BeTrue(
+					"5 lifetime confirmations must award the Dedicated badge even though " +
+					"an earlier deletion left the live confirmed count at only 4");
+		}
+		finally
+		{
+			await DeleteKeycloakUserAsync(keycloak, volunteerUserId);
+		}
+	}
+
+	private static async Task<string> CreateIndividualContactOpportunityAsync(HttpClient olafHttp, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var createOrgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"Milestone668 Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"Milestone668 {label} {suffix}",
+			description = "Created by MilestoneAchievementTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<string> ApplyAsync(HttpClient volunteerHttp, string opportunityId, string message)
+	{
+		var response = await volunteerHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task ConfirmAsync(HttpClient olafHttp, string engagementId)
+	{
+		var response = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
+		response.EnsureSuccessStatusCode();
+	}
+
+	private static async Task<(string Username, string Password, string UserId)> CreateDisposableVolunteerAsync(Uri keycloak)
+	{
+		var adminToken = await GetAdminTokenAsync(keycloak);
+		var username = $"milestone668-{Guid.NewGuid():N}";
+		var password = $"Milestone668!{Guid.NewGuid():N}";
+
+		using var adminHttp = new HttpClient { BaseAddress = keycloak };
+		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var createResponse = await adminHttp.PostAsJsonAsync($"/admin/realms/{Realm}/users", new
+		{
+			username,
+			email = $"{username}@example.test",
+			enabled = true,
+			emailVerified = true,
+			credentials = new[] { new { type = "password", value = password, temporary = false } },
+		});
+		createResponse.EnsureSuccessStatusCode();
+		var userId = createResponse.Headers.Location!.Segments[^1];
+
+		var roleResponse = await adminHttp.GetAsync($"/admin/realms/{Realm}/roles/user");
+		roleResponse.EnsureSuccessStatusCode();
+		var role = await roleResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+		var assignRoleResponse = await adminHttp.PostAsJsonAsync(
+			$"/admin/realms/{Realm}/users/{userId}/role-mappings/realm",
+			new[] { new { id = role.GetProperty("id").GetString(), name = role.GetProperty("name").GetString() } });
+		assignRoleResponse.EnsureSuccessStatusCode();
+
+		return (username, password, userId);
+	}
+
+	private static async Task DeleteKeycloakUserAsync(Uri keycloak, string userId)
+	{
+		var adminToken = await GetAdminTokenAsync(keycloak);
+
+		using var adminHttp = new HttpClient { BaseAddress = keycloak };
+		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var response = await adminHttp.DeleteAsync($"/admin/realms/{Realm}/users/{userId}");
+		response.EnsureSuccessStatusCode();
+	}
+
+	private static async Task<string> GetAdminTokenAsync(Uri keycloak)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			$"/realms/{Realm}/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "client_credentials",
+				["client_id"] = BackendClientId,
+				["client_secret"] = BackendClientSecret,
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			$"/realms/{Realm}/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = FrontendClientId,
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+}

--- a/scripts/smoke-test-668-milestone-achievements.mjs
+++ b/scripts/smoke-test-668-milestone-achievements.mjs
@@ -1,0 +1,253 @@
+// Smoke test for #668:
+//
+// Milestone achievements ("First Step" / "Dedicated" / "Century") used to be
+// awarded by matching a volunteer's live "currently confirmed" engagement
+// count against an exact threshold. That count is not monotonic - it drops
+// whenever a confirmed engagement is cancelled, including when an organizer
+// deletes the opportunity behind it (a normal, supported action), so a
+// volunteer could permanently skip past a threshold and never land on it
+// again.
+//
+// Fix: a new monotonically-increasing UserStreak.TotalConfirmedEngagements
+// counter is incremented on every confirmation and never decremented, and
+// milestones are evaluated with >= against it instead of an exact match.
+//
+// Reproducing the exact "permanently denied a badge" scenario needs a
+// disposable volunteer account with a guaranteed-clean history (the seeded
+// vera/olaf accounts have long, mixed histories that make isolating a clean
+// threshold crossing impractical) - that exact scenario is covered by the
+// automated MilestoneAchievementTests VisualTests suite in CI, which
+// provisions and tears down such an account against the local Aspire stack.
+// This live-staging script instead exercises the fixed code path itself
+// end-to-end against production data: confirm an engagement, delete its
+// opportunity (pulling the live confirmed count back down - the exact
+// trigger from #667/#668), then confirm another engagement immediately
+// after, and assert the confirmation succeeds and no previously-earned
+// achievement is lost.
+//
+// Run: node scripts/smoke-test-668-milestone-achievements.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #668.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function applyToOpportunity(token, opportunityId, message) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}/engagements`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ message }),
+		},
+	);
+	if (!res.ok)
+		throw new Error(`Apply failed: ${res.status} ${await res.text()}`);
+	return res.json();
+}
+
+async function confirmEngagement(token, engagementId) {
+	const res = await fetch(`${API}/v1/engagements/${engagementId}/confirm`, {
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok)
+		throw new Error(`Confirm failed: ${res.status} ${await res.text()}`);
+}
+
+async function deleteOpportunity(token, opportunityId) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}`,
+		{
+			method: "DELETE",
+			headers: { Authorization: `Bearer ${token}` },
+		},
+	);
+	if (!res.ok)
+		throw new Error(`Delete failed: ${res.status} ${await res.text()}`);
+}
+
+async function getAchievements(token) {
+	const res = await fetch(`${API}/v1/me/achievements`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) throw new Error(`GET /me/achievements failed: ${res.status}`);
+	return res.json();
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const veraToken = await getToken("vera", "vera123");
+
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	const achievementsBefore = await getAchievements(veraToken);
+	const namesBefore = new Set(achievementsBefore.map((a) => a.name));
+	console.log(
+		`OK  vera has ${namesBefore.size} achievement(s) before the test`,
+	);
+
+	// --- Engagement A: confirm, then delete its opportunity. This is the
+	// exact trigger from #667/#668: DeleteVolunteerOpportunityCommandHandler
+	// cancels the confirmed Engagement, pulling vera's *live* confirmed count
+	// back down without touching the new lifetime counter. ---
+	const opportunityA = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke668 MilestoneA ${Date.now()}`,
+	);
+	const engagementA = await applyToOpportunity(
+		veraToken,
+		opportunityA.id,
+		"Smoke test application A for #668.",
+	);
+	await confirmEngagement(olafToken, engagementA.id);
+	console.log(`OK  Confirmed engagement A (${engagementA.id})`);
+
+	await deleteOpportunity(olafToken, opportunityA.id);
+	console.log(
+		"OK  Deleted opportunity A - vera's live confirmed count just dropped by 1",
+	);
+
+	// --- Engagement B: confirm immediately after the count-lowering deletion.
+	// Before the fix, a volunteer landing exactly on a threshold here could
+	// have that crossing silently swallowed by the deflated live count; the
+	// fix's >= check against the monotonic lifetime counter means this must
+	// still succeed and never regress an already-earned badge. ---
+	const opportunityB = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke668 MilestoneB ${Date.now()}`,
+	);
+	const engagementB = await applyToOpportunity(
+		veraToken,
+		opportunityB.id,
+		"Smoke test application B for #668.",
+	);
+	await confirmEngagement(olafToken, engagementB.id);
+	console.log(
+		`OK  Confirmed engagement B (${engagementB.id}) right after the count-lowering deletion - RecordConfirmedEngagement()/milestone evaluation did not throw`,
+	);
+
+	const achievementsAfter = await getAchievements(veraToken);
+	const namesAfter = new Set(achievementsAfter.map((a) => a.name));
+	const lost = [...namesBefore].filter((n) => !namesAfter.has(n));
+	if (lost.length > 0) {
+		throw new Error(
+			`Achievement(s) disappeared after the confirm/delete/confirm sequence: ${lost.join(", ")}`,
+		);
+	}
+	console.log(
+		"OK  No previously-earned achievement was lost or revoked (idempotent awarding still holds)",
+	);
+
+	// === UI check: vera's achievements tab still renders cleanly ===
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			await page.goto(`${BASE}/profile?tab=achievements`, {
+				waitUntil: "networkidle",
+			});
+			await page.waitForSelector("main", { timeout: 10000 });
+			const errorLocator = page.getByText(
+				/something went wrong|ein fehler ist aufgetreten/i,
+			);
+			if ((await errorLocator.count()) > 0) {
+				throw new Error(
+					"Achievements tab rendered an error state after the confirm/delete/confirm sequence",
+				);
+			}
+			console.log("OK  vera's Achievements tab renders without error");
+		} finally {
+			await browser.close();
+		}
+	}
+
+	// Cleanup: opportunity A is already gone; delete opportunity B too.
+	await deleteOpportunity(olafToken, opportunityB.id);
+	console.log("OK  Cleaned up opportunity B");
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `ConfirmEngagementCommandHandler` awarded the "First Step" / "Dedicated" / "Century" milestone badges by matching a volunteer's live, non-monotonic "currently confirmed" engagement count against exact thresholds (`confirmedCount switch { 1 => ..., 5 => ..., 100 => ..., _ => [] }`). That count is not monotonic - it drops whenever a previously-confirmed engagement leaves the `Confirmed` status, which happens through a normal, supported action: an organizer deleting the opportunity behind it (`DeleteVolunteerOpportunityCommandHandler` cancels affected `Engagement` rows). Since achievements are awarded idempotently and never revoked, the failure mode isn't re-triggering an old badge - it's a volunteer whose live count gets pulled back down potentially never landing on an exact threshold value again, permanently and silently denying them a milestone they've genuinely earned.
- Added `UserStreak.TotalConfirmedEngagements`, a monotonically-increasing lifetime counter incremented via a new `RecordConfirmedEngagement()` method on every confirmation and never decremented by cancellations/deletions elsewhere (`UserStreak` was already the per-volunteer gamification-counters entity loaded/created on every confirmation for the existing login/activity streaks, so this reuses that instead of adding a new aggregate).
- `ConfirmEngagementCommandHandler` now evaluates milestones with `>=` against this counter instead of an exact match on the live confirmed count - so a threshold can never be skipped over or made permanently unreachable.
- Added a migration (`AddUserStreakTotalConfirmedEngagements`) that backfills the new counter from each volunteer's current confirmed-engagement count, so nobody who was already close to (or past) a threshold under the old buggy logic gets reset to zero.
- Added unit tests covering the domain method (`UserStreakTests`) and the handler's milestone logic (`ConfirmEngagementCommandHandlerTests`), including the exact regression scenario: the lifetime counter reaching 5 while the live confirmed count is deliberately stubbed lower.
- Added a `MilestoneAchievementTests` VisualTests suite that reproduces the full bug end-to-end against a disposable Keycloak volunteer account (provisioned and torn down within the test, since the seeded `vera`/`olaf` accounts have long-accumulated histories that make isolating a clean 4-to-5 crossing impractical - see #668's own note on this): confirm 4 engagements, delete the opportunity behind one of them (pulling the live confirmed count down to 3), confirm a 5th, and assert the "Dedicated" badge is still awarded.
- Added `scripts/smoke-test-668-milestone-achievements.mjs`, a live-staging Playwright/API script covering the fixed code path against production data (see "Live verification" below).

Addresses #668

## Test plan

- [x] `dotnet build` (backend, from repo root) - succeeds; migration/model-snapshot regenerated and reformatted to match the repo's tab-indentation convention (the EF tool emits 4-space + BOM by default, which the rest of the migrations directory does not use)
- [x] `dotnet run --project backend/tests/Application.UnitTests --no-build` - 217/217 passed (7 new tests)
- [x] `dotnet run --project backend/tests/ArchitectureTests --no-build` - 247/247 passed
- [x] `pnpm check` (tsc --noEmit) - passes (no frontend changes, backend-only fix)
- [x] `/self-review` - fanned out to `ef-migration-check` twice (independent runs), both confirmed the migration/backfill SQL is correct against the actual schema (table names `user_streak`/`engagement`, `user_id`/`volunteer_id` columns, `status` stored as a string so `= 'Confirmed'` is correct). No P1/P2 findings.
- [x] CI on this PR (build-and-test, lint, format-check, editorconfig, ban-typographic-dashes, PR title) - all green
- [x] Live verification against staging (release candidate) - complete, see below

## Live verification

- Cut as `v1.0.0-rc.221` from this branch; `publish.yml` build (including the full backend test suite - `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, and the new `MilestoneAchievementTests` VisualTests suite against the real Aspire/Testcontainers stack) and `deploy-staging` both completed successfully.
- `curl -sf https://api.maik-hasler.de/health` returned `200`.
- Ran `node scripts/smoke-test-668-milestone-achievements.mjs` against `https://einsatzbereit.maik-hasler.de`. This sandbox has no live-Keycloak admin credentials to provision a disposable volunteer account against the production realm (unlike the local Aspire stack `MilestoneAchievementTests` uses), so this script can't isolate a clean threshold crossing on production - that exact scenario stays covered by the CI VisualTests suite above. Instead it exercises the fixed code path end-to-end against real production data: as `vera`, confirmed an engagement, had `olaf` delete that opportunity (the exact live-count-lowering trigger from #667/#668), then confirmed a second engagement immediately after. Asserted: both confirmations succeeded (the new `RecordConfirmedEngagement()` call and `>=` milestone evaluation didn't throw against the live schema/migration), and `GET /v1/me/achievements` shows no previously-earned badge was lost or revoked across the sequence. Also confirmed vera's "My Profile -> Achievements" tab still renders cleanly afterwards. All assertions passed (`ALL CHECKS PASSED`). Both throwaway test opportunities were deleted as part of/after the run.

This PR is now ready for review. As always, this routine does not merge PRs - that remains the repository owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9CvtoK8btkyxTc6Yw1BRN)_