### PR TITLE
fix: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# https://git-scm.com/docs/gitattributes
+#
+# Normalize line endings to LF everywhere, matching .editorconfig's
+# `end_of_line = lf` root rule. This keeps Windows checkouts (autocrlf)
+# from showing the whole repo as modified due to CRLF/LF churn.
+
+* text=auto eol=lf
+
+# Explicit for extensions that use tab indentation per .editorconfig
+# (kept explicit so they're never mistaken for binary by the `text=auto`
+# heuristic).
+*.sh text eol=lf
+*.adoc text eol=lf
+*.puml text eol=lf
+
+# Binary assets - never text-normalize, never diff as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pfx binary
+*.dll binary
+*.exe binary
+*.zip binary
+*.pdf binary
+
+# SVGs are XML text, but treat as text explicitly since some are used as
+# binary-ish assets (logos, icons) and shouldn't have EOL rewritten.
+*.svg text eol=lf


### PR DESCRIPTION
Windows checkouts showed ~90 files as modified purely from CRLF/LF churn (autocrlf rewriting LF blobs to CRLF on checkout), with no actual content changes. Normalize everything to LF to match .editorconfig's end_of_line=lf, mark known binary assets as binary, and keep text=auto for anything else.

Fixes #835