### PR TITLE
fix: route apt through azure.archive.ubuntu.com instead of forcing IPv4

### DIFF
--- a/backend/src/Api/Dockerfile
+++ b/backend/src/Api/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+RUN printf 'Acquire::Retries "5";\nAcquire::ForceIPv4 "true";\nAcquire::http::Timeout "15";\n' > /etc/apt/apt.conf.d/99-retry-ipv4 && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends curl && \
+	rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080

--- a/backend/src/Api/Dockerfile
+++ b/backend/src/Api/Dockerfile
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-RUN printf 'Acquire::Retries "5";\nAcquire::ForceIPv4 "true";\nAcquire::http::Timeout "15";\n' > /etc/apt/apt.conf.d/99-retry-ipv4 && \
+# GitHub Actions runners live on Azure, where the generic archive.ubuntu.com /
+# security.ubuntu.com mirrors are known to be unreliable; route both pockets
+# through the Azure-optimized mirror instead (same one the runner host itself uses).
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources && \
+	printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retry && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends curl && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

CI's `publish.yml` -> `docker/build-push-action` was repeatedly failing to build the backend image at the `base` stage's `apt-get install curl` step, with connection timeouts to `security.ubuntu.com:80` on all resolved IPs while `archive.ubuntu.com` stayed (slowly) reachable at the same time - and it failed on every single rerun, not just occasionally.

`curl` itself can't be dropped from the base stage - `docker-compose.yml`'s backend healthcheck (`curl -sf http://localhost:8080/alive`) depends on it being present in the final image.

### First attempt (superseded) and why it was wrong

The first version of this fix forced IPv4 for apt (`Acquire::ForceIPv4`), based on an unverified hypothesis (apt/curl preferring an unreachable IPv6 route to the mirror, then timing out on IPv4 fallback). Re-analysis before merging showed this was very likely a no-op:
- Docker's default build-container network is IPv4-only unless explicitly configured otherwise - there is no IPv6 route to fall back *from* in the first place.
- The observed failure mode was a timeout, not the instant `ENETUNREACH` an unrouted IPv6 connection attempt would produce - the signature doesn't match an IPv6-fallback theory.
- The user reported the failure recurring on every rerun, which argues against a purely transient blip that retries alone would fix.

### Actual root cause and fix

`mcr.microsoft.com/dotnet/aspnet:10.0` is Ubuntu 24.04 "Noble" (confirmed via `dotnet/dotnet-docker`'s `runtime-deps` Dockerfile, which is `FROM ubuntu.azurecr.io/ubuntu:noble` with no apt source customization). GitHub Actions runners are Azure-hosted, and the generic `archive.ubuntu.com`/`security.ubuntu.com` mirrors are a documented, recurring source of flakiness from that network (`actions/runner-images` #675, #6486, #6894). GitHub's own runner hosts route around this by pointing apt at `azure.archive.ubuntu.com`, a single Azure-optimized mirror serving all pockets (main + security) - but that pre-configuration lives on the runner host, not inside a stock Ubuntu-based Docker image, which still ships the generic mirrors. That mismatch explains the exact asymmetry observed (archive reachable-but-slow, security dead).

Fix: rewrite the base image's apt sources (`/etc/apt/sources.list.d/ubuntu.sources`, Ubuntu 24.04's deb822 format) to route both pockets through `azure.archive.ubuntu.com`, plus a small `Acquire::Retries` as a hedge for the residual flakiness even that mirror occasionally has.

## Test plan

- [x] `git diff` reviewed - `backend/src/Api/Dockerfile` only
- [x] `/self-review` run twice (once per iteration) - no domain-specific subagents applicable (Dockerfile-only change); verified the sed regex doesn't double-substitute (GNU sed's global match scans past inserted replacement text) and added a one-line comment explaining the non-obvious Azure-mirror reasoning
- [ ] Docker build cannot be verified locally in this sandbox (no functioning `docker`) - verification is via a release-candidate build through `publish.yml`, see "Live verification" below once available

## Live verification

Pending - a release candidate will be cut after this PR's CI is green, to confirm `docker/build-push-action` actually builds the backend image successfully with this fix. Will update this section with the result.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XiZYs52tCYrgnxyZdYLNWs