### PR TITLE
fix: sync app language with Keycloak login/register page

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,6 +6,7 @@ import OrganizationSwitcher from "./OrganizationSwitcher";
 import LanguageSelector from "./LanguageSelector";
 import { useApiClient } from "../hooks/useApiClient";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
+import { signinLocaleArgs } from "../lib/authLocale";
 import type { NotificationSummary } from "../client/api-client";
 
 function getInitials(name: string): string {
@@ -360,14 +361,16 @@ export default function Header() {
 							<div className="flex items-center gap-3">
 								<button
 									type="button"
-									onClick={() => auth.signinRedirect()}
+									onClick={() => auth.signinRedirect(signinLocaleArgs())}
 									className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "bg-white text-brand-800 hover:bg-brand-50" : "bg-brand-700 text-white hover:bg-brand-800"}`}
 								>
 									{t("nav.signIn")}
 								</button>
 								<button
 									type="button"
-									onClick={() => void signinRedirectForRegistration()}
+									onClick={() =>
+										void signinRedirectForRegistration(signinLocaleArgs())
+									}
 									className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "border-white/50 text-white hover:border-white hover:bg-white/10" : "border-brand-700 text-brand-700 hover:bg-brand-50"}`}
 								>
 									{t("nav.register")}
@@ -597,14 +600,16 @@ export default function Header() {
 							<div className="space-y-2">
 								<button
 									type="button"
-									onClick={() => auth.signinRedirect()}
+									onClick={() => auth.signinRedirect(signinLocaleArgs())}
 									className={`block w-full text-center rounded-lg px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "bg-white text-brand-800 hover:bg-brand-50" : "bg-brand-700 text-white hover:bg-brand-800"}`}
 								>
 									{t("nav.signIn")}
 								</button>
 								<button
 									type="button"
-									onClick={() => void signinRedirectForRegistration()}
+									onClick={() =>
+										void signinRedirectForRegistration(signinLocaleArgs())
+									}
 									className={`block w-full text-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${isTransparent ? "border-white/50 text-white hover:bg-white/10" : "border-brand-700 text-brand-700 hover:bg-brand-50"}`}
 								>
 									{t("nav.register")}

--- a/frontend/src/layouts/ProtectedRoute.tsx
+++ b/frontend/src/layouts/ProtectedRoute.tsx
@@ -2,6 +2,7 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router";
 import type { ReactNode } from "react";
+import { signinLocaleArgs } from "../lib/authLocale";
 
 interface Props {
 	children: ReactNode;
@@ -22,6 +23,7 @@ export default function ProtectedRoute({ children }: Props) {
 
 	if (!auth.isAuthenticated) {
 		auth.signinRedirect({
+			...signinLocaleArgs(),
 			state: { returnTo: location.pathname + location.search },
 		});
 		return null;

--- a/frontend/src/lib/authLocale.ts
+++ b/frontend/src/lib/authLocale.ts
@@ -1,0 +1,5 @@
+import i18n from "../i18n";
+
+export function signinLocaleArgs(): { ui_locales: string } {
+	return { ui_locales: i18n.language };
+}

--- a/frontend/src/lib/keycloakRegistration.ts
+++ b/frontend/src/lib/keycloakRegistration.ts
@@ -1,4 +1,5 @@
 import { UserManager, WebStorageStateStore } from "oidc-client-ts";
+import type { ExtraSigninRequestArgs } from "oidc-client-ts";
 import { runtimeConfig } from "./runtimeConfig";
 
 let registrationUserManager: UserManager | null = null;
@@ -25,6 +26,8 @@ function getRegistrationUserManager(): UserManager {
 	return registrationUserManager;
 }
 
-export function signinRedirectForRegistration(): Promise<void> {
-	return getRegistrationUserManager().signinRedirect();
+export function signinRedirectForRegistration(
+	args?: ExtraSigninRequestArgs,
+): Promise<void> {
+	return getRegistrationUserManager().signinRedirect(args);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import "./i18n";
+import i18n from "./i18n";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
@@ -28,6 +28,10 @@ const oidcConfig = {
 	// Use localStorage so Playwright storageState captures the session
 	userStore: new WebStorageStateStore({ store: window.localStorage }),
 	onSigninCallback: (user: User | undefined) => {
+		const keycloakLocale = user?.profile?.locale;
+		if (keycloakLocale && keycloakLocale !== i18n.language) {
+			void i18n.changeLanguage(keycloakLocale);
+		}
 		const returnTo = (user?.state as { returnTo?: string })?.returnTo ?? "/";
 		window.location.replace(returnTo);
 	},

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { signinLocaleArgs } from "../lib/authLocale";
 
 const ONBOARDING_KEY = "onboarding-dismissed";
 
@@ -309,7 +310,7 @@ export default function HomePage() {
 							{!auth.isAuthenticated && (
 								<button
 									type="button"
-									onClick={() => void auth.signinRedirect()}
+									onClick={() => void auth.signinRedirect(signinLocaleArgs())}
 									className="w-full rounded-xl border border-white/50 px-8 py-3 text-base font-semibold text-white transition-colors hover:border-white hover:bg-brand-700 sm:w-auto sm:py-3.5"
 								>
 									{t("landing.heroCtaOrg")}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -17,6 +17,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
+import { signinLocaleArgs } from "../lib/authLocale";
 
 export default function VolunteerOpportunityDetailPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
@@ -525,7 +526,7 @@ export default function VolunteerOpportunityDetailPage() {
 						components={{
 							loginLink: (
 								<button
-									onClick={() => auth.signinRedirect()}
+									onClick={() => auth.signinRedirect(signinLocaleArgs())}
 									className="underline hover:text-gray-800"
 								/>
 							),


### PR DESCRIPTION
## Summary

- Addresses #690: the app's language and the Keycloak login/register page's language were completely disconnected.
- Added `frontend/src/lib/authLocale.ts` with a `signinLocaleArgs()` helper that returns `{ ui_locales: i18n.language }`, and wired it into every `auth.signinRedirect()` call site (`Header.tsx`, `HomePage.tsx`, `VolunteerOpportunityDetailPage.tsx`, `ProtectedRoute.tsx`) so Keycloak opens in the app's current language.
- In `main.tsx`'s `onSigninCallback`, read the `locale` claim off the returned ID token and call `i18n.changeLanguage()` when it differs from the app's current language, so switching languages on the Keycloak page carries back into the app after login/registration.

## Test plan

- [x] `pnpm check` (tsc) - passes
- [x] `pnpm lint` - passes
- [x] `pnpm format:write` - no changes needed
- [x] `/self-review` - clean, a11y-check confirmed no markup/a11y impact (only `signinRedirect()` call-site args changed)
- [ ] Live verification against staging (release candidate) - see follow-up comment on this PR once available

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DnuhzyGhvMAsitdYk8zL2y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnuhzyGhvMAsitdYk8zL2y)_