### PR TITLE
fix: mark SignUpModal message field as visibly required

### DIFF
--- a/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
+++ b/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #679: the "Message" textarea on a non-waitlist (Express
+/// interest) sign-up was silently HTML-required with no visible/accessible
+/// indication, so its markup had never been exercised by AccessibilityTests.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class SignUpModalMessageFieldTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task SignUpModal_ExpressInterest_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("MessageFieldA11y");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await Page.WaitForSelectorAsync("[role='dialog']");
+
+		var messageField = Page.Locator("#sign-up-message");
+		await Expect(messageField).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		var violations = result.Violations
+			.Where(v => v.Impact is "serious" or "critical")
+			.ToList();
+		violations.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task SignUpModal_MessageField_IsLabelledAndMarkedRequired()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("MessageFieldLabel");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		await Page.WaitForSelectorAsync("[role='dialog']");
+
+		var messageField = Page.GetByLabel("Message (required)");
+		await Expect(messageField).ToBeVisibleAsync();
+		await Expect(messageField).ToHaveAttributeAsync("required", "");
+	}
+
+	private async Task<string> CreateIndividualContactOpportunityAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var tokenHttp = new HttpClient { BaseAddress = keycloak };
+		var tokenResponse = await tokenHttp.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = "olaf",
+				["password"] = "olaf123",
+				["scope"] = "openid",
+			}));
+		tokenResponse.EnsureSuccessStatusCode();
+		var tokenBody = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var token = tokenBody.GetProperty("access_token").GetString();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var orgsResponse = await http.GetAsync("/v1/organizations");
+		orgsResponse.EnsureSuccessStatusCode();
+		var orgs = await orgsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = orgs.EnumerateArray().First().GetProperty("id").GetString();
+
+		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"SignUpModalMessageField {label} {suffix}",
+			description = "Created by SignUpModalMessageFieldTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		draftResponse.EnsureSuccessStatusCode();
+		var draft = await draftResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = draft.GetProperty("id").GetString()!;
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		return opportunityId;
+	}
+}

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -133,10 +133,14 @@ export default function SignUpModal({
 
 					{!isWaitlist && (
 						<div>
-							<label className="mb-1 block text-sm font-medium text-gray-700">
+							<label
+								htmlFor="sign-up-message"
+								className="mb-1 block text-sm font-medium text-gray-700"
+							>
 								{t("signUp.message")}
 							</label>
 							<textarea
+								id="sign-up-message"
 								value={message}
 								onChange={(e) => setMessage(e.target.value)}
 								required

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -290,7 +290,7 @@
       "selectTimeSlot": "Zeitslot wählen",
       "noTimeSlots": "Keine Zeitslots verfügbar.",
       "selectPlaceholder": "Bitte wählen…",
-      "message": "Nachricht",
+      "message": "Nachricht (Pflichtfeld)",
       "messagePlaceholder": "Beschreibe kurz, warum du dich engagieren möchtest…",
       "submitting": "Wird gesendet…",
       "submit": "Anmelden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -290,7 +290,7 @@
       "selectTimeSlot": "Select time slot",
       "noTimeSlots": "No time slots available.",
       "selectPlaceholder": "Please select…",
-      "message": "Message",
+      "message": "Message (required)",
       "messagePlaceholder": "Briefly describe why you want to volunteer…",
       "submitting": "Submitting…",
       "submit": "Sign up",

--- a/scripts/smoke-test-679-signup-message-required.mjs
+++ b/scripts/smoke-test-679-signup-message-required.mjs
@@ -1,0 +1,172 @@
+// Smoke test for #679: SignUpModal's "Message" textarea on a non-waitlist
+// ("Express interest") sign-up was silently HTML-required with no visual or
+// accessible indication - clicking "Sign up" with it empty produced only the
+// browser's native validation popup. Fixed by adding "(required)" to the
+// label text and associating the label with the textarea via htmlFor/id.
+//
+// Run: node scripts/smoke-test-679-signup-message-required.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const authHeaders = {
+		Authorization: `Bearer ${olafToken}`,
+		"Content-Type": "application/json",
+	};
+
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: authHeaders,
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	const createRes = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: authHeaders,
+		body: JSON.stringify({
+			title: `Smoke679 MessageRequired ${Date.now()}`,
+			description: "Automated smoke test opportunity for #679.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!createRes.ok)
+		throw new Error(
+			`Create opportunity failed: ${createRes.status} ${await createRes.text()}`,
+		);
+	const opportunity = await createRes.json();
+	console.log(`OK  Created throwaway opportunity ${opportunity.id}`);
+
+	try {
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			console.log("OK  Logged in as vera");
+
+			await page.goto(`${BASE}/volunteer-opportunities/${opportunity.id}`, {
+				waitUntil: "networkidle",
+			});
+			await page
+				.getByRole("button", { name: /express interest|interesse bekunden/i })
+				.click();
+			const dialog = page.getByRole("dialog");
+			await dialog.waitFor({ state: "visible", timeout: 15000 });
+			console.log("OK  Sign-up modal opened for a non-waitlist opportunity");
+
+			const messageField = dialog.getByLabel(/message \(required\)/i);
+			await messageField.waitFor({ state: "visible", timeout: 10000 });
+			console.log(
+				'OK  Message field has an accessible label including "(required)"',
+			);
+
+			const labelText = (
+				await dialog.locator('label[for="sign-up-message"]').textContent()
+			)?.trim();
+			if (!labelText || !/required/i.test(labelText)) {
+				throw new Error(
+					`Expected the visible label text to mention "required", got: "${labelText}"`,
+				);
+			}
+			console.log(`OK  Visible label text: "${labelText}"`);
+
+			const isRequired = await messageField.evaluate((el) => el.required);
+			if (!isRequired)
+				throw new Error(
+					"Message textarea lost its native required attribute",
+				);
+			console.log("OK  Message textarea still carries the required attribute");
+
+			// Submitting empty must not silently no-op - the browser's native
+			// validation should keep the dialog open without an app-side error.
+			await dialog.getByRole("button", { name: /^sign up$|^anmelden$/i }).click();
+			await page.waitForTimeout(500);
+			await dialog.waitFor({ state: "visible", timeout: 5000 });
+			console.log(
+				"OK  Submitting with an empty (but now visibly-required) message keeps the dialog open",
+			);
+
+			await messageField.fill("Smoke test message for #679.");
+			const [signupRes] = await Promise.all([
+				page.waitForResponse(
+					(r) =>
+						r
+							.url()
+							.includes(
+								`/volunteer-opportunities/${opportunity.id}/engagements`,
+							) && r.request().method() === "POST",
+				),
+				dialog.getByRole("button", { name: /^sign up$|^anmelden$/i }).click(),
+			]);
+			if (!signupRes.ok())
+				throw new Error(`Sign-up POST failed: ${signupRes.status()}`);
+			console.log("OK  Sign-up succeeds once the required message is filled in");
+		} finally {
+			await browser.close();
+		}
+	} finally {
+		await fetch(`${API}/v1/volunteer-opportunities/${opportunity.id}`, {
+			method: "DELETE",
+			headers: authHeaders,
+		});
+		console.log("OK  Cleaned up throwaway opportunity");
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- The "Message" textarea shown on a non-waitlist ("Express interest") sign-up carries the native HTML5 `required` attribute, but its label gave no visual or accessible indication of that - submitting empty silently produced only the browser's native validation tooltip, with no in-app explanation.
- Added `"(required)"` / `"(Pflichtfeld)"` to the label text (`signUp.message` in `en.json`/`de.json`), following the existing app-wide convention already used by `SubmitFeedbackModal.tsx`'s `feedback.ratingLabel` ("Rating (required)").
- Also fixed a smaller pre-existing gap in the same markup: the `<label>` had no `htmlFor` and the `<textarea>` had no `id`, so they weren't programmatically associated - added `htmlFor="sign-up-message"` / `id="sign-up-message"`.

Addresses #679

## Test plan

- [x] `Application.UnitTests`: 219/219 passing locally.
- [x] `ArchitectureTests`: 247/247 passing locally.
- [x] `pnpm check` / `pnpm lint` / `pnpm format:write`: all clean.
- [x] Self-review (`/self-review`) run, fanned out to `i18n-check` (`en.json`/`de.json` confirmed in sync - 676 keys on both sides, only the one value changed) and `a11y-check` (no new a11y gap; confirmed the label/textarea association fix is consistent with the adjacent `sign-up-time-slot` pattern in the same file). `a11y-check` also flagged that the non-waitlist branch of `SignUpModal` (exactly the markup this PR touches) had zero axe-core coverage in `backend/tests/VisualTests/AccessibilityTests.cs` - the existing `SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations` test only exercises the waitlist branch. Addressed by adding a new `SignUpModalMessageFieldTests.cs` (modeled on the existing `SignUpModalPreselectTests.cs` pattern - creates its own throwaway `IndividualContact` opportunity via API rather than depending on seeded data) with two tests: an axe-core check on the open modal, and an assertion that the message field is labelled `"Message (required)"` and carries the `required` attribute.
- [x] Automated `VisualTests` regression (`SignUpModalMessageFieldTests.cs`) - ran and passed as part of the `v1.0.0-rc.229` release-candidate pipeline's `Test - VisualTests` step (real Aspire stack, not local).
- [x] Live verification against staging (release candidate) - passed, see below.

## Live verification

Cut release candidate `v1.0.0-rc.229` from this branch. Full pipeline succeeded: `release-rc.yml` -> tag -> `publish.yml` (backend build, `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, `VisualTests` including the two new tests, image build/push) -> `deploy-staging` -> post-deploy health gate, all green.

- `curl -sf https://api.maik-hasler.de/health` -> `Healthy`, HTTP 200.
- `node scripts/smoke-test-679-signup-message-required.mjs` against `https://einsatzbereit.maik-hasler.de` -> **ALL CHECKS PASSED**:
  ```
  OK  API health check passed
  OK  Created throwaway opportunity 019f5984-93c0-7ea5-8ef5-916c6fb64dd5
  OK  Logged in as vera
  OK  Sign-up modal opened for a non-waitlist opportunity
  OK  Message field has an accessible label including "(required)"
  OK  Visible label text: "Message (required)"
  OK  Message textarea still carries the required attribute
  OK  Submitting with an empty (but now visibly-required) message keeps the dialog open
  OK  Sign-up succeeds once the required message is filled in
  OK  Cleaned up throwaway opportunity
  ```
  Confirms the message field's required state is now visible in the label text and programmatically associated, and that the original submit-once-filled-in flow still works end-to-end. Throwaway opportunity created as `olaf` and cleaned up (deleted) after the run - no test data left behind.
- `SignUpModalMessageFieldTests.cs` (new VisualTests regression, same assertions plus an axe-core check) passed in the `v1.0.0-rc.229` CI run against the real Aspire stack.

## Limitations / follow-up

None beyond what's in scope for #679. The broader `CreateVolunteerOpportunityModal.tsx` a11y/UX gaps are tracked separately in #676 (`needs-decision`, out of scope here).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJk6wV8GUMRYkuR62ntSPN
