### PR TITLE
fix: handle deleted-opportunity 404 in CheckInModal instead of hanging on Loading

### DIFF
--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -1,0 +1,103 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #686: CheckInModal's opportunity-details fetch had no
+/// .catch(), so a 404 (opportunity deleted after the engagements list was
+/// loaded, e.g. by an organizer in another tab, but before the volunteer
+/// clicks the still-rendered "Check in" button) left the modal stuck on
+/// "Loading..." forever with an unhandled promise rejection.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task CheckInModal_ShowsFriendlyError_WhenOpportunityDeletedAfterListLoaded()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInModalDeleted Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"CheckInModalDeleted Opportunity {suffix}";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by CheckInModalDeletedOpportunityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Applying via CheckInModalDeletedOpportunityTests." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var checkInButton = row.GetByRole(AriaRole.Button, new() { Name = "Check in" });
+		await Expect(checkInButton).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Simulate the race: the organizer deletes the opportunity in another
+		// tab/session after the volunteer's list has already loaded, but before
+		// they click the still-rendered "Check in" button.
+		(await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}"))
+			.EnsureSuccessStatusCode();
+
+		await checkInButton.ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+
+		await Expect(dialog.GetByText("This opportunity is no longer available."))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(dialog.GetByText("Loading…")).Not.ToBeVisibleAsync();
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+}

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -22,13 +22,17 @@ export default function CheckInModal({
 	const [details, setDetails] = useState<VolunteerOpportunityDetails | null>(
 		null,
 	);
+	const [loadError, setLoadError] = useState(false);
 	const [pin, setPin] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState(false);
 
 	useEffect(() => {
-		void api.getVolunteerOpportunityDetails(opportunityId).then(setDetails);
+		api
+			.getVolunteerOpportunityDetails(opportunityId)
+			.then(setDetails)
+			.catch(() => setLoadError(true));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [opportunityId]);
 
@@ -79,8 +83,14 @@ export default function CheckInModal({
 					{t("checkIn.title")}
 				</h2>
 
-				{!details && (
+				{!details && !loadError && (
 					<p className="text-sm text-gray-500">{t("opportunities.loading")}</p>
+				)}
+
+				{loadError && (
+					<p className="text-sm text-red-600" role="alert">
+						{t("checkIn.loadError")}
+					</p>
 				)}
 
 				{details && !success && checkInMethod === "QRCode" && (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -469,7 +469,8 @@
       "qrCameraError": "Kamerazugriff verweigert. Bitte Kamerazugriff erlauben und erneut versuchen.",
       "qrNotFound": "QR-Code nicht erkannt. Der Freiwillige ist möglicherweise noch nicht bestätigt.",
       "qrCheckInError": "Einchecken fehlgeschlagen. Bitte erneut versuchen.",
-      "qrSuccess": "Freiwilliger erfolgreich eingecheckt!"
+      "qrSuccess": "Freiwilliger erfolgreich eingecheckt!",
+      "loadError": "Dieser Einsatz ist nicht mehr verfügbar."
     },
     "myEngagements": {
       "title": "Meine Engagements",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -469,7 +469,8 @@
       "qrCameraError": "Camera access denied. Please allow camera access and try again.",
       "qrNotFound": "QR code not recognised. The volunteer may not be confirmed yet.",
       "qrCheckInError": "Check-in failed. Please try again.",
-      "qrSuccess": "Volunteer checked in successfully!"
+      "qrSuccess": "Volunteer checked in successfully!",
+      "loadError": "This opportunity is no longer available."
     },
     "myEngagements": {
       "title": "My Engagements",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -996,14 +996,16 @@ export default function ProfileOverviewPage() {
 												>
 													{STATUS_LABELS[e.status] ?? e.status}
 												</span>
-												{e.status === "Confirmed" && !e.isCheckedIn && (
-													<button
-														onClick={() => setCheckInEngagement(e)}
-														className="rounded-lg bg-brand-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800"
-													>
-														{t("checkIn.buttonLabel")}
-													</button>
-												)}
+												{e.status === "Confirmed" &&
+													!e.isCheckedIn &&
+													e.opportunityTitle && (
+														<button
+															onClick={() => setCheckInEngagement(e)}
+															className="rounded-lg bg-brand-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800"
+														>
+															{t("checkIn.buttonLabel")}
+														</button>
+													)}
 												{e.isCheckedIn && !e.hasFeedback && (
 													<button
 														onClick={() => setFeedbackEngagement(e)}

--- a/scripts/smoke-test-686-checkin-modal-deleted-opportunity.mjs
+++ b/scripts/smoke-test-686-checkin-modal-deleted-opportunity.mjs
@@ -1,0 +1,167 @@
+/**
+ * Smoke test for #686: CheckInModal's opportunity-details fetch had no
+ * .catch(), so a 404 (opportunity deleted after the engagements list had
+ * already loaded) left the modal stuck on "Loading..." forever with an
+ * unhandled promise rejection.
+ *
+ * Verifies against the live staging environment:
+ * - Creating an opportunity, applying as vera, and confirming as olaf (all
+ *   via the API).
+ * - Loading vera's "My Profile -> Engagements" list in the browser, where
+ *   the Confirmed engagement's "Check in" button is visible.
+ * - Deleting the opportunity via the API (simulating an organizer deleting
+ *   it in another tab, after the volunteer's page has already loaded).
+ * - Clicking the still-rendered "Check in" button shows the friendly error
+ *   message instead of hanging on "Loading...".
+ * - Cleans up the throwaway organization/opportunity afterwards.
+ *
+ * Run: node scripts/smoke-test-686-checkin-modal-deleted-opportunity.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de/realms/einsatzbereit";
+const CLIENT_ID = "frontend";
+
+async function getToken(username, password) {
+	const body = new URLSearchParams({
+		grant_type: "password",
+		client_id: CLIENT_ID,
+		username,
+		password,
+		scope: "openid",
+	});
+	const res = await fetch(`${KEYCLOAK}/protocol/openid-connect/token`, {
+		method: "POST",
+		body,
+	});
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	return data.access_token;
+}
+
+async function apiPost(path, token, body) {
+	const res = await fetch(`${API}${path}`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: body === undefined ? undefined : JSON.stringify(body),
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`POST ${path} failed: ${res.status} - ${text}`);
+	}
+	const text = await res.text();
+	return text ? JSON.parse(text) : null;
+}
+
+async function apiDelete(path, token) {
+	const res = await fetch(`${API}${path}`, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`DELETE ${path} failed: ${res.status} - ${text}`);
+	}
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const veraToken = await getToken("vera", "vera123");
+	console.log("OK  Got olaf and vera tokens");
+
+	const suffix = Date.now();
+
+	const org = await apiPost("/v1/organizations", olafToken, {
+		name: `Smoke686 Org ${suffix}`,
+	});
+	const organizationId = org.id.value;
+	console.log(`OK  Created organization ${organizationId}`);
+
+	const oppTitle = `Smoke686 CheckIn Deleted Opp ${suffix}`;
+	const opportunity = await apiPost("/v1/volunteer-opportunities", olafToken, {
+		title: oppTitle,
+		description: "Created by smoke-test-686-checkin-modal-deleted-opportunity.mjs",
+		organizationId,
+		isRemote: true,
+		occurrence: "OneTime",
+		participationType: "IndividualContact",
+		checkInMethod: "None",
+		isDraft: false,
+	});
+	const opportunityId = opportunity.id;
+	console.log(`OK  Created opportunity ${opportunityId}`);
+
+	const engagement = await apiPost(
+		`/v1/volunteer-opportunities/${opportunityId}/engagements`,
+		veraToken,
+		{ message: "Applying via smoke-test-686-checkin-modal-deleted-opportunity.mjs" },
+	);
+	const engagementId = engagement.id;
+	console.log(`OK  vera applied, engagement ${engagementId}`);
+
+	await apiPost(`/v1/engagements/${engagementId}/confirm`, olafToken);
+	console.log("OK  olaf confirmed the application");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		if ((await signInBtn.count()) > 0) {
+			await signInBtn.first().click();
+			await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+			await loginKeycloak(page, "vera", "vera123");
+		}
+		await page.waitForSelector("main", { timeout: 15000 });
+		console.log("OK  Logged in as vera");
+
+		await page.goto(`${BASE}/profile?tab=engagements`, { waitUntil: "networkidle" });
+
+		const row = page.locator("li", { hasText: oppTitle });
+		await row.waitFor({ state: "visible", timeout: 15000 });
+		const checkInButton = row.getByRole("button", { name: "Check in" });
+		await checkInButton.waitFor({ state: "visible", timeout: 15000 });
+		console.log('OK  "Check in" button visible on the Confirmed engagement');
+
+		// Simulate the race: the organizer deletes the opportunity (e.g. in
+		// another tab) after vera's engagements list has already loaded.
+		await apiDelete(`/v1/volunteer-opportunities/${opportunityId}`, olafToken);
+		console.log("OK  olaf deleted the opportunity while vera's page was still open");
+
+		await checkInButton.click();
+		const dialog = page.locator("[role='dialog']");
+		await dialog.waitFor({ state: "visible", timeout: 10000 });
+
+		const errorMessage = dialog.getByText("This opportunity is no longer available.");
+		await errorMessage.waitFor({ state: "visible", timeout: 15000 });
+		console.log("OK  Modal shows the friendly error message instead of hanging");
+
+		const stillLoading = await dialog.getByText("Loading…").count();
+		if (stillLoading > 0) {
+			throw new Error('Modal is still showing "Loading..." alongside the error message');
+		}
+		console.log('OK  Modal is not stuck on "Loading..."');
+
+		await dialog.getByRole("button", { name: "Done" }).click();
+		await dialog.waitFor({ state: "hidden", timeout: 5000 });
+		console.log('OK  "Done" closes the modal');
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
Addresses #686

## Summary

`CheckInModal`'s opportunity-details fetch (`api.getVolunteerOpportunityDetails(opportunityId)`) had no `.catch()`. If the opportunity had been deleted (e.g. by the organizer in another tab/session after the volunteer's engagements list had already loaded), the fetch 404s, the rejection went unhandled, and the modal was stuck on "Loading..." forever with no way out except the modal's own Close button.

## Changes

- `frontend/src/components/CheckInModal.tsx` - the details fetch now has a `.catch()` that sets a `loadError` state, rendering a friendly `t("checkIn.loadError")` message (`role="alert"` so it's announced to screen readers) instead of leaving the loading state stuck.
- `frontend/src/pages/ProfileOverviewPage.tsx` - the "Check in" button is now also gated on `e.opportunityTitle` being present, mirroring the existing fallback-title guard a few lines above, so it's hidden once the opportunity can no longer be resolved.
- `frontend/src/locales/en.json` / `de.json` - new `checkIn.loadError` translation key.
- `backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs` - new regression test: loads the engagements list with a Confirmed (not checked-in) engagement, deletes the opportunity via the API (simulating the race), clicks the still-rendered "Check in" button, and asserts the modal shows the friendly error instead of getting stuck on "Loading...". Passed as part of this PR's own CI run (`Test - VisualTests`).
- `scripts/smoke-test-686-checkin-modal-deleted-opportunity.mjs` - live Playwright smoke script exercising the same scenario against staging.

## Validation

- `Application.UnitTests` (237/237) and `ArchitectureTests` (247/247) passing locally.
- `pnpm format:check`/`lint`/`check` clean.
- Self-review (`/self-review`) run: `i18n-check` found no issues (686/686 keys match between locales); `a11y-check` flagged that the new dynamically-appearing error message should use `role="alert"` to match the codebase convention used elsewhere (`QRScannerModal.tsx`, `CreateVolunteerOpportunityModal`) - fixed before this PR.
- All 7 PR CI checks green (build, build-and-test, format-check, lint, ban-typographic-dashes, PR title, editorconfig).

## Live verification

Release candidate `v1.0.0-rc.234` cut from this branch - full pipeline green (build, `Application.UnitTests`/`ArchitectureTests`/`IntegrationTests`/`VisualTests`, image publish, `deploy-staging`, post-deploy health gate).

- `curl -sf https://api.maik-hasler.de/health` -> HTTP 200.
- `node scripts/smoke-test-686-checkin-modal-deleted-opportunity.mjs` against `https://einsatzbereit.maik-hasler.de`: created a throwaway opportunity, applied as vera, confirmed as olaf, loaded vera's "My Profile -> Engagements" (Check in button visible), deleted the opportunity as olaf (simulating the race), clicked the still-rendered "Check in" button, and confirmed the modal shows "This opportunity is no longer available." instead of hanging on "Loading...". All checks passed:

  ```
  OK  API health check passed
  OK  Got olaf and vera tokens
  OK  Created organization ...
  OK  Created opportunity ...
  OK  vera applied, engagement ...
  OK  olaf confirmed the application
  OK  Logged in as vera
  OK  "Check in" button visible on the Confirmed engagement
  OK  olaf deleted the opportunity while vera's page was still open
  OK  Modal shows the friendly error message instead of hanging
  OK  Modal is not stuck on "Loading..."
  OK  "Done" closes the modal

  ALL CHECKS PASSED
  ```
- The throwaway opportunity is deleted as part of the test itself (that's the scenario being verified); the throwaway organization is left behind, consistent with prior smoke scripts in this repo.

This routine never merges its own PRs - ready for your review.

## Test plan

- [x] `Application.UnitTests` / `ArchitectureTests` pass locally
- [x] Frontend `lint`/`check`/`format:check` clean
- [x] Release-candidate deploy to staging succeeds
- [x] Live Playwright smoke test confirms the modal shows a friendly error (not stuck loading) when the underlying opportunity is deleted after the list loads
- [x] New automated `VisualTests` regression passes in the RC's own CI run
