### PR TITLE
test: add direct coverage for account deletion, invitation accept/dec…

### DIFF
--- a/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Invitations.DeclineInvitation.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Invitations.DeclineInvitation;
+
+public class DeclineInvitationCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
+		Substitute.For<IAggregateRepository<OrganizationInvitation, OrganizationInvitationId>>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly DeclineInvitationCommandHandler _sut;
+
+	private static readonly OrganizationId OrgId = OrganizationId.Create(Guid.NewGuid()).GetValueOrThrow();
+	private static readonly UserId InviteeId = UserId.New();
+	private static readonly UserId InviterId = UserId.New();
+
+	public DeclineInvitationCommandHandlerTests()
+	{
+		_dbContext.OrganizationInvitations.Returns(_invitationRepo);
+		_sut = new DeclineInvitationCommandHandler(_dbContext, _unitOfWork);
+	}
+
+	private static OrganizationInvitation CreatePendingInvitation() =>
+		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId);
+
+	[Test]
+	public async Task Handle_ShouldDeclineInvitationAndSaveChanges_WhenPending(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new DeclineInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		invitation.Status.Should().Be(InvitationStatus.Declined);
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowNotFound_WhenInvitationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitationId = OrganizationInvitationId.New();
+		_invitationRepo.FindAsync(invitationId, cancellationToken).Returns((OrganizationInvitation?)null);
+		var command = new DeclineInvitationCommand(invitationId, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowForbidden_WhenRequestingUserIsNotTheInvitee(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var someoneElse = UserId.New();
+		var command = new DeclineInvitationCommand(invitation.Id, someoneElse);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		invitation.Status.Should().Be(InvitationStatus.Pending);
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenInvitationIsAlreadyDeclined(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		invitation.Decline().ThrowIfFailure();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new DeclineInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenInvitationIsAlreadyAccepted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		invitation.Accept().ThrowIfFailure();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new DeclineInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Notifications/MarkNotificationRead/MarkNotificationReadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkNotificationRead/MarkNotificationReadCommandHandlerTests.cs
@@ -1,0 +1,99 @@
+using Application.Common.Persistence;
+using Application.Notifications.MarkNotificationRead.v1;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.MarkNotificationRead;
+
+public class MarkNotificationReadCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notificationRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly MarkNotificationReadCommandHandler _sut;
+
+	public MarkNotificationReadCommandHandlerTests()
+	{
+		_dbContext.Notifications.Returns(_notificationRepo);
+		_sut = new MarkNotificationReadCommandHandler(_dbContext);
+	}
+
+	[Test]
+	public async Task Handle_ShouldMarkNotificationReadAndReturnTrue_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationReadCommand(notification.Id, recipientUserId.Value);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		notification.IsRead.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalse_WhenNotificationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var notificationId = NotificationId.New();
+		_notificationRepo.FindAsync(notificationId, cancellationToken).Returns((Notification?)null);
+		var command = new MarkNotificationReadCommand(notificationId, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalseAndNotMarkRead_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationReadCommand(notification.Id, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		// A cross-user attempt collapses into the same "false" result as a nonexistent id,
+		// deliberately not leaking whether the id belongs to someone else - this is exactly
+		// the ownership-verification branch GitHub issue #829 asks to cover directly.
+		result.Should().BeFalse();
+		notification.IsRead.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnTrue_WhenNotificationIsAlreadyRead(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		notification.MarkRead();
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationReadCommand(notification.Id, recipientUserId.Value);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		notification.IsRead.Should().BeTrue();
+	}
+}

--- a/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
@@ -1,0 +1,159 @@
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Application.Users.DeleteMyAccount.v1;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+
+namespace Application.UnitTests.Users.DeleteMyAccount;
+
+public class DeleteMyAccountCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<User, UserId> _usersRepo = Substitute.For<IAggregateRepository<User, UserId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+	private readonly DeleteMyAccountCommandHandler _sut;
+
+	private static readonly UserId DefaultUserId = UserId.New();
+
+	public DeleteMyAccountCommandHandlerTests()
+	{
+		_dbContext.Users.Returns(_usersRepo);
+		_dbContext
+			.GetEngagementsForVolunteerTrackingAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Engagement>());
+		_sut = new DeleteMyAccountCommandHandler(_dbContext, _keycloakUserService, _fileStorage);
+	}
+
+	private static Engagement CreateEngagementFor(UserId volunteerId) =>
+		Engagement.CreateWaitlistSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
+
+	[Test]
+	public async Task Handle_ShouldAnonymizeAllEngagements_ReturnedForVolunteerTracking(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementOne = CreateEngagementFor(DefaultUserId);
+		var engagementTwo = CreateEngagementFor(DefaultUserId);
+		_dbContext
+			.GetEngagementsForVolunteerTrackingAsync(DefaultUserId, cancellationToken)
+			.Returns([engagementOne, engagementTwo]);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		engagementOne.IsAnonymized.Should().BeTrue();
+		engagementTwo.IsAnonymized.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteNotificationsForRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).DeleteNotificationsForRecipientAsync(DefaultUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteAvatarForEveryKnownExtension_AndSwallowFailures(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var user = User.Create(DefaultUserId);
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_fileStorage
+			.DeleteAsync($"user-avatars/{DefaultUserId.Value}.jpg", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		// Issue #829: a failure deleting one avatar extension is swallowed rather than rolled back -
+		// the remaining extensions are still attempted even though the .jpg deletion threw.
+		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.jpg", cancellationToken);
+		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.png", cancellationToken);
+		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.webp", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheUserRow_WhenUserExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var user = User.Create(DefaultUserId);
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		_usersRepo.Received(1).Delete(user);
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkipAvatarDeletionAndUserRowDelete_ButStillDeleteKeycloakAccount_WhenLocalUserRowIsMissing(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - FindAsync is unconfigured and defaults to null, simulating a missing local user row.
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+		_usersRepo.DidNotReceive().Delete(Arg.Any<User>());
+		// The Keycloak deletion runs unconditionally, unlike the avatar cleanup and user-row delete above.
+		await _keycloakUserService.Received(1).DeleteUserAsync(DefaultUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheKeycloakAccount_AsTheFinalStep(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var user = User.Create(DefaultUserId);
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _keycloakUserService.Received(1).DeleteUserAsync(DefaultUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnTrue(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var user = User.Create(DefaultUserId);
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+	}
+}

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -1,0 +1,84 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class AccountDeletionTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task DeleteMyAccount_ShouldRemoveAccountAcrossAllSubsystems_AndAnonymizeButNotDeleteEngagementHistory(
+		CancellationToken cancellationToken)
+	{
+		// #829: DeleteMyAccount is irreversible and spans four subsystems with no
+		// rollback on partial failure, so this runs against a throwaway per-test
+		// Keycloak user (never vera/olaf/admin - those are the shared seed
+		// accounts for the whole PerTestSession) since deleting it destroys the
+		// account for good.
+		var (ephemeralUserId, ephemeralUsername, ephemeralPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Account Deletion Test Org" }, cancellationToken);
+		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Account Deletion Test Opportunity",
+				Description = "Integration test opportunity for account deletion",
+				OrganizationId = org.Id.Value,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+			},
+			cancellationToken);
+
+		var engagement = await ephemeralClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		// Fires an EngagementConfirmed notification whose recipient is the
+		// ephemeral user, giving it a notification row to prove gets hard-deleted.
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		await ephemeralClient.DeleteMyAccountAsync(cancellationToken);
+
+		// Keycloak subsystem: the account can no longer authenticate at all.
+		var reLogin = () => fixture.GetAccessTokenAsync(ephemeralUsername, ephemeralPassword);
+		await reLogin.Should().ThrowAsync<Exception>();
+
+		// Notifications subsystem: hard-deleted, not just marked read/orphaned.
+		(await fixture.CountRowsWhereAsync("notification", "recipient_id", ephemeralUserId))
+			.Should().Be(0);
+
+		// Users subsystem: the local user row is hard-deleted.
+		(await fixture.CountRowsWhereAsync("user", "id", ephemeralUserId))
+			.Should().Be(0);
+
+		// Engagements subsystem: deliberately anonymized, not deleted - the
+		// history survives for the organizer, but no longer identifies the
+		// deleted volunteer.
+		var engagements = await olafClient.GetEngagementsAsync(opportunity.Id, cancellationToken);
+		engagements.Should().ContainSingle(e => e.Id == engagement.Id && e.VolunteerId == null);
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+}

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -21,6 +21,7 @@ public class IntegrationTestFixture
 	private const string BackendClientId = "backend";
 	private const string BackendClientSecret = "backend-secret";
 	private const string OrganisatorRole = "organisator";
+	private const string DefaultUserRole = "user";
 	private const string BaselineOrganisator = "olaf";
 
 	private DistributedApplication _app = null!;
@@ -118,6 +119,22 @@ public class IntegrationTestFixture
 		await cmd.ExecuteNonQueryAsync();
 	}
 
+	// Test-only helper for asserting hard-deletes/anonymization at the DB level,
+	// e.g. proving a notification or user row no longer exists after an account
+	// deletion (#829) - there's no API to observe another user's rows directly.
+	// Column names are trusted call-site literals, not user input, so building
+	// the SQL string is fine here even though it wouldn't be for production code.
+	public async Task<int> CountRowsWhereAsync(string table, string column, Guid value)
+	{
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync();
+		await using var cmd = new NpgsqlCommand(
+			$"SELECT COUNT(*) FROM \"{table}\" WHERE {column} = @value", conn);
+		cmd.Parameters.AddWithValue("value", value);
+		var count = await cmd.ExecuteScalarAsync();
+		return Convert.ToInt32(count);
+	}
+
 	public async Task ResetAsync()
 	{
 		await ResetDatabaseAsync();
@@ -194,6 +211,69 @@ public class IntegrationTestFixture
 			var deleteResponse = await _keycloakClient.SendAsync(deleteRequest);
 			await EnsureSuccessAsync(deleteResponse);
 		}
+	}
+
+	// Creates a brand-new, disposable Keycloak user with the realm's baseline
+	// "user" role. This fixture is shared PerTestSession, so tests that need to
+	// destructively mutate an account (e.g. deleting it, #829) must never touch
+	// the shared vera/olaf/admin seed users - they should operate on a
+	// throwaway account like this one instead. No cleanup is needed even if a
+	// test fails mid-way: unlike the shared seed accounts, a leftover ephemeral
+	// user cannot affect other tests' assumptions since nothing else
+	// references it by name.
+	public async Task<(Guid UserId, string Username, string Password)> CreateEphemeralUserAsync(
+		CancellationToken cancellationToken = default)
+	{
+		var username = $"itest-{Guid.NewGuid():N}";
+		const string password = "TestPass1";
+
+		var adminToken = await GetAdminTokenAsync();
+
+		using var createRequest = new HttpRequestMessage(
+			HttpMethod.Post, $"/admin/realms/{Realm}/users")
+		{
+			Content = JsonContent.Create(new
+			{
+				username,
+				enabled = true,
+				emailVerified = true,
+				email = $"{username}@example.com",
+				credentials = new[]
+				{
+					new { type = "password", value = password, temporary = false },
+				},
+			}),
+		};
+		createRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var createResponse = await _keycloakClient.SendAsync(createRequest, cancellationToken);
+		await EnsureSuccessAsync(createResponse);
+
+		var location = createResponse.Headers.Location
+			?? throw new InvalidOperationException("Keycloak did not return a Location header for the new user.");
+		var userId = location.Segments[^1];
+
+		using var roleRequest = new HttpRequestMessage(
+			HttpMethod.Get, $"/admin/realms/{Realm}/roles/{DefaultUserRole}");
+		roleRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var roleResponse = await _keycloakClient.SendAsync(roleRequest, cancellationToken);
+		await EnsureSuccessAsync(roleResponse);
+
+		var userRole = await roleResponse.Content.ReadFromJsonAsync<KeycloakRole>(cancellationToken)
+			?? throw new InvalidOperationException("Keycloak role 'user' not found.");
+
+		using var assignRequest = new HttpRequestMessage(
+			HttpMethod.Post, $"/admin/realms/{Realm}/users/{userId}/role-mappings/realm")
+		{
+			Content = JsonContent.Create(new[] { new { id = userRole.Id, name = userRole.Name } }),
+		};
+		assignRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var assignResponse = await _keycloakClient.SendAsync(assignRequest, cancellationToken);
+		await EnsureSuccessAsync(assignResponse);
+
+		return (Guid.Parse(userId), username, password);
 	}
 
 	public Task WaitForResourceAsync(string resourceName) =>

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -59,6 +59,62 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		notification.ActionUrl.Should().Be("/my-engagements");
 	}
 
+	[Test]
+	public async Task MarkNotificationRead_ShouldReturn204AndFlagAsRead_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Mark Read Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+
+		await olafClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
+
+		var updatedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+		updatedNotifications.Single(n => n.Id == notification.Id).IsRead.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task MarkNotificationRead_ShouldReturn404AndLeaveItUnread_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Cross-User Mark Read Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+
+		// Direct ownership-check coverage for #829: vera is not the recipient of
+		// olaf's notification, so this must 404 (not 403, to avoid leaking
+		// existence) and must not flip IsRead as a side effect.
+		var act = () => veraClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+
+		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+		unchangedNotifications.Single(n => n.Id == notification.Id).IsRead.Should().BeFalse();
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
 		string username, string password)
 	{

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -309,6 +309,125 @@ public class OrganizationSettingsTests(
 	}
 
 	[Test]
+	public async Task DeclineInvitation_ShouldReturn204AndMarkDeclined_WhenRequestingUserIsTheInvitee(
+		CancellationToken cancellationToken)
+	{
+		// Direct positive-path coverage for #829: Decline had zero tests of any
+		// kind before this, unlike Accept.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Decline Success Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+
+		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
+		invitations.Should().ContainSingle(i => i.Id == invitation.InvitationId && i.Status == "Declined");
+	}
+
+	[Test]
+	public async Task DeclineInvitation_ShouldReturn403_WhenRequestingUserIsNotTheInvitee(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Decline 403 Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+
+		// admin is neither the inviter nor the invitee - guaranteed not to be vera.
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var act = () => adminClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
+
+		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
+		invitations.Should().ContainSingle(i => i.Id == invitation.InvitationId && i.Status == "Pending");
+	}
+
+	[Test]
+	public async Task DeclineInvitation_ShouldReturn404_WhenInvitationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.DeclineInvitationAsync(Guid.NewGuid(), cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task DeclineInvitation_ShouldReturn409_WhenInvitationIsAlreadyAccepted(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Decline 409 Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var act = () => veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+	}
+
+	[Test]
+	public async Task AcceptInvitation_ShouldReturn403_WhenRequestingUserIsNotTheInvitee(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Accept 403 Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+
+		// admin is neither the inviter nor the invitee - guaranteed not to be vera.
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var act = () => adminClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
+
+		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
+		invitations.Should().ContainSingle(i => i.Id == invitation.InvitationId && i.Status == "Pending");
+	}
+
+	[Test]
+	public async Task AcceptInvitation_ShouldReturn404_WhenInvitationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.AcceptInvitationAsync(Guid.NewGuid(), cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
 	public async Task GetOrgInvitations_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
…line, and notification ownership (#829)

DeleteMyAccount, AcceptInvitation/DeclineInvitation, and MarkNotificationRead had zero direct unit/integration assertions despite being the paths where an undetected regression is most expensive - irreversible account cleanup and cross-user permission checks. Adds handler-level unit tests (NSubstitute) for all three, plus integration tests against a throwaway per-test Keycloak user for account deletion, and HTTP-level negative-auth/ownership cases for the other two.

Closes #829