### PR TITLE
fix(deps): update dependency nsubstitute to v6

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -45,7 +45,7 @@
 		<PackageVersion Include="AwesomeAssertions" Version="[9.4.0]" />
 		<PackageVersion Include="Deque.AxeCore.Playwright" Version="[4.12.0]" />
 		<PackageVersion Include="NetArchTest.Rules" Version="[1.3.2]" />
-		<PackageVersion Include="NSubstitute" Version="[5.3.0]" />
+		<PackageVersion Include="NSubstitute" Version="[6.0.0]" />
 		<PackageVersion Include="Respawn" Version="[7.0.0]" />
 		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="[8.19.2]" />
 		<PackageVersion Include="TUnit" Version="[1.61.0]" />

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -186,7 +186,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.Received(1).Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "weekly-hero-4" && c.UserId == volunteerId),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "weekly-hero-4" && c.UserId == volunteerId),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -210,7 +210,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.DidNotReceive().Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "weekly-hero-4"),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "weekly-hero-4"),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -231,7 +231,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.Received(1).Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "first-step" && c.UserId == volunteerId),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "first-step" && c.UserId == volunteerId),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -258,7 +258,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.Received(1).Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "dedicated-5" && c.UserId == volunteerId),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "dedicated-5" && c.UserId == volunteerId),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -281,7 +281,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.DidNotReceive().Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "dedicated-5"),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "dedicated-5"),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -304,7 +304,7 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		await _sender.Received(1).Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "centurion-100" && c.UserId == volunteerId),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "centurion-100" && c.UserId == volunteerId),
 			Arg.Any<CancellationToken>());
 	}
 

--- a/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
@@ -100,7 +100,7 @@ public class CreateOrganizationCommandHandlerTests
 
 		// Assert
 		await _dbContext.Organizations.Received(1).AddAsync(
-			Arg.Is<Organization>(o => o.Name == "Test Org"),
+			Arg.Is<Organization>(o => o!.Name == "Test Org"),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/Users/RecordLogin/RecordLoginCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/RecordLogin/RecordLoginCommandHandlerTests.cs
@@ -73,7 +73,7 @@ public class RecordLoginCommandHandlerTests
 		await _sut.Handle(new RecordLoginCommand(userId, nextDay), cancellationToken);
 
 		await _sender.Received(1).Send(
-			Arg.Is<AwardAchievementCommand>(c => c.BadgeKey == "on-a-roll-7" && c.UserId == userId),
+			Arg.Is<AwardAchievementCommand>(c => c!.BadgeKey == "on-a-roll-7" && c.UserId == userId),
 			Arg.Any<CancellationToken>());
 	}
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -117,7 +117,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 
 		// Assert - one OpportunityDeleted notification per active volunteer, none for cancelled.
 		await _notifRepo.Received(2).AddAsync(
-			Arg.Is<Notification>(n => n.Kind == NotificationKind.OpportunityDeleted && n.RelatedEntityId == opportunityId),
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityDeleted && n.RelatedEntityId == opportunityId),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -322,7 +322,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		// Assert
 		await _notifRepo.Received(1).AddAsync(
-			Arg.Is<Notification>(n => n.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
 			cancellationToken);
 	}
 


### PR DESCRIPTION
## Summary

Supersedes Renovate's #736, which was failing CI. NSubstitute 6.0 added nullable annotations to `Arg.Is<T>`'s predicate parameter (`Predicate<T>` -> `Predicate<T?>`), which trips `CS8602` ("dereference of a possibly null reference") wherever a matcher lambda dereferences its parameter, under this repo's `Nullable=enable` + `TreatWarningsAsErrors=true` settings.

Confirmed the root cause by reflecting on the shipped `NSubstitute.dll`: the `predicate` parameter of `Arg.Is<T>(Expression<Predicate<T>>)` carries `[NullableAttribute(new byte[3] { 1, 1, 2 })]`, i.e. the `T` nested inside `Predicate<>` is now annotated nullable.

- `backend/Directory.Packages.props`: `NSubstitute` `5.3.0` -> `6.0.0`
- Null-forgive (`x!.Member`) the first member access in each affected `Arg.Is<T>(...)` matcher lambda, 10 sites across 5 test files. NSubstitute always invokes these predicates with the real, non-null captured argument, so this doesn't change test behavior - it's purely satisfying the new nullable annotation.

## Test plan

- [x] `dotnet build` - 0 warnings, 0 errors
- [x] `dotnet test tests/Application.UnitTests` - 238/238 passed
- [x] `dotnet test tests/ArchitectureTests` - 247/247 passed
- [x] `dotnet format --verify-no-changes` - clean
- [x] `/self-review` - no findings; diff is confined to `Directory.Packages.props` and `Application.UnitTests/**`, so none of the domain-specific subagents (nswag/ef-migration/architecture/a11y/i18n-check) apply

## Live verification

Not applicable - this change is confined to test-only code (NSubstitute is a test-project-only dependency) and a central package version pin. No production/runtime code, API surface, or user-visible behavior changed, so there is nothing to observe on a deployed release candidate. Verification is the green build + test suite above, which reproduces and resolves the exact CI failure from #736.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JDU3o2Rn3pKXtjNLPnCxXm)_