### PR TITLE
feat(frontend): turn mobile Organization Dashboard link into a tab submenu

### DIFF
--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -1,0 +1,60 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Issue #775: users with >=1 organization had no way to reach the org
+/// dashboard from the mobile burger menu - only the desktop org switcher and
+/// the homepage hero CTA linked to it. Adds an "Organization Dashboard" entry
+/// to the mobile menu, gated the same way as the admin-only "Administration"
+/// entry (see AdministrationNavLinkTests), resolved via the same
+/// active-org-cookie-then-alphabetical logic HomePage already uses.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const int MobileWidth = 375;
+	private const int MobileHeight = 812;
+
+	[Test]
+	public async Task MobileMenu_UserWithOrg_ShowsOrganizationDashboardLink_AndNavigatesToItsDashboard()
+	{
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		// Olaf organizes an org in seed data (see HomePageOrgCtaTests).
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Organization Dashboard" });
+		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await link.ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task MobileMenu_UserWithoutOrgs_HasNoOrganizationDashboardLink()
+	{
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		// admin has no organization memberships in seed data.
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "admin", "admin123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Administration" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Organization Dashboard" }))
+			.Not.ToBeVisibleAsync();
+	}
+}

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -6,10 +6,15 @@ namespace VisualTests;
 /// <summary>
 /// Issue #775: users with >=1 organization had no way to reach the org
 /// dashboard from the mobile burger menu - only the desktop org switcher and
-/// the homepage hero CTA linked to it. Adds an "Organization Dashboard" entry
-/// to the mobile menu, gated the same way as the admin-only "Administration"
-/// entry (see AdministrationNavLinkTests), resolved via the same
-/// active-org-cookie-then-alphabetical logic HomePage already uses.
+/// the homepage hero CTA linked to it. Adds an "Organization Dashboard"
+/// entry to the mobile menu, gated the same way as the admin-only
+/// "Administration" entry (see AdministrationNavLinkTests), resolved via the
+/// same active-org-cookie-then-alphabetical logic HomePage already uses.
+///
+/// Follow-up from PR #777 review: a single link only reached the dashboard
+/// tab, forcing an extra tap to get to opportunities/members/settings. The
+/// entry is now a collapsible submenu (ORG_TABS, shared with OrgAppLayout's
+/// own tab bar) so every org tab is reachable directly from the burger menu.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -18,7 +23,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 	private const int MobileHeight = 812;
 
 	[Test]
-	public async Task MobileMenu_UserWithOrg_ShowsOrganizationDashboardLink_AndNavigatesToItsDashboard()
+	public async Task MobileMenu_UserWithOrg_ShowsOrganizationSubmenu_AndNavigatesToEachTab()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 
@@ -34,15 +39,50 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Organization Dashboard" });
-		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		var toggle = Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" });
+		await Expect(toggle).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
-		await link.ClickAsync();
+		// Collapsed by default: the org tab links aren't reachable yet.
+		var opportunitiesLink = Page.GetByRole(AriaRole.Link, new() { Name = "Opportunities" });
+		await Expect(opportunitiesLink).Not.ToBeVisibleAsync();
+
+		await toggle.ClickAsync();
+		await Expect(opportunitiesLink).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await opportunitiesLink.ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/opportunities"), new() { Timeout = 15_000 });
+
+		// Re-open and confirm the remaining tabs are all reachable too.
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Members" })
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/members"), new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings" })
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/settings"), new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Calendar" })
+			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
 	}
 
 	[Test]
-	public async Task MobileMenu_UserWithoutOrgs_HasNoOrganizationDashboardLink()
+	public async Task MobileMenu_UserWithoutOrgs_HasNoOrganizationSubmenu()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 
@@ -57,7 +97,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 
 		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Administration" }))
 			.ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Organization Dashboard" }))
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" }))
 			.Not.ToBeVisibleAsync();
 	}
 }

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -43,7 +43,14 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Expect(toggle).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		// Collapsed by default: the org tab links aren't reachable yet.
-		var opportunitiesLink = Page.GetByRole(AriaRole.Link, new() { Name = "Opportunities" });
+		// Exact match - the homepage's hero/footer "Find opportunities" and
+		// "Browse opportunities" links are still in the DOM behind the mobile
+		// menu overlay and would otherwise ambiguously match too (Playwright's
+		// default name matching is a case-insensitive substring match).
+		var opportunitiesLink = Page.GetByRole(
+			AriaRole.Link,
+			new() { Name = "Opportunities", Exact = true }
+		);
 		await Expect(opportunitiesLink).Not.ToBeVisibleAsync();
 
 		await toggle.ClickAsync();
