### PR TITLE
fix: close PIN check-in oracle and add per-engagement lockout

### DIFF
--- a/backend/src/Api/Engagements/CheckInWithPin/v1/CheckInWithPinEndpoint.cs
+++ b/backend/src/Api/Engagements/CheckInWithPin/v1/CheckInWithPinEndpoint.cs
@@ -22,6 +22,7 @@ internal sealed class CheckInWithPinEndpoint
 			.Produces<EngagementStatusResponse>()
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4017,6 +4017,16 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {

--- a/backend/src/Application/Common/RateLimiting/ICheckInAttemptLimiter.cs
+++ b/backend/src/Application/Common/RateLimiting/ICheckInAttemptLimiter.cs
@@ -1,0 +1,12 @@
+using Domain.Engagements;
+
+namespace Application.Common.RateLimiting;
+
+public interface ICheckInAttemptLimiter
+{
+	Task<bool> IsLockedOutAsync(EngagementId engagementId, CancellationToken cancellationToken = default);
+
+	Task RegisterFailedAttemptAsync(EngagementId engagementId, CancellationToken cancellationToken = default);
+
+	Task ResetAsync(EngagementId engagementId, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
+++ b/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
@@ -1,13 +1,15 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.RateLimiting;
 using Domain.Engagements;
 using Domain.Primitives;
 
 namespace Application.Engagements.CheckInWithPin.v1;
 
 internal sealed class CheckInWithPinCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	ICheckInAttemptLimiter attemptLimiter)
 	: ICommandHandler<CheckInWithPinCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -17,14 +19,27 @@ internal sealed class CheckInWithPinCommandHandler(
 		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("Engagement.NotFound", $"Engagement '{request.EngagementId.Value}' not found."));
 
+		// Ownership must be checked before the PIN is ever compared - otherwise the
+		// "invalid PIN" vs "not owner" responses let any authenticated user tell
+		// whether a guessed PIN was correct without owning the engagement (#806).
+		if (engagement.VolunteerId!.Value.Value != request.RequestingUserId.Value)
+			throw new ResultFailureException(Error.Validation("Engagement.NotOwner", "You can only check in your own engagement."));
+
+		if (await attemptLimiter.IsLockedOutAsync(request.EngagementId, cancellationToken))
+			throw new ResultFailureException(Error.Forbidden(
+				"Engagement.CheckInLocked",
+				"Too many failed PIN attempts. Try again later."));
+
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", "Opportunity not found."));
 
 		if (opportunity.CheckInPin != request.Pin)
+		{
+			await attemptLimiter.RegisterFailedAttemptAsync(request.EngagementId, cancellationToken);
 			throw new ResultFailureException(Error.Validation("Engagement.InvalidPin", "Invalid PIN."));
+		}
 
-		if (engagement.VolunteerId!.Value.Value != request.RequestingUserId.Value)
-			throw new ResultFailureException(Error.Validation("Engagement.NotOwner", "You can only check in your own engagement."));
+		await attemptLimiter.ResetAsync(request.EngagementId, cancellationToken);
 
 		engagement.CheckIn().ThrowIfFailure();
 

--- a/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
+++ b/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+using Application.Common.RateLimiting;
+using Domain.Engagements;
+
+namespace Infrastructure.RateLimiting;
+
+// In-memory per-engagement PIN attempt tracking, independent of the generic
+// per-user/IP rate limiting policies in Api/Common/RateLimiting. A 4-digit PIN
+// has only 10,000 combinations, so a much tighter, engagement-scoped lockout is
+// needed to make brute-forcing infeasible even for an authenticated owner.
+internal sealed class CheckInAttemptLimiter : ICheckInAttemptLimiter
+{
+	private const int MaxFailedAttempts = 5;
+	private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
+
+	private readonly ConcurrentDictionary<Guid, AttemptState> _attempts = new();
+
+	public Task<bool> IsLockedOutAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	{
+		var isLockedOut = _attempts.TryGetValue(engagementId.Value, out var state)
+			&& state.LockedUntil is { } lockedUntil
+			&& lockedUntil > DateTimeOffset.UtcNow;
+
+		return Task.FromResult(isLockedOut);
+	}
+
+	public Task RegisterFailedAttemptAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	{
+		_attempts.AddOrUpdate(
+			engagementId.Value,
+			_ => new AttemptState(1, null),
+			(_, existing) =>
+			{
+				var failedAttempts = existing.FailedAttempts + 1;
+				var lockedUntil = failedAttempts >= MaxFailedAttempts
+					? DateTimeOffset.UtcNow.Add(LockoutDuration)
+					: existing.LockedUntil;
+
+				return new AttemptState(failedAttempts, lockedUntil);
+			});
+
+		return Task.CompletedTask;
+	}
+
+	public Task ResetAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	{
+		_attempts.TryRemove(engagementId.Value, out _);
+
+		return Task.CompletedTask;
+	}
+
+	private sealed record AttemptState(int FailedAttempts, DateTimeOffset? LockedUntil);
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Application.Common.Email;
 using Application.Common.Geocoding;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
+using Application.Common.RateLimiting;
 using Application.Common.Storage;
 using Application.Engagements;
 using Application.Notifications;
@@ -19,6 +20,7 @@ using Infrastructure.Persistence;
 using Infrastructure.Persistence.Interceptors;
 using Infrastructure.Persistence.Options;
 using Infrastructure.Persistence.Repositories;
+using Infrastructure.RateLimiting;
 using Infrastructure.Storage;
 using Infrastructure.VolunteerOpportunities;
 using Domain.VolunteerOpportunities;
@@ -41,6 +43,8 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<ISaveChangesInterceptor, DomainEventInterceptor>();
 
 		services.AddSingleton<IPinGenerator, RandomPinGenerator>();
+
+		services.AddSingleton<ICheckInAttemptLimiter, CheckInAttemptLimiter>();
 
 		services.AddDbContext<ApplicationDbContext>((sp, options) =>
 		{

--- a/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
@@ -1,0 +1,155 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Common.RateLimiting;
+using Application.Engagements.CheckInWithPin.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.CheckInWithPin;
+
+public class CheckInWithPinCommandHandlerTests
+{
+	private const string CorrectPin = "482170";
+
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
+		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly ICheckInAttemptLimiter _attemptLimiter = Substitute.For<ICheckInAttemptLimiter>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly CheckInWithPinCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Teststrasse", "1", "12345", "Berlin").Value;
+
+	public CheckInWithPinCommandHandlerTests()
+	{
+		_dbContext.Engagements.Returns(_engagementRepo);
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_sut = new CheckInWithPinCommandHandler(_dbContext, _attemptLimiter);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowNotOwner_BeforeComparingPin_WhenNonOwnerGuessesWrongPin(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #806: a non-owner must get the same "not owner" failure
+		// regardless of whether the guessed PIN happens to be correct or wrong -
+		// otherwise the response distinguishes valid from invalid PINs (an oracle).
+		var opportunityId = VolunteerOpportunityId.New();
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var attacker = UserId.New();
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunityId, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new CheckInWithPinCommand(engagementId, "000000", attacker);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*own engagement*");
+		await _opportunityRepo.DidNotReceive().FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>());
+		await _attemptLimiter.DidNotReceive().RegisterFailedAttemptAsync(Arg.Any<EngagementId>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowCheckInLocked_BeforeComparingPin_WhenEngagementIsLockedOut(
+		CancellationToken cancellationToken)
+	{
+		var opportunityId = VolunteerOpportunityId.New();
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunityId, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_attemptLimiter.IsLockedOutAsync(engagementId, cancellationToken).Returns(true);
+
+		var command = new CheckInWithPinCommand(engagementId, CorrectPin, owner);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*Too many failed*");
+		await _opportunityRepo.DidNotReceive().FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRegisterFailedAttempt_WhenOwnerSubmitsWrongPin(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var opportunity = CreatePinOpportunity();
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInWithPinCommand(engagementId, "000000", owner);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*Invalid PIN*");
+		await _attemptLimiter.Received(1).RegisterFailedAttemptAsync(engagementId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldResetAttempts_AndCheckIn_WhenOwnerSubmitsCorrectPin(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var opportunity = CreatePinOpportunity();
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInWithPinCommand(engagementId, CorrectPin, owner);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.IsCheckedIn.Should().BeTrue();
+		await _attemptLimiter.Received(1).ResetAsync(engagementId, cancellationToken);
+		await _attemptLimiter.DidNotReceive().RegisterFailedAttemptAsync(Arg.Any<EngagementId>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEngagementNotFound(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns((Engagement?)null);
+
+		var command = new CheckInWithPinCommand(engagementId, CorrectPin, UserId.New());
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage($"*{engagementId.Value}*");
+	}
+
+	private VolunteerOpportunity CreatePinOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId,
+			"Test",
+			"Test",
+			false,
+			DefaultAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.PINCode,
+			_pinGenerator,
+			status: OpportunityStatus.Draft,
+			checkInPin: CorrectPin).Value;
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -6898,6 +6898,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -432,6 +432,49 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(400);
 	}
 
+	[Test]
+	public async Task CheckInWithPin_ShouldReturn403_WhenTooManyFailedAttempts(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, "PINCode", cancellationToken);
+
+		var pin = await olafClient.GetOpportunityCheckInPinAsync(opportunity.Id, cancellationToken)
+			?? throw new InvalidOperationException("PIN was not generated for PINCode opportunity.");
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "Ready to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		// 5 wrong guesses trip the per-engagement lockout (independent of the
+		// generic 100 req/60s rate limit - see #806).
+		for (var attempt = 0; attempt < 5; attempt++)
+		{
+			var wrongAttempt = () => veraClient.CheckInWithPinAsync(
+				engagement.Id,
+				new CheckInWithPinRequest { Pin = "wrong-pin" },
+				cancellationToken);
+
+			var wrongException = await wrongAttempt.Should().ThrowAsync<ApiException>();
+			wrongException.Which.StatusCode.Should().Be(400);
+		}
+
+		// Even the correct PIN must now be rejected while locked out - proves the
+		// lockout blocks further attempts outright rather than just rate-limiting them.
+		var lockedOutAttempt = () => veraClient.CheckInWithPinAsync(
+			engagement.Id,
+			new CheckInWithPinRequest { Pin = pin },
+			cancellationToken);
+
+		var lockedException = await lockedOutAttempt.Should().ThrowAsync<ApiException>();
+		lockedException.Which.StatusCode.Should().Be(403);
+	}
+
 	// ── Duplicate sign-up rejection ───────────────────────────────────────────
 
 	[Test]

--- a/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
+++ b/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
@@ -114,6 +114,131 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 			"CheckInWithPin on someone else's engagement must return 400, matching pre-refactor behaviour");
 	}
 
+	[Test]
+	public async Task CheckInWithPin_ReturnsIdenticalNotOwnerError_RegardlessOfPinCorrectness_ForNonOwner()
+	{
+		// Regression for #806: a non-owner guessing PINs must not be able to tell a
+		// correct guess from a wrong one via the error response - ownership has to
+		// be checked before the PIN is ever compared, closing the validity oracle.
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinOracle Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		const string pin = "482170";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"CheckInPinOracle Opportunity {suffix}",
+			description = "Created by EngagementCheckInStatusCodeTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "PINCode",
+			checkInPin = pin,
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "IndividualContact", message = "I'd like to help!" });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", null);
+		confirmResponse.EnsureSuccessStatusCode();
+
+		var wrongPinResponse = await olafHttp.PostAsJsonAsync(
+			$"/v1/me/engagements/{engagementId}/check-in", new { pin = "000000" });
+		var correctPinResponse = await olafHttp.PostAsJsonAsync(
+			$"/v1/me/engagements/{engagementId}/check-in", new { pin });
+
+		wrongPinResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		correctPinResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+		var wrongPinProblem = await wrongPinResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var correctPinProblem = await correctPinResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+		wrongPinProblem.GetProperty("errorCode").GetString().Should().Be("Engagement.NotOwner");
+		correctPinProblem.GetProperty("errorCode").GetString().Should().Be(
+			"Engagement.NotOwner",
+			"a non-owner must never learn whether their PIN guess was correct");
+	}
+
+	[Test]
+	public async Task CheckInWithPin_Returns403_AfterTooManyFailedAttempts()
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinLockout Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		const string pin = "482170";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"CheckInPinLockout Opportunity {suffix}",
+			description = "Created by EngagementCheckInStatusCodeTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "PINCode",
+			checkInPin = pin,
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "IndividualContact", message = "Ready to help!" });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", null);
+		confirmResponse.EnsureSuccessStatusCode();
+
+		// 5 wrong guesses trip the per-engagement lockout, independent of the
+		// generic 100 req/60s rate limit.
+		for (var attempt = 0; attempt < 5; attempt++)
+		{
+			var wrongAttempt = await veraHttp.PostAsJsonAsync(
+				$"/v1/me/engagements/{engagementId}/check-in", new { pin = "000000" });
+			wrongAttempt.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		}
+
+		var lockedOutAttempt = await veraHttp.PostAsJsonAsync(
+			$"/v1/me/engagements/{engagementId}/check-in", new { pin });
+
+		lockedOutAttempt.StatusCode.Should().Be(
+			HttpStatusCode.Forbidden,
+			"the correct PIN must still be rejected once the per-engagement lockout has tripped");
+	}
+
 	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
 	{
 		using var http = new HttpClient { BaseAddress = keycloak };

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3659,6 +3659,12 @@ export class EinsatzbereitApi {
             result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Unauthorized", status, _responseText, _headers, result401);
             });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
         } else if (status === 404) {
             return response.text().then((_responseText) => {
             let result404: any = null;

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunityDetails } from "../client/api-client";
+import { getApiErrorMessage } from "../lib/apiError";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
@@ -46,8 +47,8 @@ export default function CheckInModal({
 			await api.checkInWithPin(engagementId, { pin });
 			setSuccess(true);
 			onCheckedIn();
-		} catch {
-			setError(t("checkIn.invalidPin"));
+		} catch (e) {
+			setError(getApiErrorMessage(e, t("checkIn.invalidPin")));
 		} finally {
 			setSubmitting(false);
 		}


### PR DESCRIPTION
CheckInWithPinCommandHandler compared the PIN before verifying engagement ownership, so any authenticated non-owner could distinguish "invalid PIN" from "not owner" responses and use that as a validity oracle to brute-force a 4-6 digit check-in PIN (only 10,000-1,000,000 combinations, well within the generic 100 req/60s rate limit).

- Reorder CheckInWithPinCommandHandler so ownership is checked before the PIN is ever compared.
- Add a per-engagement failed-attempt lockout (ICheckInAttemptLimiter, in-memory, 5 attempts / 15 min) independent of the generic per-user rate limit, since a legitimate owner could otherwise still brute-force their own PIN.
- Surface the new 403 lockout response in the CheckInWithPin endpoint metadata and in CheckInModal's error message.

Closes #806