### PR TITLE
ci: add manual staging reset workflow

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -9,6 +9,7 @@
 ├── docs.yml          Docs: AsciiDoc build → GitHub Pages deploy
 ├── publish.yml       Tag-triggered: build + push backend/frontend/keycloak to GHCR, then deploy-staging
 ├── release-rc.yml    Promotes a release/v* branch into a real tag (used by Claude Code on the web)
+├── reset-staging.yml Manual (workflow_dispatch): wipes staging Postgres + MinIO data, restarts with same images
 ├── lint.yml          Ban em/en dashes + EditorConfig check
 └── pr-title.yml      Validate PR title against Conventional Commits
 ```
@@ -94,6 +95,16 @@ A PAT (not the default `GITHUB_TOKEN`) is mandatory because tags pushed with `GI
 1. Poll the publish workflow's checks for the new tag (via `mcp__github__get_commit` → check_runs, or fetch `https://api.github.com/repos/{owner}/{repo}/commits/{sha}/check-runs`).
 2. Once `deploy-staging` reports success, smoke-test live: `curl https://api.maik-hasler.de/health`, then HEAD-check `https://einsatzbereit.maik-hasler.de`.
 3. If any publish job fails, diagnose from logs; if the deploy step itself fails, the SSH/GHCR secrets in the `staging` GitHub Environment are the most likely cause.
+
+## Reset Workflow (manual)
+
+`reset-staging.yml` wipes all staging test data - Postgres (`einsatzbereit` + `keycloak` databases, one instance) and MinIO uploads - then restarts the stack. It does **not** run `docker compose pull`, so the exact image tags/versions already running come back up unchanged; only data is reset.
+
+- Trigger: `workflow_dispatch` only, with a required `confirm` input that must equal exactly `RESET`
+- Runs in the `staging` GitHub Environment, reusing the same SSH secrets as `deploy-staging`
+- Removes only the `postgres_data` and `minio_data` volumes - `postgres_backups` is left alone on purpose, as the recovery path if a reset needs to be walked back
+- Because Keycloak's realm import runs with `OVERWRITE_EXISTING` (see `deploy-staging` in `publish.yml`) and the backend has `Database__MigrateOnStartup: true`, the stack re-migrates and re-imports `keycloak/realms/einsatzbereit-realm.json` on restart - the standard `vera`/`olaf`/`admin` test accounts come back automatically since they are defined in that checked-in realm config, not created ad hoc
+- Ends with the same post-deploy health gate (`/health` polling) used by `deploy-staging`
 
 ## Issue Templates
 

--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -1,0 +1,89 @@
+name: Reset Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type RESET to confirm - this permanently deletes all staging data (Postgres + Keycloak + MinIO). Currently running images/tags are kept.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  reset-staging:
+    name: Reset Staging Data
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Verify confirmation
+        env:
+          CONFIRM_INPUT: ${{ inputs.confirm }}
+        run: |
+          if [ "$CONFIRM_INPUT" != "RESET" ]; then
+            echo "::error::Confirmation input must be exactly 'RESET' to proceed. Got: '$CONFIRM_INPUT'"
+            exit 1
+          fi
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ secrets.STAGING_SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Wipe data volumes and restart stack
+        run: |
+          ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
+            set -euo pipefail
+            cd /opt/einsatzbereit
+
+            echo "Stopping stack..."
+            docker compose down
+
+            # postgres_data holds both the "einsatzbereit" and "keycloak" databases
+            # (single Postgres instance, see docker-compose.yml). minio_data holds
+            # uploaded files. postgres_backups is deliberately NOT removed - it is
+            # the safety net if this reset needs to be walked back.
+            echo "Removing data volumes (postgres_data, minio_data)..."
+            docker volume rm einsatzbereit_postgres_data einsatzbereit_minio_data
+
+            # No `docker compose pull` here on purpose: we restart with whatever
+            # images are already cached locally, i.e. the exact same tags/versions
+            # that were running before the reset. Only data is wiped.
+            echo "Starting stack..."
+            docker compose up -d --remove-orphans
+          EOF
+
+      - name: Post-reset health gate
+        run: |
+          set -uo pipefail
+          echo "Waiting for https://api.maik-hasler.de/health to report ready..."
+          for i in $(seq 1 30); do
+            code=$(curl -fsS -o /dev/null -w "%{http_code}" https://api.maik-hasler.de/health || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "API healthy (HTTP 200) after attempt $i."
+              exit 0
+            fi
+            echo "Attempt $i/30: /health -> $code; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::API did not report healthy within 5 minutes after reset."
+          exit 1
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: |
+          ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
+            set +e
+            cd /opt/einsatzbereit
+            for svc in backend keycloak postgres minio; do
+              echo "::group::docker inspect ${svc} (state)"
+              docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Health={{if .State.Health}}{{.State.Health.Status}}{{end}}' "${svc}" 2>&1 || true
+              echo "::endgroup::"
+              echo "::group::docker logs ${svc} (tail 200)"
+              docker logs --tail 200 "${svc}" 2>&1 || true
+              echo "::endgroup::"
+            done
+          EOF


### PR DESCRIPTION
## Summary

- Adds `reset-staging.yml`, a `workflow_dispatch`-only job to wipe all staging test data (Postgres - both `einsatzbereit` and `keycloak` databases live in the one instance - plus MinIO uploads) and restart the stack.
- Deliberately does **not** run `docker compose pull`, so the restart comes back up on whatever image tags/versions were already running - only data is reset, not code.
- Gated behind a required `confirm` input that must equal exactly `RESET`, runs in the `staging` GitHub Environment (same protections/secrets as `deploy-staging`), and leaves the `postgres_backups` volume untouched as a recovery path.
- Because Keycloak's realm import runs with `OVERWRITE_EXISTING` and the backend has `Database__MigrateOnStartup: true`, the stack re-migrates and re-imports `keycloak/realms/einsatzbereit-realm.json` on restart, so the standard `vera`/`olaf`/`admin` test accounts come back automatically.
- Documents the new workflow in `.github/AGENTS.md` (workflow table + a new "Reset Workflow" section).

## Why

Requested as a safe, repeatable way to clear staging test data ahead of the pre-launch live testing event, without hand-writing `TRUNCATE`/cascade-order SQL against a shared environment.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reset-staging.yml'))"` - YAML parses cleanly
- [x] Self-reviewed the diff; fixed a script-injection anti-pattern found during review (the `confirm` input was interpolated directly into a `run:` shell block instead of being passed through `env:`)
- [ ] Manually dispatch the workflow once against staging to confirm the full wipe + restart + health gate succeeds end-to-end (destructive, so left for the repo owner to trigger deliberately rather than run unsupervised here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012RkrzWXKNyFUcuLbjFEkXp)_