### PR TITLE
feat(frontend): redesign org app shell header

### DIFF
--- a/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
@@ -5,17 +5,18 @@ using Microsoft.Playwright;
 namespace VisualTests;
 
 /// <summary>
-/// Visual tests for the redesigned org app shell header requested in #742: the
-/// plain "Back to Einsatzbereit" text link became the Einsatzbereit logo (linking
-/// to the main site), an icon-led breadcrumb (home icon + current subpage label)
-/// was added, the org switcher stayed as a separate control, and the tab bar moved
-/// out of the <c>&lt;header&gt;</c> into its own landmark directly beneath it.
+/// Visual tests for the redesigned org app shell requested in #742 (and refined
+/// in the #744 review): the plain "Back to Einsatzbereit" text link became the
+/// Einsatzbereit logo (linking to the main site); the section tabs were removed
+/// from the header entirely and relocated into the org page's main content area;
+/// and an icon-led breadcrumb (home icon + current subpage label) now occupies
+/// the action bar directly beneath the header, where the tab bar used to sit.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrgAppShellHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task OrgAppShellHeader_ShowsLogoAndBreadcrumb_WithTabBarBelowHeader()
+	public async Task OrgAppShell_LogoInHeader_BreadcrumbInActionBar_TabsInMainContent()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -36,22 +37,28 @@ public class OrgAppShellHeaderTests(AspireFixture fixture) : VisualTestBase(fixt
 		await Expect(logoLink.Locator("img")).ToBeVisibleAsync();
 		await Expect(Page.GetByText("Back to Einsatzbereit")).Not.ToBeVisibleAsync();
 
-		// Breadcrumb: home-icon link + the current subpage label ("Settings").
+		// Breadcrumb: home-icon link + the current subpage label ("Settings"). It
+		// lives in the action bar beneath the header, NOT inside <header> itself.
 		var breadcrumb = Page.GetByRole(AriaRole.Navigation, new() { Name = "Breadcrumb" });
 		await Expect(breadcrumb).ToBeVisibleAsync();
 		await Expect(breadcrumb.GetByRole(AriaRole.Link, new() { Name = "Home" }))
 			.ToBeVisibleAsync();
 		await Expect(breadcrumb).ToContainTextAsync("Settings");
+		(await Page.Locator("header nav[aria-label='Breadcrumb']").CountAsync())
+			.Should().Be(0, "the breadcrumb moved out of the header into the action bar");
 
-		// The org switcher remains present as its own separate control.
+		// The org switcher remains present in the header as its own separate control.
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }))
 			.ToBeVisibleAsync();
 
-		// The tab bar is its own landmark and a sibling of <header>, not nested in it.
+		// The section tabs are gone from the header/action bar and now render inside
+		// the org page's main content area.
 		var tabBar = Page.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" });
 		await Expect(tabBar).ToBeVisibleAsync();
 		(await Page.Locator("header nav[aria-label='Organization sections']").CountAsync())
-			.Should().Be(0, "the tab bar must render beneath <header>, not inside it");
+			.Should().Be(0, "the tabs must not remain in the header");
+		(await Page.Locator("main nav[aria-label='Organization sections']").CountAsync())
+			.Should().Be(1, "the tabs moved into the org page's main content area");
 
 		// Active-tab logic is preserved: the Settings tab is marked current.
 		await Expect(tabBar.GetByRole(AriaRole.Link, new() { Name = "Settings" }))