@@ -58,7 +65,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members" })
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/members"), new() { Timeout = 15_000 });
 
@@ -67,7 +74,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings" })
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/settings"), new() { Timeout = 15_000 });
 
@@ -76,7 +83,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Calendar" })
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Calendar", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
 	}

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -20,13 +20,16 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 	[Test]
 	public async Task MobileMenu_UserWithOrg_ShowsOrganizationDashboardLink_AndNavigatesToItsDashboard()
 	{
-		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
-
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		// Olaf organizes an org in seed data (see HomePageOrgCtaTests).
+		// FastSignInAsync verifies auth by waiting for the desktop "User menu"
+		// button, which is CSS-hidden below the md breakpoint - so sign in
+		// before shrinking to a mobile viewport, not after.
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
@@ -41,13 +44,13 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 	[Test]
 	public async Task MobileMenu_UserWithoutOrgs_HasNoOrganizationDashboardLink()
 	{
-		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
-
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		// admin has no organization memberships in seed data.
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "admin", "admin123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -36,10 +36,18 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 
 		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+		// Scope every mobile-menu lookup below to the <header> landmark
+		// (implicit ARIA "banner" role). Once we're inside the org app shell,
+		// OrgAppLayout's own tab bar (visible at every viewport width, not just
+		// desktop - see its "Organization sections" nav) renders links with the
+		// exact same names ("Members", "Settings", ...), so an unscoped
+		// GetByRole lookup is ambiguous between the two navs.
+		var banner = Page.GetByRole(AriaRole.Banner);
+
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		var toggle = Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" });
+		var toggle = banner.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" });
 		await Expect(toggle).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		// Collapsed by default: the org tab links aren't reachable yet.
@@ -47,7 +55,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		// "Browse opportunities" links are still in the DOM behind the mobile
 		// menu overlay and would otherwise ambiguously match too (Playwright's
 		// default name matching is a case-insensitive substring match).
-		var opportunitiesLink = Page.GetByRole(
+		var opportunitiesLink = banner.GetByRole(
 			AriaRole.Link,
 			new() { Name = "Opportunities", Exact = true }
 		);
@@ -60,30 +68,30 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/opportunities"), new() { Timeout = 15_000 });
 
 		// Re-open and confirm the remaining tabs are all reachable too.
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true })
+		await banner.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/members"), new() { Timeout = 15_000 });
 
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true })
+		await banner.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/settings"), new() { Timeout = 15_000 });
 
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Organization Dashboard" })
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Calendar", Exact = true })
+		await banner.GetByRole(AriaRole.Link, new() { Name = "Calendar", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
 	}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -126,6 +126,7 @@ export default function Header({
 	) as string[];
 	const isAdmin = roles.includes("admin");
 	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
+	const [orgsLoading, setOrgsLoading] = useState(true);
 	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
@@ -150,9 +151,11 @@ export default function Header({
 	useEffect(() => {
 		if (!isLoggedIn) {
 			setOrgs([]);
+			setOrgsLoading(false);
 			return;
 		}
 		let cancelled = false;
+		setOrgsLoading(true);
 		api
 			.getOrganizations()
 			.then((data) => {
@@ -160,6 +163,9 @@ export default function Header({
 			})
 			.catch(() => {
 				if (!cancelled) setOrgs([]);
+			})
+			.finally(() => {
+				if (!cancelled) setOrgsLoading(false);
 			});
 		return () => {
 			cancelled = true;
@@ -204,6 +210,8 @@ export default function Header({
 								<OrganizationSwitcher
 									currentOrgId={orgSwitcher.currentOrgId}
 									currentTab={orgSwitcher.currentTab}
+									orgs={orgs}
+									loading={orgsLoading}
 								/>
 							</div>
 						)}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,9 +6,12 @@ import LanguageSelector from "./LanguageSelector";
 import AccountControls from "./AccountControls";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../hooks/useAccountMenu";
+import { useApiClient } from "../hooks/useApiClient";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../lib/authLocale";
+import { getActiveOrgId, resolveOrgAppPath } from "../lib/activeOrg";
 import type { BreadcrumbItem } from "../contexts/ToolbarContext";
+import type { OrganizationSummaryDto } from "../client/api-client";
 
 function getInitials(name: string): string {
 	const parts = name.trim().split(/\s+/);
@@ -111,6 +114,7 @@ export default function Header({
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const location = useLocation();
+	const api = useApiClient();
 	const isLoggedIn = auth.isAuthenticated;
 	const user = auth.user?.profile;
 	const displayName = (user?.name ??
@@ -121,6 +125,8 @@ export default function Header({
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
 	const isAdmin = roles.includes("admin");
+	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
+	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
 	const mobileNotifRef = useRef<HTMLDivElement>(null);
@@ -140,6 +146,26 @@ export default function Header({
 		window.addEventListener("scroll", onScroll, { passive: true });
 		return () => window.removeEventListener("scroll", onScroll);
 	}, []);
+
+	useEffect(() => {
+		if (!isLoggedIn) {
+			setOrgs([]);
+			return;
+		}
+		let cancelled = false;
+		api
+			.getOrganizations()
+			.then((data) => {
+				if (!cancelled) setOrgs(data);
+			})
+			.catch(() => {
+				if (!cancelled) setOrgs([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isLoggedIn]);
 
 	const isTransparent = location.pathname === "/" && !scrolled;
 
@@ -420,6 +446,15 @@ export default function Header({
 											className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-600"}`}
 										>
 											{t("nav.administration")}
+										</Link>
+									)}
+									{orgAppPath && (
+										<Link
+											to={orgAppPath}
+											onClick={() => setMobileOpen(false)}
+											className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-600"}`}
+										>
+											{t("nav.organizationDashboard")}
 										</Link>
 									)}
 									<button

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,7 +9,8 @@ import { useAccountMenu } from "../hooks/useAccountMenu";
 import { useApiClient } from "../hooks/useApiClient";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../lib/authLocale";
-import { getActiveOrgId, resolveOrgAppPath } from "../lib/activeOrg";
+import { getActiveOrgId, resolveActiveOrg } from "../lib/activeOrg";
+import { ORG_TABS } from "../lib/orgTabs";
 import type { BreadcrumbItem } from "../contexts/ToolbarContext";
 import type { OrganizationSummaryDto } from "../client/api-client";
 
@@ -127,8 +128,9 @@ export default function Header({
 	const isAdmin = roles.includes("admin");
 	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
 	const [orgsLoading, setOrgsLoading] = useState(true);
-	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
+	const activeOrg = resolveActiveOrg(orgs, getActiveOrgId());
 	const [mobileOpen, setMobileOpen] = useState(false);
+	const [orgMenuOpen, setOrgMenuOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
 	const mobileNotifRef = useRef<HTMLDivElement>(null);
 	const menu = useAccountMenu([mobileNotifRef]);
@@ -147,6 +149,10 @@ export default function Header({
 		window.addEventListener("scroll", onScroll, { passive: true });
 		return () => window.removeEventListener("scroll", onScroll);
 	}, []);
+
+	useEffect(() => {
+		if (!mobileOpen) setOrgMenuOpen(false);
+	}, [mobileOpen]);
 
 	useEffect(() => {
 		if (!isLoggedIn) {
@@ -456,14 +462,47 @@ export default function Header({
 											{t("nav.administration")}
 										</Link>
 									)}
-									{orgAppPath && (
-										<Link
-											to={orgAppPath}
-											onClick={() => setMobileOpen(false)}
-											className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-600"}`}
-										>
-											{t("nav.organizationDashboard")}
-										</Link>
+									{activeOrg && (
+										<div>
+											<button
+												type="button"
+												onClick={() => setOrgMenuOpen((o) => !o)}
+												aria-expanded={orgMenuOpen}
+												className={`flex w-full items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-700 hover:bg-brand-50 hover:text-brand-600"}`}
+											>
+												{t("nav.organizationDashboard")}
+												<svg
+													className={`h-4 w-4 shrink-0 transition-transform ${orgMenuOpen ? "rotate-180" : ""}`}
+													fill="none"
+													viewBox="0 0 24 24"
+													strokeWidth="2"
+													stroke="currentColor"
+													aria-hidden="true"
+												>
+													<path
+														strokeLinecap="round"
+														strokeLinejoin="round"
+														d="m19.5 8.25-7.5 7.5-7.5-7.5"
+													/>
+												</svg>
+											</button>
+											{orgMenuOpen && (
+												<div
+													className={`ml-3 space-y-1 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
+												>
+													{ORG_TABS.map((tab) => (
+														<Link
+															key={tab.key}
+															to={`/app/${activeOrg.id}/${tab.key}`}
+															onClick={() => setMobileOpen(false)}
+															className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-600"}`}
+														>
+															{t(tab.labelKey)}
+														</Link>
+													))}
+												</div>
+											)}
+										</div>
 									)}
 									<button
 										type="button"

--- a/frontend/src/components/OrganizationSwitcher.tsx
+++ b/frontend/src/components/OrganizationSwitcher.tsx
@@ -5,21 +5,24 @@ import type {
 	Organization,
 	OrganizationSummaryDto,
 } from "../client/api-client";
-import { useApiClient } from "../hooks/useApiClient";
 import CreateOrganizationModal from "./CreateOrganizationModal";
 
 export default function OrganizationSwitcher({
 	currentOrgId,
 	currentTab,
+	orgs,
+	loading,
 }: {
 	currentOrgId: string;
 	currentTab: string;
+	// Fetched by the parent Header (which needs the same list for its own
+	// nav-gating logic) so this component isn't firing a second, identical
+	// getOrganizations() request on every org-app-shell page load.
+	orgs: OrganizationSummaryDto[];
+	loading: boolean;
 }) {
-	const api = useApiClient();
 	const navigate = useNavigate();
 	const { t } = useTranslation();
-	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
-	const [loading, setLoading] = useState(true);
 	const [open, setOpen] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -29,20 +32,6 @@ export default function OrganizationSwitcher({
 	function orgPath(org: OrganizationSummaryDto) {
 		return `/app/${org.id}/${currentTab}`;
 	}
-
-	function fetchOrgs() {
-		setLoading(true);
-		api
-			.getOrganizations()
-			.then((data: OrganizationSummaryDto[]) => setOrgs(data))
-			.catch(() => setOrgs([]))
-			.finally(() => setLoading(false));
-	}
-
-	useEffect(() => {
-		fetchOrgs();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	useEffect(() => {
 		const handleClick = (e: MouseEvent) => {

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -5,6 +5,7 @@ import type { OrganizationDetailsResponse } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { setActiveOrgId } from "../lib/activeOrg";
+import { ORG_TABS } from "../lib/orgTabs";
 import {
 	OrgBreadcrumbProvider,
 	useOrgBreadcrumbExtra,
@@ -16,13 +17,6 @@ export interface OrgAppContext {
 	org: OrganizationDetailsResponse;
 	reloadOrg: () => void;
 }
-
-const TABS = [
-	{ key: "dashboard", labelKey: "orgOverview.tabCalendar" },
-	{ key: "opportunities", labelKey: "orgOverview.tabOpportunities" },
-	{ key: "members", labelKey: "orgOverview.tabMembers" },
-	{ key: "settings", labelKey: "orgOverview.tabSettings" },
-] as const;
 
 // Renders the org app shell body inside OrgBreadcrumbProvider so it can read
 // the nested-page breadcrumb extra (see useSetOrgBreadcrumbExtra) and pass
@@ -69,7 +63,7 @@ function OrgAppShell({
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
 				<nav aria-label={t("orgApp.tabsLabel")} className="mb-6 sm:mb-8">
 					<div className="flex gap-6 overflow-x-auto border-b border-gray-200 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-						{TABS.map((tab) => (
+						{ORG_TABS.map((tab) => (
 							<Link
 								key={tab.key}
 								to={`/app/${organizationId}/${tab.key}`}
@@ -144,8 +138,9 @@ export default function OrgAppLayout() {
 		.slice(`/app/${organizationId}/`.length)
 		.split("/")[0];
 	const activeTabKey =
-		TABS.find((tab) => tab.key === tabSegment)?.key ?? "dashboard";
-	const activeTab = TABS.find((tab) => tab.key === activeTabKey) ?? TABS[0];
+		ORG_TABS.find((tab) => tab.key === tabSegment)?.key ?? "dashboard";
+	const activeTab =
+		ORG_TABS.find((tab) => tab.key === activeTabKey) ?? ORG_TABS[0];
 	const activeTabLabel = t(activeTab.labelKey);
 
 	if (loading) {

--- a/frontend/src/lib/activeOrg.ts
+++ b/frontend/src/lib/activeOrg.ts
@@ -14,20 +14,27 @@ export function setActiveOrgId(organizationId: string): void {
 	document.cookie = `${COOKIE_NAME}=${encodeURIComponent(organizationId)}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
 }
 
-// Resolves where the org app shell should open without ever showing an
-// intermediate picker: the last-opened org (active-org cookie) if the user
-// still belongs to it, otherwise the first org alphabetically by name.
-export function resolveOrgAppPath(
+// Resolves which organization the org app shell (and any org-scoped nav
+// link) should open without ever showing an intermediate picker: the
+// last-opened org (active-org cookie) if the user still belongs to it,
+// otherwise the first org alphabetically by name.
+export function resolveActiveOrg(
 	orgs: OrganizationSummaryDto[],
 	activeOrgId: string | null,
-): string | null {
+): OrganizationSummaryDto | null {
 	if (orgs.length === 0) return null;
-	if (orgs.length === 1) return `/app/${orgs[0].id}/dashboard`;
+	if (orgs.length === 1) return orgs[0];
 
 	const active = activeOrgId
 		? orgs.find((org) => org.id === activeOrgId)
 		: undefined;
-	const target =
-		active ?? [...orgs].sort((a, b) => a.name.localeCompare(b.name))[0];
-	return `/app/${target.id}/dashboard`;
+	return active ?? [...orgs].sort((a, b) => a.name.localeCompare(b.name))[0];
+}
+
+export function resolveOrgAppPath(
+	orgs: OrganizationSummaryDto[],
+	activeOrgId: string | null,
+): string | null {
+	const org = resolveActiveOrg(orgs, activeOrgId);
+	return org ? `/app/${org.id}/dashboard` : null;
 }

--- a/frontend/src/lib/orgTabs.ts
+++ b/frontend/src/lib/orgTabs.ts
@@ -1,0 +1,9 @@
+// Single source of truth for the org app shell's tabs, shared between the
+// tab bar rendered inside OrgAppLayout and any org-scoped nav link that needs
+// to jump straight to one of them (e.g. Header's mobile burger submenu).
+export const ORG_TABS = [
+	{ key: "dashboard", labelKey: "orgOverview.tabCalendar" },
+	{ key: "opportunities", labelKey: "orgOverview.tabOpportunities" },
+	{ key: "members", labelKey: "orgOverview.tabMembers" },
+	{ key: "settings", labelKey: "orgOverview.tabSettings" },
+] as const;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -13,6 +13,7 @@
       "myAchievements": "Meine Errungenschaften",
       "profileSettings": "Profileinstellungen",
       "administration": "Administration",
+      "organizationDashboard": "Organisations-Dashboard",
       "signOut": "Abmelden",
       "signIn": "Anmelden",
       "register": "Registrieren",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,6 +13,7 @@
       "myAchievements": "My Achievements",
       "profileSettings": "Profile Settings",
       "administration": "Administration",
+      "organizationDashboard": "Organization Dashboard",
       "signOut": "Sign out",
       "signIn": "Sign in",
       "register": "Register",

--- a/scripts/smoke-test-775-org-dashboard-nav.mjs
+++ b/scripts/smoke-test-775-org-dashboard-nav.mjs
@@ -1,0 +1,91 @@
+/**
+ * Smoke test for issue #775: users with >=1 organization had no way to reach
+ * the org dashboard from the mobile burger menu. Adds an "Organization
+ * Dashboard" entry there, gated on org count, resolved via the same
+ * active-org-cookie-then-alphabetical logic HomePage already uses.
+ *
+ * Verifies against live staging (mobile viewport):
+ *  - olaf (organizes an org) sees "Organization Dashboard" in the mobile
+ *    menu and it navigates to /app/:id/dashboard
+ *  - admin (no organizations) does not see the entry, but still sees
+ *    "Administration"
+ *
+ * Run: node scripts/smoke-test-775-org-dashboard-nav.mjs
+ */
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function signIn(page, username, password) {
+	await page.goto(BASE, { waitUntil: "networkidle" });
+	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
+	await signInBtn.first().click();
+	await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
+	await loginKeycloak(page, username, password);
+	await page.waitForURL(`${BASE}/`, { timeout: 15000 });
+}
+
+async function openMobileMenu(page) {
+	const burger = page.getByRole("button", { name: /open menu|men. öffnen/i });
+	await burger.waitFor({ state: "visible", timeout: 10000 });
+	await burger.click();
+	await page.waitForTimeout(300);
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	await page.setViewportSize({ width: 375, height: 812 });
+	try {
+		// --- olaf: organizes an org, sees the entry and it navigates correctly ---
+		await signIn(page, "olaf", "olaf123");
+		console.log("OK  Logged in as olaf");
+
+		await openMobileMenu(page);
+		const orgLink = page.getByRole("link", { name: "Organization Dashboard" });
+		await orgLink.waitFor({ state: "visible", timeout: 10000 });
+		console.log("OK  olaf sees the Organization Dashboard nav entry");
+
+		await orgLink.click();
+		await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
+		console.log("OK  Organization Dashboard entry navigates to /app/:id/dashboard");
+
+		await page
+			.getByRole("button", { name: /sign out|abmelden/i })
+			.click()
+			.catch(async () => {
+				await openMobileMenu(page);
+				await page.getByRole("button", { name: /sign out|abmelden/i }).click();
+			});
+		await page.waitForURL(`${BASE}/`, { timeout: 15000 });
+		console.log("OK  Signed out olaf");
+
+		// --- admin: no organizations, no entry, Administration still there ---
+		await signIn(page, "admin", "admin123");
+		console.log("OK  Logged in as admin");
+
+		await openMobileMenu(page);
+		await page
+			.getByRole("link", { name: "Administration" })
+			.waitFor({ state: "visible", timeout: 10000 });
+		const adminOrgLink = page.getByRole("link", { name: "Organization Dashboard" });
+		if ((await adminOrgLink.count()) > 0) {
+			throw new Error("admin (no orgs) must not see the Organization Dashboard nav entry");
+		}
+		console.log("OK  admin (no orgs) does not see the Organization Dashboard nav entry");
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});

--- a/scripts/smoke-test-775-org-dashboard-nav.mjs
+++ b/scripts/smoke-test-775-org-dashboard-nav.mjs
@@ -18,13 +18,20 @@ import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
 const BASE = "https://einsatzbereit.maik-hasler.de";
 const API = "https://api.maik-hasler.de";
 
+// FastSignInAsync's C# counterpart confirms auth via the desktop "User menu"
+// button, which is CSS-hidden below the md breakpoint - the real Keycloak
+// flow here has the same problem with its "Sign in" button. Sign in at a
+// normal desktop viewport, then shrink to mobile once authenticated, not
+// before - resizing first leaves no visible "Sign in" button to click.
 async function signIn(page, username, password) {
+	await page.setViewportSize({ width: 1280, height: 800 });
 	await page.goto(BASE, { waitUntil: "networkidle" });
 	const signInBtn = page.getByRole("button", { name: /sign in|anmelden/i });
 	await signInBtn.first().click();
 	await page.waitForURL(/login\.maik-hasler\.de/, { timeout: 15000 });
 	await loginKeycloak(page, username, password);
 	await page.waitForURL(`${BASE}/`, { timeout: 15000 });
+	await page.setViewportSize({ width: 375, height: 812 });
 }
 
 async function openMobileMenu(page) {
@@ -40,7 +47,6 @@ async function main() {
 	console.log("OK  API health check passed");
 
 	const { browser, page } = await launchLiveBrowser();
-	await page.setViewportSize({ width: 375, height: 812 });
 	try {
 		// --- olaf: organizes an org, sees the entry and it navigates correctly ---
 		await signIn(page, "olaf", "olaf123");
@@ -55,13 +61,8 @@ async function main() {
 		await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
 		console.log("OK  Organization Dashboard entry navigates to /app/:id/dashboard");
 
-		await page
-			.getByRole("button", { name: /sign out|abmelden/i })
-			.click()
-			.catch(async () => {
-				await openMobileMenu(page);
-				await page.getByRole("button", { name: /sign out|abmelden/i }).click();
-			});
+		await openMobileMenu(page);
+		await page.getByRole("button", { name: /sign out|abmelden/i }).click();
 		await page.waitForURL(`${BASE}/`, { timeout: 15000 });
 		console.log("OK  Signed out olaf");
 


### PR DESCRIPTION
## Summary

Follow-up on the latest review comment on #777, which this stacks on top of (built on the `claude/issue-775-feature-1d1362` branch so it includes that PR's changes - once #777 merges, this diff will automatically shrink to just the commit below):

> The burger menu should have a submenu in case of the organization which can direct to the Dashboard / opportunities / settings / members site, so that each site can be accessed without the dashboard.

- The mobile burger menu's single "Organization Dashboard" link is now a collapsible submenu (accordion) listing all four org app tabs - Calendar (the dashboard tab), Opportunities, Members, Settings - each linking straight to `/app/:organizationId/<tab>`.
- Extracted the tab list (`ORG_TABS`) into a new shared `frontend/src/lib/orgTabs.ts` so `OrgAppLayout`'s own tab bar and this new submenu stay in sync instead of duplicating the same array.
- Refactored `activeOrg.ts`: added `resolveActiveOrg` (returns the resolved `OrganizationSummaryDto`) and rebuilt the existing `resolveOrgAppPath` (used by `HomePage`'s hero CTA) on top of it, since the submenu needs the raw org id, not just a dashboard path.
- The submenu's expanded/collapsed state resets whenever the burger menu itself closes, so re-opening it doesn't show a stale expanded state.
- Gating is unchanged: only rendered when the signed-in user belongs to >=1 organization, same as the existing admin-only "Administration" entry.

**Note:** base is set to `main` (not #777's branch) so this repo's `pull_request: branches: [main]`-gated CI workflows (`dotnet.yml`, `frontend.yml`, `lint.yml`) actually run - they don't trigger for PRs targeting a non-main base.

## Test plan

- [x] `pnpm check` (tsc), `pnpm lint` (eslint, zero warnings), `pnpm format:check` - all pass locally.
- [x] Updated `backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs` to cover the new submenu: expanding it and navigating to each of the four tabs, and confirming users without an organization see no submenu (this project's sandboxed Claude Code web session can't run Aspire/Testcontainers locally - see `AGENTS.md` "Sandbox Limitations" - so this test runs in CI against the real stack, not locally in this session).
- [x] Live verification: no RC was cut for this change at the requester's explicit request (they're wiring the RC themselves). Instead, verified locally with a throwaway preview harness (temporary Vite entry mocking auth + a stub API server for `GET /v1/organizations`, deleted before commit - never part of this diff) driven by Playwright at a 375x812 mobile viewport, in both the normal and homepage-hero (transparent header) visual states. Screenshots were sent directly to the requester in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
