### PR TITLE
fix: add concurrency cancel-in-progress groups to push/PR workflows

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/keycloak-realm-import.yml
+++ b/.github/workflows/keycloak-realm-import.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   import-check:
     name: Import realm on production Keycloak version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ban-typographic-dashes:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conventional-commits:
     name: Validate PR title (Conventional Commits)


### PR DESCRIPTION
Rapid consecutive pushes queued redundant runs instead of superseding them, wasting CI minutes and delaying feedback. Adds the same concurrency group pattern already used by dotnet.yml to frontend.yml, keycloak-realm-import.yml, lint.yml, and pr-title.yml.

Fixes #865