### PR TITLE
fix: remove orphaned breadcrumb.* i18n keys from pre-restructure routes

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -758,12 +758,7 @@
     "breadcrumb": {
       "label": "Navigationspfad",
       "home": "Startseite",
-      "volunteerOpportunities": "Einsatzmöglichkeiten",
-      "engagements": "Bewerbungen",
-      "settings": "Einstellungen",
-      "account": "Konto",
       "profile": "Profil",
-      "achievements": "Meine Errungenschaften",
       "userAchievements": "Errungenschaften",
       "organizations": "Organisationen"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -758,12 +758,7 @@
     "breadcrumb": {
       "label": "Breadcrumb",
       "home": "Home",
-      "volunteerOpportunities": "Volunteer Opportunities",
-      "engagements": "Engagements",
-      "settings": "Settings",
-      "account": "Account",
       "profile": "Profile",
-      "achievements": "My Achievements",
       "userAchievements": "Achievements",
       "organizations": "Organizations"
     },


### PR DESCRIPTION
Five breadcrumb keys (volunteerOpportunities, engagements, settings, account, achievements) were left over after routes were renamed and have no remaining references in en.json or de.json.

Fixes #840