### PR TITLE
fix: prevent withdrawing an engagement after check-in

### DIFF
--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -108,6 +108,9 @@ public sealed class Engagement
 		if (Status is EngagementStatus.Cancelled or EngagementStatus.Withdrawn)
 			throw new DomainException("Engagement is already terminated.");
 
+		if (IsCheckedIn)
+			throw new DomainException("A checked-in engagement can no longer be withdrawn.");
+
 		Status = EngagementStatus.Withdrawn;
 	}
 

--- a/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
@@ -221,6 +221,18 @@ public class EngagementTests
 		act.Should().Throw<DomainException>().WithMessage("*already terminated*");
 	}
 
+	[Test]
+	public void Withdraw_ShouldThrow_WhenCheckedIn()
+	{
+		var engagement = Engagement.CreateWaitlistSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Confirm();
+		engagement.CheckIn();
+
+		Action act = () => engagement.Withdraw();
+
+		act.Should().Throw<DomainException>().WithMessage("*checked-in*");
+	}
+
 	// --- Reactivate ---
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
@@ -161,4 +161,24 @@ public class WithdrawEngagementCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<DomainException>().WithMessage("*already terminated*");
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEngagementIsCheckedIn(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreatePendingEngagementWithVolunteer();
+		engagement.Confirm();
+		engagement.CheckIn();
+		var engagementId = new EngagementId(Guid.CreateVersion7());
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new WithdrawEngagementCommand(engagementId, volunteerId.Value);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<DomainException>().WithMessage("*checked-in*");
+	}
 }

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -956,15 +956,15 @@ export default function ProfileOverviewPage() {
 															end={e.timeSlotEndDateTime}
 														/>
 													)}
-												{(e.status === "Pending" ||
-													e.status === "Confirmed") && (
-													<button
-														onClick={() => setConfirmWithdrawId(e.id)}
-														className="rounded-lg border border-red-200 px-3 py-1 text-xs text-red-600 transition-colors hover:bg-red-50"
-													>
-														{t("myEngagements.withdraw")}
-													</button>
-												)}
+												{(e.status === "Pending" || e.status === "Confirmed") &&
+													!e.isCheckedIn && (
+														<button
+															onClick={() => setConfirmWithdrawId(e.id)}
+															className="rounded-lg border border-red-200 px-3 py-1 text-xs text-red-600 transition-colors hover:bg-red-50"
+														>
+															{t("myEngagements.withdraw")}
+														</button>
+													)}
 											</div>
 										</div>
 									</li>


### PR DESCRIPTION
## Summary

- `Engagement.Withdraw()` only rejected an already-terminal status (`Cancelled`/`Withdrawn`), never checking `IsCheckedIn` - so a volunteer who had already been checked in for a shift could still withdraw, leaving a self-contradictory "Withdrawn" + "Checked in" record visible on the organizer's "Manage applications" page.
- Added the missing precondition guard to `Engagement.Withdraw()` (`backend/src/Domain/Engagements/Engagement.cs`), throwing a `DomainException` when `IsCheckedIn` is true, before flipping `Status`. This mirrors the guard pattern every other transition on this aggregate already has (`Confirm`/`CheckIn`/`Reactivate` all validate their starting state).
- Hid the "Withdraw" button in "My Profile -> Engagements" (`frontend/src/pages/ProfileOverviewPage.tsx`) once `isCheckedIn` is true, consistent with the existing `!e.isCheckedIn` guard already used for the "Check in" button on the same list.

Addresses #673

## Test plan

- [x] `Application.UnitTests`: 212/212 passing locally, including two new tests - `Withdraw_ShouldThrow_WhenCheckedIn` (domain) and `Handle_ShouldThrow_WhenEngagementIsCheckedIn` (command handler).
- [x] `ArchitectureTests`: 247/247 passing locally.
- [x] `pnpm check` / `pnpm lint` / `pnpm format:write`: all clean.
- [x] Self-review (`/self-review`) run, fanned out to `ef-migration-check` (no schema change, no migration needed) and `a11y-check` (no regression - button hiding mirrors the existing `Check in` button pattern) - both clean, no findings.
- [ ] Live verification against staging (release candidate) - pending, will update this section once the RC deploys.
- [ ] Automated `VisualTests` regression test (`backend/tests/VisualTests/`) - pending, added alongside live verification.

## Live verification

Pending - will be added once the release-candidate deploys to staging.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mVYuPai9SrocpKMHaBQdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012mVYuPai9SrocpKMHaBQdZ)_