### PR TITLE
fix: dashboard crash + org dashboard UX follow-up (tab bar removal, whole-tile drag)

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -226,7 +226,10 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		if (!await NavigateToOrgAppDashboardAsOlafAsync(frontend))
 			return;
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true }).ClickAsync();
+		// The tab bar is gone (dashboard UX redesign) - reach Members via the
+		// Settings widget's member-count link instead (its accessible name is
+		// "N members", so match the substring rather than an exact count).
+		await Page.GetByRole(AriaRole.Link, new() { Name = "members" }).ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -238,6 +238,56 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task DirectNavigation_ToEachDashboardNestedRoute_RendersRealContent_NotErrorBoundary()
+	{
+		// Regression for #783/#787: opportunities/members/settings (and the
+		// dashboard index) are nested under a pathless "dashboard" parent
+		// route (see App.tsx) whose element used to be a bare <Outlet />
+		// with no `context` prop - that starts a brand new outlet context
+		// instead of forwarding OrgAppLayout's <Outlet context={{org,
+		// reloadOrg}}>, so every one of these pages got undefined from
+		// useOutletContext<OrgAppContext>() and crashed on the very first
+		// destructure, caught by the app-wide ErrorBoundary. A direct
+		// (full page load) navigation to each route below exercises that
+		// same render chain from scratch every time, unlike a client-side
+		// Link click that could in principle reuse already-mounted state.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = match.Groups[1].Value;
+
+		var errorBoundaryHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Something went wrong" });
+
+		foreach (var (path, activeTabName) in new[]
+		{
+			("dashboard", "Dashboard"),
+			("dashboard/opportunities", "Opportunities"),
+			("dashboard/members", "Members"),
+			("dashboard/settings", "Settings"),
+		})
+		{
+			await Page.GotoAsync($"{origin}/app/{organizationId}/{path}");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			(await errorBoundaryHeading.CountAsync()).Should().Be(0,
+				$"/{path} should render real content, not the ErrorBoundary fallback");
+
+			// A crash unmounts OrgAppLayout entirely (the ErrorBoundary sits
+			// above it, at the app root), taking the tab bar down with it - so
+			// the active tab link is present precisely when the page rendered
+			// for real, regardless of whether the org has any opportunities/
+			// members/etc. to show.
+			await Expect(Page.GetByRole(AriaRole.Link, new() { Name = activeTabName, Exact = true }))
+				.ToHaveAttributeAsync("aria-current", "page", new() { Timeout = 10_000 });
+		}
+	}
+
+	[Test]
 	public async Task MobileMenu_LanguageSelector_HasDarkTransparentTheme_OnHero()
 	{
 		// Regression: LanguageSelector inside the mobile menu on the hero section

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -218,7 +218,10 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true }).ClickAsync();
+		// The tab bar is gone (dashboard UX redesign) - reach Members via the
+		// Settings widget's member-count link instead (its accessible name is
+		// "N members", so match the substring rather than an exact count).
+		await Page.GetByRole(AriaRole.Link, new() { Name = "members" }).ClickAsync();
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/members"), new() { Timeout = 15_000 });
 
 		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
@@ -262,8 +265,9 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var organizationId = match.Groups[1].Value;
 
 		var errorBoundaryHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Something went wrong" });
+		var breadcrumb = Page.Locator("nav[aria-label='Breadcrumb']");
 
-		foreach (var (path, activeTabName) in new[]
+		foreach (var (path, activePageLabel) in new[]
 		{
 			("dashboard", "Dashboard"),
 			("dashboard/opportunities", "Opportunities"),
@@ -278,12 +282,12 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 				$"/{path} should render real content, not the ErrorBoundary fallback");
 
 			// A crash unmounts OrgAppLayout entirely (the ErrorBoundary sits
-			// above it, at the app root), taking the tab bar down with it - so
-			// the active tab link is present precisely when the page rendered
-			// for real, regardless of whether the org has any opportunities/
-			// members/etc. to show.
-			await Expect(Page.GetByRole(AriaRole.Link, new() { Name = activeTabName, Exact = true }))
-				.ToHaveAttributeAsync("aria-current", "page", new() { Timeout = 10_000 });
+			// above it, at the app root), taking the breadcrumb down with it -
+			// so its current-page label is present precisely when the page
+			// rendered for real, regardless of whether the org has any
+			// opportunities/members/etc. to show.
+			await Expect(breadcrumb.Locator("[aria-current='page']"))
+				.ToHaveTextAsync(activePageLabel, new() { Timeout = 10_000 });
 		}
 	}
 

