### PR TITLE
fix: revert edge resize handles, make dashboard grid rows scale with column width

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -398,6 +398,52 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	}
 
 	[Test]
+	public async Task GridCellShape_StaysConsistentAcrossViewportWidths()
+	{
+		// #783 review feedback (comment #5049781309): "When I move it to a
+		// different sized monitor, everything becomes a weird size." The grid
+		// used a flat auto-rows-[64px] while column width already scaled with
+		// the viewport (grid-cols-8's 1fr tracks) - a widget's on-screen shape
+		// (row height relative to column width) would warp between a wide
+		// monitor and a narrower one even though its stored cell width/height
+		// never changed. Row height now tracks the actual rendered column
+		// width via a container query (.dashboard-widget-grid in global.css),
+		// so a grid cell's aspect ratio should barely move between two very
+		// differently-sized viewports, even though its absolute pixel size
+		// does.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(1400, 900);
+		await CreateOrganizationAsync("Visual DashViewportShape");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		var cell = Page.GetByTestId("dashboard-grid-guide-cell").First;
+		await Expect(cell).ToBeVisibleAsync();
+
+		var wideBox = await cell.BoundingBoxAsync();
+		wideBox.Should().NotBeNull();
+
+		await Page.SetViewportSizeAsync(1024, 900);
+		// The grid reflows on viewport change - re-fetch rather than reuse
+		// the same Locator's now-stale box.
+		var narrowBox = await Page.GetByTestId("dashboard-grid-guide-cell").First.BoundingBoxAsync();
+		narrowBox.Should().NotBeNull();
+
+		(wideBox!.Width - narrowBox!.Width).Should().BeGreaterThan(5,
+			"column width should actually shrink at the narrower viewport - otherwise this test isn't exercising anything");
+
+		var wideAspect = wideBox.Height / wideBox.Width;
+		var narrowAspect = narrowBox.Height / narrowBox.Width;
+		Math.Abs(wideAspect - narrowAspect).Should().BeLessThan(0.15,
+			"a grid cell's shape (row height relative to column width) should stay roughly the same across viewport "
+				+ "widths - a fixed row height would keep cells short-and-wide on a wide viewport and "
+				+ "square-ish on a narrow one, changing every widget's on-screen proportions between screens");
+	}
+
+	[Test]
 	public async Task RemovingAWidget_AutomaticallyClosesTheHorizontalGapNextToIt()
 	{
 		// #830 follow-up on the widget-placement UX: compaction used to only

--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -337,20 +337,24 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	}
 
 	[Test]
