### PR TITLE
fix: accepting an org invitation now grants real Organizer capability

### DIFF
--- a/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
+++ b/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
@@ -2,6 +2,7 @@ using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Domain.Organizations;
 using Domain.Primitives;
 
 namespace Application.Invitations.AcceptInvitation.v1;
@@ -24,10 +25,29 @@ internal sealed class AcceptInvitationCommandHandler(
 
 		invitation.Accept().ThrowIfFailure();
 
+		// Accepting grants full Organizer capability, the only membership tier
+		// this app currently gives any real access - matching how
+		// CreateOrganizationCommandHandler seats the org's creator. Without this,
+		// an accepted invitee is a Keycloak org member with no local
+		// OrganizationMembership row and no "organisator" realm role, so every
+		// org-scoped endpoint (all gated by that role and/or a per-org Organizer
+		// check) stays unreachable for them and they never appear in their own
+		// org switcher - accepting would grant no functional capability at all.
 		await keycloakOrganizationService.AddMemberAsync(
 			invitation.OrganizationId.Value,
 			invitation.InviteeId.Value,
 			cancellationToken);
+
+		await keycloakOrganizationService.AssignOrganizerRoleAsync(
+			invitation.InviteeId.Value,
+			cancellationToken);
+
+		var membership = OrganizationMembership.Create(
+			invitation.OrganizationId,
+			invitation.InviteeId,
+			OrganizationMemberRole.Organizer);
+
+		await dbContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
@@ -56,7 +56,7 @@ public class AcceptInvitationCommandHandlerTests
 		await _keycloakService.Received(1).AssignOrganizerRoleAsync(InviteeId.Value, cancellationToken);
 		await _membershipRepo.Received(1).AddAsync(
 			Arg.Is<OrganizationMembership>(m =>
-				m.OrganizationId == OrgId && m.UserId == InviteeId && m.Role == OrganizationMemberRole.Organizer),
+				m != null && m.OrganizationId == OrgId && m.UserId == InviteeId && m.Role == OrganizationMemberRole.Organizer),
 			cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
@@ -1,0 +1,118 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Invitations.AcceptInvitation.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Invitations.AcceptInvitation;
+
+public class AcceptInvitationCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
+		Substitute.For<IAggregateRepository<OrganizationInvitation, OrganizationInvitationId>>();
+	private readonly IAggregateRepository<OrganizationMembership, OrganizationMembershipId> _membershipRepo =
+		Substitute.For<IAggregateRepository<OrganizationMembership, OrganizationMembershipId>>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly AcceptInvitationCommandHandler _sut;
+
+	private static readonly OrganizationId OrgId = OrganizationId.Create(Guid.NewGuid()).GetValueOrThrow();
+	private static readonly UserId InviteeId = UserId.New();
+	private static readonly UserId InviterId = UserId.New();
+
+	public AcceptInvitationCommandHandlerTests()
+	{
+		_dbContext.OrganizationInvitations.Returns(_invitationRepo);
+		_dbContext.OrganizationMemberships.Returns(_membershipRepo);
+		_sut = new AcceptInvitationCommandHandler(_dbContext, _unitOfWork, _keycloakService);
+	}
+
+	private static OrganizationInvitation CreatePendingInvitation() =>
+		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId);
+
+	[Test]
+	public async Task Handle_ShouldGrantOrganizerCapability_OnAccept(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new AcceptInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert - accepting must grant real, functional capability, not just
+		// Keycloak org membership with nothing behind it (#826): the invitee
+		// becomes a full Organizer, the only membership tier this app
+		// currently gives any real access.
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).AddMemberAsync(OrgId.Value, InviteeId.Value, cancellationToken);
+		await _keycloakService.Received(1).AssignOrganizerRoleAsync(InviteeId.Value, cancellationToken);
+		await _membershipRepo.Received(1).AddAsync(
+			Arg.Is<OrganizationMembership>(m =>
+				m.OrganizationId == OrgId && m.UserId == InviteeId && m.Role == OrganizationMemberRole.Organizer),
+			cancellationToken);
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenInvitationNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitationId = OrganizationInvitationId.New();
+		_invitationRepo.FindAsync(invitationId, cancellationToken).Returns((OrganizationInvitation?)null);
+		var command = new AcceptInvitationCommand(invitationId, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>();
+		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var someoneElse = UserId.New();
+		var command = new AcceptInvitationCommand(invitation.Id, someoneElse);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>();
+		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenInvitationIsNotPending(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		invitation.Accept().ThrowIfFailure();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new AcceptInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>();
+		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -273,6 +273,34 @@ public class OrganizationSettingsTests(
 	}
 
 	[Test]
+	public async Task AcceptInvitation_ShouldGrantOrganizerCapability_NotJustKeycloakMembership(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #826: accepting an invitation used to only add the
+		// user to Keycloak's org group, never to the local organization_membership
+		// table - so the org never showed up in the invitee's own organization
+		// list, and every org-scoped endpoint (all gated by a per-org Organizer
+		// check) stayed a 403 for them. Accepting now grants full Organizer
+		// capability, so both must work immediately afterwards.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Accept Grants Capability Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var veraOrganizations = await veraClient.GetOrganizationsAsync(cancellationToken);
+		veraOrganizations.Should().Contain(o => o.Id == org.Id.Value);
+
+		var details = await veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		details.Members.Should().Contain(m => m.UserId == vera.Id && m.IsOrganisator);
+	}
+
+	[Test]
 	public async Task GetOrgInvitations_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -195,6 +195,7 @@ public class OrganizationSettingsTests(
 		// Regression for #691: being an organizer of one org (which grants the
 		// platform-wide Keycloak "organisator" role) must not grant authority
 		// over a different org the same user is merely a plain member of.
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
@@ -203,16 +204,17 @@ public class OrganizationSettingsTests(
 		// the platform-wide "organisator" role.
 		await veraClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Vera's Own Org 4" }, cancellationToken);
+		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 
 		var org = await olafClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Escalation Test Org" }, cancellationToken);
 
-		// olaf invites vera to his org as a plain member; she accepts but is
-		// never promoted to organizer of this specific org.
-		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
-		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
-		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+		// olaf's org gains vera as a plain member via the admin-only AddMember
+		// path - never promoted to Organizer of this specific org. (Accepting
+		// an invitation now also grants Organizer capability on the invited
+		// org - #826 - so that flow no longer produces a plain-member-only
+		// state and can't be used to set this scenario up anymore.)
+		await adminClient.AddMemberAsync(org.Id.Value, new AddMemberRequest { UserId = vera.Id }, cancellationToken);
 
 		var act = () => veraClient.UpdateOrganizationAsync(
 			org.Id.Value,
@@ -296,6 +298,12 @@ public class OrganizationSettingsTests(
 		var veraOrganizations = await veraClient.GetOrganizationsAsync(cancellationToken);
 		veraOrganizations.Should().Contain(o => o.Id == org.Id.Value);
 
+		// GetOrganizationDetails is gated by the Organisator policy, a role
+		// claim baked into the JWT at mint time - vera's original token
+		// predates the "organisator" role grant that just happened as a side
+		// effect of accepting, so a fresh token is needed here (same pattern
+		// as the #691 escalation test below).
+		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var details = await veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
 		details.Members.Should().Contain(m => m.UserId == vera.Id && m.IsOrganisator);
 	}
@@ -391,10 +399,14 @@ public class OrganizationSettingsTests(
 		CancellationToken cancellationToken)
 	{
 		// Regression for #825: the org has *two* members overall, but only one
-		// Organizer (accepting an invitation does not grant the Organizer role -
-		// see #826). The old guard only blocked removal when the org had exactly
-		// one member in total, so the organizer here could leave and permanently
-		// orphan the org, since no path exists to promote the remaining member.
+		// Organizer. The old guard only blocked removal when the org had
+		// exactly one member in total, so the organizer here could leave and
+		// permanently orphan the org, since no path exists to promote the
+		// remaining member. (Accepting an invitation now also grants
+		// Organizer capability - #826 - so that flow no longer produces a
+		// plain-member-only state; the admin-only AddMember path is used
+		// here instead to reconstruct it.)
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
@@ -403,9 +415,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Sole Organizer Test Org" }, cancellationToken);
 		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
 
-		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
-		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+		await adminClient.AddMemberAsync(org.Id.Value, new AddMemberRequest { UserId = vera.Id }, cancellationToken);
 
 		var act = () => olafClient.RemoveMemberAsync(org.Id.Value, olaf.Id, cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes #826 - a High-severity finding from the repository audit, and the natural follow-on to #825 (merged): both stem from the org membership model only ever granting the Organizer role once, at org creation.

`AcceptInvitationCommandHandler` only called `keycloakOrganizationService.AddMemberAsync(...)`, which adds the user to Keycloak's org group - it never wrote to the local `organization_membership` table. Every authorization check (`OwnershipGuard.EnsureIsOrganizerAsync`, `GetOrganizerOrganizationsAsync`) and every org-scoped endpoint's outer policy reads from that table / the "organisator" Keycloak realm role, neither of which the accepted invitee ever got. So accepting an invitation:
- never made the org appear in the invitee's own organization list
- never let them open any org page (dashboard, opportunities, members, settings - all gated by a per-org Organizer check)
- left them showing up in the members list only as a removable entry

**Fix:** `AcceptInvitationCommandHandler` now mirrors exactly what `CreateOrganizationCommandHandler` already does when seating an org's creator - assign the Keycloak `organisator` realm role and create a local `OrganizationMembership` row with the `Organizer` role. Organizer is the only membership tier this app currently gives any real access to (the `Member` enum value exists in `OrganizationMemberRole` but has no wired-up authorization path anywhere in the codebase today - building that out is a materially larger, more subjective scope than this fix and was left alone).

No frontend changes needed: the org switcher, members list ("Organizer" badge), and page-level authorization already handle Organizer members correctly - the bug was entirely that acceptance never actually granted the role.

**Side effect worth noting for reviewers:** this changes what "accepting an invitation" produces, which broke two pre-existing integration tests that had baked the old (broken) behavior in as their setup - a plain member who wasn't promoted to Organizer, produced via invite+accept. Both were updated to reconstruct that state through the admin-only `AddMember` endpoint instead (the only remaining way to add a member without granting Organizer), preserving what they actually test (see the third commit).

## Test plan

- [x] `Application.UnitTests`: new `AcceptInvitationCommandHandlerTests` (this handler had zero coverage before, per the audit's separate test-gap finding) - covers the grant-on-accept path, invitation-not-found, wrong-recipient, and not-pending branches
- [x] `IntegrationTests`: added `AcceptInvitation_ShouldGrantOrganizerCapability_NotJustKeycloakMembership` - creates a real invitation, accepts it, and asserts the invitee's own `GetOrganizations` now includes the org and `GetOrganizationDetails` (previously a 403 for them) succeeds and lists them as an organizer; updated the `#691` escalation test and the `#825` sole-organizer regression test to use the admin `AddMember` endpoint for their plain-member setup, since accept-invitation no longer produces that state
- [x] `/self-review` - dispatched `architecture-check`, clean (no layering violations; no endpoint/DTO changes so `nswag-check`/`i18n-check`/`a11y-check` don't apply, no schema change so no migration needed)
- [x] CI green on this PR (all 7 checks, after two follow-up fixes: a nullable-reference compile error in my new unit test, and the two pre-existing integration tests above)
- [x] Live verification on staging

## Live verification

Cut `v1.0.0-rc.318` and deployed to staging per this repo's mandatory workflow. All `publish.yml` jobs succeeded (backend/frontend/keycloak images, fast/integration/visual test suites), and `Deploy to Staging`'s own post-deploy health gate against `https://api.maik-hasler.de/health` passed (confirmed from GitHub's runner).

**Could not complete a hands-on Playwright pass against the live site from this session**, same as #882: this sandbox's egress policy denies `api.maik-hasler.de`/`einsatzbereit.maik-hasler.de` (reconfirmed with a single `curl` attempt just now - `403` at the proxy, a policy denial, not retried per this environment's guidance).

What I can attest to instead:
- The deploy itself is confirmed healthy (GitHub's own health gate, above).
- The actual regression this PR fixes is validated end-to-end against a real backend (Testcontainers Postgres + Keycloak) by the `IntegrationTests` case listed above, which passed in CI - it accepts a real invitation and then calls the two previously-403 endpoints as the invitee.

If you'd like a full hands-on staging pass, either grant this session network access to `maik-hasler.de`, or I'm happy to walk through manual verification steps for you to run.