--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -14,9 +14,12 @@ namespace VisualTests;
 /// already covered by <c>MobileHeaderTests</c>. What's specific to the org
 /// app here is that the org switcher's own name must not overflow onto the
 /// bell/hamburger. #771 removed the tab bar and the per-page org-name
-/// heading, dropping the header-stacking test that used to live here - but
-/// #775/#777 brought the tab bar back (shared ORG_TABS, also reused by the
-/// burger menu's org submenu), so its no-wrap-on-mobile coverage stays.
+/// heading; #775/#777 brought the tab bar back for a time (shared ORG_TABS,
+/// also reused by the burger menu's org submenu), but the dashboard UX
+/// redesign removed it again in favor of the dashboard's own widget links
+/// plus the burger menu's org submenu as the sole way to reach opportunities/
+/// members/settings - see <c>OrganizationDashboardNavLinkTests</c> for that
+/// submenu's own coverage.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -62,47 +65,5 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 			.ToBeVisibleAsync();
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }))
 			.ToBeVisibleAsync();
-	}
-
-	[Test]
-	public async Task TabBar_AllFourTabs_StayOnOneRow_NoWrapOnMobile()
-	{
-		// Log in at the default (desktop) viewport - AuthHelper.LoginAsync looks
-		// for the "Sign in" button that only exists in the public header's
-		// desktop nav (`hidden md:flex`); at mobile width it lives behind that
-		// header's own hamburger instead. Resize only after landing in the app.
-		var frontend = Fixture.GetEndpoint("frontend");
-		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
-		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
-		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
-
-		var tabBar = Page.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" });
-		await Expect(tabBar).ToBeVisibleAsync();
-
-		var tabNames = new[] { "Dashboard", "Opportunities", "Settings", "Members" };
-		var tabYPositions = new List<float>();
-		foreach (var name in tabNames)
-		{
-			var box = await tabBar.GetByRole(AriaRole.Link, new() { Name = name }).BoundingBoxAsync();
-			box.Should().NotBeNull($"could not measure the '{name}' tab");
-			tabYPositions.Add(box!.Y);
-		}
-
-		// All four tabs must sit on the same visual row (previously `flex
-		// gap-6` with no wrapping/scrolling let them run off-screen instead).
-		var firstY = tabYPositions[0];
-		foreach (var y in tabYPositions.Skip(1))
-			Math.Abs(y - firstY).Should().BeLessThan(2, "tabs must stay on a single row, not wrap");
-
-		// The tab row must be configured to scroll horizontally rather than wrap
-		// or clip once a translation/tab set overflows the 375px container -
-		// checked via the CSS mechanism itself (overflow-x: auto) rather than
-		// scrollWidth > clientWidth, since whether today's specific English tab
-		// labels happen to overflow at this exact viewport is a font-rendering
-		// detail, not the thing this test should be pinned to.
-		var overflowX = await tabBar.EvaluateAsync<string>(
-			"el => getComputedStyle(el.firstElementChild).overflowX");
-		overflowX.Should().Be("auto",
-			"the tab row must allow horizontal scrolling so a longer/translated tab set stays reachable");
 	}
 }

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -65,7 +65,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Expect(opportunitiesLink).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		await opportunitiesLink.ClickAsync();
-		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/opportunities"), new() { Timeout = 15_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/opportunities"), new() { Timeout = 15_000 });
 
 		// Re-open and confirm the remaining tabs are all reachable too.
 		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
@@ -75,7 +75,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 
 		await banner.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
-		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/members"), new() { Timeout = 15_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/members"), new() { Timeout = 15_000 });
 
 		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
@@ -84,7 +84,7 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 
 		await banner.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
-		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/settings"), new() { Timeout = 15_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/settings"), new() { Timeout = 15_000 });
 
 		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -37,11 +37,9 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 
 		// Scope every mobile-menu lookup below to the <header> landmark
