### PR TITLE
fix: allow saving partial edits to an existing draft opportunity

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -367,6 +367,82 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task EditWizard_ReopenedDraft_ShowsSaveAsDraftAndAcceptsPartialSave()
+	{
+		// Regression for #707: reopening a saved draft via "Edit" hid the
+		// "Save as draft" action entirely (gated on create-vs-edit mode
+		// instead of the opportunity's actual Draft/Published status), so an
+		// organizer could not persist further incremental edits without
+		// first satisfying full publish-level validation.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var uniqueTitle = $"Edit Draft Visual Test {Guid.NewGuid().ToString("N")[..8]}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
+		if (await switcherBtn.CountAsync() == 0)
+			return; // no org membership in seed - skip
+
+		await switcherBtn.First.ClickAsync();
+		var dashboardLink = Page.GetByTestId("org-dashboard-link");
+		if (await dashboardLink.CountAsync() == 0)
+			return; // no org selected in seed - skip
+
+		await dashboardLink.First.ClickAsync();
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		try
+		{
+			await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+		}
+		catch
+		{
+			return; // modal did not open - skip remaining assertions
+		}
+
+		// Deliberately leave the draft incomplete - only a title, no address,
+		// no description - the exact situation "save as draft" exists for.
+		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
+		await Page.GetByTestId("modal-save-draft").ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync();
+
+		// Reopen the draft via the dashboard's Drafts section.
+		var draftsSection = Page.GetByTestId("drafts-section");
+		await Expect(draftsSection).ToBeVisibleAsync();
+		await draftsSection.GetByRole(AriaRole.Link, new() { Name = uniqueTitle }).ClickAsync();
+
+		// On the draft's own detail page, open the edit wizard.
+		var editBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" });
+		await Expect(editBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await editBtn.ClickAsync();
+
+		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+
+		// The regression: this action must be available in edit mode too,
+		// since the opportunity being edited is still a Draft.
+		var saveDraftBtn = Page.GetByTestId("modal-save-draft");
+		await Expect(saveDraftBtn).ToBeVisibleAsync();
+
+		// Make an incremental edit - still no address, still no time slots -
+		// and persist it via "Save as draft" rather than the strict "Save".
+		var updatedTitle = $"{uniqueTitle} Updated";
+		await Page.Locator("#opportunity-title").FillAsync(updatedTitle);
+		await saveDraftBtn.ClickAsync();
+
+		// A lenient partial save must succeed without full-publish validation
+		// blocking it - the dialog closes and no validation error is shown.
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync();
+
+		// The edit persisted - the detail page reloads the opportunity after
+		// a successful save and reflects the new title.
+		await Expect(Page.Locator("h1").GetByText(updatedTitle)).ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task PublishWaitlist_BlockedWithNoTimeSlots_SucceedsAfterAddingOne()
 	{
 		// Regression for #542: a Waitlist opportunity could be published with

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -103,6 +103,10 @@ export default function CreateVolunteerOpportunityModal({
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const isEditMode = initialOpportunity !== undefined;
+	// A still-unpublished draft accepts lenient partial saves from any step,
+	// same as during initial creation - an already-published opportunity
+	// keeps the stricter publish-level validation on its single "Save" button.
+	const canSaveDraft = !isEditMode || initialOpportunity.status === "Draft";
 
 	const schema = useMemo(() => buildOpportunityFormSchema(t), [t]);
 	const {
@@ -749,7 +753,7 @@ export default function CreateVolunteerOpportunityModal({
 					</button>
 
 					<div className="flex items-center gap-2">
-						{!isEditMode && (
+						{canSaveDraft && (
 							<button
 								type="button"
 								data-testid="modal-save-draft"

--- a/scripts/smoke-test-707-edit-draft-save.mjs
+++ b/scripts/smoke-test-707-edit-draft-save.mjs
@@ -1,0 +1,156 @@
+// Smoke test for #707: reopening a saved draft volunteer opportunity via
+// "Edit" hid the "Save as draft" action entirely (gated on create-vs-edit
+// mode instead of the opportunity's actual Draft/Published status), so an
+// organizer could not persist further incremental edits without first
+// satisfying full publish-level validation. Verifies:
+//   1. A draft created with only a title (deliberately incomplete) can be
+//      reopened via "Edit".
+//   2. The "Save as draft" button IS now visible in edit mode (the
+//      regression - it used to be entirely absent).
+//   3. A partial edit (title change only, still no address/time slots) can
+//      be persisted via that button without full-publish validation
+//      blocking it.
+// Creates a throwaway organization + draft opportunity and deletes both
+// afterwards so this script doesn't leave junk data on the live site.
+// Run: node scripts/smoke-test-707-edit-draft-save.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const token = await getToken("olaf", "olaf123");
+	const authHeaders = {
+		Authorization: `Bearer ${token}`,
+		"Content-Type": "application/json",
+	};
+	console.log("OK  Got access token for olaf (organisator)");
+
+	const orgRes = await fetch(`${API}/v1/organizations`, {
+		method: "POST",
+		headers: authHeaders,
+		body: JSON.stringify({ name: `Smoke707 Org ${Date.now()}` }),
+	});
+	if (!orgRes.ok)
+		throw new Error(`Create organization failed: ${orgRes.status} ${await orgRes.text()}`);
+	const org = await orgRes.json();
+	const orgId = org.id.value;
+	console.log(`OK  Created throwaway organization ${orgId}`);
+
+	let opportunityId;
+	try {
+		const draftTitle = `Smoke707 Draft ${Date.now()}`;
+		const oppRes = await fetch(`${API}/v1/volunteer-opportunities`, {
+			method: "POST",
+			headers: authHeaders,
+			body: JSON.stringify({
+				title: draftTitle,
+				organizationId: orgId,
+				isRemote: true,
+				occurrence: "OneTime",
+				participationType: "IndividualContact",
+				checkInMethod: "None",
+				isDraft: true,
+			}),
+		});
+		if (!oppRes.ok)
+			throw new Error(`Create draft opportunity failed: ${oppRes.status} ${await oppRes.text()}`);
+		const opportunity = await oppRes.json();
+		opportunityId = opportunity.id;
+		if (opportunity.status !== "Draft")
+			throw new Error(`Expected Draft status, got ${opportunity.status}`);
+		console.log(`OK  Created draft opportunity ${opportunityId} (title only, no description/address)`);
+
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			await page.goto(BASE, { waitUntil: "networkidle" });
+			await page.click("text=/sign in|anmelden/i");
+			await page.waitForURL(/\/realms\//, { timeout: 30000 });
+			await loginKeycloak(page, "olaf", "olaf123");
+
+			await page.goto(`${BASE}/volunteer-opportunities/${opportunityId}`, {
+				waitUntil: "networkidle",
+			});
+
+			const editBtn = page.getByRole("button", { name: "Edit" });
+			await editBtn.waitFor({ state: "visible", timeout: 15000 });
+			await editBtn.click();
+			console.log("OK  Opened the draft's edit wizard via \"Edit\"");
+
+			const dialog = page.locator("[role='dialog']");
+			await dialog.waitFor({ state: "visible", timeout: 5000 });
+
+			// The regression: this action used to be entirely absent in edit mode.
+			const saveDraftBtn = page.getByTestId("modal-save-draft");
+			await saveDraftBtn.waitFor({ state: "visible", timeout: 5000 });
+			console.log(
+				'OK  "Save as draft" button IS visible while editing an existing draft (#707 fixed)',
+			);
+
+			const updatedTitle = `${draftTitle} Updated`;
+			await page.locator("#opportunity-title").fill(updatedTitle);
+			await saveDraftBtn.click();
+
+			// A lenient partial save must succeed without full-publish validation
+			// blocking it - still no address, still no time slots.
+			await dialog.waitFor({ state: "hidden", timeout: 10000 });
+			console.log("OK  Partial edit saved via \"Save as draft\" without full-publish validation blocking it");
+
+			await page.locator("h1", { hasText: updatedTitle }).waitFor({
+				state: "visible",
+				timeout: 10000,
+			});
+			console.log(`OK  Detail page reflects the persisted edit ("${updatedTitle}")`);
+		} finally {
+			await browser.close();
+		}
+	} finally {
+		if (opportunityId) {
+			await fetch(`${API}/v1/volunteer-opportunities/${opportunityId}`, {
+				method: "DELETE",
+				headers: authHeaders,
+			});
+		}
+		await fetch(`${API}/v1/organizations/${orgId}`, {
+			method: "DELETE",
+			headers: authHeaders,
+		});
+		console.log("OK  Cleaned up throwaway draft opportunity and organization");
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #707 - the "Save as draft" action in the create/edit volunteer opportunity wizard was gated purely on `!isEditMode`, so it never rendered while editing an already-saved draft. The only persist action left in that state was the single "Save" button on the last step, which runs full publish-level validation (every required field, plus at least one time slot for Waitlist opportunities) - blocking the exact lenient partial-save workflow "save as draft" exists for.

**Root cause and fix**

`frontend/src/components/CreateVolunteerOpportunityModal/index.tsx:105` derived `isEditMode` once from a stable prop and used it to gate the button's visibility for the modal's entire lifetime, regardless of which step/tab was active. This was purely a frontend gap - the backend already supports lenient partial updates to a `Draft`: `VolunteerOpportunity.Update()` (`backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs:196-197`) only runs the strict `EnsurePublishable(...)` check when `Status == OpportunityStatus.Published`, and `UpdateVolunteerOpportunityCommandHandler` already falls back gracefully on a blank title for a `Draft`.

The fix replaces the `!isEditMode` gate with `canSaveDraft = !isEditMode || initialOpportunity.status === "Draft"`, so:
- Creating a new opportunity: unchanged, draft-save always available.
- Editing an opportunity still in `Draft` status: draft-save is now available too, using the existing lenient `submit(true)` path (skips full-step validation and the Waitlist time-slot check, same as during creation).
- Editing an already-`Published` opportunity: unchanged, only the strict "Save" button is shown - published content stays under the stricter validation, per the issue's stated expectation.

No backend change was needed - the gap was entirely in the frontend gate.

## Test plan

- [x] `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- [x] `dotnet build` - 0 warnings, 0 errors
- [x] `dotnet test tests/Application.UnitTests` - 237/237 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] Added `VisualTests/VolunteerOpportunityTests.cs::EditWizard_ReopenedDraft_ShowsSaveAsDraftAndAcceptsPartialSave` - reproduces the exact scenario from the issue: create a draft with only a title, reopen it via "Edit", assert the draft-save button is now visible, make an incremental edit (still no address, no time slots) and persist it via that button without full-publish validation blocking it. Ran green in CI's `dotnet.yml`-equivalent `Publish Backend` job on the release candidate (Application.UnitTests, ArchitectureTests, IntegrationTests, and VisualTests all passed on a real runner with Testcontainers/Aspire).
- [x] `/self-review` fan-out: `a11y-check` (clean - pure boolean-condition change gating an existing, unmodified `<button>`; same testid/markup/ARIA, nothing new for axe-core to flag; noted as a non-blocking observation that `AccessibilityTests.cs`'s existing modal coverage only exercises create mode, not this new edit-mode-draft branch - the new VisualTests functional test covers the render path itself)

## Live verification

Verified against live staging (`https://einsatzbereit.maik-hasler.de`, backend `https://api.maik-hasler.de`) after release candidate `v1.0.0-rc.248` deployed successfully:

- [x] `curl -sf https://api.maik-hasler.de/health` -> HTTP 200
- [x] `node scripts/smoke-test-707-edit-draft-save.mjs` - all assertions passed (exit 0):
  ```
  OK  API health check passed
  OK  Got access token for olaf (organisator)
  OK  Created throwaway organization a1c1f16c-cfaf-43e0-a4fc-ee24cd4cc49d
  OK  Created draft opportunity 019f6ae8-2fee-7659-ab64-ab081e8e70d2 (title only, no description/address)
  OK  Opened the draft's edit wizard via "Edit"
  OK  "Save as draft" button IS visible while editing an existing draft (#707 fixed)
  OK  Partial edit saved via "Save as draft" without full-publish validation blocking it
  OK  Detail page reflects the persisted edit ("Smoke707 Draft 1784205027588 Updated")
  OK  Cleaned up throwaway draft opportunity and organization

  ALL CHECKS PASSED
  ```
  The script creates a throwaway organization + draft opportunity via the API, drives the real browser through the Keycloak login and the "Edit" wizard on the live site, and cleans up both afterward.
- [x] The same assertions are also covered by an automated C# TUnit test (`VisualTests/VolunteerOpportunityTests.cs::EditWizard_ReopenedDraft_ShowsSaveAsDraftAndAcceptsPartialSave`), which ran and passed against the local Aspire stack as part of CI on this release candidate.

This PR is open and awaiting the repository owner's review - this routine does not merge PRs itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_013fzKVrrEWm794GNWafSo6S)_