### PR TITLE
fix: gate draft volunteer opportunity details behind organizer check

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -248,6 +248,18 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (result is null)
 			return null;
 
+		if (result.Status != OpportunityStatus.Published)
+		{
+			var isOrganizer = requestingUserId is Guid requestingUserId_ &&
+				await dbContext.IsOrganizerAsync(
+					result.OrganizationId,
+					UserId.Create(requestingUserId_).GetValueOrThrow(),
+					cancellationToken);
+
+			if (!isOrganizer)
+				return null;
+		}
+
 		var timeSlots = await dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => vo.Id == opportunityId_)
 			.SelectMany(vo => vo.TimeSlots)

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityDetailsTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityDetailsTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetVolunteerOpportunityDetailsTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetVolunteerOpportunityDetails_ShouldReturn404_WhenOpportunityIsDraftAndRequesterIsAnonymous(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var anonymousClient = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => anonymousClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunityDetails_ShouldReturn404_WhenOpportunityIsDraftAndRequesterIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => veraClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunityDetails_ShouldReturnDetails_WhenOpportunityIsDraftAndRequesterIsOrganizer(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var details = await olafClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+
+		details.Should().NotBeNull();
+		details.Status.Should().Be("Draft");
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunityDetails_ShouldReturnDetails_WhenOpportunityIsPublishedAndRequesterIsAnonymous(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var anonymousClient = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var details = await anonymousClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+
+		details.Should().NotBeNull();
+		details.Status.Should().Be("Published");
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"DetailsTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateDraftOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken) =>
+		await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				IsDraft = true,
+			},
+			cancellationToken);
+}


### PR DESCRIPTION
GetVolunteerOpportunityDetails let anyone view a Draft opportunity's details by ID, unlike the public listing which already filters to Published. Non-Published opportunities now return 404 unless the requester is an organizer of the owning organization.

Closes #905