### PR TITLE
fix: restore main build broken by DDD refactor

### DIFF
--- a/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
@@ -37,19 +37,15 @@ internal sealed class CreateOrganizationCommandHandler(
 
 		var address = request.Address is null
 			? null
-			: new Address(
+			: Address.Create(
 				request.Address.Street,
 				request.Address.HouseNumber,
 				request.Address.ZipCode,
-				request.Address.City);
+				request.Address.City).GetValueOrThrow();
 
-		organization.Update(
-			request.Name,
-			request.Description,
-			request.ContactEmail,
-			request.ContactPhone,
-			request.Website,
-			address);
+		organization.ChangeDescription(request.Description);
+		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website);
+		organization.Relocate(address);
 
 		await dbContext.Organizations.AddAsync(organization, cancellationToken);
 

--- a/scripts/smoke-test-718-org-create-fields.mjs
+++ b/scripts/smoke-test-718-org-create-fields.mjs
@@ -1,0 +1,162 @@
+/**
+ * Smoke test for #718: restore Organization creation after the DDD refactor
+ * (#716) and the organization-creation-fields feature (#715) collided on
+ * main.
+ *
+ * #715 added description/contact email/phone/website/address to org
+ * creation via `organization.Update(...)` + `new Address(...)`. #716,
+ * merged first, replaced both with `Rename`/`ChangeDescription`/
+ * `ChangeContactInfo`/`Relocate` and `Address.Create(...) -> Result`.
+ * When #715 was merged on top afterwards it broke the build entirely
+ * (CS1729/CS1061), so this exercises the fixed handler end-to-end: fill
+ * every new field in the live `CreateOrganizationModal`, submit, and
+ * confirm they actually persisted (not just an in-memory response echo).
+ *
+ * Run: node scripts/smoke-test-718-org-create-fields.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+const KEYCLOAK = "https://login.maik-hasler.de";
+const CLIENT_ID = "frontend";
+const REALM = "einsatzbereit";
+
+async function getToken(username, password) {
+	const res = await fetch(
+		`${KEYCLOAK}/realms/${REALM}/protocol/openid-connect/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "password",
+				client_id: CLIENT_ID,
+				username,
+				password,
+				scope: "openid",
+			}),
+		},
+	);
+	if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+	const data = await res.json();
+	if (!data.access_token) throw new Error("No access_token in response");
+	return data.access_token;
+}
+
+async function api(token, method, path) {
+	const res = await fetch(`${API}${path}`, {
+		method,
+		headers: token ? { Authorization: `Bearer ${token}` } : {},
+	});
+	const text = await res.text();
+	const json = text ? JSON.parse(text) : null;
+	return { status: res.status, body: json };
+}
+
+const fields = {
+	description: `Smoke718 automated org description ${Date.now()}`,
+	contactEmail: "smoke718@example.com",
+	contactPhone: "+49 441 1234567",
+	website: "https://example.com/smoke718",
+	street: "Smoke718 Street",
+	houseNumber: "42a",
+	zipCode: "26122",
+	city: "Oldenburg",
+};
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const olafToken = await getToken("olaf", "olaf123");
+	const orgName = `Smoke718 Org ${Date.now()}`;
+
+	const { browser, page } = await launchLiveBrowser();
+	let organizationId;
+	try {
+		await page.goto(`${BASE}/profile`, { waitUntil: "networkidle" });
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		if ((await signInBtn.count()) > 0) {
+			await signInBtn.first().click();
+			await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+			await loginKeycloak(page, "olaf", "olaf123");
+			await page.waitForURL(`${BASE}/profile`, { timeout: 15000 });
+		}
+		console.log("OK  Logged in as olaf and reached /profile");
+
+		await page.getByTestId("create-org-btn").click();
+		await page.waitForSelector('[role="dialog"]', { timeout: 10000 });
+		console.log("OK  CreateOrganizationModal opened");
+
+		await page.fill("#create-org-name", orgName);
+		await page.fill("#create-org-description", fields.description);
+		await page.fill("#create-org-contact-email", fields.contactEmail);
+		await page.fill("#create-org-phone", fields.contactPhone);
+		await page.fill("#create-org-website", fields.website);
+		await page.fill("#create-org-street", fields.street);
+		await page.fill("#create-org-house-number", fields.houseNumber);
+		await page.fill("#create-org-zip", fields.zipCode);
+		await page.fill("#create-org-city", fields.city);
+
+		const [createResponse] = await Promise.all([
+			page.waitForResponse(
+				(resp) =>
+					resp.url().endsWith("/v1/organizations") &&
+					resp.request().method() === "POST",
+			),
+			page.getByTestId("modal-submit").click(),
+		]);
+		if (createResponse.status() !== 200) {
+			throw new Error(
+				`CreateOrganization request failed: ${createResponse.status()} ${await createResponse.text()}`,
+			);
+		}
+		const created = await createResponse.json();
+		organizationId = created.id?.value ?? created.id;
+		if (!organizationId) throw new Error(`No organization id in response: ${JSON.stringify(created)}`);
+		console.log(`OK  Submitted form, organization created (${organizationId})`);
+
+		await page.waitForSelector('[role="dialog"]', { state: "detached", timeout: 10000 });
+		console.log("OK  Modal closed after successful submit (no ResultFailureException from Update()/new Address(...))");
+
+		// === Confirm the fields actually persisted, not just an in-memory echo ===
+		const { status, body } = await api(olafToken, "GET", `/v1/organizations/${organizationId}`);
+		if (status !== 200) throw new Error(`GetOrganizationDetails failed: ${status} ${JSON.stringify(body)}`);
+
+		const checks = [
+			["name", body.name, orgName],
+			["description", body.description, fields.description],
+			["contactEmail", body.contactEmail, fields.contactEmail],
+			["contactPhone", body.contactPhone, fields.contactPhone],
+			["website", body.website, fields.website],
+			["address.street", body.address?.street, fields.street],
+			["address.houseNumber", body.address?.houseNumber, fields.houseNumber],
+			["address.zipCode", body.address?.zipCode, fields.zipCode],
+			["address.city", body.address?.city, fields.city],
+		];
+		for (const [label, actual, expected] of checks) {
+			if (actual !== expected)
+				throw new Error(`Expected persisted ${label} === ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+		}
+		console.log("OK  All fields (description, contact email/phone, website, address) persisted exactly as submitted");
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+		if (organizationId) {
+			const { status } = await api(olafToken, "DELETE", `/v1/organizations/${organizationId}`);
+			console.log(
+				status === 204
+					? `OK  Cleaned up organization ${organizationId}`
+					: `WARN cleanup DELETE returned ${status} for organization ${organizationId}`,
+			);
+		}
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

`main`'s build was broken. Root cause is a merge-order collision, not any single PR being wrong in isolation:

- PR #716 ("align with basic functional programming DDD rules") was merged first (`855f982`). It replaced `Organization`'s catch-all `Update(name, description, contactEmail, contactPhone, website, address)` method with named methods (`Rename`, `ChangeDescription`, `ChangeContactInfo`, `Relocate`), and replaced `Address`'s public constructor with a validating `Address.Create(...) -> Result<Address>` factory.
- Five backlog PRs from the autonomous triage routine - #715, #714, #713, #711, #709 - were then merged on top of it in quick succession (all within the same 90 seconds), each having been developed and verified against `main` **before** #716 landed.
- Of those five, only #715 ("add description, contact info, address, and logo to organization creation") touched the same `Organization`/`Address` surface #716 changed. Its `CreateOrganizationCommandHandler.cs` still called the now-removed `organization.Update(...)` and `new Address(...)` constructor, so `main` no longer compiled:
  ```
  error CS1729: 'Address' does not contain a constructor that takes 4 arguments
  error CS1061: 'Organization' does not contain a definition for 'Update'
  ```

The other four (#714, #713, #711, #709) are frontend-only changes with no dependency on the refactored domain API, so they merged in cleanly - confirmed by manual inspection (see Test plan).

Directly confirmed this against CI history: `Publish v1.0.0-rc.254` (the RC cut right after the 6-PR merge spree, before this fix) failed its `Publish Backend` job with these exact two errors - almost certainly what prompted this issue being reported.

## Fix

`CreateOrganizationCommandHandler.cs` now uses the exact same post-#716 pattern its sibling `UpdateOrganizationCommandHandler.cs` already uses: `Address.Create(...).GetValueOrThrow()` plus `ChangeDescription`/`ChangeContactInfo`/`Relocate` (no `Rename` needed since `Organization.Create(id, name)` on the preceding line already sets the name).

## Test plan

- [x] `dotnet build` (from a clean `main` checkout) - reproduced the exact `CS1729`/`CS1061` failure before the fix; 0 warnings/0 errors after
- [x] `dotnet test tests/Application.UnitTests` - 238/238 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] `pnpm check` (tsc), `pnpm lint --max-warnings 0` - both clean
- [x] Manually confirmed the other four merged PRs are all intact and coexist correctly: #711's "Scheduled: ..." engagement-card line and #714's achievements-reorder/grid layout both render in `ProfileOverviewPage.tsx` (the one file both touched), #709's `canSaveDraft` gate in `CreateVolunteerOpportunityModal/index.tsx`, and #713's `handleOrgCta`/`signinRedirectForRegistration` wiring in `HomePage.tsx`
- [x] `/self-review` - no findings (single-handler fix, matches an existing sibling pattern exactly)
- [x] The exact scenario this fixes is already covered by an automated C# TUnit test added in #715 (`VisualTests/OrganizationTests.cs::CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation`) - no new test was needed, see Live verification below for it running green on this RC

## Live verification

Verified against live staging (`https://einsatzbereit.maik-hasler.de`, backend `https://api.maik-hasler.de`) after release candidate `v1.0.0-rc.255` deployed successfully (`Publish` workflow green: Publish Keycloak/Backend/Frontend + Deploy to Staging, including the post-deploy health gate, all passed).

- [x] `curl -sf https://api.maik-hasler.de/health` -> `Healthy`, HTTP 200
- [x] `node scripts/smoke-test-718-org-create-fields.mjs` - all assertions passed (exit 0):
  ```
  OK  API health check passed
  OK  Logged in as olaf and reached /profile
  OK  CreateOrganizationModal opened
  OK  Submitted form, organization created (3d2655d9-51f5-46f8-b01f-5b4214076626)
  OK  Modal closed after successful submit (no ResultFailureException from Update()/new Address(...))
  OK  All fields (description, contact email/phone, website, address) persisted exactly as submitted

  ALL CHECKS PASSED
  OK  Cleaned up organization 3d2655d9-51f5-46f8-b01f-5b4214076626
  ```
  The script drives the real `CreateOrganizationModal` on the live site as olaf, fills every optional field (description, contact email/phone, website, address), submits, and confirms via `GET /v1/organizations/{id}` that everything actually persisted through the fixed handler rather than just echoing the in-memory object back.
- [x] Root cause corroborated directly against CI history: `Publish v1.0.0-rc.254`'s `Publish Backend` job failed with the identical `CS1729`/`CS1061` errors this PR fixes.
- [x] `VisualTests/OrganizationTests.cs::CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation` (added by #715, exercises the same create-with-full-details flow) ran and passed as part of this RC's `Publish Backend` job (`Test - VisualTests` step, green against the local Aspire stack).
