### PR TITLE
fix(frontend): replace bare loading text with skeleton states

### DIFF
--- a/backend/tests/VisualTests/HomePageOrgCtaTests.cs
+++ b/backend/tests/VisualTests/HomePageOrgCtaTests.cs
@@ -38,21 +38,31 @@ public class HomePageOrgCtaTests(AspireFixture fixture) : VisualTestBase(fixture
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
+		// vera is shared across this whole test session (no DB reset between
+		// tests), so another test (e.g. OrganizationTests inviting her as a
+		// member elsewhere) can give her an org at any point up to and
+		// including the moment we click. Wait for whichever of the two the
+		// org-count fetch actually resolves to, rather than asserting the
+		// button specifically - a separate, later Expect on just the button
+		// re-opens exactly this race, which is what actually broke this
+		// test previously (see git blame).
 		var cta = Page.GetByRole(AriaRole.Button, new() { Name = "Create an organisation" });
-		if (await cta.CountAsync() == 0)
-			return; // a previous retry already gave vera an org - skip
+		var overviewLink = Page.GetByRole(AriaRole.Link, new() { Name = "Organization overview" });
+		await Expect(cta.Or(overviewLink).First).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
-		await Expect(cta.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		if (await overviewLink.CountAsync() > 0)
+			return; // vera already organizes an org - skip, nothing to exercise here
+
 		try
 		{
 			await cta.First.ClickAsync(new() { Timeout = 5_000 });
 		}
 		catch (TimeoutException)
 		{
-			// The org-count fetch can still resolve after NetworkIdle and swap
-			// the button out for the dashboard Link right as we click - if that
-			// happened, vera already has an org, so this is the same "skip"
-			// case as the CountAsync() check above, not a real failure.
+			// The org-count fetch can still resolve and swap the button out
+			// for the dashboard Link in the narrow window right as we click -
+			// if that happened, vera already has an org, so this is the same
+			// "skip" case as the check above, not a real failure.
 			if (await cta.CountAsync() == 0)
 				return;
 			throw;

--- a/backend/tests/VisualTests/LoadingStateTests.cs
+++ b/backend/tests/VisualTests/LoadingStateTests.cs
@@ -1,0 +1,146 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #765: several pages rendered bare, unstyled "Loading..."
+/// text while fetching, with no visual sign anything was happening. These
+/// tests delay the underlying API call so the loading state is observable
+/// long enough to assert on it, then confirm real content replaces it.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task HomePage_ShowsLoadingSkeleton_WhileOpportunitiesFetch()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.RouteAsync("**/v1/volunteer-opportunities?*", async route =>
+		{
+			if (route.Request.Method == "GET")
+				await Task.Delay(1500);
+			await route.ContinueAsync();
+		});
+
+		await Page.GotoAsync(frontend.ToString());
+
+		// The skeleton's accessible name comes from a sr-only span; the
+		// pulsing placeholder blocks themselves are aria-hidden.
+		var loadingStatus = Page.Locator("[role='status']").First;
+		await Expect(loadingStatus).ToBeVisibleAsync();
+		await Expect(loadingStatus).ToContainTextAsync("Loading");
+		(await loadingStatus.Locator(".animate-pulse").CountAsync()).Should().BeGreaterThan(0);
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(loadingStatus).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(Page.Locator("main")).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task DetailPage_ShowsLoadingSkeleton_WhileOpportunityFetches()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("LoadingSkeleton");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", async route =>
+		{
+			if (route.Request.Method == "GET")
+				await Task.Delay(1500);
+			await route.ContinueAsync();
+		});
+
+		await Page.GotoAsync(detailUrl);
+
+		var loadingStatus = Page.Locator("[role='status']").First;
+		await Expect(loadingStatus).ToBeVisibleAsync();
+		await Expect(loadingStatus).ToContainTextAsync("Loading");
+		(await loadingStatus.Locator(".animate-pulse").CountAsync()).Should().BeGreaterThan(0);
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(loadingStatus).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task AdminOrganizationsPage_ShowsSpinner_WhileOrganizationsFetch()
+	{
+		// Covers the shared Spinner component's contract (role="status", a
+		// visible label, an aria-hidden spin icon) used by every other
+		// converted loading spot in this diff (ProtectedRoute, OrgAppLayout,
+		// EngagementManagementPage, etc.) - they all render the exact same
+		// component, so exercising it once here is representative.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+
+		await Page.RouteAsync("**/v1/organizations", async route =>
+		{
+			if (route.Request.Method == "GET")
+				await Task.Delay(1500);
+			await route.ContinueAsync();
+		});
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/admin/organizations");
+
+		var loadingStatus = Page.Locator("[role='status']").First;
+		await Expect(loadingStatus).ToBeVisibleAsync();
+		await Expect(loadingStatus).ToContainTextAsync("Loading");
+		await Expect(loadingStatus.Locator("svg.animate-spin")).ToBeVisibleAsync();
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(loadingStatus).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+
+	private async Task<string> CreateIndividualContactOpportunityAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var tokenHttp = new HttpClient { BaseAddress = keycloak };
+		var tokenResponse = await tokenHttp.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = "olaf",
+				["password"] = "olaf123",
+				["scope"] = "openid",
+			}));
+		tokenResponse.EnsureSuccessStatusCode();
+		var tokenBody = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var token = tokenBody.GetProperty("access_token").GetString();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var orgsResponse = await http.GetAsync("/v1/organizations");
+		orgsResponse.EnsureSuccessStatusCode();
+		var orgs = await orgsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = orgs.EnumerateArray().First().GetProperty("id").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"LoadingState {label} {suffix}",
+			description = "Created by LoadingStateTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opp = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opp.GetProperty("id").GetProperty("value").GetString()
+			?? throw new InvalidOperationException("Created opportunity had no id.");
+	}
+}

