### PR TITLE
fix: center opportunity detail and organization profile page content

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -155,6 +155,30 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		settingsBox.X.Should().Be(calendarBox.X);
 	}
 
+	[Test]
+	public async Task PublicProfilePage_ContentIsCenteredWithinMain()
+	{
+		// Regression for #694: OrganizationProfileView's content wrapper
+		// (`max-w-2xl`) had no `mx-auto`, so it hugged the left edge of <main>
+		// instead of being centered like every other page.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual694 Centering");
+
+		var match = Regex.Match(Page.Url, @"/organizations/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = match.Groups[1].Value;
+
+		await Page.GotoAsync($"{origin}/organizations/{organizationId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertMaxWidthContentCenteredAsync("Organization profile page");
+	}
+
 	private async Task<string> CreateOrganizationAsync(string namePrefix)
 	{
 		var orgName = $"{namePrefix} {Guid.NewGuid():N}";

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions;
 using Microsoft.Playwright;
 using TUnit.Playwright;
 
@@ -47,5 +48,29 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				headers["X-Forwarded-For"] = uniqueTestIp;
 			await route.ContinueAsync(new() { Headers = headers });
 		});
+	}
+
+	/// <summary>
+	/// Asserts the page's `.max-w-2xl` content wrapper inside `&lt;main&gt;` has equal
+	/// left/right whitespace, i.e. it is horizontally centered via `mx-auto`
+	/// rather than left-aligned. See #694.
+	/// </summary>
+	protected async Task AssertMaxWidthContentCenteredAsync(string label)
+	{
+		var main = Page.Locator("main");
+		await Expect(main).ToBeVisibleAsync();
+		var container = main.Locator(".max-w-2xl").First;
+		await Expect(container).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var mainBox = await main.BoundingBoxAsync();
+		var containerBox = await container.BoundingBoxAsync();
+		mainBox.Should().NotBeNull();
+		containerBox.Should().NotBeNull();
+
+		var leftGap = containerBox!.X - mainBox!.X;
+		var rightGap = mainBox.X + mainBox.Width - (containerBox.X + containerBox.Width);
+
+		Math.Abs(leftGap - rightGap).Should().BeLessThan(2,
+			$"{label}: .max-w-2xl content should be horizontally centered within <main>");
 	}
 }

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -221,6 +221,32 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task DetailPage_ContentIsCenteredWithinMain()
+	{
+		// Regression for #694: the content wrapper (`max-w-2xl`) had no
+		// `mx-auto`, so it hugged the left edge of <main> instead of being
+		// centered within the page like every other page.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
+
+		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
+		if (await firstCard.CountAsync() == 0)
+			return; // no opportunities seeded, skip
+
+		var href = await firstCard.GetAttributeAsync("href");
+		if (href is null)
+			return;
+
+		await Page.GotoAsync($"{origin}{href}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertMaxWidthContentCenteredAsync("Opportunity detail page");
+	}
+
+	[Test]
 	public async Task HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist()
 	{
 		// Regression: EF Core 10 query translation failure caused HTTP 500 on all

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -74,7 +74,7 @@ export default function OrganizationProfileView({
 				{actions}
 			</div>
 
-			<div className="max-w-2xl">
+			<div className="mx-auto max-w-2xl">
 				{beforeContent}
 
 				{description && (

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -190,7 +190,7 @@ export default function VolunteerOpportunityDetailPage() {
 		opportunity.timeSlots.every((ts) => ts.bookedCount >= ts.maxParticipants);
 
 	return (
-		<div className="max-w-2xl">
+		<div className="mx-auto max-w-2xl">
 			{/* Banner image */}
 			{opportunity.bannerImageUrl && (
 				<img

--- a/scripts/smoke-test-694-centering.mjs
+++ b/scripts/smoke-test-694-centering.mjs
@@ -1,0 +1,92 @@
+// Smoke test for #694 (PR #697): the opportunity detail page and organization
+// profile page wrapped their content in a max-w-2xl container with no
+// mx-auto, so it hugged the left edge of the already-centered AppLayout main
+// area instead of being centered like every other page.
+//
+// Verifies both pages now have roughly equal left/right whitespace around
+// their max-w-2xl content container (i.e. it is horizontally centered
+// within its parent), on a viewport wide enough that the container doesn't
+// just fill the full width.
+//
+// No throwaway data is created - existing seed/smoke-test opportunities and
+// organizations are used read-only.
+// Run: node scripts/smoke-test-694-centering.mjs
+
+import { launchLiveBrowser } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function assertCentered(page, url, label) {
+	await page.goto(url, { waitUntil: "networkidle" });
+
+	const box = await page.evaluate(() => {
+		const main = document.querySelector("main");
+		if (!main) return null;
+		const container = main.querySelector(".max-w-2xl");
+		if (!container) return null;
+		const mainRect = main.getBoundingClientRect();
+		const containerRect = container.getBoundingClientRect();
+		return {
+			leftGap: containerRect.left - mainRect.left,
+			rightGap: mainRect.right - containerRect.right,
+		};
+	});
+
+	if (!box) throw new Error(`${label}: could not find main > .max-w-2xl`);
+
+	const diff = Math.abs(box.leftGap - box.rightGap);
+	console.log(
+		`OK  ${label}: leftGap=${box.leftGap.toFixed(1)} rightGap=${box.rightGap.toFixed(1)} diff=${diff.toFixed(1)}`,
+	);
+	if (diff > 2) {
+		throw new Error(
+			`${label}: content is not centered (leftGap=${box.leftGap}, rightGap=${box.rightGap})`,
+		);
+	}
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const oppsRes = await fetch(
+		`${API}/v1/volunteer-opportunities?PageNumber=1&PageSize=1`,
+	);
+	if (!oppsRes.ok)
+		throw new Error(`GET /volunteer-opportunities failed: ${oppsRes.status}`);
+	const opps = await oppsRes.json();
+	const opportunity = opps.items?.[0];
+	if (!opportunity)
+		throw new Error("No volunteer opportunities found - cannot run this smoke test");
+	console.log(`OK  Using opportunity ${opportunity.id}`);
+	console.log(`OK  Using organization ${opportunity.organizationId}`);
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		// Wide viewport so max-w-2xl (42rem/672px) sits well inside the
+		// max-w-7xl (80rem/1280px) AppLayout main and centering is measurable.
+		await page.setViewportSize({ width: 1400, height: 900 });
+
+		await assertCentered(
+			page,
+			`${BASE}/volunteer-opportunities/${opportunity.id}`,
+			"Opportunity detail page",
+		);
+		await assertCentered(
+			page,
+			`${BASE}/organizations/${opportunity.organizationId}`,
+			"Organization profile page",
+		);
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `VolunteerOpportunityDetailPage.tsx` and `OrganizationProfileView.tsx` (used by `OrganizationProfilePage.tsx`) wrapped their content in a `max-w-2xl` container with no `mx-auto`, so instead of being centered *within* the already-centered `max-w-7xl` `AppLayout` main area, it sat flush against the left edge.
- Added `mx-auto` to both containers, matching the centering pattern already used elsewhere (`Header.tsx`, `Footer.tsx`).
- Audited the rest of the frontend for the same `max-w-*` (without `mx-auto`) pattern - the only other `max-w-md` usages (`ErrorPage.tsx`, `ErrorBoundary.tsx`) already live inside a `flex items-center justify-center` container, so they don't need the fix.
- Added regression coverage: `scripts/smoke-test-694-centering.mjs` (live-staging Playwright smoke script) and matching automated TUnit tests (`VolunteerOpportunityTests.DetailPage_ContentIsCenteredWithinMain`, `OrganizationTests.PublicProfilePage_ContentIsCenteredWithinMain`, sharing a new `AssertMaxWidthContentCenteredAsync` helper in `VisualTestBase`).

Addresses #694

## Test plan

- [x] `pnpm format:write`, `pnpm lint`, `pnpm check` all pass.
- [x] Backend `dotnet build` (full solution), `Application.UnitTests` (237 passed), `ArchitectureTests` (247 passed) all pass locally.
- [x] CI green on all 7 checks (build, lint, build-and-test, format-check, editorconfig, ban-typographic-dashes, PR title).
- [x] Live verification against release candidate `v1.0.0-rc.237` on staging (see below).

## Live verification

Deployed via `release/v1.0.0-rc.237` (tag `v1.0.0-rc.237`), `deploy-staging` succeeded.

- `curl -sf https://api.maik-hasler.de/health` returned HTTP 200.
- Ran `node scripts/smoke-test-694-centering.mjs` against `https://einsatzbereit.maik-hasler.de` (wide 1400px viewport): both the opportunity detail page and the organization profile page now report `leftGap == rightGap == 304.0px` around the `max-w-2xl` content container (previously flush-left with `leftGap = 0`). Script exited 0, all checks passed.
- Added the same assertion as an automated TUnit `VisualTests` test (runs against the local Aspire stack in CI on every PR going forward).

This PR is open and awaiting the repository owner's review/merge - this routine does not merge PRs itself.
