### PR TITLE
feat(frontend,backend): add organization directory page

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -155,6 +155,7 @@ As of this writing no domain event has a registered `INotificationHandler` - the
 | Method | Route | Auth | Handler |
 |---|---|---|---|
 | GET | `/v1/organizations` | DefaultUser | `GetOrganizations` |
+| GET | `/v1/organizations/directory` | Anonymous | `GetPublicOrganizations` |
 | POST | `/v1/organizations` | DefaultUser | `CreateOrganization` |
 | GET | `/v1/organizations/{id}` | Organisator | `GetOrganizationDetails` |
 | PUT | `/v1/organizations/{id}` | Organisator | `UpdateOrganization` |

--- a/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsEndpoint.cs
@@ -1,0 +1,45 @@
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Common.Pagination;
+using Application.Organizations.GetPublicOrganizations.v1;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Organizations.GetPublicOrganizations.v1;
+
+internal sealed class GetPublicOrganizationsEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/organizations/directory", GetPublicOrganizationsAsync)
+			.WithName("GetPublicOrganizations")
+			.Produces<PagedList<PublicOrganizationSummary>>()
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> GetPublicOrganizationsAsync(
+		[AsParameters] GetPublicOrganizationsRequest request,
+		[FromServices] ISender sender,
+		CancellationToken cancellationToken)
+	{
+		if (request.PageNumber < 1)
+			return Results.Problem("PageNumber must be at least 1.", statusCode: StatusCodes.Status400BadRequest);
+
+		if (request.PageSize < 1 || request.PageSize > 100)
+			return Results.Problem("PageSize must be between 1 and 100.", statusCode: StatusCodes.Status400BadRequest);
+
+		var query = new GetPublicOrganizationsQuery(
+			request.PageNumber,
+			request.PageSize,
+			request.Search);
+
+		var result = await sender.Send(query, cancellationToken);
+
+		return Results.Ok(result);
+	}
+}

--- a/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsRequest.cs
+++ b/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsRequest.cs
@@ -1,0 +1,6 @@
+namespace Api.Organizations.GetPublicOrganizations.v1;
+
+public sealed record GetPublicOrganizationsRequest(
+	int PageNumber,
+	int PageSize,
+	string? Search);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1435,6 +1435,239 @@
         }
       }
     },
+    "/v1/admin/users/{userId}/enabled": {
+      "put": {
+        "tags": [
+          "Admin"
+        ],
+        "operationId": "SetUserEnabled",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserEnabledRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/users/{userId}/admin-status": {
+      "put": {
+        "tags": [
+          "Admin"
+        ],
+        "operationId": "SetUserAdminStatus",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserAdminStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/users": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "operationId": "ListUsers",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedListOfAdminUserListItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/{userId}/public-profile": {
       "get": {
         "tags": [
@@ -2175,6 +2408,84 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/organizations": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "operationId": "ListOrganizations",
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedListOfAdminOrganizationSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4131,6 +4442,78 @@
           }
         }
       },
+      "AdminOrganizationSummary": {
+        "required": [
+          "id",
+          "name",
+          "logoUrl",
+          "isVerified"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "logoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isVerified": {
+            "type": "boolean"
+          }
+        }
+      },
+      "AdminUserListItem": {
+        "required": [
+          "id",
+          "username",
+          "firstName",
+          "lastName",
+          "email",
+          "enabled",
+          "realmRoles"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "lastName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "realmRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "BadgeCatalogEntry": {
         "required": [
           "key",
@@ -5508,6 +5891,84 @@
           }
         }
       },
+      "PagedListOfAdminOrganizationSummary": {
+        "required": [
+          "currentPage",
+          "items"
+        ],
+        "type": "object",
+        "properties": {
+          "totalItems": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "currentPage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pageCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminOrganizationSummary"
+            }
+          }
+        }
+      },
+      "PagedListOfAdminUserListItem": {
+        "required": [
+          "currentPage",
+          "items"
+        ],
+        "type": "object",
+        "properties": {
+          "totalItems": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "currentPage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pageCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminUserListItem"
+            }
+          }
+        }
+      },
       "PagedListOfEngagementSummary": {
         "required": [
           "currentPage",
@@ -5964,6 +6425,28 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "SetUserAdminStatusRequest": {
+        "required": [
+          "isAdmin"
+        ],
+        "type": "object",
+        "properties": {
+          "isAdmin": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SetUserEnabledRequest": {
+        "required": [
+          "enabled"
+        ],
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
           }
         }
       },
@@ -6657,6 +7140,9 @@
     },
     {
       "name": "Users"
+    },
+    {
+      "name": "Admin"
     },
     {
       "name": "VerifyOrganizationEndpoint"

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5834,7 +5834,8 @@
           "description",
           "city",
           "logoUrl",
-          "isVerified"
+          "isVerified",
+          "openOpportunityCount"
         ],
         "type": "object",
         "properties": {
@@ -5865,6 +5866,14 @@
           },
           "isVerified": {
             "type": "boolean"
+          },
+          "openOpportunityCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
           }
         }
       },

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1435,239 +1435,6 @@
         }
       }
     },
-    "/v1/admin/users/{userId}/enabled": {
-      "put": {
-        "tags": [
-          "Admin"
-        ],
-        "operationId": "SetUserEnabled",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetUserEnabledRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/admin/users/{userId}/admin-status": {
-      "put": {
-        "tags": [
-          "Admin"
-        ],
-        "operationId": "SetUserAdminStatus",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetUserAdminStatusRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/admin/users": {
-      "get": {
-        "tags": [
-          "Admin"
-        ],
-        "operationId": "ListUsers",
-        "parameters": [
-          {
-            "name": "search",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": [
-                "integer",
-                "string"
-              ],
-              "format": "int32"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": [
-                "integer",
-                "string"
-              ],
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedListOfAdminUserListItem"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/users/{userId}/public-profile": {
       "get": {
         "tags": [
@@ -2429,15 +2196,15 @@
         }
       }
     },
-    "/v1/admin/organizations": {
+    "/v1/organizations/directory": {
       "get": {
         "tags": [
-          "Admin"
+          "GetPublicOrganizationsEndpoint"
         ],
-        "operationId": "ListOrganizations",
+        "operationId": "GetPublicOrganizations",
         "parameters": [
           {
-            "name": "pageNumber",
+            "name": "PageNumber",
             "in": "query",
             "required": true,
             "schema": {
@@ -2450,7 +2217,7 @@
             }
           },
           {
-            "name": "pageSize",
+            "name": "PageSize",
             "in": "query",
             "required": true,
             "schema": {
@@ -2460,6 +2227,13 @@
                 "string"
               ],
               "format": "int32"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -2469,23 +2243,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedListOfAdminOrganizationSummary"
+                  "$ref": "#/components/schemas/PagedListOfPublicOrganizationSummary"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
+          "400": {
+            "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4367,78 +4131,6 @@
           }
         }
       },
-      "AdminOrganizationSummary": {
-        "required": [
-          "id",
-          "name",
-          "logoUrl",
-          "isVerified"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string"
-          },
-          "logoUrl": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "isVerified": {
-            "type": "boolean"
-          }
-        }
-      },
-      "AdminUserListItem": {
-        "required": [
-          "id",
-          "username",
-          "firstName",
-          "lastName",
-          "email",
-          "enabled",
-          "realmRoles"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "username": {
-            "type": "string"
-          },
-          "firstName": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "lastName": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "email": {
-            "type": "string"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "realmRoles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "BadgeCatalogEntry": {
         "required": [
           "key",
@@ -5816,84 +5508,6 @@
           }
         }
       },
-      "PagedListOfAdminOrganizationSummary": {
-        "required": [
-          "currentPage",
-          "items"
-        ],
-        "type": "object",
-        "properties": {
-          "totalItems": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "currentPage": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "pageCount": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AdminOrganizationSummary"
-            }
-          }
-        }
-      },
-      "PagedListOfAdminUserListItem": {
-        "required": [
-          "currentPage",
-          "items"
-        ],
-        "type": "object",
-        "properties": {
-          "totalItems": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "currentPage": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "pageCount": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AdminUserListItem"
-            }
-          }
-        }
-      },
       "PagedListOfEngagementSummary": {
         "required": [
           "currentPage",
@@ -5929,6 +5543,45 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EngagementSummary"
+            }
+          }
+        }
+      },
+      "PagedListOfPublicOrganizationSummary": {
+        "required": [
+          "currentPage",
+          "items"
+        ],
+        "type": "object",
+        "properties": {
+          "totalItems": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "currentPage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pageCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicOrganizationSummary"
             }
           }
         }
@@ -6174,6 +5827,47 @@
           }
         }
       },
+      "PublicOrganizationSummary": {
+        "required": [
+          "id",
+          "name",
+          "description",
+          "city",
+          "logoUrl",
+          "isVerified"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "city": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "logoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isVerified": {
+            "type": "boolean"
+          }
+        }
+      },
       "PublicUserProfileResponse": {
         "required": [
           "displayName",
@@ -6261,28 +5955,6 @@
               "null",
               "string"
             ]
-          }
-        }
-      },
-      "SetUserAdminStatusRequest": {
-        "required": [
-          "isAdmin"
-        ],
-        "type": "object",
-        "properties": {
-          "isAdmin": {
-            "type": "boolean"
-          }
-        }
-      },
-      "SetUserEnabledRequest": {
-        "required": [
-          "enabled"
-        ],
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
           }
         }
       },
@@ -6978,9 +6650,6 @@
       "name": "Users"
     },
     {
-      "name": "Admin"
-    },
-    {
       "name": "VerifyOrganizationEndpoint"
     },
     {
@@ -7000,6 +6669,9 @@
     },
     {
       "name": "RemoveMemberEndpoint"
+    },
+    {
+      "name": "GetPublicOrganizationsEndpoint"
     },
     {
       "name": "GetPublicOrganizationProfileEndpoint"

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQuery.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQuery.cs
@@ -1,0 +1,10 @@
+using Application.Common.Messaging;
+using Application.Common.Pagination;
+
+namespace Application.Organizations.GetPublicOrganizations.v1;
+
+public sealed record GetPublicOrganizationsQuery(
+	int PageNumber,
+	int PageSize,
+	string? Search)
+	: IQuery<PagedList<PublicOrganizationSummary>>;

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQueryHandler.cs
@@ -1,0 +1,23 @@
+using Application.Common.Messaging;
+using Application.Common.Pagination;
+
+namespace Application.Organizations.GetPublicOrganizations.v1;
+
+internal sealed class GetPublicOrganizationsQueryHandler(
+	IOrganizationReadRepository readRepository)
+	: IQueryHandler<GetPublicOrganizationsQuery, PagedList<PublicOrganizationSummary>>
+{
+	private const int MaxPageSize = 100;
+
+	public async ValueTask<PagedList<PublicOrganizationSummary>> Handle(
+		GetPublicOrganizationsQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var pageNumber = Math.Max(1, request.PageNumber);
+		var pageSize = Math.Clamp(request.PageSize, 1, MaxPageSize);
+
+		var filter = new OrganizationFilter(pageNumber, pageSize, request.Search);
+
+		return await readRepository.GetPagedPublicSummariesAsync(filter, cancellationToken);
+	}
+}

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/OrganizationFilter.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/OrganizationFilter.cs
@@ -1,0 +1,6 @@
+namespace Application.Organizations.GetPublicOrganizations.v1;
+
+public sealed record OrganizationFilter(
+	int PageNumber,
+	int PageSize,
+	string? Search = null);

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/PublicOrganizationSummary.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/PublicOrganizationSummary.cs
@@ -6,4 +6,5 @@ public sealed record PublicOrganizationSummary(
 	string? Description,
 	string? City,
 	string? LogoUrl,
-	bool IsVerified);
+	bool IsVerified,
+	int OpenOpportunityCount);

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/PublicOrganizationSummary.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/PublicOrganizationSummary.cs
@@ -1,0 +1,9 @@
+namespace Application.Organizations.GetPublicOrganizations.v1;
+
+public sealed record PublicOrganizationSummary(
+	Guid Id,
+	string Name,
+	string? Description,
+	string? City,
+	string? LogoUrl,
+	bool IsVerified);

