### PR TITLE
fix: show scheduled time slot on My Engagements cards

### DIFF
--- a/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
@@ -1,0 +1,96 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MyEngagementsTimeSlotTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	/// <summary>
+	/// Regression for #705: an engagement card for a "Scheduled slots" opportunity only
+	/// showed the "Signed up" date, never the opportunity's own scheduled time slot -
+	/// forcing volunteers to open the opportunity's detail page just to see when to show up.
+	/// </summary>
+	[Test]
+	public async Task ConfirmedEngagementWithTimeSlot_ShowsScheduledTimeSlot_OnEngagementCard()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualSlot {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"VisualSlot Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by MyEngagementsTimeSlotTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "Waitlist",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(3);
+		var end = start.AddHours(2);
+		var slotResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 });
+		slotResponse.EnsureSuccessStatusCode();
+		var slots = await slotResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var timeSlotId = slots[0].GetProperty("id").GetString();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		var engagementResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "Waitlist", timeSlotId, message = (string?)null });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await http.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The card must render the slot's own scheduled date, not just "Signed up: ...".
+		await Expect(row.GetByText("Scheduled:")).ToBeVisibleAsync();
+		await Expect(row.GetByText("Signed up:")).ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -485,6 +485,7 @@
       "scopeUpcoming": "Aktuell & Bevorstehend",
       "scopePast": "Vergangen",
       "loadMore": "Mehr laden",
+      "scheduledFor": "Termin: {{range}}",
       "registeredOn": "Angemeldet: {{date}}",
       "deletedOpportunityTitle": "Dieser Bedarf wurde entfernt",
       "checkIn": "Einchecken",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -485,6 +485,7 @@
       "scopeUpcoming": "Current & Upcoming",
       "scopePast": "Past",
       "loadMore": "Load more",
+      "scheduledFor": "Scheduled: {{range}}",
       "registeredOn": "Signed up: {{date}}",
       "deletedOpportunityTitle": "This opportunity has been removed",
       "checkIn": "Check in",

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -16,6 +16,7 @@ import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 import { inputClass, textareaClass } from "../lib/formClasses";
+import { formatDateTime } from "../lib/format";
 import AddToCalendarMenu from "../components/AddToCalendarMenu";
 import BadgeGrid from "../components/BadgeGrid";
 import CheckInModal from "../components/CheckInModal";
