### PR TITLE
fix: wire hero "Register your organisation" CTA to real org creation

### DIFF
--- a/backend/tests/VisualTests/HomePageOrgCtaTests.cs
+++ b/backend/tests/VisualTests/HomePageOrgCtaTests.cs
@@ -1,0 +1,53 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class HomePageOrgCtaTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Anonymous_HeroOrgCta_RedirectsToKeycloakRegistrationEndpoint()
+	{
+		// #693: the hero's second CTA is labelled "Create an organisation" - it must
+		// behave like the header's "Register" button (registration, not a plain login),
+		// and it must stay visible for anonymous visitors (this is the case here).
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Create an organisation" })
+			.First.ClickAsync();
+
+		await Expect(Page).ToHaveURLAsync(
+			new Regex(@"/realms/einsatzbereit/protocol/openid-connect/registrations"));
+		await Expect(Page.Locator("#kc-register-form")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+	}
+
+	[Test]
+	public async Task Authenticated_HeroOrgCta_OpensCreateOrganizationModalInPlace()
+	{
+		// #693: for a signed-in visitor the CTA must stay visible (previously it
+		// vanished once authenticated) and open org creation directly on the
+		// homepage, with no navigation away.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var cta = Page.GetByRole(AriaRole.Button, new() { Name = "Create an organisation" });
+		await Expect(cta.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await cta.First.ClickAsync();
+
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(dialog.GetByText("Create organization")).ToBeVisibleAsync();
+
+		await Expect(Page).ToHaveURLAsync($"{origin}/");
+
+		await Page.Locator("[data-testid='modal-cancel']").ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -35,7 +35,7 @@
       "heroTitle": "Ehrenamt muss nicht schwer sein.",
       "heroSubtitle": "Immer weniger Menschen engagieren sich - aus Zeitmangel, Aufwand und Bürokratie. Einsatzbereit macht Mikro-Ehrenamt möglich: ein paar Stunden, echter Impact, null Overhead.",
       "heroCta": "Einsätze finden",
-      "heroCtaOrg": "Organisation registrieren",
+      "heroCtaOrg": "Organisation erstellen",
       "heroStat1Value": "2 min",
       "heroStat1Label": "bis zur Anmeldung",
       "heroStat2Value": "0 €",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -35,7 +35,7 @@
       "heroTitle": "Volunteering doesn't have to be hard.",
       "heroSubtitle": "Fewer people volunteer each year - due to time pressure, effort, and bureaucracy. Einsatzbereit makes micro-volunteering possible: a few hours, real impact, zero overhead.",
       "heroCta": "Find opportunities",
-      "heroCtaOrg": "Register your organisation",
+      "heroCtaOrg": "Create an organisation",
       "heroStat1Value": "2 min",
       "heroStat1Label": "to sign up",
       "heroStat2Value": "€0",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useId, useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router";
 import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList";
+import CreateOrganizationModal from "../components/CreateOrganizationModal";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { signinLocaleArgs } from "../lib/authLocale";
+import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 
 const ONBOARDING_KEY = "onboarding-dismissed";
 
@@ -114,6 +117,8 @@ export default function HomePage() {
 	const missionTitleId = useId();
 
 	const [showOnboarding, setShowOnboarding] = useState(false);
+	const [showCreateOrgModal, setShowCreateOrgModal] = useState(false);
+	const [searchParams, setSearchParams] = useSearchParams();
 
 	useEffect(() => {
 		if (auth.isAuthenticated && !localStorage.getItem(ONBOARDING_KEY)) {
@@ -121,9 +126,29 @@ export default function HomePage() {
 		}
 	}, [auth.isAuthenticated]);
 
+	useEffect(() => {
+		if (searchParams.get("createOrg") === "1" && auth.isAuthenticated) {
+			setShowCreateOrgModal(true);
+			const next = new URLSearchParams(searchParams);
+			next.delete("createOrg");
+			setSearchParams(next, { replace: true });
+		}
+	}, [searchParams, auth.isAuthenticated, setSearchParams]);
+
 	function handleDismissOnboarding() {
 		localStorage.setItem(ONBOARDING_KEY, "1");
 		setShowOnboarding(false);
+	}
+
+	function handleOrgCta() {
+		if (auth.isAuthenticated) {
+			setShowCreateOrgModal(true);
+		} else {
+			void signinRedirectForRegistration({
+				...signinLocaleArgs(),
+				state: { returnTo: "/?createOrg=1" },
+			});
+		}
 	}
 
 	const steps = [
@@ -307,15 +332,13 @@ export default function HomePage() {
 							>
 								{t("landing.heroCta")}
 							</a>
-							{!auth.isAuthenticated && (
-								<button
-									type="button"
-									onClick={() => void auth.signinRedirect(signinLocaleArgs())}
-									className="w-full rounded-xl border border-white/50 px-8 py-3 text-base font-semibold text-white transition-colors hover:border-white hover:bg-brand-700 sm:w-auto sm:py-3.5"
-								>
-									{t("landing.heroCtaOrg")}
-								</button>
-							)}
+							<button
+								type="button"
+								onClick={handleOrgCta}
+								className="w-full rounded-xl border border-white/50 px-8 py-3 text-base font-semibold text-white transition-colors hover:border-white hover:bg-brand-700 sm:w-auto sm:py-3.5"
+							>
+								{t("landing.heroCtaOrg")}
+							</button>
 						</div>
 						<div className="animate-fade-up-d4 mt-8 hidden grid-cols-3 gap-6 border-t border-white/10 pt-8 sm:mt-12 sm:grid sm:pt-10">
 							{stats.map(({ id, value, label }) => (
@@ -465,6 +488,13 @@ export default function HomePage() {
 				)}
 				<VolunteerOpportunitiesList />
 			</div>
+
+			{showCreateOrgModal && (
+				<CreateOrganizationModal
+					onClose={() => setShowCreateOrgModal(false)}
+					onSuccess={() => setShowCreateOrgModal(false)}
+				/>
+			)}
 		</>
 	);
 }


### PR DESCRIPTION
## Summary

Addresses #693 - the second CTA button in the homepage hero was labelled "Register your organisation" (`landing.heroCtaOrg`), but its `onClick` was just a generic `auth.signinRedirect()` - the same call as the header's plain "Sign in" button, no different flow, no org-specific destination. It also only rendered `!auth.isAuthenticated`, so it disappeared entirely for signed-in visitors.

The issue owner left an explicit decision comment resolving both problems and outlining the fix (quoted below), so this PR implements that decision directly rather than re-litigating it.

**Decision (from the issue thread):**
> Decision: wire the CTA to real org creation, for both auth states.
> - Copy: swap `landing.heroCtaOrg` from "Register your organisation" to "Create an organisation"
> - Always render the button regardless of `auth.isAuthenticated`
> - Logged out: call `signinRedirectForRegistration(signinLocaleArgs())` instead of the plain `auth.signinRedirect()` - carry a hint through the OIDC round-trip so org creation opens automatically once the callback completes
> - Logged in: open the existing `CreateOrganizationModal` directly in place - no navigation away from the homepage

## Changes

- `frontend/src/locales/{en,de}.json`: `landing.heroCtaOrg` -> "Create an organisation" / "Organisation erstellen" (reusing the already-translated `landing.ngoCta` copy per the decision, rather than inventing new strings).
- `frontend/src/pages/HomePage.tsx`:
  - The CTA button is now always rendered (dropped the `!auth.isAuthenticated &&` guard).
  - `handleOrgCta()`: if authenticated, opens `CreateOrganizationModal` in place (same show/hide pattern already used in `ProfileOverviewPage.tsx` / `OrganizationSwitcher.tsx`); otherwise calls `signinRedirectForRegistration` (existing helper, unchanged) with `state: { returnTo: "/?createOrg=1" }`.
  - A small effect reads `?createOrg=1` off the URL on mount - if present and the visitor is now authenticated (i.e. they just came back from the registration round-trip), it opens the modal automatically and strips the query param via `setSearchParams(..., { replace: true })`. This reuses the existing `user.state.returnTo` -> `window.location.replace(returnTo)` mechanism already wired in `main.tsx` (the same one `ProtectedRoute.tsx` uses) - no new auth plumbing needed.

No backend change was needed - `signinRedirectForRegistration`, `CreateOrganizationModal`, and `createOrganization` all already existed.

## Test plan

- [x] `pnpm check` (tsc), `pnpm lint --max-warnings 0`, `pnpm format:write` - all clean
- [x] `dotnet build backend/tests/VisualTests/VisualTests.csproj` - 0 warnings, 0 errors
- [x] `/self-review` fan-out: `a11y-check` (clean - button unchanged aside from no longer being conditionally wrapped; modal invocation matches the existing backdrop-button/`role=dialog` convention used elsewhere; Home already has `AccessibilityTests.cs` coverage, no new route added), `i18n-check` (clean - `heroCtaOrg` value-only change in both locale files, key parity intact, 683/683 keys match)
- [x] Added `VisualTests/HomePageOrgCtaTests.cs`:
  - `Anonymous_HeroOrgCta_RedirectsToKeycloakRegistrationEndpoint` - clicking the CTA while logged out lands on Keycloak's `/protocol/openid-connect/registrations` form (not the plain login form)
  - `Authenticated_HeroOrgCta_OpensCreateOrganizationModalInPlace` - clicking the CTA while logged in (as olaf) opens the `CreateOrganizationModal` dialog directly on the homepage, with no navigation away
  - `IntegrationTests`/full `VisualTests` run need Testcontainers/Aspire (not reliably available in this sandbox) - relying on CI's `dotnet.yml` for those, plus the live-verification pass below.

## Live verification

_To be added once the release-candidate deploy completes._

This PR is open and awaiting the repository owner's review - this routine does not merge PRs itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T5gfTsLUsQAa9D56aAmnit)_