### PR TITLE
refactor: consolidate profile page to 2 tabs (Profile+Achievements, Activity)

### DIFF
--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -65,6 +65,18 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
 		await Page.GotoAsync($"{origin}/achievements");
 
+		var userId = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.profile?.sub) return entry.profile.sub;
+				}
+			}
+			return null;
+		}");
+		userId.Should().NotBeNull("the logged-in user's id must be available via the OIDC profile claims");
+
 		var shareBtn = Page.GetByRole(AriaRole.Button,
 			new() { Name = "Share achievements" });
 		await Expect(shareBtn).ToBeVisibleAsync(new() { Timeout = 20_000 });
@@ -76,12 +88,14 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// QR code SVG is rendered inside the dialog
 		await Expect(dialog.Locator("svg").First).ToBeVisibleAsync();
 
-		// Share URL contains /achievements
+		// #695: share URL now points at the combined public profile
+		// (/users/:userId), not the achievements-only deep link.
 		var dialogText = await dialog.TextContentAsync();
 		await Expect(dialog.GetByRole(AriaRole.Button,
 			new() { Name = "Copy link" }))
 			.ToBeVisibleAsync();
-		dialogText.Should().Contain("/achievements");
+		dialogText.Should().Contain($"/users/{userId}");
+		dialogText.Should().NotContain("/achievements");
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -7,10 +7,11 @@ namespace VisualTests;
 public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task ProfilePage_ShowsThreeTabButtons_WhenAuthenticated()
+	public async Task ProfilePage_ShowsTwoTabButtons_WhenAuthenticated()
 	{
 		// Regression: /profile should render a tab bar instead of a flat page.
-		// Introduced by PR #508 (RC.150 - unified profile overview).
+		// Introduced by PR #508 (RC.150 - unified profile overview), consolidated
+		// from four tabs to two (Profile+Achievements, Activity) by #695.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -22,11 +23,12 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Profile" }))
 			.ToBeVisibleAsync(new() { Timeout = 20_000 });
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Engagements" }))
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Activity" }))
 			.ToBeVisibleAsync(new() { Timeout = 5_000 });
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Achievements" }))
-			.ToBeVisibleAsync(new() { Timeout = 5_000 });
+		// Achievements now live on the Profile tab itself, not a separate tab.
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Share achievements" }))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
 	}
 
 	[Test]

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -626,15 +626,11 @@
     },
     "profileOverview": {
       "tabProfile": "Profil",
-      "tabEngagements": "Engagements",
-      "tabAchievements": "Errungenschaften",
-      "tabInvitations": "Einladungen"
+      "tabActivity": "Aktivität",
+      "invitationsHeading": "Offene Einladungen"
     },
     "invitations": {
-      "loading": "Wird geladen…",
       "loadError": "Einladungen konnten nicht geladen werden.",
-      "empty": "Keine ausstehenden Einladungen.",
-      "emptyHint": "Wenn du zu einer Organisation eingeladen wirst, erscheint die Einladung hier.",
       "invitedOn": "Eingeladen am {{date}}",
       "accept": "Annehmen",
       "decline": "Ablehnen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -626,15 +626,11 @@
     },
     "profileOverview": {
       "tabProfile": "Profile",
-      "tabEngagements": "Engagements",
-      "tabAchievements": "Achievements",
-      "tabInvitations": "Invitations"
+      "tabActivity": "Activity",
+      "invitationsHeading": "Open Invitations"
     },
     "invitations": {
-      "loading": "Loading…",
       "loadError": "Could not load invitations.",
-      "empty": "No pending invitations.",
-      "emptyHint": "When you're invited to join an organization, it will appear here.",
       "invitedOn": "Invited {{date}}",
       "accept": "Accept",
       "decline": "Decline",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -873,8 +873,7 @@ export default function ProfileOverviewPage() {
 						)}
 					</div>
 
