### PR TITLE
fix(tests): retry keyboard ArrowLeft in dashboard reorder test to fix flake

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -267,13 +267,26 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 		var todoGrip = Page.GetByRole(AriaRole.Button, new() { Name = "Drag Needs Your Attention to reorder" });
 		await todoGrip.FocusAsync();
 		await Page.Keyboard.PressAsync("Space");
-		await Page.Keyboard.PressAsync("ArrowLeft");
 
-		// handleDragOver reorders live as the dragged tile crosses another one
-		// - wait for that to land before dropping, rather than assuming a
-		// fixed delay.
-		await Expect(Page.Locator("[data-testid^='widget-tile-']").First)
-			.ToHaveAttributeAsync("data-testid", "widget-tile-ToDo", new() { Timeout = 10_000 });
+		// A single ArrowLeft right after grabbing can race dnd-kit's
+		// post-grab rect measurement - a real user always leaves a natural
+		// gap between grabbing and steering that Playwright's instant
+		// keypress doesn't, and a keypress that lands before measurement
+		// finishes is silently swallowed by handleDragOver's over===null
+		// bail-out with nothing left to retry it later. Poll the key instead
+		// of trusting one press to land; once the swap has actually
+		// happened, further presses are no-ops (ToDo has no more left
+		// neighbor to swap with).
+		var firstTile = Page.Locator("[data-testid^='widget-tile-']").First;
+		var deadline = DateTime.UtcNow.AddSeconds(10);
+		while (await firstTile.GetAttributeAsync("data-testid") != "widget-tile-ToDo")
+		{
+			if (DateTime.UtcNow > deadline)
+				throw new TimeoutException(
+					"Keyboard ArrowLeft never reordered ToDo to the front of the widget grid.");
+			await Page.Keyboard.PressAsync("ArrowLeft");
+			await Page.WaitForTimeoutAsync(200);
+		}
 
 		await Page.Keyboard.PressAsync("Space");
 


### PR DESCRIPTION
## Summary
- Fixes the flaky `KeyboardDragReorder_SwapsWidgetWithLeftNeighbor_AndPersistsAcrossReload` VisualTests test (green on one CI run, failed with a 10s timeout on the next, same commit).
- Root cause: the test sends a single `ArrowLeft` keypress immediately after `Space` (grab). That can race dnd-kit's post-grab rect measurement - Playwright dispatches the two keys far faster than a real user's natural grab-to-steer gap. A keypress that lands before measurement finishes is silently swallowed by `handleDragOver`'s `over === null` bail-out (`frontend/src/pages/app/OrgDashboardPage/index.tsx`), and nothing retries it later - so the widget order never changes and the subsequent 10s `Expect(...).ToHaveAttributeAsync(...)` wait times out.
- Fix: poll the `ArrowLeft` keypress (checking the first tile's `data-testid` before each attempt, bounded to the same 10s budget) instead of trusting a single press to land. This is a test-only change - no production code touched, since real users don't hit this race (a real arrow-key press always comes well after the grab completes).

## Test plan
- [x] `dotnet build tests/VisualTests/VisualTests.csproj` - compiles clean, 0 warnings/errors.
- [x] Self-review (`/self-review`) - clean, no findings (test-only diff, no domain-check triggers).
- [ ] CI (`dotnet.yml`) green, including the fixed `VisualTests` test.
- [ ] Live verification (see below, added after RC deploy).

## Live verification
_Pending - to be added once the release-candidate deploy finishes._
