### PR TITLE
feat: add description, contact info, address, and logo to organization creation

### DIFF
--- a/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationEndpoint.cs
+++ b/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationEndpoint.cs
@@ -42,7 +42,25 @@ internal sealed class CreateOrganizationEndpoint
 		if (request.Name.Length > 100)
 			return Results.Problem("Name must not exceed 100 characters.", statusCode: StatusCodes.Status400BadRequest);
 
-		var command = new CreateOrganizationCommand(request.Name, userId);
+		if (request.Description is { Length: > 1000 })
+			return Results.Problem("Description must not exceed 1000 characters.", statusCode: StatusCodes.Status400BadRequest);
+
+		var addressCommand = request.Address is null
+			? null
+			: new CreateAddressCommand(
+				request.Address.Street,
+				request.Address.HouseNumber,
+				request.Address.ZipCode,
+				request.Address.City);
+
+		var command = new CreateOrganizationCommand(
+			request.Name,
+			userId,
+			request.Description,
+			request.ContactEmail,
+			request.ContactPhone,
+			request.Website,
+			addressCommand);
 
 		var result = await sender.Send(command, cancellationToken);
 

--- a/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationRequest.cs
+++ b/backend/src/Api/Organizations/CreateOrganization/v1/CreateOrganizationRequest.cs
@@ -3,4 +3,15 @@ using System.ComponentModel.DataAnnotations;
 namespace Api.Organizations.CreateOrganization.v1;
 
 public sealed record CreateOrganizationRequest(
-	[MaxLength(100)] string Name);
+	[MaxLength(100)] string Name,
+	[MaxLength(1000)] string? Description,
+	[MaxLength(254)] string? ContactEmail,
+	[MaxLength(30)] string? ContactPhone,
+	[MaxLength(500)] string? Website,
+	CreateAddressRequest? Address);
+
+public sealed record CreateAddressRequest(
+	[MaxLength(200)] string Street,
+	[MaxLength(20)] string HouseNumber,
+	[MaxLength(10)] string ZipCode,
+	[MaxLength(100)] string City);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -3971,6 +3971,29 @@
           }
         }
       },
+      "CreateAddressRequest": {
+        "required": [
+          "street",
+          "houseNumber",
+          "zipCode",
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string"
+          },
+          "houseNumber": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          }
+        }
+      },
       "CreateEngagementRequest": {
         "required": [
           "type",
@@ -4049,12 +4072,51 @@
       },
       "CreateOrganizationRequest": {
         "required": [
-          "name"
+          "name",
+          "description",
+          "contactEmail",
+          "contactPhone",
+          "website",
+          "address"
         ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "contactEmail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "contactPhone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "website": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CreateAddressRequest"
+              }
+            ]
           }
         }
       },

--- a/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommand.cs
+++ b/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommand.cs
@@ -5,5 +5,16 @@ namespace Application.Organizations.CreateOrganization.v1;
 
 public sealed record CreateOrganizationCommand(
 	string Name,
-	Guid UserId)
+	Guid UserId,
+	string? Description,
+	string? ContactEmail,
+	string? ContactPhone,
+	string? Website,
+	CreateAddressCommand? Address)
 	: ICommand<Organization>;
+
+public sealed record CreateAddressCommand(
+	string Street,
+	string HouseNumber,
+	string ZipCode,
+	string City);

--- a/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Domain.Common;
 using Domain.Organizations;
 using Domain.Primitives;
 
@@ -31,6 +32,22 @@ internal sealed class CreateOrganizationCommandHandler(
 			request.UserId, cancellationToken);
 
 		var organization = Organization.Create(new OrganizationId(keycloakId), request.Name);
+
+		var address = request.Address is null
+			? null
+			: new Address(
+				request.Address.Street,
+				request.Address.HouseNumber,
+				request.Address.ZipCode,
+				request.Address.City);
+
+		organization.Update(
+			request.Name,
+			request.Description,
+			request.ContactEmail,
+			request.ContactPhone,
+			request.Website,
+			address);
 
 		await dbContext.Organizations.AddAsync(organization, cancellationToken);
 

