### PR TITLE
fix: correct stale ADR-4 callout in wiki, exempt wiki from lens drift audits

### DIFF
--- a/.claude/skills/lens/references/lens-docs-drift.md
+++ b/.claude/skills/lens/references/lens-docs-drift.md
@@ -43,3 +43,8 @@ Style findings are Low/Medium and never outnumber drift findings.
 Docs may describe intended future state - check git history: if the doc
 predates the divergent code, it is drift; if it postdates it, it may be
 a roadmap statement. Say which.
+
+`wiki/` is out of scope for this lens (repo-map trap 8). It is informal
+knowledge by design, not held to the same currency bar as the docs above -
+its own `/lint` skill is what keeps it current, on its own cadence. Do not
+file a wiki page falling behind `docs/`/code as a drift finding.

--- a/.claude/skills/lens/references/repo-map.md
+++ b/.claude/skills/lens/references/repo-map.md
@@ -59,6 +59,15 @@ codebases.
    configuration abstractions (`IConfiguration`, `import.meta.env`).
    Search both naming conventions (SCREAMING_SNAKE and colon-nested)
    before claiming a variable is unread.
+8. **Wiki staleness.** `wiki/` is informal knowledge, not a lagging formal
+   doc - `wiki/AGENTS.md`'s Ingest section claims completeness only for
+   the `notes/` channel, never for how current a page stays against
+   `docs/` or code. Unlike `docs/` or a `CLAUDE.md`, a wiki page falling
+   behind fast-moving source is expected, not drift. Keeping it current is
+   the `/lint` skill's job, on its own cadence, not something a repo-wide
+   lens should independently re-flag. Don't treat a stale wiki page as a
+   docs-drift or repo-hygiene finding (see issue #862, filed for exactly
+   this).
 
 ## Tooling quick reference
 

--- a/wiki/bundle/log.md
+++ b/wiki/bundle/log.md
@@ -12,6 +12,7 @@ dates and a bold action-word prefix, e.g. `**Added**`, `**Updated**`,
 
 ## 2026-07-24
 
+- **Fixed** - `reference/adr-tdr-index.md`: the callout claiming `docs/AGENTS.md`'s structure block "stops at ADR-3" was itself stale (#862) - true when the page was written (2026-07-18 14:37, commit `c8bb3c9`) but false again ~90 minutes later the same day once `docs/AGENTS.md` was corrected (commit `6d8ead5`). Reworded to a general, still-true trap (the structure block *can* drift behind `docs/ADRs/`, it has before) instead of a point-in-time claim that expires.
 - **Added** - `decisions/scripts-folder-removed.md`: root `scripts/` (106 tracked files, re-verified against `origin/main` rather than the issue's now-stale 98) and root `package.json`/`package-lock.json` deleted per #791 discussion, expanded beyond the issue's 16 orphaned scripts to the whole persisted-script convention. Live-verification scripts are now scratch-only, never committed.
 - **Updated** - `process/deploy-verify-flow.md` and `process/live-playwright-scripts.md`: smoke script section and the shared-helper page rewritten for the scratch-directory approach (no more `scripts/lib/live-browser.mjs`); `process/index.md` description updated to match. `gotchas/sandbox-limitations.md`'s Related line reworded ("browser helper" -> "launch args") to match.
 

--- a/wiki/bundle/reference/adr-tdr-index.md
+++ b/wiki/bundle/reference/adr-tdr-index.md
@@ -8,14 +8,14 @@ tags:
   - keycloak
   - rate-limiting
   - wiki
-timestamp: 2026-07-18
+timestamp: 2026-07-24
 ---
 
 # Index of formal ADRs and TDRs
 
 The reviewed decisions live under `docs/` as arc42-style AsciiDoc, not in this wiki. This page is a pointer so agents find the authoritative record fast. When a topic is already an ADR or TDR, link the `.adoc` file; do not copy its content into a wiki page, which would then drift.
 
-Trust the directory listing, not the summary. The structure block in `docs/AGENTS.md` stops at ADR-3, but `docs/ADRs/` also contains ADR-4. Run `ls docs/ADRs docs/TDRs` for the real set.
+Trust the directory listing over any prose summary, including this page's own table below. `docs/AGENTS.md`'s structure block has drifted behind `docs/ADRs/` before - it listed only ADR-1 through ADR-3 for about 90 minutes after ADR-4 was accepted, until commit `6d8ead5` caught it up the same day (2026-07-18). Run `ls docs/ADRs docs/TDRs` for the real set rather than trusting either summary.
 
 ## Architecture decisions (docs/ADRs/)
 


### PR DESCRIPTION
## Summary

- `wiki/bundle/reference/adr-tdr-index.md` claimed `docs/AGENTS.md`'s structure block "stops at ADR-3, but `docs/ADRs/` also contains ADR-4." That was true for about 90 minutes on 2026-07-18 (page written in `c8bb3c9` at 14:37, `docs/AGENTS.md` corrected in `6d8ead5` at 16:05 the same day) and false ever since - a wiki page whose job is staying current had itself gone stale. Reworded the callout into a general, still-true trap ("this summary has drifted behind the directory before") instead of a point-in-time claim that expires, and logged the fix per the wiki's own Ingest workflow.
- Per the issue's follow-up comment, the wiki is intentionally informal and isn't supposed to be complete - so a review process treating a lagging wiki page as "drift" is itself the bug to fix, not just this one page. Added a trap to `.claude/skills/lens/references/repo-map.md` (read before every lens run) and a matching scope note in `lens-docs-drift.md`, so a future review doesn't re-flag wiki staleness as docs-drift: keeping the wiki current is the wiki's own `/lint` skill's job, on its own cadence, not a repo-wide lens's.

## Test plan

- [x] `python wiki/scripts/validate.py` passes (20 concept files checked)
- [x] `/self-review` run against the diff - no findings after fixing a bold-formatting inconsistency and a misattributed citation in my own first pass
- [x] Checked for Unicode dashes (none)

## Live verification

Not applicable - this is a content/tooling-only change to `wiki/` and `.claude/skills/lens/`, neither of which is part of the deployed backend/frontend build or served by the running app. There is no user-facing behavior to observe on staging, so no release candidate was cut for this fix.

---

Fixes #862

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019YRgpXT1Vmnufsg5hoKG56

---
_Generated by [Claude Code](https://claude.ai/code/session_019YRgpXT1Vmnufsg5hoKG56)_