### PR TITLE
fix: extract shared ImageUploadValidator for avatar/logo/banner uploa…

### DIFF
--- a/backend/src/Api/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoEndpoint.cs
+++ b/backend/src/Api/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoEndpoint.cs
@@ -3,6 +3,7 @@ using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
+using Application.Common.Storage;
 using Application.Organizations.UploadOrganizationLogo.v1;
 using Domain.Primitives;
 using Domain.Users;
@@ -14,11 +15,6 @@ namespace Api.Organizations.UploadOrganizationLogo.v1;
 internal sealed class UploadOrganizationLogoEndpoint
 	: IEndpoint
 {
-	private const long MaxFileSizeBytes = 2 * 1024 * 1024;
-
-	private static readonly string[] AllowedContentTypes =
-		["image/jpeg", "image/png", "image/webp"];
-
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
 		app.MapPut("/organizations/{organizationId:guid}/logo", UploadOrganizationLogoAsync)
 			.WithName("UploadOrganizationLogo")
@@ -45,26 +41,7 @@ internal sealed class UploadOrganizationLogoEndpoint
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		if (file.Length == 0)
-		{
-			return Results.Problem(
-				"Logo image must not be empty.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (file.Length > MaxFileSizeBytes)
-		{
-			return Results.Problem(
-				"Logo image must not exceed 2 MB.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (!AllowedContentTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
-		{
-			return Results.Problem(
-				"Logo image must be a JPEG, PNG or WebP image.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
+		ImageUploadValidator.EnsureValid(file.Length, file.ContentType, "Logo");
 
 		using var memoryStream = new MemoryStream();
 		await file.CopyToAsync(memoryStream, cancellationToken);

--- a/backend/src/Api/Users/UploadUserAvatar/v1/UploadUserAvatarEndpoint.cs
+++ b/backend/src/Api/Users/UploadUserAvatar/v1/UploadUserAvatarEndpoint.cs
@@ -3,6 +3,7 @@ using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
+using Application.Common.Storage;
 using Application.Users.UploadUserAvatar.v1;
 using Domain.Primitives;
 using Domain.Users;
@@ -14,11 +15,6 @@ namespace Api.Users.UploadUserAvatar.v1;
 internal sealed class UploadUserAvatarEndpoint
 	: IEndpoint
 {
-	private const long MaxFileSizeBytes = 2 * 1024 * 1024;
-
-	private static readonly string[] AllowedContentTypes =
-		["image/jpeg", "image/png", "image/webp"];
-
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
 		app.MapPut("/users/me/avatar", UploadUserAvatarAsync)
 			.WithName("UploadUserAvatar")
@@ -42,26 +38,7 @@ internal sealed class UploadUserAvatarEndpoint
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		if (file.Length == 0)
-		{
-			return Results.Problem(
-				"Avatar image must not be empty.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (file.Length > MaxFileSizeBytes)
-		{
-			return Results.Problem(
-				"Avatar image must not exceed 2 MB.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (!AllowedContentTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
-		{
-			return Results.Problem(
-				"Avatar image must be a JPEG, PNG or WebP image.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
+		ImageUploadValidator.EnsureValid(file.Length, file.ContentType, "Avatar");
 
 		using var memoryStream = new MemoryStream();
 		await file.CopyToAsync(memoryStream, cancellationToken);

--- a/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
@@ -3,6 +3,7 @@ using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
+using Application.Common.Storage;
 using Application.VolunteerOpportunities.UploadOpportunityBanner.v1;
 using Domain.Primitives;
 using Domain.Users;
@@ -14,11 +15,6 @@ namespace Api.VolunteerOpportunities.UploadOpportunityBanner.v1;
 internal sealed class UploadOpportunityBannerEndpoint
 	: IEndpoint
 {
-	private const long MaxFileSizeBytes = 2 * 1024 * 1024;
-
-	private static readonly string[] AllowedContentTypes =
-		["image/jpeg", "image/png", "image/webp"];
-
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
 		app.MapPut("/volunteer-opportunities/{opportunityId:guid}/banner", UploadOpportunityBannerAsync)
 			.WithName("UploadOpportunityBanner")
@@ -44,26 +40,7 @@ internal sealed class UploadOpportunityBannerEndpoint
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		if (file.Length == 0)
-		{
-			return Results.Problem(
-				"Banner image must not be empty.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (file.Length > MaxFileSizeBytes)
-		{
-			return Results.Problem(
-				"Banner image must not exceed 2 MB.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
-
-		if (!AllowedContentTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
-		{
-			return Results.Problem(
-				"Banner image must be a JPEG, PNG or WebP image.",
-				statusCode: StatusCodes.Status400BadRequest);
-		}
+		ImageUploadValidator.EnsureValid(file.Length, file.ContentType, "Banner");
 
 		using var memoryStream = new MemoryStream();
 		await file.CopyToAsync(memoryStream, cancellationToken);

--- a/backend/src/Application/Common/Storage/ImageUploadValidator.cs
+++ b/backend/src/Application/Common/Storage/ImageUploadValidator.cs
@@ -1,0 +1,40 @@
+using Application.Common.Exceptions;
+using Domain.Primitives;
+
+namespace Application.Common.Storage;
+
+public static class ImageUploadValidator
+{
+	public const long MaxFileSizeBytes = 2 * 1024 * 1024;
+
+	public static readonly string[] AllowedContentTypes =
+		["image/jpeg", "image/png", "image/webp"];
+
+	private static readonly Dictionary<string, string> Extensions = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["image/jpeg"] = ".jpg",
+		["image/png"] = ".png",
+		["image/webp"] = ".webp",
+	};
+
+	public static void EnsureValid(long fileLength, string contentType, string subject)
+	{
+		if (fileLength == 0)
+			throw new ResultFailureException(Error.Validation(
+				"FileUpload.Empty",
+				$"{subject} image must not be empty."));
+
+		if (fileLength > MaxFileSizeBytes)
+			throw new ResultFailureException(Error.Validation(
+				"FileUpload.TooLarge",
+				$"{subject} image must not exceed 2 MB."));
+
+		if (!AllowedContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
+			throw new ResultFailureException(Error.Validation(
+				"FileUpload.InvalidContentType",
+				$"{subject} image must be a JPEG, PNG or WebP image."));
+	}
+
+	public static string GetExtension(string contentType) =>
+		Extensions.GetValueOrDefault(contentType, ".jpg");
+}

--- a/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
+++ b/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
@@ -13,17 +13,12 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 	IFileStorageService fileStorage)
 	: ICommandHandler<UploadOrganizationLogoCommand, bool>
 {
-	private static readonly Dictionary<string, string> Extensions = new(StringComparer.OrdinalIgnoreCase)
-	{
-		["image/jpeg"] = ".jpg",
-		["image/png"] = ".png",
-		["image/webp"] = ".webp",
-	};
-
 	public async ValueTask<bool> Handle(
 		UploadOrganizationLogoCommand request,
 		CancellationToken cancellationToken = default)
 	{
+		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Logo");
+
 		var organization = await dbContext.Organizations.FindAsync(
 			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(), cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("Organization.NotFound", $"Organization '{request.OrganizationId}' not found."));
@@ -34,7 +29,7 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var ext = Extensions.GetValueOrDefault(request.ContentType, ".jpg");
+		var ext = ImageUploadValidator.GetExtension(request.ContentType);
 		var objectKey = $"organization-logos/{request.OrganizationId}{ext}";
 
 		using var stream = new MemoryStream(request.Content);

--- a/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
+++ b/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
@@ -1,7 +1,6 @@
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Common.Storage;
-using Domain.Primitives;
 using Domain.Users;
 
 namespace Application.Users.UploadUserAvatar.v1;
@@ -11,17 +10,12 @@ internal sealed class UploadUserAvatarCommandHandler(
 	IFileStorageService fileStorage)
 	: ICommandHandler<UploadUserAvatarCommand, bool>
 {
-	private static readonly Dictionary<string, string> Extensions = new(StringComparer.OrdinalIgnoreCase)
-	{
-		["image/jpeg"] = ".jpg",
-		["image/png"] = ".png",
-		["image/webp"] = ".webp",
-	};
-
 	public async ValueTask<bool> Handle(
 		UploadUserAvatarCommand request,
 		CancellationToken cancellationToken = default)
 	{
+		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Avatar");
+
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 
 		if (user is null)
@@ -30,7 +24,7 @@ internal sealed class UploadUserAvatarCommandHandler(
 			await dbContext.Users.AddAsync(user, cancellationToken);
 		}
 
-		var ext = Extensions.GetValueOrDefault(request.ContentType, ".jpg");
+		var ext = ImageUploadValidator.GetExtension(request.ContentType);
 		var objectKey = $"user-avatars/{request.UserId.Value}{ext}";
 
 		using var stream = new MemoryStream(request.Content);

--- a/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
@@ -13,17 +13,12 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 	IFileStorageService fileStorage)
 	: ICommandHandler<UploadOpportunityBannerCommand, bool>
 {
-	private static readonly Dictionary<string, string> Extensions = new(StringComparer.OrdinalIgnoreCase)
-	{
-		["image/jpeg"] = ".jpg",
-		["image/png"] = ".png",
-		["image/webp"] = ".webp",
-	};
-
 	public async ValueTask<bool> Handle(
 		UploadOpportunityBannerCommand request,
 		CancellationToken cancellationToken = default)
 	{
+		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Banner");
+
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
 			VolunteerOpportunityId.Create(request.OpportunityId).GetValueOrThrow(), cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId}' not found."));
@@ -34,7 +29,7 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var ext = Extensions.GetValueOrDefault(request.ContentType, ".jpg");
+		var ext = ImageUploadValidator.GetExtension(request.ContentType);
 		var objectKey = $"opportunity-banners/{request.OpportunityId}{ext}";
 
 		using var stream = new MemoryStream(request.Content);

--- a/backend/tests/Application.UnitTests/Common/Storage/ImageUploadValidatorTests.cs
+++ b/backend/tests/Application.UnitTests/Common/Storage/ImageUploadValidatorTests.cs
@@ -1,0 +1,70 @@
+using Application.Common.Exceptions;
+using Application.Common.Storage;
+using AwesomeAssertions;
+using Domain.Primitives;
+
+namespace Application.UnitTests.Common.Storage;
+
+public class ImageUploadValidatorTests
+{
+	[Test]
+	public void EnsureValid_ShouldNotThrow_WhenFileIsValid()
+	{
+		// Act
+		Action act = () => ImageUploadValidator.EnsureValid(1024, "image/png", "Avatar");
+
+		// Assert
+		act.Should().NotThrow();
+	}
+
+	[Test]
+	public void EnsureValid_ShouldThrowValidationError_WhenFileIsEmpty()
+	{
+		// Act
+		Action act = () => ImageUploadValidator.EnsureValid(0, "image/png", "Avatar");
+
+		// Assert
+		act.Should().Throw<ResultFailureException>()
+			.WithMessage("Avatar image must not be empty.")
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+
+	[Test]
+	public void EnsureValid_ShouldThrowValidationError_WhenFileExceedsMaxSize()
+	{
+		// Act
+		Action act = () => ImageUploadValidator.EnsureValid(
+			ImageUploadValidator.MaxFileSizeBytes + 1, "image/png", "Logo");
+
+		// Assert
+		act.Should().Throw<ResultFailureException>()
+			.WithMessage("Logo image must not exceed 2 MB.")
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+
+	[Test]
+	public void EnsureValid_ShouldThrowValidationError_WhenContentTypeIsNotAllowed()
+	{
+		// Act
+		Action act = () => ImageUploadValidator.EnsureValid(1024, "image/gif", "Banner");
+
+		// Assert
+		act.Should().Throw<ResultFailureException>()
+			.WithMessage("Banner image must be a JPEG, PNG or WebP image.")
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+
+	[Test]
+	[Arguments("image/jpeg", ".jpg")]
+	[Arguments("image/png", ".png")]
+	[Arguments("image/webp", ".webp")]
+	[Arguments("image/gif", ".jpg")]
+	public void GetExtension_ShouldMapKnownContentTypes_AndFallBackToJpg(string contentType, string expectedExtension)
+	{
+		// Act
+		var extension = ImageUploadValidator.GetExtension(contentType);
+
+		// Assert
+		extension.Should().Be(expectedExtension);
+	}
+}


### PR DESCRIPTION
…ds (#875)

Size limit and content-type rules for the three Upload*Endpoint.cs files were duplicated with no shared validator and no enforcement in the Application handlers. Added Application.Common.Storage.ImageUploadValidator and wired it into both the endpoints and their command handlers.

Closes #875