--- a/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
@@ -29,7 +29,7 @@ public class CreateOrganizationCommandHandlerTests
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Sample Fire Department", userId);
+		var command = new CreateOrganizationCommand("Sample Fire Department", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Sample Fire Department", cancellationToken)
@@ -49,7 +49,7 @@ public class CreateOrganizationCommandHandlerTests
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Test Org", userId);
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Test Org", cancellationToken)
@@ -69,7 +69,7 @@ public class CreateOrganizationCommandHandlerTests
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Test Org", userId);
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Test Org", cancellationToken)
@@ -89,7 +89,7 @@ public class CreateOrganizationCommandHandlerTests
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Test Org", userId);
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Test Org", cancellationToken)
@@ -111,7 +111,7 @@ public class CreateOrganizationCommandHandlerTests
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Test Org", userId);
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
 		var callOrder = new List<string>();
 
 		_keycloakService
@@ -144,7 +144,7 @@ public class CreateOrganizationCommandHandlerTests
 	{
 		// Arrange
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Bad Org", userId);
+		var command = new CreateOrganizationCommand("Bad Org", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Bad Org", cancellationToken)
@@ -160,13 +160,45 @@ public class CreateOrganizationCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldPersistOptionalFields_WhenProvided(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var keycloakId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		var command = new CreateOrganizationCommand(
+			"Test Org",
+			userId,
+			"A helpful description",
+			"contact@example.com",
+			"+49 30 1234567",
+			"https://example.com",
+			new CreateAddressCommand("Main Street", "1", "12345", "Berlin"));
+
+		_keycloakService
+			.CreateOrganizationAsync("Test Org", cancellationToken)
+			.Returns(keycloakId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Description.Should().Be("A helpful description");
+		result.ContactEmail.Should().Be("contact@example.com");
+		result.ContactPhone.Should().Be("+49 30 1234567");
+		result.Website.Should().Be("https://example.com");
+		result.Address.Should().NotBeNull();
+		result.Address!.City.Should().Be("Berlin");
+	}
+
+	[Test]
 	public async Task Handle_ShouldPropagateException_WhenAddMemberFails(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var keycloakId = Guid.NewGuid();
 		var userId = Guid.NewGuid();
-		var command = new CreateOrganizationCommand("Test Org", userId);
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
 
 		_keycloakService
 			.CreateOrganizationAsync("Test Org", cancellationToken)

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -6945,6 +6945,37 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateAddressRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("street")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Street { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("houseNumber")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string HouseNumber { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("zipCode")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string ZipCode { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("city")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string City { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CreateEngagementRequest
     {
 
@@ -7045,6 +7076,21 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("name")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Name { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public string? Description { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("contactEmail")]
+        public string? ContactEmail { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("contactPhone")]
+        public string? ContactPhone { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("website")]
+        public string? Website { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("address")]
+        public CreateAddressRequest? Address { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -126,6 +126,67 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation()
+	{
+		// #712: the create-organization modal used to collect only Name -
+		// description, contact info, address and logo were only reachable
+		// afterwards via the Settings tab. Verifies the richer create form
+		// persists all of them in one step.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var orgName = $"Visual712 FullDetails {Guid.NewGuid():N}";
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
+		if (await switcherBtn.CountAsync() > 0)
+		{
+			await switcherBtn.First.ClickAsync();
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+		}
+		else
+		{
+			await Page.GotoAsync($"{origin}/profile");
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+		}
+
+		var createDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(createDialog).ToBeVisibleAsync();
+		await createDialog.Locator("#create-org-name").FillAsync(orgName);
+		await createDialog.Locator("#create-org-description").FillAsync("A helpful description for volunteers.");
+		await createDialog.Locator("#create-org-contact-email").FillAsync("contact@visual712.example.com");
+		await createDialog.Locator("#create-org-phone").FillAsync("+49 30 1234567");
+		await createDialog.Locator("#create-org-website").FillAsync("https://visual712.example.com");
+		await createDialog.Locator("#create-org-street").FillAsync("Main Street");
+		await createDialog.Locator("#create-org-house-number").FillAsync("1");
+		await createDialog.Locator("#create-org-zip").FillAsync("12345");
+		await createDialog.Locator("#create-org-city").FillAsync("Berlin");
+
+		await Page.GetByTestId("modal-submit").ClickAsync();
+		await Expect(createDialog).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.GotoAsync(origin);
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).First.ClickAsync();
+		var orgRow = Page.Locator("li", new() { HasText = orgName });
+		await orgRow.GetByTestId("org-dashboard-link").ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/organizations/.+/dashboard"), new() { Timeout = 10_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Settings" }).ClickAsync();
+
+		await Expect(Page.GetByText("A helpful description for volunteers.")).ToBeVisibleAsync(
+			new() { Timeout = 10_000 });
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "contact@visual712.example.com" }))
+			.ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "+49 30 1234567" })).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "https://visual712.example.com" }))
+			.ToBeVisibleAsync();
+		await Expect(Page.GetByText("Main Street 1, 12345 Berlin")).ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
 	{
 		// Regression for #641: the header/tab-bar used to be wrapped in the same

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3560,6 +3560,15 @@ export interface CheckInWithPinRequest {
     [key: string]: any;
 }
 
+export interface CreateAddressRequest {
+    street: string;
+    houseNumber: string;
+    zipCode: string;
+    city: string;
+
+    [key: string]: any;
+}
+
 export interface CreateEngagementRequest {
     type: string;
     timeSlotId: string | undefined;
@@ -3591,6 +3600,11 @@ export interface CreateInvitationResponse {
 
 export interface CreateOrganizationRequest {
     name: string;
+    description: string | undefined;
+    contactEmail: string | undefined;
+    contactPhone: string | undefined;
+    website: string | undefined;
+    address: CreateAddressRequest | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -1,16 +1,33 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
+import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
+import { getApiErrorMessage } from "../lib/apiError";
 
 interface Props {
 	onClose: () => void;
 	onSuccess: () => void;
 }
 
+const MAX_LOGO_BYTES = 2 * 1024 * 1024;
+const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
 export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [contactEmail, setContactEmail] = useState("");
+	const [contactPhone, setContactPhone] = useState("");
+	const [website, setWebsite] = useState("");
+	const [street, setStreet] = useState("");
+	const [houseNumber, setHouseNumber] = useState("");
+	const [zipCode, setZipCode] = useState("");
+	const [city, setCity] = useState("");
+	const [logoFile, setLogoFile] = useState<File | null>(null);
+	const [logoPreview, setLogoPreview] = useState<string | null>(null);
+	const [logoError, setLogoError] = useState<string | null>(null);
+	const logoInputRef = useRef<HTMLInputElement>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -22,26 +39,70 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [onClose]);
 
+	useEffect(() => {
+		return () => {
+			if (logoPreview) URL.revokeObjectURL(logoPreview);
+		};
+	}, [logoPreview]);
+
+	const hasAddress = street || houseNumber || zipCode || city;
+
+	function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+		const file = e.target.files?.[0];
+		e.target.value = "";
+		if (!file) return;
+		if (!LOGO_TYPES.includes(file.type)) {
+			setLogoError(t("orgSettings.logoHint"));
+			return;
+		}
+		if (file.size > MAX_LOGO_BYTES) {
+			setLogoError(t("orgSettings.logoHint"));
+			return;
+		}
+		setLogoError(null);
+		setLogoFile(file);
+		setLogoPreview(URL.createObjectURL(file));
+	}
+
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setLoading(true);
 		setError(null);
 
 		try {
-			await api.createOrganization({ name });
+			const organization = await api.createOrganization({
+				name,
+				description: description || undefined,
+				contactEmail: contactEmail || undefined,
+				contactPhone: contactPhone || undefined,
+				website: website || undefined,
+				address: hasAddress
+					? { street, houseNumber, zipCode, city }
+					: undefined,
+			});
+			const organizationId = organization.id?.value;
+			if (logoFile && organizationId) {
+				try {
+					await api.uploadOrganizationLogo(organizationId, {
+						data: logoFile,
+						fileName: logoFile.name,
+					});
+				} catch {
+					// Non-fatal: the organization was created successfully - the
+					// logo can still be added later from the Settings tab.
+				}
+			}
 			onSuccess();
 			onClose();
 		} catch (err: unknown) {
-			setError(
-				err instanceof Error ? err.message : t("organization.unknownError"),
-			);
+			setError(getApiErrorMessage(err, t("organization.unknownError")));
 		} finally {
 			setLoading(false);
 		}
 	};
 
 	return (
-		<div className="fixed inset-0 z-[2000] flex items-center justify-center p-3 sm:p-4">
+		<div className="fixed inset-0 z-[2000] flex items-center justify-center overflow-hidden p-3 sm:p-4">
 			<button
 				type="button"
 				className="absolute inset-0 bg-black/50"
@@ -53,31 +114,200 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 				role="dialog"
 				aria-modal="true"
 				aria-labelledby="create-org-dialog-title"
-				className="relative z-10 w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
+				className="relative z-10 flex max-h-[min(85vh,720px)] w-full max-w-md flex-col overflow-hidden rounded-xl bg-white shadow-xl"
 			>
-				<h2 id="create-org-dialog-title" className="mb-4 text-lg font-semibold">
+				<h2
+					id="create-org-dialog-title"
+					className="border-b border-gray-100 px-6 py-4 text-lg font-semibold"
+				>
 					{t("organization.create")}
 				</h2>
 
-				<form onSubmit={handleSubmit} className="space-y-4">
-					<div>
-						<label className="mb-1 block text-sm font-medium">
-							{t("organization.nameLabel")}
-						</label>
-						<input
-							type="text"
-							required
-							maxLength={100}
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder={t("organization.namePlaceholder")}
-							className="w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-						/>
+				<form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+					<div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
+						<div>
+							<p className={labelClass}>{t("orgSettings.fieldLogo")}</p>
+							<div className="mt-1 flex items-center gap-4">
+								{logoPreview ? (
+									<img
+										src={logoPreview}
+										alt=""
+										className="h-14 w-14 rounded-lg object-contain ring-1 ring-gray-200"
+									/>
+								) : (
+									<span className="flex h-14 w-14 items-center justify-center rounded-lg bg-brand-100 text-xl font-semibold text-brand-700">
+										{name.charAt(0).toUpperCase() || "?"}
+									</span>
+								)}
+								<div>
+									<label
+										htmlFor="create-org-logo-upload"
+										className="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+									>
+										{t("orgSettings.logoUpload")}
+									</label>
+									<input
+										ref={logoInputRef}
+										id="create-org-logo-upload"
+										type="file"
+										accept="image/jpeg,image/png,image/webp"
+										className="sr-only"
+										onChange={handleLogoChange}
+									/>
+									<p className="mt-1 text-xs text-gray-500">
+										{t("orgSettings.logoHint")}
+									</p>
+									{logoError && (
+										<p className="mt-1 text-xs text-red-600">{logoError}</p>
+									)}
+								</div>
+							</div>
+						</div>
+
+						<div>
+							<label
+								htmlFor="create-org-name"
+								className="mb-1 block text-sm font-medium"
+							>
+								{t("organization.nameLabel")}
+							</label>
+							<input
+								id="create-org-name"
+								type="text"
+								required
+								maxLength={100}
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder={t("organization.namePlaceholder")}
+								className="w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="create-org-description"
+								className="mb-1 block text-sm font-medium"
+							>
+								{t("orgSettings.fieldDescription")}
+							</label>
+							<textarea
+								id="create-org-description"
+								rows={3}
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								className={textareaClass}
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="create-org-contact-email"
+								className="mb-1 block text-sm font-medium"
+							>
+								{t("orgSettings.fieldContactEmail")}
+							</label>
+							<input
+								id="create-org-contact-email"
+								type="email"
+								value={contactEmail}
+								onChange={(e) => setContactEmail(e.target.value)}
+								className={inputClass}
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="create-org-phone"
+								className="mb-1 block text-sm font-medium"
+							>
+								{t("orgSettings.fieldPhone")}
+							</label>
+							<input
+								id="create-org-phone"
+								type="tel"
+								value={contactPhone}
+								onChange={(e) => setContactPhone(e.target.value)}
+								className={inputClass}
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="create-org-website"
+								className="mb-1 block text-sm font-medium"
+							>
+								{t("orgSettings.fieldWebsite")}
+							</label>
+							<input
+								id="create-org-website"
+								type="url"
+								value={website}
+								onChange={(e) => setWebsite(e.target.value)}
+								placeholder="https://"
+								className={inputClass}
+							/>
+						</div>
+
+						<fieldset className="rounded-md border border-gray-200 p-4">
+							<legend className="px-1 text-sm font-medium text-gray-700">
+								{t("orgSettings.fieldAddress")}
+							</legend>
+							<div className="mt-3 grid grid-cols-3 gap-3">
+								<div className="col-span-2">
+									<label htmlFor="create-org-street" className={labelClass}>
+										{t("orgSettings.fieldStreet")}
+									</label>
+									<input
+										id="create-org-street"
+										value={street}
+										onChange={(e) => setStreet(e.target.value)}
+										className={inputClass}
+									/>
+								</div>
+								<div>
+									<label
+										htmlFor="create-org-house-number"
+										className={labelClass}
+									>
+										{t("orgSettings.fieldHouseNumber")}
+									</label>
+									<input
+										id="create-org-house-number"
+										value={houseNumber}
+										onChange={(e) => setHouseNumber(e.target.value)}
+										className={inputClass}
+									/>
+								</div>
+								<div>
+									<label htmlFor="create-org-zip" className={labelClass}>
+										{t("orgSettings.fieldZip")}
+									</label>
+									<input
+										id="create-org-zip"
+										maxLength={5}
+										value={zipCode}
+										onChange={(e) => setZipCode(e.target.value)}
+										className={inputClass}
+									/>
+								</div>
+								<div className="col-span-2">
+									<label htmlFor="create-org-city" className={labelClass}>
+										{t("orgSettings.fieldCity")}
+									</label>
+									<input
+										id="create-org-city"
+										value={city}
+										onChange={(e) => setCity(e.target.value)}
+										className={inputClass}
+									/>
+								</div>
+							</div>
+						</fieldset>
+
+						{error && <p className="text-sm text-red-600">{error}</p>}
 					</div>
 
-					{error && <p className="text-sm text-red-600">{error}</p>}
-
-					<div className="flex justify-end gap-2">
+					<div className="flex justify-end gap-2 border-t border-gray-100 px-6 py-4">
 						<button
 							type="button"
 							onClick={onClose}


### PR DESCRIPTION
## Summary

Addresses #712 - `CreateOrganizationModal` (used from `OrganizationSwitcher` and `ProfileOverviewPage`) collected only **Name** and called `api.createOrganization({ name })`. Everything else an organization can have - description, contact email, contact phone, website, address, logo - was only reachable afterwards by editing the org from the Organization Dashboard's Settings tab.

**Root cause and fix**

The domain (`Organization.cs`), `UpdateOrganizationRequest`/`Command`, and the Settings tab's edit form already fully supported these fields as optional. The gap was purely in the **create** path: `CreateOrganizationRequest`/`Command`/`Organization.Create()` only took `Name`, and `CreateOrganizationModal.tsx` only rendered a Name input.

Following the issue's suggested approach:

- `CreateOrganizationRequest`/`CreateOrganizationCommand` gain the same optional fields `UpdateOrganizationRequest`/`Command` already accept (description, contact email/phone, website, address), with matching `[MaxLength]` validation attributes.
- `CreateOrganizationCommandHandler` calls `Organization.Create(id, name)` immediately followed by the existing `organization.Update(...)` - no new domain logic needed, since `Update()` already does exactly this assignment.
- The logo stays a second call after creation (an org id has to exist first) - mirrors how `CreateVolunteerOpportunityModal` creates the opportunity, then uploads the banner in a follow-up step. `uploadOrganizationLogo` already existed for this.
- `CreateOrganizationModal.tsx` is expanded with the same fields as the Settings tab's edit form (description, contact email/phone, website, an address fieldset, and a logo uploader), reusing the existing `orgSettings.field*` translation keys rather than duplicating them - no locale file changes needed, since all keys already exist in both `en.json`/`de.json`.
- Only `Name` stays required; leaving every other field blank still succeeds, exactly like before.

## Test plan

- [x] `dotnet build` (backend) - 0 warnings, 0 errors, NSwag client regenerated
- [x] `Application.UnitTests` - 238/238 passed (updated existing `CreateOrganizationCommandHandlerTests` call sites for the new command shape, added `Handle_ShouldPersistOptionalFields_WhenProvided`)
- [x] `ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- [x] Added `VisualTests/OrganizationTests.cs::CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation` - fills every new field in the create modal, submits, and asserts the Settings tab renders description/contact email/phone/website/address afterwards. Runs against the local Aspire stack in CI (not runnable locally per this repo's sandbox limitations).
- [x] `/self-review` fan-out: `nswag-check` (PASS - regenerated `openapi-v1.json`/`api-client.ts` match, no hand-edits), `architecture-check` (PASS - layer deps, naming, rate-limiting all consistent with existing `UpdateOrganization`/`UpdateAddressCommand` precedent), `a11y-check` (PASS - backdrop-button/dialog pattern, Escape handling, and all new field labels correct; noted as advisory-only that this modal, like several others, has no dedicated axe test since a modal only exists in the DOM while open - out of scope for this change)

## Live verification

_In progress - will update this section once the release candidate deploys and staging verification completes._

This PR is open and awaiting the repository owner's review - this routine does not merge PRs itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcSga6dSgCPrcCu5nVjEqb)_