### PR TITLE
fix: point Register button at Keycloak's registration endpoint

### DIFF
--- a/backend/tests/VisualTests/AuthGuardTests.cs
+++ b/backend/tests/VisualTests/AuthGuardTests.cs
@@ -40,4 +40,21 @@ public class AuthGuardTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign in" }).First)
 			.ToBeVisibleAsync();
 	}
+
+	[Test]
+	public async Task Header_Anonymous_RegisterButton_RedirectsToKeycloakRegistrationEndpoint()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Register" }).First.ClickAsync();
+
+		// Distinct from Header_Anonymous_ShowsSignInButton: "Register" must land on
+		// Keycloak's registration form, not the login form the "Sign in" button uses.
+		await Expect(Page).ToHaveURLAsync(
+			new Regex(@"/realms/einsatzbereit/protocol/openid-connect/registrations"));
+		await Expect(Page.Locator("#kc-register-form")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+	}
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link, useLocation } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import LanguageSelector from "./LanguageSelector";
 import { useApiClient } from "../hooks/useApiClient";
+import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 import type { NotificationSummary } from "../client/api-client";
 
 function getInitials(name: string): string {
@@ -366,7 +367,7 @@ export default function Header() {
 								</button>
 								<button
 									type="button"
-									onClick={() => auth.signinRedirect()}
+									onClick={() => void signinRedirectForRegistration()}
 									className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "border-white/50 text-white hover:border-white hover:bg-white/10" : "border-brand-700 text-brand-700 hover:bg-brand-50"}`}
 								>
 									{t("nav.register")}
@@ -603,7 +604,7 @@ export default function Header() {
 								</button>
 								<button
 									type="button"
-									onClick={() => auth.signinRedirect()}
+									onClick={() => void signinRedirectForRegistration()}
 									className={`block w-full text-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "border-white/50 text-white hover:bg-white/10" : "border-brand-700 text-brand-700 hover:bg-brand-50"}`}
 								>
 									{t("nav.register")}

--- a/frontend/src/lib/keycloakRegistration.ts
+++ b/frontend/src/lib/keycloakRegistration.ts
@@ -1,0 +1,30 @@
+import { UserManager, WebStorageStateStore } from "oidc-client-ts";
+import { runtimeConfig } from "./runtimeConfig";
+
+let registrationUserManager: UserManager | null = null;
+
+// Keycloak exposes a separate registration endpoint that accepts the same
+// OIDC authorization params as the login endpoint and completes with the
+// same authorization-code callback. A dedicated UserManager lets us override
+// just authorization_endpoint (via metadataSeed, which wins over the fetched
+// discovery document) while sharing localStorage-backed state/user stores
+// with the app's default UserManager so /callback can still validate it.
+function getRegistrationUserManager(): UserManager {
+	if (!registrationUserManager) {
+		registrationUserManager = new UserManager({
+			authority: runtimeConfig.keycloakAuthorityUrl,
+			client_id: runtimeConfig.keycloakClientId,
+			redirect_uri: window.location.origin + "/callback",
+			scope: "openid profile email",
+			userStore: new WebStorageStateStore({ store: window.localStorage }),
+			metadataSeed: {
+				authorization_endpoint: `${runtimeConfig.keycloakAuthorityUrl}/protocol/openid-connect/registrations`,
+			},
+		});
+	}
+	return registrationUserManager;
+}
+
+export function signinRedirectForRegistration(): Promise<void> {
+	return getRegistrationUserManager().signinRedirect();
+}

--- a/scripts/smoke-test-692-register-button.mjs
+++ b/scripts/smoke-test-692-register-button.mjs
@@ -1,0 +1,53 @@
+// Smoke test for #692: the header's "Register" button called the same
+// auth.signinRedirect() as "Sign in", so it always landed on Keycloak's
+// login form instead of the registration form. The fix points "Register"
+// at a dedicated UserManager (frontend/src/lib/keycloakRegistration.ts)
+// that targets Keycloak's /protocol/openid-connect/registrations endpoint.
+//
+// Verifies clicking "Register" (logged out) lands on the registrations
+// endpoint with the registration form visible, distinct from "Sign in"
+// which must still land on the plain login form.
+//
+// No data is created, nothing to clean up.
+// Run: node scripts/smoke-test-692-register-button.mjs
+
+import { launchLiveBrowser } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(BASE, { waitUntil: "networkidle" });
+
+		await page.getByRole("button", { name: /^register$/i }).first().click();
+		await page.waitForURL(/\/realms\/einsatzbereit\/protocol\/openid-connect\/registrations/, {
+			timeout: 30000,
+		});
+		console.log("OK  Register button navigated to the registrations endpoint");
+
+		await page.locator("#kc-register-form").waitFor({ state: "visible", timeout: 15000 });
+		console.log("OK  Keycloak registration form is visible");
+
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.getByRole("button", { name: /sign in|anmelden/i }).first().click();
+		await page.waitForURL(/\/realms\/einsatzbereit\/protocol\/openid-connect\/auth/, {
+			timeout: 30000,
+		});
+		console.log("OK  Sign in button still navigates to the plain login endpoint (unaffected)");
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- The header's **Register** button called the exact same `auth.signinRedirect()` as **Sign in**, so it always landed on Keycloak's login form instead of the registration form (the user had to notice and click a "Register" link inside the login page).
- Added `frontend/src/lib/keycloakRegistration.ts`: a dedicated `oidc-client-ts` `UserManager` that overrides just `authorization_endpoint` (via `metadataSeed`, which wins over the fetched discovery document) to point at Keycloak's `/protocol/openid-connect/registrations` endpoint, while sharing the app's default localStorage-backed state/user stores so `/callback` still validates the PKCE state and exchanges the code normally against the real `token_endpoint`.
- Both **Register** buttons (desktop nav and mobile menu) in `Header.tsx` now call `signinRedirectForRegistration()` instead of `auth.signinRedirect()`. **Sign in** / **Sign out** are untouched.
- Verified the realm has `registrationAllowed: true` (`keycloak/realms/einsatzbereit-realm.json`) and that the custom theme's registration form uses `id="kc-register-form"` (`keycloak/themes/einsatzbereit/login/register-user-profile.ftl`), which the new test asserts on.
- Added `AuthGuardTests.Header_Anonymous_RegisterButton_RedirectsToKeycloakRegistrationEndpoint` (backend/tests/VisualTests), mirroring the existing `Header_Anonymous_ShowsSignInButton` / login-redirect tests but asserting the Register button lands on `/realms/einsatzbereit/protocol/openid-connect/registrations` with the registration form visible.
- Added `scripts/smoke-test-692-register-button.mjs`, a live-staging Playwright smoke script asserting the same behaviour end-to-end, plus that `Sign in` is unaffected.

Addresses #692

## Test plan

- [x] `pnpm check` (tsc --noEmit) and `pnpm lint` (zero warnings) pass.
- [x] `pnpm format:write` - no changes needed.
- [x] Backend `dotnet build` (full solution incl. `VisualTests`), `Application.UnitTests` (237 passed), `ArchitectureTests` (247 passed) all pass locally.
- [x] a11y-check subagent: no regression - only the `onClick` handler body changed on two pre-existing `<button>` elements, no JSX/ARIA changes, no new route added.
- [x] CI green on all 7 checks (build, lint, build-and-test, format-check, editorconfig, ban-typographic-dashes, PR title).
- [x] Live verification against release candidate `v1.0.0-rc.238` on staging (see below).

## Live verification

Deployed via `release/v1.0.0-rc.238` (tag `v1.0.0-rc.238`), `deploy-staging` succeeded.

- `curl -sf https://api.maik-hasler.de/health` returned HTTP 200.
- Ran `node scripts/smoke-test-692-register-button.mjs` against `https://einsatzbereit.maik-hasler.de`:
  - Clicking **Register** navigates to `/realms/einsatzbereit/protocol/openid-connect/registrations` (previously the plain login endpoint) with the Keycloak registration form (`#kc-register-form`) visible.
  - Clicking **Sign in** still navigates to `/realms/einsatzbereit/protocol/openid-connect/auth` as before - confirmed unaffected.
  - Script exited 0, all checks passed.
- Added the same assertion as an automated TUnit `VisualTests` test (runs against the local Aspire stack in CI on every PR going forward).

This PR is open and awaiting the repository owner's review/merge - this routine does not merge PRs itself.
