### PR TITLE
feat: enrich opportunity detail page

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -104,6 +104,7 @@ A PAT (not the default `GITHUB_TOKEN`) is mandatory because tags pushed with `GI
 - Runs in the `staging` GitHub Environment, reusing the same SSH secrets as `deploy-staging`
 - Removes only the `postgres_data` and `minio_data` volumes - `postgres_backups` is left alone on purpose, as the recovery path if a reset needs to be walked back
 - Because Keycloak's realm import runs with `OVERWRITE_EXISTING` (see `deploy-staging` in `publish.yml`) and the backend has `Database__MigrateOnStartup: true`, the stack re-migrates and re-imports `keycloak/realms/einsatzbereit-realm.json` on restart - the standard `vera`/`olaf`/`admin` test accounts come back automatically since they are defined in that checked-in realm config, not created ad hoc
+- The backend also has `Database__SeedOnStartup: true` (staging only, see `docker-compose.yml`), so `ApplicationDbContextInitializer.SeedAsync()` runs on restart alongside the migrate/backfill calls - staging comes back with the standard seeded organizations and published opportunities instead of an empty database. `SeedAsync()` is idempotent (no-ops if any `Organization` row already exists), so this is safe on every reset and on ordinary redeploys
 - Ends with the same post-deploy health gate (`/health` polling) used by `deploy-staging`
 
 ## Issue Templates

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -154,6 +154,10 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 	var initializer = scope.ServiceProvider.GetRequiredService<IApplicationDbContextInitializer>();
 
 	await initializer.MigrateAsync();
+
+	if (app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
+		await initializer.SeedAsync();
+
 	await initializer.BackfillOrganizationMembershipsAsync();
 }
 

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -82,6 +82,39 @@ internal sealed class ApplicationDbContextInitializer(
 				CheckInMethod.None,
 				pinGenerator).GetValueOrThrow();
 
+			var opp2b = VolunteerOpportunity.Create(
+				org1Id,
+				"Sanitatsdienst bei Stadtfest",
+				"Begleiten Sie unser Sanitatsteam beim jahrlichen Stadtfest und leisten Sie Erste Hilfe vor Ort.",
+				isRemote: false,
+				Address.Create("Marktplatz", "2", "12345", "Musterstadt").GetValueOrThrow(),
+				Occurrence.OneTime,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
+			var opp2c = VolunteerOpportunity.Create(
+				org1Id,
+				"Kleidersammlung fur Bedurftige",
+				"Helfen Sie beim Sortieren und Verteilen gespendeter Kleidung an Bedurftige in der Region.",
+				isRemote: false,
+				Address.Create("Lagerstrasse", "10", "12345", "Musterstadt").GetValueOrThrow(),
+				Occurrence.Recurring,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
+			var opp2d = VolunteerOpportunity.Create(
+				org1Id,
+				"Erste-Hilfe-Schulung fur Vereine",
+				"Vermitteln Sie Vereinen und Ehrenamtlichen die Grundlagen der Ersten Hilfe in Online-Schulungen.",
+				isRemote: true,
+				address: null,
+				Occurrence.Recurring,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
 			var opp3 = VolunteerOpportunity.Create(
 				org2Id,
 				"Tierheim Helfer gesucht",
@@ -108,7 +141,41 @@ internal sealed class ApplicationDbContextInitializer(
 				CheckInMethod.None,
 				pinGenerator).GetValueOrThrow();
 
-			dbContext.Set<VolunteerOpportunity>().AddRange(opp1, opp2, opp3, opp4);
+			var opp4b = VolunteerOpportunity.Create(
+				org2Id,
+				"Gassi-Service fur Tierheim-Hunde",
+				"Drehen Sie regelmasig Ihre Runden mit unseren Tierheim-Hunden und schenken Sie ihnen Auslauf.",
+				isRemote: false,
+				Address.Create("Tiergartenweg", "5", "12345", "Musterstadt").GetValueOrThrow(),
+				Occurrence.Recurring,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
+			var opp4c = VolunteerOpportunity.Create(
+				org2Id,
+				"Spendenaktion Tierfutter",
+				"Sammeln Sie Futter- und Sachspenden fur unsere Schutzlinge bei einer lokalen Aktion.",
+				isRemote: false,
+				Address.Create("Feldweg", "3", "12345", "Musterstadt").GetValueOrThrow(),
+				Occurrence.OneTime,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
+			var opp4d = VolunteerOpportunity.Create(
+				org2Id,
+				"Patenschaften fur Pflegetiere",
+				"Ubernehmen Sie eine Tierpatenschaft und begleiten Sie ein Pflegetier bei seiner Vermittlung.",
+				isRemote: true,
+				address: null,
+				Occurrence.Recurring,
+				ParticipationType.IndividualContact,
+				CheckInMethod.None,
+				pinGenerator).GetValueOrThrow();
+
+			dbContext.Set<VolunteerOpportunity>().AddRange(
+				opp1, opp2, opp2b, opp2c, opp2d, opp3, opp4, opp4b, opp4c, opp4d);
 
 			var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
 

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -59,10 +59,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp1 = VolunteerOpportunity.Create(
 				org1Id,
-				"Erste Hilfe Kurs",
-				"Lernen Sie lebensrettende Erste-Hilfe-Massnahmen in unserem praxisnahen Tageskurs.",
+				"First Aid Course",
+				"Learn life-saving first aid techniques in our hands-on one-day course.",
 				isRemote: false,
-				Address.Create("Hauptstrasse", "1", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Main Street", "1", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.OneTime,
 				ParticipationType.Waitlist,
 				CheckInMethod.Manual,
@@ -73,10 +73,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp2 = VolunteerOpportunity.Create(
 				org1Id,
-				"Blutspende-Aktion",
-				"Unterstutzen Sie unsere regelmasige Blutspende-Aktion und helfen Sie, Leben zu retten.",
+				"Blood Donation Drive",
+				"Support our regular blood donation drive and help save lives.",
 				isRemote: false,
-				Address.Create("Rathausplatz", "1", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Town Hall Square", "1", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.Recurring,
 				ParticipationType.IndividualContact,
 				CheckInMethod.None,
@@ -84,10 +84,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp2b = VolunteerOpportunity.Create(
 				org1Id,
-				"Sanitatsdienst bei Stadtfest",
-				"Begleiten Sie unser Sanitatsteam beim jahrlichen Stadtfest und leisten Sie Erste Hilfe vor Ort.",
+				"Paramedic Service at the Town Festival",
+				"Join our paramedic team at the annual town festival and provide first aid on site.",
 				isRemote: false,
-				Address.Create("Marktplatz", "2", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Market Square", "2", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.OneTime,
 				ParticipationType.IndividualContact,
 				CheckInMethod.None,
@@ -95,10 +95,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp2c = VolunteerOpportunity.Create(
 				org1Id,
-				"Kleidersammlung fur Bedurftige",
-				"Helfen Sie beim Sortieren und Verteilen gespendeter Kleidung an Bedurftige in der Region.",
+				"Clothing Collection for People in Need",
+				"Help sort and distribute donated clothing to people in need in the region.",
 				isRemote: false,
-				Address.Create("Lagerstrasse", "10", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Warehouse Street", "10", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.Recurring,
 				ParticipationType.IndividualContact,
 				CheckInMethod.None,
@@ -106,8 +106,8 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp2d = VolunteerOpportunity.Create(
 				org1Id,
-				"Erste-Hilfe-Schulung fur Vereine",
-				"Vermitteln Sie Vereinen und Ehrenamtlichen die Grundlagen der Ersten Hilfe in Online-Schulungen.",
+				"First Aid Training for Clubs and Associations",
+				"Teach clubs and volunteer groups the basics of first aid in online training sessions.",
 				isRemote: true,
 				address: null,
 				Occurrence.Recurring,
@@ -117,10 +117,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp3 = VolunteerOpportunity.Create(
 				org2Id,
-				"Tierheim Helfer gesucht",
-				"Helfen Sie uns bei der Betreuung und Pflege der Tiere in unserem Tierheim.",
+				"Animal Shelter Helpers Wanted",
+				"Help us care for and look after the animals in our shelter.",
 				isRemote: false,
-				Address.Create("Tiergartenweg", "5", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.Recurring,
 				ParticipationType.Waitlist,
 				CheckInMethod.QRCode,
@@ -132,8 +132,8 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp4 = VolunteerOpportunity.Create(
 				org2Id,
-				"Online-Fundraising Unterstutzung",
-				"Unterstutzen Sie unser Online-Fundraising-Team bequem von zu Hause aus.",
+				"Online Fundraising Support",
+				"Support our online fundraising team from the comfort of your own home.",
 				isRemote: true,
 				address: null,
 				Occurrence.OneTime,
@@ -143,10 +143,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp4b = VolunteerOpportunity.Create(
 				org2Id,
-				"Gassi-Service fur Tierheim-Hunde",
-				"Drehen Sie regelmasig Ihre Runden mit unseren Tierheim-Hunden und schenken Sie ihnen Auslauf.",
+				"Dog Walking Service for Shelter Dogs",
+				"Take our shelter dogs for regular walks and give them the exercise they need.",
 				isRemote: false,
-				Address.Create("Tiergartenweg", "5", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.Recurring,
 				ParticipationType.IndividualContact,
 				CheckInMethod.None,
@@ -154,10 +154,10 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp4c = VolunteerOpportunity.Create(
 				org2Id,
-				"Spendenaktion Tierfutter",
-				"Sammeln Sie Futter- und Sachspenden fur unsere Schutzlinge bei einer lokalen Aktion.",
+				"Pet Food Donation Drive",
+				"Collect food and supply donations for our animals at a local drive.",
 				isRemote: false,
-				Address.Create("Feldweg", "3", "12345", "Musterstadt").GetValueOrThrow(),
+				Address.Create("Field Lane", "3", "12345", "Fairview").GetValueOrThrow(),
 				Occurrence.OneTime,
 				ParticipationType.IndividualContact,
 				CheckInMethod.None,
@@ -165,8 +165,8 @@ internal sealed class ApplicationDbContextInitializer(
 
 			var opp4d = VolunteerOpportunity.Create(
 				org2Id,
-				"Patenschaften fur Pflegetiere",
-				"Ubernehmen Sie eine Tierpatenschaft und begleiten Sie ein Pflegetier bei seiner Vermittlung.",
+				"Foster Animal Sponsorships",
+				"Take on a sponsorship for a foster animal and support them through their placement.",
 				isRemote: true,
 				address: null,
 				Occurrence.Recurring,
@@ -184,7 +184,7 @@ internal sealed class ApplicationDbContextInitializer(
 				Engagement.CreateIndividualContact(
 					opp2.Id,
 					veraUserId,
-					"Ich wuerde gerne bei der nachsten Blutspende-Aktion als Helfer dabei sein.").GetValueOrThrow(),
+					"I would love to help out as a volunteer at the next blood donation drive.").GetValueOrThrow(),
 				Engagement.CreateWaitlistSignUp(opp3.Id, veraUserId, opp3.TimeSlots.First().Id));
 
 			await dbContext.SaveChangesAsync(cancellationToken);
@@ -240,18 +240,18 @@ internal sealed class ApplicationDbContextInitializer(
 	private async Task<OrganizationId> SeedOrg1Async(CancellationToken cancellationToken)
 	{
 		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(
-			"Rotes Kreuz Musterstadt",
+			"Fairview Red Cross",
 			cancellationToken);
 
 		await keycloakOrganizationService.AddMemberAsync(keycloakId, OlafId, cancellationToken);
 		await keycloakOrganizationService.AssignOrganizerRoleAsync(OlafId, cancellationToken);
 		await keycloakOrganizationService.AddMemberAsync(keycloakId, VeraId, cancellationToken);
 
-		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Rotes Kreuz Musterstadt")
+		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Fairview Red Cross")
 			.GetValueOrThrow();
-		org.ChangeDescription("Ihr lokaler Verband des Deutschen Roten Kreuzes - wir helfen Menschen in Not.");
-		org.ChangeContactInfo("info@rk-musterstadt.de", "+49 1234 567890", "https://www.drk.de");
-		org.Relocate(Address.Create("Hauptstrasse", "1", "12345", "Musterstadt").GetValueOrThrow());
+		org.ChangeDescription("Your local Red Cross chapter - we help people in need.");
+		org.ChangeContactInfo("info@fairview-redcross.org", "+1 555 0100", "https://www.fairview-redcross.example");
+		org.Relocate(Address.Create("Main Street", "1", "12345", "Fairview").GetValueOrThrow());
 
 		dbContext.Set<Organization>().Add(org);
 
@@ -264,17 +264,17 @@ internal sealed class ApplicationDbContextInitializer(
 	private async Task<OrganizationId> SeedOrg2Async(CancellationToken cancellationToken)
 	{
 		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(
-			"Tierschutzverein Musterstadt",
+			"Fairview Animal Welfare Association",
 			cancellationToken);
 
 		await keycloakOrganizationService.AddMemberAsync(keycloakId, OlafId, cancellationToken);
 		await keycloakOrganizationService.AssignOrganizerRoleAsync(OlafId, cancellationToken);
 
-		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Tierschutzverein Musterstadt")
+		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Fairview Animal Welfare Association")
 			.GetValueOrThrow();
-		org.ChangeDescription("Wir setzen uns fur das Wohl von Tieren in Musterstadt und Umgebung ein.");
-		org.ChangeContactInfo("info@tsv-musterstadt.de", "+49 1234 567891", null);
-		org.Relocate(Address.Create("Tiergartenweg", "5", "12345", "Musterstadt").GetValueOrThrow());
+		org.ChangeDescription("We are committed to the wellbeing of animals in Fairview and the surrounding area.");
+		org.ChangeContactInfo("info@fairview-animalwelfare.org", "+1 555 0101", null);
+		org.Relocate(Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow());
 
 		dbContext.Set<Organization>().Add(org);
 

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -36,8 +36,8 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// among them - only that seeding failing silently in CI produces the
 		// same symptom (no card links to either seed org) as it would if
 		// vera genuinely had zero engagements. Skip in both cases.
-		var seedOrgCard = Page.GetByText("Rotes Kreuz Musterstadt")
-			.Or(Page.GetByText("Tierschutzverein Musterstadt"));
+		var seedOrgCard = Page.GetByText("Fairview Red Cross")
+			.Or(Page.GetByText("Fairview Animal Welfare Association"));
 		if (await seedOrgCard.CountAsync() == 0)
 		{
 			return;
@@ -50,7 +50,7 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// Both seed org names must appear somewhere on the page. .First avoids a
 		// Playwright strict-mode violation once Vera has more than one engagement
 		// with the same org (seed data grows release over release).
-		await Expect(Page.GetByText("Rotes Kreuz Musterstadt").First).ToBeVisibleAsync();
-		await Expect(Page.GetByText("Tierschutzverein Musterstadt").First).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Fairview Red Cross").First).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Fairview Animal Welfare Association").First).ToBeVisibleAsync();
 	}
 }

--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -267,13 +267,26 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 		var todoGrip = Page.GetByRole(AriaRole.Button, new() { Name = "Drag Needs Your Attention to reorder" });
 		await todoGrip.FocusAsync();
 		await Page.Keyboard.PressAsync("Space");
-		await Page.Keyboard.PressAsync("ArrowLeft");
 
-		// handleDragOver reorders live as the dragged tile crosses another one
-		// - wait for that to land before dropping, rather than assuming a
-		// fixed delay.
-		await Expect(Page.Locator("[data-testid^='widget-tile-']").First)
-			.ToHaveAttributeAsync("data-testid", "widget-tile-ToDo", new() { Timeout = 10_000 });
+		// A single ArrowLeft right after grabbing can race dnd-kit's
+		// post-grab rect measurement - a real user always leaves a natural
+		// gap between grabbing and steering that Playwright's instant
+		// keypress doesn't, and a keypress that lands before measurement
+		// finishes is silently swallowed by handleDragOver's over===null
+		// bail-out with nothing left to retry it later. Poll the key instead
+		// of trusting one press to land; once the swap has actually
+		// happened, further presses are no-ops (ToDo has no more left
+		// neighbor to swap with).
+		var firstTile = Page.Locator("[data-testid^='widget-tile-']").First;
+		var deadline = DateTime.UtcNow.AddSeconds(10);
+		while (await firstTile.GetAttributeAsync("data-testid") != "widget-tile-ToDo")
+		{
+			if (DateTime.UtcNow > deadline)
+				throw new TimeoutException(
+					"Keyboard ArrowLeft never reordered ToDo to the front of the widget grid.");
+			await Page.Keyboard.PressAsync("ArrowLeft");
+			await Page.WaitForTimeoutAsync(200);
+		}
 
 		await Page.Keyboard.PressAsync("Space");
 

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -234,6 +234,108 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task DetailPage_ShowsAboutOrganizationCard_SocialProofStat_AndMoreFromOrgTeaser()
+	{
+		// Issue #759: the detail page adds four frontend-only enrichment
+		// sections so it stays substantial even when an organizer writes a
+		// short description - an "About this organization" card (reusing the
+		// org's already-public contact info), a participant-count social-proof
+		// stat, a "more from this organization" teaser capped at 3 and
+		// excluding the opportunity being viewed, and a "posted X days ago"
+		// freshness line.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgName = $"Detail Enrichment Org {suffix}";
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var contactEmail = $"contact-{suffix}@example.test";
+		var updateResponse = await http.PutAsJsonAsync($"/v1/organizations/{organizationId}", new
+		{
+			name = orgName,
+			description = "We coordinate volunteers across the region for issue 759 coverage.",
+			contactEmail,
+			contactPhone = "+49 555 0100",
+			website = "https://example.test",
+			address = new { street = "Teststrasse", houseNumber = "1", zipCode = "12345", city = "Musterstadt" },
+		});
+		updateResponse.EnsureSuccessStatusCode();
+
+		async Task<(string Id, string Title)> CreateOpportunityAsync(string label)
+		{
+			var title = $"{label} {suffix}";
+			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+			{
+				title,
+				description = $"{label} opportunity for detail enrichment coverage.",
+				organizationId,
+				isRemote = true,
+				occurrence = "OneTime",
+				participationType = "IndividualContact",
+				checkInMethod = "None",
+				isDraft = false,
+			});
+			response.EnsureSuccessStatusCode();
+			var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+			return (body.GetProperty("id").GetString()!, title);
+		}
+
+		// Created sequentially: Primary first (oldest), then Other1..Other4
+		// (newest last). GetPublicOrganizationProfile orders by CreatedOn
+		// descending, so after excluding Primary and capping at 3, the teaser
+		// should show Other4/Other3/Other2 and drop Other1 (the oldest "other").
+		var (primaryId, primaryTitle) = await CreateOpportunityAsync("Primary");
+		var others = new List<(string Id, string Title)>();
+		for (var i = 1; i <= 4; i++)
+			others.Add(await CreateOpportunityAsync($"Other{i}"));
+
+		// Vera engages with the primary opportunity so currentParticipantCount > 0.
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{primaryId}/engagements",
+			new { message = "Signing up for issue 759 detail enrichment coverage." });
+		engagementResponse.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{primaryId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Freshness line - "Posted today"/"Posted X days ago" both contain "Posted".
+		await Expect(Page.GetByText(new Regex("posted", RegexOptions.IgnoreCase)))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Social proof: Vera's engagement is reflected as a participant-count stat.
+		await Expect(Page.GetByText(new Regex(@"1\s+person", RegexOptions.IgnoreCase)))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// About this organization: description + all contact fields surfaced.
+		var aboutOrg = Page.GetByTestId("about-organization");
+		await Expect(aboutOrg).ToBeVisibleAsync();
+		await Expect(aboutOrg.GetByRole(AriaRole.Link, new() { Name = contactEmail }))
+			.ToBeVisibleAsync();
+		await Expect(aboutOrg.GetByText("Teststrasse 1, 12345 Musterstadt")).ToBeVisibleAsync();
+
+		// More from this organization: capped at 3, excludes the opportunity being viewed.
+		var teaser = Page.GetByTestId("more-from-organization");
+		await Expect(teaser).ToBeVisibleAsync();
+		await Expect(teaser.Locator("li")).ToHaveCountAsync(3);
+		await Expect(teaser.GetByText(primaryTitle)).Not.ToBeVisibleAsync();
+		await Expect(teaser.GetByText(others[0].Title)).Not.ToBeVisibleAsync(); // oldest "other", pushed out by the cap
+		foreach (var other in others.Skip(1))
+			await Expect(teaser.GetByText(other.Title)).ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task HomePage_LoadsWithoutError_WhenPublishedOpportunitiesExist()
 	{
 		// Regression: EF Core 10 query translation failure caused HTTP 500 on all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Staging
       Database__MigrateOnStartup: "true"
+      Database__SeedOnStartup: "true"
       ConnectionStrings__einsatzbereit: "Host=postgres;Database=einsatzbereit;Username=${POSTGRES_USER:-postgres};Password=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}"
       Authentication__Authority: https://login.maik-hasler.de/realms/einsatzbereit
       Authentication__ValidIssuers__0: https://login.maik-hasler.de/realms/einsatzbereit

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,4 +1,5 @@
 import type { TFunction } from "i18next";
+import { differenceInCalendarDays } from "date-fns";
 
 export function formatOccurrence(occurrence: string, t: TFunction): string {
 	return occurrence === "Recurring"
@@ -17,4 +18,11 @@ export function formatDateTime(dt: string, locale: string = "en"): string {
 		dateStyle: "medium",
 		timeStyle: "short",
 	});
+}
+
+export function formatPostedAgo(dt: string, t: TFunction): string {
+	const days = differenceInCalendarDays(new Date(), new Date(dt));
+	return days <= 0
+		? t("opportunities.postedToday")
+		: t("opportunities.postedDaysAgo", { count: days });
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -181,7 +181,16 @@
       "publishing": "Wird veröffentlicht…",
       "publishSuccess": "Bedarf veröffentlicht.",
       "loginToApply": "Bitte <loginLink>melde dich an</loginLink>, um dich für diesen Einsatz anzumelden.",
-      "yourApplication": "Deine Bewerbung"
+      "yourApplication": "Deine Bewerbung",
+      "aboutOrganization": "Über diese Organisation",
+      "moreFromOrganization": "Weitere Angebote dieser Organisation",
+      "postedToday": "Heute veröffentlicht",
+      "postedDaysAgo": "Vor {{count}} Tagen veröffentlicht",
+      "postedDaysAgo_one": "Vor {{count}} Tag veröffentlicht",
+      "postedDaysAgo_other": "Vor {{count}} Tagen veröffentlicht",
+      "participantsJoined": "{{count}} Personen haben sich bereits angemeldet",
+      "participantsJoined_one": "{{count}} Person hat sich bereits angemeldet",
+      "participantsJoined_other": "{{count}} Personen haben sich bereits angemeldet"
     },
     "createOpportunity": {
       "title": "Bedarf erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -181,7 +181,16 @@
       "publishing": "Publishing…",
       "publishSuccess": "Opportunity published.",
       "loginToApply": "Please <loginLink>sign in</loginLink> to sign up for this opportunity.",
-      "yourApplication": "Your application"
+      "yourApplication": "Your application",
+      "aboutOrganization": "About this organization",
+      "moreFromOrganization": "More from this organization",
+      "postedToday": "Posted today",
+      "postedDaysAgo": "Posted {{count}} days ago",
+      "postedDaysAgo_one": "Posted {{count}} day ago",
+      "postedDaysAgo_other": "Posted {{count}} days ago",
+      "participantsJoined": "{{count}} people have already joined",
+      "participantsJoined_one": "{{count}} person has already joined",
+      "participantsJoined_other": "{{count}} people have already joined"
     },
     "createOpportunity": {
       "title": "Create opportunity",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -242,7 +242,7 @@ export default function VolunteerOpportunityDetailPage() {
 			<h1 className="mb-1 text-2xl font-bold text-gray-900 sm:text-3xl">
 				{opportunity.title}
 			</h1>
-			<p className="mb-3 text-xs text-gray-400">
+			<p className="mb-3 text-xs text-gray-600">
 				{formatPostedAgo(opportunity.createdOn as unknown as string, t)}
 			</p>
 
@@ -387,7 +387,7 @@ export default function VolunteerOpportunityDetailPage() {
 			{opportunity.participationType === "Waitlist" &&
 				opportunity.timeSlots.length > 0 && (
 					<div className="mb-6">
-						<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+						<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-600">
 							{t("opportunities.availableTimeSlots")}
 						</h2>
 						<ul className="space-y-2">
@@ -407,7 +407,7 @@ export default function VolunteerOpportunityDetailPage() {
 											i18n.language,
 										)}
 									</span>
-									<span className="ml-3 shrink-0 text-xs text-gray-400">
+									<span className="ml-3 shrink-0 text-xs text-gray-600">
 										{t("opportunities.maxParticipants", {
 											count: ts.maxParticipants,
 										})}
@@ -504,7 +504,7 @@ export default function VolunteerOpportunityDetailPage() {
 					orgProfile.website ||
 					orgProfile.address) && (
 					<div className="mb-6" data-testid="about-organization">
-						<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+						<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-600">
 							{t("opportunities.aboutOrganization")}
 						</h2>
 						{orgProfile.description && (
@@ -627,7 +627,7 @@ export default function VolunteerOpportunityDetailPage() {
 			{/* More from this organization */}
 			{otherOrgOpportunities.length > 0 && (
 				<div className="mb-6" data-testid="more-from-organization">
-					<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+					<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-600">
 						{t("opportunities.moreFromOrganization")}
 					</h2>
 					<ul className="space-y-3">

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -2,12 +2,16 @@ import { useEffect, useRef, useState } from "react";
 import { useParams, Link } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation, Trans } from "react-i18next";
-import type { VolunteerOpportunityDetails } from "../client/api-client";
+import type {
+	PublicOrganizationProfileResponse,
+	VolunteerOpportunityDetails,
+} from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import {
 	formatDateTime,
 	formatOccurrence,
 	formatParticipationType,
+	formatPostedAgo,
 } from "../lib/format";
 import SignUpModal from "../components/SignUpModal";
 import ConfirmDialog from "../components/ConfirmDialog";
@@ -61,10 +65,27 @@ export default function VolunteerOpportunityDetailPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isOrganisator]);
 
+	const [orgProfile, setOrgProfile] =
+		useState<PublicOrganizationProfileResponse | null>(null);
+
+	useEffect(() => {
+		if (!opportunity?.organizationId) return;
+		api
+			.getPublicOrganizationProfile(opportunity.organizationId)
+			.then(setOrgProfile)
+			.catch(() => {});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [opportunity?.organizationId]);
+
 	const latestRequestRef = useRef(0);
 
 	useEffect(() => {
 		if (!opportunityId) return;
+		// Avoids briefly showing the previous opportunity's organization card
+		// (email/phone/address) while the new one loads, since this state isn't
+		// otherwise tied to opportunityId and would only refresh once the
+		// organizationId effect below notices it changed.
+		setOrgProfile(null);
 		load();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [opportunityId, api]);
@@ -167,6 +188,11 @@ export default function VolunteerOpportunityDetailPage() {
 		opportunity.timeSlots.length > 0 &&
 		opportunity.timeSlots.every((ts) => ts.bookedCount >= ts.maxParticipants);
 
+	const otherOrgOpportunities =
+		orgProfile?.openOpportunities
+			.filter((opp) => opp.id !== opportunity.id)
+			.slice(0, 3) ?? [];
+
 	return (
 		<div className="mx-auto max-w-2xl">
 			{/* Banner image */}
@@ -213,9 +239,12 @@ export default function VolunteerOpportunityDetailPage() {
 			</div>
 
 			{/* Title */}
-			<h1 className="mb-3 text-2xl font-bold text-gray-900 sm:text-3xl">
+			<h1 className="mb-1 text-2xl font-bold text-gray-900 sm:text-3xl">
 				{opportunity.title}
 			</h1>
+			<p className="mb-3 text-xs text-gray-400">
+				{formatPostedAgo(opportunity.createdOn as unknown as string, t)}
+			</p>
 
 			{/* Description */}
 			{opportunity.description && (
@@ -310,6 +339,15 @@ export default function VolunteerOpportunityDetailPage() {
 					</div>
 				)}
 			</div>
+
+			{/* Social proof */}
+			{opportunity.currentParticipantCount > 0 && (
+				<p className="mb-6 text-sm font-medium text-gray-600">
+					{t("opportunities.participantsJoined", {
+						count: opportunity.currentParticipantCount,
+					})}
+				</p>
+			)}
 
 			{/* Category and tags */}
 			{(opportunity.category ||
@@ -456,6 +494,182 @@ export default function VolunteerOpportunityDetailPage() {
 						}}
 					/>
 				</p>
+			)}
+
+			{/* About this organization */}
+			{orgProfile &&
+				(orgProfile.description ||
+					orgProfile.contactEmail ||
+					orgProfile.contactPhone ||
+					orgProfile.website ||
+					orgProfile.address) && (
+					<div className="mb-6" data-testid="about-organization">
+						<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+							{t("opportunities.aboutOrganization")}
+						</h2>
+						{orgProfile.description && (
+							<p className="mb-3 leading-relaxed text-gray-600">
+								{orgProfile.description}
+							</p>
+						)}
+						{(orgProfile.contactEmail ||
+							orgProfile.contactPhone ||
+							orgProfile.website ||
+							orgProfile.address) && (
+							<div className="space-y-2.5 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+								{orgProfile.contactEmail && (
+									<div className="flex items-center gap-3">
+										<svg
+											className="h-4 w-4 shrink-0 text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
+											/>
+										</svg>
+										<a
+											href={`mailto:${orgProfile.contactEmail}`}
+											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+										>
+											{orgProfile.contactEmail}
+										</a>
+									</div>
+								)}
+								{orgProfile.contactPhone && (
+									<div className="flex items-center gap-3">
+										<svg
+											className="h-4 w-4 shrink-0 text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z"
+											/>
+										</svg>
+										<a
+											href={`tel:${orgProfile.contactPhone}`}
+											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+										>
+											{orgProfile.contactPhone}
+										</a>
+									</div>
+								)}
+								{orgProfile.website && (
+									<div className="flex items-center gap-3">
+										<svg
+											className="h-4 w-4 shrink-0 text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418"
+											/>
+										</svg>
+										<a
+											href={orgProfile.website}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+										>
+											{orgProfile.website}
+										</a>
+									</div>
+								)}
+								{orgProfile.address && (
+									<div className="flex items-center gap-3">
+										<svg
+											className="h-4 w-4 shrink-0 text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+											/>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+											/>
+										</svg>
+										<span>
+											{orgProfile.address.street}{" "}
+											{orgProfile.address.houseNumber},{" "}
+											{orgProfile.address.zipCode} {orgProfile.address.city}
+										</span>
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				)}
+
+			{/* More from this organization */}
+			{otherOrgOpportunities.length > 0 && (
+				<div className="mb-6" data-testid="more-from-organization">
+					<h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+						{t("opportunities.moreFromOrganization")}
+					</h2>
+					<ul className="space-y-3">
+						{otherOrgOpportunities.map((opp) => (
+							<li
+								key={opp.id}
+								className="relative rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+							>
+								<Link
+									to={`/volunteer-opportunities/${opp.id}`}
+									className="absolute inset-0 rounded-xl"
+									aria-label={opp.title}
+								/>
+								<strong className="block text-sm font-semibold text-gray-900">
+									{opp.title}
+								</strong>
+								{opp.description && (
+									<p className="mt-1 line-clamp-2 text-sm text-gray-500">
+										{opp.description}
+									</p>
+								)}
+								<div className="mt-2 flex flex-wrap gap-2">
+									<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+										{formatOccurrence(opp.occurrence, t)}
+									</span>
+									<span className="rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+										{formatParticipationType(opp.participationType, t)}
+									</span>
+									{opp.isRemote ? (
+										<span className="rounded-full bg-green-50 px-2 py-0.5 text-xs text-green-700">
+											{t("opportunities.remote")}
+										</span>
+									) : opp.street ? (
+										<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+											{opp.street} {opp.houseNumber}, {opp.zipCode} {opp.city}
+										</span>
+									) : null}
+								</div>
+							</li>
+						))}
+					</ul>
+				</div>
 			)}
 
 			{showSignUp && (


### PR DESCRIPTION
…roof, and related opportunities

Resolves #759's Option A scope (frontend-only): reuses already-public organization data (contact info via GetPublicOrganizationProfile) and the opportunity's own CreatedOn/CurrentParticipantCount so the detail page stays substantial even when an organizer writes a short description.

Also expands seed data to 5 published opportunities per org (was 2) and wires Database:SeedOnStartup for staging, so reset-staging.yml leaves staging with enough seeded data to exercise the new "more from this organization" cap.