### PR TITLE
fix: inject MinIO root credentials via env vars in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 # deploy-staging job (publish.yml) from GitHub Environment secrets and copied
 # to the host on each RC deploy - you do not place this file by hand.
 # Required secrets in the `staging` GitHub Environment:
-#   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD
+#   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD,
+#   MINIO_ROOT_USER, MINIO_ROOT_PASSWORD
 # (Plus deploy creds: STAGING_SSH_KEY/HOST/USER, GHCR_USERNAME, GHCR_TOKEN.)
 #
 # Traefik runs as a separate host-level container (shared across projects on
@@ -16,3 +17,7 @@ POSTGRES_PASSWORD=change-me
 # Keycloak bootstrap admin (master realm).
 KEYCLOAK_ADMIN_USER=admin
 KEYCLOAK_ADMIN_PASSWORD=change-me
+
+# MinIO root credentials. Used by MinIO and the backend's Storage__AccessKey/SecretKey.
+MINIO_ROOT_USER=change-me
+MINIO_ROOT_PASSWORD=change-me

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -337,6 +337,8 @@ jobs:
           # Backend Keycloak client secret. Matches the static value defined in
           # keycloak/realms/einsatzbereit-realm.json ("secret": "backend-secret").
           KEYCLOAK_BACKEND_SECRET: backend-secret
+          MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+          MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
         run: |
           umask 077
           # Wrap each value in double quotes and escape \ and " so secrets that
@@ -354,6 +356,8 @@ jobs:
             printf 'KEYCLOAK_ADMIN_USER="%s"\n' "$(escape "$KEYCLOAK_ADMIN_USER")"
             printf 'KEYCLOAK_ADMIN_PASSWORD="%s"\n' "$(escape "$KEYCLOAK_ADMIN_PASSWORD")"
             printf 'KEYCLOAK_BACKEND_SECRET="%s"\n' "$(escape "$KEYCLOAK_BACKEND_SECRET")"
+            printf 'MINIO_ROOT_USER="%s"\n' "$(escape "$MINIO_ROOT_USER")"
+            printf 'MINIO_ROOT_PASSWORD="%s"\n' "$(escape "$MINIO_ROOT_PASSWORD")"
           } > .env
 
       - name: Copy compose file and .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,8 +116,8 @@ services:
           memory: 512m
           cpus: "0.50"
     environment:
-      MINIO_ROOT_USER: einsatzbereit-minio
-      MINIO_ROOT_PASSWORD: einsatzbereit-minio-secret
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
     volumes:
       - minio_data:/data
     healthcheck:
@@ -174,8 +174,8 @@ services:
       Keycloak__ClientSecret: ${KEYCLOAK_BACKEND_SECRET:?set KEYCLOAK_BACKEND_SECRET in .env}
       Cors__Origins__0: https://einsatzbereit.maik-hasler.de
       Storage__Endpoint: http://minio:9000
-      Storage__AccessKey: einsatzbereit-minio
-      Storage__SecretKey: einsatzbereit-minio-secret
+      Storage__AccessKey: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      Storage__SecretKey: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
       Storage__BucketName: einsatzbereit
       Storage__PublicEndpoint: https://storage.maik-hasler.de
     labels:


### PR DESCRIPTION
Production MinIO credentials were hardcoded in docker-compose.yml (root user/password and the backend's Storage__AccessKey/SecretKey), exposing root access to the internet-facing object store to anyone reading the public repo. Switch to the same required-env-var pattern already used for Postgres/Keycloak secrets.

Fixes #824