### PR TITLE
fix: add checkInMethod None branch to CheckInModal

### DIFF
--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -54,7 +54,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 
 		var engagementResponse = await http.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
-			new { message = (string?)null });
+			new { message = "Applying via CheckInAndSlotTests regression check." });
 		engagementResponse.EnsureSuccessStatusCode();
 		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var engagementId = engagement.GetProperty("id").GetString();

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Microsoft.Playwright;
@@ -12,6 +14,87 @@ namespace VisualTests;
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
+	/// <summary>
+	/// Regression for #671: the "Check in" modal rendered no branch for
+	/// checkInMethod == "None", so clicking "Check in" on such an engagement
+	/// opened a blank modal with only a title and a "Done" button.
+	/// </summary>
+	[Test]
+	public async Task CheckInModal_ShowsInstruction_ForNoneCheckInMethod()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInNone Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"CheckInNone Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by CheckInAndSlotTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var engagementResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = (string?)null });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await http.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await row.GetByRole(AriaRole.Button, new() { Name = "Check in" }).ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+
+		await Expect(dialog.GetByText("This opportunity doesn't require an explicit check-in step."))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
 	[Test]
 	public async Task EditOpportunity_SwitchToPINCode_GeneratesPin()
 	{

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -141,6 +141,12 @@ export default function CheckInModal({
 					</p>
 				)}
 
+				{details && !success && checkInMethod === "None" && (
+					<p className="text-sm text-gray-600">
+						{t("checkIn.noneInstruction")}
+					</p>
+				)}
+
 				{success && (
 					<p className="text-sm font-medium text-green-700">
 						{t("checkIn.success")}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -450,6 +450,7 @@
       "success": "Erfolgreich eingecheckt!",
       "invalidPin": "Falsche PIN. Bitte erneut versuchen.",
       "manualInstruction": "Der Veranstalter wird dich manuell einchecken.",
+      "noneInstruction": "Für diesen Einsatz ist kein ausdrücklicher Check-in erforderlich.",
       "close": "Fertig",
       "organizerPin": "Eincheck-PIN",
       "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen, damit sie einchecken können.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -450,6 +450,7 @@
       "success": "Checked in successfully!",
       "invalidPin": "Invalid PIN. Please try again.",
       "manualInstruction": "The organizer will check you in manually.",
+      "noneInstruction": "This opportunity doesn't require an explicit check-in step.",
       "close": "Done",
       "organizerPin": "Check-in PIN",
       "organizerPinHint": "Share this PIN with your volunteers so they can check in.",

--- a/scripts/smoke-test-671-checkin-none.mjs
+++ b/scripts/smoke-test-671-checkin-none.mjs
@@ -1,0 +1,157 @@
+/**
+ * Smoke test for #671: "Check in" opened a blank modal with no way to check
+ * in when the opportunity's check-in method is "None".
+ *
+ * Verifies against the live staging environment:
+ * - Creating a "None" check-in opportunity, applying, and confirming the
+ *   engagement (all via the API, as olaf both organizer and applicant).
+ * - Opening the "Check in" modal from "My Profile -> Engagements" in the
+ *   browser shows the new instruction text instead of a blank dialog.
+ * - Cleans up the throwaway opportunity afterwards.
+ *
+ * Run: node scripts/smoke-test-671-checkin-none.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de/realms/einsatzbereit";
+const CLIENT_ID = "frontend";
+
+async function getToken(username, password) {
+	const body = new URLSearchParams({
+		grant_type: "password",
+		client_id: CLIENT_ID,
+		username,
+		password,
+		scope: "openid",
+	});
+	const res = await fetch(`${KEYCLOAK}/protocol/openid-connect/token`, {
+		method: "POST",
+		body,
+	});
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	return data.access_token;
+}
+
+async function apiPost(path, token, body) {
+	const res = await fetch(`${API}${path}`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: body === undefined ? undefined : JSON.stringify(body),
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`POST ${path} failed: ${res.status} - ${text}`);
+	}
+	const text = await res.text();
+	return text ? JSON.parse(text) : null;
+}
+
+async function apiDelete(path, token) {
+	const res = await fetch(`${API}${path}`, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`DELETE ${path} failed: ${res.status} - ${text}`);
+	}
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	console.log("OK  Got olaf token");
+
+	const suffix = Date.now();
+
+	const org = await apiPost("/v1/organizations", olafToken, {
+		name: `Smoke671 Org ${suffix}`,
+	});
+	const organizationId = org.id.value;
+	console.log(`OK  Created organization ${organizationId}`);
+
+	const oppTitle = `Smoke671 None CheckIn ${suffix}`;
+	const opportunity = await apiPost("/v1/volunteer-opportunities", olafToken, {
+		title: oppTitle,
+		description: "Created by smoke-test-671-checkin-none.mjs",
+		organizationId,
+		isRemote: true,
+		occurrence: "OneTime",
+		participationType: "IndividualContact",
+		checkInMethod: "None",
+		isDraft: false,
+	});
+	const opportunityId = opportunity.id;
+	console.log(`OK  Created "None" check-in opportunity ${opportunityId}`);
+
+	const engagement = await apiPost(
+		`/v1/volunteer-opportunities/${opportunityId}/engagements`,
+		olafToken,
+		{ message: "Applying via smoke-test-671-checkin-none.mjs" },
+	);
+	const engagementId = engagement.id;
+	console.log(`OK  Applied, engagement ${engagementId}`);
+
+	await apiPost(`/v1/engagements/${engagementId}/confirm`, olafToken);
+	console.log("OK  Confirmed engagement");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		if ((await signInBtn.count()) > 0) {
+			await signInBtn.first().click();
+			await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+			await loginKeycloak(page, "olaf", "olaf123");
+		}
+		await page.waitForSelector("main", { timeout: 15000 });
+		console.log("OK  Logged in as olaf");
+
+		await page.goto(`${BASE}/profile?tab=engagements`, { waitUntil: "networkidle" });
+
+		const row = page.locator("li", { hasText: oppTitle });
+		await row.waitFor({ state: "visible", timeout: 15000 });
+		console.log("OK  Engagement card visible in My Profile -> Engagements");
+
+		await row.getByRole("button", { name: "Check in" }).click();
+		const dialog = page.locator("[role='dialog']");
+		await dialog.waitFor({ state: "visible", timeout: 10000 });
+
+		const instruction = dialog.getByText(
+			"This opportunity doesn't require an explicit check-in step.",
+		);
+		await instruction.waitFor({ state: "visible", timeout: 10000 });
+		console.log('OK  Modal shows the "None" instruction text instead of a blank dialog');
+
+		const dialogText = await dialog.textContent();
+		if (!dialogText || dialogText.trim() === "Check in") {
+			throw new Error(`Expected modal content beyond the title, got: "${dialogText}"`);
+		}
+
+		await dialog.getByRole("button", { name: "Done" }).click();
+		await dialog.waitFor({ state: "hidden", timeout: 5000 });
+		console.log('OK  "Done" closes the modal');
+	} finally {
+		await browser.close();
+	}
+
+	await apiDelete(`/v1/volunteer-opportunities/${opportunityId}`, olafToken);
+	console.log("OK  Deleted throwaway opportunity (cleanup)");
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `CheckInModal` (`frontend/src/components/CheckInModal.tsx`) had content branches for only 3 of the 4 possible `checkInMethod` values (`QRCode`, `PINCode`, `Manual`). For an opportunity using `checkInMethod === "None"` ("None (automatic)"), clicking "Check in" on a `Confirmed` engagement in "My Profile -> Engagements" opened a modal with only the title and a "Done" button - no instruction, no confirmation, a dead-end for the volunteer.
- Added a `checkInMethod === "None"` branch, following the exact same pattern already used for `"Manual"`, with a new `checkIn.noneInstruction` locale key ("This opportunity doesn't require an explicit check-in step." / "Für diesen Einsatz ist kein ausdrücklicher Check-in erforderlich.") explaining that this opportunity doesn't require an explicit check-in step.
- Added a `CheckInModal_ShowsInstruction_ForNoneCheckInMethod` regression test to `backend/tests/VisualTests/CheckInAndSlotTests.cs` (runs against the local Aspire stack in CI): creates a `None` check-in opportunity, applies and confirms an engagement, opens the "Check in" modal from "My Profile -> Engagements", and asserts the instruction text renders instead of a blank dialog.
- Added `scripts/smoke-test-671-checkin-none.mjs`, a live-staging Playwright/API script covering the same scenario against production data (see "Live verification" below).

Addresses #671

## Test plan

- [x] `pnpm check` (tsc --noEmit) - passes
- [x] `pnpm lint` - zero warnings
- [x] `pnpm format:write` - no changes needed
- [x] `/self-review` - fanned out to `a11y-check` (no regression - the new branch is a structural copy of the existing `Manual` branch, no new interactive elements; no new page/route so no `AccessibilityTests.cs` entry needed) and `i18n-check` (both locale files stay in sync, 675/675 keys, new key present and correctly nested in both). No findings.
- [x] `dotnet build` (backend/src/Api, backend/tests/Application.UnitTests, backend/tests/ArchitectureTests, backend/tests/VisualTests) - all succeed
- [x] `dotnet run --project backend/tests/Application.UnitTests` - 210/210 passed
- [x] `dotnet run --project backend/tests/ArchitectureTests` - 247/247 passed
- [x] CI on this PR (build-and-test including `Application.UnitTests`/`ArchitectureTests`/`IntegrationTests`/`VisualTests`, lint, format-check, editorconfig, ban-typographic-dashes, PR title) - all green
- [x] Live verification against staging (release candidate) - complete, see below

## Live verification

- First cut as `v1.0.0-rc.222`; its `publish.yml` run failed in the `VisualTests` job - the new regression test posted a `null` message when creating an `IndividualContact` engagement, which `Engagement.CreateIndividualContact` rejects ("Message is required for individual contact."), a bug in the test itself, not the fix. Fixed (commit `44a1ae5`) and re-cut as `v1.0.0-rc.223`, which built, tested (including the fixed `CheckInModal_ShowsInstruction_ForNoneCheckInMethod`), and deployed to staging successfully.
- `curl -sf https://api.maik-hasler.de/health` returned `Healthy`.
- Ran `node scripts/smoke-test-671-checkin-none.mjs` against `https://einsatzbereit.maik-hasler.de`: created a live "None" check-in opportunity as `olaf`, applied and confirmed the engagement, then opened "My Profile -> Engagements" and clicked "Check in". Confirmed the modal now shows "This opportunity doesn't require an explicit check-in step." instead of a blank dialog, and that "Done" still closes it. The throwaway opportunity was deleted afterwards. All assertions passed (`ALL CHECKS PASSED`).

This PR is now ready for review. As always, this routine does not merge it - that remains the repository owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
