### PR TITLE
fix: scroll/focus and announce the publish-blocking time-slot error

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -401,6 +401,15 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(Page.Locator("[role='dialog']")).ToBeVisibleAsync();
 		await Expect(Page.GetByTestId("wizard-step-4")).ToBeVisibleAsync();
 
+		// #688 regression: the publish-blocking error must be announced
+		// (role="alert") and scrolled/focused into view, not merely present
+		// somewhere in the DOM below the fold of the modal's scrollable body.
+		var publishError = Page.GetByRole(AriaRole.Alert)
+			.Filter(new() { HasTextString = "time slot" });
+		await Expect(publishError).ToBeVisibleAsync();
+		await Expect(publishError).ToBeInViewportAsync();
+		await Expect(publishError).ToBeFocusedAsync();
+
 		// Add a time slot, then publishing must succeed.
 		var start = DateTimeOffset.UtcNow.AddDays(7);
 		var end = start.AddHours(2);

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller } from "react-hook-form";
 import type { Control } from "react-hook-form";
@@ -40,6 +41,10 @@ interface Props {
 	recurrenceCount: number;
 	onRecurrenceCountChange: (count: number) => void;
 	error: string | null;
+	/** Bumped on every submit attempt that sets `error`, including repeats of
+	 * the same message - lets the scroll/focus effect below re-run even when
+	 * the error text itself didn't change. */
+	errorToken: number;
 }
 
 const CATEGORY_VALUES = [
@@ -80,8 +85,19 @@ export default function DetailsStep({
 	recurrenceCount,
 	onRecurrenceCountChange,
 	error,
+	errorToken,
 }: Props) {
 	const { t } = useTranslation();
+	const errorRef = useRef<HTMLParagraphElement>(null);
+
+	// The publish-blocking error (e.g. "needs a time slot") can land below the
+	// fold of this step's scrollable body - scroll and focus it into view so
+	// it isn't effectively invisible, on top of role="alert" announcing it.
+	useEffect(() => {
+		if (!error) return;
+		errorRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+		errorRef.current?.focus();
+	}, [error, errorToken]);
 
 	return (
 		<div className="space-y-5" data-testid="wizard-step-4">
@@ -314,7 +330,12 @@ export default function DetailsStep({
 			)}
 
 			{error && (
-				<p className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+				<p
+					ref={errorRef}
+					role="alert"
+					tabIndex={-1}
+					className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700 focus:outline-none"
+				>
 					{error}
 				</p>
 			)}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -127,6 +127,11 @@ export default function CreateVolunteerOpportunityModal({
 		null,
 	);
 	const [error, setError] = useState<string | null>(null);
+	// Bumped on every submit attempt that sets `error`, even when the message
+	// text is identical to the previous attempt (e.g. retrying without
+	// changing anything) - lets DetailsStep re-scroll/re-focus the error each
+	// time, since a dependency on the string alone wouldn't change.
+	const [errorToken, setErrorToken] = useState(0);
 	const [orgAddress, setOrgAddress] = useState<AddressDto | null>(null);
 	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
@@ -438,6 +443,7 @@ export default function CreateVolunteerOpportunityModal({
 			const totalSlots = pendingSlots.length + existingSlots.length;
 			if (totalSlots === 0) {
 				setError(t("timeSlots.requiredForPublish"));
+				setErrorToken((tk) => tk + 1);
 				setStep(4);
 				return;
 			}
@@ -544,6 +550,7 @@ export default function CreateVolunteerOpportunityModal({
 						: t("createOpportunity.unknownError"),
 				),
 			);
+			setErrorToken((tk) => tk + 1);
 		} finally {
 			setSubmitting(null);
 		}
@@ -564,7 +571,9 @@ export default function CreateVolunteerOpportunityModal({
 		t("createOpportunity.step1Subtitle"),
 		t("createOpportunity.step2Subtitle"),
 		t("createOpportunity.step3Subtitle"),
-		t("createOpportunity.step4Subtitle"),
+		isWaitlist
+			? t("createOpportunity.step4SubtitleWaitlist")
+			: t("createOpportunity.step4Subtitle"),
 	];
 
 	const allTimeSlots = isEditMode
@@ -721,6 +730,7 @@ export default function CreateVolunteerOpportunityModal({
 							recurrenceCount={recurrenceCount}
 							onRecurrenceCountChange={setRecurrenceCount}
 							error={error}
+							errorToken={errorToken}
 						/>
 					)}
 				</div>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -186,6 +186,7 @@
       "step3Subtitle": "Wie oft findet der Einsatz statt und wie melden sich Freiwillige an?",
       "step4Title": "Details",
       "step4Subtitle": "Optional: Kategorie, Tags und Zeitfenster helfen Freiwilligen, den passenden Einsatz zu finden.",
+      "step4SubtitleWaitlist": "Kategorie und Tags sind optional. Ein Zeitslots-Einsatz benötigt außerdem mindestens einen Zeitslot, bevor er veröffentlicht werden kann.",
       "back": "Zurück",
       "next": "Weiter",
       "fieldTitle": "Titel",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -186,6 +186,7 @@
       "step3Subtitle": "How often does this run and how do volunteers sign up?",
       "step4Title": "Details",
       "step4Subtitle": "Optional: category, tags, and time slots help volunteers find the right fit.",
+      "step4SubtitleWaitlist": "Category and tags are optional. A Scheduled slots opportunity also needs at least one time slot before it can be published.",
       "back": "Back",
       "next": "Next",
       "fieldTitle": "Title",

--- a/scripts/smoke-test-688-publish-error-visible.mjs
+++ b/scripts/smoke-test-688-publish-error-visible.mjs
@@ -1,0 +1,176 @@
+// Smoke test for #688 (PR #689): in the create-opportunity wizard, publishing
+// a "Scheduled slots" (Waitlist) opportunity with no time slot appeared to do
+// nothing - the blocking error ("A Scheduled slots opportunity must have at
+// least one time slot before it can be published.") was real but rendered
+// below the fold with no role="alert" and nothing to scroll/focus it into
+// view. Verifies:
+//   1. Step 4's subtitle now reads the Waitlist-specific copy instead of the
+//      unconditional "Optional: ..." text.
+//   2. Clicking Publish with no time slot added surfaces the error with
+//      role="alert", scrolled into the viewport, and focused.
+//
+// Run: node scripts/smoke-test-688-publish-error-visible.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const authHeaders = {
+		Authorization: `Bearer ${olafToken}`,
+		"Content-Type": "application/json",
+	};
+
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: authHeaders,
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+	console.log(`OK  Using organization ${orgId}`);
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await loginAsUser(page, "olaf", "olaf123");
+		console.log("OK  Logged in as olaf");
+
+		await page.goto(`${BASE}/organizations/${orgId}/dashboard`, {
+			waitUntil: "networkidle",
+		});
+
+		await page
+			.getByRole("button", { name: /\+ create opportunity/i })
+			.click();
+		const dialog = page.getByRole("dialog");
+		await dialog.waitFor({ state: "visible", timeout: 15000 });
+		console.log("OK  Create-opportunity wizard opened");
+
+		// Step 1 - Basics
+		await dialog.locator("#opportunity-title").fill(`Smoke688 ${Date.now()}`);
+		await dialog
+			.locator("#opportunity-description")
+			.fill("Automated smoke test opportunity for #688 (never published).");
+		await dialog.getByTestId("modal-next").click();
+
+		// Step 2 - Location: mark Remote so no address is required
+		await dialog.locator("#opportunity-remote").check();
+		await dialog.getByTestId("modal-next").click();
+
+		// Step 3 - Format: leave every default ("Scheduled slots"/Waitlist
+		// participation type is pre-selected, matching the issue's repro steps)
+		await dialog.getByTestId("modal-next").click();
+
+		// Step 4 - Details: subtitle must reflect the Waitlist-specific copy
+		await dialog.waitFor({ state: "visible" });
+		const waitlistSubtitle = dialog.getByText(
+			/also needs at least one time slot before it can be published/i,
+		);
+		await waitlistSubtitle.waitFor({ state: "visible", timeout: 10000 });
+		console.log(
+			"OK  Step 4 subtitle shows the Waitlist-specific copy (time slot not optional)",
+		);
+
+		// Leave everything default (no time slot added) and click Publish.
+		await dialog.getByTestId("modal-submit").click();
+
+		const errorAlert = dialog.getByRole("alert").filter({
+			hasText:
+				/scheduled slots opportunity must have at least one time slot/i,
+		});
+		await errorAlert.waitFor({ state: "visible", timeout: 10000 });
+		console.log('OK  Publish-blocking error rendered with role="alert"');
+
+		const box = await errorAlert.boundingBox();
+		const viewport = page.viewportSize();
+		if (!box) throw new Error("Could not read error element's bounding box");
+		if (!viewport) throw new Error("Could not read page viewport size");
+		const inViewport =
+			box.y >= 0 &&
+			box.y + box.height <= viewport.height &&
+			box.x >= 0 &&
+			box.x + box.width <= viewport.width;
+		if (!inViewport)
+			throw new Error(
+				`Error element is outside the viewport: box=${JSON.stringify(box)} viewport=${JSON.stringify(viewport)}`,
+			);
+		console.log("OK  Error element is scrolled into the visible viewport");
+
+		const isFocused = await errorAlert.evaluate(
+			(el) => el === document.activeElement,
+		);
+		if (!isFocused)
+			throw new Error("Error element did not receive focus after Publish");
+		console.log("OK  Error element received focus");
+
+		// Re-submitting the identical failure must re-fire the scroll/focus
+		// effect (the errorToken fix) instead of silently no-oping on a repeat.
+		await page.evaluate(() => (document.activeElement)?.blur());
+		await dialog.getByTestId("modal-submit").click();
+		await errorAlert.waitFor({ state: "visible", timeout: 10000 });
+		const isFocusedAgain = await errorAlert.evaluate(
+			(el) => el === document.activeElement,
+		);
+		if (!isFocusedAgain)
+			throw new Error(
+				"Error element did not regain focus on a repeat identical submit failure",
+			);
+		console.log("OK  Repeat submit with the same error re-focuses the alert");
+	} finally {
+		await browser.close();
+	}
+
+	console.log(
+		"\nNo opportunity was created - Publish was blocked by validation both times, as expected.",
+	);
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #688 - in the create-opportunity wizard, publishing a "Scheduled slots" (Waitlist) opportunity with no time slot silently appeared to do nothing. The blocking error was real (`timeSlots.requiredForPublish`) but rendered as a plain `<p>` below the fold of the modal's scrollable step 4 body, with no `role="alert"` and nothing to scroll or focus it into view.

- `DetailsStep.tsx`: the error `<p>` now has `role="alert"` and `tabIndex={-1}`, and a `useEffect` calls `scrollIntoView`/`focus()` on it whenever a submit attempt sets the error - including a repeat of the exact same message, via a new `errorToken` counter (bumped on every `setError` call in `index.tsx`) so the effect re-fires even when the message text is unchanged.
- `index.tsx`: step 4's subtitle now conditionally reads `step4SubtitleWaitlist` ("...also needs at least one time slot...") instead of the unconditional "Optional: ..." copy when the participation type is Waitlist.
- New `step4SubtitleWaitlist` key added to both `en.json`/`de.json`.

## Test plan

- [x] `pnpm check` / `pnpm lint` / `pnpm format:check` - clean.
- [x] `Application.UnitTests` (237/237) and `ArchitectureTests` (247/247) passing locally.
- [x] `/self-review` run: `a11y-check` flagged that the scroll/focus effect wouldn't re-fire on a second identical-message submit failure (dependency on the error string alone) - fixed via the `errorToken` counter before opening this PR. `i18n-check` confirmed en/de key parity.
- [x] New regression test `PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne` (extended) in `backend/tests/VisualTests/VolunteerOpportunityTests.cs` asserts the error is visible, in viewport, and focused via `role="alert"`.
- [x] Live verification against staging - see below.

## Live verification

- Release candidate `v1.0.0-rc.235` cut from this PR's branch. Full `Publish` pipeline green (frontend build, backend build/test including `IntegrationTests`/`VisualTests`, Docker image publish) through `Deploy to Staging` and its post-deploy health gate.
- `curl -sf https://api.maik-hasler.de/health` -> `Healthy` (200).
- `scripts/smoke-test-688-publish-error-visible.mjs` (new, checked in) run against `https://einsatzbereit.maik-hasler.de` as `olaf`: opened the create-opportunity wizard, confirmed step 4's subtitle shows the Waitlist-specific copy, left the default "Scheduled slots" participation type with no time slot added, clicked Publish, and confirmed the blocking error is rendered with `role="alert"`, scrolled into the visible viewport, and receives focus - including on a repeat submit of the identical error (the `errorToken` fix). All checks passed. No opportunity was created - Publish was correctly blocked by validation both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6Es5fEUkUqduDzP2dAyRV)_