### PR TITLE
ci: gate publish on green CI instead of re-running the full suite

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -51,11 +51,44 @@ All images pushed to **GitHub Container Registry (GHCR)**.
 **Full release:** Tag without `-rc` suffix → image published + `latest` tag updated.
 
 ### Publish flow (backend/frontend)
-1. Run full test suite (same as CI workflow)
+1. `require-green` gate (see below) - proves CI already passed on this tree; no re-test here
 2. Login to GHCR
 3. Extract version from tag (strips component prefix)
 4. Build and push Docker image
 5. Tag with version + `latest` (if not RC)
+
+### Release green gate (`require-green` in `publish.yml`)
+
+`publish.yml` no longer re-runs the test suite. Instead its first job,
+`require-green`, is a hard precondition for every publish job: it proves the
+deployed tree is green and fails closed otherwise. This removes ~8 min of
+duplicated backend tests + frontend lint/build from every deploy - the same
+tests already ran once on the PR / `main`.
+
+How it decides:
+- Resolves the tag commit to the **tested tree**. Handles both tag shapes: a tag
+  on a real commit (its own sha carries the CI run) and the empty `release: vX`
+  commit (byte-identical tree to its parent - it walks first-parents while the
+  tree is unchanged).
+- Requires a **successful `dotnet.yml` run** for that tree, from `main` or
+  `release/*`. While CI is still running it polls (up to ~45 min) rather than
+  failing; a completed non-success blocks the deploy.
+- `frontend.yml` is block-if-present: it must be green **if** it ran on the tree
+  (a backend-only change legitimately has no frontend run).
+
+**Recovery when the gate fails closed** ("No successful dotnet.yml run for tree
+... within deadline"): the deployed commit was never tested by `dotnet.yml`
+(push trigger is `main`-only). In order of preference:
+1. Route the fix through a normal PR to `main`, let CI go green, then cut
+   `release/vX.Y.Z-rc.N` **from that green `main` commit`** (the intended flow -
+   the empty-commit tree-walk then finds the parent's proof).
+2. For a hotfix committed directly on a `release/*` branch, dispatch CI on it
+   first: `gh workflow run dotnet.yml --ref <branch>`, wait for green, then
+   promote.
+
+Do not "cut the release branch from a feature branch" - a PR's CI proof lives on
+the throwaway `refs/pull/N/merge` sha, which the gate cannot see, so it fails
+closed. Always cut from `main`.
 
 ## Cutting a release from Claude Code on the web
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,12 @@
 name: Build and Test Backend
 
+# LOAD-BEARING for the release gate: publish.yml's require-green job proves a
+# deploy is safe by requiring a successful run of THIS workflow (by filename
+# 'dotnet.yml') on the deployed tree, from the main / release/* branches. Do not
+# rename this file, change its `name`, or drop the `push: branches: [main]`
+# trigger without updating require-green in publish.yml - otherwise every release
+# fails closed.
+
 on:
   push:
     branches: [main]
@@ -8,6 +15,10 @@ on:
       - 'frontend/**'
       - 'keycloak/**'
       - '.github/workflows/dotnet.yml'
+      # The release gate (publish.yml require-green) needs a build-and-test run to
+      # exist for release-machinery-only changes too, so gate them through CI.
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/release-rc.yml'
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +26,10 @@ on:
       - 'frontend/**'
       - 'keycloak/**'
       - '.github/workflows/dotnet.yml'
+      # The release gate (publish.yml require-green) needs a build-and-test run to
+      # exist for release-machinery-only changes too, so gate them through CI.
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/release-rc.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,140 @@ permissions:
   packages: write
 
 jobs:
+  require-green:
+    name: Require green CI for tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      # Full-suite CI workflow whose success is the authoritative proof that the
+      # deployed tree is green. This filename (and dotnet.yml's push:main trigger)
+      # are load-bearing for the release gate - see .github/AGENTS.md
+      # "Release green gate".
+      CI_WORKFLOW: dotnet.yml
+      # Component CI that must not be red IF it ran on this tree. Path-filtered,
+      # so a legitimate absence (e.g. a backend-only change) is fine.
+      BLOCK_IF_PRESENT: "frontend.yml"
+      # Branches whose CI run we accept as proof for the deployed tree.
+      ALLOWED_BRANCHES: "main release/"
+      # Fail closed if no successful CI_WORKFLOW run appears within this window
+      # (covers a tag cut right after merge while CI is still running).
+      GATE_DEADLINE_SECONDS: "2700"
+      GATE_POLL_SECONDS: "30"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 10
+
+      - name: Require successful CI for the deployed tree
+        run: |
+          set -uo pipefail
+
+          # 1. Resolve tree-identical candidate commits for BOTH tag shapes.
+          #    Recent shape: the tag sits on a real commit; its own sha carries
+          #    the CI run. Older shape: an empty "release: vX" commit whose tree
+          #    is byte-identical to its parent - walk first-parents while the tree
+          #    is unchanged (also survives doubly-stacked empty commits).
+          HEAD_SHA="$(git rev-parse HEAD)"
+          HEAD_TREE="$(git rev-parse "HEAD^{tree}")"
+          CANDIDATES=("$HEAD_SHA"); sha="$HEAD_SHA"
+          for _ in $(seq 1 8); do
+            parent="$(git rev-parse --verify --quiet "${sha}^" || true)"
+            [ -z "$parent" ] && break
+            [ "$(git rev-parse "${parent}^{tree}")" != "$HEAD_TREE" ] && break
+            CANDIDATES+=("$parent"); sha="$parent"
+          done
+          echo "Deployable tree: $HEAD_TREE"
+          echo "Candidate commits: ${CANDIDATES[*]}"
+
+          branch_allowed() {
+            local b="$1" p
+            for p in $ALLOWED_BRANCHES; do
+              case "$b" in "$p"|"$p"*) return 0 ;; esac
+            done
+            return 1
+          }
+
+          # Latest COMPLETED run of a workflow across the candidate shas.
+          # Emits "<conclusion>\t<head_branch>"; empty if none completed.
+          latest_completed_run() {
+            local wf="$1" s out=""
+            for s in "${CANDIDATES[@]}"; do
+              out="${out}$(gh api --paginate \
+                "repos/${REPO}/actions/workflows/${wf}/runs?head_sha=${s}&per_page=100" \
+                --jq '.workflow_runs[] | select(.status=="completed")
+                      | [.created_at, .conclusion, .head_branch] | @tsv' 2>/dev/null)"$'\n'
+            done
+            printf '%s\n' "$out" | awk 'NF' | sort -r | head -n1 | cut -f2,3
+          }
+
+          any_pending_run() {
+            local wf="$1" s n
+            for s in "${CANDIDATES[@]}"; do
+              n="$(gh api --paginate \
+                "repos/${REPO}/actions/workflows/${wf}/runs?head_sha=${s}&per_page=100" \
+                --jq '[.workflow_runs[] | select(.status!="completed")] | length' 2>/dev/null || echo 0)"
+              [ "${n:-0}" -gt 0 ] && return 0
+            done
+            return 1
+          }
+
+          # 2. Poll for authoritative proof from CI_WORKFLOW. Absent means it has
+          #    not run yet / is still running: keep waiting until the deadline,
+          #    then fail closed. A completed non-success is a red tree - block.
+          DEADLINE=$(( $(date +%s) + GATE_DEADLINE_SECONDS ))
+          while :; do
+            RES="$(latest_completed_run "$CI_WORKFLOW")"
+            CONCL="$(printf '%s' "$RES" | cut -f1)"
+            BRANCH="$(printf '%s' "$RES" | cut -f2)"
+            if [ -n "$CONCL" ]; then
+              if ! branch_allowed "$BRANCH"; then
+                echo "::error::${CI_WORKFLOW} proof ran on untrusted branch '${BRANCH}'."
+                exit 1
+              fi
+              if [ "$CONCL" = "success" ]; then
+                echo "Proof: ${CI_WORKFLOW} succeeded on '${BRANCH}' for tree ${HEAD_TREE}."
+                break
+              fi
+              echo "::error::${CI_WORKFLOW} concluded '${CONCL}' for the deployed tree. Refusing to publish red code."
+              exit 1
+            fi
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "::error::No successful ${CI_WORKFLOW} run for tree ${HEAD_TREE} within ${GATE_DEADLINE_SECONDS}s. Failing closed."
+              echo "::error::Hotfix committed directly on a release/* branch? See recovery in .github/AGENTS.md."
+              exit 1
+            fi
+            if any_pending_run "$CI_WORKFLOW"; then
+              echo "${CI_WORKFLOW} still running; polling again in ${GATE_POLL_SECONDS}s..."
+            else
+              echo "No ${CI_WORKFLOW} run yet; waiting ${GATE_POLL_SECONDS}s for the post-merge run..."
+            fi
+            sleep "$GATE_POLL_SECONDS"
+          done
+
+          # 3. Block-if-present: component CI that DID run on this tree must be green.
+          for wf in $BLOCK_IF_PRESENT; do
+            RES="$(latest_completed_run "$wf")"
+            CONCL="$(printf '%s' "$RES" | cut -f1)"
+            if [ -z "$CONCL" ]; then
+              echo "${wf}: not run on this tree (path-filtered); ok."
+              continue
+            fi
+            if [ "$CONCL" != "success" ]; then
+              echo "::error::${wf} concluded '${CONCL}' for the deployed tree. Refusing."
+              exit 1
+            fi
+            echo "${wf}: success; ok."
+          done
+          echo "Green gate passed for ${HEAD_SHA}."
+
   publish-backend:
     name: Publish Backend
+    needs: require-green
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.repository }}-backend
@@ -24,49 +156,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: backend/global.json
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          package_json_file: frontend/package.json
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: frontend/package.json
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: pnpm install --frozen-lockfile
-
-      - name: Restore backend
-        working-directory: backend
-        run: dotnet restore
-
-      - name: Build backend
-        working-directory: backend
-        run: dotnet build --no-restore
-
-      - name: Test - Application.UnitTests
-        working-directory: backend
-        run: dotnet run --project tests/Application.UnitTests --no-build
-
-      - name: Test - ArchitectureTests
-        working-directory: backend
-        run: dotnet run --project tests/ArchitectureTests --no-build
-
-      - name: Test - IntegrationTests
-        working-directory: backend
-        run: dotnet run --project tests/IntegrationTests --no-build
-
-      - name: Test - VisualTests
-        working-directory: backend
-        run: dotnet run --project tests/VisualTests --no-build
-
+      # No build/test here: require-green already proved dotnet.yml passed on this
+      # exact tree. The image is built from source inside backend/src/Api/Dockerfile.
       - name: Log in to Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -106,37 +197,15 @@ jobs:
 
   publish-frontend:
     name: Publish Frontend
+    needs: require-green
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.repository }}-frontend
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          package_json_file: frontend/package.json
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: frontend/package.json
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - run: pnpm install --frozen-lockfile
-        working-directory: frontend
-
-      - name: Lint
-        working-directory: frontend
-        run: pnpm lint
-
-      - name: Type check
-        working-directory: frontend
-        run: pnpm check
-
-      - name: Build
-        working-directory: frontend
-        run: pnpm build
-
+      # No lint/check/build here: require-green already proved frontend.yml passed
+      # on this tree. The image is built from source inside frontend/Dockerfile.
       - name: Log in to Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -175,6 +244,7 @@ jobs:
 
   publish-keycloak:
     name: Publish Keycloak
+    needs: require-green
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.repository }}-keycloak


### PR DESCRIPTION
publish.yml re-ran the entire backend test suite (Application.UnitTests, ArchitectureTests, IntegrationTests, VisualTests) plus frontend lint/check/build before building the images - about 8 of the Publish Backend job's ~10 min - on the exact same tree that the PR / main run of dotnet.yml already tested green. The Dockerfiles rebuild everything from source, so the CI-side build outputs were discarded anyway. That duplication is the second long wait on every deploy.

Replace the re-test with a `require-green` preflight job that all publish jobs depend on. It proves the deployed tree is green rather than reproving it:

- Resolves the tag commit to its tested tree, handling both tag shapes in this repo's history: a tag on a real commit (own sha carries the CI run) and the empty `release: vX` commit (byte-identical tree to its parent - walks first-parents while the tree is unchanged).
- Requires a successful `dotnet.yml` run for that tree from main / release/*, bound to the workflow file (not a check-run name, which could be forged or masked). Polls while CI is still running; a completed non-success blocks.
- frontend.yml is block-if-present (a backend-only change legitimately has no frontend run). Fails closed when no green proof exists.

Also add publish.yml / release-rc.yml to dotnet.yml's path filter so release-machinery-only changes still get a build-and-test run for the gate to find, and document the gate + its fail-closed recovery in .github/AGENTS.md.

Net: removes ~8 min of duplicated work from every deploy; tests still run exactly once, on the PR. Publish no longer independently re-tests - the dotnet.yml run on main is now the sole functional gate (see the load-bearing note added to dotnet.yml).