### PR TITLE
test: add coverage for VerifyOrganization admin action (#885)

### DIFF
--- a/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
@@ -66,4 +66,64 @@ public class OrganizationTests
 
 		result.IsFailure.Should().BeTrue();
 	}
+
+	[Test]
+	public void Verify_ShouldSetIsVerifiedTrue()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+
+		// Act
+		var result = org.Verify();
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		org.IsVerified.Should().BeTrue();
+	}
+
+	[Test]
+	public void Verify_ShouldFail_WhenAlreadyVerified()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		org.Verify();
+
+		// Act
+		var result = org.Verify();
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Organization is already verified.");
+		org.IsVerified.Should().BeTrue();
+	}
+
+	[Test]
+	public void RevokeVerification_ShouldSetIsVerifiedFalse()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		org.Verify();
+
+		// Act
+		var result = org.RevokeVerification();
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		org.IsVerified.Should().BeFalse();
+	}
+
+	[Test]
+	public void RevokeVerification_ShouldFail_WhenNotVerified()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+
+		// Act
+		var result = org.RevokeVerification();
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Organization is not verified.");
+		org.IsVerified.Should().BeFalse();
+	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/VerifyOrganization/VerifyOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/VerifyOrganization/VerifyOrganizationCommandHandlerTests.cs
@@ -1,0 +1,117 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Organizations.VerifyOrganization.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.VerifyOrganization;
+
+public class VerifyOrganizationCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Organization, OrganizationId> _organizationRepo =
+		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
+	private readonly VerifyOrganizationCommandHandler _sut;
+
+	public VerifyOrganizationCommandHandlerTests()
+	{
+		_dbContext.Organizations.Returns(_organizationRepo);
+		_sut = new VerifyOrganizationCommandHandler(_dbContext);
+	}
+
+	private static Organization CreateOrganization(Guid id) =>
+		Organization.Create(OrganizationId.Create(id).GetValueOrThrow(), "Test Org").Value;
+
+	[Test]
+	public async Task Handle_ShouldVerifyOrganization_WhenIsVerifiedIsTrue(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		var command = new VerifyOrganizationCommand(orgId, true);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		organization.IsVerified.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldRevokeVerification_WhenIsVerifiedIsFalse(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.Verify();
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		var command = new VerifyOrganizationCommand(orgId, false);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		organization.IsVerified.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOrganizationNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns((Organization?)null);
+		var command = new VerifyOrganizationCommand(orgId, true);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage($"*{orgId}*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenAlreadyVerifiedAndVerifyingAgain(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.Verify();
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		var command = new VerifyOrganizationCommand(orgId, true);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*already verified*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenNotVerifiedAndRevokingAgain(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		var command = new VerifyOrganizationCommand(orgId, false);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*not verified*");
+	}
+}

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -524,6 +524,86 @@ public class OrganizationSettingsTests(
 		stillThere.Id.Should().Be(org.Id.Value);
 	}
 
+	// ── VerifyOrganization (#885) ────────────────────────────────────────────
+
+	[Test]
+	public async Task VerifyOrganization_ShouldReturn401_WhenNotAuthenticated(
+		CancellationToken cancellationToken)
+	{
+		var client = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => client.VerifyOrganizationAsync(
+			Guid.NewGuid(), new VerifyOrganizationRequest { IsVerified = true }, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(401);
+	}
+
+	[Test]
+	public async Task VerifyOrganization_ShouldReturn403_WhenRequestingUserIsNotAdmin(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Verify 403 Test Org" }, cancellationToken);
+
+		var act = () => olafClient.VerifyOrganizationAsync(
+			org.Id.Value, new VerifyOrganizationRequest { IsVerified = true }, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.IsVerified.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task VerifyOrganization_ShouldReturn204AndPersistFlag_WhenAdminVerifies(
+		CancellationToken cancellationToken)
+	{
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Verify Success Test Org" }, cancellationToken);
+
+		await adminClient.VerifyOrganizationAsync(
+			org.Id.Value, new VerifyOrganizationRequest { IsVerified = true }, cancellationToken);
+
+		var result = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		result.IsVerified.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task VerifyOrganization_ShouldReturn204AndPersistFlag_WhenAdminRevokesVerification(
+		CancellationToken cancellationToken)
+	{
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Revoke Verify Test Org" }, cancellationToken);
+		await adminClient.VerifyOrganizationAsync(
+			org.Id.Value, new VerifyOrganizationRequest { IsVerified = true }, cancellationToken);
+
+		await adminClient.VerifyOrganizationAsync(
+			org.Id.Value, new VerifyOrganizationRequest { IsVerified = false }, cancellationToken);
+
+		var result = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		result.IsVerified.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task VerifyOrganization_ShouldReturn404_WhenOrganizationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var act = () => adminClient.VerifyOrganizationAsync(
+			Guid.NewGuid(), new VerifyOrganizationRequest { IsVerified = true }, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
 	{
 		var token = await fixture.GetAccessTokenAsync(username, password);


### PR DESCRIPTION
VerifyOrganizationCommandHandler and Organization.Verify()/RevokeVerification() had zero automated test coverage despite being a mutating, admin-only action that grants a public trust signal - a regression breaking the admin-only guard would have shipped undetected.

- Domain tests for Verify()/RevokeVerification() success and conflict cases
- Handler unit tests for not-found, verify, revoke, and re-verify/re-revoke conflicts
- Integration tests for 401 (unauthenticated), 403 (non-admin), 404 (not found), and 204 with persisted isVerified flag across verify/revoke round-trips

Closes #885