### PR TITLE
refactor: extract shared useLoadMore hook for list pagination

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import { useLoadMore } from "../hooks/useLoadMore";
 import { formatOccurrence } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
@@ -846,12 +847,54 @@ export default function VolunteerOpportunitiesList() {
 	const nominatimAbortRef = useRef<AbortController | null>(null);
 	const filterBarRef = useRef<HTMLDivElement>(null);
 
-	const [items, setItems] = useState<VolunteerOpportunitySummary[]>([]);
-	const [page, setPage] = useState(1);
-	const [pageCount, setPageCount] = useState(1);
-	const [loading, setLoading] = useState(true);
-	const [loadingMore, setLoadingMore] = useState(false);
-	const [error, setError] = useState<string | null>(null);
+	const { items, loading, loadingMore, error, hasMore, loadMore } =
+		useLoadMore<VolunteerOpportunitySummary>(
+			(pageNumber) => {
+				const isRemoteBool =
+					isRemoteParam === "true"
+						? true
+						: isRemoteParam === "false"
+							? false
+							: undefined;
+				const dateFromParsed = dateFrom ? new Date(dateFrom) : undefined;
+				const dateToParsed = dateTo ? new Date(dateTo) : undefined;
+				const centerLatitude = hasLocation ? parseFloat(lat) : undefined;
+				const centerLongitude = hasLocation ? parseFloat(lng) : undefined;
+				const radiusKm = hasLocation ? parseFloat(radius) : undefined;
+
+				return fetchVolunteerOpportunities(api, {
+					pageNumber,
+					pageSize: LIST_PAGE_SIZE,
+					occurrence: occurrence || undefined,
+					participationType: participationType || undefined,
+					isRemote: isRemoteBool,
+					dateFrom: dateFromParsed,
+					dateTo: dateToParsed,
+					centerLatitude,
+					centerLongitude,
+					radiusKm,
+					categories:
+						selectedCategories.length > 0 ? selectedCategories : undefined,
+					tag: tag || undefined,
+				});
+			},
+			{
+				deps: [
+					lat,
+					lng,
+					radius,
+					occurrence,
+					participationType,
+					isRemoteParam,
+					dateFrom,
+					dateTo,
+					categoriesParam,
+					tag,
+				],
+				getErrorMessage: (err) =>
+					getApiErrorMessage(err, t("error.serverError")),
+			},
+		);
 
 	useEffect(() => {
 		function handleOutside(e: MouseEvent) {
@@ -913,120 +956,6 @@ export default function VolunteerOpportunitiesList() {
 			controller.abort();
 		};
 	}, [locationCityInput]);
-
-	const prevFiltersRef = useRef({
-		lat,
-		lng,
-		radius,
-		occurrence,
-		participationType,
-		isRemoteParam,
-		dateFrom,
-		dateTo,
-		categories: categoriesParam,
-		tag,
-	});
-
-	useEffect(() => {
-		const prev = prevFiltersRef.current;
-		const filterChanged =
-			prev.lat !== lat ||
-			prev.lng !== lng ||
-			prev.radius !== radius ||
-			prev.occurrence !== occurrence ||
-			prev.participationType !== participationType ||
-			prev.isRemoteParam !== isRemoteParam ||
-			prev.dateFrom !== dateFrom ||
-			prev.dateTo !== dateTo ||
-			prev.categories !== categoriesParam ||
-			prev.tag !== tag;
-
-		prevFiltersRef.current = {
-			lat,
-			lng,
-			radius,
-			occurrence,
-			participationType,
-			isRemoteParam,
-			dateFrom,
-			dateTo,
-			categories: categoriesParam,
-			tag,
-		};
-
-		if (filterChanged) {
-			setItems([]);
-			if (page !== 1) {
-				setPage(1);
-				return;
-			}
-		}
-
-		if (page > 1) setLoadingMore(true);
-		else setLoading(true);
-		setError(null);
-
-		let cancelled = false;
-		const isRemoteBool =
-			isRemoteParam === "true"
-				? true
-				: isRemoteParam === "false"
-					? false
-					: undefined;
-		const dateFromParsed = dateFrom ? new Date(dateFrom) : undefined;
-		const dateToParsed = dateTo ? new Date(dateTo) : undefined;
-
-		const centerLatitude = hasLocation ? parseFloat(lat) : undefined;
-		const centerLongitude = hasLocation ? parseFloat(lng) : undefined;
-		const radiusKm = hasLocation ? parseFloat(radius) : undefined;
-
-		fetchVolunteerOpportunities(api, {
-			pageNumber: page,
-			pageSize: LIST_PAGE_SIZE,
-			occurrence: occurrence || undefined,
-			participationType: participationType || undefined,
-			isRemote: isRemoteBool,
-			dateFrom: dateFromParsed,
-			dateTo: dateToParsed,
-			centerLatitude,
-			centerLongitude,
-			radiusKm,
-			categories:
-				selectedCategories.length > 0 ? selectedCategories : undefined,
-			tag: tag || undefined,
-		})
-			.then((result) => {
-				if (cancelled) return;
-				if (page === 1) setItems(result.items);
-				else setItems((prev) => [...prev, ...result.items]);
-				setPageCount(result.pageCount ?? 1);
-				setLoading(false);
-				setLoadingMore(false);
-			})
-			.catch((err) => {
-				if (cancelled) return;
-				setError(getApiErrorMessage(err, t("error.serverError")));
-				setLoading(false);
-				setLoadingMore(false);
-			});
-
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		page,
-		lat,
-		lng,
-		radius,
-		occurrence,
-		participationType,
-		isRemoteParam,
-		dateFrom,
-		dateTo,
-		categoriesParam,
-		tag,
-	]);
 
 	function updateFilter(key: string, value: string) {
 		const next = new URLSearchParams(window.location.search);
@@ -1737,10 +1666,10 @@ export default function VolunteerOpportunitiesList() {
 						</ul>
 					)}
 
-					{items.length > 0 && page < pageCount && (
+					{items.length > 0 && hasMore && (
 						<div className="mt-8 flex justify-center">
 							<button
-								onClick={() => setPage((p) => p + 1)}
+								onClick={loadMore}
 								disabled={loadingMore}
 								className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
 							>

--- a/frontend/src/hooks/useLoadMore.ts
+++ b/frontend/src/hooks/useLoadMore.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+export interface LoadMorePage<T> {
+	items: T[];
+	pageCount?: number;
+}
+
+export type FetchPage<T> = (page: number) => Promise<LoadMorePage<T>>;
+
+export interface UseLoadMoreOptions {
+	/**
+	 * Values that, when changed, reset to page 1 and refetch - the
+	 * useEffect-deps equivalent for "filters/search changed". Omit for lists
+	 * that only ever reset via the returned `reset()` (e.g. a scope switch or
+	 * search-submit handler that already has the fresher value in hand).
+	 */
+	deps?: unknown[];
+	getErrorMessage?: (error: unknown) => string;
+}
+
+export interface UseLoadMoreResult<T> {
+	items: T[];
+	setItems: Dispatch<SetStateAction<T[]>>;
+	page: number;
+	pageCount: number;
+	loading: boolean;
+	loadingMore: boolean;
+	error: string | null;
+	hasMore: boolean;
+	loadMore: () => void;
+	reset: () => void;
+}
+
+function defaultGetErrorMessage(error: unknown): string {
+	return error instanceof Error
+		? error.message
+		: "An unexpected error occurred.";
+}
+
+/**
+ * Shared load-more pagination: items/page/pageCount/loading/loadingMore/error
+ * plus the fetch-on-page-change effect, extracted from four independent copies
+ * of this exact state (see einsatzbereit#868).
+ *
+ * `fetchPage` is read via a ref updated on every render rather than listed as
+ * an effect dep, so a caller passing a fresh inline closure each render (the
+ * common case - it captures current filters/search) doesn't retrigger the
+ * fetch effect; only a `page` change or an explicit `reset()` does.
+ *
+ * `deps` covers the "reactive" case (filters change -> reset to page 1 and
+ * refetch, mirrors VolunteerOpportunitiesList/OrganizationsPage's own effect
+ * dependency arrays). For the "imperative" case (a scope tab, a search-submit
+ * button), skip `deps` and call `reset()` directly from the event handler
+ * instead, right after committing whatever changed to a state variable that
+ * `fetchPage` itself closes over (not a plain local variable) - React batches
+ * that state update with reset()'s, so the re-render in between picks up the
+ * new value and refreshes this ref before the fetch effect reads it. `reset`
+ * takes no override: the ref is unconditionally re-synced to `fetchPage`
+ * every render, so an override would just get clobbered by the next one.
+ */
+export function useLoadMore<T>(
+	fetchPage: FetchPage<T>,
+	options: UseLoadMoreOptions = {},
+): UseLoadMoreResult<T> {
+	const { deps = [], getErrorMessage = defaultGetErrorMessage } = options;
+
+	const [items, setItems] = useState<T[]>([]);
+	const [page, setPage] = useState(1);
+	const [pageCount, setPageCount] = useState(1);
+	const [loading, setLoading] = useState(true);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [resetToken, setResetToken] = useState(0);
+
+	const fetchPageRef = useRef(fetchPage);
+	fetchPageRef.current = fetchPage;
+
+	const isFirstDepsRun = useRef(true);
+	useEffect(() => {
+		if (isFirstDepsRun.current) {
+			isFirstDepsRun.current = false;
+			return;
+		}
+		setItems([]);
+		setPage(1);
+		setResetToken((n) => n + 1);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps);
+
+	useEffect(() => {
+		let cancelled = false;
+		if (page > 1) setLoadingMore(true);
+		else setLoading(true);
+		setError(null);
+
+		fetchPageRef
+			.current(page)
+			.then((result) => {
+				if (cancelled) return;
+				setItems((prev) =>
+					page === 1 ? result.items : [...prev, ...result.items],
+				);
+				setPageCount(result.pageCount ?? 1);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				setError(getErrorMessage(err));
+			})
+			.finally(() => {
+				if (cancelled) return;
+				setLoading(false);
+				setLoadingMore(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [page, resetToken]);
+
+	const loadMore = useCallback(() => {
+		setPage((p) => p + 1);
+	}, []);
+
+	const reset = useCallback(() => {
+		setItems([]);
+		setError(null);
+		setPage(1);
+		setResetToken((n) => n + 1);
+	}, []);
+
+	return {
+		items,
+		setItems,
+		page,
+		pageCount,
+		loading,
+		loadingMore,
+		error,
+		hasMore: page < pageCount,
+		loadMore,
+		reset,
+	};
+}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import type { AdminUserListItem } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import { useLoadMore } from "../hooks/useLoadMore";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
 import { inputClass } from "../lib/formClasses";
@@ -73,41 +74,28 @@ function OrganizationsSection() {
 	const { t } = useTranslation();
 	const api = useApiClient();
 
-	const [rows, setRows] = useState<OrgRow[]>([]);
-	const [page, setPage] = useState(1);
-	const [pageCount, setPageCount] = useState(1);
-	const [loading, setLoading] = useState(true);
-	const [loadingMore, setLoadingMore] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [toggling, setToggling] = useState<string | null>(null);
 
-	function load(pageNumber: number) {
-		if (pageNumber > 1) setLoadingMore(true);
-		else setLoading(true);
-		setError(null);
-		api
-			.listOrganizations(pageNumber, PAGE_SIZE)
-			.then((result) => {
-				const mapped = result.items.map((o) => ({
+	const {
+		items: rows,
+		setItems: setRows,
+		loading,
+		loadingMore,
+		error,
+		hasMore,
+		loadMore,
+	} = useLoadMore<OrgRow>(
+		(pageNumber) =>
+			api.listOrganizations(pageNumber, PAGE_SIZE).then((result) => ({
+				items: result.items.map((o) => ({
 					id: o.id,
 					name: o.name,
 					isVerified: o.isVerified,
-				}));
-				if (pageNumber === 1) setRows(mapped);
-				else setRows((prev) => [...prev, ...mapped]);
-				setPageCount(result.pageCount ?? 1);
-			})
-			.catch(() => setError(t("administration.organizations.error")))
-			.finally(() => {
-				setLoading(false);
-				setLoadingMore(false);
-			});
-	}
-
-	useEffect(() => {
-		load(1);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+				})),
+				pageCount: result.pageCount,
+			})),
+		{ getErrorMessage: () => t("administration.organizations.error") },
+	);
 
 	async function toggleVerified(orgId: string, next: boolean) {
 		setToggling(orgId);
@@ -191,15 +179,11 @@ function OrganizationsSection() {
 					</tbody>
 				</table>
 			</div>
-			{page < pageCount && (
+			{hasMore && (
 				<LoadMoreButton
 					loading={loadingMore}
 					label={t("administration.organizations.loadMore")}
-					onClick={() => {
-						const next = page + 1;
-						setPage(next);
-						load(next);
-					}}
+					onClick={loadMore}
 				/>
 			)}
 		</>
@@ -212,44 +196,29 @@ function UsersSection() {
 	const api = useApiClient();
 	const currentUserId = auth.user?.profile?.sub;
 
-	const [rows, setRows] = useState<AdminUserListItem[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [loadingMore, setLoadingMore] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [search, setSearch] = useState("");
 	const [appliedSearch, setAppliedSearch] = useState("");
-	const [page, setPage] = useState(1);
-	const [pageCount, setPageCount] = useState(1);
 	const [pendingUserId, setPendingUserId] = useState<string | null>(null);
 
-	function load(searchTerm: string, pageNumber: number) {
-		if (pageNumber > 1) setLoadingMore(true);
-		else setLoading(true);
-		setError(null);
-		api
-			.listUsers(searchTerm.trim() || undefined, pageNumber, PAGE_SIZE)
-			.then((result) => {
-				if (pageNumber === 1) setRows(result.items);
-				else setRows((prev) => [...prev, ...result.items]);
-				setPageCount(result.pageCount ?? 1);
-			})
-			.catch(() => setError(t("administration.users.error")))
-			.finally(() => {
-				setLoading(false);
-				setLoadingMore(false);
-			});
-	}
-
-	useEffect(() => {
-		load("", 1);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	const {
+		items: rows,
+		setItems: setRows,
+		loading,
+		loadingMore,
+		error,
+		hasMore,
+		loadMore,
+		reset,
+	} = useLoadMore<AdminUserListItem>(
+		(pageNumber) =>
+			api.listUsers(appliedSearch.trim() || undefined, pageNumber, PAGE_SIZE),
+		{ getErrorMessage: () => t("administration.users.error") },
+	);
 
 	function handleSearchSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		setAppliedSearch(search);
-		setPage(1);
-		load(search, 1);
+		reset();
 	}
 
 	async function toggleEnabled(userId: string, next: boolean) {
@@ -444,15 +413,11 @@ function UsersSection() {
 							</tbody>
 						</table>
 					</div>
-					{page < pageCount && (
+					{hasMore && (
 						<LoadMoreButton
 							loading={loadingMore}
 							label={t("administration.users.loadMore")}
-							onClick={() => {
-								const next = page + 1;
-								setPage(next);
-								load(appliedSearch, next);
-							}}
+							onClick={loadMore}
 						/>
 					)}
 				</>

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { PublicOrganizationSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import { useLoadMore } from "../hooks/useLoadMore";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
@@ -20,54 +21,20 @@ export default function OrganizationsPage() {
 	const search = searchParams.get("search") ?? "";
 	const [searchInput, setSearchInput] = useState(search);
 	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const prevSearchRef = useRef(search);
 
-	const [items, setItems] = useState<PublicOrganizationSummary[]>([]);
-	const [page, setPage] = useState(1);
-	const [pageCount, setPageCount] = useState(1);
-	const [loading, setLoading] = useState(true);
-	const [loadingMore, setLoadingMore] = useState(false);
-	const [error, setError] = useState<string | null>(null);
+	const { items, loading, loadingMore, error, hasMore, loadMore } =
+		useLoadMore<PublicOrganizationSummary>(
+			(pageNumber) =>
+				api.getPublicOrganizations(pageNumber, PAGE_SIZE, search || undefined),
+			{
+				deps: [search],
+				getErrorMessage: (err) =>
+					getApiErrorMessage(err, t("error.serverError")),
+			},
+		);
 
 	usePageTitle(t("organizationsPage.title"));
 	usePageToolbar([{ label: t("breadcrumb.organizations") }]);
-
-	useEffect(() => {
-		if (prevSearchRef.current === search) return;
-		prevSearchRef.current = search;
-		setItems([]);
-		setPage(1);
-	}, [search]);
-
-	useEffect(() => {
-		let cancelled = false;
-		if (page > 1) setLoadingMore(true);
-		else setLoading(true);
-		setError(null);
-
-		api
-			.getPublicOrganizations(page, PAGE_SIZE, search || undefined)
-			.then((result) => {
-				if (cancelled) return;
-				if (page === 1) setItems(result.items);
-				else setItems((prev) => [...prev, ...result.items]);
-				setPageCount(result.pageCount ?? 1);
-			})
-			.catch((err) => {
-				if (cancelled) return;
-				setError(getApiErrorMessage(err, t("error.serverError")));
-			})
-			.finally(() => {
-				if (cancelled) return;
-				setLoading(false);
-				setLoadingMore(false);
-			});
-
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [page, search]);
 
 	function commitSearch(value: string) {
 		setSearchParams(
@@ -222,10 +189,10 @@ export default function OrganizationsPage() {
 							))}
 						</ul>
 
-						{page < pageCount && (
+						{hasMore && (
 							<div className="mt-8 flex justify-center">
 								<button
-									onClick={() => setPage((p) => p + 1)}
+									onClick={loadMore}
 									disabled={loadingMore}
 									className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
 								>

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -6,6 +6,7 @@ import type {
 	MyInvitationDto,
 } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
+import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
 import { formatDateTime } from "../../lib/format";
@@ -38,12 +39,26 @@ export default function ActivitySection() {
 	// --- Engagements ---
 	const [engagementsScope, setEngagementsScope] =
 		useState<EngagementsScope>("upcoming");
-	const [engagements, setEngagements] = useState<EngagementSummary[]>([]);
-	const [engagementsPage, setEngagementsPage] = useState(1);
-	const [engagementsPageCount, setEngagementsPageCount] = useState(1);
-	const [engagementsLoading, setEngagementsLoading] = useState(false);
-	const [engagementsLoadingMore, setEngagementsLoadingMore] = useState(false);
-	const [engagementsError, setEngagementsError] = useState<string | null>(null);
+	const {
+		items: engagements,
+		setItems: setEngagements,
+		loading: engagementsLoading,
+		loadingMore: engagementsLoadingMore,
+		error: engagementsError,
+		hasMore: hasMoreEngagements,
+		loadMore: loadMoreEngagements,
+		reset: resetEngagements,
+	} = useLoadMore<EngagementSummary>(
+		(pageNumber) =>
+			api.getMyEngagements(
+				pageNumber,
+				ENGAGEMENTS_PAGE_SIZE,
+				engagementsScope === "upcoming",
+			),
+		{
+			getErrorMessage: (err) => getApiErrorMessage(err, t("error.serverError")),
+		},
+	);
 	const [confirmWithdrawId, setConfirmWithdrawId] = useState<string | null>(
 		null,
 	);
@@ -64,39 +79,11 @@ export default function ActivitySection() {
 		string | null
 	>(null);
 
-	function fetchEngagements(scope: EngagementsScope, page: number) {
-		if (page > 1) setEngagementsLoadingMore(true);
-		else setEngagementsLoading(true);
-		setEngagementsError(null);
-		api
-			.getMyEngagements(page, ENGAGEMENTS_PAGE_SIZE, scope === "upcoming")
-			.then((result) => {
-				setEngagements((prev) =>
-					page === 1 ? result.items : [...prev, ...result.items],
-				);
-				setEngagementsPage(page);
-				setEngagementsPageCount(result.pageCount ?? 1);
-			})
-			.catch((err) =>
-				setEngagementsError(getApiErrorMessage(err, t("error.serverError"))),
-			)
-			.finally(() => {
-				setEngagementsLoading(false);
-				setEngagementsLoadingMore(false);
-			});
-	}
-
 	function switchEngagementsScope(scope: EngagementsScope) {
 		if (scope === engagementsScope) return;
 		setEngagementsScope(scope);
-		setEngagements([]);
-		fetchEngagements(scope, 1);
+		resetEngagements();
 	}
-
-	useEffect(() => {
-		fetchEngagements("upcoming", 1);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	useEffect(() => {
 		setInvitationsLoading(true);
@@ -435,12 +422,10 @@ export default function ActivitySection() {
 			{!engagementsLoading &&
 				!engagementsError &&
 				engagements.length > 0 &&
-				engagementsPage < engagementsPageCount && (
+				hasMoreEngagements && (
 					<div className="mt-6 flex justify-center">
 						<button
-							onClick={() =>
-								fetchEngagements(engagementsScope, engagementsPage + 1)
-							}
+							onClick={loadMoreEngagements}
 							disabled={engagementsLoadingMore}
 							className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
 						>


### PR DESCRIPTION
Four list components (VolunteerOpportunitiesList, OrganizationsPage, AdministrationPage's org/user sections, ActivitySection's engagements) each hand-duplicated the same items/page/pageCount/loading/loadingMore/ error state and fetch-on-page-change effect. Extract it into frontend/src/hooks/useLoadMore.ts and wire all four call sites to it.

Closes #868