### PR TITLE
fix: bucket non-terminal engagements for deleted opportunities into Past

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -91,14 +91,28 @@ internal sealed class EngagementReadRepository(
 		// Current/upcoming vs. past split (#675): a checked-in Confirmed engagement
 		// represents a shift that has already happened, so it counts as past even
 		// though its status is not yet terminal.
+		//
+		// opportunityExists is only used to reclassify bucket membership below,
+		// not to join in opportunity data - that still happens separately further
+		// down per the no-inner-join note above, so a deleted opportunity's
+		// engagements keep appearing here rather than vanishing per #667.
+		var opportunityExists = dbContext.VolunteerOpportunitiesQuery.Select(o => o.Id);
+
+		// A non-terminal engagement whose opportunity was deleted can never be
+		// confirmed, checked into, or otherwise acted on again, so it belongs in
+		// Past rather than staying in "Current & Upcoming" forever (#703).
 		scopedQuery = upcoming
 			? scopedQuery.Where(e =>
-				e.Status == EngagementStatus.Pending
-				|| (e.Status == EngagementStatus.Confirmed && !e.IsCheckedIn))
+				(e.Status == EngagementStatus.Pending
+					|| (e.Status == EngagementStatus.Confirmed && !e.IsCheckedIn))
+				&& opportunityExists.Contains(e.OpportunityId))
 			: scopedQuery.Where(e =>
 				e.Status == EngagementStatus.Cancelled
 				|| e.Status == EngagementStatus.Withdrawn
-				|| (e.Status == EngagementStatus.Confirmed && e.IsCheckedIn));
+				|| (e.Status == EngagementStatus.Confirmed && e.IsCheckedIn)
+				|| ((e.Status == EngagementStatus.Pending
+						|| (e.Status == EngagementStatus.Confirmed && !e.IsCheckedIn))
+					&& !opportunityExists.Contains(e.OpportunityId)));
 
 		var totalCount = await scopedQuery.CountAsync(cancellationToken);
 

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -255,6 +255,35 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		myEngagements.Items.Single().Status.Should().Be("Pending");
 	}
 
+	// ── Non-terminal engagement for a deleted opportunity (#703) ─────────────
+
+	[Test]
+	public async Task GetMyEngagements_MovesToPast_WhenOpportunityIsGoneAndEngagementIsNonTerminal(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		// Simulate the opportunity's row being gone without its engagements
+		// having been cancelled first - e.g. data predating the cancellation
+		// safeguard in DeleteVolunteerOpportunityCommandHandler. The engagement
+		// itself is left Pending, which the normal delete flow never produces.
+		await fixture.DeleteOpportunityRowDirectlyAsync(opportunity.Id);
+
+		var upcoming = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: true, cancellationToken);
+		upcoming.Items.Should().NotContain(e => e.Id == engagement.Id);
+
+		var past = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: false, cancellationToken);
+		past.Items.Should().ContainSingle(e => e.Id == engagement.Id && e.Status == "Pending");
+	}
+
 	// ── CheckInEngagement ────────────────────────────────────────────────────
 
 	[Test]

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -113,7 +113,7 @@ public class IntegrationTestFixture
 		await using var conn = new NpgsqlConnection(_connectionString);
 		await conn.OpenAsync();
 		await using var cmd = new NpgsqlCommand(
-			"DELETE FROM volunteer_opportunities WHERE id = @id", conn);
+			"DELETE FROM volunteer_opportunity WHERE id = @id", conn);
 		cmd.Parameters.AddWithValue("id", opportunityId);
 		await cmd.ExecuteNonQueryAsync();
 	}

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -105,6 +105,19 @@ public class IntegrationTestFixture
 		await _respawner.ResetAsync(conn);
 	}
 
