### PR TITLE
fix: remove orphaned nav i18n keys after header consolidation

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -14,10 +14,7 @@
     "nav": {
       "primaryLabel": "Hauptnavigation",
       "userMenu": "Benutzermenü",
-      "myEngagements": "Meine Engagements",
       "myProfile": "Mein Profil",
-      "myAchievements": "Meine Errungenschaften",
-      "profileSettings": "Profileinstellungen",
       "administration": "Administration",
       "organization": "Organisation",
       "signOut": "Abmelden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -14,10 +14,7 @@
     "nav": {
       "primaryLabel": "Main navigation",
       "userMenu": "User menu",
-      "myEngagements": "My Engagements",
       "myProfile": "My Profile",
-      "myAchievements": "My Achievements",
-      "profileSettings": "Profile Settings",
       "administration": "Administration",
       "organization": "Organization",
       "signOut": "Sign out",


### PR DESCRIPTION
nav.myEngagements, nav.myAchievements, and nav.profileSettings were left behind in en.json/de.json when the header nav was consolidated into a single Profile link; no code references them anymore.

Fixes #841