### PR TITLE
feat: add remove-logo endpoint for organizations (#845)

### DIFF
--- a/backend/src/Api/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoEndpoint.cs
+++ b/backend/src/Api/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoEndpoint.cs
@@ -1,0 +1,44 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Organizations.DeleteOrganizationLogo.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Organizations.DeleteOrganizationLogo.v1;
+
+internal sealed class DeleteOrganizationLogoEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapDelete("/organizations/{organizationId:guid}/logo", DeleteOrganizationLogoAsync)
+			.WithName("DeleteOrganizationLogo")
+			.WithTags("Organizations")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> DeleteOrganizationLogoAsync(
+		[FromRoute] Guid organizationId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		await sender.Send(
+			new DeleteOrganizationLogoCommand(organizationId, userId),
+			cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1882,6 +1882,58 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "DeleteOrganizationLogo",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/organizations/{organizationId}": {

--- a/backend/src/Application/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoCommand.cs
+++ b/backend/src/Application/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoCommand.cs
@@ -1,0 +1,9 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.Organizations.DeleteOrganizationLogo.v1;
+
+public sealed record DeleteOrganizationLogoCommand(
+	Guid OrganizationId,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganizationLogo/v1/DeleteOrganizationLogoCommandHandler.cs
@@ -1,0 +1,48 @@
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Application.Organizations.DeleteOrganizationLogo.v1;
+
+internal sealed class DeleteOrganizationLogoCommandHandler(
+	IApplicationDbContext dbContext,
+	IFileStorageService fileStorage)
+	: ICommandHandler<DeleteOrganizationLogoCommand, bool>
+{
+	private static readonly string[] LogoExtensions = [".jpg", ".png", ".webp"];
+
+	public async ValueTask<bool> Handle(
+		DeleteOrganizationLogoCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var organization = await dbContext.Organizations.FindAsync(
+			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(), cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("Organization.NotFound", $"Organization '{request.OrganizationId}' not found."));
+
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			request.OrganizationId,
+			request.RequestingUserId,
+			cancellationToken);
+
+		foreach (var ext in LogoExtensions)
+		{
+			try
+			{
+				await fileStorage.DeleteAsync($"organization-logos/{request.OrganizationId}{ext}", cancellationToken);
+			}
+			catch
+			{
+				// Object may not exist for this extension; continue
+			}
+		}
+
+		organization.SetLogoUrl(null);
+
+		return true;
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -165,6 +165,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteOrganizationLogoAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task UpdateOrganizationAsync(System.Guid organizationId, UpdateOrganizationRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -3304,6 +3309,106 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteOrganizationLogoAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/organizations/{organizationId}/logo"
+                    urlBuilder_.Append("v1/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/logo");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Playwright;
 using Microsoft.Playwright;
@@ -328,6 +331,70 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
+
+	[Test]
+	public async Task OrganizationSettingsPage_EditModeWithLogo_HasNoSeriousA11yViolations()
+	{
+		// #845: the "Remove" button next to the logo only renders once an
+		// organization has a logo. Olaf's seeded org has none, so the edit-mode
+		// scan above never renders it - seed a fresh org with a logo here
+		// instead of mutating Olaf's shared seed data.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await GetAccessTokenAsync();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11yLogo {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		using var content = new MultipartFormDataContent();
+		using var fileContent = new ByteArrayContent(TinyPng);
+		fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+		content.Add(fileContent, "file", "logo.png");
+
+		(await http.PutAsync($"/v1/organizations/{organizationId}/logo", content)).EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Remove" })).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	private async Task<string> GetAccessTokenAsync()
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		return token!;
+	}
+
+	// 1x1 transparent PNG.
+	private static readonly byte[] TinyPng = Convert.FromBase64String(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
 
 	[Test]
 	public async Task OrgDashboardPage_EditMode_AsOlaf_HasNoSeriousA11yViolations()

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -117,6 +117,56 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(orgLink.Locator("img")).ToBeVisibleAsync(new() { Timeout = 10_000 });
 	}
 
+	[Test]
+	public async Task RemoveOrganizationLogo_ClearsLogoUrl_AndHidesRemoveButton()
+	{
+		// #845: the organization-logo upload feature had no matching
+		// delete/remove endpoint, unlike the symmetric opportunity-banner
+		// feature. Verifies the new DELETE endpoint and its "Remove" button
+		// in OrgSettingsPage actually clear the stored logo.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await GetAccessTokenAsync();
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"LogoRemoval {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		using var content = new MultipartFormDataContent();
+		using var fileContent = new ByteArrayContent(TinyPng);
+		fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+		content.Add(fileContent, "file", "logo.png");
+
+		(await http.PutAsync($"/v1/organizations/{organizationId}/logo", content)).EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync();
+
+		var removeButton = Page.GetByRole(AriaRole.Button, new() { Name = "Remove" });
+		await Expect(removeButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await removeButton.ClickAsync();
+		await Expect(removeButton).ToBeHiddenAsync(new() { Timeout = 10_000 });
+
+		var afterResponse = await http.GetAsync($"/v1/organizations/{organizationId}");
+		afterResponse.EnsureSuccessStatusCode();
+		var afterOrg = await afterResponse.Content.ReadFromJsonAsync<JsonElement>();
+		afterOrg.GetProperty("logoUrl").ValueKind.Should().Be(JsonValueKind.Null);
+	}
+
 	private async Task<string> GetAccessTokenAsync()
 	{
 		var token = await Page.EvaluateAsync<string?>(@"() => {

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1693,6 +1693,61 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    deleteOrganizationLogo(organizationId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/logo";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteOrganizationLogo(_response);
+        });
+    }
+
+    protected processDeleteOrganizationLogo(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     updateOrganization(organizationId: string, body: UpdateOrganizationRequest, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/organizations/{organizationId}";
         if (organizationId === undefined || organizationId === null)

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -408,6 +408,8 @@
       "logoUploading": "Wird hochgeladen…",
       "logoUploadError": "Logo-Upload fehlgeschlagen.",
       "logoRemove": "Entfernen",
+      "logoRemoving": "Wird entfernt…",
+      "logoRemoveError": "Logo konnte nicht entfernt werden.",
       "fieldName": "Name *",
       "fieldDescription": "Beschreibung",
       "fieldContactEmail": "Kontakt-E-Mail",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -408,6 +408,8 @@
       "logoUploading": "Uploading…",
       "logoUploadError": "Failed to upload logo.",
       "logoRemove": "Remove",
+      "logoRemoving": "Removing…",
+      "logoRemoveError": "Failed to remove logo.",
       "fieldName": "Name *",
       "fieldDescription": "Description",
       "fieldContactEmail": "Contact email",

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -51,6 +51,7 @@ export default function OrgSettingsPage() {
 	});
 	const [logoUrl, setLogoUrl] = useState<string | null>(org.logoUrl ?? null);
 	const [uploadingLogo, setUploadingLogo] = useState(false);
+	const [removingLogo, setRemovingLogo] = useState(false);
 	const [logoError, setLogoError] = useState<string | null>(null);
 	const logoInputRef = useRef<HTMLInputElement>(null);
 	const formRef = useRef<HTMLFormElement>(null);
@@ -115,6 +116,19 @@ export default function OrgSettingsPage() {
 		} finally {
 			setUploadingLogo(false);
 			if (logoInputRef.current) logoInputRef.current.value = "";
+		}
+	}
+
+	async function handleRemoveLogo() {
+		setRemovingLogo(true);
+		setLogoError(null);
+		try {
+			await api.deleteOrganizationLogo(org.id);
+			setLogoUrl(null);
+		} catch {
+			setLogoError(t("orgSettings.logoRemoveError"));
+		} finally {
+			setRemovingLogo(false);
 		}
 	}
 
@@ -247,23 +261,37 @@ export default function OrgSettingsPage() {
 										</span>
 									)}
 									<div>
-										<label
-											htmlFor="logo-upload"
-											className={`cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 ${uploadingLogo ? "opacity-50 pointer-events-none" : ""}`}
-										>
-											{uploadingLogo
-												? t("orgSettings.logoUploading")
-												: t("orgSettings.logoUpload")}
-										</label>
-										<input
-											ref={logoInputRef}
-											id="logo-upload"
-											type="file"
-											accept="image/jpeg,image/png,image/webp"
-											className="sr-only"
-											onChange={handleLogoChange}
-											disabled={uploadingLogo}
-										/>
+										<div className="flex items-center gap-3">
+											<label
+												htmlFor="logo-upload"
+												className={`cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 ${uploadingLogo || removingLogo ? "opacity-50 pointer-events-none" : ""}`}
+											>
+												{uploadingLogo
+													? t("orgSettings.logoUploading")
+													: t("orgSettings.logoUpload")}
+											</label>
+											<input
+												ref={logoInputRef}
+												id="logo-upload"
+												type="file"
+												accept="image/jpeg,image/png,image/webp"
+												className="sr-only"
+												onChange={handleLogoChange}
+												disabled={uploadingLogo || removingLogo}
+											/>
+											{logoUrl && (
+												<button
+													type="button"
+													onClick={handleRemoveLogo}
+													disabled={uploadingLogo || removingLogo}
+													className="text-sm font-medium text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+												>
+													{removingLogo
+														? t("orgSettings.logoRemoving")
+														: t("orgSettings.logoRemove")}
+												</button>
+											)}
+										</div>
 										<p className="mt-1 text-xs text-gray-500">
 											{t("orgSettings.logoHint")}
 										</p>


### PR DESCRIPTION
Organization logos could only be replaced, never cleared, unlike the symmetric opportunity-banner feature which has upload/delete. Adds a DeleteOrganizationLogo command/handler and endpoint mirroring DeleteOpportunityBanner, and wires a "Remove" button into OrgSettingsPage using the previously-dangling logoRemove i18n key.

Closes #845