### PR TITLE
style(frontend): unify transactional form styling with discovery UI

### DIFF
--- a/backend/tests/VisualTests/HomePageOrgCtaTests.cs
+++ b/backend/tests/VisualTests/HomePageOrgCtaTests.cs
@@ -43,7 +43,20 @@ public class HomePageOrgCtaTests(AspireFixture fixture) : VisualTestBase(fixture
 			return; // a previous retry already gave vera an org - skip
 
 		await Expect(cta.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await cta.First.ClickAsync();
+		try
+		{
+			await cta.First.ClickAsync(new() { Timeout = 5_000 });
+		}
+		catch (TimeoutException)
+		{
+			// The org-count fetch can still resolve after NetworkIdle and swap
+			// the button out for the dashboard Link right as we click - if that
+			// happened, vera already has an org, so this is the same "skip"
+			// case as the CountAsync() check above, not a real failure.
+			if (await cta.CountAsync() == 0)
+				return;
+			throw;
+		}
 
 		var dialog = Page.GetByRole(AriaRole.Dialog);
 		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10_000 });

--- a/backend/tests/VisualTests/OrgAppRestructureTests.cs
+++ b/backend/tests/VisualTests/OrgAppRestructureTests.cs
@@ -80,7 +80,20 @@ public class OrgAppRestructureTests(AspireFixture fixture) : VisualTestBase(fixt
 			return; // a previous retry already gave vera an org - skip
 
 		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await createBtn.First.ClickAsync();
+		try
+		{
+			await createBtn.First.ClickAsync(new() { Timeout = 5_000 });
+		}
+		catch (TimeoutException)
+		{
+			// The org-count fetch can still resolve after NetworkIdle and swap
+			// the button out for the dashboard Link right as we click - if that
+			// happened, vera already has an org, so this is the same "skip"
+			// case as the CountAsync() check above, not a real failure.
+			if (await createBtn.CountAsync() == 0)
+				return;
+			throw;
+		}
 		var createDialog = Page.GetByRole(AriaRole.Dialog);
 		await Expect(createDialog).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await createDialog.Locator("input[type='text']").FillAsync(orgName);

--- a/backend/tests/VisualTests/SharedFormClassesTests.cs
+++ b/backend/tests/VisualTests/SharedFormClassesTests.cs
@@ -13,7 +13,7 @@ public class SharedFormClassesTests(AspireFixture fixture) : VisualTestBase(fixt
 	// input styling can't silently drift from the other without touching the
 	// shared module.
 	private const string ExpectedInputClass =
-		"mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none";
+		"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30";
 
 	[Test]
 	public async Task ProfilePageInput_UsesSharedInputClass()

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -130,7 +130,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 							<div>
 								<label
 									htmlFor="create-org-logo-upload"
-									className="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+									className="cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
 								>
 									{t("orgSettings.logoUpload")}
 								</label>
@@ -167,7 +167,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 							value={name}
 							onChange={(e) => setName(e.target.value)}
 							placeholder={t("organization.namePlaceholder")}
-							className="w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+							className={inputClass}
 						/>
 					</div>
 
@@ -236,7 +236,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						/>
 					</div>
 
-					<fieldset className="rounded-md border border-gray-200 p-4">
+					<fieldset className="rounded-xl border border-gray-200 p-4">
 						<legend className="px-1 text-sm font-medium text-gray-700">
 							{t("orgSettings.fieldAddress")}
 						</legend>
@@ -297,7 +297,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						type="button"
 						onClick={onClose}
 						data-testid="modal-cancel"
-						className="rounded px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+						className="rounded-xl px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100"
 					>
 						{t("organization.cancel")}
 					</button>
@@ -305,7 +305,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						type="submit"
 						disabled={loading}
 						data-testid="modal-submit"
-						className="rounded bg-brand-700 px-4 py-2 text-sm text-white hover:bg-brand-800 disabled:opacity-50"
+						className="rounded-xl bg-brand-700 px-4 py-2 text-sm text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
 					>
 						{loading ? t("organization.creating") : t("organization.submit")}
 					</button>

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -4,6 +4,7 @@ import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatDateTime } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
+import { textareaClass } from "../lib/formClasses";
 import Dropdown from "./Dropdown";
 import Modal from "./Modal";
 
@@ -88,7 +89,7 @@ export default function SignUpModal({
 								value={selectedTimeSlotId}
 								onChange={setSelectedTimeSlotId}
 								placeholder={t("signUp.selectPlaceholder")}
-								className="rounded border px-3 py-2 text-sm"
+								className="mt-1 w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
 								options={timeSlots.map((ts) => {
 									const spotsLeft = ts.maxParticipants - ts.bookedCount;
 									const slotFull = spotsLeft <= 0;
@@ -128,7 +129,7 @@ export default function SignUpModal({
 							required
 							rows={4}
 							placeholder={t("signUp.messagePlaceholder")}
-							className="w-full rounded border px-3 py-2 text-sm"
+							className={textareaClass}
 						/>
 					</div>
 				)}
@@ -139,14 +140,14 @@ export default function SignUpModal({
 					<button
 						type="button"
 						onClick={onClose}
-						className="rounded px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+						className="rounded-xl px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100"
 					>
 						{t("signUp.cancel")}
 					</button>
 					<button
 						type="submit"
 						disabled={submitting || (isWaitlist && timeSlots.length === 0)}
-						className="rounded bg-brand-700 px-4 py-2 text-sm text-white hover:bg-brand-800 disabled:opacity-50"
+						className="rounded-xl bg-brand-700 px-4 py-2 text-sm text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
 					>
 						{submitting ? t("signUp.submitting") : t("signUp.submit")}
 					</button>

--- a/frontend/src/lib/formClasses.ts
+++ b/frontend/src/lib/formClasses.ts
@@ -1,6 +1,6 @@
 export const inputClass =
-	"mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none";
+	"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30";
 
 export const textareaClass = `${inputClass} resize-y`;
 
-export const labelClass = "block text-xs text-gray-600";
+export const labelClass = "block text-xs font-medium text-gray-600";

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -195,7 +195,7 @@ export default function EngagementManagementPage() {
 					<button
 						type="button"
 						onClick={() => setQrScannerOpen(true)}
-						className="inline-flex items-center gap-2 rounded-lg bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800"
+						className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-800"
 					>
 						<svg
 							className="h-4 w-4"
@@ -318,7 +318,7 @@ export default function EngagementManagementPage() {
 											<button
 												onClick={() => handleConfirm(e.id)}
 												disabled={confirming === e.id}
-												className="rounded-lg bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50"
+												className="rounded-xl bg-green-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
 											>
 												{confirming === e.id
 													? t("engagementManagement.processing")
@@ -326,7 +326,7 @@ export default function EngagementManagementPage() {
 											</button>
 											<button
 												onClick={() => setConfirmCancelId(e.id)}
-												className="rounded-lg border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50"
+												className="rounded-xl border border-red-200 px-3 py-1 text-xs text-red-600 transition-colors hover:bg-red-50"
 											>
 												{t("engagementManagement.cancel")}
 											</button>
@@ -338,7 +338,7 @@ export default function EngagementManagementPage() {
 												<button
 													onClick={() => handleCheckIn(e.id)}
 													disabled={checkingIn === e.id}
-													className="rounded-lg bg-brand-700 px-3 py-1 text-xs font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+													className="rounded-xl bg-brand-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
 												>
 													{checkingIn === e.id
 														? t("checkIn.markingCheckedIn")

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import { getApiErrorMessage } from "../../lib/apiError";
+import { inputClass } from "../../lib/formClasses";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
@@ -133,12 +134,12 @@ export default function OrgMembersPage() {
 
 			<div className="mx-auto max-w-2xl">
 				{successMessage && (
-					<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+					<div className="mb-4 rounded-xl bg-green-50 px-4 py-3 text-sm text-green-700">
 						{successMessage}
 					</div>
 				)}
 				{settingsError && (
-					<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+					<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
 						{settingsError}
 					</div>
 				)}
@@ -156,7 +157,7 @@ export default function OrgMembersPage() {
 						value={memberSearch}
 						onChange={(e) => handleMemberSearchChange(e.target.value)}
 						placeholder={t("orgSettings.invitePlaceholder")}
-						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-700 focus:outline-none"
+						className={inputClass}
 					/>
 					{memberSearchLoading && (
 						<p className="mt-1 text-xs text-gray-500">
@@ -164,7 +165,7 @@ export default function OrgMembersPage() {
 						</p>
 					)}
 					{memberCandidates.length > 0 && (
-						<ul className="mt-1 divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+						<ul className="mt-1 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
 							{memberCandidates.map((candidate) => (
 								<li
 									key={candidate.userId}
@@ -183,7 +184,7 @@ export default function OrgMembersPage() {
 									<button
 										type="button"
 										onClick={() => handleInviteMember(candidate.userId)}
-										className="ml-3 shrink-0 rounded-md bg-brand-700 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-800"
+										className="ml-3 shrink-0 rounded-xl bg-brand-700 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800"
 									>
 										{t("orgSettings.invite")}
 									</button>
@@ -205,7 +206,7 @@ export default function OrgMembersPage() {
 						<h2 className="mb-2 text-sm font-medium text-gray-700">
 							{t("orgSettings.pendingInvitations")}
 						</h2>
-						<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+						<ul className="divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
 							{invitations
 								.filter((i) => i.status === "Pending")
 								.map((invitation) => (
@@ -240,7 +241,7 @@ export default function OrgMembersPage() {
 						<h2 className="mb-2 text-sm font-medium text-gray-700">
 							{t("orgSettings.declinedInvitations")}
 						</h2>
-						<ul className="divide-y divide-gray-100 rounded-md border border-gray-200 bg-white shadow-sm">
+						<ul className="divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
 							{invitations
 								.filter((i) => i.status === "Declined")
 								.map((invitation) => (

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -179,7 +179,7 @@ export default function OrgSettingsPage() {
 							<button
 								type="button"
 								onClick={() => setEditing(true)}
-								className="shrink-0 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+								className="shrink-0 rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
 							>
 								{t("orgSettings.edit")}
 							</button>
@@ -187,12 +187,12 @@ export default function OrgSettingsPage() {
 						beforeContent={
 							<>
 								{successMessage && (
-									<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+									<div className="mb-4 rounded-xl bg-green-50 px-4 py-3 text-sm text-green-700">
 										{successMessage}
 									</div>
 								)}
 								{settingsError && (
-									<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+									<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
 										{settingsError}
 									</div>
 								)}
@@ -210,7 +210,7 @@ export default function OrgSettingsPage() {
 								type="button"
 								onClick={() => setShowDeleteConfirm(true)}
 								disabled={!isSoleMember}
-								className="mt-3 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400 disabled:hover:bg-white"
+								className="mt-3 rounded-xl border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400 disabled:hover:bg-white"
 							>
 								{t("orgSettings.deleteOrganization")}
 							</button>
@@ -221,7 +221,7 @@ export default function OrgSettingsPage() {
 				{editing && (
 					<>
 						{settingsError && (
-							<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+							<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
 								{settingsError}
 							</div>
 						)}
@@ -246,7 +246,7 @@ export default function OrgSettingsPage() {
 									<div>
 										<label
 											htmlFor="logo-upload"
-											className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
+											className={`cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
 										>
 											{uploadingLogo
 												? t("orgSettings.logoUploading")
@@ -338,7 +338,7 @@ export default function OrgSettingsPage() {
 								/>
 							</Field>
 
-							<fieldset className="rounded-md border border-gray-200 p-4">
+							<fieldset className="rounded-xl border border-gray-200 p-4">
 								<legend className="px-1 text-sm font-medium text-gray-700">
 									{t("orgSettings.fieldAddress")}
 								</legend>
@@ -403,14 +403,14 @@ export default function OrgSettingsPage() {
 								<button
 									type="button"
 									onClick={handleCancelEdit}
-									className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+									className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
 								>
 									{t("orgSettings.cancel")}
 								</button>
 								<button
 									type="submit"
 									disabled={saving}
-									className="rounded-md bg-brand-700 px-5 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+									className="rounded-xl bg-brand-700 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
 								>
 									{saving ? t("orgSettings.saving") : t("orgSettings.save")}
 								</button>


### PR DESCRIPTION
formClasses.ts's inputClass/textareaClass/labelClass, plus SignUpModal, CreateOrganizationModal, EngagementManagementPage, OrgMembersPage, and OrgSettingsPage, adopt the same rounded-xl/shadow-sm/focus-ring treatment already used by the app's own polished wizard-step inputs (CreateVolunteerOpportunityModal), instead of plain rounded-md/rounded borders with no focus ring.

Closes #764