### PR TITLE
fix: reject CreateTimeSlot requests with RecurrenceCount > 1 and null…

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
@@ -48,6 +48,13 @@ internal sealed class CreateTimeSlotEndpoint : IEndpoint
 				statusCode: StatusCodes.Status400BadRequest);
 		}
 
+		if (request.RecurrenceFrequency is null && recurrenceCount > 1)
+		{
+			return Results.Problem(
+				"RecurrenceFrequency is required when RecurrenceCount is greater than 1.",
+				statusCode: StatusCodes.Status400BadRequest);
+		}
+
 		var command = new CreateTimeSlotCommand(
 			opportunityId,
 			request.StartDateTime,

--- a/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
@@ -28,7 +28,9 @@ internal sealed class CreateTimeSlotCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var count = Math.Clamp(request.RecurrenceCount, 1, MaxRecurrenceCount);
+		var count = request.RecurrenceFrequency is null
+			? 1
+			: Math.Clamp(request.RecurrenceCount, 1, MaxRecurrenceCount);
 		var duration = request.EndDateTime - request.StartDateTime;
 		var slots = new List<TimeSlot>(count);
 		var now = DateTimeOffset.UtcNow;

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -144,6 +144,27 @@ public class CreateTimeSlotCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldCreateSingleSlot_WhenFrequencyIsNullEvenIfCountIsGreaterThan1(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new CreateTimeSlotCommand(
+			opportunityId, BaseStart, BaseEnd, 10, DefaultRequestingUserId,
+			RecurrenceFrequency: null, RecurrenceCount: 5);
+
+		var result = await _sut.Handle(command, cancellationToken);
+
+		result.Should().HaveCount(1);
+		result[0].StartDateTime.Should().Be(BaseStart);
+		result[0].EndDateTime.Should().Be(BaseEnd);
+	}
+
+	[Test]
 	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/CreateTimeSlotTests.cs
+++ b/backend/tests/IntegrationTests/CreateTimeSlotTests.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class CreateTimeSlotTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	// ── CreateTimeSlot (#907) ─────────────────────────────────────────────────
+
+	[Test]
+	public async Task CreateTimeSlot_ShouldReturn400_WhenRecurrenceCountGreaterThan1AndFrequencyIsNull(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var act = () => olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = null,
+				RecurrenceCount = 5,
+			},
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task CreateTimeSlot_ShouldReturn1Slot_WhenFrequencyIsNullAndCountIsOne(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = null,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		timeSlots.Should().HaveCount(1);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"CreateTimeSlotTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		// Time slots can only be added to Waitlist opportunities (see
+		// VolunteerOpportunity.AddTimeSlot). Created as a draft since a Waitlist
+		// opportunity can't be published until it has at least one time slot.
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "Recurring",
+				ParticipationType = "Waitlist",
+				CheckInMethod = "None",
+				IsDraft = true,
+			},
+			cancellationToken);
+	}
+}


### PR DESCRIPTION
… RecurrenceFrequency

Endpoint validation now rejects the combination with a 400. The handler also defends independently by forcing count to 1 when frequency is null, since previously it silently created N identical, fully-overlapping slots.

Fixes #907