-	public async Task EdgeResizeHandles_ResizeOnlyTheirOwnAxis_AndPersistAcrossReload()
+	public async Task CornerResizeHandle_PointerDrag_ResizesBothAxesTogether_AndPersistsAcrossReload()
 	{
-		// #830 follow-up on the widget-placement UX: alongside the existing
-		// corner handle (which resizes both axes together), dedicated
-		// right-edge and bottom-edge handles let an organizer change just the
-		// width or just the height - a more familiar direct-manipulation
-		// pattern (like a spreadsheet column border) than only ever having a
-		// single corner dot for both dimensions at once.
+		// #830 briefly added dedicated right-edge/bottom-edge handles alongside
+		// this corner one, for single-axis resizing - reverted in the #783
+		// review round-trip: on top of the existing grip/corner-resize/remove
+		// trio, two more permanently-visible controls left too little bare
+		// tile surface to grab-and-drag on the smaller widget sizes, which the
+		// organizer read as "you added more buttons, I can't move anything
+		// else - it's just not working". The corner handle (both axes at once
+		// via a real pointer drag, distinct from the click-click-click/
+		// keyboard flow covered elsewhere in this file) is the only
+		// mouse-driven resize affordance again - this is its regression guard.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await CreateOrganizationAsync("Visual DashEdgeResize");
+		await CreateOrganizationAsync("Visual DashCornerResize");
 
 		await Page.GetByTestId("quick-action-edit").ClickAsync();
 		await RemoveAllWidgetsAsync();
@@ -368,34 +372,17 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 		var colPx = tileBox!.Width / 4;
 		var rowPx = tileBox.Height / 2;
 
-		// Drag the right-edge handle one column further right: width 4 -> 5,
-		// height must stay exactly 2.
-		var widthHandle = tile.GetByTestId("widget-resize-handle-width");
-		var widthHandleBox = await widthHandle.BoundingBoxAsync();
-		widthHandleBox.Should().NotBeNull();
-		var widthStartX = widthHandleBox!.X + widthHandleBox.Width / 2;
-		var widthStartY = widthHandleBox.Y + widthHandleBox.Height / 2;
+		// Drag the corner handle one column right and one row down: width
+		// 4 -> 5 and height 2 -> 3 together, from the same single drag.
+		var cornerHandle = tile.GetByTestId("widget-resize-handle-corner");
+		var cornerHandleBox = await cornerHandle.BoundingBoxAsync();
+		cornerHandleBox.Should().NotBeNull();
+		var startX = cornerHandleBox!.X + cornerHandleBox.Width / 2;
+		var startY = cornerHandleBox.Y + cornerHandleBox.Height / 2;
 
-		await Page.Mouse.MoveAsync(widthStartX, widthStartY);
+		await Page.Mouse.MoveAsync(startX, startY);
 		await Page.Mouse.DownAsync();
-		await Page.Mouse.MoveAsync(widthStartX + colPx, widthStartY, new() { Steps = 5 });
-		await Page.Mouse.UpAsync();
-
-		await AssertWidgetOccupiesCellsAsync("ToDo", x: 1, y: 1, width: 5, height: 2);
-
-		// Drag the bottom-edge handle one row further down: height 2 -> 3,
-		// width must stay exactly the 5 the previous step just set.
-		tileBox = await tile.BoundingBoxAsync();
-		tileBox.Should().NotBeNull();
-		var heightHandle = tile.GetByTestId("widget-resize-handle-height");
-		var heightHandleBox = await heightHandle.BoundingBoxAsync();
-		heightHandleBox.Should().NotBeNull();
-		var heightStartX = heightHandleBox!.X + heightHandleBox.Width / 2;
-		var heightStartY = heightHandleBox.Y + heightHandleBox.Height / 2;
-
-		await Page.Mouse.MoveAsync(heightStartX, heightStartY);
-		await Page.Mouse.DownAsync();
-		await Page.Mouse.MoveAsync(heightStartX, heightStartY + rowPx, new() { Steps = 5 });
+		await Page.Mouse.MoveAsync(startX + colPx, startY + rowPx, new() { Steps = 5 });
 		await Page.Mouse.UpAsync();
 
 		await AssertWidgetOccupiesCellsAsync("ToDo", x: 1, y: 1, width: 5, height: 3);

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -67,29 +67,21 @@ interface Props {
 	organizationId: string;
 	refreshKey: number;
 	size: WidgetSizeClass;
-	// The widget's own grid row span (its organizer-drawn height, #782), so
-	// the calendar's pixel height can track what was actually placed instead
-	// of a constant - see CALENDAR_ROW_PX/CALENDAR_GAP_PX below.
-	heightRows: number;
 }
 
-// Mirrors the dashboard grid's own row sizing (OrgDashboardPage's
-// `lg:auto-rows-[minmax(64px,auto)]` and `gap-4`) so a calendar spanning N
-// rows renders at roughly the pixel height those N rows actually occupy,
-// instead of a flat constant that's disconnected from the widget's real
-// footprint - which used to force the shared row band (every OTHER widget
-// in those same row indices, regardless of column) to grow to match
-// whatever the constant demanded, distorting them too (#15).
-const CALENDAR_ROW_PX = 64;
-const CALENDAR_GAP_PX = 16;
+// The dashboard grid's row height isn't a flat pixel constant (it tracks
+// the rendered column width, see .dashboard-widget-grid in global.css, so a
+// widget's on-screen shape stays consistent across screen sizes) - mirroring
+// that in a second, JS-side constant here would just be a new way for the
+// two to drift apart again. Filling 100% of the widget's own card area (see
+// WidgetCard) instead means the calendar always matches whatever height the
+// organizer's placement actually rendered at, on any screen, with no
+// separate row-to-pixel formula to keep in sync. MIN_HEIGHT is just a floor
+// so a very short placement doesn't squash the calendar unusably small -
+// WidgetCard's own overflow-y-auto handles the rest.
 const CALENDAR_MIN_HEIGHT_PX = 400;
 
-function CalendarWidget({
-	organizationId,
-	refreshKey,
-	size,
-	heightRows,
-}: Props) {
+function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 	const { t } = useTranslation();
 	const api = useApiClient();
 
@@ -169,7 +161,7 @@ function CalendarWidget({
 				</p>
 			)}
 			{!calLoading && !calError && (
-				<div className="rbc-container">
+				<div className="rbc-container h-full">
 					<Calendar
 						localizer={localizer}
 						events={calEvents}
@@ -178,13 +170,7 @@ function CalendarWidget({
 						date={calDate}
 						onNavigate={(d: Date) => setCalDate(d)}
 						views={["month", "week", "work_week", "day", "agenda"]}
-						style={{
-							height: Math.max(
-								CALENDAR_MIN_HEIGHT_PX,
-								heightRows * CALENDAR_ROW_PX +
-									(heightRows - 1) * CALENDAR_GAP_PX,
-							),
-						}}
+						style={{ height: "100%", minHeight: CALENDAR_MIN_HEIGHT_PX }}
 						components={{ event: CalEventChip }}
 						eventPropGetter={(event: object) => {
 							const e = event as CalEvent;

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -64,7 +64,7 @@ interface Cell {
 // handleAdvance).
 interface DragSession {
 	key: WidgetKey;
-	mode: "move" | "resize" | "resize-width" | "resize-height";
+	mode: "move" | "resize";
 	startClientX: number;
 	startClientY: number;
 	colPx: number;
@@ -164,8 +164,6 @@ function EditableWidgetTile({
 	onRemove,
 	onGripPointerDown,
 	onResizePointerDown,
-	onResizeWidthPointerDown,
-	onResizeHeightPointerDown,
 	children,
 }: {
 	widgetKey: WidgetKey;
@@ -186,12 +184,6 @@ function EditableWidgetTile({
 	onRemove: () => void;
 	onGripPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
 	onResizePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
-	// #830: dedicated edge handles alongside the corner one, so resizing just
-	// the width or just the height is a normal edge-drag (like a spreadsheet
-	// column or a window pane) instead of only being reachable by fighting a
-	// single small corner dot for both axes at once.
-	onResizeWidthPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
-	onResizeHeightPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
 	children: ReactNode;
 }) {
 	const { t } = useTranslation();
@@ -315,12 +307,23 @@ function EditableWidgetTile({
 						// 1x1 preview box at its own current top-left cell (see
 						// previewRect/normalizeRect(cursor, cursor, ...) below) until
 						// a first corner is picked - with the tile that small, this
-						// handle (and the two edge handles below) would otherwise sit
-						// almost exactly on top of the very backdrop cell the
-						// corner-to-corner flow needs the next click to land on.
-						// Resizing mid-placement isn't a meaningful action anyway.
+						// handle would otherwise sit almost exactly on top of the
+						// very backdrop cell the corner-to-corner flow needs the
+						// next click to land on. Resizing mid-placement isn't a
+						// meaningful action anyway.
+						//
+						// A dedicated right-edge (width-only) and bottom-edge
+						// (height-only) handle pair briefly existed alongside this
+						// one (#830) but got reverted (#783 review) - on top of the
+						// existing grip/corner-resize/remove trio, two more
+						// permanently-visible controls left too little bare tile
+						// surface to grab-and-drag on the smaller widget sizes,
+						// which the organizer's feedback described as "you added
+						// more buttons, I can't move anything else - it's just not
+						// working" rather than as an improvement.
 						<button
 							type="button"
+							data-testid="widget-resize-handle-corner"
 							tabIndex={-1}
 							aria-hidden="true"
 							onPointerDown={(e) => {
@@ -332,43 +335,6 @@ function EditableWidgetTile({
 						>
 							<ResizeHandleIcon />
 						</button>
-					)}
-					{showPlacementControls && !isPlacing && (
-						// Right-edge handle (#830): width-only resize, dragged
-						// horizontally like a spreadsheet column border - grabbing
-						// just an edge to change one dimension is a far more
-						// familiar direct-manipulation pattern than only ever
-						// having a single corner dot that changes both dimensions
-						// at once. Same stopPropagation/tab-order/hidden/hidden-
-						// while-placing reasoning as the corner handle above.
-						<button
-							type="button"
-							data-testid="widget-resize-handle-width"
-							tabIndex={-1}
-							aria-hidden="true"
-							onPointerDown={(e) => {
-								e.stopPropagation();
-								onResizeWidthPointerDown(e);
-							}}
-							disabled={placingDisabled}
-							className="pointer-events-auto absolute right-0 top-1/2 z-20 h-10 w-2.5 -translate-y-1/2 cursor-ew-resize touch-none rounded-full bg-gray-300/70 hover:bg-brand-400 disabled:cursor-not-allowed disabled:opacity-30"
-						/>
-					)}
-					{showPlacementControls && !isPlacing && (
-						// Bottom-edge handle (#830): height-only resize, the same
-						// idea as the right-edge handle but for the vertical axis.
-						<button
-							type="button"
-							data-testid="widget-resize-handle-height"
-							tabIndex={-1}
-							aria-hidden="true"
-							onPointerDown={(e) => {
-								e.stopPropagation();
-								onResizeHeightPointerDown(e);
-							}}
-							disabled={placingDisabled}
-							className="pointer-events-auto absolute bottom-0 left-1/2 z-20 h-2.5 w-10 -translate-x-1/2 cursor-ns-resize touch-none rounded-full bg-gray-300/70 hover:bg-brand-400 disabled:cursor-not-allowed disabled:opacity-30"
-						/>
 					)}
 					<button
 						type="button"
@@ -620,7 +586,7 @@ export default function OrgDashboardPage() {
 	function startDrag(
 		event: ReactPointerEvent<HTMLElement>,
 		key: WidgetKey,
-		mode: "move" | "resize" | "resize-width" | "resize-height",
+		mode: "move" | "resize",
 	) {
 		if (event.pointerType === "mouse" && event.button !== 0) return;
 		const widget = (draftLayout ?? []).find((w) => w.widgetKey === key);
@@ -666,11 +632,6 @@ export default function OrgDashboardPage() {
 			}
 			const deltaCol = Math.round(deltaX / session.colPx);
 			const deltaRow = Math.round(deltaY / session.rowPx);
-			// "resize" (the corner handle) changes both axes together; the two
-			// edge handles (#830) change only the one axis they sit on, so a
-			// widget can be widened/narrowed or shortened/heightened
-			// independently, without also nudging the axis the organizer didn't
-			// touch.
 			const nextRect: PlacedWidget =
 				session.mode === "move"
 					? {
@@ -678,21 +639,11 @@ export default function OrgDashboardPage() {
 							x: Math.max(1, session.origRect.x + deltaCol),
 							y: Math.max(1, session.origRect.y + deltaRow),
 						}
-					: session.mode === "resize-width"
-						? {
-								...session.origRect,
-								width: Math.max(1, session.origRect.width + deltaCol),
-							}
-						: session.mode === "resize-height"
-							? {
-									...session.origRect,
-									height: Math.max(1, session.origRect.height + deltaRow),
-								}
-							: {
-									...session.origRect,
-									width: Math.max(1, session.origRect.width + deltaCol),
-									height: Math.max(1, session.origRect.height + deltaRow),
-								};
+					: {
+							...session.origRect,
+							width: Math.max(1, session.origRect.width + deltaCol),
+							height: Math.max(1, session.origRect.height + deltaRow),
+						};
 			session.currentRect = nextRect;
 			setDragPreview(nextRect);
 		}
@@ -828,11 +779,7 @@ export default function OrgDashboardPage() {
 		});
 	}
 
-	function renderWidget(
-		key: WidgetKey,
-		size: WidgetSizeClass,
-		heightRows: number,
-	) {
+	function renderWidget(key: WidgetKey, size: WidgetSizeClass) {
 		switch (key) {
 			case "ToDo":
 				return <ToDoWidget organizationId={organizationId} size={size} />;
@@ -850,7 +797,6 @@ export default function OrgDashboardPage() {
 						organizationId={organizationId}
 						refreshKey={refreshKey}
 						size={size}
-						heightRows={heightRows}
 					/>
 				);
 			case "Settings":
@@ -932,15 +878,25 @@ export default function OrgDashboardPage() {
 	) : (
 		<div
 			data-testid="dashboard-widget-grid"
-			// Fixed row height, not minmax(64px, auto): CSS Grid auto-rows apply
-			// to the whole row band across every column, not just the cell whose
-			// content demanded the extra height - so a single tall widget used to
-			// stretch its ENTIRE row, including the plain green backdrop guide
-			// cells and any other widget sharing that row, making edit mode look
-			// like an inconsistent, randomly-sized grid instead of the uniform
-			// one it's meant to convey. A widget whose content exceeds its
-			// allotted rows now scrolls internally instead (see WidgetCard).
-			className="grid grid-cols-1 gap-4 lg:grid-cols-8 lg:auto-rows-[64px]"
+			// Uniform (not minmax(64px, auto)) row height: CSS Grid auto-rows
+			// apply to the whole row band across every column, not just the cell
+			// whose content demanded the extra height - so a single tall widget
+			// used to stretch its ENTIRE row, including the plain green backdrop
+			// guide cells and any other widget sharing that row, making edit mode
+			// look like an inconsistent, randomly-sized grid instead of the
+			// uniform one it's meant to convey. A widget whose content exceeds
+			// its allotted rows scrolls internally instead (see WidgetCard).
+			//
+			// The row height itself (see .dashboard-widget-grid in global.css)
+			// tracks the actual rendered column width via a container query,
+			// rather than a flat pixel constant - width already scales with the
+			// viewport (grid-cols-8's 1fr tracks), so a fixed row height meant a
+			// widget's on-screen shape (short-and-wide vs. tall-and-narrow)
+			// warped between a wide monitor and a narrower one even though its
+			// stored cell width/height never changed. Matching the two keeps
+			// every cell roughly square, and a widget's proportions consistent,
+			// on any screen the organizer views it on.
+			className="dashboard-widget-grid grid grid-cols-1 gap-4 lg:grid-cols-8"
 		>
 			{/* Light green cell backdrop behind the whole grid while editing, so
 			an organizer can see the underlying 8-column structure. These cells
@@ -1016,14 +972,8 @@ export default function OrgDashboardPage() {
 						onResizePointerDown={(e) =>
 							startDrag(e, widget.widgetKey, "resize")
 						}
-						onResizeWidthPointerDown={(e) =>
-							startDrag(e, widget.widgetKey, "resize-width")
-						}
-						onResizeHeightPointerDown={(e) =>
-							startDrag(e, widget.widgetKey, "resize-height")
-						}
 					>
-						{renderWidget(widget.widgetKey, sizeClass, rect.height)}
+						{renderWidget(widget.widgetKey, sizeClass)}
 					</EditableWidgetTile>
 				);
 			})}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -332,6 +332,28 @@ input[type="number"]::-webkit-outer-spin-button {
 	}
 }
 
+/* ── Dashboard widget grid: row height tracks column width ───────────────
+ * A widget's stored width/height (OrgDashboardPage/widgetCatalog.ts) are
+ * grid-cell counts meant to describe one consistent on-screen shape -
+ * that only holds if a cell is the same shape on every screen. grid-cols-8
+ * already makes column width a fraction of the container (so it scales
+ * with the viewport); rows need the same treatment, or a widget's
+ * proportions warp between a wide monitor and a narrower one even though
+ * its cell counts never changed. Container query units key off this
+ * element's own measured width rather than the viewport, matching exactly
+ * what a column's 1fr track resolves to (100cqw minus the 7 inter-column
+ * gaps, split across 8 columns). Floored at 64px so rows stay usable on
+ * the narrowest qualifying (`lg`, 1024px) viewport. */
+.dashboard-widget-grid {
+	container-type: inline-size;
+}
+
+@media (min-width: 1024px) {
+	.dashboard-widget-grid {
+		grid-auto-rows: max(64px, calc((100cqw - 7rem) / 8));
+	}
+}
+
 @theme {
 	--color-brand-50: #f0faf5;
 	--color-brand-100: #d6f0e3;

--- a/scripts/smoke-test-798-dashboard-widget-roundtrip.mjs
+++ b/scripts/smoke-test-798-dashboard-widget-roundtrip.mjs
@@ -1,0 +1,149 @@
+// Smoke test for PR #798, a follow-up round-trip on #783's review feedback
+// (https://github.com/maik-hasler/einsatzbereit/pull/783#issuecomment-5049781309):
+// "You added more buttons, I can't move anything else - basically its just
+// not working at all anymore. When I move it to a different sized monitor,
+// everything becomes a weird size."
+//
+// Verifies:
+//  1. The dedicated width-only/height-only edge resize handles added in
+//     918119c are gone - only the corner handle remains, alongside the
+//     grip (move) and remove buttons.
+//  2. Whole-tile drag-to-move still works (regression guard - #798 touched
+//     the same pointer-drag code path the edge handles used to share).
+//  3. A widget tile's on-screen shape (row height relative to column width)
+//     stays consistent across two different viewport widths, instead of
+//     row height staying frozen at a flat pixel value while column width
+//     scales with the viewport - the actual "weird size on a different
+//     monitor" bug.
+//
+// No throwaway data is created (an existing org from seed data is used), so
+// there is nothing to clean up (see #630).
+// Run: node scripts/smoke-test-798-dashboard-widget-roundtrip.mjs
+
+import { launchLiveBrowser, loginKeycloak } from "./lib/live-browser.mjs";
+
+const BASE = "https://einsatzbereit.maik-hasler.de";
+const API = "https://api.maik-hasler.de";
+
+async function main() {
+	const healthRes = await fetch(`${API}/health`);
+	if (!healthRes.ok) throw new Error(`Health check failed: ${healthRes.status}`);
+	console.log("OK  API health check passed");
+
+	const { browser, page } = await launchLiveBrowser();
+	try {
+		await page.setViewportSize({ width: 1400, height: 900 });
+		await page.goto(BASE, { waitUntil: "networkidle" });
+		await page.click("text=/sign in|anmelden/i");
+		await page.waitForURL(/\/realms\//, { timeout: 30000 });
+		await loginKeycloak(page, "olaf", "olaf123");
+		await page.waitForURL(`${BASE}/`, { timeout: 30000 });
+
+		const cta = page.getByRole("link", { name: "Organization overview" });
+		await cta.first().waitFor({ timeout: 25000 });
+		await cta.first().click();
+		await page.waitForURL(/\/app\/[^/]+\/dashboard/, { timeout: 15000 });
+		console.log("OK  Navigated to org dashboard");
+
+		const crashed = await page
+			.getByRole("heading", { name: "Something went wrong" })
+			.count();
+		if (crashed > 0) throw new Error("Dashboard shows the ErrorBoundary fallback");
+		console.log("OK  No ErrorBoundary crash");
+
+		await page.getByTestId("quick-action-edit").click();
+		await page.waitForSelector('[data-testid="quick-action-save"]', {
+			timeout: 10000,
+		});
+		console.log("OK  Entered edit mode");
+
+		// 1. Fewer buttons: the two edge-only resize handles must be gone, the
+		// corner handle must still be there.
+		const widthHandles = await page.getByTestId("widget-resize-handle-width").count();
+		const heightHandles = await page.getByTestId("widget-resize-handle-height").count();
+		if (widthHandles > 0 || heightHandles > 0) {
+			throw new Error(
+				`Edge resize handles still present (width=${widthHandles}, height=${heightHandles})`,
+			);
+		}
+		const cornerHandles = await page.getByTestId("widget-resize-handle-corner").count();
+		if (cornerHandles < 1) throw new Error("Corner resize handle is missing");
+		console.log(
+			`OK  Edge resize handles removed, corner handle present (${cornerHandles} tiles)`,
+		);
+
+		// 2. Whole-tile drag still moves a widget (regression guard).
+		const tile = page.getByTestId("widget-tile-CreateOpportunity");
+		await tile.waitFor({ timeout: 10000 });
+		const gridColBefore = await tile.evaluate((el) => getComputedStyle(el).gridColumnStart);
+		let box = await tile.boundingBox();
+		if (!box) throw new Error("Could not measure CreateOpportunity tile");
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.down();
+		await page.mouse.move(box.x + box.width / 2 + 220, box.y + box.height / 2 + 5, {
+			steps: 8,
+		});
+		await page.mouse.up();
+		await page.waitForTimeout(300);
+		const gridColAfter = await tile.evaluate((el) => getComputedStyle(el).gridColumnStart);
+		if (gridColBefore === gridColAfter) {
+			throw new Error(
+				`Whole-tile drag did not move the widget (gridColumnStart stayed ${gridColBefore})`,
+			);
+		}
+		console.log(
+			`OK  Whole-tile drag moved CreateOpportunity (gridColumnStart ${gridColBefore} -> ${gridColAfter})`,
+		);
+		await page.getByTestId("quick-action-cancel").click();
+		await page.waitForSelector('[data-testid="quick-action-edit"]', { timeout: 10000 });
+		await page.getByTestId("quick-action-edit").click();
+		await page.waitForSelector('[data-testid="quick-action-save"]', { timeout: 10000 });
+
+		// 3. Grid cell shape stays consistent across viewport widths - the
+		// "different sized monitor" regression. Settings is full-width
+		// (x=1, width=8) in DEFAULT_LAYOUT, so its tile's per-column width is
+		// simple to derive from its own bounding box at any viewport.
+		const settingsTile = page.getByTestId("widget-tile-Settings");
+		await settingsTile.waitFor({ timeout: 10000 });
+
+		async function perCellShape() {
+			const b = await settingsTile.boundingBox();
+			if (!b) throw new Error("Could not measure Settings tile");
+			// DEFAULT_LAYOUT: Settings is width=8, height=2 (widgetCatalog.ts).
+			return { w: b.width / 8, h: b.height / 2 };
+		}
+
+		const wide = await perCellShape();
+		await page.setViewportSize({ width: 1024, height: 900 });
+		await page.waitForTimeout(300);
+		const narrow = await perCellShape();
+
+		if (Math.abs(wide.w - narrow.w) < 5) {
+			throw new Error(
+				"Column width did not actually change between viewports - test setup is not meaningful",
+			);
+		}
+		const widthRatio = narrow.w / wide.w;
+		const heightRatio = narrow.h / wide.h;
+		const drift = Math.abs(widthRatio - heightRatio);
+		if (drift > 0.15) {
+			throw new Error(
+				`Row height is not tracking column width across viewports (width scaled by ${widthRatio.toFixed(2)}x, height by ${heightRatio.toFixed(2)}x) - a widget's shape would look different on a different monitor`,
+			);
+		}
+		console.log(
+			`OK  Grid cell shape stays consistent across viewport widths (width x${widthRatio.toFixed(2)}, height x${heightRatio.toFixed(2)})`,
+		);
+
+		await page.getByTestId("quick-action-cancel").click().catch(() => {});
+
+		console.log("\nALL CHECKS PASSED");
+	} finally {
+		await browser.close();
+	}
+}
+
+main().catch((err) => {
+	console.error("FAIL", err.message);
+	process.exit(1);
+});


### PR DESCRIPTION
Follow-up on #783, implementing review feedback from [#783 (comment)](https://github.com/maik-hasler/einsatzbereit/pull/783#issuecomment-5049781309):

> You resolved the first two issues, but the widget dashboard became even weirder. You added more buttons, I can't move anything else - basically its just not working at all anymore. When I move it to a different sized monitor, everything becomes a weird size. Please make a new roundtrip

## Root causes

**"You added more buttons, I can't move anything else"** - `918119c` added dedicated right-edge (width-only) and bottom-edge (height-only) resize handles alongside the existing corner handle. On top of the pre-existing grip (move) + corner-resize + remove trio, that's 5 permanently-visible absolutely-positioned controls crowded onto every tile. On the smaller widget sizes there was barely any bare tile surface left to press-and-drag from - the very thing the "whole tile is the drag surface" fix (from the original #787 follow-up) was supposed to provide. Reverted: back to grip + single corner-resize (both axes) + remove.

**"Moved to a different sized monitor, everything becomes a weird size"** - the grid's column width already scales with the viewport (`grid-cols-8`'s `1fr` tracks), but row height was a flat `auto-rows-[64px]`. A widget's on-screen shape (its width:height ratio) therefore changed between a wide monitor and a narrower one even though its stored cell width/height never changed - short-and-wide on one screen, tall-and-narrow on another. Fixed by having row height track the actual rendered column width via a CSS container query (`.dashboard-widget-grid` in `global.css`), so a grid cell stays roughly square on any screen.

As a consequence, `CalendarWidget` also had its own JS-side `heightRows * 64 + ...` formula mirroring the grid's old fixed row height - a second, independent source of truth for "pixels per row" that would have silently drifted out of sync with the new dynamic row height. Replaced with the calendar simply filling 100% of its `WidgetCard` content area (with a `min-height` floor), so it always matches whatever height the organizer's placement actually renders at, on any screen, with nothing left to keep in sync by hand.

## Changes

- `frontend/src/pages/app/OrgDashboardPage/index.tsx` - removed the two edge-only resize handles/handlers/drag modes; grid container now uses the new `dashboard-widget-grid` CSS class instead of a hardcoded `auto-rows-[64px]`.
- `frontend/src/styles/global.css` - new `.dashboard-widget-grid` rule: `container-type: inline-size` + a `grid-auto-rows` calc keyed off `100cqw`, floored at 64px, gated to the `lg` (1024px) breakpoint where the grid is active.
- `frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx` - dropped the `heightRows`/`CALENDAR_ROW_PX`/`CALENDAR_GAP_PX` calculation in favor of `height: 100%` + a `min-height` floor.
- `backend/tests/VisualTests/OrgDashboardCustomizeTests.cs` - replaced the now-invalid `EdgeResizeHandles_...` test with `CornerResizeHandle_PointerDrag_ResizesBothAxesTogether_AndPersistsAcrossReload`, keeping mouse-drag resize covered now that the corner handle is the only such control (also gave it a `data-testid` for the first time, since it previously had none).

## Self-review

Ran `/self-review`: `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` all pass. Grepped for every removed identifier across frontend and backend to confirm no stale references remain. Checked other VisualTests (widget/a11y/mobile) for hidden coupling to the removed controls or the old pixel constants - none found.

## Live verification

**Blocked in this sandboxed session**: the SessionStart hook's `dotnet-install.sh` could not reach `builds.dotnet.microsoft.com` (this session's egress proxy returned a 403 policy denial for that host - see `/root/.ccr/README.md`'s guidance not to retry policy denials), so `dotnet build`/`dotnet test`/the RC-cut-and-Playwright-smoke-test flow mandated by `AGENTS.md` could not be run locally. Frontend-side verification (`tsc`, `eslint`, `prettier`) passed. This PR still needs the RC cut + live-staging Playwright smoke test once CI can build it - flagging this explicitly rather than claiming a live-verified fix I could not actually run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2nsQLmnoaboUXhshW1ASS)_