### PR TITLE
fix: stop persisting hardcoded German "Unbenannt" as untitled draft placeholder

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -104,12 +104,8 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 				request.ZipCode ?? string.Empty,
 				request.City ?? string.Empty).GetValueOrThrow();
 
-		var title = status == OpportunityStatus.Draft && string.IsNullOrWhiteSpace(request.Title)
-			? "Unbenannt"
-			: request.Title ?? string.Empty;
-
 		var command = new CreateVolunteerOpportunityCommand(
-			title,
+			request.Title ?? string.Empty,
 			request.Description ?? string.Empty,
 			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(),
 			request.IsRemote,

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -51,11 +51,6 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 					"ParticipationType cannot be changed while active engagements exist."));
 		}
 
-		var title = opportunity.Status == OpportunityStatus.Draft
-			&& string.IsNullOrWhiteSpace(request.Title)
-				? "Unbenannt"
-				: request.Title;
-
 		var address = request.Address;
 
 		if (!request.IsRemote && address is not null)
@@ -66,7 +61,7 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 		var prevAddress = opportunity.Address;
 		var prevOccurrence = opportunity.Occurrence;
 
-		opportunity.Rename(title).ThrowIfFailure();
+		opportunity.Rename(request.Title).ThrowIfFailure();
 		opportunity.ChangeDescription(request.Description).ThrowIfFailure();
 		opportunity.Relocate(request.IsRemote, address).ThrowIfFailure();
 		opportunity.Reschedule(request.Occurrence);

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -105,9 +105,6 @@ public sealed class VolunteerOpportunity
 		OpportunityStatus status = OpportunityStatus.Published,
 		string? checkInPin = null)
 	{
-		if (string.IsNullOrWhiteSpace(title))
-			return Result.Failure<VolunteerOpportunity>(Error.Validation("VolunteerOpportunity.TitleRequired", "Title must not be empty."));
-
 		if (checkInMethod == CheckInMethod.PINCode && checkInPin is not null)
 		{
 			var validPin = EnsureValidPin(checkInPin);
@@ -117,7 +114,7 @@ public sealed class VolunteerOpportunity
 
 		if (status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(description, isRemote, address);
+			var publishable = EnsurePublishable(title, description, isRemote, address);
 			if (publishable.IsFailure)
 				return Result.Failure<VolunteerOpportunity>(publishable.Error);
 
@@ -149,10 +146,14 @@ public sealed class VolunteerOpportunity
 	}
 
 	private static Result EnsurePublishable(
+		string title,
 		string description,
 		bool isRemote,
 		Address? address)
 	{
+		if (string.IsNullOrWhiteSpace(title))
+			return Result.Failure(Error.Validation("VolunteerOpportunity.TitleRequired", "Title must not be empty."));
+
 		if (string.IsNullOrWhiteSpace(description))
 			return Result.Failure(Error.Validation("VolunteerOpportunity.DescriptionRequired", "Description must not be empty."));
 
@@ -167,7 +168,7 @@ public sealed class VolunteerOpportunity
 		if (Status == OpportunityStatus.Published)
 			return Result.Failure(Error.Conflict("VolunteerOpportunity.AlreadyPublished", "Opportunity is already published."));
 
-		var publishable = EnsurePublishable(Description, IsRemote, Address);
+		var publishable = EnsurePublishable(Title, Description, IsRemote, Address);
 		if (publishable.IsFailure)
 			return publishable;
 
@@ -202,8 +203,12 @@ public sealed class VolunteerOpportunity
 
 	public Result Rename(string title)
 	{
-		if (string.IsNullOrWhiteSpace(title))
-			return Result.Failure(Error.Validation("VolunteerOpportunity.TitleRequired", "Title must not be empty."));
+		if (Status == OpportunityStatus.Published)
+		{
+			var publishable = EnsurePublishable(title, Description, IsRemote, Address);
+			if (publishable.IsFailure)
+				return publishable;
+		}
 
 		Title = title;
 		return Result.Success();
@@ -213,7 +218,7 @@ public sealed class VolunteerOpportunity
 	{
 		if (Status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(description, IsRemote, Address);
+			var publishable = EnsurePublishable(Title, description, IsRemote, Address);
 			if (publishable.IsFailure)
 				return publishable;
 		}
@@ -226,7 +231,7 @@ public sealed class VolunteerOpportunity
 	{
 		if (Status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(Description, isRemote, address);
+			var publishable = EnsurePublishable(Title, Description, isRemote, address);
 			if (publishable.IsFailure)
 				return publishable;
 		}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -70,6 +70,32 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldPersistEmptyTitle_WhenDraftAndTitleOmitted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new CreateVolunteerOpportunityCommand(
+			string.Empty,
+			"For moving",
+			TestOrganizationId,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			null,
+			[],
+			OpportunityStatus.Draft,
+			DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Title.Should().Be(string.Empty);
+	}
+
+	[Test]
 	public async Task Handle_ShouldUseGivenCheckInPin(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -52,6 +52,9 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	private VolunteerOpportunity CreateOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
 		VolunteerOpportunity.Create(DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator).Value;
 
+	private VolunteerOpportunity CreateDraftOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
+		VolunteerOpportunity.Create(DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+
 	private VolunteerOpportunity CreatePublishedWaitlistOpportunity()
 	{
 		var opportunity = VolunteerOpportunity.Create(
@@ -287,6 +290,29 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>()
 			.WithMessage("*Title must not be empty*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldAllowEmptyTitle_WhenDraft(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateDraftOpportunity();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.Title.Should().Be(string.Empty);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -87,6 +87,30 @@ public class VolunteerOpportunityTests
 	[Arguments("")]
 	[Arguments("   ")]
 	[Arguments(null)]
+	public void Create_ShouldAllow_EmptyTitle_WhenDraft(string? title)
+	{
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			title!,
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Title.Should().Be(title);
+	}
+
+	[Test]
+	[Arguments("")]
+	[Arguments("   ")]
+	[Arguments(null)]
 	public void Create_ShouldFail_WhenDescriptionIsEmpty(string? description)
 	{
 		// Act
@@ -270,9 +294,23 @@ public class VolunteerOpportunityTests
 	[Arguments("")]
 	[Arguments("   ")]
 	[Arguments(null)]
-	public void Rename_ShouldFail_WhenTitleIsEmpty(string? title)
+	public void Rename_ShouldAllow_EmptyTitle_WhenDraft(string? title)
 	{
 		var opportunity = CreateDraftWaitlistOpportunity();
+
+		var result = opportunity.Rename(title!);
+
+		result.IsSuccess.Should().BeTrue();
+		opportunity.Title.Should().Be(title);
+	}
+
+	[Test]
+	[Arguments("")]
+	[Arguments("   ")]
+	[Arguments(null)]
+	public void Rename_ShouldFail_WhenTitleIsEmpty_AndPublished(string? title)
+	{
+		var opportunity = CreatePublishedWaitlistOpportunity();
 
 		var result = opportunity.Rename(title!);
 


### PR DESCRIPTION
## Summary

- Untitled draft volunteer opportunities were saved with the literal German title `"Unbenannt"` instead of an empty title, hardcoded in two places (`CreateVolunteerOpportunityEndpoint.cs` and `UpdateVolunteerOpportunityCommandHandler.cs`). Every client - including the English UI, which already has a correct, localized `"Unnamed Draft"` fallback (`orgDashboard.unnamedDraft`) for a falsy title - displayed the raw German word instead.
- The domain's title-required invariant on `VolunteerOpportunity` now only applies once an opportunity is `Published`, mirroring how `Description` and `Address` are already gated via `EnsurePublishable`. A `Draft` can now be created or renamed with an empty title.
- Both hardcoded `"Unbenannt"` fallbacks are removed; the title is passed straight through as-is (defaulting only `null` to `""`, same as `Description`).
- The frontend already reads this correctly wherever a draft's title can be empty (`OrgOpportunitiesPage.tsx`, `UpcomingOpportunitiesWidget.tsx`, `QuickCheckInWidget.tsx` all do `item.title || t("orgDashboard.unnamedDraft")`), so no frontend changes were needed - the bug was purely a wrong-language string being persisted server-side.

## Test plan

- [x] Added `VolunteerOpportunity.Create`/`Rename` unit tests covering: empty title allowed while `Draft`, still rejected once `Published` (renamed existing `Rename_ShouldFail_WhenTitleIsEmpty` -> `Rename_ShouldFail_WhenTitleIsEmpty_AndPublished` to match the existing `ChangeDescription`/`Relocate` pattern, and added a new `Rename_ShouldAllow_EmptyTitle_WhenDraft`).
- [x] Added `CreateVolunteerOpportunityCommandHandler`/`UpdateVolunteerOpportunityCommandHandler` tests asserting an empty title is persisted verbatim for a Draft (no `"Unbenannt"`/other fallback).
- [x] `dotnet build` (Domain/Application/Api) - 0 errors, 0 warnings.
- [x] `Application.UnitTests` - 320/320 passed.
- [x] `ArchitectureTests` - 271/271 passed.
- [x] Confirmed no NSwag client regeneration needed (no DTO/route shape changed) and no EF Core migration needed (no entity/column shape changed - `Title` was already NOT NULL and an empty string satisfies that same as before).

## Live verification

Pending - will cut a release candidate, deploy to staging, and verify as Organizer Olaf that creating a draft with no title (and clearing an existing draft's title) shows "Unnamed Draft" in English rather than "Unbenannt", per this repo's mandatory deploy-and-verify process. Will update this section with the result.

Fixes #808

---
_Generated by [Claude Code](https://claude.ai/code/session_017BUWZiJPDZMRyJReZv6UEq)_