### PR TITLE
fix: close Header dropdowns/overlays on Escape, not just outside-clic…

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -357,4 +357,81 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var mobileBtnClass = await mobileLangBtn.GetAttributeAsync("class") ?? string.Empty;
 		mobileBtnClass.Should().MatchRegex(new Regex("border-white|text-white"));
 	}
+
+	[Test]
+	public async Task HomePage_LanguageSelector_ClosesOnEscape()
+	{
+		// #884: dropdown/overlay menus in the Header only closed on outside
+		// click - Escape did nothing. useDismissableOverlay fixes this.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var langBtn = Page.Locator("header button[aria-haspopup='listbox']").First;
+		await langBtn.ClickAsync();
+
+		var dropdown = Page.Locator("header ul[role='listbox']").First;
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(dropdown).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+
+	[Test]
+	public async Task MobileMenu_ClosesOnEscape()
+	{
+		// #884: MobileMenu offered neither outside-click nor Escape dismissal
+		// at all - useDismissableOverlay now backs it too.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.SetViewportSizeAsync(390, 844);
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var menuBtn = Page.Locator("header button[aria-label]")
+			.Filter(new() { HasNotText = "English" })
+			.Filter(new() { HasNotText = "Deutsch" });
+		var menuBtnCount = await menuBtn.CountAsync();
+		ILocator? hamburger = null;
+		for (var i = 0; i < menuBtnCount; i++)
+		{
+			var label = await menuBtn.Nth(i).GetAttributeAsync("aria-label");
+			if (label is not null && Regex.IsMatch(label, "menu|menü|open|öffnen", RegexOptions.IgnoreCase))
+			{
+				hamburger = menuBtn.Nth(i);
+				break;
+			}
+		}
+
+		if (hamburger is null)
+			return; // hamburger not found at this viewport - skip gracefully
+
+		await hamburger.ClickAsync();
+
+		var mobileLangBtn = Page.Locator("button[aria-haspopup='listbox']").Last;
+		await Expect(mobileLangBtn).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(mobileLangBtn).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+
+	[Test]
+	public async Task AccountControls_UserMenu_ClosesOnEscape()
+	{
+		// #884: the account/notification dropdowns (useAccountMenu) only
+		// closed on outside click.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		var userMenuBtn = Page.GetByRole(AriaRole.Button, new() { Name = "User menu" });
+		await userMenuBtn.ClickAsync();
+
+		var profileLink = Page.GetByRole(AriaRole.Link, new() { Name = "My Profile" });
+		await Expect(profileLink).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(profileLink).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
 }

--- a/frontend/src/components/AddToCalendarMenu.tsx
+++ b/frontend/src/components/AddToCalendarMenu.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { runtimeConfig } from "../lib/runtimeConfig";
+import { useDismissableOverlay } from "../hooks/useDismissableOverlay";
 
 interface AddToCalendarMenuProps {
 	engagementId: string;
@@ -33,18 +34,9 @@ export default function AddToCalendarMenu({
 }: AddToCalendarMenuProps) {
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
-	const rootRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		if (!open) return;
-		function handleClick(e: MouseEvent) {
-			if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-				setOpen(false);
-			}
-		}
-		document.addEventListener("click", handleClick);
-		return () => document.removeEventListener("click", handleClick);
-	}, [open]);
+	const rootRef = useDismissableOverlay<HTMLDivElement>(open, () =>
+		setOpen(false),
+	);
 
 	const startDate = new Date(start);
 	const endDate = new Date(end);

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useDismissableOverlay } from "../hooks/useDismissableOverlay";
 
 export interface DropdownOption {
 	value: string;
@@ -45,7 +46,9 @@ export default function Dropdown({
 }: DropdownProps) {
 	const [open, setOpen] = useState(false);
 	const [activeIndex, setActiveIndex] = useState(-1);
-	const rootRef = useRef<HTMLDivElement>(null);
+	const rootRef = useDismissableOverlay<HTMLDivElement>(open, () =>
+		setOpen(false),
+	);
 	const listRef = useRef<HTMLUListElement>(null);
 	const typeaheadBuffer = useRef("");
 	const typeaheadTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -55,17 +58,6 @@ export default function Dropdown({
 
 	const selectedIndex = options.findIndex((o) => o.value === value);
 	const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined;
-
-	useEffect(() => {
-		if (!open) return;
-		function handleClick(e: MouseEvent) {
-			if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-				setOpen(false);
-			}
-		}
-		document.addEventListener("click", handleClick);
-		return () => document.removeEventListener("click", handleClick);
-	}, [open]);
 
 	useEffect(() => {
 		if (open) {
@@ -150,12 +142,6 @@ export default function Dropdown({
 				e.preventDefault();
 				if (open) commit(activeIndex);
 				else setOpen(true);
-				break;
-			case "Escape":
-				if (open) {
-					e.preventDefault();
-					setOpen(false);
-				}
 				break;
 			case "Tab":
 				setOpen(false);

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -61,6 +61,7 @@ export default function Header({
 	const [orgMenuOpen, setOrgMenuOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
 	const mobileNotifRef = useRef<HTMLDivElement>(null);
+	const mobileMenuButtonRef = useRef<HTMLButtonElement>(null);
 	const menu = useAccountMenu([mobileNotifRef]);
 	const { avatarUrl } = menu;
 
@@ -173,6 +174,7 @@ export default function Header({
 							setMobileOpen={setMobileOpen}
 							menu={menu}
 							notifContainerRef={mobileNotifRef}
+							menuButtonRef={mobileMenuButtonRef}
 							onNotificationNavigate={handleNotificationNavigate}
 						/>
 					</div>
@@ -189,6 +191,7 @@ export default function Header({
 						activeOrg={activeOrg}
 						orgMenuOpen={orgMenuOpen}
 						setOrgMenuOpen={setOrgMenuOpen}
+						triggerRef={mobileMenuButtonRef}
 						onClose={() => setMobileOpen(false)}
 						onSignIn={handleSignIn}
 						onRegister={handleRegister}

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 
 const LANGUAGES = [
 	{ code: "en", flag: "🇬🇧", label: "English" },
@@ -15,22 +16,12 @@ export default function LanguageSelector({
 }) {
 	const { i18n, t } = useTranslation();
 	const [open, setOpen] = useState(false);
-	const ref = useRef<HTMLDivElement>(null);
+	const ref = useDismissableOverlay<HTMLDivElement>(open, () => setOpen(false));
 
 	const currentCode: LangCode = LANGUAGES.some((l) => l.code === i18n.language)
 		? (i18n.language as LangCode)
 		: "en";
 	const current = LANGUAGES.find((l) => l.code === currentCode) ?? LANGUAGES[0];
-
-	useEffect(() => {
-		const handler = (e: MouseEvent) => {
-			if (ref.current && !ref.current.contains(e.target as Node)) {
-				setOpen(false);
-			}
-		};
-		document.addEventListener("click", handler);
-		return () => document.removeEventListener("click", handler);
-	}, []);
 
 	return (
 		<div className="relative" ref={ref}>

--- a/frontend/src/components/Header/MobileHeader.tsx
+++ b/frontend/src/components/Header/MobileHeader.tsx
@@ -13,6 +13,7 @@ export default function MobileHeader({
 	setMobileOpen,
 	menu,
 	notifContainerRef,
+	menuButtonRef,
 	onNotificationNavigate,
 }: {
 	isLoggedIn: boolean;
@@ -21,6 +22,7 @@ export default function MobileHeader({
 	setMobileOpen: Dispatch<SetStateAction<boolean>>;
 	menu: AccountMenuState;
 	notifContainerRef: RefObject<HTMLDivElement | null>;
+	menuButtonRef: RefObject<HTMLButtonElement | null>;
 	onNotificationNavigate: (actionUrl: string | null | undefined) => void;
 }) {
 	const { t } = useTranslation();
@@ -38,6 +40,7 @@ export default function MobileHeader({
 				/>
 			)}
 			<button
+				ref={menuButtonRef}
 				type="button"
 				onClick={() => setMobileOpen((o) => !o)}
 				className={`inline-flex items-center justify-center p-2 rounded-lg transition-colors ${isTransparent ? "text-white hover:bg-white/10" : "text-gray-500 hover:text-brand-600 hover:bg-brand-50"}`}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import LanguageSelector from "./LanguageSelector";
@@ -18,6 +18,7 @@ export default function MobileMenu({
 	activeOrg,
 	orgMenuOpen,
 	setOrgMenuOpen,
+	triggerRef,
 	onClose,
 	onSignIn,
 	onRegister,
@@ -32,6 +33,11 @@ export default function MobileMenu({
 	activeOrg: OrganizationSummaryDto | null | undefined;
 	orgMenuOpen: boolean;
 	setOrgMenuOpen: Dispatch<SetStateAction<boolean>>;
+	// The hamburger button that toggles this menu open/closed - rendered as a
+	// sibling in MobileHeader, not a descendant here. Without treating it as
+	// "inside", the outside-click check below would see the very click that
+	// opens this menu as an outside click and immediately close it again.
+	triggerRef: RefObject<HTMLButtonElement | null>;
 	onClose: () => void;
 	onSignIn: () => void;
 	onRegister: () => void;
@@ -46,7 +52,9 @@ export default function MobileMenu({
 		: "text-gray-700 hover:bg-brand-50 hover:text-brand-600";
 	// Only ever mounted while open (see Header.tsx), so dismissal listeners
 	// attach for this component's entire lifetime.
-	const rootRef = useDismissableOverlay<HTMLDivElement>(true, onClose);
+	const rootRef = useDismissableOverlay<HTMLDivElement>(true, onClose, [
+		triggerRef,
+	]);
 
 	return (
 		<div

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import LanguageSelector from "./LanguageSelector";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
+import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 
 // Mobile menu overlay (absolute-positioned so it doesn't push content down),
 // toggled open by MobileHeader's burger button.
@@ -43,9 +44,13 @@ export default function MobileMenu({
 	const menuItemVariant = isTransparent
 		? "text-white/90 hover:bg-white/10 hover:text-white"
 		: "text-gray-700 hover:bg-brand-50 hover:text-brand-600";
+	// Only ever mounted while open (see Header.tsx), so dismissal listeners
+	// attach for this component's entire lifetime.
+	const rootRef = useDismissableOverlay<HTMLDivElement>(true, onClose);
 
 	return (
 		<div
+			ref={rootRef}
 			className={`absolute left-0 right-0 top-full border-t md:hidden shadow-lg ${isTransparent ? "border-white/20 bg-brand-800" : "border-gray-100 bg-white"}`}
 		>
 			{isTransparent && (

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import type {
@@ -6,6 +6,7 @@ import type {
 	OrganizationSummaryDto,
 } from "../../client/api-client";
 import { orgTabPath } from "../../lib/orgTabs";
+import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 import CreateOrganizationModal from "../CreateOrganizationModal";
 
 export default function OrganizationSwitcher({
@@ -26,26 +27,15 @@ export default function OrganizationSwitcher({
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
 	const [showModal, setShowModal] = useState(false);
-	const containerRef = useRef<HTMLDivElement>(null);
+	const containerRef = useDismissableOverlay<HTMLDivElement>(open, () =>
+		setOpen(false),
+	);
 
 	const currentOrg = orgs.find((o) => o.id === currentOrgId) ?? null;
 
 	function orgPath(org: OrganizationSummaryDto) {
 		return orgTabPath(org.id, currentTab);
 	}
-
-	useEffect(() => {
-		const handleClick = (e: MouseEvent) => {
-			if (
-				containerRef.current &&
-				!containerRef.current.contains(e.target as Node)
-			) {
-				setOpen(false);
-			}
-		};
-		document.addEventListener("click", handleClick);
-		return () => document.removeEventListener("click", handleClick);
-	}, []);
 
 	function handleSwitch(org: OrganizationSummaryDto) {
 		setOpen(false);

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useAuth } from "react-oidc-context";
 import { useApiClient } from "./useApiClient";
+import { useDismissableOverlay } from "./useDismissableOverlay";
 import type { NotificationSummary } from "../client/api-client";
 
 export interface AccountMenuState {
@@ -36,30 +37,14 @@ export function useAccountMenu(
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [notifOpen, setNotifOpen] = useState(false);
 	const [notifications, setNotifications] = useState<NotificationSummary[]>([]);
-	const dropdownRef = useRef<HTMLDivElement>(null);
-	const notifRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		const handler = (e: MouseEvent) => {
-			if (
-				dropdownRef.current &&
-				!dropdownRef.current.contains(e.target as Node)
-			) {
-				setDropdownOpen(false);
-			}
-			const insideNotif =
-				(notifRef.current && notifRef.current.contains(e.target as Node)) ||
-				extraNotifContainers.some(
-					(ref) => ref.current && ref.current.contains(e.target as Node),
-				);
-			if (!insideNotif) {
-				setNotifOpen(false);
-			}
-		};
-		document.addEventListener("click", handler);
-		return () => document.removeEventListener("click", handler);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	const dropdownRef = useDismissableOverlay<HTMLDivElement>(dropdownOpen, () =>
+		setDropdownOpen(false),
+	);
+	const notifRef = useDismissableOverlay<HTMLDivElement>(
+		notifOpen,
+		() => setNotifOpen(false),
+		extraNotifContainers,
+	);
 
 	useEffect(() => {
 		if (!isLoggedIn) return;

--- a/frontend/src/hooks/useDismissableOverlay.ts
+++ b/frontend/src/hooks/useDismissableOverlay.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+// Shared across every hook instance in the app - tracks currently-open
+// overlays, most-recently-opened last, so Escape dismisses only the topmost
+// one instead of cascading through an ancestor (e.g. LanguageSelector opened
+// inside MobileMenu: without this, one Escape press would close both since
+// both listen on `document` with no nesting relationship between them).
+const openStack: symbol[] = [];
+
+/**
+ * Shared dismissal behavior for dropdowns/overlays: closes on outside click
+ * AND on Escape, mirroring Modal.tsx's Escape handling. `extraContainers`
+ * lets a caller that renders a second copy of the trigger/panel elsewhere in
+ * the DOM (e.g. a mobile-header duplicate) keep clicks inside it from being
+ * treated as "outside".
+ *
+ * `onDismiss`/`extraContainers` are read via refs updated on every render
+ * rather than listed as effect deps - callers pass a fresh inline closure
+ * each render, and depending on it directly would tear down and re-add the
+ * document listeners on every re-render instead of only on open/close.
+ */
+export function useDismissableOverlay<T extends HTMLElement = HTMLDivElement>(
+	open: boolean,
+	onDismiss: () => void,
+	extraContainers: RefObject<HTMLElement | null>[] = [],
+): RefObject<T | null> {
+	const containerRef = useRef<T>(null);
+	const onDismissRef = useRef(onDismiss);
+	onDismissRef.current = onDismiss;
+	const extraContainersRef = useRef(extraContainers);
+	extraContainersRef.current = extraContainers;
+	const idRef = useRef(Symbol("dismissableOverlay"));
+
+	useEffect(() => {
+		if (!open) return;
+
+		const id = idRef.current;
+		openStack.push(id);
+
+		function isInside(target: Node) {
+			return (
+				(containerRef.current?.contains(target) ?? false) ||
+				extraContainersRef.current.some((ref) => ref.current?.contains(target))
+			);
+		}
+
+		function handleClick(e: MouseEvent) {
+			if (!isInside(e.target as Node)) onDismissRef.current();
+		}
+
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key !== "Escape") return;
+			// Only the topmost overlay reacts - an outer one gets its turn on
+			// the next Escape press, once this one has closed and popped off.
+			if (openStack[openStack.length - 1] !== id) return;
+			onDismissRef.current();
+		}
+
+		document.addEventListener("click", handleClick);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			const index = openStack.indexOf(id);
+			if (index !== -1) openStack.splice(index, 1);
+			document.removeEventListener("click", handleClick);
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [open]);
+
+	return containerRef;
+}


### PR DESCRIPTION
…k (#884)

Dropdown, LanguageSelector, OrganizationSwitcher, AddToCalendarMenu, and useAccountMenu's dropdown/notification panels only dismissed on outside click. MobileMenu had neither outside-click nor Escape handling at all.

Add a shared useDismissableOverlay hook (outside-click + Escape, mirroring Modal.tsx) and wire it into all six, so future overlay components can reuse it instead of re-adding ad hoc click listeners. The hook tracks a global open-overlay stack so Escape dismisses only the topmost overlay instead of cascading into an ancestor (e.g. LanguageSelector opened inside MobileMenu).

Add VisualTests regression coverage for Escape-closing the language dropdown, the mobile burger menu, and the account user menu.

Closes #884