--- a/backend/src/Application/Organizations/IOrganizationReadRepository.cs
+++ b/backend/src/Application/Organizations/IOrganizationReadRepository.cs
@@ -1,0 +1,11 @@
+using Application.Common.Pagination;
+using Application.Organizations.GetPublicOrganizations.v1;
+
+namespace Application.Organizations;
+
+public interface IOrganizationReadRepository
+{
+	ValueTask<PagedList<PublicOrganizationSummary>> GetPagedPublicSummariesAsync(
+		OrganizationFilter filter,
+		CancellationToken cancellationToken = default);
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
@@ -1,6 +1,7 @@
 using Application.Common.Pagination;
 using Application.Organizations;
 using Application.Organizations.GetPublicOrganizations.v1;
+using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
@@ -23,18 +24,42 @@ internal sealed class OrganizationReadRepository(
 
 		var total = await query.CountAsync(cancellationToken);
 
-		var items = await query
+		var page = await query
 			.OrderBy(o => o.Name)
 			.Skip((filter.PageNumber - 1) * filter.PageSize)
 			.Take(filter.PageSize)
+			.Select(o => new
+			{
+				o.Id,
+				o.Name,
+				o.Description,
+				City = o.Address != null ? o.Address.City : null,
+				o.LogoUrl,
+				o.IsVerified,
+			})
+			.ToListAsync(cancellationToken);
+
+		if (page.Count == 0)
+			return new PagedList<PublicOrganizationSummary>([], total, filter.PageNumber, filter.PageSize);
+
+		var orgIds = page.Select(o => o.Id).ToList();
+
+		var openCounts = await dbContext.VolunteerOpportunitiesQuery
+			.Where(vo => orgIds.Contains(vo.OrganizationId) && vo.Status == OpportunityStatus.Published)
+			.GroupBy(vo => vo.OrganizationId)
+			.Select(g => new { OrganizationId = g.Key, Count = g.Count() })
+			.ToDictionaryAsync(x => x.OrganizationId, x => x.Count, cancellationToken);
+
+		var items = page
 			.Select(o => new PublicOrganizationSummary(
 				o.Id.Value,
 				o.Name,
 				o.Description,
-				o.Address != null ? o.Address.City : null,
+				o.City,
 				o.LogoUrl,
-				o.IsVerified))
-			.ToListAsync(cancellationToken);
+				o.IsVerified,
+				openCounts.GetValueOrDefault(o.Id, 0)))
+			.ToList();
 
 		return new PagedList<PublicOrganizationSummary>(items, total, filter.PageNumber, filter.PageSize);
 	}

