### PR TITLE
fix: wrap getVolunteerOpportunities 17-arg call in named-options helper

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -63,6 +63,8 @@ await api.createOrganization({ name });
 
 For one-off calls outside React (e.g., scripts), use `createApiClient(token)` directly.
 
+For endpoints with many optional query params (e.g. `getVolunteerOpportunities`, 17 positional params), don't call the generated client method directly - write a named-options wrapper instead, see `lib/volunteerOpportunities.ts`'s `fetchVolunteerOpportunities`.
+
 ## Environment Variables
 
 Defined in `.env.development`. Exposed client-side via Vite (must use `VITE_` prefix).

--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -6,6 +6,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import { formatOccurrence } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
+import { fetchVolunteerOpportunities } from "../lib/volunteerOpportunities";
 import EmptyState from "./EmptyState";
 import Skeleton from "./Skeleton";
 
@@ -979,26 +980,21 @@ export default function VolunteerOpportunitiesList() {
 		const centerLongitude = hasLocation ? parseFloat(lng) : undefined;
 		const radiusKm = hasLocation ? parseFloat(radius) : undefined;
 
-		api
-			.getVolunteerOpportunities(
-				page,
-				LIST_PAGE_SIZE,
-				undefined,
-				occurrence || undefined,
-				participationType || undefined,
-				isRemoteBool,
-				dateFromParsed,
-				dateToParsed,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				centerLatitude,
-				centerLongitude,
-				radiusKm,
+		fetchVolunteerOpportunities(api, {
+			pageNumber: page,
+			pageSize: LIST_PAGE_SIZE,
+			occurrence: occurrence || undefined,
+			participationType: participationType || undefined,
+			isRemote: isRemoteBool,
+			dateFrom: dateFromParsed,
+			dateTo: dateToParsed,
+			centerLatitude,
+			centerLongitude,
+			radiusKm,
+			categories:
 				selectedCategories.length > 0 ? selectedCategories : undefined,
-				tag || undefined,
-			)
+			tag: tag || undefined,
+		})
 			.then((result) => {
 				if (cancelled) return;
 				if (page === 1) setItems(result.items);

--- a/frontend/src/lib/volunteerOpportunities.ts
+++ b/frontend/src/lib/volunteerOpportunities.ts
@@ -1,0 +1,55 @@
+import type {
+	EinsatzbereitApi,
+	PagedListOfVolunteerOpportunitySummary,
+} from "../client/api-client";
+
+export interface FetchVolunteerOpportunitiesOptions {
+	pageNumber: number;
+	pageSize: number;
+	city?: string;
+	occurrence?: string;
+	participationType?: string;
+	isRemote?: boolean;
+	dateFrom?: Date;
+	dateTo?: Date;
+	north?: number;
+	south?: number;
+	east?: number;
+	west?: number;
+	centerLatitude?: number;
+	centerLongitude?: number;
+	radiusKm?: number;
+	categories?: string[];
+	tag?: string;
+}
+
+/**
+ * Named-options wrapper around the NSwag-generated `EinsatzbereitApi.getVolunteerOpportunities`,
+ * which takes 17 positional parameters - see einsatzbereit#870.
+ */
+export function fetchVolunteerOpportunities(
+	api: EinsatzbereitApi,
+	options: FetchVolunteerOpportunitiesOptions,
+	signal?: AbortSignal,
+): Promise<PagedListOfVolunteerOpportunitySummary> {
+	return api.getVolunteerOpportunities(
+		options.pageNumber,
+		options.pageSize,
+		options.city,
+		options.occurrence,
+		options.participationType,
+		options.isRemote,
+		options.dateFrom,
+		options.dateTo,
+		options.north,
+		options.south,
+		options.east,
+		options.west,
+		options.centerLatitude,
+		options.centerLongitude,
+		options.radiusKm,
+		options.categories,
+		options.tag,
+		signal,
+	);
+}


### PR DESCRIPTION
Positional call had many undefined args and no compiler help matching values to the right slot. Add fetchVolunteerOpportunities wrapper in lib/volunteerOpportunities.ts around the NSwag-generated client method.

Closes #870