### PR TITLE
refactor: reorder profile achievements above account actions, adopt grid layout

### DIFF
--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -88,6 +88,44 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 	}
 
 	[Test]
+	public async Task ProfilePage_RendersAchievementsAboveAccountActionCards()
+	{
+		// #706: achievements used to render last on the Profile tab, below the
+		// "Create organization" and "Danger zone" cards, in a full-width block
+		// that visually broke away from the narrower profile column above it.
+		// They should now render above both account-action cards.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		await Page.GotoAsync($"{origin}/profile");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var badgesHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Badges" });
+		var organizationsHeading = Page.GetByRole(
+			AriaRole.Heading,
+			new() { Name = "Organizations" }
+		);
+		var dangerZoneHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Danger zone" });
+
+		await Expect(badgesHeading).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(organizationsHeading).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(dangerZoneHeading).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var badgesBox = await badgesHeading.BoundingBoxAsync();
+		var organizationsBox = await organizationsHeading.BoundingBoxAsync();
+		var dangerZoneBox = await dangerZoneHeading.BoundingBoxAsync();
+
+		badgesBox.Should().NotBeNull();
+		organizationsBox.Should().NotBeNull();
+		dangerZoneBox.Should().NotBeNull();
+
+		badgesBox!.Y.Should().BeLessThan(organizationsBox!.Y, "achievements must render above the account cards");
+		badgesBox.Y.Should().BeLessThan(dangerZoneBox!.Y, "achievements must render above the account cards");
+	}
+
+	[Test]
 	public async Task PublicUserProfile_ShowsBioSkillsLanguagesAndPreferredContact()
 	{
 		// #576: bio/skills/languages/preferredContact were captured on the owner's

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -559,403 +559,413 @@ export default function ProfileOverviewPage() {
 			{/* Profile tab */}
 			{activeTab === "profile" && (
 				<>
-					<div className="mx-auto max-w-2xl">
-						{profileLoading && (
-							<div className="flex items-center justify-center py-16">
-								<span className="text-gray-500">{t("profile.loading")}</span>
-							</div>
-						)}
+					{profileLoading && (
+						<div className="flex items-center justify-center py-16">
+							<span className="text-gray-500">{t("profile.loading")}</span>
+						</div>
+					)}
 
-						{!profileLoading && (
-							<>
-								{profileError && (
-									<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-										{profileError}
-									</div>
-								)}
-								{successMessage && (
-									<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
-										{successMessage}
-									</div>
-								)}
-
-								{/* View mode */}
-								{!editing && (
-									<div className="space-y-5">
-										<div className="flex items-start justify-between">
-											<div className="flex items-center gap-4">
-												{avatarUrl ? (
-													<img
-														src={avatarUrl}
-														alt=""
-														className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
-													/>
-												) : (
-													<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-														{profile?.username?.charAt(0).toUpperCase() ?? "?"}
-													</span>
-												)}
-												<div>
-													<p className="text-xl font-semibold text-gray-900">
-														{firstName || lastName
-															? `${firstName} ${lastName}`.trim()
-															: profile?.username}
-													</p>
-													<p className="text-sm text-gray-500">
-														@{profile?.username}
-													</p>
-													<p className="text-sm text-gray-500">
-														{profile?.email}
-													</p>
-												</div>
-											</div>
-											<button
-												type="button"
-												onClick={() => setEditing(true)}
-												className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-											>
-												{t("profile.edit")}
-											</button>
-										</div>
-
-										<ProfileFieldsView
-											bio={bio}
-											skills={skills}
-											languages={languages}
-											preferredContact={preferredContact || null}
-										/>
-									</div>
-								)}
-
-								{/* Edit mode */}
-								{editing && (
-									<form onSubmit={handleSave} className="space-y-6">
-										<section>
-											<h2 className="mb-4 text-base font-semibold text-gray-900">
-												{t("account.title")}
-											</h2>
-											<div className="space-y-5">
-												<div>
-													<p className="mb-1 block text-sm font-medium text-gray-700">
-														{t("profile.fieldAvatar")}
-													</p>
-													<div className="flex items-center gap-4">
-														{avatarUrl ? (
-															<img
-																src={avatarUrl}
-																alt=""
-																className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
-															/>
-														) : (
-															<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-																{profile?.username?.charAt(0).toUpperCase() ??
-																	"?"}
-															</span>
-														)}
-														<div>
-															<label
-																htmlFor="avatar-upload"
-																className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingAvatar ? "opacity-50 pointer-events-none" : ""}`}
-															>
-																{uploadingAvatar
-																	? t("profile.avatarUploading")
-																	: t("profile.avatarUpload")}
-															</label>
-															<input
-																ref={avatarInputRef}
-																id="avatar-upload"
-																type="file"
-																accept="image/jpeg,image/png,image/webp"
-																className="sr-only"
-																onChange={handleAvatarChange}
-																disabled={uploadingAvatar}
-															/>
-															<p className="mt-1 text-xs text-gray-500">
-																{t("profile.avatarHint")}
-															</p>
-															{avatarError && (
-																<p className="mt-1 text-xs text-red-600">
-																	{avatarError}
-																</p>
-															)}
-														</div>
-													</div>
-												</div>
-
-												<Field label={t("account.fieldUsername")} id="username">
-													<input
-														id="username"
-														disabled
-														value={profile?.username ?? ""}
-														className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
-													/>
-												</Field>
-
-												<Field label={t("account.fieldEmail")} id="email">
-													<input
-														id="email"
-														disabled
-														type="email"
-														value={profile?.email ?? ""}
-														className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
-													/>
-													<p className="mt-1 text-xs text-gray-500">
-														{t("account.emailHint")}
-													</p>
-												</Field>
-
-												<Field
-													label={t("account.fieldFirstName")}
-													id="first-name"
-												>
-													<input
-														id="first-name"
-														value={firstName}
-														onChange={(e) => setFirstName(e.target.value)}
-														className={inputClass}
-													/>
-												</Field>
-
-												<Field
-													label={t("account.fieldLastName")}
-													id="last-name"
-												>
-													<input
-														id="last-name"
-														value={lastName}
-														onChange={(e) => setLastName(e.target.value)}
-														className={inputClass}
-													/>
-												</Field>
-											</div>
-										</section>
-
-										<hr className="border-gray-200" />
-
-										<section>
-											<h2 className="mb-4 text-base font-semibold text-gray-900">
-												{t("profile.sectionDetails")}
-											</h2>
-											<div className="space-y-5">
-												<Field label={t("profile.fieldBio")} id="bio">
-													<textarea
-														id="bio"
-														rows={4}
-														value={bio}
-														placeholder={t("profile.bioPlaceholder")}
-														onChange={(e) => setBio(e.target.value)}
-														className={textareaClass}
-													/>
-												</Field>
-
-												<Field
-													label={t("profile.fieldSkills")}
-													id="skill-input"
-												>
-													<ChipInput
-														inputRef={skillInputRef}
-														inputId="skill-input"
-														chips={skills}
-														inputValue={skillInput}
-														placeholder={t("profile.skillsPlaceholder")}
-														onInputChange={setSkillInput}
-														onAdd={(v) =>
-															addChip(v, skills, setSkills, setSkillInput)
-														}
-														onRemove={(v) => removeChip(v, skills, setSkills)}
-														removeLabel={t("profile.removeChip")}
-													/>
-												</Field>
-
-												<Field
-													label={t("profile.fieldLanguages")}
-													id="lang-input"
-												>
-													<ChipInput
-														inputRef={langInputRef}
-														inputId="lang-input"
-														chips={languages}
-														inputValue={langInput}
-														placeholder={t("profile.languagesPlaceholder")}
-														onInputChange={setLangInput}
-														onAdd={(v) =>
-															addChip(v, languages, setLanguages, setLangInput)
-														}
-														onRemove={(v) =>
-															removeChip(v, languages, setLanguages)
-														}
-														removeLabel={t("profile.removeChip")}
-													/>
-												</Field>
-
-												<Field
-													label={t("profile.fieldPreferredContact")}
-													id="preferred-contact"
-												>
-													<Dropdown
-														id="preferred-contact"
-														value={preferredContact}
-														onChange={(v) =>
-															setPreferredContact(v as ContactPref)
-														}
-														className={inputClass}
-														options={[
-															{
-																value: "",
-																label: t("profile.preferredContactNone"),
-															},
-															{
-																value: "Email",
-																label: t("profile.preferredContactEmail"),
-															},
-															{
-																value: "Phone",
-																label: t("profile.preferredContactPhone"),
-															},
-														]}
-													/>
-												</Field>
-											</div>
-										</section>
-
-										<div className="flex justify-end gap-3">
-											<button
-												type="button"
-												onClick={handleCancel}
-												className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-											>
-												{t("profile.cancel")}
-											</button>
-											<button
-												type="submit"
-												disabled={saving}
-												className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
-											>
-												{saving ? t("profile.saving") : t("profile.save")}
-											</button>
-										</div>
-									</form>
-								)}
-
-								<div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6">
-									<h2 className="mb-1 text-base font-semibold text-gray-900">
-										{t("profile.sectionOrganization")}
-									</h2>
-									<p className="mb-4 text-sm text-gray-600">
-										{t("profile.createOrgHint")}
-									</p>
-									<button
-										type="button"
-										onClick={() => setShowCreateOrgModal(true)}
-										data-testid="create-org-btn"
-										className="rounded-md border border-brand-700 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-50"
-									>
-										{t("organization.create")}
-									</button>
-								</div>
-
-								<div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-6">
-									<h2 className="mb-1 text-base font-semibold text-red-800">
-										{t("account.dangerZoneTitle")}
-									</h2>
-									<p className="mb-4 text-sm text-red-700">
-										{t("account.dangerZoneDescription")}
-									</p>
-									<button
-										type="button"
-										onClick={() => setShowDeleteDialog(true)}
-										className="rounded-md border border-red-700 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
-									>
-										{t("account.deleteAccountButton")}
-									</button>
-								</div>
-							</>
-						)}
-					</div>
-
-					{/* Achievements - merged into the Profile tab, matching the layout UserProfilePage.tsx already uses for the public view */}
 					{!profileLoading && (
-						<div className="mt-10">
-							{achievementsError && (
-								<p className="text-sm text-red-600">
-									{t("achievements.error", { message: achievementsError })}
-								</p>
+						<div className="mx-auto max-w-7xl">
+							{profileError && (
+								<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									{profileError}
+								</div>
+							)}
+							{successMessage && (
+								<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+									{successMessage}
+								</div>
 							)}
 
-							{!achievementsError && (
-								<>
-									<div className="mb-6 flex items-center justify-between">
-										<div />
-										<button
-											type="button"
-											onClick={() => setShareModalOpen(true)}
-											className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-										>
-											<svg
-												className="h-4 w-4"
-												fill="none"
-												viewBox="0 0 24 24"
-												strokeWidth="1.5"
-												stroke="currentColor"
-												aria-hidden="true"
-											>
-												<path
-													strokeLinecap="round"
-													strokeLinejoin="round"
-													d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
-												/>
-											</svg>
-											{t("achievements.shareButton")}
-										</button>
-									</div>
+							<div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
+								<div className="lg:col-span-2">
+									{/* View mode */}
+									{!editing && (
+										<div className="space-y-5">
+											<div className="flex items-start justify-between">
+												<div className="flex items-center gap-4">
+													{avatarUrl ? (
+														<img
+															src={avatarUrl}
+															alt=""
+															className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
+														/>
+													) : (
+														<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+															{profile?.username?.charAt(0).toUpperCase() ??
+																"?"}
+														</span>
+													)}
+													<div>
+														<p className="text-xl font-semibold text-gray-900">
+															{firstName || lastName
+																? `${firstName} ${lastName}`.trim()
+																: profile?.username}
+														</p>
+														<p className="text-sm text-gray-500">
+															@{profile?.username}
+														</p>
+														<p className="text-sm text-gray-500">
+															{profile?.email}
+														</p>
+													</div>
+												</div>
+												<button
+													type="button"
+													onClick={() => setEditing(true)}
+													className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+												>
+													{t("profile.edit")}
+												</button>
+											</div>
 
-									{streaks && (
-										<div className="mb-6 flex flex-wrap gap-3">
-											<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-												<span className="text-2xl" aria-hidden="true">
-													🔥
-												</span>
-												<div>
-													<p className="text-xl font-bold text-gray-900">
-														{streaks.loginStreak}
-													</p>
-													<p className="text-xs text-gray-500">
-														{t("achievements.loginStreak", {
-															count: streaks.loginStreak,
-														})}
-													</p>
-												</div>
-											</div>
-											<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-												<span className="text-2xl" aria-hidden="true">
-													📅
-												</span>
-												<div>
-													<p className="text-xl font-bold text-gray-900">
-														{streaks.activityStreak}
-													</p>
-													<p className="text-xs text-gray-500">
-														{t("achievements.activityStreak", {
-															count: streaks.activityStreak,
-														})}
-													</p>
-												</div>
-											</div>
+											<ProfileFieldsView
+												bio={bio}
+												skills={skills}
+												languages={languages}
+												preferredContact={preferredContact || null}
+											/>
 										</div>
 									)}
 
-									<section>
-										<h2 className="mb-4 text-base font-semibold text-gray-700">
-											{t("achievements.badgesTitle")}
-										</h2>
-										<BadgeGrid
-											earned={achievements}
-											catalog={catalog}
-											loading={achievementsLoading}
-										/>
-									</section>
-								</>
-							)}
+									{/* Edit mode */}
+									{editing && (
+										<form onSubmit={handleSave} className="space-y-6">
+											<section>
+												<h2 className="mb-4 text-base font-semibold text-gray-900">
+													{t("account.title")}
+												</h2>
+												<div className="space-y-5">
+													<div>
+														<p className="mb-1 block text-sm font-medium text-gray-700">
+															{t("profile.fieldAvatar")}
+														</p>
+														<div className="flex items-center gap-4">
+															{avatarUrl ? (
+																<img
+																	src={avatarUrl}
+																	alt=""
+																	className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
+																/>
+															) : (
+																<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+																	{profile?.username?.charAt(0).toUpperCase() ??
+																		"?"}
+																</span>
+															)}
+															<div>
+																<label
+																	htmlFor="avatar-upload"
+																	className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingAvatar ? "opacity-50 pointer-events-none" : ""}`}
+																>
+																	{uploadingAvatar
+																		? t("profile.avatarUploading")
+																		: t("profile.avatarUpload")}
+																</label>
+																<input
+																	ref={avatarInputRef}
+																	id="avatar-upload"
+																	type="file"
+																	accept="image/jpeg,image/png,image/webp"
+																	className="sr-only"
+																	onChange={handleAvatarChange}
+																	disabled={uploadingAvatar}
+																/>
+																<p className="mt-1 text-xs text-gray-500">
+																	{t("profile.avatarHint")}
+																</p>
+																{avatarError && (
+																	<p className="mt-1 text-xs text-red-600">
+																		{avatarError}
+																	</p>
+																)}
+															</div>
+														</div>
+													</div>
+
+													<Field
+														label={t("account.fieldUsername")}
+														id="username"
+													>
+														<input
+															id="username"
+															disabled
+															value={profile?.username ?? ""}
+															className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+														/>
+													</Field>
+
+													<Field label={t("account.fieldEmail")} id="email">
+														<input
+															id="email"
+															disabled
+															type="email"
+															value={profile?.email ?? ""}
+															className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+														/>
+														<p className="mt-1 text-xs text-gray-500">
+															{t("account.emailHint")}
+														</p>
+													</Field>
+
+													<Field
+														label={t("account.fieldFirstName")}
+														id="first-name"
+													>
+														<input
+															id="first-name"
+															value={firstName}
+															onChange={(e) => setFirstName(e.target.value)}
+															className={inputClass}
+														/>
+													</Field>
+
+													<Field
+														label={t("account.fieldLastName")}
+														id="last-name"
+													>
+														<input
+															id="last-name"
+															value={lastName}
+															onChange={(e) => setLastName(e.target.value)}
+															className={inputClass}
+														/>
+													</Field>
+												</div>
+											</section>
+
+											<hr className="border-gray-200" />
+
+											<section>
+												<h2 className="mb-4 text-base font-semibold text-gray-900">
+													{t("profile.sectionDetails")}
+												</h2>
+												<div className="space-y-5">
+													<Field label={t("profile.fieldBio")} id="bio">
+														<textarea
+															id="bio"
+															rows={4}
+															value={bio}
+															placeholder={t("profile.bioPlaceholder")}
+															onChange={(e) => setBio(e.target.value)}
+															className={textareaClass}
+														/>
+													</Field>
+
+													<Field
+														label={t("profile.fieldSkills")}
+														id="skill-input"
+													>
+														<ChipInput
+															inputRef={skillInputRef}
+															inputId="skill-input"
+															chips={skills}
+															inputValue={skillInput}
+															placeholder={t("profile.skillsPlaceholder")}
+															onInputChange={setSkillInput}
+															onAdd={(v) =>
+																addChip(v, skills, setSkills, setSkillInput)
+															}
+															onRemove={(v) => removeChip(v, skills, setSkills)}
+															removeLabel={t("profile.removeChip")}
+														/>
+													</Field>
+
+													<Field
+														label={t("profile.fieldLanguages")}
+														id="lang-input"
+													>
+														<ChipInput
+															inputRef={langInputRef}
+															inputId="lang-input"
+															chips={languages}
+															inputValue={langInput}
+															placeholder={t("profile.languagesPlaceholder")}
+															onInputChange={setLangInput}
+															onAdd={(v) =>
+																addChip(
+																	v,
+																	languages,
+																	setLanguages,
+																	setLangInput,
+																)
+															}
+															onRemove={(v) =>
+																removeChip(v, languages, setLanguages)
+															}
+															removeLabel={t("profile.removeChip")}
+														/>
+													</Field>
+
+													<Field
+														label={t("profile.fieldPreferredContact")}
+														id="preferred-contact"
+													>
+														<Dropdown
+															id="preferred-contact"
+															value={preferredContact}
+															onChange={(v) =>
+																setPreferredContact(v as ContactPref)
+															}
+															className={inputClass}
+															options={[
+																{
+																	value: "",
+																	label: t("profile.preferredContactNone"),
+																},
+																{
+																	value: "Email",
+																	label: t("profile.preferredContactEmail"),
+																},
+																{
+																	value: "Phone",
+																	label: t("profile.preferredContactPhone"),
+																},
+															]}
+														/>
+													</Field>
+												</div>
+											</section>
+
+											<div className="flex justify-end gap-3">
+												<button
+													type="button"
+													onClick={handleCancel}
+													className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+												>
+													{t("profile.cancel")}
+												</button>
+												<button
+													type="submit"
+													disabled={saving}
+													className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+												>
+													{saving ? t("profile.saving") : t("profile.save")}
+												</button>
+											</div>
+										</form>
+									)}
+								</div>
+
+								{/* Achievements - promoted above account-management actions, side by side with
+								    the profile column on desktop instead of a mismatched full-width block below it */}
+								<div className="lg:col-span-3">
+									{achievementsError && (
+										<p className="text-sm text-red-600">
+											{t("achievements.error", { message: achievementsError })}
+										</p>
+									)}
+
+									{!achievementsError && (
+										<>
+											<div className="mb-6 flex items-center justify-between">
+												<div />
+												<button
+													type="button"
+													onClick={() => setShareModalOpen(true)}
+													className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+												>
+													<svg
+														className="h-4 w-4"
+														fill="none"
+														viewBox="0 0 24 24"
+														strokeWidth="1.5"
+														stroke="currentColor"
+														aria-hidden="true"
+													>
+														<path
+															strokeLinecap="round"
+															strokeLinejoin="round"
+															d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
+														/>
+													</svg>
+													{t("achievements.shareButton")}
+												</button>
+											</div>
+
+											{streaks && (
+												<div className="mb-6 flex flex-wrap gap-3">
+													<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+														<span className="text-2xl" aria-hidden="true">
+															🔥
+														</span>
+														<div>
+															<p className="text-xl font-bold text-gray-900">
+																{streaks.loginStreak}
+															</p>
+															<p className="text-xs text-gray-500">
+																{t("achievements.loginStreak", {
+																	count: streaks.loginStreak,
+																})}
+															</p>
+														</div>
+													</div>
+													<div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+														<span className="text-2xl" aria-hidden="true">
+															📅
+														</span>
+														<div>
+															<p className="text-xl font-bold text-gray-900">
+																{streaks.activityStreak}
+															</p>
+															<p className="text-xs text-gray-500">
+																{t("achievements.activityStreak", {
+																	count: streaks.activityStreak,
+																})}
+															</p>
+														</div>
+													</div>
+												</div>
+											)}
+
+											<section>
+												<h2 className="mb-4 text-base font-semibold text-gray-700">
+													{t("achievements.badgesTitle")}
+												</h2>
+												<BadgeGrid
+													earned={achievements}
+													catalog={catalog}
+													loading={achievementsLoading}
+												/>
+											</section>
+										</>
+									)}
+								</div>
+							</div>
+
+							<div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6">
+								<h2 className="mb-1 text-base font-semibold text-gray-900">
+									{t("profile.sectionOrganization")}
+								</h2>
+								<p className="mb-4 text-sm text-gray-600">
+									{t("profile.createOrgHint")}
+								</p>
+								<button
+									type="button"
+									onClick={() => setShowCreateOrgModal(true)}
+									data-testid="create-org-btn"
+									className="rounded-md border border-brand-700 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-50"
+								>
+									{t("organization.create")}
+								</button>
+							</div>
+
+							<div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-6">
+								<h2 className="mb-1 text-base font-semibold text-red-800">
+									{t("account.dangerZoneTitle")}
+								</h2>
+								<p className="mb-4 text-sm text-red-700">
+									{t("account.dangerZoneDescription")}
+								</p>
+								<button
+									type="button"
+									onClick={() => setShowDeleteDialog(true)}
+									className="rounded-md border border-red-700 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+								>
+									{t("account.deleteAccountButton")}
+								</button>
+							</div>
 						</div>
 					)}
 				</>

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -848,8 +848,7 @@ export default function ProfileOverviewPage() {
 									)}
 								</div>
 
-								{/* Achievements - promoted above account-management actions, side by side with
-								    the profile column on desktop instead of a mismatched full-width block below it */}
+								{/* Achievements - promoted above account-management actions, side by side with the profile column on desktop instead of a mismatched full-width block below it */}
 								<div className="lg:col-span-3">
 									{achievementsError && (
 										<p className="text-sm text-red-600">

--- a/scripts/smoke-test-706-profile-achievements-reorder.mjs
+++ b/scripts/smoke-test-706-profile-achievements-reorder.mjs
@@ -1,0 +1,73 @@
+// Smoke test for #706: achievements on the Profile tab used to render last,
+// below the "Create organization" and "Danger zone" account-action cards, in
+// a separate full-width block outside the profile column's narrow wrapper.
+// The fix reorders achievements to render directly under the identity/profile
+// content, above both account-action cards, inside a single responsive grid.
+//
+// Verifies the "Badges" heading's bounding-box Y position is above both the
+// "Organizations" and "Danger zone" headings on the live /profile page.
+//
+// No throwaway data is created (an existing seed user is used), so there is
+// nothing to clean up (see #630).
+// Run: node scripts/smoke-test-706-profile-achievements-reorder.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.click("text=/sign in|anmelden/i");
+		await page.waitForURL(/\/realms\//, { timeout: 30000 });
+		await loginKeycloak(page, "vera", "vera123");
+		console.log("OK  Logged in as vera");
+
+		await page.goto(`${BASE}/profile`, { waitUntil: "networkidle" });
+
+		const badgesHeading = page.getByRole("heading", { name: "Badges" });
+		const organizationsHeading = page.getByRole("heading", { name: "Organizations" });
+		const dangerZoneHeading = page.getByRole("heading", { name: "Danger zone" });
+
+		await badgesHeading.waitFor({ state: "visible", timeout: 20000 });
+		await organizationsHeading.waitFor({ state: "visible", timeout: 5000 });
+		await dangerZoneHeading.waitFor({ state: "visible", timeout: 5000 });
+		console.log("OK  Badges, Organizations, and Danger zone headings all visible on /profile");
+
+		const badgesBox = await badgesHeading.boundingBox();
+		const organizationsBox = await organizationsHeading.boundingBox();
+		const dangerZoneBox = await dangerZoneHeading.boundingBox();
+		if (!badgesBox || !organizationsBox || !dangerZoneBox) {
+			throw new Error("Could not measure bounding box of one of the headings");
+		}
+
+		if (badgesBox.y >= organizationsBox.y) {
+			throw new Error(
+				`Achievements (y=${badgesBox.y}) do not render above the "Organizations" card (y=${organizationsBox.y})`,
+			);
+		}
+		if (badgesBox.y >= dangerZoneBox.y) {
+			throw new Error(
+				`Achievements (y=${badgesBox.y}) do not render above the "Danger zone" card (y=${dangerZoneBox.y})`,
+			);
+		}
+		console.log(
+			`OK  Achievements render above both account-action cards (badges y=${badgesBox.y}, organizations y=${organizationsBox.y}, danger zone y=${dangerZoneBox.y})`,
+		);
+	} finally {
+		await browser.close();
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses #706 - the "Achievements" section on the Profile tab (`ProfileOverviewPage.tsx`, "Profile" tab) rendered last, below the "Create organization" and "Danger zone" account-action cards, and lived in a separate full-width `<div>` outside the profile column's `mx-auto max-w-2xl` wrapper. Scrolling from the profile card into achievements produced an abrupt width jump (~672px centered column -> ~1280px full-width block), and `BadgeGrid`'s `grid-cols-3 sm:grid-cols-4 md:grid-cols-6` responded to that extra width with more columns than the profile column above it would suggest. The issue's proposed change was already resolved in conversation with the repository owner (no further product decision needed).

## Changes

`frontend/src/pages/ProfileOverviewPage.tsx` (Profile tab only - Activity tab, `UserProfilePage.tsx`, `UserAchievementsPage.tsx`, and the achievement/badge/streak logic itself are all unchanged, per the issue's stated scope):

- **Reorder**: achievements (share button, streaks, `BadgeGrid`) now render directly under the identity/profile-fields content, above the "Create organization" and "Danger zone" cards - on both breakpoints.
- **Single container**: replaced the narrow `mx-auto max-w-2xl` wrapper (profile column) + separate full-width `mt-10` block (achievements) with one `mx-auto max-w-7xl` wrapper around the whole tab, removing the width jump.
- **Desktop**: added a `grid grid-cols-1 gap-8 lg:grid-cols-5` layout with the profile column at `lg:col-span-2` and achievements at `lg:col-span-3`, placing them side by side instead of stacked, using the page's existing `max-w-7xl` width deliberately.
- **Mobile**: `grid-cols-1` naturally stacks in DOM order - identity/profile fields, then achievements, then the org/danger-zone cards - matching the promoted order.
- `ProfileFieldsView` and `BadgeGrid` are untouched, as scoped by the issue - this is purely a layout/composition change in `ProfileOverviewPage.tsx`.

No backend or API changes were needed.

## Test plan

- [x] `pnpm check` (tsc), `pnpm lint --max-warnings 0`, `pnpm format:write` - all clean
- [x] `pnpm build` - production build succeeds (pre-existing chunk-size warning, unrelated)
- [x] `dotnet build` - 0 warnings, 0 errors
- [x] `dotnet test tests/Application.UnitTests` - 237/237 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] Added `VisualTests/ProfileOverviewTests.cs::ProfilePage_RendersAchievementsAboveAccountActionCards` - logs in as vera, navigates to `/profile`, and asserts the "Badges" heading's bounding-box Y position is above both the "Organizations" and "Danger zone" headings. Ran green in CI's `Publish Backend` job on the release candidate (Application.UnitTests, ArchitectureTests, IntegrationTests, and VisualTests all passed on a real runner with Testcontainers/Aspire).
- [x] `/self-review` fan-out: `a11y-check` (clean - no heading-hierarchy issue from the reorder since both `<h2>`s are siblings at the same depth; no `order-*` utilities used, so DOM order matches visual/tab order on both breakpoints; `AccountPage_HasNoSeriousA11yViolations` in `AccessibilityTests.cs` already exercises `/account` -> `/profile`'s default "profile" tab, so no new a11y test entry needed)

## Live verification

Verified against live staging (`https://einsatzbereit.maik-hasler.de`, backend `https://api.maik-hasler.de`) after release candidate `v1.0.0-rc.251` deployed successfully (`Publish` workflow green, `Deploy to Staging` job's post-deploy health gate passed):

- [x] `curl -sf https://api.maik-hasler.de/health` -> `Healthy`, HTTP 200
- [x] `node scripts/smoke-test-706-profile-achievements-reorder.mjs` - all assertions passed (exit 0):
  ```
  OK  API health check passed
  OK  Logged in as vera
  OK  Badges, Organizations, and Danger zone headings all visible on /profile
  OK  Achievements render above both account-action cards (badges y=415, organizations y=720.5, danger zone y=904.5)

  ALL CHECKS PASSED
  ```
  The script logs in as vera on the live site and confirms the "Badges" heading's bounding-box Y position sits above both the "Organizations" and "Danger zone" headings on `/profile`.
- [x] The same assertions are also covered by an automated C# TUnit test (`VisualTests/ProfileOverviewTests.cs::ProfilePage_RendersAchievementsAboveAccountActionCards`), which ran and passed against the local Aspire stack as part of CI on this release candidate (see Test plan above).

This PR is open and awaiting the repository owner's review - this routine does not merge PRs itself.