--- a/backend/tests/VisualTests/LoadingStateTests.cs
+++ b/backend/tests/VisualTests/LoadingStateTests.cs
@@ -140,7 +140,7 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 		});
 		oppResponse.EnsureSuccessStatusCode();
 		var opp = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
-		return opp.GetProperty("id").GetProperty("value").GetString()
+		return opp.GetProperty("id").GetString()
 			?? throw new InvalidOperationException("Created opportunity had no id.");
 	}
 }

--- a/backend/tests/VisualTests/OrgAppRestructureTests.cs
+++ b/backend/tests/VisualTests/OrgAppRestructureTests.cs
@@ -70,26 +70,33 @@ public class OrgAppRestructureTests(AspireFixture fixture) : VisualTestBase(fixt
 
 		// The hero CTA renders the "Create an organisation" button until the
 		// async org-count fetch resolves, then swaps to a dashboard Link if the
-		// user turns out to have orgs after all - wait for that fetch to settle
-		// first so we never click a button that's about to be swapped out from
-		// under us (which would hang waiting for it to reappear).
+		// user turns out to have orgs after all - vera is shared across this
+		// whole test session (no DB reset between tests), so another test (e.g.
+		// OrganizationTests inviting her as a member elsewhere) can flip that
+		// fetch's result at any point up to and including the moment we click.
+		// Wait for whichever of the two the fetch actually resolves to, rather
+		// than asserting the button specifically - a separate, later Expect on
+		// just the button re-opens exactly this race, which is what actually
+		// broke this test previously (see git blame).
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create an organisation" });
-		if (await createBtn.CountAsync() == 0)
-			return; // a previous retry already gave vera an org - skip
+		var overviewLink = Page.GetByRole(AriaRole.Link, new() { Name = "Organization overview" });
+		await Expect(createBtn.Or(overviewLink).First).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
-		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		if (await overviewLink.CountAsync() > 0)
+			return; // vera already organizes an org - skip, nothing to exercise here
+
 		try
 		{
 			await createBtn.First.ClickAsync(new() { Timeout = 5_000 });
 		}
 		catch (TimeoutException)
 		{
-			// The org-count fetch can still resolve after NetworkIdle and swap
-			// the button out for the dashboard Link right as we click - if that
-			// happened, vera already has an org, so this is the same "skip"
-			// case as the CountAsync() check above, not a real failure.
+			// The org-count fetch can still resolve and swap the button out for
+			// the dashboard Link in the narrow window right as we click - if
+			// that happened, vera already has an org, so this is the same
+			// "skip" case as the check above, not a real failure.
 			if (await createBtn.CountAsync() == 0)
 				return;
 			throw;

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -3,6 +3,7 @@ import type {
 	AchievementSummary,
 	BadgeCatalogEntry,
 } from "../client/api-client";
+import Spinner from "./Spinner";
 
 const TYPE_ICON: Record<string, string> = {
 	Milestone: "🏆",
@@ -119,7 +120,11 @@ export default function BadgeGrid({
 	const { t } = useTranslation();
 
 	if (loading) {
-		return <p className="text-sm text-gray-500">{t("achievements.loading")}</p>;
+		return (
+			<div className="flex items-center justify-center py-6">
+				<Spinner label={t("achievements.loading")} size="sm" />
+			</div>
+		);
 	}
 
 	const earnedByKey = new Map(

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunityDetails } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
+import Spinner from "./Spinner";
 
 interface CheckInModalProps {
 	engagementId: string;
@@ -64,7 +65,9 @@ export default function CheckInModal({
 			</h2>
 
 			{!details && !loadError && (
-				<p className="text-sm text-gray-500">{t("opportunities.loading")}</p>
+				<div className="flex items-center justify-center py-6">
+					<Spinner label={t("opportunities.loading")} size="sm" />
+				</div>
 			)}
 
 			{loadError && (

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
+import Spinner from "./Spinner";
 
 declare global {
 	class BarcodeDetector {
@@ -137,7 +138,9 @@ export default function QRScannerModal({
 			</h2>
 
 			{supported === null && (
-				<p className="text-sm text-gray-500">{t("opportunities.loading")}</p>
+				<div className="flex items-center justify-center py-6">
+					<Spinner label={t("opportunities.loading")} size="sm" />
+				</div>
 			)}
 
 			{supported === false && (

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,12 @@
+interface Props {
+	className?: string;
+}
+
+export default function Skeleton({ className = "" }: Props) {
+	return (
+		<div
+			aria-hidden="true"
+			className={`animate-pulse rounded-md bg-gray-200 motion-reduce:animate-none ${className}`}
+		/>
+	);
+}

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,0 +1,44 @@
+interface Props {
+	label: string;
+	size?: "sm" | "md" | "lg";
+	className?: string;
+}
+
+const SIZE_CONFIG: Record<
+	NonNullable<Props["size"]>,
+	{ icon: string; text: string }
+> = {
+	sm: { icon: "h-4 w-4", text: "text-sm" },
+	md: { icon: "h-5 w-5", text: "" },
+	lg: { icon: "h-8 w-8", text: "" },
+};
+
+export default function Spinner({ label, size = "md", className = "" }: Props) {
+	const { icon, text } = SIZE_CONFIG[size];
+
+	return (
+		<div role="status" className={`flex items-center gap-2 ${className}`}>
+			<svg
+				className={`${icon} shrink-0 animate-spin text-brand-500 motion-reduce:animate-none`}
+				viewBox="0 0 24 24"
+				fill="none"
+				aria-hidden="true"
+			>
+				<circle
+					className="opacity-25"
+					cx="12"
+					cy="12"
+					r="10"
+					stroke="currentColor"
+					strokeWidth="4"
+				/>
+				<path
+					className="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Z"
+				/>
+			</svg>
+			<span className={`${text} text-gray-500`}>{label}</span>
+		</div>
+	);
+}

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -7,6 +7,7 @@ import { formatOccurrence } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
 import EmptyState from "./EmptyState";
+import Skeleton from "./Skeleton";
 
 const LIST_PAGE_SIZE = 10;
 
@@ -1551,7 +1552,23 @@ export default function VolunteerOpportunitiesList() {
 			</div>
 
 			{loading && items.length === 0 && (
-				<p className="text-gray-500">{t("opportunities.loading")}</p>
+				<div role="status" className="space-y-3">
+					<span className="sr-only">{t("opportunities.loading")}</span>
+					{Array.from({ length: 3 }).map((_, i) => (
+						<div
+							key={i}
+							aria-hidden="true"
+							className="flex flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm sm:flex-row"
+						>
+							<Skeleton className="h-24 w-full shrink-0 rounded-none sm:h-auto sm:w-36 lg:w-44" />
+							<div className="flex-1 space-y-2 p-4">
+								<Skeleton className="h-4 w-2/3" />
+								<Skeleton className="h-3 w-1/2" />
+								<Skeleton className="h-3 w-1/3" />
+							</div>
+						</div>
+					))}
+				</div>
 			)}
 			{error && (
 				<p className="text-red-600" data-testid="opportunities-error">

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -10,6 +10,7 @@ import {
 	useOrgBreadcrumbExtra,
 } from "../contexts/OrgBreadcrumbContext";
 import Header from "../components/Header";
+import Spinner from "../components/Spinner";
 
 export interface OrgAppContext {
 	org: OrganizationDetailsResponse;
@@ -150,7 +151,7 @@ export default function OrgAppLayout() {
 	if (loading) {
 		return (
 			<div className="flex min-h-screen items-center justify-center bg-gray-50">
-				<span className="text-gray-500">{t("orgDashboard.loading")}</span>
+				<Spinner label={t("orgDashboard.loading")} size="lg" />
 			</div>
 		);
 	}

--- a/frontend/src/layouts/ProtectedRoute.tsx
+++ b/frontend/src/layouts/ProtectedRoute.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router";
 import type { ReactNode } from "react";
 import { signinLocaleArgs } from "../lib/authLocale";
+import Spinner from "../components/Spinner";
 
 interface Props {
 	children: ReactNode;
@@ -16,7 +17,7 @@ export default function ProtectedRoute({ children }: Props) {
 	if (auth.isLoading) {
 		return (
 			<div className="flex min-h-screen items-center justify-center">
-				<span className="text-gray-500">{t("auth.loading")}</span>
+				<Spinner label={t("auth.loading")} size="lg" />
 			</div>
 		);
 	}

--- a/frontend/src/pages/AdminOrganizationsPage.tsx
+++ b/frontend/src/pages/AdminOrganizationsPage.tsx
@@ -6,6 +6,7 @@ import { runtimeConfig } from "../lib/runtimeConfig";
 import { dispatchToast } from "../lib/toastBus";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
+import Spinner from "../components/Spinner";
 
 interface OrgRow {
 	id: string;
@@ -78,7 +79,12 @@ export default function AdminOrganizationsPage() {
 		}
 	}
 
-	if (loading) return <p className="text-gray-500">{t("adminOrgs.loading")}</p>;
+	if (loading)
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Spinner label={t("adminOrgs.loading")} />
+			</div>
+		);
 	if (error) return <p className="text-red-600">{error}</p>;
 	if (rows.length === 0)
 		return <p className="text-gray-500">{t("adminOrgs.noOrgs")}</p>;

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -10,6 +10,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import QRScannerModal from "../components/QRScannerModal";
+import Spinner from "../components/Spinner";
 import NotFoundPage from "./NotFoundPage";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -222,7 +223,9 @@ export default function EngagementManagementPage() {
 			)}
 
 			{loading && (
-				<p className="text-gray-500">{t("engagementManagement.loading")}</p>
+				<div className="flex items-center justify-center py-16">
+					<Spinner label={t("engagementManagement.loading")} />
+				</div>
 			)}
 			{error && (
 				<p className="text-red-600">

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { PublicOrganizationProfileResponse } from "../client/api-client";
 import OrganizationProfileView from "../components/OrganizationProfileView";
+import Spinner from "../components/Spinner";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatOccurrence, formatParticipationType } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -33,7 +34,11 @@ export default function OrganizationProfilePage() {
 	}, [organizationId]);
 
 	if (loading)
-		return <p className="text-gray-500">{t("orgProfile.loading")}</p>;
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Spinner label={t("orgProfile.loading")} />
+			</div>
+		);
 	if (error)
 		return (
 			<p className="text-red-600">

--- a/frontend/src/pages/ProfileOverviewPage.tsx
+++ b/frontend/src/pages/ProfileOverviewPage.tsx
@@ -26,6 +26,7 @@ import EmptyState from "../components/EmptyState";
 import ProfileFieldsView from "../components/ProfileFieldsView";
 import ShareAchievementsModal from "../components/ShareAchievementsModal";
 import SubmitFeedbackModal from "../components/SubmitFeedbackModal";
+import Spinner from "../components/Spinner";
 
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 const AVATAR_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -557,7 +558,7 @@ export default function ProfileOverviewPage() {
 				<>
 					{profileLoading && (
 						<div className="flex items-center justify-center py-16">
-							<span className="text-gray-500">{t("profile.loading")}</span>
+							<Spinner label={t("profile.loading")} />
 						</div>
 					)}
 
@@ -1056,7 +1057,9 @@ export default function ProfileOverviewPage() {
 					</div>
 
 					{engagementsLoading && (
-						<p className="text-gray-500">{t("myEngagements.loading")}</p>
+						<div className="flex items-center justify-center py-16">
+							<Spinner label={t("myEngagements.loading")} />
+						</div>
 					)}
 					{engagementsError && (
 						<p className="text-red-600">

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../client/api-client";
 import BadgeGrid from "../components/BadgeGrid";
 import ProfileFieldsView from "../components/ProfileFieldsView";
+import Spinner from "../components/Spinner";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
@@ -40,7 +41,11 @@ export default function UserProfilePage() {
 	}, [userId]);
 
 	if (loading)
-		return <p className="text-gray-500">{t("userProfile.loading")}</p>;
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Spinner label={t("userProfile.loading")} />
+			</div>
+		);
 	if (error) return <p className="text-red-600">{error}</p>;
 	if (!profile)
 		return <p className="text-gray-500">{t("userProfile.notFound")}</p>;

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 import SignUpModal from "../components/SignUpModal";
 import ConfirmDialog from "../components/ConfirmDialog";
 import SingleMarkerMap from "../components/SingleMarkerMap";
+import Skeleton from "../components/Skeleton";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
@@ -123,7 +124,20 @@ export default function VolunteerOpportunityDetailPage() {
 	}
 
 	if (loading)
-		return <p className="text-gray-500">{t("opportunities.loading")}</p>;
+		return (
+			<div className="mx-auto max-w-2xl" role="status">
+				<span className="sr-only">{t("opportunities.loading")}</span>
+				<Skeleton className="mb-6 h-56 w-full sm:h-72" />
+				<div className="mb-3 flex items-center justify-between gap-3">
+					<Skeleton className="h-6 w-32 rounded-full" />
+					<Skeleton className="h-8 w-20 rounded-lg" />
+				</div>
+				<Skeleton className="mb-3 h-8 w-3/4" />
+				<Skeleton className="mb-2 h-4 w-full" />
+				<Skeleton className="mb-6 h-4 w-2/3" />
+				<Skeleton className="h-32 w-full" />
+			</div>
+		);
 	if (error)
 		return (
 			<p className="text-red-600">

--- a/frontend/src/pages/app/OrgDashboardPage.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage.tsx
@@ -9,6 +9,7 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import type { OrganizationCalendarEventDto } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
+import Spinner from "../../components/Spinner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const rbcLocales = {
@@ -167,9 +168,7 @@ export default function OrgDashboardPage() {
 
 			{calLoading && (
 				<div className="flex items-center justify-center py-16">
-					<span className="text-gray-500">
-						{t("orgOverview.calendarLoading")}
-					</span>
+					<Spinner label={t("orgOverview.calendarLoading")} />
 				</div>
 			)}
 			{calError && (

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -11,6 +11,7 @@ import { getApiErrorMessage } from "../../lib/apiError";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
+import Spinner from "../../components/Spinner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 export default function OrgOpportunitiesPage() {
@@ -268,7 +269,7 @@ export default function OrgOpportunitiesPage() {
 
 			{items === null && !error && (
 				<div className="flex items-center justify-center py-16">
-					<span className="text-gray-500">{t("orgOpportunities.loading")}</span>
+					<Spinner label={t("orgOpportunities.loading")} />
 				</div>
 			)}
 


### PR DESCRIPTION
Opportunity detail and the home list get layout-shaped skeletons; every other page/modal loading spot gets a shared Spinner component. Both wrap the loading region in role="status" so it stays announced to screen readers, closing the a11y regression the plain text also had.

Fixes #765