-					{/* Achievements - merged into the Profile tab, matching the layout
-				    UserProfilePage.tsx already uses for the public view */}
+					{/* Achievements - merged into the Profile tab, matching the layout UserProfilePage.tsx already uses for the public view */}
 					{!profileLoading && (
 						<div className="mt-10">
 							{achievementsError && (

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -1031,6 +1031,10 @@ export default function ProfileOverviewPage() {
 						</div>
 					)}
 
+					<h2 className="mb-3 text-base font-semibold text-gray-900">
+						{t("myEngagements.title")}
+					</h2>
+
 					<div className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
 						<button
 							type="button"

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -31,19 +31,25 @@ const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 const AVATAR_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const ENGAGEMENTS_PAGE_SIZE = 10;
 
-type Tab = "profile" | "engagements" | "achievements" | "invitations";
+type Tab = "profile" | "activity";
 type EngagementsScope = "upcoming" | "past";
 type ContactPref = "Email" | "Phone" | "";
 
-const VALID_TABS: Tab[] = [
-	"profile",
-	"engagements",
-	"achievements",
-	"invitations",
-];
+const VALID_TABS: Tab[] = ["profile", "activity"];
 
-function isTab(value: string | null): value is Tab {
-	return VALID_TABS.includes(value as Tab);
+// Pre-consolidation deep links (?tab=engagements/achievements/invitations, still
+// used by /my-engagements and /achievements redirects and old bookmarks/shares)
+// keep resolving to the merged tab that now contains that content.
+const LEGACY_TAB_ALIASES: Record<string, Tab> = {
+	engagements: "activity",
+	achievements: "profile",
+	invitations: "activity",
+};
+
+function resolveTab(value: string | null): Tab {
+	if (value && (VALID_TABS as string[]).includes(value)) return value as Tab;
+	if (value && value in LEGACY_TAB_ALIASES) return LEGACY_TAB_ALIASES[value];
+	return "profile";
 }
 
 function Field({
@@ -147,7 +153,7 @@ export default function ProfileOverviewPage() {
 	]);
 
 	const rawTab = searchParams.get("tab");
-	const activeTab: Tab = isTab(rawTab) ? rawTab : "profile";
+	const activeTab: Tab = resolveTab(rawTab);
 
 	function switchTab(tab: Tab) {
 		setSearchParams(tab === "profile" ? {} : { tab }, { replace: true });
@@ -305,17 +311,17 @@ export default function ProfileOverviewPage() {
 		fetchEngagements(scope, 1);
 	}
 
-	// Load engagements lazily on first visit to that tab
+	// Load engagements lazily on first visit to the Activity tab
 	useEffect(() => {
-		if (activeTab !== "engagements" || engagementsInitialized) return;
+		if (activeTab !== "activity" || engagementsInitialized) return;
 		setEngagementsInitialized(true);
 		fetchEngagements(engagementsScope, 1);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [activeTab, engagementsInitialized]);
 
-	// Load invitations lazily on first visit to that tab
+	// Load invitations lazily on first visit to the Activity tab
 	useEffect(() => {
-		if (activeTab !== "invitations" || invitationsInitialized) return;
+		if (activeTab !== "activity" || invitationsInitialized) return;
 		setInvitationsInitialized(true);
 		setInvitationsLoading(true);
 		api
@@ -326,9 +332,9 @@ export default function ProfileOverviewPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [activeTab, invitationsInitialized]);
 
-	// Load achievements lazily on first visit to that tab
+	// Load achievements lazily on first visit to the Profile tab
 	useEffect(() => {
-		if (activeTab !== "achievements" || achievementsInitialized) return;
+		if (activeTab !== "profile" || achievementsInitialized) return;
 		setAchievementsInitialized(true);
 		setAchievementsLoading(true);
 		Promise.all([
@@ -515,17 +521,12 @@ export default function ProfileOverviewPage() {
 	}
 
 	const shareUrl = auth.user?.profile?.sub
-		? window.location.origin +
-			"/users/" +
-			auth.user.profile.sub +
-			"/achievements"
-		: window.location.origin + "/profile?tab=achievements";
+		? window.location.origin + "/users/" + auth.user.profile.sub
+		: window.location.origin + "/profile";
 
 	const tabs: { key: Tab; label: string }[] = [
 		{ key: "profile", label: t("profileOverview.tabProfile") },
-		{ key: "engagements", label: t("profileOverview.tabEngagements") },
-		{ key: "achievements", label: t("profileOverview.tabAchievements") },
-		{ key: "invitations", label: t("profileOverview.tabInvitations") },
+		{ key: "activity", label: t("profileOverview.tabActivity") },
 	];
 
 	return (
@@ -557,318 +558,479 @@ export default function ProfileOverviewPage() {
 
 			{/* Profile tab */}
 			{activeTab === "profile" && (
-				<div className="mx-auto max-w-2xl">
-					{profileLoading && (
-						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">{t("profile.loading")}</span>
+				<>
+					<div className="mx-auto max-w-2xl">
+						{profileLoading && (
+							<div className="flex items-center justify-center py-16">
+								<span className="text-gray-500">{t("profile.loading")}</span>
+							</div>
+						)}
+
+						{!profileLoading && (
+							<>
+								{profileError && (
+									<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+										{profileError}
+									</div>
+								)}
+								{successMessage && (
+									<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+										{successMessage}
+									</div>
+								)}
+
+								{/* View mode */}
+								{!editing && (
+									<div className="space-y-5">
+										<div className="flex items-start justify-between">
+											<div className="flex items-center gap-4">
+												{avatarUrl ? (
+													<img
+														src={avatarUrl}
+														alt=""
+														className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
+													/>
+												) : (
+													<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+														{profile?.username?.charAt(0).toUpperCase() ?? "?"}
+													</span>
+												)}
+												<div>
+													<p className="text-xl font-semibold text-gray-900">
+														{firstName || lastName
+															? `${firstName} ${lastName}`.trim()
+															: profile?.username}
+													</p>
+													<p className="text-sm text-gray-500">
+														@{profile?.username}
+													</p>
+													<p className="text-sm text-gray-500">
+														{profile?.email}
+													</p>
+												</div>
+											</div>
+											<button
+												type="button"
+												onClick={() => setEditing(true)}
+												className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+											>
+												{t("profile.edit")}
+											</button>
+										</div>
+
+										<ProfileFieldsView
+											bio={bio}
+											skills={skills}
+											languages={languages}
+											preferredContact={preferredContact || null}
+										/>
+									</div>
+								)}
+
+								{/* Edit mode */}
+								{editing && (
+									<form onSubmit={handleSave} className="space-y-6">
+										<section>
+											<h2 className="mb-4 text-base font-semibold text-gray-900">
+												{t("account.title")}
+											</h2>
+											<div className="space-y-5">
+												<div>
+													<p className="mb-1 block text-sm font-medium text-gray-700">
+														{t("profile.fieldAvatar")}
+													</p>
+													<div className="flex items-center gap-4">
+														{avatarUrl ? (
+															<img
+																src={avatarUrl}
+																alt=""
+																className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
+															/>
+														) : (
+															<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+																{profile?.username?.charAt(0).toUpperCase() ??
+																	"?"}
+															</span>
+														)}
+														<div>
+															<label
+																htmlFor="avatar-upload"
+																className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingAvatar ? "opacity-50 pointer-events-none" : ""}`}
+															>
+																{uploadingAvatar
+																	? t("profile.avatarUploading")
+																	: t("profile.avatarUpload")}
+															</label>
+															<input
+																ref={avatarInputRef}
+																id="avatar-upload"
+																type="file"
+																accept="image/jpeg,image/png,image/webp"
+																className="sr-only"
+																onChange={handleAvatarChange}
+																disabled={uploadingAvatar}
+															/>
+															<p className="mt-1 text-xs text-gray-500">
+																{t("profile.avatarHint")}
+															</p>
+															{avatarError && (
+																<p className="mt-1 text-xs text-red-600">
+																	{avatarError}
+																</p>
+															)}
+														</div>
+													</div>
+												</div>
+
+												<Field label={t("account.fieldUsername")} id="username">
+													<input
+														id="username"
+														disabled
+														value={profile?.username ?? ""}
+														className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+													/>
+												</Field>
+
+												<Field label={t("account.fieldEmail")} id="email">
+													<input
+														id="email"
+														disabled
+														type="email"
+														value={profile?.email ?? ""}
+														className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+													/>
+													<p className="mt-1 text-xs text-gray-500">
+														{t("account.emailHint")}
+													</p>
+												</Field>
+
+												<Field
+													label={t("account.fieldFirstName")}
+													id="first-name"
+												>
+													<input
+														id="first-name"
+														value={firstName}
+														onChange={(e) => setFirstName(e.target.value)}
+														className={inputClass}
+													/>
+												</Field>
+
+												<Field
+													label={t("account.fieldLastName")}
+													id="last-name"
+												>
+													<input
+														id="last-name"
+														value={lastName}
+														onChange={(e) => setLastName(e.target.value)}
+														className={inputClass}
+													/>
+												</Field>
+											</div>
+										</section>
+
+										<hr className="border-gray-200" />
+
+										<section>
+											<h2 className="mb-4 text-base font-semibold text-gray-900">
+												{t("profile.sectionDetails")}
+											</h2>
+											<div className="space-y-5">
+												<Field label={t("profile.fieldBio")} id="bio">
+													<textarea
+														id="bio"
+														rows={4}
+														value={bio}
+														placeholder={t("profile.bioPlaceholder")}
+														onChange={(e) => setBio(e.target.value)}
+														className={textareaClass}
+													/>
+												</Field>
+
+												<Field
+													label={t("profile.fieldSkills")}
+													id="skill-input"
+												>
+													<ChipInput
+														inputRef={skillInputRef}
+														inputId="skill-input"
+														chips={skills}
+														inputValue={skillInput}
+														placeholder={t("profile.skillsPlaceholder")}
+														onInputChange={setSkillInput}
+														onAdd={(v) =>
+															addChip(v, skills, setSkills, setSkillInput)
+														}
+														onRemove={(v) => removeChip(v, skills, setSkills)}
+														removeLabel={t("profile.removeChip")}
+													/>
+												</Field>
+
+												<Field
+													label={t("profile.fieldLanguages")}
+													id="lang-input"
+												>
+													<ChipInput
+														inputRef={langInputRef}
+														inputId="lang-input"
+														chips={languages}
+														inputValue={langInput}
+														placeholder={t("profile.languagesPlaceholder")}
+														onInputChange={setLangInput}
+														onAdd={(v) =>
+															addChip(v, languages, setLanguages, setLangInput)
+														}
+														onRemove={(v) =>
+															removeChip(v, languages, setLanguages)
+														}
+														removeLabel={t("profile.removeChip")}
+													/>
+												</Field>
+
+												<Field
+													label={t("profile.fieldPreferredContact")}
+													id="preferred-contact"
+												>
+													<Dropdown
+														id="preferred-contact"
+														value={preferredContact}
+														onChange={(v) =>
+															setPreferredContact(v as ContactPref)
+														}
+														className={inputClass}
+														options={[
+															{
+																value: "",
+																label: t("profile.preferredContactNone"),
+															},
+															{
+																value: "Email",
+																label: t("profile.preferredContactEmail"),
+															},
+															{
+																value: "Phone",
+																label: t("profile.preferredContactPhone"),
+															},
+														]}
+													/>
+												</Field>
+											</div>
+										</section>
+
+										<div className="flex justify-end gap-3">
+											<button
+												type="button"
+												onClick={handleCancel}
+												className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+											>
+												{t("profile.cancel")}
+											</button>
+											<button
+												type="submit"
+												disabled={saving}
+												className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+											>
+												{saving ? t("profile.saving") : t("profile.save")}
+											</button>
+										</div>
+									</form>
+								)}
+
+								<div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6">
+									<h2 className="mb-1 text-base font-semibold text-gray-900">
+										{t("profile.sectionOrganization")}
+									</h2>
+									<p className="mb-4 text-sm text-gray-600">
+										{t("profile.createOrgHint")}
+									</p>
+									<button
+										type="button"
+										onClick={() => setShowCreateOrgModal(true)}
+										data-testid="create-org-btn"
+										className="rounded-md border border-brand-700 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-50"
+									>
+										{t("organization.create")}
+									</button>
+								</div>
+
+								<div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-6">
+									<h2 className="mb-1 text-base font-semibold text-red-800">
+										{t("account.dangerZoneTitle")}
+									</h2>
+									<p className="mb-4 text-sm text-red-700">
+										{t("account.dangerZoneDescription")}
+									</p>
+									<button
+										type="button"
+										onClick={() => setShowDeleteDialog(true)}
+										className="rounded-md border border-red-700 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+									>
+										{t("account.deleteAccountButton")}
+									</button>
+								</div>
+							</>
+						)}
+					</div>
+
+					{/* Achievements - merged into the Profile tab, matching the layout
+				    UserProfilePage.tsx already uses for the public view */}
+					{!profileLoading && (
+						<div className="mt-10">
+							{achievementsError && (
+								<p className="text-sm text-red-600">
+									{t("achievements.error", { message: achievementsError })}
+								</p>
+							)}
+
+							{!achievementsError && (
+								<>
+									<div className="mb-6 flex items-center justify-between">
+										<div />
+										<button
+											type="button"
+											onClick={() => setShareModalOpen(true)}
+											className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+										>
+											<svg
+												className="h-4 w-4"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth="1.5"
+												stroke="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
+												/>
+											</svg>
+											{t("achievements.shareButton")}
+										</button>
+									</div>
+
+									{streaks && (
+										<div className="mb-6 flex flex-wrap gap-3">
+											<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+												<span className="text-2xl" aria-hidden="true">
+													🔥
+												</span>
+												<div>
+													<p className="text-xl font-bold text-gray-900">
+														{streaks.loginStreak}
+													</p>
+													<p className="text-xs text-gray-500">
+														{t("achievements.loginStreak", {
+															count: streaks.loginStreak,
+														})}
+													</p>
+												</div>
+											</div>
+											<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+												<span className="text-2xl" aria-hidden="true">
+													📅
+												</span>
+												<div>
+													<p className="text-xl font-bold text-gray-900">
+														{streaks.activityStreak}
+													</p>
+													<p className="text-xs text-gray-500">
+														{t("achievements.activityStreak", {
+															count: streaks.activityStreak,
+														})}
+													</p>
+												</div>
+											</div>
+										</div>
+									)}
+
+									<section>
+										<h2 className="mb-4 text-base font-semibold text-gray-700">
+											{t("achievements.badgesTitle")}
+										</h2>
+										<BadgeGrid
+											earned={achievements}
+											catalog={catalog}
+											loading={achievementsLoading}
+										/>
+									</section>
+								</>
+							)}
+						</div>
+					)}
+				</>
+			)}
+
+			{/* Activity tab (Engagements + Invitations) */}
+			{activeTab === "activity" && (
+				<>
+					{/* Open invitations banner */}
+					{invitationsError && (
+						<p className="text-red-600">{invitationsError}</p>
+					)}
+					{invitationActionError && (
+						<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+							{invitationActionError}
+						</div>
+					)}
+					{!invitationsLoading && invitations.length > 0 && (
+						<div className="mb-8">
+							<h2 className="mb-3 text-base font-semibold text-gray-900">
+								{t("profileOverview.invitationsHeading")}
+							</h2>
+							<ul className="space-y-3">
+								{invitations.map((inv) => (
+									<li
+										key={inv.id}
+										className="rounded-xl border border-gray-100 bg-white px-4 py-4 shadow-sm"
+									>
+										<div className="flex items-start justify-between gap-3">
+											<div>
+												<p className="text-sm font-semibold text-gray-900">
+													{inv.organizationName}
+												</p>
+												<p className="mt-0.5 text-xs text-gray-500">
+													{t("invitations.invitedOn", {
+														date: new Date(inv.createdOn).toLocaleDateString(
+															locale,
+														),
+													})}
+												</p>
+											</div>
+											<div className="flex shrink-0 gap-2">
+												<button
+													type="button"
+													onClick={() => handleAcceptInvitation(inv.id)}
+													disabled={
+														acceptingId === inv.id || decliningId === inv.id
+													}
+													className="rounded-md bg-brand-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+												>
+													{acceptingId === inv.id
+														? t("invitations.accepting")
+														: t("invitations.accept")}
+												</button>
+												<button
+													type="button"
+													onClick={() => handleDeclineInvitation(inv.id)}
+													disabled={
+														acceptingId === inv.id || decliningId === inv.id
+													}
+													className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+												>
+													{decliningId === inv.id
+														? t("invitations.declining")
+														: t("invitations.decline")}
+												</button>
+											</div>
+										</div>
+									</li>
+								))}
+							</ul>
 						</div>
 					)}
 
-					{!profileLoading && (
-						<>
-							{profileError && (
-								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-									{profileError}
-								</div>
-							)}
-							{successMessage && (
-								<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
-									{successMessage}
-								</div>
-							)}
-
-							{/* View mode */}
-							{!editing && (
-								<div className="space-y-5">
-									<div className="flex items-start justify-between">
-										<div className="flex items-center gap-4">
-											{avatarUrl ? (
-												<img
-													src={avatarUrl}
-													alt=""
-													className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
-												/>
-											) : (
-												<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-													{profile?.username?.charAt(0).toUpperCase() ?? "?"}
-												</span>
-											)}
-											<div>
-												<p className="text-xl font-semibold text-gray-900">
-													{firstName || lastName
-														? `${firstName} ${lastName}`.trim()
-														: profile?.username}
-												</p>
-												<p className="text-sm text-gray-500">
-													@{profile?.username}
-												</p>
-												<p className="text-sm text-gray-500">
-													{profile?.email}
-												</p>
-											</div>
-										</div>
-										<button
-											type="button"
-											onClick={() => setEditing(true)}
-											className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-										>
-											{t("profile.edit")}
-										</button>
-									</div>
-
-									<ProfileFieldsView
-										bio={bio}
-										skills={skills}
-										languages={languages}
-										preferredContact={preferredContact || null}
-									/>
-								</div>
-							)}
-
-							{/* Edit mode */}
-							{editing && (
-								<form onSubmit={handleSave} className="space-y-6">
-									<section>
-										<h2 className="mb-4 text-base font-semibold text-gray-900">
-											{t("account.title")}
-										</h2>
-										<div className="space-y-5">
-											<div>
-												<p className="mb-1 block text-sm font-medium text-gray-700">
-													{t("profile.fieldAvatar")}
-												</p>
-												<div className="flex items-center gap-4">
-													{avatarUrl ? (
-														<img
-															src={avatarUrl}
-															alt=""
-															className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
-														/>
-													) : (
-														<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-															{profile?.username?.charAt(0).toUpperCase() ??
-																"?"}
-														</span>
-													)}
-													<div>
-														<label
-															htmlFor="avatar-upload"
-															className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingAvatar ? "opacity-50 pointer-events-none" : ""}`}
-														>
-															{uploadingAvatar
-																? t("profile.avatarUploading")
-																: t("profile.avatarUpload")}
-														</label>
-														<input
-															ref={avatarInputRef}
-															id="avatar-upload"
-															type="file"
-															accept="image/jpeg,image/png,image/webp"
-															className="sr-only"
-															onChange={handleAvatarChange}
-															disabled={uploadingAvatar}
-														/>
-														<p className="mt-1 text-xs text-gray-500">
-															{t("profile.avatarHint")}
-														</p>
-														{avatarError && (
-															<p className="mt-1 text-xs text-red-600">
-																{avatarError}
-															</p>
-														)}
-													</div>
-												</div>
-											</div>
-
-											<Field label={t("account.fieldUsername")} id="username">
-												<input
-													id="username"
-													disabled
-													value={profile?.username ?? ""}
-													className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
-												/>
-											</Field>
-
-											<Field label={t("account.fieldEmail")} id="email">
-												<input
-													id="email"
-													disabled
-													type="email"
-													value={profile?.email ?? ""}
-													className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
-												/>
-												<p className="mt-1 text-xs text-gray-500">
-													{t("account.emailHint")}
-												</p>
-											</Field>
-
-											<Field
-												label={t("account.fieldFirstName")}
-												id="first-name"
-											>
-												<input
-													id="first-name"
-													value={firstName}
-													onChange={(e) => setFirstName(e.target.value)}
-													className={inputClass}
-												/>
-											</Field>
-
-											<Field label={t("account.fieldLastName")} id="last-name">
-												<input
-													id="last-name"
-													value={lastName}
-													onChange={(e) => setLastName(e.target.value)}
-													className={inputClass}
-												/>
-											</Field>
-										</div>
-									</section>
-
-									<hr className="border-gray-200" />
-
-									<section>
-										<h2 className="mb-4 text-base font-semibold text-gray-900">
-											{t("profile.sectionDetails")}
-										</h2>
-										<div className="space-y-5">
-											<Field label={t("profile.fieldBio")} id="bio">
-												<textarea
-													id="bio"
-													rows={4}
-													value={bio}
-													placeholder={t("profile.bioPlaceholder")}
-													onChange={(e) => setBio(e.target.value)}
-													className={textareaClass}
-												/>
-											</Field>
-
-											<Field label={t("profile.fieldSkills")} id="skill-input">
-												<ChipInput
-													inputRef={skillInputRef}
-													inputId="skill-input"
-													chips={skills}
-													inputValue={skillInput}
-													placeholder={t("profile.skillsPlaceholder")}
-													onInputChange={setSkillInput}
-													onAdd={(v) =>
-														addChip(v, skills, setSkills, setSkillInput)
-													}
-													onRemove={(v) => removeChip(v, skills, setSkills)}
-													removeLabel={t("profile.removeChip")}
-												/>
-											</Field>
-
-											<Field
-												label={t("profile.fieldLanguages")}
-												id="lang-input"
-											>
-												<ChipInput
-													inputRef={langInputRef}
-													inputId="lang-input"
-													chips={languages}
-													inputValue={langInput}
-													placeholder={t("profile.languagesPlaceholder")}
-													onInputChange={setLangInput}
-													onAdd={(v) =>
-														addChip(v, languages, setLanguages, setLangInput)
-													}
-													onRemove={(v) =>
-														removeChip(v, languages, setLanguages)
-													}
-													removeLabel={t("profile.removeChip")}
-												/>
-											</Field>
-
-											<Field
-												label={t("profile.fieldPreferredContact")}
-												id="preferred-contact"
-											>
-												<Dropdown
-													id="preferred-contact"
-													value={preferredContact}
-													onChange={(v) =>
-														setPreferredContact(v as ContactPref)
-													}
-													className={inputClass}
-													options={[
-														{
-															value: "",
-															label: t("profile.preferredContactNone"),
-														},
-														{
-															value: "Email",
-															label: t("profile.preferredContactEmail"),
-														},
-														{
-															value: "Phone",
-															label: t("profile.preferredContactPhone"),
-														},
-													]}
-												/>
-											</Field>
-										</div>
-									</section>
-
-									<div className="flex justify-end gap-3">
-										<button
-											type="button"
-											onClick={handleCancel}
-											className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-										>
-											{t("profile.cancel")}
-										</button>
-										<button
-											type="submit"
-											disabled={saving}
-											className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-										>
-											{saving ? t("profile.saving") : t("profile.save")}
-										</button>
-									</div>
-								</form>
-							)}
-
-							<div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6">
-								<h2 className="mb-1 text-base font-semibold text-gray-900">
-									{t("profile.sectionOrganization")}
-								</h2>
-								<p className="mb-4 text-sm text-gray-600">
-									{t("profile.createOrgHint")}
-								</p>
-								<button
-									type="button"
-									onClick={() => setShowCreateOrgModal(true)}
-									data-testid="create-org-btn"
-									className="rounded-md border border-brand-700 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-50"
-								>
-									{t("organization.create")}
-								</button>
-							</div>
-
-							<div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-6">
-								<h2 className="mb-1 text-base font-semibold text-red-800">
-									{t("account.dangerZoneTitle")}
-								</h2>
-								<p className="mb-4 text-sm text-red-700">
-									{t("account.dangerZoneDescription")}
-								</p>
-								<button
-									type="button"
-									onClick={() => setShowDeleteDialog(true)}
-									className="rounded-md border border-red-700 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
-								>
-									{t("account.deleteAccountButton")}
-								</button>
-							</div>
-						</>
-					)}
-				</div>
-			)}
-
-			{/* Engagements tab */}
-			{activeTab === "engagements" && (
-				<>
 					<div className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
 						<button
 							type="button"
@@ -1068,168 +1230,6 @@ export default function ProfileOverviewPage() {
 								</button>
 							</div>
 						)}
-				</>
-			)}
-
-			{/* Achievements tab */}
-			{activeTab === "achievements" && (
-				<>
-					{achievementsError && (
-						<p className="text-sm text-red-600">
-							{t("achievements.error", { message: achievementsError })}
-						</p>
-					)}
-
-					{!achievementsError && (
-						<>
-							<div className="mb-6 flex items-center justify-between">
-								<div />
-								<button
-									type="button"
-									onClick={() => setShareModalOpen(true)}
-									className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-								>
-									<svg
-										className="h-4 w-4"
-										fill="none"
-										viewBox="0 0 24 24"
-										strokeWidth="1.5"
-										stroke="currentColor"
-										aria-hidden="true"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
-										/>
-									</svg>
-									{t("achievements.shareButton")}
-								</button>
-							</div>
-
-							{streaks && (
-								<div className="mb-6 flex flex-wrap gap-3">
-									<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-										<span className="text-2xl" aria-hidden="true">
-											🔥
-										</span>
-										<div>
-											<p className="text-xl font-bold text-gray-900">
-												{streaks.loginStreak}
-											</p>
-											<p className="text-xs text-gray-500">
-												{t("achievements.loginStreak", {
-													count: streaks.loginStreak,
-												})}
-											</p>
-										</div>
-									</div>
-									<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-										<span className="text-2xl" aria-hidden="true">
-											📅
-										</span>
-										<div>
-											<p className="text-xl font-bold text-gray-900">
-												{streaks.activityStreak}
-											</p>
-											<p className="text-xs text-gray-500">
-												{t("achievements.activityStreak", {
-													count: streaks.activityStreak,
-												})}
-											</p>
-										</div>
-									</div>
-								</div>
-							)}
-
-							<section>
-								<h2 className="mb-4 text-base font-semibold text-gray-700">
-									{t("achievements.badgesTitle")}
-								</h2>
-								<BadgeGrid
-									earned={achievements}
-									catalog={catalog}
-									loading={achievementsLoading}
-								/>
-							</section>
-						</>
-					)}
-				</>
-			)}
-
-			{/* Invitations tab */}
-			{activeTab === "invitations" && (
-				<>
-					{invitationsLoading && (
-						<p className="text-gray-500">{t("invitations.loading")}</p>
-					)}
-					{invitationsError && (
-						<p className="text-red-600">{invitationsError}</p>
-					)}
-					{invitationActionError && (
-						<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-							{invitationActionError}
-						</div>
-					)}
-					{!invitationsLoading &&
-						!invitationsError &&
-						invitations.length === 0 && (
-							<EmptyState
-								title={t("invitations.empty")}
-								message={t("invitations.emptyHint")}
-							/>
-						)}
-					{!invitationsLoading && invitations.length > 0 && (
-						<ul className="space-y-3">
-							{invitations.map((inv) => (
-								<li
-									key={inv.id}
-									className="rounded-xl border border-gray-100 bg-white px-4 py-4 shadow-sm"
-								>
-									<div className="flex items-start justify-between gap-3">
-										<div>
-											<p className="text-sm font-semibold text-gray-900">
-												{inv.organizationName}
-											</p>
-											<p className="mt-0.5 text-xs text-gray-500">
-												{t("invitations.invitedOn", {
-													date: new Date(inv.createdOn).toLocaleDateString(
-														locale,
-													),
-												})}
-											</p>
-										</div>
-										<div className="flex shrink-0 gap-2">
-											<button
-												type="button"
-												onClick={() => handleAcceptInvitation(inv.id)}
-												disabled={
-													acceptingId === inv.id || decliningId === inv.id
-												}
-												className="rounded-md bg-brand-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-											>
-												{acceptingId === inv.id
-													? t("invitations.accepting")
-													: t("invitations.accept")}
-											</button>
-											<button
-												type="button"
-												onClick={() => handleDeclineInvitation(inv.id)}
-												disabled={
-													acceptingId === inv.id || decliningId === inv.id
-												}
-												className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-											>
-												{decliningId === inv.id
-													? t("invitations.declining")
-													: t("invitations.decline")}
-											</button>
-										</div>
-									</div>
-								</li>
-							))}
-						</ul>
-					)}
 				</>
 			)}
 

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -78,7 +78,7 @@ export default function UserProfilePage() {
 				profile.skills.length > 0 ||
 				profile.languages.length > 0 ||
 				profile.preferredContact) && (
-				<div className="mb-8 max-w-2xl space-y-5">
+				<div className="mx-auto mb-8 max-w-2xl space-y-5">
 					<ProfileFieldsView
 						bio={profile.bio}
 						skills={profile.skills}

--- a/scripts/smoke-test-695-profile-tabs.mjs
+++ b/scripts/smoke-test-695-profile-tabs.mjs
@@ -1,0 +1,230 @@
+// Smoke test for #695:
+//
+// The own-profile page (/profile) was split into 4 separate tabs: Profile,
+// Engagements, Achievements, Invitations. Consolidated down to 2: "Profile"
+// (profile fields + achievements merged in below, matching the combined
+// layout /users/:userId already uses) and "Activity" (engagements + an
+// open-invitations banner above the list). Old ?tab=engagements/
+// achievements/invitations deep links (used by the /my-engagements and
+// /achievements redirects) must keep resolving to the right merged tab.
+// The achievements share URL now points at /users/:userId instead of
+// /users/:userId/achievements.
+//
+// Run: node scripts/smoke-test-695-profile-tabs.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function getUserId(token) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/userinfo`,
+		{ headers: { Authorization: `Bearer ${token}` } },
+	);
+	if (!res.ok) throw new Error(`Userinfo request failed: ${res.status}`);
+	const data = await res.json();
+	return data.sub;
+}
+
+async function createOrganization(token, name) {
+	const res = await fetch(`${API}/v1/organizations`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ name }),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create organization failed: ${res.status} ${await res.text()}`,
+		);
+	const org = await res.json();
+	return org.id.value ?? org.id;
+}
+
+async function createInvitation(token, orgId, inviteeId) {
+	const res = await fetch(`${API}/v1/organizations/${orgId}/invitations`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ inviteeId }),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create invitation failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function deleteOrganization(token, orgId) {
+	const res = await fetch(`${API}/v1/organizations/${orgId}`, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) throw new Error(`Delete organization failed: ${res.status}`);
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const suffix = Date.now();
+	const veraToken = await getToken("vera", "vera123");
+	const veraUserId = await getUserId(veraToken);
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgId = await createOrganization(
+		olafToken,
+		`Smoke695 Org ${suffix}`,
+	);
+	const invitation = await createInvitation(olafToken, orgId, veraUserId);
+	console.log(
+		`OK  Created org ${orgId} and invited vera (invitation ${invitation.invitationId})`,
+	);
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await loginAsUser(page, "vera", "vera123");
+		await page.goto(`${BASE}/profile`, { waitUntil: "networkidle" });
+
+		// === Tab bar shows exactly 2 tabs, not the old 4 ===
+		await page
+			.getByRole("button", { name: "Profile", exact: true })
+			.waitFor({ timeout: 20000 });
+		await page
+			.getByRole("button", { name: "Activity", exact: true })
+			.waitFor({ timeout: 5000 });
+		for (const oldLabel of ["Engagements", "Achievements", "Invitations"]) {
+			const count = await page
+				.getByRole("button", { name: oldLabel, exact: true })
+				.count();
+			if (count > 0) {
+				throw new Error(
+					`Old tab button "${oldLabel}" is still present - tabs were not consolidated`,
+				);
+			}
+		}
+		console.log(
+			'OK  Tab bar shows exactly "Profile" and "Activity" - no leftover Engagements/Achievements/Invitations buttons',
+		);
+
+		// === Achievements merged directly into the Profile tab ===
+		const shareBtn = page.getByRole("button", { name: "Share achievements" });
+		await shareBtn.waitFor({ timeout: 20000 });
+		console.log(
+			'OK  "Share achievements" button is visible on the Profile tab without switching tabs',
+		);
+
+		await shareBtn.click();
+		const dialog = page.locator("[role='dialog']");
+		await dialog.waitFor({ timeout: 10000 });
+		const shareUrlText = (await dialog.textContent()) ?? "";
+		if (
+			!shareUrlText.includes(`/users/${veraUserId}`) ||
+			shareUrlText.includes("/achievements")
+		) {
+			throw new Error(
+				`Share URL should point at the combined public profile (/users/${veraUserId}), dialog text was: ${shareUrlText}`,
+			);
+		}
+		console.log(
+			"OK  Share achievements URL points at the combined public profile, not the achievements-only page",
+		);
+		await page.keyboard.press("Escape");
+
+		// === Activity tab merges Engagements + an open-invitations banner ===
+		await page.getByRole("button", { name: "Activity", exact: true }).click();
+		await page
+			.locator("[data-testid='engagements-scope-upcoming']")
+			.waitFor({ timeout: 15000 });
+		await page.getByText("Open Invitations").waitFor({ timeout: 15000 });
+		await page
+			.getByText(`Smoke695 Org ${suffix}`)
+			.first()
+			.waitFor({ timeout: 10000 });
+		console.log(
+			"OK  Activity tab shows the engagements scope toggle and the open-invitations banner together",
+		);
+
+		await page.getByRole("button", { name: "Decline" }).first().click();
+		await page
+			.getByText(`Smoke695 Org ${suffix}`)
+			.waitFor({ state: "hidden", timeout: 10000 });
+		console.log("OK  Declining the invitation removes it from the banner");
+
+		// === Legacy ?tab= deep links keep resolving to the right merged tab ===
+		await page.goto(`${BASE}/profile?tab=achievements`, {
+			waitUntil: "networkidle",
+		});
+		await page
+			.getByRole("button", { name: "Share achievements" })
+			.waitFor({ timeout: 20000 });
+		console.log(
+			"OK  Legacy /profile?tab=achievements deep link still resolves to the Profile tab",
+		);
+
+		await page.goto(`${BASE}/profile?tab=engagements`, {
+			waitUntil: "networkidle",
+		});
+		await page
+			.locator("[data-testid='engagements-scope-upcoming']")
+			.waitFor({ timeout: 15000 });
+		console.log(
+			"OK  Legacy /profile?tab=engagements deep link still resolves to the Activity tab",
+		);
+	} finally {
+		await browser.close();
+	}
+
+	// --- Cleanup ---
+	await deleteOrganization(olafToken, orgId);
+	console.log("OK  Cleaned up test organization");
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Addresses #695: the own-profile page (`/profile`) had 4 separate tabs (Profile, Engagements, Achievements, Invitations), each thin relative to the page width, with achievements split away from the profile fields it's supposed to accompany.
- Consolidates to 2 tabs:
  - **Profile** - unchanged profile fields/edit-form/org-creation/danger-zone, plus the achievements section (streaks, share button, badge grid) merged directly below, matching the combined layout `UserProfilePage.tsx` (`/users/:userId`) already uses for the public view.
  - **Activity** - the existing Engagements content, with an "Open Invitations" banner shown above the engagement list when there are any pending invitations.
- The achievements share URL now points at the combined public profile (`/users/:userId`) instead of the achievements-only deep link (`/users/:userId/achievements`).
- Fixes `UserProfilePage.tsx`'s `ProfileFieldsView` wrapper missing `mx-auto` (same pattern as #694, called out explicitly in #695).
- Old `?tab=engagements` / `?tab=achievements` / `?tab=invitations` deep links (used by the `/my-engagements` and `/achievements` redirects, and any old bookmarks/shared links) keep resolving to the correct merged tab via an alias map, so nothing existing breaks.
- Removed the now-unused `invitations.loading`/`invitations.empty`/`invitations.emptyHint` locale keys (the invitations banner only renders when there's something to show, per the issue's "banner" framing).
- Added a "My Engagements" heading to the Activity tab for heading-hierarchy parity with the new invitations banner's heading (flagged by `a11y-check`).
- Updated `backend/tests/VisualTests/AchievementsTests.cs` - CI caught that `ShareButton_OpensModal_WithQrCodeAndCopyLink` still asserted the old achievements-only share URL; updated it to assert the new `/users/:userId` URL instead.

## Test plan

- [x] `pnpm check` (tsc) - passes
- [x] `pnpm lint` - passes, zero warnings
- [x] `pnpm format:write` - applied
- [x] `dotnet build` (backend, incl. VisualTests project) - passes
- [x] `dotnet test tests/Application.UnitTests` - 237/237 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] `/self-review` fan-out: `i18n-check` (PASS - en/de key parity confirmed, all `t()` calls resolve) and `a11y-check` (no rule violations; one heading-parity nit addressed)
- [x] Updated `backend/tests/VisualTests/ProfileOverviewTests.cs` for the new 2-tab bar
- [x] CI green on all 7 checks (build, lint, format-check, editorconfig, ban-typographic-dashes, PR-title, build-and-test incl. IntegrationTests + VisualTests)
- [x] Live verification against staging (release candidate v1.0.0-rc.241) - see below

## Live verification

Cut release candidate `v1.0.0-rc.241` from this branch (note: `v1.0.0-rc.240` was claimed by a concurrent session's unrelated commit in a race - see the tag history - so this PR's RC is 241) and deployed to staging via `publish.yml`/`deploy-staging`. All three publish jobs (frontend/backend/keycloak) and `deploy-staging` succeeded.

Ran `scripts/smoke-test-695-profile-tabs.mjs` against `https://einsatzbereit.maik-hasler.de` immediately after deploy:

```
OK  API health check passed
OK  Created org ... and invited vera
OK  Tab bar shows exactly "Profile" and "Activity" - no leftover Engagements/Achievements/Invitations buttons
OK  "Share achievements" button is visible on the Profile tab without switching tabs
OK  Share achievements URL points at the combined public profile, not the achievements-only page
OK  Activity tab shows the engagements scope toggle and the open-invitations banner together
OK  Declining the invitation removes it from the banner
OK  Legacy /profile?tab=achievements deep link still resolves to the Profile tab
OK  Legacy /profile?tab=engagements deep link still resolves to the Activity tab
OK  Cleaned up test organization

ALL CHECKS PASSED
```

All 9 checks passed. This is not this routine's call to merge - ready for the repository owner's review.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RfRRYBaAgZAHbmSDSvgteL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfRRYBaAgZAHbmSDSvgteL)_