+	// Test-only escape hatch to simulate an opportunity row removed without
+	// going through the command handler that cancels its engagements first -
+	// e.g. data predating that cancellation safeguard (#703).
+	public async Task DeleteOpportunityRowDirectlyAsync(Guid opportunityId)
+	{
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync();
+		await using var cmd = new NpgsqlCommand(
+			"DELETE FROM volunteer_opportunities WHERE id = @id", conn);
+		cmd.Parameters.AddWithValue("id", opportunityId);
+		await cmd.ExecuteNonQueryAsync();
+	}
+
 	public async Task ResetAsync()
 	{
 		await ResetDatabaseAsync();

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -2,6 +2,7 @@ using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 using Projects;
 using TUnit.Core.Interfaces;
 
@@ -12,6 +13,7 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 	private const string Realm = "einsatzbereit";
 
 	private DistributedApplication _app = null!;
+	private string _connectionString = null!;
 
 	public async Task InitializeAsync()
 	{
@@ -31,6 +33,22 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 
 		await WaitForRealmReadyAsync();
 		await WaitForBackendReadyAsync();
+
+		_connectionString = await _app.GetConnectionStringAsync("einsatzbereit")
+			?? throw new InvalidOperationException("Connection string 'einsatzbereit' not found.");
+	}
+
+	// Test-only escape hatch to simulate an opportunity row removed without
+	// going through the command handler that cancels its engagements first -
+	// e.g. data predating that cancellation safeguard (#703).
+	public async Task DeleteOpportunityRowDirectlyAsync(Guid opportunityId)
+	{
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync();
+		await using var cmd = new NpgsqlCommand(
+			"DELETE FROM volunteer_opportunity WHERE id = @id", conn);
+		cmd.Parameters.AddWithValue("id", opportunityId);
+		await cmd.ExecuteNonQueryAsync();
 	}
 
 	private async Task WaitForBackendReadyAsync()

--- a/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
@@ -84,6 +84,47 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 			.ToBeVisibleAsync(new() { Timeout = 15_000 });
 	}
 
