### PR TITLE
fix: verify uploaded avatar/logo/banner images via magic bytes, not c…

### DIFF
--- a/backend/src/Application/Common/Storage/ImageUploadValidator.cs
+++ b/backend/src/Application/Common/Storage/ImageUploadValidator.cs
@@ -17,6 +17,11 @@ public static class ImageUploadValidator
 		["image/webp"] = ".webp",
 	};
 
+	private static readonly byte[] JpegSignature = [0xFF, 0xD8, 0xFF];
+	private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+	private static readonly byte[] RiffSignature = [0x52, 0x49, 0x46, 0x46];
+	private static readonly byte[] WebpSignature = [0x57, 0x45, 0x42, 0x50];
+
 	public static void EnsureValid(long fileLength, string contentType, string subject)
 	{
 		if (fileLength == 0)
@@ -35,6 +40,35 @@ public static class ImageUploadValidator
 				$"{subject} image must be a JPEG, PNG or WebP image."));
 	}
 
+	// Returns the content-type detected from the actual bytes (magic-byte check), not the
+	// client-declared header, so callers store/serve the file under its real, verified type.
+	public static string EnsureValid(byte[] content, string contentType, string subject)
+	{
+		EnsureValid(content.Length, contentType, subject);
+
+		return DetectContentType(content) ?? throw new ResultFailureException(Error.Validation(
+			"FileUpload.InvalidContentType",
+			$"{subject} image must be a JPEG, PNG or WebP image."));
+	}
+
 	public static string GetExtension(string contentType) =>
 		Extensions.GetValueOrDefault(contentType, ".jpg");
+
+	private static string? DetectContentType(byte[] content)
+	{
+		if (StartsWith(content, JpegSignature))
+			return "image/jpeg";
+
+		if (StartsWith(content, PngSignature))
+			return "image/png";
+
+		if (content.Length >= 12 && StartsWith(content, RiffSignature) &&
+			content.AsSpan(8, 4).SequenceEqual(WebpSignature))
+			return "image/webp";
+
+		return null;
+	}
+
+	private static bool StartsWith(byte[] content, byte[] signature) =>
+		content.Length >= signature.Length && content.AsSpan(0, signature.Length).SequenceEqual(signature);
 }

--- a/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
+++ b/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
@@ -17,7 +17,7 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 		UploadOrganizationLogoCommand request,
 		CancellationToken cancellationToken = default)
 	{
-		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Logo");
+		var contentType = ImageUploadValidator.EnsureValid(request.Content, request.ContentType, "Logo");
 
 		var organization = await dbContext.Organizations.FindAsync(
 			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(), cancellationToken)
@@ -29,11 +29,11 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var ext = ImageUploadValidator.GetExtension(request.ContentType);
+		var ext = ImageUploadValidator.GetExtension(contentType);
 		var objectKey = $"organization-logos/{request.OrganizationId}{ext}";
 
 		using var stream = new MemoryStream(request.Content);
-		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, request.ContentType, cancellationToken);
+		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, contentType, cancellationToken);
 
 		organization.SetLogoUrl(url);
 

--- a/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
+++ b/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
@@ -14,7 +14,7 @@ internal sealed class UploadUserAvatarCommandHandler(
 		UploadUserAvatarCommand request,
 		CancellationToken cancellationToken = default)
 	{
-		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Avatar");
+		var contentType = ImageUploadValidator.EnsureValid(request.Content, request.ContentType, "Avatar");
 
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 
@@ -24,11 +24,11 @@ internal sealed class UploadUserAvatarCommandHandler(
 			await dbContext.Users.AddAsync(user, cancellationToken);
 		}
 
-		var ext = ImageUploadValidator.GetExtension(request.ContentType);
+		var ext = ImageUploadValidator.GetExtension(contentType);
 		var objectKey = $"user-avatars/{request.UserId.Value}{ext}";
 
 		using var stream = new MemoryStream(request.Content);
-		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, request.ContentType, cancellationToken);
+		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, contentType, cancellationToken);
 
 		user.SetAvatarUrl(url);
 