--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
@@ -1,0 +1,41 @@
+using Application.Common.Pagination;
+using Application.Organizations;
+using Application.Organizations.GetPublicOrganizations.v1;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence.Repositories;
+
+internal sealed class OrganizationReadRepository(
+	ApplicationDbContext dbContext)
+	: IOrganizationReadRepository
+{
+	public async ValueTask<PagedList<PublicOrganizationSummary>> GetPagedPublicSummariesAsync(
+		OrganizationFilter filter,
+		CancellationToken cancellationToken = default)
+	{
+		var query = dbContext.OrganizationsQuery;
+
+		if (!string.IsNullOrWhiteSpace(filter.Search))
+		{
+			var search = filter.Search.ToLower();
+			query = query.Where(o => o.Name.ToLower().Contains(search));
+		}
+
+		var total = await query.CountAsync(cancellationToken);
+
+		var items = await query
+			.OrderBy(o => o.Name)
+			.Skip((filter.PageNumber - 1) * filter.PageSize)
+			.Take(filter.PageSize)
+			.Select(o => new PublicOrganizationSummary(
+				o.Id.Value,
+				o.Name,
+				o.Description,
+				o.Address != null ? o.Address.City : null,
+				o.LogoUrl,
+				o.IsVerified))
+			.ToListAsync(cancellationToken);
+
+		return new PagedList<PublicOrganizationSummary>(items, total, filter.PageNumber, filter.PageSize);
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
@@ -1,6 +1,8 @@
+using Application.Common.Exceptions;
 using Application.Common.Pagination;
 using Application.Organizations;
 using Application.Organizations.GetPublicOrganizations.v1;
+using Domain.Organizations;
 using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 
@@ -30,7 +32,7 @@ internal sealed class OrganizationReadRepository(
 			.Take(filter.PageSize)
 			.Select(o => new
 			{
-				o.Id,
+				Id = o.Id.Value,
 				o.Name,
 				o.Description,
 				City = o.Address != null ? o.Address.City : null,
@@ -42,17 +44,17 @@ internal sealed class OrganizationReadRepository(
 		if (page.Count == 0)
 			return new PagedList<PublicOrganizationSummary>([], total, filter.PageNumber, filter.PageSize);
 
-		var orgIds = page.Select(o => o.Id).ToList();
+		var orgIds = page.Select(o => OrganizationId.Create(o.Id).GetValueOrThrow()).ToList();
 
 		var openCounts = await dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => orgIds.Contains(vo.OrganizationId) && vo.Status == OpportunityStatus.Published)
 			.GroupBy(vo => vo.OrganizationId)
-			.Select(g => new { OrganizationId = g.Key, Count = g.Count() })
+			.Select(g => new { OrganizationId = g.Key.Value, Count = g.Count() })
 			.ToDictionaryAsync(x => x.OrganizationId, x => x.Count, cancellationToken);
 
 		var items = page
 			.Select(o => new PublicOrganizationSummary(
-				o.Id.Value,
+				o.Id,
 				o.Name,
 				o.Description,
 				o.City,

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -62,6 +62,8 @@ public static class ServiceCollectionExtensions
 
 		services.AddScoped<IVolunteerOpportunityReadRepository, VolunteerOpportunityReadRepository>();
 
+		services.AddScoped<IOrganizationReadRepository, OrganizationReadRepository>();
+
 		services.AddScoped<IEngagementReadRepository, EngagementReadRepository>();
 
 		services.AddScoped<INotificationReadRepository, NotificationReadRepository>();

--- a/backend/tests/Application.UnitTests/Organizations/GetPublicOrganizations/GetPublicOrganizationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetPublicOrganizations/GetPublicOrganizationsQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using Application.Common.Pagination;
+using Application.Organizations;
+using Application.Organizations.GetPublicOrganizations.v1;
+using AwesomeAssertions;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.GetPublicOrganizations;
+
+public class GetPublicOrganizationsQueryHandlerTests
+{
+	private readonly IOrganizationReadRepository _readRepo =
+		Substitute.For<IOrganizationReadRepository>();
+	private readonly GetPublicOrganizationsQueryHandler _sut;
+
+	public GetPublicOrganizationsQueryHandlerTests()
+	{
+		_readRepo
+			.GetPagedPublicSummariesAsync(Arg.Any<OrganizationFilter>(), Arg.Any<CancellationToken>())
+			.Returns(new PagedList<PublicOrganizationSummary>([], 0, 1, 10));
+		_sut = new GetPublicOrganizationsQueryHandler(_readRepo);
+	}
+
+	private static GetPublicOrganizationsQuery Query(int pageNumber, int pageSize, string? search = null) =>
+		new(pageNumber, pageSize, search);
+
+	private async Task<OrganizationFilter> CapturedFilterAsync(int pageNumber, int pageSize, string? search = null)
+	{
+		OrganizationFilter? captured = null;
+		_readRepo
+			.GetPagedPublicSummariesAsync(Arg.Do<OrganizationFilter>(f => captured = f), Arg.Any<CancellationToken>())
+			.Returns(new PagedList<PublicOrganizationSummary>([], 0, 1, 10));
+
+		await _sut.Handle(Query(pageNumber, pageSize, search), CancellationToken.None);
+
+		captured.Should().NotBeNull();
+		return captured!;
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampZeroPageNumber_ToOne()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 0, pageSize: 10);
+		filter.PageNumber.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampNegativePageNumber_ToOne()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: -5, pageSize: 10);
+		filter.PageNumber.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPreservePositivePageNumber()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 3, pageSize: 10);
+		filter.PageNumber.Should().Be(3);
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampZeroPageSize_ToOne()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 1, pageSize: 0);
+		filter.PageSize.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCapExcessivePageSize_ToHundred()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 1, pageSize: 5000);
+		filter.PageSize.Should().Be(100);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPreservePageSizeWithinBounds()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 1, pageSize: 25);
+		filter.PageSize.Should().Be(25);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPassSearchTerm_ToFilter()
+	{
+		var filter = await CapturedFilterAsync(pageNumber: 1, pageSize: 10, search: "Red Cross");
+		filter.Search.Should().Be("Red Cross");
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -8703,6 +8703,11 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("isVerified")]
         public bool IsVerified { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("openOpportunityCount")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int OpenOpportunityCount { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -132,21 +132,6 @@ namespace IntegrationTests
         System.Threading.Tasks.Task DeleteMyAccountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>No Content</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task SetUserEnabledAsync(System.Guid userId, SetUserEnabledRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>No Content</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task SetUserAdminStatusAsync(System.Guid userId, SetUserAdminStatusRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<PagedListOfAdminUserListItem> ListUsersAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<PublicUserProfileResponse> GetPublicUserProfileAsync(System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -204,7 +189,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<PagedListOfPublicOrganizationSummary> GetPublicOrganizationsAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -2634,355 +2619,6 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>No Content</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task SetUserEnabledAsync(System.Guid userId, SetUserEnabledRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
-        {
-            if (userId == null)
-                throw new System.ArgumentNullException("userId");
-
-            if (body == null)
-                throw new System.ArgumentNullException("body");
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
-                    var content_ = new System.Net.Http.ByteArrayContent(json_);
-                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
-                    request_.Content = content_;
-                    request_.Method = new System.Net.Http.HttpMethod("PUT");
-
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                
-                    // Operation Path: "v1/admin/users/{userId}/enabled"
-                    urlBuilder_.Append("v1/admin/users/");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(userId, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append("/enabled");
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
-                        foreach (var item_ in response_.Headers)
-                            headers_[item_.Key] = item_.Value;
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 204)
-                        {
-                            return;
-                        }
-                        else
-                        if (status_ == 401)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 403)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 409)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 500)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>No Content</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task SetUserAdminStatusAsync(System.Guid userId, SetUserAdminStatusRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
-        {
-            if (userId == null)
-                throw new System.ArgumentNullException("userId");
-
-            if (body == null)
-                throw new System.ArgumentNullException("body");
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
-                    var content_ = new System.Net.Http.ByteArrayContent(json_);
-                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
-                    request_.Content = content_;
-                    request_.Method = new System.Net.Http.HttpMethod("PUT");
-
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                
-                    // Operation Path: "v1/admin/users/{userId}/admin-status"
-                    urlBuilder_.Append("v1/admin/users/");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(userId, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append("/admin-status");
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
-                        foreach (var item_ in response_.Headers)
-                            headers_[item_.Key] = item_.Value;
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 204)
-                        {
-                            return;
-                        }
-                        else
-                        if (status_ == 401)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 403)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 409)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 500)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<PagedListOfAdminUserListItem> ListUsersAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
-        {
-            if (pageNumber == null)
-                throw new System.ArgumentNullException("pageNumber");
-
-            if (pageSize == null)
-                throw new System.ArgumentNullException("pageSize");
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                
-                    // Operation Path: "v1/admin/users"
-                    urlBuilder_.Append("v1/admin/users");
-                    urlBuilder_.Append('?');
-                    urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
-                    urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
-                    if (search != null)
-                    {
-                        urlBuilder_.Append(System.Uri.EscapeDataString("search")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(search, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
-                    }
-                    urlBuilder_.Length--;
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
-                        foreach (var item_ in response_.Headers)
-                            headers_[item_.Key] = item_.Value;
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<PagedListOfAdminUserListItem>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
-                        }
-                        else
-                        if (status_ == 401)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 403)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 500)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<PublicUserProfileResponse> GetPublicUserProfileAsync(System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -4233,7 +3869,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<PagedListOfPublicOrganizationSummary> GetPublicOrganizationsAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (pageNumber == null)
                 throw new System.ArgumentNullException("pageNumber");
@@ -4252,11 +3888,15 @@ namespace IntegrationTests
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                 
-                    // Operation Path: "v1/admin/organizations"
-                    urlBuilder_.Append("v1/admin/organizations");
+                    // Operation Path: "v1/organizations/directory"
+                    urlBuilder_.Append("v1/organizations/directory");
                     urlBuilder_.Append('?');
-                    urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
-                    urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("PageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("PageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    if (search != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("Search")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(search, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
                     urlBuilder_.Length--;
 
                     PrepareRequest(client_, request_, urlBuilder_);
@@ -4284,7 +3924,7 @@ namespace IntegrationTests
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<PagedListOfAdminOrganizationSummary>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<PagedListOfPublicOrganizationSummary>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -4292,24 +3932,14 @@ namespace IntegrationTests
                             return objectResponse_.Object;
                         }
                         else
-                        if (status_ == 401)
+                        if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 403)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -7575,75 +7205,6 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class AdminOrganizationSummary
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("id")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.Guid Id { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("name")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Name { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("logoUrl")]
-        public string? LogoUrl { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("isVerified")]
-        public bool IsVerified { get; set; } = default!;
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class AdminUserListItem
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("id")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.Guid Id { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("username")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Username { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("firstName")]
-        public string? FirstName { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("lastName")]
-        public string? LastName { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("email")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Email { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
-        public bool Enabled { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("realmRoles")]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<string> RealmRoles { get; set; } = new System.Collections.ObjectModel.Collection<string>();
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class BadgeCatalogEntry
     {
 
@@ -8860,70 +8421,6 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class PagedListOfAdminOrganizationSummary
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int TotalItems { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int CurrentPage { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int PageCount { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("items")]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<AdminOrganizationSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<AdminOrganizationSummary>();
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class PagedListOfAdminUserListItem
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int TotalItems { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int CurrentPage { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
-        public int PageCount { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("items")]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<AdminUserListItem> Items { get; set; } = new System.Collections.ObjectModel.Collection<AdminUserListItem>();
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PagedListOfEngagementSummary
     {
 
@@ -8943,6 +8440,38 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("items")]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<EngagementSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<EngagementSummary>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PagedListOfPublicOrganizationSummary
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int TotalItems { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int CurrentPage { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int PageCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<PublicOrganizationSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<PublicOrganizationSummary>();
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
@@ -9151,6 +8680,41 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PublicOrganizationSummary
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid Id { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Name { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public string? Description { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("city")]
+        public string? City { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("logoUrl")]
+        public string? LogoUrl { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("isVerified")]
+        public bool IsVerified { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PublicUserProfileResponse
     {
 
@@ -9220,42 +8784,6 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("color")]
         public string? Color { get; set; } = default!;
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class SetUserAdminStatusRequest
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("isAdmin")]
-        public bool IsAdmin { get; set; } = default!;
-
-        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
-
-        [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class SetUserEnabledRequest
-    {
-
-        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
-        public bool Enabled { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -132,6 +132,21 @@ namespace IntegrationTests
         System.Threading.Tasks.Task DeleteMyAccountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task SetUserEnabledAsync(System.Guid userId, SetUserEnabledRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task SetUserAdminStatusAsync(System.Guid userId, SetUserAdminStatusRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<PagedListOfAdminUserListItem> ListUsersAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<PublicUserProfileResponse> GetPublicUserProfileAsync(System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -185,6 +200,11 @@ namespace IntegrationTests
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task RemoveMemberAsync(System.Guid organizationId, System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -2619,6 +2639,355 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task SetUserEnabledAsync(System.Guid userId, SetUserEnabledRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (userId == null)
+                throw new System.ArgumentNullException("userId");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/admin/users/{userId}/enabled"
+                    urlBuilder_.Append("v1/admin/users/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(userId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/enabled");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task SetUserAdminStatusAsync(System.Guid userId, SetUserAdminStatusRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (userId == null)
+                throw new System.ArgumentNullException("userId");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/admin/users/{userId}/admin-status"
+                    urlBuilder_.Append("v1/admin/users/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(userId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/admin-status");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<PagedListOfAdminUserListItem> ListUsersAsync(int pageNumber, int pageSize, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (pageNumber == null)
+                throw new System.ArgumentNullException("pageNumber");
+
+            if (pageSize == null)
+                throw new System.ArgumentNullException("pageSize");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/admin/users"
+                    urlBuilder_.Append("v1/admin/users");
+                    urlBuilder_.Append('?');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    if (search != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("search")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(search, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<PagedListOfAdminUserListItem>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<PublicUserProfileResponse> GetPublicUserProfileAsync(System.Guid userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -3835,6 +4204,117 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (pageNumber == null)
+                throw new System.ArgumentNullException("pageNumber");
+
+            if (pageSize == null)
+                throw new System.ArgumentNullException("pageSize");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/admin/organizations"
+                    urlBuilder_.Append("v1/admin/organizations");
+                    urlBuilder_.Append('?');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<PagedListOfAdminOrganizationSummary>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -7205,6 +7685,75 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AdminOrganizationSummary
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid Id { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Name { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("logoUrl")]
+        public string? LogoUrl { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("isVerified")]
+        public bool IsVerified { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AdminUserListItem
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid Id { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("username")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Username { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("firstName")]
+        public string? FirstName { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("lastName")]
+        public string? LastName { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("email")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Email { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+        public bool Enabled { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("realmRoles")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<string> RealmRoles { get; set; } = new System.Collections.ObjectModel.Collection<string>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class BadgeCatalogEntry
     {
 
@@ -8421,6 +8970,70 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PagedListOfAdminOrganizationSummary
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int TotalItems { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int CurrentPage { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int PageCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<AdminOrganizationSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<AdminOrganizationSummary>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PagedListOfAdminUserListItem
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int TotalItems { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int CurrentPage { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int PageCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<AdminUserListItem> Items { get; set; } = new System.Collections.ObjectModel.Collection<AdminUserListItem>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PagedListOfEngagementSummary
     {
 
@@ -8789,6 +9402,42 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("color")]
         public string? Color { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class SetUserAdminStatusRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("isAdmin")]
+        public bool IsAdmin { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class SetUserEnabledRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+        public bool Enabled { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -36,6 +36,22 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrganizationsDirectoryPage_HasNoSeriousA11yViolations()
+	{
+		// #763: the public organization directory page - not covered by any
+		// existing a11y test, which is exactly how the text-gray-400 city-line
+		// contrast violation (same defect as the "Received:" meta line fixed
+		// alongside it) would have shipped unnoticed.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task MyEngagementsPage_AsVera_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -390,6 +390,18 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrganizationsPage_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task PrivacyPolicyPage_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -91,16 +91,16 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		{
 			setupHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {setupSession.AccessToken}");
 
-			var suffix = Guid.NewGuid().ToString("N");
+			var setupSuffix = Guid.NewGuid().ToString("N");
 			var orgResponse = await setupHttp.PostAsJsonAsync(
-				"/v1/organizations", new { name = $"AchievementSeed Org {suffix}" });
+				"/v1/organizations", new { name = $"AchievementSeed Org {setupSuffix}" });
 			orgResponse.EnsureSuccessStatusCode();
 			var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 			var organizationId = org.GetProperty("id").GetProperty("value").GetString();
 
 			var oppResponse = await setupHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title = $"AchievementSeed Opportunity {suffix}",
+				title = $"AchievementSeed Opportunity {setupSuffix}",
 				description = "Created by AchievementsTests to guarantee a confirmed engagement",
 				organizationId,
 				isRemote = true,

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -12,8 +12,7 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 	/// Regression for #645: useAchievementNotifier only seeded the "seen"
 	/// localStorage set when the account had zero achievements, so a fresh
 	/// browser/device/profile for an account that already has achievements
-	/// (e.g. olaf, who already has confirmed-engagement achievements from seed
-	/// data) re-announced every existing achievement as newly unlocked.
+	/// re-announced every existing achievement as newly unlocked.
 	/// </summary>
 	[Test]
 	public async Task ExistingAchievements_DoNotReToastAsNew_OnFreshBrowserContext()
@@ -75,6 +74,68 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 				.EnsureSuccessStatusCode();
 		}
 
+		// Deterministically guarantee olaf has at least one achievement before
+		// he ever logs in below, instead of relying on some other VisualTests
+		// class having already confirmed an engagement for him. AspireFixture
+		// is shared (Shared = SharedType.PerTestSession) across every test
+		// class with no ordering guarantee between them, so that assumption
+		// was a race: if this test happened to run before whichever class
+		// first grants olaf his "first-step" badge, GET /v1/me/achievements
+		// legitimately came back empty. Achievement rows are never deleted
+		// once granted, so seeding one here (following the same
+		// create-org/create-opportunity/publish/apply/confirm flow as
+		// EngagementCalendarTests) is safe regardless of what other tests do
+		// concurrently.
+		var setupSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using (var setupHttp = new HttpClient { BaseAddress = backend })
+		{
+			setupHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {setupSession.AccessToken}");
+
+			var suffix = Guid.NewGuid().ToString("N");
+			var orgResponse = await setupHttp.PostAsJsonAsync(
+				"/v1/organizations", new { name = $"AchievementSeed Org {suffix}" });
+			orgResponse.EnsureSuccessStatusCode();
+			var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+			var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+			var oppResponse = await setupHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+			{
+				title = $"AchievementSeed Opportunity {suffix}",
+				description = "Created by AchievementsTests to guarantee a confirmed engagement",
+				organizationId,
+				isRemote = true,
+				occurrence = "OneTime",
+				participationType = "Waitlist",
+				checkInMethod = "None",
+				isDraft = true,
+			});
+			oppResponse.EnsureSuccessStatusCode();
+			var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+			var opportunityId = opportunity.GetProperty("id").GetString();
+
+			var start = DateTimeOffset.UtcNow.AddDays(3);
+			var end = start.AddHours(2);
+			var slotResponse = await setupHttp.PostAsJsonAsync(
+				$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+				new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 });
+			slotResponse.EnsureSuccessStatusCode();
+			var slots = await slotResponse.Content.ReadFromJsonAsync<JsonElement>();
+			var timeSlotId = slots[0].GetProperty("id").GetString();
+
+			(await setupHttp.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+				.EnsureSuccessStatusCode();
+
+			var engagementResponse = await setupHttp.PostAsJsonAsync(
+				$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+				new { type = "Waitlist", timeSlotId, message = (string?)null });
+			engagementResponse.EnsureSuccessStatusCode();
+			var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+			var engagementId = engagement.GetProperty("id").GetString();
+
+			(await setupHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+				.EnsureSuccessStatusCode();
+		}
+
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
@@ -96,7 +157,8 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		achievementsResponse.EnsureSuccessStatusCode();
 		var achievements = await achievementsResponse.Content.ReadFromJsonAsync<JsonElement>();
 		achievements.GetArrayLength().Should().BeGreaterThan(0,
-			"olaf must already have at least one achievement for this regression test to be meaningful");
+			"the confirmed engagement set up above must have granted olaf at least one achievement " +
+			"for this regression test to be meaningful");
 
 		// Each VisualTests test gets a fresh, isolated browser context (see
 		// VisualTestBase) - no einsatzbereit:seen-achievements localStorage entry

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -63,10 +63,13 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task OrganizationProfilePage_BreadcrumbShowsHomeAndOrgName()
+	public async Task OrganizationProfilePage_BreadcrumbShowsHomeOrganizationsAndOrgName()
 	{
 		// #574: OrganizationProfilePage had no way back at all - revived
 		// breadcrumb must show "Home > {organization name}".
+		// #772 review follow-up (issue #763): the trail must also link back
+		// to the organization directory - "Home > Organizations > {org name}",
+		// not jump straight from Home to the org.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -90,8 +93,51 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var homeCrumb = breadcrumb.Locator("a[href='/']");
 		await Expect(homeCrumb).ToBeVisibleAsync();
 
+		var organizationsCrumb = breadcrumb.GetByRole(AriaRole.Link, new() { Name = "Organizations" });
+		await Expect(organizationsCrumb).ToBeVisibleAsync();
+		await Expect(organizationsCrumb).ToHaveAttributeAsync("href", "/organizations");
+
 		var orgName = await Page.Locator("h1").First.InnerTextAsync();
 		await Expect(breadcrumb.GetByText(orgName, new() { Exact = true })).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task HeaderDesktopNav_ShowsOrganizationsLink_LoggedOutAndLoggedIn()
+	{
+		// #772 review follow-up (issue #763): the organization directory had
+		// no entry point besides a footer link - a persistent "Organizations"
+		// link must be visible in the Header nav regardless of auth state.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var loggedOutLink = Page.Locator("nav a[href='/organizations']");
+		await Expect(loggedOutLink).ToBeVisibleAsync();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var loggedInLink = Page.Locator("nav a[href='/organizations']");
+		await Expect(loggedInLink).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task MobileMenu_ShowsOrganizationsLink()
+	{
+		// #772 review follow-up (issue #763): the entry point must also be
+		// reachable from the mobile menu, not just the desktop nav.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.SetViewportSizeAsync(390, 844);
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var menuBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" });
+		await Expect(menuBtn).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await menuBtn.ClickAsync();
+
+		await Expect(Page.Locator("a[href='/organizations']")).ToBeVisibleAsync(new() { Timeout = 5_000 });
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -137,7 +137,12 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(menuBtn).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await menuBtn.ClickAsync();
 
-		await Expect(Page.Locator("a[href='/organizations']")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		// A plain href selector also matches the desktop nav's own Organizations
+		// link (still in the DOM, just CSS-hidden at this viewport) and the
+		// footer's "Browse organizations" link (visible, just off-screen) -
+		// three elements total. The testid is the only unambiguous match.
+		await Expect(Page.GetByTestId("mobile-nav-organizations-link"))
+			.ToBeVisibleAsync(new() { Timeout = 5_000 });
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -102,47 +102,24 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task HeaderDesktopNav_ShowsOrganizationsLink_LoggedOutAndLoggedIn()
+	public async Task HomePage_ShowsOrganizationsTeaser_LinkingToDirectory()
 	{
-		// #772 review follow-up (issue #763): the organization directory had
-		// no entry point besides a footer link - a persistent "Organizations"
-		// link must be visible in the Header nav regardless of auth state.
+		// #772 review follow-up round 2 (issue #763): a permanent Header nav
+		// entry point was judged too heavy a commitment for an unvalidated
+		// use case - replaced with a homepage section instead, so the
+		// directory stays discoverable without growing the global nav.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		var loggedOutLink = Page.Locator("nav a[href='/organizations']");
-		await Expect(loggedOutLink).ToBeVisibleAsync();
+		var teaserCta = Page.GetByTestId("organizations-teaser-cta");
+		await teaserCta.ScrollIntoViewIfNeededAsync();
+		await Expect(teaserCta).ToBeVisibleAsync();
+		await Expect(teaserCta).ToHaveAttributeAsync("href", "/organizations");
 
-		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
-		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
-
-		var loggedInLink = Page.Locator("nav a[href='/organizations']");
-		await Expect(loggedInLink).ToBeVisibleAsync();
-	}
-
-	[Test]
-	public async Task MobileMenu_ShowsOrganizationsLink()
-	{
-		// #772 review follow-up (issue #763): the entry point must also be
-		// reachable from the mobile menu, not just the desktop nav.
-		var frontend = Fixture.GetEndpoint("frontend");
-
-		await Page.SetViewportSizeAsync(390, 844);
-		await Page.GotoAsync(frontend.ToString());
-		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
-
-		var menuBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" });
-		await Expect(menuBtn).ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await menuBtn.ClickAsync();
-
-		// A plain href selector also matches the desktop nav's own Organizations
-		// link (still in the DOM, just CSS-hidden at this viewport) and the
-		// footer's "Browse organizations" link (visible, just off-screen) -
-		// three elements total. The testid is the only unambiguous match.
-		await Expect(Page.GetByTestId("mobile-nav-organizations-link"))
-			.ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await teaserCta.ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/organizations$"), new() { Timeout = 10_000 });
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -170,6 +170,104 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
+	{
+		// Regression for #641 (and a guard against reintroducing it): the tab
+		// bar now lives in the persistent /app shell (OrgAppLayout) at the top
+		// of the main content area, decoupled from any individual tab page's own
+		// content-width wrapper - it must not shrink or shift when navigating
+		// between tabs.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual641 Alignment");
+
+		// Measure the tab row's flex container inside the tabs nav; its width
+		// tracks the enclosing <main class="...max-w-7xl...">, which is constant
+		// across tab switches. Scope by the nav's accessible name so the
+		// breadcrumb nav - which also surfaces the current tab label - isn't
+		// matched too.
+		var tabBar = Page
+			.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" })
+			.Locator("div")
+			.First;
+		var dashboardBox = await tabBar.BoundingBoxAsync();
+		dashboardBox.Should().NotBeNull();
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Edit", Exact = true })).ToBeVisibleAsync(
+			new() { Timeout = 10_000 });
+
+		var settingsBox = await tabBar.BoundingBoxAsync();
+		settingsBox.Should().NotBeNull();
+
+		settingsBox!.Width.Should().Be(dashboardBox!.Width);
+		settingsBox.X.Should().Be(dashboardBox.X);
+	}
+
+	[Test]
+	public async Task Directory_ShowsOpenOpportunityCount_ForOrgWithPublishedOpportunity()
+	{
+		// #772 review follow-up (issue #763): "the site looks a bit dead" -
+		// the public organization directory now shows each org's count of
+		// open (Published) volunteer opportunities instead of just a bare
+		// name/description, so a card with real opportunities reads as such.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var orgName = await CreateOrganizationAsync("Visual772 OpenCount");
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		try
+		{
+			await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+		}
+		catch
+		{
+			return; // modal did not open - skip remaining assertions
+		}
+
+		// Step 1: title/description.
+		await Page.Locator("#opportunity-title").FillAsync("Visual772 Opportunity");
+		await Page.Locator("#opportunity-description").FillAsync(
+			"Coverage for the organization directory's open-opportunity count.");
+
+		// Step 2: remote, so no address fields are required.
+		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
+		await Page.Locator("#opportunity-remote").CheckAsync();
+
+		// Step 3: IndividualContact (Express interest) - unlike Waitlist, this
+		// type can publish with no time slots, keeping this test focused on
+		// the directory count rather than the slot-creation flow.
+		await Page.GetByTestId("wizard-stepper-3").ClickAsync();
+		await Page.Locator("label:has(input[name='participationType'][value='IndividualContact'])")
+			.ClickAsync();
+
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+		await Page.GetByTestId("modal-submit").ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		// The public directory, filtered to this org, must show "1 open opportunity".
+		await Page.GotoAsync($"{origin}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.Locator("#organizations-search").FillAsync(orgName);
+
+		var orgCard = Page.Locator("li").Filter(new() { HasTextString = orgName });
+		await Expect(orgCard).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(orgCard.GetByText("1 open opportunity", new() { Exact = true }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
 	public async Task PublicProfilePage_ContentIsCenteredWithinMain()
 	{
 		// Regression for #694: OrganizationProfileView's content wrapper

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -170,44 +170,6 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task TabBar_StaysFullWidth_AcrossTabSwitches()
-	{
-		// Regression for #641 (and a guard against reintroducing it): the tab
-		// bar now lives in the persistent /app shell (OrgAppLayout) at the top
-		// of the main content area, decoupled from any individual tab page's own
-		// content-width wrapper - it must not shrink or shift when navigating
-		// between tabs.
-		var frontend = Fixture.GetEndpoint("frontend");
-
-		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
-		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
-
-		await CreateOrganizationAsync("Visual641 Alignment");
-
-		// Measure the tab row's flex container inside the tabs nav; its width
-		// tracks the enclosing <main class="...max-w-7xl...">, which is constant
-		// across tab switches. Scope by the nav's accessible name so the
-		// breadcrumb nav - which also surfaces the current tab label - isn't
-		// matched too.
-		var tabBar = Page
-			.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" })
-			.Locator("div")
-			.First;
-		var dashboardBox = await tabBar.BoundingBoxAsync();
-		dashboardBox.Should().NotBeNull();
-
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true }).ClickAsync();
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Edit", Exact = true })).ToBeVisibleAsync(
-			new() { Timeout = 10_000 });
-
-		var settingsBox = await tabBar.BoundingBoxAsync();
-		settingsBox.Should().NotBeNull();
-
-		settingsBox!.Width.Should().Be(dashboardBox!.Width);
-		settingsBox.X.Should().Be(dashboardBox.X);
-	}
-
-	[Test]
 	public async Task Directory_ShowsOpenOpportunityCount_ForOrgWithPublishedOpportunity()
 	{
 		// #772 review follow-up (issue #763): "the site looks a bit dead" -

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import EngagementManagementPage from "./pages/EngagementManagementPage";
 import ProfileOverviewPage from "./pages/ProfileOverviewPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import OrganizationProfilePage from "./pages/OrganizationProfilePage";
+import OrganizationsPage from "./pages/OrganizationsPage";
 import UserAchievementsPage from "./pages/UserAchievementsPage";
 import AdministrationPage from "./pages/AdministrationPage";
 import UserProfilePage from "./pages/UserProfilePage";
@@ -189,7 +190,7 @@ export default function App() {
 					path="/opportunities"
 					element={<Navigate to="/#opportunities" replace />}
 				/>
-				<Route path="/organizations" element={<Navigate to="/" replace />} />
+				<Route path="/organizations" element={<OrganizationsPage />} />
 				<Route path="*" element={<NotFoundPage />} />
 			</Route>
 		</Routes>

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -4474,6 +4474,7 @@ export interface PublicOrganizationSummary {
     city: string | undefined;
     logoUrl: string | undefined;
     isVerified: boolean;
+    openOpportunityCount: number;
 
     [key: string]: any;
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -2188,68 +2188,6 @@ export class EinsatzbereitApi {
     }
 
     /**
-     * @param search (optional) 
-     * @return OK
-     */
-    getPublicOrganizations(pageNumber: number, pageSize: number, search: string | undefined, signal?: AbortSignal): Promise<PagedListOfPublicOrganizationSummary> {
-        let url_ = this.baseUrl + "/v1/organizations/directory?";
-        if (pageNumber === undefined || pageNumber === null)
-            throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
-        else
-            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
-        if (pageSize === undefined || pageSize === null)
-            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
-        else
-            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
-        if (search === null)
-            throw new globalThis.Error("The parameter 'search' cannot be null.");
-        else if (search !== undefined)
-            url_ += "Search=" + encodeURIComponent("" + search) + "&";
-        url_ = url_.replace(/[?&]$/, "");
-
-        let options_: RequestInit = {
-            method: "GET",
-            signal,
-            headers: {
-                "Accept": "application/json"
-            }
-        };
-
-        return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processGetPublicOrganizations(_response);
-        });
-    }
-
-    protected processGetPublicOrganizations(response: Response): Promise<PagedListOfPublicOrganizationSummary> {
-        const status = response.status;
-        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 200) {
-            return response.text().then((_responseText) => {
-            let result200: any = null;
-            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as PagedListOfPublicOrganizationSummary;
-            return result200;
-            });
-        } else if (status === 400) {
-            return response.text().then((_responseText) => {
-            let result400: any = null;
-            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
-            return throwException("Bad Request", status, _responseText, _headers, result400);
-            });
-        } else if (status === 500) {
-            return response.text().then((_responseText) => {
-            let result500: any = null;
-            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
-            return throwException("Internal Server Error", status, _responseText, _headers, result500);
-            });
-        } else if (status !== 200 && status !== 204) {
-            return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-            });
-        }
-        return Promise.resolve<PagedListOfPublicOrganizationSummary>(null as any);
-    }
-
-    /**
      * @return OK
      */
     listOrganizations(pageNumber: number, pageSize: number, signal?: AbortSignal): Promise<PagedListOfAdminOrganizationSummary> {
@@ -2310,6 +2248,68 @@ export class EinsatzbereitApi {
             });
         }
         return Promise.resolve<PagedListOfAdminOrganizationSummary>(null as any);
+    }
+
+    /**
+     * @param search (optional) 
+     * @return OK
+     */
+    getPublicOrganizations(pageNumber: number, pageSize: number, search: string | undefined, signal?: AbortSignal): Promise<PagedListOfPublicOrganizationSummary> {
+        let url_ = this.baseUrl + "/v1/organizations/directory?";
+        if (pageNumber === undefined || pageNumber === null)
+            throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
+        else
+            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (search === null)
+            throw new globalThis.Error("The parameter 'search' cannot be null.");
+        else if (search !== undefined)
+            url_ += "Search=" + encodeURIComponent("" + search) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetPublicOrganizations(_response);
+        });
+    }
+
+    protected processGetPublicOrganizations(response: Response): Promise<PagedListOfPublicOrganizationSummary> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as PagedListOfPublicOrganizationSummary;
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<PagedListOfPublicOrganizationSummary>(null as any);
     }
 
     /**

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -2188,6 +2188,68 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @param search (optional) 
+     * @return OK
+     */
+    getPublicOrganizations(pageNumber: number, pageSize: number, search: string | undefined, signal?: AbortSignal): Promise<PagedListOfPublicOrganizationSummary> {
+        let url_ = this.baseUrl + "/v1/organizations/directory?";
+        if (pageNumber === undefined || pageNumber === null)
+            throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
+        else
+            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (search === null)
+            throw new globalThis.Error("The parameter 'search' cannot be null.");
+        else if (search !== undefined)
+            url_ += "Search=" + encodeURIComponent("" + search) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetPublicOrganizations(_response);
+        });
+    }
+
+    protected processGetPublicOrganizations(response: Response): Promise<PagedListOfPublicOrganizationSummary> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as PagedListOfPublicOrganizationSummary;
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<PagedListOfPublicOrganizationSummary>(null as any);
+    }
+
+    /**
      * @return OK
      */
     listOrganizations(pageNumber: number, pageSize: number, signal?: AbortSignal): Promise<PagedListOfAdminOrganizationSummary> {
@@ -4337,6 +4399,15 @@ export interface PagedListOfEngagementSummary {
     [key: string]: any;
 }
 
+export interface PagedListOfPublicOrganizationSummary {
+    totalItems?: number;
+    currentPage: number;
+    pageCount?: number;
+    items: PublicOrganizationSummary[];
+
+    [key: string]: any;
+}
+
 export interface PagedListOfVolunteerOpportunitySummary {
     totalItems?: number;
     currentPage: number;
@@ -4392,6 +4463,17 @@ export interface PublicOrganizationProfileResponse {
     isVerified: boolean;
     openOpportunities: PublicOpportunitySummaryDto[];
     logoUrl: string | undefined;
+
+    [key: string]: any;
+}
+
+export interface PublicOrganizationSummary {
+    id: string;
+    name: string;
+    description: string | undefined;
+    city: string | undefined;
+    logoUrl: string | undefined;
+    isVerified: boolean;
 
     [key: string]: any;
 }

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -36,6 +36,14 @@ export default function Footer() {
 									{t("footer.participate")}
 								</Link>
 							</li>
+							<li>
+								<Link
+									to="/organizations"
+									className="hover:text-white transition-colors"
+								>
+									{t("footer.browseOrganizations")}
+								</Link>
+							</li>
 						</ul>
 
 						<h3 className="text-white font-semibold mb-4 mt-6 uppercase text-xs tracking-wider">

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -41,6 +41,7 @@ export default function DesktopHeader({
 		>
 			<Link
 				to="/organizations"
+				data-testid="desktop-nav-organizations-link"
 				className={`text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:text-white" : "text-gray-700 hover:text-brand-600"}`}
 			>
 				{t("breadcrumb.organizations")}

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router";
 import AccountControls from "./AccountControls";
 import LanguageSelector from "./LanguageSelector";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
@@ -39,13 +38,6 @@ export default function DesktopHeader({
 			aria-label={t("nav.primaryLabel")}
 			className="hidden md:flex items-center gap-3"
 		>
-			<Link
-				to="/organizations"
-				data-testid="desktop-nav-organizations-link"
-				className={`text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:text-white" : "text-gray-700 hover:text-brand-600"}`}
-			>
-				{t("breadcrumb.organizations")}
-			</Link>
 			{isLoggedIn ? (
 				<AccountControls
 					transparent={isTransparent}

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
 import AccountControls from "./AccountControls";
 import LanguageSelector from "./LanguageSelector";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
@@ -35,9 +36,15 @@ export default function DesktopHeader({
 
 	return (
 		<nav
-			aria-label={t("nav.accountLabel")}
+			aria-label={t("nav.primaryLabel")}
 			className="hidden md:flex items-center gap-3"
 		>
+			<Link
+				to="/organizations"
+				className={`text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:text-white" : "text-gray-700 hover:text-brand-600"}`}
+			>
+				{t("breadcrumb.organizations")}
+			</Link>
 			{isLoggedIn ? (
 				<AccountControls
 					transparent={isTransparent}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -63,6 +63,7 @@ export default function MobileMenu({
 				</div>
 				<Link
 					to="/organizations"
+					data-testid="mobile-nav-organizations-link"
 					onClick={onClose}
 					className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${menuItemVariant}`}
 				>

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -61,14 +61,6 @@ export default function MobileMenu({
 				<div className="pb-2">
 					<LanguageSelector transparent={isTransparent} />
 				</div>
-				<Link
-					to="/organizations"
-					data-testid="mobile-nav-organizations-link"
-					onClick={onClose}
-					className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${menuItemVariant}`}
-				>
-					{t("breadcrumb.organizations")}
-				</Link>
 				{isLoggedIn ? (
 					<div className="space-y-1">
 						<div className="flex items-center gap-3 px-3 py-2">

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -61,6 +61,13 @@ export default function MobileMenu({
 				<div className="pb-2">
 					<LanguageSelector transparent={isTransparent} />
 				</div>
+				<Link
+					to="/organizations"
+					onClick={onClose}
+					className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${menuItemVariant}`}
+				>
+					{t("breadcrumb.organizations")}
+				</Link>
 				{isLoggedIn ? (
 					<div className="space-y-1">
 						<div className="flex items-center gap-3 px-3 py-2">

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -12,7 +12,7 @@
       "cancel": "Abbrechen"
     },
     "nav": {
-      "accountLabel": "Konto",
+      "primaryLabel": "Hauptnavigation",
       "userMenu": "Benutzermenü",
       "myEngagements": "Meine Engagements",
       "myProfile": "Mein Profil",
@@ -872,7 +872,10 @@
       "noResultsWithSearch": "Keine Organisationen gefunden für \"{{search}}\".",
       "clearSearch": "Suche zurücksetzen",
       "loadMore": "Mehr laden",
-      "verified": "Verifizierte Organisation"
+      "verified": "Verifizierte Organisation",
+      "openOpportunities": "{{count}} offene Einsätze",
+      "openOpportunities_one": "{{count}} offener Einsatz",
+      "openOpportunities_other": "{{count}} offene Einsätze"
     },
     "orgOverview": {
       "tabDashboard": "Dashboard",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -88,7 +88,10 @@
       "heroRightCard1": "In Minuten veröffentlichen",
       "heroRightCard2": "Freiwillige einfach verwalten",
       "heroRightCard3": "Kostenlos & Open Source",
-      "heroRightCardActive": "Jetzt Einsätze verfügbar"
+      "heroRightCardActive": "Jetzt Einsätze verfügbar",
+      "orgsTeaserTitle": "Kennst du schon eine Organisation?",
+      "orgsTeaserDesc": "Durchsuche das Verzeichnis, um eine Organisation zu finden, die du schon kennst, etwa das Rote Kreuz, und zu sehen, was sie gerade macht.",
+      "orgsTeaserCta": "Organisationen durchsuchen"
     },
     "opportunities": {
       "currentNeeds": "Aktuelle Einsätze",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -29,6 +29,7 @@
       "platform": "Plattform",
       "findOpportunities": "Einsätze finden",
       "participate": "Mitmachen",
+      "browseOrganizations": "Organisationen durchsuchen",
       "legal": "Rechtliches",
       "imprint": "Impressum",
       "privacy": "Datenschutz",
@@ -789,7 +790,8 @@
       "account": "Konto",
       "profile": "Profil",
       "achievements": "Meine Errungenschaften",
-      "userAchievements": "Errungenschaften"
+      "userAchievements": "Errungenschaften",
+      "organizations": "Organisationen"
     },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",
@@ -859,6 +861,18 @@
         "demoteError": "Admin-Rechte konnten nicht entzogen werden.",
         "loadMore": "Mehr laden"
       }
+    },
+    "organizationsPage": {
+      "title": "Organisationen",
+      "subtitle": "Durchsuche Organisationen, um eine bereits bekannte zu finden.",
+      "searchPlaceholder": "Organisationen nach Namen suchen…",
+      "loading": "Organisationen werden geladen…",
+      "error": "Fehler: {{message}}",
+      "noResults": "Keine Organisationen gefunden.",
+      "noResultsWithSearch": "Keine Organisationen gefunden für \"{{search}}\".",
+      "clearSearch": "Suche zurücksetzen",
+      "loadMore": "Mehr laden",
+      "verified": "Verifizierte Organisation"
     },
     "orgOverview": {
       "tabDashboard": "Dashboard",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -88,7 +88,10 @@
       "heroRightCard1": "Publish in minutes",
       "heroRightCard2": "Manage volunteers easily",
       "heroRightCard3": "Free & open source",
-      "heroRightCardActive": "Opportunities available now"
+      "heroRightCardActive": "Opportunities available now",
+      "orgsTeaserTitle": "Already know an organization?",
+      "orgsTeaserDesc": "Search the directory to find an organization you already know, like the Red Cross, and see what they're up to.",
+      "orgsTeaserCta": "Browse organizations"
     },
     "opportunities": {
       "currentNeeds": "Current Opportunities",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -12,7 +12,7 @@
       "cancel": "Cancel"
     },
     "nav": {
-      "accountLabel": "Account",
+      "primaryLabel": "Main navigation",
       "userMenu": "User menu",
       "myEngagements": "My Engagements",
       "myProfile": "My Profile",
@@ -872,7 +872,10 @@
       "noResultsWithSearch": "No organizations match \"{{search}}\".",
       "clearSearch": "Clear search",
       "loadMore": "Load more",
-      "verified": "Verified organization"
+      "verified": "Verified organization",
+      "openOpportunities": "{{count}} open opportunities",
+      "openOpportunities_one": "{{count}} open opportunity",
+      "openOpportunities_other": "{{count}} open opportunities"
     },
     "orgOverview": {
       "tabDashboard": "Dashboard",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -29,6 +29,7 @@
       "platform": "Platform",
       "findOpportunities": "Find opportunities",
       "participate": "Get involved",
+      "browseOrganizations": "Browse organizations",
       "legal": "Legal",
       "imprint": "Imprint",
       "privacy": "Privacy Policy",
@@ -789,7 +790,8 @@
       "account": "Account",
       "profile": "Profile",
       "achievements": "My Achievements",
-      "userAchievements": "Achievements"
+      "userAchievements": "Achievements",
+      "organizations": "Organizations"
     },
     "error": {
       "forbidden": "You do not have permission to do this.",
@@ -859,6 +861,18 @@
         "demoteError": "Failed to remove admin access.",
         "loadMore": "Load more"
       }
+    },
+    "organizationsPage": {
+      "title": "Organizations",
+      "subtitle": "Browse and search organizations to find one you already know.",
+      "searchPlaceholder": "Search organizations by name…",
+      "loading": "Loading organizations…",
+      "error": "Error: {{message}}",
+      "noResults": "No organizations found.",
+      "noResultsWithSearch": "No organizations match \"{{search}}\".",
+      "clearSearch": "Clear search",
+      "loadMore": "Load more",
+      "verified": "Verified organization"
     },
     "orgOverview": {
       "tabDashboard": "Dashboard",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -120,6 +120,7 @@ export default function HomePage() {
 	const heroTitleId = useId();
 	const howItWorksTitleId = useId();
 	const missionTitleId = useId();
+	const orgsTeaserTitleId = useId();
 
 	const [showOnboarding, setShowOnboarding] = useState(false);
 	const [showCreateOrgModal, setShowCreateOrgModal] = useState(false);
@@ -516,6 +517,30 @@ export default function HomePage() {
 					>
 						{t("landing.missionCta")}
 					</a>
+				</div>
+			</section>
+
+			{/* Organizations directory teaser */}
+			<section aria-labelledby={orgsTeaserTitleId} className="mb-20">
+				<div className="animate-fade-up flex flex-col items-center gap-6 rounded-2xl border border-gray-100 bg-white p-8 text-center shadow-sm sm:flex-row sm:items-center sm:justify-between sm:p-10 sm:text-left">
+					<div>
+						<h2
+							id={orgsTeaserTitleId}
+							className="text-xl font-bold text-gray-900 sm:text-2xl"
+						>
+							{t("landing.orgsTeaserTitle")}
+						</h2>
+						<p className="mt-2 text-sm text-gray-600 sm:text-base">
+							{t("landing.orgsTeaserDesc")}
+						</p>
+					</div>
+					<Link
+						to="/organizations"
+						data-testid="organizations-teaser-cta"
+						className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-brand-700 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-800"
+					>
+						{t("landing.orgsTeaserCta")}
+					</Link>
 				</div>
 			</section>
 

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -21,7 +21,10 @@ export default function OrganizationProfilePage() {
 	const [error, setError] = useState<string | null>(null);
 
 	usePageTitle(profile?.name ?? t("orgProfile.loading"));
-	usePageToolbar([{ label: profile?.name ?? t("orgProfile.loading") }]);
+	usePageToolbar([
+		{ label: t("breadcrumb.organizations"), href: "/organizations" },
+		{ label: profile?.name ?? t("orgProfile.loading") },
+	]);
 
 	useEffect(() => {
 		if (!organizationId) return;

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router";
+import { useTranslation } from "react-i18next";
+import type { PublicOrganizationSummary } from "../client/api-client";
+import { useApiClient } from "../hooks/useApiClient";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { usePageToolbar } from "../contexts/ToolbarContext";
+import { getApiErrorMessage } from "../lib/apiError";
+import EmptyState from "../components/EmptyState";
+import Skeleton from "../components/Skeleton";
+
+const PAGE_SIZE = 10;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default function OrganizationsPage() {
+	const api = useApiClient();
+	const { t } = useTranslation();
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const search = searchParams.get("search") ?? "";
+	const [searchInput, setSearchInput] = useState(search);
+	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const prevSearchRef = useRef(search);
+
+	const [items, setItems] = useState<PublicOrganizationSummary[]>([]);
+	const [page, setPage] = useState(1);
+	const [pageCount, setPageCount] = useState(1);
+	const [loading, setLoading] = useState(true);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	usePageTitle(t("organizationsPage.title"));
+	usePageToolbar([{ label: t("breadcrumb.organizations") }]);
+
+	useEffect(() => {
+		if (prevSearchRef.current === search) return;
+		prevSearchRef.current = search;
+		setItems([]);
+		setPage(1);
+	}, [search]);
+
+	useEffect(() => {
+		let cancelled = false;
+		if (page > 1) setLoadingMore(true);
+		else setLoading(true);
+		setError(null);
+
+		api
+			.getPublicOrganizations(page, PAGE_SIZE, search || undefined)
+			.then((result) => {
+				if (cancelled) return;
+				if (page === 1) setItems(result.items);
+				else setItems((prev) => [...prev, ...result.items]);
+				setPageCount(result.pageCount ?? 1);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				setError(getApiErrorMessage(err, t("error.serverError")));
+			})
+			.finally(() => {
+				if (cancelled) return;
+				setLoading(false);
+				setLoadingMore(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [page, search]);
+
+	function commitSearch(value: string) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (value) next.set("search", value);
+				else next.delete("search");
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleSearchInputChange(value: string) {
+		setSearchInput(value);
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		searchTimer.current = setTimeout(
+			() => commitSearch(value),
+			SEARCH_DEBOUNCE_MS,
+		);
+	}
+
+	function handleClearSearch() {
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		setSearchInput("");
+		commitSearch("");
+	}
+
+	return (
+		<div>
+			<h1 className="text-2xl font-bold text-gray-900">
+				{t("organizationsPage.title")}
+			</h1>
+			<p className="mt-1 text-sm text-gray-500">
+				{t("organizationsPage.subtitle")}
+			</p>
+
+			<div className="mt-6">
+				<label htmlFor="organizations-search" className="sr-only">
+					{t("organizationsPage.searchPlaceholder")}
+				</label>
+				<input
+					id="organizations-search"
+					type="search"
+					value={searchInput}
+					onChange={(e) => handleSearchInputChange(e.target.value)}
+					placeholder={t("organizationsPage.searchPlaceholder")}
+					className="w-full max-w-md rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+				/>
+			</div>
+
+			<div className="mt-6">
+				{loading ? (
+					<div role="status" className="space-y-3">
+						<span className="sr-only">{t("organizationsPage.loading")}</span>
+						{Array.from({ length: 3 }).map((_, i) => (
+							<div
+								key={i}
+								aria-hidden="true"
+								className="flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-4 shadow-sm"
+							>
+								<Skeleton className="h-12 w-12 shrink-0 rounded-full" />
+								<div className="flex-1 space-y-2">
+									<Skeleton className="h-4 w-1/3" />
+									<Skeleton className="h-3 w-1/2" />
+								</div>
+							</div>
+						))}
+					</div>
+				) : error ? (
+					<p className="text-red-600">
+						{t("organizationsPage.error", { message: error })}
+					</p>
+				) : items.length === 0 ? (
+					<EmptyState
+						title={
+							search
+								? t("organizationsPage.noResultsWithSearch", { search })
+								: t("organizationsPage.noResults")
+						}
+						action={
+							search
+								? {
+										label: t("organizationsPage.clearSearch"),
+										onClick: handleClearSearch,
+									}
+								: undefined
+						}
+					/>
+				) : (
+					<>
+						<ul className="space-y-3">
+							{items.map((org) => (
+								<li
+									key={org.id}
+									className="relative flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+								>
+									{org.logoUrl ? (
+										<img
+											src={org.logoUrl}
+											alt=""
+											className="h-12 w-12 shrink-0 rounded-full object-cover"
+										/>
+									) : (
+										<span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-brand-100 text-lg font-semibold text-brand-700">
+											{org.name.charAt(0).toUpperCase()}
+										</span>
+									)}
+									<div className="min-w-0 flex-1">
+										<Link
+											to={`/organizations/${org.id}`}
+											className="absolute inset-0 rounded-xl"
+											aria-label={org.name}
+										/>
+										<div className="flex items-center gap-2">
+											<strong className="block truncate text-sm font-semibold text-gray-900">
+												{org.name}
+											</strong>
+											{org.isVerified && (
+												<svg
+													className="h-4 w-4 shrink-0 text-brand-600"
+													viewBox="0 0 20 20"
+													fill="currentColor"
+													aria-label={t("organizationsPage.verified")}
+													role="img"
+												>
+													<path
+														fillRule="evenodd"
+														d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+														clipRule="evenodd"
+													/>
+												</svg>
+											)}
+										</div>
+										{org.description && (
+											<p className="mt-1 line-clamp-1 text-sm text-gray-500">
+												{org.description}
+											</p>
+										)}
+										{org.city && (
+											<p className="mt-1 text-xs text-gray-400">{org.city}</p>
+										)}
+									</div>
+								</li>
+							))}
+						</ul>
+
+						{page < pageCount && (
+							<div className="mt-8 flex justify-center">
+								<button
+									onClick={() => setPage((p) => p + 1)}
+									disabled={loadingMore}
+									className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
+								>
+									{loadingMore
+										? t("organizationsPage.loading")
+										: t("organizationsPage.loadMore")}
+								</button>
+							</div>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -210,6 +210,13 @@ export default function OrganizationsPage() {
 										{org.city && (
 											<p className="mt-1 text-xs text-gray-400">{org.city}</p>
 										)}
+										{org.openOpportunityCount > 0 && (
+											<p className="mt-1 text-xs font-medium text-brand-700">
+												{t("organizationsPage.openOpportunities", {
+													count: org.openOpportunityCount,
+												})}
+											</p>
+										)}
 									</div>
 								</li>
 							))}

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -208,7 +208,7 @@ export default function OrganizationsPage() {
 											</p>
 										)}
 										{org.city && (
-											<p className="mt-1 text-xs text-gray-400">{org.city}</p>
+											<p className="mt-1 text-xs text-gray-500">{org.city}</p>
 										)}
 										{org.openOpportunityCount > 0 && (
 											<p className="mt-1 text-xs font-medium text-brand-700">

--- a/scripts/lib/live-browser.mjs
+++ b/scripts/lib/live-browser.mjs
@@ -7,25 +7,32 @@
  * Playwright scripts" for why the launch args below are required.
  */
 import { chromium } from "playwright";
+import { existsSync } from "node:fs";
+
+const SANDBOX_CHROMIUM_PATH = "/opt/pw-browsers/chromium";
 
 /**
- * Launches Chromium with the args needed to survive this sandbox's
- * TLS-reterminating egress proxy, and returns a ready-to-use page.
- * Not needed outside this sandboxed runner.
+ * Launches Chromium with the args needed to survive the Claude Code web/cloud
+ * sandbox's TLS-reterminating egress proxy, and returns a ready-to-use page.
+ * Outside that sandbox (e.g. a local dev machine with direct internet
+ * access) the sandbox-only chromium binary this relies on doesn't exist, so
+ * this falls back to a plain launch instead.
  */
 export async function launchLiveBrowser() {
-	const browser = await chromium.launch({
-		executablePath: "/opt/pw-browsers/chromium",
-		proxy: { server: process.env.HTTPS_PROXY ?? "http://127.0.0.1:42149" },
-		args: [
-			"--no-sandbox",
-			"--disable-setuid-sandbox",
-			"--disable-http2",
-			"--disable-quic",
-			"--ssl-version-max=tls1.2",
-			"--disable-features=PostQuantumKyber,EncryptedClientHello",
-		],
-	});
+	const browser = existsSync(SANDBOX_CHROMIUM_PATH)
+		? await chromium.launch({
+				executablePath: SANDBOX_CHROMIUM_PATH,
+				proxy: { server: process.env.HTTPS_PROXY ?? "http://127.0.0.1:42149" },
+				args: [
+					"--no-sandbox",
+					"--disable-setuid-sandbox",
+					"--disable-http2",
+					"--disable-quic",
+					"--ssl-version-max=tls1.2",
+					"--disable-features=PostQuantumKyber,EncryptedClientHello",
+				],
+			})
+		: await chromium.launch();
 	const context = await browser.newContext({ ignoreHTTPSErrors: true });
 	const page = await context.newPage();
 	return { browser, context, page };

--- a/scripts/smoke-test-772-a11y-contrast.mjs
+++ b/scripts/smoke-test-772-a11y-contrast.mjs
@@ -1,0 +1,237 @@
+/**
+ * Smoke test for the color-contrast a11y fix that came out of PR #772's CI
+ * (issue #763's org directory work): axe-core flagged text-gray-400 meta
+ * text on white cards (~2.54:1) as a "serious" WCAG AA violation. Fixed by
+ * switching to text-gray-500 (~4.83:1), matching the convention already
+ * used elsewhere (e.g. SettingsWidget.tsx, smoke-test-659-contrast.mjs).
+ *
+ * Verifies both spots that were changed, driving the UI the same way a real
+ * user (and backend/tests/VisualTests/OrganizationTests.cs's
+ * Directory_ShowsOpenOpportunityCount_ForOrgWithPublishedOpportunity test)
+ * would - the `frontend` client has ROPC disabled, so unlike some older
+ * scripts in this directory this can't shortcut data setup through a
+ * password-grant token request:
+ *   1. Engagement management page's "Received: {date}" meta line.
+ *   2. The public organization directory card's city line (added by #763,
+ *      same defect).
+ *
+ * Run: node scripts/smoke-test-772-a11y-contrast.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function loginAsUser(page, username, password) {
+	// The app's LanguageDetector falls back to the browser's locale when
+	// nothing is in localStorage yet; force English so the text selectors
+	// below (which mirror the English-locale VisualTests C# suite) match
+	// regardless of the machine this script runs on.
+	await page.addInitScript(() => localStorage.setItem("i18nextLng", "en"));
+	await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	if ((await signInBtn.count()) > 0) {
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, username, password);
+	}
+	await page.waitForSelector("main", { timeout: 15000 });
+}
+
+async function assertContrastFixed(locator, label) {
+	await locator.waitFor({ timeout: 15000 });
+	const cls = await locator.getAttribute("class");
+	if (cls?.includes("text-gray-400")) {
+		throw new Error(
+			`${label} still uses the low-contrast text-gray-400 class="${cls}"`,
+		);
+	}
+	if (!cls?.includes("text-gray-500")) {
+		throw new Error(
+			`Expected ${label} to use text-gray-500, got class="${cls}"`,
+		);
+	}
+	const color = await locator.evaluate((el) => getComputedStyle(el).color);
+	console.log(`OK  ${label} uses text-gray-500 (computed color: ${color})`);
+}
+
+// Mirrors OrganizationTests.cs's CreateOrganizationAsync helper: create via
+// the org switcher's "Create organization" entry, reachable from within any
+// org the caller already organizes (olaf's seed data always has one).
+async function createOrganizationViaUi(page, namePrefix, city) {
+	const orgName = `${namePrefix} ${Date.now()}`;
+
+	const overviewCta = page.getByRole("link", { name: "Organization overview" });
+	await overviewCta.first().waitFor({ timeout: 15000 });
+	await overviewCta.first().click();
+	await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
+
+	await page.getByRole("button", { name: "Switch organization" }).click();
+	await page.getByRole("button", { name: "Create organization" }).click();
+
+	const dialog = page.getByRole("dialog");
+	await dialog.waitFor({ state: "visible", timeout: 10000 });
+	await dialog.locator("input[type='text']").first().fill(orgName);
+	// The address sub-fields are all required together once any one of them
+	// is filled in (CreateAddressRequest has no optional fields) - a city
+	// alone triggers "Street must not be empty."
+	await page.locator("#create-org-street").fill("Teststrasse");
+	await page.locator("#create-org-house-number").fill("1");
+	await page.locator("#create-org-zip").fill("12345");
+	await page.locator("#create-org-city").fill(city);
+	await page.getByTestId("modal-submit").click();
+
+	await page
+		.getByRole("button", { name: "Switch organization" })
+		.filter({ hasText: orgName })
+		.waitFor({ timeout: 15000 });
+	await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
+
+	const match = page.url().match(/\/app\/([^/]+)\/dashboard/);
+	if (!match) throw new Error(`Could not extract org id from URL: ${page.url()}`);
+	return { orgId: match[1], orgName };
+}
+
+// Mirrors the wizard steps OrganizationTests.cs's
+// Directory_ShowsOpenOpportunityCount test drives: IndividualContact +
+// remote, so the opportunity can publish with no time slots required.
+async function createOpportunityViaUi(page, title) {
+	const createBtn = page.getByRole("button", { name: "Create opportunity" });
+	await createBtn.first().waitFor({ timeout: 15000 });
+	await createBtn.first().click();
+
+	await page.waitForSelector("[role='dialog']", { timeout: 5000 });
+	await page.locator("#opportunity-title").fill(title);
+	await page
+		.locator("#opportunity-description")
+		.fill("Automated smoke test opportunity for the a11y contrast fix.");
+
+	await page.getByTestId("wizard-stepper-2").click();
+	await page.locator("#opportunity-remote").check();
+
+	await page.getByTestId("wizard-stepper-3").click();
+	await page
+		.locator("label:has(input[name='participationType'][value='IndividualContact'])")
+		.click();
+
+	await page.getByTestId("wizard-stepper-4").click();
+	await page.getByTestId("modal-submit").click();
+	await page.locator("[role='dialog']").waitFor({ state: "hidden", timeout: 30000 });
+}
+
+async function findManageApplicationsHref(page, orgId, title) {
+	await page.goto(`${BASE}/app/${orgId}/opportunities`, {
+		waitUntil: "networkidle",
+	});
+	const row = page.locator("li").filter({ hasText: title }).first();
+	await row.waitFor({ timeout: 15000 });
+	const link = row.getByRole("link", { name: "Manage applications" });
+	await link.waitFor({ timeout: 10000 });
+	const href = await link.getAttribute("href");
+	const match = href?.match(/\/opportunities\/([^/]+)\/engagements/);
+	if (!match) throw new Error(`Could not extract opportunity id from href: ${href}`);
+	return match[1];
+}
+
+// Deleting the opportunity first also cancels its active engagement
+// (#548) - deleting the organization directly would otherwise be rejected
+// with "Organization.HasBlockingOpportunities".
+async function cleanupViaUi(page, orgId, opportunityId) {
+	await page.goto(`${BASE}/app/${orgId}/opportunities`, { waitUntil: "networkidle" });
+	const row = page
+		.locator("li")
+		.filter({ has: page.locator(`[href*="${opportunityId}"]`) })
+		.first();
+	await row.getByTestId("opportunity-delete").click();
+	await page.getByRole("button", { name: "Yes, delete" }).click();
+	await page.getByRole("dialog").waitFor({ state: "hidden", timeout: 10000 });
+
+	await page.goto(`${BASE}/app/${orgId}/settings`, { waitUntil: "networkidle" });
+	await page.getByRole("button", { name: "Delete Organization" }).click();
+	await page.getByRole("button", { name: "Yes, delete" }).click();
+	await page.getByRole("dialog").waitFor({ state: "hidden", timeout: 10000 });
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser: olafBrowser, page: olafPage } = await launchLiveBrowser();
+	let orgId, orgName, opportunityId;
+	const title = `Smoke772Contrast Opportunity ${Date.now()}`;
+
+	try {
+		await loginAsUser(olafPage, "olaf", "olaf123");
+		({ orgId, orgName } = await createOrganizationViaUi(
+			olafPage,
+			"Smoke772Contrast Org",
+			"Smoketestdorf",
+		));
+		console.log(`OK  Created organization "${orgName}" with city "Smoketestdorf"`);
+
+		await createOpportunityViaUi(olafPage, title);
+		opportunityId = await findManageApplicationsHref(olafPage, orgId, title);
+		console.log(`OK  Created opportunity ${opportunityId}`);
+	} finally {
+		await olafBrowser.close();
+	}
+
+	{
+		const { browser: veraBrowser, page: veraPage } = await launchLiveBrowser();
+		try {
+			await loginAsUser(veraPage, "vera", "vera123");
+			await veraPage.goto(`${BASE}/volunteer-opportunities/${opportunityId}`, {
+				waitUntil: "networkidle",
+			});
+			await veraPage.getByRole("button", { name: "Express interest" }).click();
+			await veraPage.locator("#sign-up-message").fill(
+				"Smoke test application for the a11y contrast fix.",
+			);
+			await veraPage.getByRole("button", { name: "Sign up" }).click();
+			await veraPage
+				.getByRole("dialog")
+				.waitFor({ state: "hidden", timeout: 15000 });
+			console.log("OK  Vera applied - produced an engagement with a Received date");
+		} finally {
+			await veraBrowser.close();
+		}
+	}
+
+	{
+		const { browser, page } = await launchLiveBrowser();
+		try {
+			// --- 1. Engagement management page "Received:" meta line ---
+			await loginAsUser(page, "olaf", "olaf123");
+			await page.goto(
+				`${BASE}/app/${orgId}/opportunities/${opportunityId}/engagements`,
+				{ waitUntil: "networkidle" },
+			);
+			const receivedLine = page.getByText(/Received:/).first();
+			await assertContrastFixed(receivedLine, '"Received" meta line');
+
+			// --- 2. Organization directory card's city line ---
+			await page.goto(`${BASE}/organizations`, { waitUntil: "networkidle" });
+			const searchBox = page.locator("#organizations-search");
+			await searchBox.waitFor({ timeout: 15000 });
+			await searchBox.fill(orgName);
+			const orgCard = page.locator("li").filter({ hasText: orgName });
+			await orgCard.waitFor({ timeout: 15000 });
+			const cityLine = orgCard.getByText("Smoketestdorf", { exact: true });
+			await assertContrastFixed(cityLine, "Organization directory city line");
+
+			await cleanupViaUi(page, orgId, opportunityId);
+			console.log("OK  Cleaned up throwaway opportunity and organization");
+		} finally {
+			await browser.close();
+		}
+	}
+
+	console.log("\nALL CHECKS PASSED");
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});

--- a/scripts/smoke-test-772-org-directory-feedback.mjs
+++ b/scripts/smoke-test-772-org-directory-feedback.mjs
@@ -1,0 +1,117 @@
+/**
+ * Smoke test for PR #772 review feedback on the organization directory
+ * feature (issue #763): verifies the three fixes actually landed on live
+ * staging:
+ *   1. A persistent "Organizations" entry point exists in the Header nav
+ *      (desktop and mobile), visible whether logged in or not.
+ *   2. The organization profile page's breadcrumb reads
+ *      Home > Organizations > {org name}, with "Organizations" linking
+ *      back to the directory.
+ *   3. The organization directory shows an open-opportunity count on
+ *      cards that have published opportunities.
+ * Run: node scripts/smoke-test-772-org-directory-feedback.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const apiRes = await fetch(`${API}/health`);
+	if (!apiRes.ok) throw new Error(`Health check failed: ${apiRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+
+	try {
+		// --- 1a. Desktop nav: "Organizations" link visible while logged out ---
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		await page.waitForSelector("h1", { timeout: 15000 });
+
+		const desktopOrgLink = page.locator("nav a[href='/organizations']").first();
+		await desktopOrgLink.waitFor({ state: "visible", timeout: 10000 });
+		console.log("OK  Desktop nav shows an Organizations link (logged out)");
+
+		// --- 1b. Mobile menu: "Organizations" link visible ---
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		const menuBtn = page.getByRole("button", { name: /open menu|menü öffnen/i });
+		await menuBtn.waitFor({ state: "visible", timeout: 10000 });
+		await menuBtn.click();
+		const mobileOrgLink = page.locator("a[href='/organizations']").first();
+		await mobileOrgLink.waitFor({ state: "visible", timeout: 10000 });
+		console.log("OK  Mobile menu shows an Organizations link (logged out)");
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		// --- 1c. Desktop nav: still visible after logging in ---
+		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+		await signInBtn.first().click();
+		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+		await loginKeycloak(page, "vera", "vera123");
+		await page.waitForSelector("main", { timeout: 15000 });
+
+		const loggedInOrgLink = page.locator("nav a[href='/organizations']").first();
+		await loggedInOrgLink.waitFor({ state: "visible", timeout: 10000 });
+		console.log("OK  Desktop nav shows an Organizations link (logged in)");
+
+		// --- 2. Directory page: at least one org card, open-opportunity count ---
+		await loggedInOrgLink.click();
+		await page.waitForURL(/\/organizations$/, { timeout: 10000 });
+		await page.waitForLoadState("networkidle");
+
+		const firstOrgLink = page
+			.locator("a[href^='/organizations/']")
+			.first();
+		await firstOrgLink.waitFor({ state: "visible", timeout: 15000 });
+		const orgHref = await firstOrgLink.getAttribute("href");
+		console.log(`OK  Organization directory lists at least one organization (${orgHref})`);
+
+		// --- 2b. That card shows an open-opportunity count, if it has any ---
+		const orgCard = firstOrgLink.locator(
+			"xpath=ancestor::li[1]",
+		);
+		const countText = await orgCard.locator("p", {
+			hasText: /open opportunit|offene? Einsätze|offener Einsatz/i,
+		}).first().textContent().catch(() => null);
+		if (countText) {
+			console.log(`OK  Organization card shows open-opportunity count: "${countText.trim()}"`);
+		} else {
+			console.log(
+				"WARN  First organization card shows no open-opportunity count (it may have zero published opportunities)",
+			);
+		}
+
+		// --- 3. Org profile page: breadcrumb is Home > Organizations > {name} ---
+		await firstOrgLink.click();
+		await page.waitForURL(/\/organizations\/.+/, { timeout: 10000 });
+		await page.waitForLoadState("networkidle");
+
+		const breadcrumb = page.locator("nav[aria-label='Navigationspfad'], nav[aria-label='Breadcrumb']");
+		await breadcrumb.waitFor({ state: "visible", timeout: 10000 });
+
+		const orgCrumb = breadcrumb.locator(`a[href='/organizations']`);
+		await orgCrumb.waitFor({ state: "visible", timeout: 5000 });
+		console.log("OK  Org profile breadcrumb includes an Organizations crumb linking to /organizations");
+
+		const crumbTexts = await breadcrumb.locator("a, span").allTextContents();
+		const trail = crumbTexts.map((t) => t.trim()).filter(Boolean);
+		if (trail.length < 3) {
+			throw new Error(
+				`Expected a 3-part breadcrumb trail (Home > Organizations > org name), got: ${JSON.stringify(trail)}`,
+			);
+		}
+		console.log(`OK  Breadcrumb trail: ${trail.join(" > ")}`);
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});

--- a/scripts/smoke-test-772-org-directory-feedback.mjs
+++ b/scripts/smoke-test-772-org-directory-feedback.mjs
@@ -1,9 +1,10 @@
 /**
  * Smoke test for PR #772 review feedback on the organization directory
- * feature (issue #763): verifies the three fixes actually landed on live
- * staging:
- *   1. A persistent "Organizations" entry point exists in the Header nav
- *      (desktop and mobile), visible whether logged in or not.
+ * feature (issue #763), round 2: verifies the follow-up fixes actually
+ * landed on live staging:
+ *   1. A homepage section (not a permanent Header nav item) links to the
+ *      organization directory - the header nav link from round 1 was
+ *      judged too heavy a commitment and was removed.
  *   2. The organization profile page's breadcrumb reads
  *      Home > Organizations > {org name}, with "Organizations" linking
  *      back to the directory.
@@ -12,7 +13,7 @@
  * Run: node scripts/smoke-test-772-org-directory-feedback.mjs
  */
 
-import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+import { launchLiveBrowser } from "./lib/live-browser.mjs";
 
 const BASE = "https://einsatzbereit.maik-hasler.de";
 const API = "https://api.maik-hasler.de";
@@ -25,57 +26,51 @@ async function main() {
 	const { browser, page } = await launchLiveBrowser();
 
 	try {
-		// --- 1a. Desktop nav: "Organizations" link visible while logged out ---
+		// --- 1. Homepage teaser section links to the directory ---
 		await page.setViewportSize({ width: 1280, height: 900 });
 		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
 		await page.waitForSelector("h1", { timeout: 15000 });
 
-		const desktopOrgLink = page.locator("nav a[href='/organizations']").first();
-		await desktopOrgLink.waitFor({ state: "visible", timeout: 10000 });
-		console.log("OK  Desktop nav shows an Organizations link (logged out)");
+		const teaserCta = page.getByTestId("organizations-teaser-cta");
+		await teaserCta.scrollIntoViewIfNeeded();
+		await teaserCta.waitFor({ state: "visible", timeout: 10000 });
+		const teaserHref = await teaserCta.getAttribute("href");
+		if (teaserHref !== "/organizations") {
+			throw new Error(
+				`Expected homepage teaser to link to /organizations, got: ${teaserHref}`,
+			);
+		}
+		console.log("OK  Homepage shows an organizations directory teaser section");
 
-		// --- 1b. Mobile menu: "Organizations" link visible ---
-		await page.setViewportSize({ width: 390, height: 844 });
-		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
-		const menuBtn = page.getByRole("button", { name: /open menu|menü öffnen/i });
-		await menuBtn.waitFor({ state: "visible", timeout: 10000 });
-		await menuBtn.click();
-		const mobileOrgLink = page.locator("a[href='/organizations']").first();
-		await mobileOrgLink.waitFor({ state: "visible", timeout: 10000 });
-		console.log("OK  Mobile menu shows an Organizations link (logged out)");
-		await page.setViewportSize({ width: 1280, height: 900 });
-
-		// --- 1c. Desktop nav: still visible after logging in ---
-		await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
-		const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
-		await signInBtn.first().click();
-		await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
-		await loginKeycloak(page, "vera", "vera123");
-		await page.waitForSelector("main", { timeout: 15000 });
-
-		const loggedInOrgLink = page.locator("nav a[href='/organizations']").first();
-		await loggedInOrgLink.waitFor({ state: "visible", timeout: 10000 });
-		console.log("OK  Desktop nav shows an Organizations link (logged in)");
+		// --- 1b. Header nav must NOT carry a permanent organizations link anymore ---
+		const headerOrgLink = page.locator("header nav a[href='/organizations']");
+		const headerOrgLinkCount = await headerOrgLink.count();
+		if (headerOrgLinkCount !== 0) {
+			throw new Error(
+				"Expected no permanent Organizations link in the Header nav (moved to a homepage section)",
+			);
+		}
+		console.log("OK  Header nav has no permanent Organizations entry (as intended)");
 
 		// --- 2. Directory page: at least one org card, open-opportunity count ---
-		await loggedInOrgLink.click();
+		await teaserCta.click();
 		await page.waitForURL(/\/organizations$/, { timeout: 10000 });
 		await page.waitForLoadState("networkidle");
 
-		const firstOrgLink = page
-			.locator("a[href^='/organizations/']")
-			.first();
+		const firstOrgLink = page.locator("a[href^='/organizations/']").first();
 		await firstOrgLink.waitFor({ state: "visible", timeout: 15000 });
 		const orgHref = await firstOrgLink.getAttribute("href");
 		console.log(`OK  Organization directory lists at least one organization (${orgHref})`);
 
 		// --- 2b. That card shows an open-opportunity count, if it has any ---
-		const orgCard = firstOrgLink.locator(
-			"xpath=ancestor::li[1]",
-		);
-		const countText = await orgCard.locator("p", {
-			hasText: /open opportunit|offene? Einsätze|offener Einsatz/i,
-		}).first().textContent().catch(() => null);
+		const orgCard = firstOrgLink.locator("xpath=ancestor::li[1]");
+		const countText = await orgCard
+			.locator("p", {
+				hasText: /open opportunit|offene? Einsätze|offener Einsatz/i,
+			})
+			.first()
+			.textContent()
+			.catch(() => null);
 		if (countText) {
 			console.log(`OK  Organization card shows open-opportunity count: "${countText.trim()}"`);
 		} else {
@@ -89,7 +84,9 @@ async function main() {
 		await page.waitForURL(/\/organizations\/.+/, { timeout: 10000 });
 		await page.waitForLoadState("networkidle");
 
-		const breadcrumb = page.locator("nav[aria-label='Navigationspfad'], nav[aria-label='Breadcrumb']");
+		const breadcrumb = page.locator(
+			"nav[aria-label='Navigationspfad'], nav[aria-label='Breadcrumb']",
+		);
 		await breadcrumb.waitFor({ state: "visible", timeout: 10000 });
 
 		const orgCrumb = breadcrumb.locator(`a[href='/organizations']`);


### PR DESCRIPTION
Volunteers previously had no way to find an organization they already know - /organizations was a hard redirect to the homepage and the only path into an org's profile was through one of its opportunity listings.

Adds a public, anonymous GET /organizations/directory endpoint (paged, searchable by name) and a new OrganizationsPage that lists and searches organizations, linking each result to its existing public profile page.

Closes #763.