@@ -1128,6 +1129,13 @@ export default function ProfileOverviewPage() {
 												{e.message && (
 													<p className="mt-1 truncate text-sm italic text-gray-500">
 														&ldquo;{e.message}&rdquo;
+													</p>
+												)}
+												{e.timeSlotStartDateTime && e.timeSlotEndDateTime && (
+													<p className="mt-1 text-xs font-medium text-gray-700">
+														{t("myEngagements.scheduledFor", {
+															range: `${formatDateTime(e.timeSlotStartDateTime as unknown as string, i18n.language)} - ${formatDateTime(e.timeSlotEndDateTime as unknown as string, i18n.language)}`,
+														})}
 													</p>
 												)}
 												<p className="mt-1.5 text-xs text-gray-500">

--- a/scripts/smoke-test-705-engagement-timeslot.mjs
+++ b/scripts/smoke-test-705-engagement-timeslot.mjs
@@ -1,0 +1,151 @@
+/**
+ * Smoke test for #705: "My Profile -> Activity" engagement cards only ever
+ * showed the "Signed up: <date>" line, never the opportunity's own
+ * scheduled time slot - forcing a volunteer to open the opportunity's own
+ * detail page just to see when to show up for a "Scheduled slots"
+ * opportunity.
+ *
+ * Verifies against the live staging environment:
+ * - A Confirmed engagement with a time slot shows a "Scheduled: <range>"
+ *   line on its "My Engagements" card, distinct from the existing
+ *   "Signed up: <date>" line.
+ *
+ * Setup (org/opportunity/time slot/sign-up/confirm) is done directly
+ * against the API as olaf (organizer), mirroring smoke-test-572-calendar.mjs.
+ *
+ * Run: node scripts/smoke-test-705-engagement-timeslot.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+function getAccessToken(page) {
+	return page.evaluate(() => {
+		for (const k of Object.keys(localStorage)) {
+			if (k.includes("oidc")) {
+				return JSON.parse(localStorage.getItem(k)).access_token;
+			}
+		}
+		return null;
+	});
+}
+
+async function main() {
+	const apiRes = await fetch(`${API}/health`);
+	if (!apiRes.ok) throw new Error(`Health check failed: ${apiRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+
+	try {
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		if ((await signInBtn.count()) > 0) {
+			await signInBtn.first().click();
+			await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+			await loginKeycloak(page, "olaf", "olaf123");
+		}
+		await page.waitForSelector("main", { timeout: 10000 });
+		console.log("OK  Logged in as olaf");
+
+		const token = await getAccessToken(page);
+		if (!token) throw new Error("Could not read access token from localStorage");
+		const authed = (path, init = {}) =>
+			fetch(`${API}${path}`, {
+				...init,
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+					...init.headers,
+				},
+			});
+
+		const orgName = `Smoke705 ${Date.now()}`;
+		const orgRes = await authed("/v1/organizations", {
+			method: "POST",
+			body: JSON.stringify({ name: orgName }),
+		});
+		if (!orgRes.ok) throw new Error(`Create org failed: ${orgRes.status} ${await orgRes.text()}`);
+		const org = await orgRes.json();
+		const orgId = org.id?.value ?? org.id;
+		console.log(`OK  Created organization "${orgName}" (${orgId})`);
+
+		const oppTitle = `Smoke705 Scheduled Slot Test ${Date.now()}`;
+		const oppRes = await authed("/v1/volunteer-opportunities", {
+			method: "POST",
+			body: JSON.stringify({
+				title: oppTitle,
+				description: "Created by smoke-test-705-engagement-timeslot.mjs",
+				organizationId: orgId,
+				isRemote: true,
+				occurrence: "OneTime",
+				participationType: "Waitlist",
+				checkInMethod: "None",
+				isDraft: true,
+			}),
+		});
+		if (!oppRes.ok) throw new Error(`Create opportunity failed: ${oppRes.status} ${await oppRes.text()}`);
+		const opp = await oppRes.json();
+		console.log(`OK  Created opportunity "${oppTitle}" (${opp.id})`);
+
+		const start = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+		const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+		const slotRes = await authed(`/v1/volunteer-opportunities/${opp.id}/time-slots`, {
+			method: "POST",
+			body: JSON.stringify({
+				startDateTime: start.toISOString(),
+				endDateTime: end.toISOString(),
+				maxParticipants: 5,
+				recurrenceCount: 1,
+			}),
+		});
+		if (!slotRes.ok) throw new Error(`Create time slot failed: ${slotRes.status} ${await slotRes.text()}`);
+		const [slot] = await slotRes.json();
+		console.log(`OK  Created time slot ${slot.id} (${start.toISOString()} - ${end.toISOString()})`);
+
+		const publishRes = await authed(`/v1/volunteer-opportunities/${opp.id}/publish`, { method: "POST" });
+		if (!publishRes.ok) throw new Error(`Publish failed: ${publishRes.status} ${await publishRes.text()}`);
+		console.log("OK  Published opportunity");
+
+		const engagementRes = await authed(`/v1/volunteer-opportunities/${opp.id}/engagements`, {
+			method: "POST",
+			body: JSON.stringify({ type: "Waitlist", timeSlotId: slot.id, message: null }),
+		});
+		if (!engagementRes.ok) throw new Error(`Sign-up failed: ${engagementRes.status} ${await engagementRes.text()}`);
+		const engagement = await engagementRes.json();
+		console.log(`OK  Signed up (engagement ${engagement.id})`);
+
+		const confirmRes = await authed(`/v1/engagements/${engagement.id}/confirm`, { method: "POST" });
+		if (!confirmRes.ok) throw new Error(`Confirm failed: ${confirmRes.status} ${await confirmRes.text()}`);
+		console.log("OK  Confirmed engagement");
+
+		// --- UI: "My Engagements" shows the new "Scheduled:" time slot line ---
+		await page.goto(`${BASE}/profile?tab=engagements`, { waitUntil: "networkidle" });
+		const row = page.locator("li", { hasText: oppTitle });
+		await row.waitFor({ state: "visible", timeout: 15000 });
+		console.log("OK  Confirmed engagement visible in My Engagements");
+
+		const scheduledText = await row.getByText(/^Scheduled:/).textContent();
+		if (!scheduledText) {
+			throw new Error('Engagement card is missing the "Scheduled: <range>" line (#705 not fixed)');
+		}
+		console.log(`OK  Engagement card shows the opportunity's own scheduled time slot: "${scheduledText.trim()}"`);
+
+		const signedUpCount = await row.getByText(/^Signed up:/).count();
+		if (signedUpCount === 0) {
+			throw new Error('Engagement card unexpectedly lost the existing "Signed up: <date>" line');
+		}
+		console.log('OK  Existing "Signed up:" line is still present alongside the new "Scheduled:" line');
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #705 - engagement cards on "My Profile -> Activity" (`ProfileOverviewPage`'s Activity tab, `GET /v1/me/engagements`) only rendered the "Signed up: DD/MM/YYYY" line, never the opportunity's own scheduled time slot. For a "Scheduled slots" opportunity this hides a real, different date (when the deployment actually happens) from when the volunteer applied - forcing a volunteer to open each opportunity's own detail page just to check when to show up.

**Root cause and fix**

Purely a frontend rendering gap - the backend already returns the data. `EngagementReadRepository.GetByVolunteerAsync` (`backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs:159-183`) already joins in the `TimeSlot` and populates `EngagementSummary.TimeSlotStartDateTime`/`TimeSlotEndDateTime` - proven by the existing "Add to Calendar" button on the same card, which already consumes those same two fields. `ProfileOverviewPage.tsx` just never rendered them as text.

The fix adds a `"Scheduled: <range>"` line to each engagement card, shown whenever both `timeSlotStartDateTime` and `timeSlotEndDateTime` are present (i.e. for any "Scheduled slots" engagement with an assigned time slot, regardless of status), positioned above the existing "Signed up" line so the more actionable date is not buried below the account/meta info. Uses the existing `formatDateTime` helper (same formatting already used by `EngagementManagementPage.tsx` and `VolunteerOpportunityDetailPage.tsx` for time slot ranges) for consistency.

No backend change was needed.

## Test plan

- [x] `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- [x] `dotnet build backend/tests/VisualTests/VisualTests.csproj` - 0 warnings, 0 errors
- [x] `Application.UnitTests` - 237/237 passed
- [x] `ArchitectureTests` - 247/247 passed
- [x] Added `VisualTests/MyEngagementsTimeSlotTests.cs::ConfirmedEngagementWithTimeSlot_ShowsScheduledTimeSlot_OnEngagementCard` - creates a throwaway org + Scheduled-slots opportunity + time slot via the API, confirms an engagement against it, and asserts the "My Engagements" card shows both the new "Scheduled:" line and the existing "Signed up:" line. Ran green in CI's `dotnet.yml`-equivalent `Publish Backend` job on the release candidate (Application.UnitTests, ArchitectureTests, **IntegrationTests, and VisualTests all passed on a real runner with Testcontainers/Aspire**).
- [x] `/self-review` fan-out: `a11y-check` (clean - plain text `<p>`, no new interactive elements/links/icons; `AccessibilityTests.cs` already covers `/my-engagements`, no new entry needed), `i18n-check` (clean - `myEngagements.scheduledFor` key parity confirmed in en/de across all 684 keys, `range` interpolation variable matches)

## Live verification

Verified against live staging (`https://einsatzbereit.maik-hasler.de`, backend `https://api.maik-hasler.de`) after release candidate `v1.0.0-rc.249` deployed successfully:

- [x] `curl -sf https://api.maik-hasler.de/health` -> `Healthy`, HTTP 200
- [x] `node scripts/smoke-test-705-engagement-timeslot.mjs` - all assertions passed (exit 0):
  ```
  OK  API health check passed
  OK  Logged in as olaf
  OK  Created organization "Smoke705 1784216558936" (fe430013-befb-4096-807c-c83d1d08b2d1)
  OK  Created opportunity "Smoke705 Scheduled Slot Test 1784216560425" (019f6b98-2463-7421-b531-f5aafe2169b3)
  OK  Created time slot 019f6b98-271d-73d8-a6ae-a8d756a8dbf3 (2026-07-19T15:42:41.019Z - 2026-07-19T17:42:41.019Z)
  OK  Published opportunity
  OK  Signed up (engagement 019f6b98-29a1-7940-b4a0-300003683c32)
  OK  Confirmed engagement
  OK  Confirmed engagement visible in My Engagements
  OK  Engagement card shows the opportunity's own scheduled time slot: "Scheduled: 19 Jul 2026, 15:42 - 19 Jul 2026, 17:42"
  OK  Existing "Signed up:" line is still present alongside the new "Scheduled:" line

  ALL CHECKS PASSED
  ```
  The script creates a throwaway organization + Scheduled-slots opportunity + time slot + engagement via the API as olaf, drives the real browser through Keycloak login and "My Engagements", and confirms the new line renders without regressing the existing "Signed up:" line.
- [x] The same assertions are also covered by an automated C# TUnit test (`VisualTests/MyEngagementsTimeSlotTests.cs::ConfirmedEngagementWithTimeSlot_ShowsScheduledTimeSlot_OnEngagementCard`), which ran and passed against the local Aspire stack as part of CI on this release candidate (see Test plan above).

This PR is open and awaiting the repository owner's review - this routine does not merge PRs itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197UueexEpHbnpPMUbDjzoe)_