-		// (implicit ARIA "banner" role). Once we're inside the org app shell,
-		// OrgAppLayout's own tab bar (visible at every viewport width, not just
-		// desktop - see its "Organization sections" nav) renders links with the
-		// exact same names ("Members", "Settings", ...), so an unscoped
-		// GetByRole lookup is ambiguous between the two navs.
+		// (implicit ARIA "banner" role) - the dashboard's own widgets also
+		// link to some of these same destinations (e.g. Settings' member-count
+		// link), so an unscoped GetByRole lookup could match either.
 		var banner = Page.GetByRole(AriaRole.Banner);
 
 		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -32,7 +32,10 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true }).ClickAsync();
+		// The tab bar is gone (dashboard UX redesign) - reach Members via the
+		// Settings widget's member-count link instead (its accessible name is
+		// "N members", so match the substring rather than an exact count).
+		await Page.GetByRole(AriaRole.Link, new() { Name = "members" }).ClickAsync();
 
 		await Page.Locator("#member-search").FillAsync("vera");
 
@@ -71,7 +74,10 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual580 Leave");
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Members", Exact = true }).ClickAsync();
+		// The tab bar is gone (dashboard UX redesign) - reach Members via the
+		// Settings widget's member-count link instead (its accessible name is
+		// "N members", so match the substring rather than an exact count).
+		await Page.GetByRole(AriaRole.Link, new() { Name = "members" }).ClickAsync();
 
 		var leaveButton = Page.GetByRole(AriaRole.Button, new() { Name = "Leave" });
 		await Expect(leaveButton).ToBeVisibleAsync(new() { Timeout = 10_000 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,16 @@
-import { Routes, Route, Navigate, Outlet, useParams } from "react-router";
+import {
+	Routes,
+	Route,
+	Navigate,
+	Outlet,
+	useOutletContext,
+	useParams,
+} from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
-import OrgAppLayout from "./layouts/OrgAppLayout";
+import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
 import HomePage from "./pages/HomePage";
 import PrivacyPolicyPage from "./pages/PrivacyPolicyPage";
 import ImprintPage from "./pages/ImprintPage";
@@ -23,6 +30,17 @@ import OrgSettingsPage from "./pages/app/OrgSettingsPage";
 function OrgAppRedirect({ tab }: { tab: string }) {
 	const { organizationId } = useParams<{ organizationId: string }>();
 	return <Navigate to={`/app/${organizationId}/${tab}`} replace />;
+}
+
+// A bare <Outlet /> element (no `context` prop) starts a brand new outlet
+// context of its own - it does NOT transparently forward whatever an
+// ancestor <Outlet context={...}> (OrgAppLayout's) already provided. Without
+// this relay, every route nested under the pathless "dashboard" parent below
+// would have useOutletContext<OrgAppContext>() resolve to undefined instead
+// of OrgAppLayout's {org, reloadOrg}, crashing on the very first destructure.
+function OrgAppOutletRelay() {
+	const context = useOutletContext<OrgAppContext>();
+	return <Outlet context={context} />;
 }
 
 // Pre-#9 bookmarks to a specific opportunity's engagement management page
@@ -75,10 +93,11 @@ export default function App() {
 				{/* Pathless parent (#9): opportunities/members/settings are now
 				nested under /dashboard/... in the URL - see OrgAppLayout's
 				orgTabPath - while staying siblings in the render tree (this
-				Route's own element is just an Outlet, no extra chrome), so
+				Route's own element renders no extra chrome, just relays
+				OrgAppLayout's outlet context - see OrgAppOutletRelay), so
 				OrgAppLayout's single Outlet keeps rendering whichever page
 				unchanged. */}
-				<Route path="dashboard" element={<Outlet />}>
+				<Route path="dashboard" element={<OrgAppOutletRelay />}>
 					<Route index element={<OrgDashboardPage />} />
 					<Route path="opportunities" element={<OrgOpportunitiesPage />} />
 					<Route

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -69,25 +69,6 @@ function OrgAppShell({
 			/>
 
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
-				<nav aria-label={t("orgApp.tabsLabel")} className="mb-6 sm:mb-8">
-					<div className="flex gap-6 overflow-x-auto border-b border-gray-200 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-						{ORG_TABS.map((tab) => (
-							<Link
-								key={tab.key}
-								to={orgTabPath(organizationId ?? "", tab.key)}
-								aria-current={activeTabKey === tab.key ? "page" : undefined}
-								className={`shrink-0 whitespace-nowrap border-b-2 pb-3 pt-3 text-sm font-medium transition-colors ${
-									activeTabKey === tab.key
-										? "border-brand-700 text-brand-700"
-										: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
-								}`}
-							>
-								{t(tab.labelKey)}
-							</Link>
-						))}
-					</div>
-				</nav>
-
 				<Outlet
 					context={{ org, reloadOrg: load } satisfies OrgAppContext}
 					// Outlet re-mounts children on org identity change so per-tab state resets cleanly

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -341,8 +341,7 @@
     },
     "orgApp": {
       "backToSite": "Zurueck zu Einsatzbereit",
-      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation.",
-      "tabsLabel": "Organisationsbereiche"
+      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation."
     },
     "orgOpportunities": {
       "loading": "Wird geladen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -341,8 +341,7 @@
     },
     "orgApp": {
       "backToSite": "Back to Einsatzbereit",
-      "notAuthorized": "You don't have access to this organization.",
-      "tabsLabel": "Organization sections"
+      "notAuthorized": "You don't have access to this organization."
     },
     "orgOpportunities": {
       "loading": "Loading…",

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -77,10 +77,11 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 			)}
 			{opportunities !== null && !error && opportunities.length > 0 && (
 				// Side by side once there's enough width for both to stay
-				// readable (this widget's own max column footprint keeps it
-				// from ever getting classified "full", only "compact" or
-				// "medium"); stacked at compact - #771 follow-up review
-				// feedback (adaptive layouts per size).
+				// readable - the select grows to fill whatever room it's
+				// given via flex-1, so this already scales continuously with
+				// the organizer's own placement instead of needing a
+				// separate "full" treatment; stacked at compact - #771
+				// follow-up review feedback (adaptive layouts per size).
 				<div
 					className={
 						size !== "compact" ? "flex items-center gap-3" : "space-y-3"

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -215,15 +215,17 @@ function EditableWidgetTile({
 			// anything are exactly the friction this is meant to remove. That
 			// means the tile opts INTO pointer events here (rather than passing
 			// clicks through to the grid-guide backdrop beneath, as it used to) -
-			// but only while it's NOT the widget actively being placed
-			// (!isPlacing): once a placement starts (real drag or the
-			// click-click-click flow), completing it very often means clicking a
-			// backdrop cell that falls inside THIS SAME widget's own current
-			// footprint (e.g. shrinking/growing it from within its own bounds) -
-			// if the tile itself still captured pointer events, it would
-			// intercept exactly those clicks meant for its own backdrop. A real
-			// drag already committed to via document-level pointermove/pointerup
-			// listeners isn't affected by this tile losing pointer-events
+			// but only while NO placement is active at all anywhere on the
+			// board (!isPlacing && !placingDisabled, i.e. activeKey === null).
+			// Once ANY widget's placement is active (real drag or the
+			// click-click-click flow), completing it very often means clicking
+			// a backdrop cell that falls inside another widget's current
+			// footprint - that's the whole point of #18 (an overlapping
+			// placement displaces what's in the way instead of being
+			// rejected), so every OTHER tile must let those clicks through
+			// too, not just the one actually being placed. A real drag
+			// already committed to via document-level pointermove/pointerup
+			// listeners isn't affected by tiles losing pointer-events
 			// mid-drag - only where a NEW press lands is.
 			onPointerDown={
 				editing && showPlacementControls && !placingDisabled && !isPlacing
@@ -231,7 +233,7 @@ function EditableWidgetTile({
 					: undefined
 			}
 			className={`relative h-full ${
-				editing && showPlacementControls && !isPlacing
+				editing && showPlacementControls && !isPlacing && !placingDisabled
 					? "cursor-grab touch-none active:cursor-grabbing"
 					: editing
 						? "pointer-events-none"

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -215,20 +215,23 @@ function EditableWidgetTile({
 			// anything are exactly the friction this is meant to remove. That
 			// means the tile opts INTO pointer events here (rather than passing
 			// clicks through to the grid-guide backdrop beneath, as it used to) -
-			// the backdrop is still reachable over any empty cell, and dropping a
-			// tile onto an occupied one still displaces what's there (see
-			// settlePlacement), so the one thing actually lost is completing a
-			// click-click-click placement by clicking a backdrop cell hidden
-			// under a DIFFERENT tile; the keyboard flow (arrow keys + the grip
-			// button's Enter/Space) reaches every cell regardless and isn't
-			// affected.
+			// but only while it's NOT the widget actively being placed
+			// (!isPlacing): once a placement starts (real drag or the
+			// click-click-click flow), completing it very often means clicking a
+			// backdrop cell that falls inside THIS SAME widget's own current
+			// footprint (e.g. shrinking/growing it from within its own bounds) -
+			// if the tile itself still captured pointer events, it would
+			// intercept exactly those clicks meant for its own backdrop. A real
+			// drag already committed to via document-level pointermove/pointerup
+			// listeners isn't affected by this tile losing pointer-events
+			// mid-drag - only where a NEW press lands is.
 			onPointerDown={
-				editing && showPlacementControls && !placingDisabled
+				editing && showPlacementControls && !placingDisabled && !isPlacing
 					? onGripPointerDown
 					: undefined
 			}
 			className={`relative h-full ${
-				editing && showPlacementControls
+				editing && showPlacementControls && !isPlacing
 					? "cursor-grab touch-none active:cursor-grabbing"
 					: editing
 						? "pointer-events-none"

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -182,8 +182,8 @@ function EditableWidgetTile({
 	onAdvance: () => void;
 	onArrowKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
 	onRemove: () => void;
-	onGripPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
-	onResizePointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+	onGripPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+	onResizePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
 	children: ReactNode;
 }) {
 	const { t } = useTranslation();
@@ -200,25 +200,40 @@ function EditableWidgetTile({
 			data-testid={`widget-tile-${widgetKey}`}
 			style={gridStyle}
 			// No z-index here on purpose: this div is `position: relative` (for
-			// the absolutely-positioned move/remove buttons) but must NOT also
-			// get a z-index, because that would give it its own stacking
-			// context - any modal a widget renders inside itself (e.g.
-			// CreateOpportunityWidget's wizard) would then be scoped to THIS
-			// tile's stacking order instead of the page's, so a later sibling
-			// tile (also positioned) could paint over the modal despite its own
-			// z-[2000] and swallow clicks meant for it. That same
-			// position:relative is exactly why this tile paints ABOVE the
-			// green backdrop cells beneath it regardless of DOM order (a
-			// positioned element always paints above an in-flow, non-
-			// positioned sibling within the same stacking context) - which
-			// would otherwise block clicks meant for a backdrop cell that
-			// happens to fall under this widget's own current footprint
-			// (e.g. clicking its existing top-left corner to start a
-			// resize from there). pointer-events-none on this wrapper while
-			// editing lets those clicks pass through to the grid beneath;
-			// the two buttons below opt back in with pointer-events-auto,
-			// which CSS honors even under a pointer-events-none ancestor.
-			className={`relative h-full ${editing ? "pointer-events-none" : ""} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
+			// the absolutely-positioned remove button and the tile itself acting
+			// as the drag-to-move surface) but must NOT also get a z-index,
+			// because that would give it its own stacking context - any modal a
+			// widget renders inside itself (e.g. CreateOpportunityWidget's
+			// wizard) would then be scoped to THIS tile's stacking order instead
+			// of the page's, so a later sibling tile (also positioned) could
+			// paint over the modal despite its own z-[2000] and swallow clicks
+			// meant for it.
+			//
+			// The whole tile is the primary press-and-drag-to-move target while
+			// editing (not just a small grip icon) - dashboard-builder UIs that
+			// make organizers hunt for a tiny handle before they can reposition
+			// anything are exactly the friction this is meant to remove. That
+			// means the tile opts INTO pointer events here (rather than passing
+			// clicks through to the grid-guide backdrop beneath, as it used to) -
+			// the backdrop is still reachable over any empty cell, and dropping a
+			// tile onto an occupied one still displaces what's there (see
+			// settlePlacement), so the one thing actually lost is completing a
+			// click-click-click placement by clicking a backdrop cell hidden
+			// under a DIFFERENT tile; the keyboard flow (arrow keys + the grip
+			// button's Enter/Space) reaches every cell regardless and isn't
+			// affected.
+			onPointerDown={
+				editing && showPlacementControls && !placingDisabled
+					? onGripPointerDown
+					: undefined
+			}
+			className={`relative h-full ${
+				editing && showPlacementControls
+					? "cursor-grab touch-none active:cursor-grabbing"
+					: editing
+						? "pointer-events-none"
+						: ""
+			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
 		>
 			<div inert={editing} className={`h-full ${editing ? "opacity-60" : ""}`}>
 				{children}
@@ -226,19 +241,21 @@ function EditableWidgetTile({
 			{editing && (
 				<>
 					{showPlacementControls && (
-						// This button is BOTH the mouse/touch entry point into the
-						// click-click-click corner-to-corner flow (onClick, still the
-						// accessible path via onKeyDown's arrow keys/Enter - #17) AND,
-						// via onPointerDown, the real drag-to-move gesture (#16): a
-						// press-and-drag beyond DRAG_THRESHOLD_PX commits a move
-						// directly instead of needing two separate clicks. A
-						// plain click/tap (no real movement) falls through to
-						// onClick unchanged.
+						// Still the entry point into the click-click-click
+						// corner-to-corner flow (onClick) and its accessible
+						// keyboard path (onKeyDown's arrow keys/Enter, #17) - the
+						// whole tile above now also starts a real pointer drag
+						// (#16) on its own, so this button's own onPointerDown
+						// would otherwise fire a second, redundant drag-start for
+						// the exact same press; stopPropagation keeps it to one.
 						<button
 							type="button"
 							onClick={onAdvance}
 							onKeyDown={onArrowKeyDown}
-							onPointerDown={onGripPointerDown}
+							onPointerDown={(e) => {
+								e.stopPropagation();
+								onGripPointerDown(e);
+							}}
 							disabled={placingDisabled}
 							className={`pointer-events-auto absolute left-1/2 top-2 z-30 -translate-x-1/2 cursor-pointer touch-none rounded-lg bg-white p-1.5 text-gray-600 shadow-md ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 ${isPlacing ? "ring-2 ring-brand-500" : ""}`}
 							aria-label={moveLabel}
@@ -252,12 +269,18 @@ function EditableWidgetTile({
 						// accessibly via the two-corner flow, so this one is taken out
 						// of the tab order and hidden from assistive tech (#17) rather
 						// than exposing a second, keyboard-inert control for the same
-						// capability.
+						// capability. stopPropagation is required here, not just an
+						// optimization - without it, the tile's own move-drag handler
+						// (above) would also see this same press and immediately
+						// overwrite the resize session with a move session.
 						<button
 							type="button"
 							tabIndex={-1}
 							aria-hidden="true"
-							onPointerDown={onResizePointerDown}
+							onPointerDown={(e) => {
+								e.stopPropagation();
+								onResizePointerDown(e);
+							}}
 							disabled={placingDisabled}
 							className="pointer-events-auto absolute bottom-2 right-2 z-20 cursor-nwse-resize touch-none rounded-lg bg-white/95 p-1 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30"
 						>
@@ -266,6 +289,7 @@ function EditableWidgetTile({
 					)}
 					<button
 						type="button"
+						onPointerDown={(e) => e.stopPropagation()}
 						onClick={onRemove}
 						disabled={placingDisabled}
 						className="pointer-events-auto absolute right-2 top-2 z-20 rounded-lg bg-white/95 p-1.5 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-30"
@@ -501,14 +525,17 @@ export default function OrgDashboardPage() {
 		}
 	}
 
-	// Starts a real pointer drag (#16) on a widget's grip (move) or resize
-	// handle. Measures cell size off the widget's OWN rendered tile rather
-	// than the grid container, so it stays correct regardless of viewport
-	// width. A plain click/tap (pointer released before moving past
-	// DRAG_THRESHOLD_PX) is left alone here - it falls through to the
-	// button's own onClick (handleAdvance) exactly as before.
+	// Starts a real pointer drag (#16) on a widget's tile (move, from
+	// anywhere on it) or resize handle. Measures cell size off the widget's
+	// OWN rendered tile rather than the grid container, so it stays correct
+	// regardless of viewport width. A plain click/tap (pointer released
+	// before moving past DRAG_THRESHOLD_PX) is left alone here - a press on
+	// the grip button specifically still falls through to its own onClick
+	// (handleAdvance) exactly as before; the tile itself has no click
+	// handler to fall through to, so a plain click anywhere else on it is
+	// simply a no-op, same as before the whole tile became draggable.
 	function startDrag(
-		event: ReactPointerEvent<HTMLButtonElement>,
+		event: ReactPointerEvent<HTMLElement>,
 		key: WidgetKey,
 		mode: "move" | "resize",
 	) {

--- a/scripts/smoke-test-783-dashboard-outlet-context.mjs
+++ b/scripts/smoke-test-783-dashboard-outlet-context.mjs
@@ -1,0 +1,79 @@
+// Smoke test for PR #783/#787: the pathless "dashboard" parent route added
+// to nest opportunities/members/settings under /app/:organizationId/dashboard/...
+// rendered a bare <Outlet /> with no `context` prop, which starts its own
+// outlet context instead of forwarding OrgAppLayout's
+// <Outlet context={{org, reloadOrg}}>. Every page nested under it got
+// undefined from useOutletContext<OrgAppContext>() and crashed on the first
+// destructure, caught by the app-wide ErrorBoundary ("Something went wrong").
+//
+// Verifies the dashboard and its nested opportunities/members/settings pages
+// all render real content instead of the ErrorBoundary fallback.
+//
+// No throwaway data is created (an existing org from seed data is used), so
+// there is nothing to clean up (see #630).
+// Run: node scripts/smoke-test-783-dashboard-outlet-context.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function assertNoErrorBoundary(page, label) {
+	const crashed = await page
+		.getByRole("heading", { name: "Something went wrong" })
+		.count();
+	if (crashed > 0) {
+		throw new Error(`${label}: ErrorBoundary fallback is showing (crash)`);
+	}
+	console.log(`OK  ${label}: no ErrorBoundary crash`);
+}
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.click("text=/sign in|anmelden/i");
+		await page.waitForURL(/\/realms\//, { timeout: 30000 });
+		await loginKeycloak(page, "olaf", "olaf123");
+
+		await page.waitForURL(`${BASE}/`, { timeout: 30000 });
+
+		const cta = page.getByRole("link", { name: "Organization overview" });
+		await cta.first().waitFor({ timeout: 25000 });
+		await cta.first().click();
+
+		await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
+		console.log("OK  Navigated to org dashboard");
+		await assertNoErrorBoundary(page, "Dashboard");
+
+		const createOpportunityBtn = page.getByRole("button", {
+			name: "Create opportunity",
+		});
+		await createOpportunityBtn.first().waitFor({ timeout: 15000 });
+		console.log("OK  Dashboard rendered real content (Create opportunity widget)");
+
+		const orgIdMatch = page.url().match(/\/app\/([^/]+)\/dashboard/);
+		if (!orgIdMatch) throw new Error("Could not extract organizationId from URL");
+		const orgId = orgIdMatch[1];
+
+		for (const tab of ["opportunities", "members", "settings"]) {
+			await page.goto(`${BASE}/app/${orgId}/dashboard/${tab}`, {
+				waitUntil: "networkidle",
+			});
+			await assertNoErrorBoundary(page, `dashboard/${tab}`);
+		}
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

**Part 1 - fixes the `visual-tests` failures on PR #783** (48/156 tests failing with the app-wide `ErrorBoundary` "Something went wrong" screen).

**Root cause 1 (the crash, `frontend/src/App.tsx`):** PR #783's route restructuring nested `opportunities`/`members`/`settings`/the dashboard index under a new pathless `dashboard` parent route in `App.tsx`, whose element was a bare `<Outlet />` with no `context` prop. React Router's `<Outlet>` always starts its own outlet context - it does not transparently forward an ancestor `<Outlet context={...}>`'s value - so every page nested under `/dashboard/...` got `undefined` from `useOutletContext<OrgAppContext>()` instead of `OrgAppLayout`'s `{org, reloadOrg}`, and crashed on the very first destructure. That crash is caught by the top-level `ErrorBoundary`, which is why it manifested as widespread, seemingly-unrelated test failures.

Fix: a small `OrgAppOutletRelay` component reads the outer outlet context and re-provides it to the inner `<Outlet context={context} />`.

**Root cause 2 (a leftover test gap):** `OrganizationDashboardNavLinkTests` still asserted the pre-#9 flat `/app/:organizationId/opportunities|members|settings` URLs, so `WaitForURLAsync`'s regexes could never match the now-nested paths.

**Part 2 - dashboard UX follow-up**, from direct feedback while reviewing the live fix on staging:

- Removed the standalone "Dashboard / Opportunities / Members / Settings" tab bar from the org app shell. Those pages stay reachable via the dashboard widgets' own links (Settings' member-count link, "View opportunities", etc.) and the burger menu's org submenu (all viewports).
- Repositioning a widget while editing no longer requires grabbing a small grip icon - the whole tile is now the press-and-drag-to-move surface. The resize handle stays a dedicated corner grab (a resize needs a specific corner); the grip button remains the keyboard-accessible entry point into the two-corner placement flow.
- Updated the VisualTests that depended on the removed tab bar to reach Members/Settings via the Settings widget's own link instead, and reworked the outlet-context regression test to key off the breadcrumb's current-page label rather than a tab link.

## Root cause verification (Part 1)

Reproduced locally without Docker/Aspire (not available in this sandbox) by running the Vite dev server directly and mocking the backend API responses to match the exact "Fairview Red Cross" seed-data shape used by the VisualTests suite:

```
TypeError: Cannot destructure property 'org' of 'useOutletContext(...)' as it is undefined.
    at OrgDashboardPage (index.tsx:279)
```

Also confirmed the original PR's CI failure was 100% deterministic, not flaky/contention-based: cut a diagnostic RC (`v1.0.0-rc.306`) from the unfixed branch and its `visual-tests` run failed with the *exact same* 48/156 test names as the original PR CI run (byte-for-byte identical list).

After the `App.tsx` fix, this PR's own `visual-tests` run dropped from 48 failures to exactly 1 (the `OrganizationDashboardNavLinkTests` URL-regex gap); after the second fix, 0 failures across two separate CI runs (156/156 passing, including a new regression test).

## Live verification (Part 1, before the Part 2 redesign)

Cut `v1.0.0-rc.307` from the Part 1 fix; `release-rc.yml` -> `publish.yml` (including a full re-run of `backend-visual-tests`, 156/156 passing) -> `deploy-staging` all succeeded. Ran `scripts/smoke-test-783-dashboard-outlet-context.mjs` against `https://einsatzbereit.maik-hasler.de`:

```
OK  API health check passed
OK  Navigated to org dashboard
OK  Dashboard: no ErrorBoundary crash
OK  Dashboard rendered real content (Create opportunity widget)
OK  dashboard/opportunities: no ErrorBoundary crash
OK  dashboard/members: no ErrorBoundary crash
OK  dashboard/settings: no ErrorBoundary crash

ALL CHECKS PASSED
```

Part 2 (tab bar removal, whole-tile drag) verified locally against a mocked backend (Docker/Aspire unavailable in this sandbox): no crash, tab bar absent, breadcrumb current-page label intact, widget tile carries the drag-surface styling, and the grip/resize/remove controls are all still present. Will re-verify on a fresh staging deploy once CI is green on this latest push.

## Test plan

- [x] `pnpm check`, `pnpm lint`, `pnpm build`, `pnpm format:check`, i18n key-parity check all pass
- [x] Backend `dotnet build` (VisualTests) passes
- [x] Local reproduction with mocked backend confirms both the crash fix and the redesign
- [x] CI `visual-tests` for Part 1: 48 -> 1 -> 0 failures (156/156 passing)
- [x] Release candidate (`v1.0.0-rc.307`) cut + live staging verification for Part 1
- [x] VisualTests C# regression assertion added for the outlet-context crash
- [ ] CI green for Part 2 (tab bar removal / whole-tile drag) - pending this push
- [ ] Fresh RC + live staging verification for Part 2