--- a/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for the redesigned org app shell header requested in #742: the
+/// plain "Back to Einsatzbereit" text link became the Einsatzbereit logo (linking
+/// to the main site), an icon-led breadcrumb (home icon + current subpage label)
+/// was added, the org switcher stayed as a separate control, and the tab bar moved
+/// out of the <c>&lt;header&gt;</c> into its own landmark directly beneath it.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgAppShellHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OrgAppShellHeader_ShowsLogoAndBreadcrumb_WithTabBarBelowHeader()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = match.Groups[1].Value;
+
+		// Land on a known subpage so the breadcrumb has a stable current-page label.
+		await Page.GotoAsync($"{origin}/app/{organizationId}/settings");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Logo replaces the old text link and sits top-left in the header.
+		var logoLink = Page.Locator("header a[href='/']");
+		await Expect(logoLink.Locator("img")).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Back to Einsatzbereit")).Not.ToBeVisibleAsync();
+
+		// Breadcrumb: home-icon link + the current subpage label ("Settings").
+		var breadcrumb = Page.GetByRole(AriaRole.Navigation, new() { Name = "Breadcrumb" });
+		await Expect(breadcrumb).ToBeVisibleAsync();
+		await Expect(breadcrumb.GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToBeVisibleAsync();
+		await Expect(breadcrumb).ToContainTextAsync("Settings");
+
+		// The org switcher remains present as its own separate control.
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }))
+			.ToBeVisibleAsync();
+
+		// The tab bar is its own landmark and a sibling of <header>, not nested in it.
+		var tabBar = Page.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" });
+		await Expect(tabBar).ToBeVisibleAsync();
+		(await Page.Locator("header nav[aria-label='Organization sections']").CountAsync())
+			.Should().Be(0, "the tab bar must render beneath <header>, not inside it");
+
+		// Active-tab logic is preserved: the Settings tab is marked current.
+		await Expect(tabBar.GetByRole(AriaRole.Link, new() { Name = "Settings" }))
+			.ToHaveAttributeAsync("aria-current", "page");
+
+		// Clicking the logo navigates to the main site.
+		await logoLink.ClickAsync();
+		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 15_000 });
+	}
+}

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -165,10 +165,10 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
 	{
 		// Regression for #641 (and a guard against reintroducing it): the tab
-		// bar now lives in the persistent /app shell (OrgAppLayout) as its own
-		// nav landmark beneath the header, decoupled from any individual tab
-		// page's own content-width wrapper - it must not shrink or shift when
-		// navigating between tabs.
+		// bar now lives in the persistent /app shell (OrgAppLayout) at the top
+		// of the main content area, decoupled from any individual tab page's own
+		// content-width wrapper - it must not shrink or shift when navigating
+		// between tabs.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
@@ -176,9 +176,11 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual641 Alignment");
 
-		// Measure the tab bar's inner content container (the mx-auto max-w-7xl
-		// wrapper). Scope by the nav's accessible name so the breadcrumb nav -
-		// which also surfaces the current tab label - isn't matched too.
+		// Measure the tab row's flex container inside the tabs nav; its width
+		// tracks the enclosing <main class="...max-w-7xl...">, which is constant
+		// across tab switches. Scope by the nav's accessible name so the
+		// breadcrumb nav - which also surfaces the current tab label - isn't
+		// matched too.
 		var tabBar = Page
 			.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" })
 			.Locator("div")

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -165,9 +165,10 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
 	{
 		// Regression for #641 (and a guard against reintroducing it): the tab
-		// bar now lives in the persistent /app header (OrgAppLayout), decoupled
-		// from any individual tab page's own content-width wrapper - it must not
-		// shrink or shift when navigating between tabs.
+		// bar now lives in the persistent /app shell (OrgAppLayout) as its own
+		// nav landmark beneath the header, decoupled from any individual tab
+		// page's own content-width wrapper - it must not shrink or shift when
+		// navigating between tabs.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await AuthHelper.LoginAsync(Page, frontend, "olaf", "olaf123");
@@ -175,7 +176,13 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual641 Alignment");
 
-		var tabBar = Page.Locator("nav").Filter(new() { HasText = "Settings" });
+		// Measure the tab bar's inner content container (the mx-auto max-w-7xl
+		// wrapper). Scope by the nav's accessible name so the breadcrumb nav -
+		// which also surfaces the current tab label - isn't matched too.
+		var tabBar = Page
+			.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" })
+			.Locator("div")
+			.First;
 		var dashboardBox = await tabBar.BoundingBoxAsync();
 		dashboardBox.Should().NotBeNull();
 

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -103,51 +103,9 @@ export default function OrgAppLayout() {
 		<div className="flex min-h-screen flex-col bg-gray-50">
 			<header className="border-b border-gray-200 bg-white">
 				<div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-					<div className="flex min-w-0 items-center gap-3">
-						<Link to="/" className="flex shrink-0 items-center">
-							<img src="/logo.svg" alt={t("brand.name")} className="h-8" />
-						</Link>
-
-						<div
-							className="hidden h-6 w-px shrink-0 bg-gray-200 sm:block"
-							aria-hidden="true"
-						/>
-
-						<nav
-							aria-label={t("breadcrumb.label")}
-							className="hidden min-w-0 items-center gap-1.5 text-sm sm:flex"
-						>
-							<Link
-								to={`/app/${organizationId}/dashboard`}
-								aria-label={t("breadcrumb.home")}
-								className="flex shrink-0 items-center text-gray-400 transition-colors hover:text-brand-700"
-							>
-								<svg
-									className="h-4 w-4"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth="1.5"
-									stroke="currentColor"
-									aria-hidden="true"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
-									/>
-								</svg>
-							</Link>
-							<span className="shrink-0 text-gray-300" aria-hidden="true">
-								&rsaquo;
-							</span>
-							<span
-								className="truncate font-medium text-gray-900"
-								aria-current="page"
-							>
-								{t(activeTab.labelKey)}
-							</span>
-						</nav>
-					</div>
+					<Link to="/" className="flex shrink-0 items-center">
+						<img src="/logo.svg" alt={t("brand.name")} className="h-8" />
+					</Link>
 
 					<div className="min-w-0 flex-1 sm:flex-none">
 						<OrganizationSwitcher
@@ -174,29 +132,65 @@ export default function OrgAppLayout() {
 				</div>
 			</header>
 
-			<nav
-				className="border-b border-gray-200 bg-white"
-				aria-label={t("orgApp.tabsLabel")}
-			>
-				<div className="mx-auto flex max-w-7xl gap-6 px-4 sm:px-6 lg:px-8">
-					{TABS.map((tab) => (
+			<div className="border-b border-gray-200 bg-white">
+				<div className="mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
+					<nav
+						aria-label={t("breadcrumb.label")}
+						className="flex min-w-0 items-center gap-1.5 text-sm"
+					>
 						<Link
-							key={tab.key}
-							to={`/app/${organizationId}/${tab.key}`}
-							aria-current={activeTabKey === tab.key ? "page" : undefined}
-							className={`border-b-2 pb-3 pt-3 text-sm font-medium transition-colors ${
-								activeTabKey === tab.key
-									? "border-brand-700 text-brand-700"
-									: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
-							}`}
+							to={`/app/${organizationId}/dashboard`}
+							aria-label={t("breadcrumb.home")}
+							className="flex shrink-0 items-center text-gray-400 transition-colors hover:text-brand-700"
 						>
-							{t(tab.labelKey)}
+							<svg
+								className="h-4 w-4"
+								fill="none"
+								viewBox="0 0 24 24"
+								strokeWidth="1.5"
+								stroke="currentColor"
+								aria-hidden="true"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+								/>
+							</svg>
 						</Link>
-					))}
+						<span className="shrink-0 text-gray-300" aria-hidden="true">
+							&rsaquo;
+						</span>
+						<span
+							className="truncate font-medium text-gray-900"
+							aria-current="page"
+						>
+							{t(activeTab.labelKey)}
+						</span>
+					</nav>
 				</div>
-			</nav>
+			</div>
 
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+				<nav aria-label={t("orgApp.tabsLabel")} className="mb-6 sm:mb-8">
+					<div className="flex gap-6 border-b border-gray-200">
+						{TABS.map((tab) => (
+							<Link
+								key={tab.key}
+								to={`/app/${organizationId}/${tab.key}`}
+								aria-current={activeTabKey === tab.key ? "page" : undefined}
+								className={`border-b-2 pb-3 pt-3 text-sm font-medium transition-colors ${
+									activeTabKey === tab.key
+										? "border-brand-700 text-brand-700"
+										: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+								}`}
+							>
+								{t(tab.labelKey)}
+							</Link>
+						))}
+					</div>
+				</nav>
+
 				<Outlet
 					context={{ org, reloadOrg: load } satisfies OrgAppContext}
 					// Outlet re-mounts children on org identity change so per-tab state resets cleanly

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -68,6 +68,7 @@ export default function OrgAppLayout() {
 	const activeTabKey =
 		TABS.find((tab) => location.pathname.endsWith(`/${tab.key}`))?.key ??
 		"dashboard";
+	const activeTab = TABS.find((tab) => tab.key === activeTabKey) ?? TABS[0];
 
 	const displayName = (auth.user?.profile?.name ??
 		auth.user?.profile?.preferred_username ??
@@ -102,26 +103,51 @@ export default function OrgAppLayout() {
 		<div className="flex min-h-screen flex-col bg-gray-50">
 			<header className="border-b border-gray-200 bg-white">
 				<div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-					<Link
-						to="/"
-						className="flex shrink-0 items-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-brand-700"
-					>
-						<svg
-							className="h-4 w-4"
-							fill="none"
-							viewBox="0 0 24 24"
-							strokeWidth="2"
-							stroke="currentColor"
+					<div className="flex min-w-0 items-center gap-3">
+						<Link to="/" className="flex shrink-0 items-center">
+							<img src="/logo.svg" alt={t("brand.name")} className="h-8" />
+						</Link>
+
+						<div
+							className="hidden h-6 w-px shrink-0 bg-gray-200 sm:block"
 							aria-hidden="true"
+						/>
+
+						<nav
+							aria-label={t("breadcrumb.label")}
+							className="hidden min-w-0 items-center gap-1.5 text-sm sm:flex"
 						>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-							/>
-						</svg>
-						<span className="hidden sm:inline">{t("orgApp.backToSite")}</span>
-					</Link>
+							<Link
+								to={`/app/${organizationId}/dashboard`}
+								aria-label={t("breadcrumb.home")}
+								className="flex shrink-0 items-center text-gray-400 transition-colors hover:text-brand-700"
+							>
+								<svg
+									className="h-4 w-4"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth="1.5"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+									/>
+								</svg>
+							</Link>
+							<span className="shrink-0 text-gray-300" aria-hidden="true">
+								&rsaquo;
+							</span>
+							<span
+								className="truncate font-medium text-gray-900"
+								aria-current="page"
+							>
+								{t(activeTab.labelKey)}
+							</span>
+						</nav>
+					</div>
 
 					<div className="min-w-0 flex-1 sm:flex-none">
 						<OrganizationSwitcher
@@ -146,29 +172,29 @@ export default function OrgAppLayout() {
 						<LanguageSelector />
 					</div>
 				</div>
-
-				<nav
-					className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
-					aria-label={org.name}
-				>
-					<div className="flex gap-6 border-t border-gray-100">
-						{TABS.map((tab) => (
-							<Link
-								key={tab.key}
-								to={`/app/${organizationId}/${tab.key}`}
-								aria-current={activeTabKey === tab.key ? "page" : undefined}
-								className={`border-b-2 pb-3 pt-3 text-sm font-medium transition-colors ${
-									activeTabKey === tab.key
-										? "border-brand-700 text-brand-700"
-										: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
-								}`}
-							>
-								{t(tab.labelKey)}
-							</Link>
-						))}
-					</div>
-				</nav>
 			</header>
+
+			<nav
+				className="border-b border-gray-200 bg-white"
+				aria-label={t("orgApp.tabsLabel")}
+			>
+				<div className="mx-auto flex max-w-7xl gap-6 px-4 sm:px-6 lg:px-8">
+					{TABS.map((tab) => (
+						<Link
+							key={tab.key}
+							to={`/app/${organizationId}/${tab.key}`}
+							aria-current={activeTabKey === tab.key ? "page" : undefined}
+							className={`border-b-2 pb-3 pt-3 text-sm font-medium transition-colors ${
+								activeTabKey === tab.key
+									? "border-brand-700 text-brand-700"
+									: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+							}`}
+						>
+							{t(tab.labelKey)}
+						</Link>
+					))}
+				</div>
+			</nav>
 
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
 				<Outlet

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -325,7 +325,8 @@
     },
     "orgApp": {
       "backToSite": "Zurueck zu Einsatzbereit",
-      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation."
+      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation.",
+      "tabsLabel": "Organisationsbereiche"
     },
     "orgAppEntry": {
       "title": "Organisationsübersicht",
@@ -736,6 +737,7 @@
       }
     },
     "breadcrumb": {
+      "label": "Navigationspfad",
       "home": "Startseite",
       "orgApp": "Organisationen",
       "volunteerOpportunities": "Einsatzmöglichkeiten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -325,7 +325,8 @@
     },
     "orgApp": {
       "backToSite": "Back to Einsatzbereit",
-      "notAuthorized": "You don't have access to this organization."
+      "notAuthorized": "You don't have access to this organization.",
+      "tabsLabel": "Organization sections"
     },
     "orgAppEntry": {
       "title": "Organization Overview",
@@ -736,6 +737,7 @@
       }
     },
     "breadcrumb": {
+      "label": "Breadcrumb",
       "home": "Home",
       "orgApp": "Organizations",
       "volunteerOpportunities": "Volunteer Opportunities",


### PR DESCRIPTION
…cated tab bar)

Aligns the org app shell (/app/:organizationId/...) with the app branding and improves wayfinding (issue #742):

- Replace the "Back to Einsatzbereit" text link with the Einsatzbereit logo, matching Header.tsx and linking to the main site.
- Add an icon-led breadcrumb: home icon (linking to the org dashboard) + separator + current subpage label. The label reuses the existing orgOverview.tab* keys, so no duplicate i18n keys.
- Keep OrganizationSwitcher unchanged as a separate control.
- Move the tab bar out of <header> into its own <nav> landmark directly beneath it, preserving active-tab styling and aria-current="page".

Both the breadcrumb and tab-bar navs get distinct, localized aria-labels (new keys breadcrumb.label and orgApp.tabsLabel, added to en.json and de.json).

Adds a VisualTest (OrgAppShellHeaderTests) asserting the logo links to the main site, the breadcrumb shows the home link + current page, the switcher remains, and the tab bar renders as a sibling of <header>.

Closes #742