+	/// <summary>
+	/// Regression for #703: a Pending/Confirmed-but-not-checked-in engagement
+	/// whose opportunity was removed without going through
+	/// DeleteVolunteerOpportunityCommandHandler's cancellation step (e.g. data
+	/// predating that safeguard) has no date field left to compare against and
+	/// no code path to re-evaluate it, so it stayed in "Current & Upcoming"
+	/// forever. The row is deleted directly here (bypassing the DELETE
+	/// endpoint, which already cancels active engagements on the normal path)
+	/// to reproduce that stale state.
+	/// </summary>
+	[Test]
+	public async Task MyEngagementsPage_MovesToPast_ForNonTerminalEngagementWithGoneOpportunity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistOrphanedUi");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		await Fixture.DeleteOpportunityRowDirectlyAsync(Guid.Parse(opportunityId));
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Default tab is "Current & Upcoming" - the orphaned Pending engagement
+		// must not appear here.
+		await Expect(Page.GetByText("This opportunity has been removed"))
+			.Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.Locator("[data-testid='engagements-scope-past']").ClickAsync();
+
+		await Expect(Page.GetByText("This opportunity has been removed").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
 	private static async Task<string> ApplyAsync(HttpClient http, string opportunityId, string message)
 	{
 		var response = await http.PostAsJsonAsync(

--- a/scripts/smoke-test-703-deleted-opportunity-engagement-past.mjs
+++ b/scripts/smoke-test-703-deleted-opportunity-engagement-past.mjs
@@ -1,0 +1,226 @@
+// Smoke test for #703:
+//
+// EngagementReadRepository.GetByVolunteerAsync bucketed a volunteer's own
+// engagements into "Current & Upcoming" vs. "Past" purely by
+// Engagement.Status. A Pending, or Confirmed-but-not-checked-in, engagement
+// whose opportunity had been hard-deleted has no date field left to compare
+// against and no code path ever re-evaluated it, so it stayed in "Current &
+// Upcoming" forever.
+//
+// Fix: GetByVolunteerAsync now also checks whether the engagement's
+// opportunity still exists. A non-terminal engagement whose opportunity is
+// gone is now bucketed into Past instead.
+//
+// Note on live-verification scope: DeleteVolunteerOpportunityCommandHandler
+// already cancels every active (Pending/Confirmed) engagement before
+// deleting the opportunity row, so a *freshly* deleted opportunity's
+// engagement always ends up Cancelled, not Pending/Confirmed - the exact
+// "opportunity gone but engagement still non-terminal" state #703 reports
+// can only arise from stale data (or any path that removes the row without
+// going through that handler), which cannot be reproduced against live
+// staging without direct DB access. That state - and the fix's bucketing of
+// it into Past - is covered by the new automated
+// IntegrationTests/EngagementTests.cs::GetMyEngagements_MovesToPast_WhenOpportunityIsGoneAndEngagementIsNonTerminal
+// and VisualTests/EngagementHistoryForDeletedOpportunityTests.cs::MyEngagementsPage_MovesToPast_ForNonTerminalEngagementWithGoneOpportunity
+// tests instead, both of which delete the opportunity row directly. This
+// script instead verifies the *normal* delete-opportunity path is
+// unaffected by the query rewrite: the Cancelled-and-deleted case (#667)
+// still resolves the same way as before.
+//
+// Run: node scripts/smoke-test-703-deleted-opportunity-engagement-past.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function createOpportunity(token, orgId, title) {
+	const res = await fetch(`${API}/v1/volunteer-opportunities`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			title,
+			description: "Automated smoke test opportunity for #703.",
+			organizationId: orgId,
+			isRemote: true,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			isDraft: false,
+		}),
+	});
+	if (!res.ok)
+		throw new Error(
+			`Create opportunity failed: ${res.status} ${await res.text()}`,
+		);
+	return res.json();
+}
+
+async function applyToOpportunity(token, opportunityId, message) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}/engagements`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ message }),
+		},
+	);
+	if (!res.ok)
+		throw new Error(`Apply failed: ${res.status} ${await res.text()}`);
+	return res.json();
+}
+
+async function deleteOpportunity(token, opportunityId) {
+	const res = await fetch(
+		`${API}/v1/volunteer-opportunities/${opportunityId}`,
+		{
+			method: "DELETE",
+			headers: { Authorization: `Bearer ${token}` },
+		},
+	);
+	if (!res.ok)
+		throw new Error(`Delete failed: ${res.status} ${await res.text()}`);
+}
+
+async function getMyEngagements(token, upcoming) {
+	const res = await fetch(
+		`${API}/v1/me/engagements?pageNumber=1&pageSize=50&upcoming=${upcoming}`,
+		{ headers: { Authorization: `Bearer ${token}` } },
+	);
+	if (!res.ok) throw new Error(`GET /me/engagements failed: ${res.status}`);
+	return res.json();
+}
+
+async function loginAsUser(page, username, password) {
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok)
+		throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgsRes = await fetch(`${API}/v1/organizations`, {
+		headers: { Authorization: `Bearer ${olafToken}` },
+	});
+	if (!orgsRes.ok)
+		throw new Error(`GET /organizations failed: ${orgsRes.status}`);
+	const orgs = await orgsRes.json();
+	if (!Array.isArray(orgs) || orgs.length === 0)
+		throw new Error("olaf has no organizations - cannot run this smoke test");
+	const orgId = orgs[0].id;
+
+	const opportunity = await createOpportunity(
+		olafToken,
+		orgId,
+		`Smoke703 EngagementBucketing ${Date.now()}`,
+	);
+	console.log(`OK  Created opportunity ${opportunity.id}`);
+
+	const veraToken = await getToken("vera", "vera123");
+	const engagement = await applyToOpportunity(
+		veraToken,
+		opportunity.id,
+		"Smoke test application for #703 - left Pending, never confirmed.",
+	);
+	console.log(`OK  vera applied (left Pending) - engagement ${engagement.id}`);
+
+	await deleteOpportunity(olafToken, opportunity.id);
+	console.log("OK  olaf deleted the opportunity");
+
+	// === Ground-truth data check: the normal delete flow still cancels a
+	// Pending engagement (not just Confirmed) and buckets it into Past. ===
+	const upcoming = await getMyEngagements(veraToken, true);
+	if (upcoming.items.some((e) => e.id === engagement.id)) {
+		throw new Error(
+			"Deleted-opportunity engagement unexpectedly still appears under upcoming=true",
+		);
+	}
+	console.log("OK  upcoming=true no longer lists the deleted-opportunity engagement");
+
+	const past = await getMyEngagements(veraToken, false);
+	const historyEntry = past.items.find((e) => e.id === engagement.id);
+	if (!historyEntry) {
+		throw new Error(
+			"Engagement for the deleted opportunity is missing from upcoming=false - it should still appear as Cancelled",
+		);
+	}
+	if (historyEntry.status !== "Cancelled") {
+		throw new Error(
+			`Expected status "Cancelled" for the deleted-opportunity engagement, got "${historyEntry.status}"`,
+		);
+	}
+	console.log(
+		"OK  upcoming=false lists the engagement, status Cancelled (normal delete-cancels-active-engagements path unaffected)",
+	);
+
+	// === UI check: "My Profile -> Activity" Past tab shows the fallback title ===
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await loginAsUser(page, "vera", "vera123");
+			await page.goto(`${BASE}/my-engagements`, { waitUntil: "networkidle" });
+
+			await page.click("[data-testid='engagements-scope-past']");
+
+			const fallbackTitle = page.getByText(
+				/this opportunity has been removed|dieser bedarf wurde entfernt/i,
+			);
+			await fallbackTitle.first().waitFor({ timeout: 15000 });
+			console.log(
+				'OK  "My Profile -> Activity" Past tab shows the fallback title for the deleted opportunity',
+			);
+		} finally {
+			await browser.close();
+		}
+	}
+
+	console.log(
+		"\nNote: the exact bug scenario (opportunity gone, engagement still Pending/Confirmed, i.e. not cancelled first) cannot be reproduced against live staging - the app's own delete flow always cancels active engagements first. That state is covered by the automated IntegrationTests/VisualTests added in this PR, which delete the opportunity row directly.",
+	);
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #703 - engagements for a deleted opportunity never leave "Current & Upcoming", regardless of age.

`EngagementReadRepository.GetByVolunteerAsync` (backing `GET /v1/me/engagements`, the volunteer's "My Profile -> Activity" list) bucketed a volunteer's own engagements into "Current & Upcoming" vs. "Past" purely by `Engagement.Status`. A `Pending`, or `Confirmed`-but-not-checked-in, engagement whose opportunity had been hard-deleted (its title already falls back to "This opportunity has been removed" per #667) has no date field left to compare against, and no code path ever re-evaluated it - so it stayed in "Current & Upcoming" indefinitely, with no way to ever leave it.

- `GetByVolunteerAsync` now also checks whether the engagement's `OpportunityId` still resolves to a live `VolunteerOpportunity` row. A non-terminal engagement whose opportunity is gone can never be confirmed, checked into, or otherwise acted on again by either party, so it's now bucketed into **Past** instead of **Current & Upcoming**.
- This is a pure read-time reclassification (no new column, no migration) - existing rows in this stale state are fixed as soon as they're queried, not just newly-deleted opportunities going forward.
- Left the existing badge (Pending/Confirmed) and the "This opportunity has been removed" fallback title as-is - only the bucket placement changes, per the issue's "at minimum" ask. A dedicated status/badge for this specific case was flagged as optional in the issue and not required to resolve the core problem.

## Test plan

- [x] `dotnet build` - passes, 0 warnings
- [x] `dotnet test tests/Application.UnitTests` - 237/237 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] `dotnet format --verify-no-changes` - clean
- [x] Added `IntegrationTests/EngagementTests.cs::GetMyEngagements_MovesToPast_WhenOpportunityIsGoneAndEngagementIsNonTerminal` - creates a `Pending` engagement, then removes the opportunity's row directly (via a new test-only `IntegrationTestFixture.DeleteOpportunityRowDirectlyAsync` helper) to simulate an opportunity gone without going through `DeleteVolunteerOpportunityCommandHandler`'s engagement-cancellation step (the scenario behind the currently-stale production rows), and asserts the engagement moves from the `upcoming=true` result into `upcoming=false`.
- [x] Added `VisualTests/EngagementHistoryForDeletedOpportunityTests.cs::MyEngagementsPage_MovesToPast_ForNonTerminalEngagementWithGoneOpportunity` - same scenario, browser-level, asserting the fallback title is absent under "Current & Upcoming" and present under "Past". Required adding a matching `AspireFixture.DeleteOpportunityRowDirectlyAsync` helper (VisualTests had no DB access before this PR).
- [x] `/self-review` fan-out: `ef-migration-check` (clean - confirmed no entity/Fluent API/`ApplicationDbContext` model changes, so no migration needed; the change is confined to a LINQ predicate)
- IntegrationTests/VisualTests need Testcontainers/Aspire (real container networking), not reliably available in this sandbox - verified via CI's `dotnet.yml`, which is green on this PR (build, lint, format-check, build-and-test all passing on commit `4ef330e`; `5c9b6e2`/`0453d9f` are test/script-only additions after that).

## Live verification

Cut release candidate `v1.0.0-rc.245` from this PR's branch (commit `4ef330e`); `deploy-staging` succeeded. `curl https://api.maik-hasler.de/health` returned `200`.

Ran `node scripts/smoke-test-703-deleted-opportunity-engagement-past.mjs` against `https://einsatzbereit.maik-hasler.de` - all checks passed:
- Created an opportunity, had vera apply (left `Pending`, never confirmed), had olaf delete the opportunity.
- `GET /v1/me/engagements?upcoming=true` no longer lists the engagement.
- `GET /v1/me/engagements?upcoming=false` lists it with status `Cancelled` (the normal delete-cancels-active-engagements path, unaffected by the query rewrite).
- "My Profile -> Activity" Past tab shows the "This opportunity has been removed" fallback title.

**Scope note:** the exact bug precondition from #703 - an opportunity gone but its engagement still `Pending`/`Confirmed` (i.e. never cancelled first) - can't be reproduced against live staging: the app's own delete flow (`DeleteVolunteerOpportunityCommandHandler`) always cancels active engagements before deleting the opportunity row, and there's no live-reachable path that skips that step. That's exactly why the bug exists only for stale/legacy data (or any future path that bypasses the handler) rather than anything a fresh live smoke test can trigger. That specific state - and the fix's bucketing of it into Past - is what the new `IntegrationTests`/`VisualTests` cases cover directly, by deleting the opportunity row without going through the handler.
