### PR TITLE
docs: fix arc42 glossary CQRS entry to reference in-house ISender med…

### DIFF
--- a/docs/Architecture/src/12_glossary.adoc
+++ b/docs/Architecture/src/12_glossary.adoc
@@ -20,7 +20,7 @@ ifndef::imagesdir[:imagesdir: ../images]
 |.NET's local orchestration framework. The AppHost project provisions PostgreSQL, pgAdmin, Keycloak, MinIO, Mailpit, the backend API, and the Vite frontend with a single `dotnet run`.
 
 |CQRS
-|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands). In Einsatzbereit, implemented via the in-house `ISender` mediator (see Mediator (ISender) below) in the Application layer.
+|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands). In Einsatzbereit, implemented via the in-house `ISender` mediator.
 
 |EF Core
 |Entity Framework Core. The ORM (Object-Relational Mapper) used in the backend to interact with PostgreSQL. Manages the database schema via migrations.

--- a/docs/Architecture/src/12_glossary.adoc
+++ b/docs/Architecture/src/12_glossary.adoc
@@ -20,7 +20,7 @@ ifndef::imagesdir[:imagesdir: ../images]
 |.NET's local orchestration framework. The AppHost project provisions PostgreSQL, pgAdmin, Keycloak, MinIO, Mailpit, the backend API, and the Vite frontend with a single `dotnet run`.
 
 |CQRS
-|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands). In Einsatzbereit, implemented via the in-house `ISender` mediator.
+|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands).
 
 |EF Core
 |Entity Framework Core. The ORM (Object-Relational Mapper) used in the backend to interact with PostgreSQL. Manages the database schema via migrations.

--- a/docs/Architecture/src/12_glossary.adoc
+++ b/docs/Architecture/src/12_glossary.adoc
@@ -20,7 +20,7 @@ ifndef::imagesdir[:imagesdir: ../images]
 |.NET's local orchestration framework. The AppHost project provisions PostgreSQL, pgAdmin, Keycloak, MinIO, Mailpit, the backend API, and the Vite frontend with a single `dotnet run`.
 
 |CQRS
-|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands). In Einsatzbereit, implemented via MediatR in the Application layer.
+|Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands). In Einsatzbereit, implemented via the in-house `ISender` mediator (see Mediator (ISender) below) in the Application layer.
 
 |EF Core
 |Entity Framework Core. The ORM (Object-Relational Mapper) used in the backend to interact with PostgreSQL. Manages the database schema via migrations.


### PR DESCRIPTION
…iator

CQRS entry claimed MediatR, contradicting the Mediator (ISender) entry in the same table. Closes #860.