### PR TITLE
fix: enforce VolunteerOpportunity title/description length limits in …

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -39,12 +39,6 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		if (request.Title is { Length: > 200 })
-			return Results.Problem("Title must not exceed 200 characters.", statusCode: StatusCodes.Status400BadRequest);
-
-		if (request.Description is { Length: > 5000 })
-			return Results.Problem("Description must not exceed 5000 characters.", statusCode: StatusCodes.Status400BadRequest);
-
 		if (!Enum.TryParse<Occurrence>(request.Occurrence, ignoreCase: true, out var occurrence))
 		{
 			return Results.Problem(

--- a/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
@@ -38,12 +38,6 @@ internal sealed class UpdateVolunteerOpportunityEndpoint
 	{
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? UserId.Create(uid).GetValueOrThrow() : throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		if (request.Title is { Length: > 200 })
-			return Results.Problem("Title must not exceed 200 characters.", statusCode: StatusCodes.Status400BadRequest);
-
-		if (request.Description is { Length: > 5000 })
-			return Results.Problem("Description must not exceed 5000 characters.", statusCode: StatusCodes.Status400BadRequest);
-
 		if (request.CheckInPin is { Length: > 0 } pin && (pin.Length < 4 || pin.Length > 6 || !pin.All(char.IsAsciiDigit)))
 		{
 			return Results.Problem(

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -8,6 +8,10 @@ public sealed class VolunteerOpportunity
 	: AggregateRoot<VolunteerOpportunityId>,
 		IAuditableEntity
 {
+	public const int MaxTitleLength = 200;
+
+	public const int MaxDescriptionLength = 5000;
+
 	private readonly List<TimeSlot> _timeSlots = [];
 
 	private List<string> _tags = [];
@@ -90,6 +94,22 @@ public sealed class VolunteerOpportunity
 		return Result.Success();
 	}
 
+	private static Result EnsureValidTitleLength(string? title)
+	{
+		if (title is { Length: > MaxTitleLength })
+			return Result.Failure(Error.Validation("VolunteerOpportunity.TitleTooLong", $"Title must not exceed {MaxTitleLength} characters."));
+
+		return Result.Success();
+	}
+
+	private static Result EnsureValidDescriptionLength(string? description)
+	{
+		if (description is { Length: > MaxDescriptionLength })
+			return Result.Failure(Error.Validation("VolunteerOpportunity.DescriptionTooLong", $"Description must not exceed {MaxDescriptionLength} characters."));
+
+		return Result.Success();
+	}
+
 	public static Result<VolunteerOpportunity> Create(
 		OrganizationId organizationId,
 		string title,
@@ -105,6 +125,14 @@ public sealed class VolunteerOpportunity
 		OpportunityStatus status = OpportunityStatus.Published,
 		string? checkInPin = null)
 	{
+		var validTitleLength = EnsureValidTitleLength(title);
+		if (validTitleLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validTitleLength.Error);
+
+		var validDescriptionLength = EnsureValidDescriptionLength(description);
+		if (validDescriptionLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validDescriptionLength.Error);
+
 		if (checkInMethod == CheckInMethod.PINCode && checkInPin is not null)
 		{
 			var validPin = EnsureValidPin(checkInPin);
@@ -203,6 +231,10 @@ public sealed class VolunteerOpportunity
 
 	public Result Rename(string title)
 	{
+		var validTitleLength = EnsureValidTitleLength(title);
+		if (validTitleLength.IsFailure)
+			return validTitleLength;
+
 		if (Status == OpportunityStatus.Published)
 		{
 			var publishable = EnsurePublishable(title, Description, IsRemote, Address);
@@ -216,6 +248,10 @@ public sealed class VolunteerOpportunity
 
 	public Result ChangeDescription(string description)
 	{
+		var validDescriptionLength = EnsureValidDescriptionLength(description);
+		if (validDescriptionLength.IsFailure)
+			return validDescriptionLength;
+
 		if (Status == OpportunityStatus.Published)
 		{
 			var publishable = EnsurePublishable(Title, description, IsRemote, Address);

--- a/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
@@ -27,9 +27,11 @@ internal sealed class VolunteerOpportunityConfiguration
 			.IsRequired();
 
 		builder.Property(vo => vo.Title)
+			.HasMaxLength(VolunteerOpportunity.MaxTitleLength)
 			.IsRequired();
 
 		builder.Property(vo => vo.Description)
+			.HasMaxLength(VolunteerOpportunity.MaxDescriptionLength)
 			.IsRequired();
 
 		builder.Property(vo => vo.IsRemote)

--- a/backend/src/Infrastructure/Persistence/Migrations/20260724064648_AddVolunteerOpportunityTitleDescriptionMaxLength.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260724064648_AddVolunteerOpportunityTitleDescriptionMaxLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260724064648_AddVolunteerOpportunityTitleDescriptionMaxLength")]
+	partial class AddVolunteerOpportunityTitleDescriptionMaxLength
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260724064648_AddVolunteerOpportunityTitleDescriptionMaxLength.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260724064648_AddVolunteerOpportunityTitleDescriptionMaxLength.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddVolunteerOpportunityTitleDescriptionMaxLength : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<string>(
+				name: "title",
+				table: "volunteer_opportunity",
+				type: "character varying(200)",
+				maxLength: 200,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "text");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "description",
+				table: "volunteer_opportunity",
+				type: "character varying(5000)",
+				maxLength: 5000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "text");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<string>(
+				name: "title",
+				table: "volunteer_opportunity",
+				type: "text",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "character varying(200)",
+				oldMaxLength: 200);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "description",
+				table: "volunteer_opportunity",
+				type: "text",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "character varying(5000)",
+				oldMaxLength: 5000);
+		}
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -131,6 +131,100 @@ public class VolunteerOpportunityTests
 	}
 
 	[Test]
+	public void Create_ShouldFail_WhenTitleExceedsMaxLength()
+	{
+		// Arrange
+		var title = new string('a', VolunteerOpportunity.MaxTitleLength + 1);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			title,
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Title must not exceed {VolunteerOpportunity.MaxTitleLength} characters.");
+	}
+
+	[Test]
+	public void Create_ShouldAllow_TitleAtMaxLength()
+	{
+		// Arrange
+		var title = new string('a', VolunteerOpportunity.MaxTitleLength);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			title,
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+	}
+
+	[Test]
+	public void Create_ShouldFail_WhenDescriptionExceedsMaxLength()
+	{
+		// Arrange
+		var description = new string('a', VolunteerOpportunity.MaxDescriptionLength + 1);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			description,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Description must not exceed {VolunteerOpportunity.MaxDescriptionLength} characters.");
+	}
+
+	[Test]
+	public void Create_ShouldAllow_DescriptionAtMaxLength()
+	{
+		// Arrange
+		var description = new string('a', VolunteerOpportunity.MaxDescriptionLength);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			description,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+	}
+
+	[Test]
 	public void Create_ShouldFail_WhenNotRemoteAndAddressIsNull()
 	{
 		// Act
@@ -330,6 +424,30 @@ public class VolunteerOpportunityTests
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Be("Description must not be empty.");
+	}
+
+	[Test]
+	public void Rename_ShouldFail_WhenTitleExceedsMaxLength_EvenWhenDraft()
+	{
+		var opportunity = CreateDraftWaitlistOpportunity();
+		var title = new string('a', VolunteerOpportunity.MaxTitleLength + 1);
+
+		var result = opportunity.Rename(title);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Title must not exceed {VolunteerOpportunity.MaxTitleLength} characters.");
+	}
+
+	[Test]
+	public void ChangeDescription_ShouldFail_WhenDescriptionExceedsMaxLength_EvenWhenDraft()
+	{
+		var opportunity = CreateDraftWaitlistOpportunity();
+		var description = new string('a', VolunteerOpportunity.MaxDescriptionLength + 1);
+
+		var result = opportunity.ChangeDescription(description);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Description must not exceed {VolunteerOpportunity.MaxDescriptionLength} characters.");
 	}
 
 	[Test]


### PR DESCRIPTION
…Domain

Title (200) and description (5000) max lengths were only checked by hand-rolled if-blocks in the Create/Update endpoints, so any non-HTTP caller of the command (or a future endpoint) could bypass them entirely. Move the guard into VolunteerOpportunity.Create/Rename/ChangeDescription (unconditional, like the existing PIN-length check) and mirror the limits in the EF Core column configuration so the database enforces them too.

Closes #874 