--- a/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
@@ -17,7 +17,7 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 		UploadOpportunityBannerCommand request,
 		CancellationToken cancellationToken = default)
 	{
-		ImageUploadValidator.EnsureValid(request.Content.Length, request.ContentType, "Banner");
+		var contentType = ImageUploadValidator.EnsureValid(request.Content, request.ContentType, "Banner");
 
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
 			VolunteerOpportunityId.Create(request.OpportunityId).GetValueOrThrow(), cancellationToken)
@@ -29,11 +29,11 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var ext = ImageUploadValidator.GetExtension(request.ContentType);
+		var ext = ImageUploadValidator.GetExtension(contentType);
 		var objectKey = $"opportunity-banners/{request.OpportunityId}{ext}";
 
 		using var stream = new MemoryStream(request.Content);
-		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, request.ContentType, cancellationToken);
+		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, contentType, cancellationToken);
 
 		opportunity.SetBannerImageUrl(url).ThrowIfFailure();
 

--- a/backend/tests/Application.UnitTests/Common/Storage/ImageUploadValidatorTests.cs
+++ b/backend/tests/Application.UnitTests/Common/Storage/ImageUploadValidatorTests.cs
@@ -67,4 +67,68 @@ public class ImageUploadValidatorTests
 		// Assert
 		extension.Should().Be(expectedExtension);
 	}
+
+	private static byte[] JpegBytes => [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+
+	private static byte[] PngBytes => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
+
+	private static byte[] WebpBytes =>
+		[0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50];
+
+	[Test]
+	public void EnsureValid_WithContentBytes_ShouldReturnDetectedType_ForJpegMagicBytes()
+	{
+		// Act
+		var contentType = ImageUploadValidator.EnsureValid(JpegBytes, "image/jpeg", "Avatar");
+
+		// Assert
+		contentType.Should().Be("image/jpeg");
+	}
+
+	[Test]
+	public void EnsureValid_WithContentBytes_ShouldReturnDetectedType_ForPngMagicBytes()
+	{
+		// Act
+		var contentType = ImageUploadValidator.EnsureValid(PngBytes, "image/png", "Logo");
+
+		// Assert
+		contentType.Should().Be("image/png");
+	}
+
+	[Test]
+	public void EnsureValid_WithContentBytes_ShouldReturnDetectedType_ForWebpMagicBytes()
+	{
+		// Act
+		var contentType = ImageUploadValidator.EnsureValid(WebpBytes, "image/webp", "Banner");
+
+		// Assert
+		contentType.Should().Be("image/webp");
+	}
+
+	[Test]
+	public void EnsureValid_WithContentBytes_ShouldThrow_WhenDeclaredTypeIsSpoofed()
+	{
+		// Arrange: declares image/png but the bytes are neither JPEG, PNG nor WebP.
+		var htmlBytes = "<script>alert(1)</script>"u8.ToArray();
+
+		// Act
+		Action act = () => ImageUploadValidator.EnsureValid(htmlBytes, "image/png", "Avatar");
+
+		// Assert
+		act.Should().Throw<ResultFailureException>()
+			.WithMessage("Avatar image must be a JPEG, PNG or WebP image.")
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+
+	[Test]
+	public void EnsureValid_WithContentBytes_ShouldReturnRealType_WhenDeclaredTypeDoesNotMatchActualBytes()
+	{
+		// Arrange: client declares PNG but the actual bytes are a valid JPEG - the
+		// detected, real type must win over the client-supplied header.
+		// Act
+		var contentType = ImageUploadValidator.EnsureValid(JpegBytes, "image/png", "Avatar");
+
+		// Assert
+		contentType.Should().Be("image/jpeg");
+	}
 }


### PR DESCRIPTION
…lient Content-Type

Client-declared Content-Type on upload was trusted as-is and re-served from public storage with that same (spoofable) type intact. ImageUploadValidator now inspects the actual file bytes for JPEG/PNG/WebP signatures and the detected type - not the client header - is used for the storage extension and content-type going forward.

Fixes #855