### PR TITLE
refactor: extract widget-placement state machine from OrgDashboardPage

### DIFF
--- a/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
@@ -1,0 +1,245 @@
+import {
+	type CSSProperties,
+	type KeyboardEvent,
+	type PointerEvent as ReactPointerEvent,
+	type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { TrashIcon } from "../../../components/QuickActionIcons";
+import { WIDGET_CATALOG, type WidgetKey } from "./widgetCatalog";
+
+function GripIcon() {
+	return (
+		<svg
+			className="h-4 w-4"
+			viewBox="0 0 16 16"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<circle cx="5" cy="3" r="1.25" />
+			<circle cx="11" cy="3" r="1.25" />
+			<circle cx="5" cy="8" r="1.25" />
+			<circle cx="11" cy="8" r="1.25" />
+			<circle cx="5" cy="13" r="1.25" />
+			<circle cx="11" cy="13" r="1.25" />
+		</svg>
+	);
+}
+
+function ResizeHandleIcon() {
+	return (
+		<svg
+			className="h-3.5 w-3.5"
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			aria-hidden="true"
+		>
+			<path d="M13 3 3 13M13 8 8 13" />
+		</svg>
+	);
+}
+
+export default function EditableWidgetTile({
+	widgetKey,
+	gridStyle,
+	editing,
+	showPlacementControls,
+	isPlacing,
+	hasAnchor,
+	placingDisabled,
+	isCornerFlowActive,
+	onAdvance,
+	onArrowKeyDown,
+	onRemove,
+	onGripPointerDown,
+	onResizePointerDown,
+	children,
+}: {
+	widgetKey: WidgetKey;
+	gridStyle?: CSSProperties;
+	editing: boolean;
+	showPlacementControls: boolean;
+	isPlacing: boolean;
+	hasAnchor: boolean;
+	placingDisabled: boolean;
+	// Whether the click-click-click/keyboard corner flow specifically (not a
+	// real pointer drag, #16) is what's active for this widget - `isPlacing`
+	// alone can't tell the two apart (a drag sets it too, for the ring
+	// highlight below), and `hasAnchor`/hasAnchor's "pick a corner" wording
+	// would be actively wrong read out mid-drag if used for that.
+	isCornerFlowActive: boolean;
+	onAdvance: () => void;
+	onArrowKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+	onRemove: () => void;
+	onGripPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+	onResizePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+	children: ReactNode;
+}) {
+	const { t } = useTranslation();
+	const catalogEntry = WIDGET_CATALOG[widgetKey];
+	const title = t(catalogEntry.titleKey);
+	const moveLabel = !isCornerFlowActive
+		? t("orgDashboard.moveOrResize", { widget: title })
+		: hasAnchor
+			? t("orgDashboard.placementPickEndCorner", { widget: title })
+			: t("orgDashboard.placementPickStartCorner", { widget: title });
+
+	return (
+		<div
+			data-testid={`widget-tile-${widgetKey}`}
+			style={gridStyle}
+			// No z-index here on purpose: this div is `position: relative` (for
+			// the absolutely-positioned remove button and the tile itself acting
+			// as the drag-to-move surface) but must NOT also get a z-index,
+			// because that would give it its own stacking context - any modal a
+			// widget renders inside itself (e.g. CreateOpportunityWidget's
+			// wizard) would then be scoped to THIS tile's stacking order instead
+			// of the page's, so a later sibling tile (also positioned) could
+			// paint over the modal despite its own z-[2000] and swallow clicks
+			// meant for it.
+			//
+			// The whole tile is the primary press-and-drag-to-move target while
+			// editing (not just a small grip icon) - dashboard-builder UIs that
+			// make organizers hunt for a tiny handle before they can reposition
+			// anything are exactly the friction this is meant to remove. That
+			// means the tile opts INTO pointer events here (rather than passing
+			// clicks through to the grid-guide backdrop beneath, as it used to) -
+			// but only while NO placement is active at all anywhere on the
+			// board (!isPlacing && !placingDisabled, i.e. activeKey === null).
+			// Once ANY widget's placement is active (real drag or the
+			// click-click-click flow), completing it very often means clicking
+			// a backdrop cell that falls inside another widget's current
+			// footprint - that's the whole point of #18 (an overlapping
+			// placement displaces what's in the way instead of being
+			// rejected), so every OTHER tile must let those clicks through
+			// too, not just the one actually being placed. A real drag
+			// already committed to via document-level pointermove/pointerup
+			// listeners isn't affected by tiles losing pointer-events
+			// mid-drag - only where a NEW press lands is.
+			onPointerDown={
+				editing && showPlacementControls && !placingDisabled && !isPlacing
+					? onGripPointerDown
+					: undefined
+			}
+			className={`relative h-full ${
+				editing && showPlacementControls && !isPlacing && !placingDisabled
+					? "cursor-grab touch-none active:cursor-grabbing"
+					: editing
+						? "pointer-events-none"
+						: ""
+			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
+		>
+			<div inert={editing} className={`h-full ${editing ? "opacity-60" : ""}`}>
+				{children}
+			</div>
+			{editing && (
+				<>
+					{showPlacementControls && (
+						// Still the entry point into the click-click-click
+						// corner-to-corner flow (onClick) and its accessible
+						// keyboard path (onKeyDown's arrow keys/Enter, #17) - the
+						// whole tile above now also starts a real pointer drag
+						// (#16) on its own, so this button's own onPointerDown
+						// would otherwise fire a second, redundant drag-start for
+						// the exact same press; stopPropagation keeps it to one.
+						//
+						// Mouse hit-testing only (#830 follow-up), not pointer-
+						// events-none outright: while the click-click-click corner
+						// flow is active for this widget with no anchor picked yet,
+						// its tile has collapsed to a 1x1 preview box at its own
+						// current top-left cell (see previewRect/normalizeRect
+						// (cursor, cursor, ...) below), putting this centered
+						// button almost exactly on top of the very backdrop cell
+						// the next click needs to land on - so it stops claiming
+						// mouse clicks for that one narrow window. Gated on
+						// isCornerFlowActive specifically, not the broader
+						// isPlacing (which a fresh press's own onPointerDown/
+						// startDrag call above already flips true, transiently,
+						// before the browser has even dispatched this SAME click's
+						// "click" event) - isCornerFlowActive only reflects
+						// placingKey, set by onAdvance below, which only runs once
+						// the click event actually fires - so a fresh press can
+						// never self-disable its own click via this class.
+						// Keyboard Enter/Space activation is untouched regardless
+						// (pointer-events doesn't gate that), so the accessible
+						// path this button exists for - not requiring pointer
+						// precision on a tiny backdrop cell - still works exactly
+						// the same via a focused Enter press.
+						<button
+							type="button"
+							onClick={onAdvance}
+							onKeyDown={onArrowKeyDown}
+							onPointerDown={(e) => {
+								e.stopPropagation();
+								onGripPointerDown(e);
+							}}
+							disabled={placingDisabled}
+							className={`absolute left-1/2 top-2 z-30 -translate-x-1/2 cursor-pointer touch-none rounded-lg bg-white p-1.5 text-gray-600 shadow-md ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 ${isCornerFlowActive && !hasAnchor ? "pointer-events-none" : "pointer-events-auto"} ${isPlacing ? "ring-2 ring-brand-500" : ""}`}
+							aria-label={moveLabel}
+						>
+							<GripIcon />
+						</button>
+					)}
+					{showPlacementControls && !isPlacing && (
+						// Pure mouse/touch drag-to-resize affordance (#16) - the
+						// existing grip button + arrow keys already cover resizing
+						// accessibly via the two-corner flow, so this one is taken out
+						// of the tab order and hidden from assistive tech (#17) rather
+						// than exposing a second, keyboard-inert control for the same
+						// capability. stopPropagation is required here, not just an
+						// optimization - without it, the tile's own move-drag handler
+						// (above) would also see this same press and immediately
+						// overwrite the resize session with a move session.
+						//
+						// Hidden entirely while THIS widget is being placed (#830
+						// follow-up): starting a placement collapses the tile to a
+						// 1x1 preview box at its own current top-left cell (see
+						// previewRect/normalizeRect(cursor, cursor, ...) below) until
+						// a first corner is picked - with the tile that small, this
+						// handle would otherwise sit almost exactly on top of the
+						// very backdrop cell the corner-to-corner flow needs the
+						// next click to land on. Resizing mid-placement isn't a
+						// meaningful action anyway.
+						//
+						// A dedicated right-edge (width-only) and bottom-edge
+						// (height-only) handle pair briefly existed alongside this
+						// one (#830) but got reverted (#783 review) - on top of the
+						// existing grip/corner-resize/remove trio, two more
+						// permanently-visible controls left too little bare tile
+						// surface to grab-and-drag on the smaller widget sizes,
+						// which the organizer's feedback described as "you added
+						// more buttons, I can't move anything else - it's just not
+						// working" rather than as an improvement.
+						<button
+							type="button"
+							data-testid="widget-resize-handle-corner"
+							tabIndex={-1}
+							aria-hidden="true"
+							onPointerDown={(e) => {
+								e.stopPropagation();
+								onResizePointerDown(e);
+							}}
+							disabled={placingDisabled}
+							className="pointer-events-auto absolute bottom-2 right-2 z-20 cursor-nwse-resize touch-none rounded-lg bg-white/95 p-1 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30"
+						>
+							<ResizeHandleIcon />
+						</button>
+					)}
+					<button
+						type="button"
+						onPointerDown={(e) => e.stopPropagation()}
+						onClick={onRemove}
+						disabled={placingDisabled}
+						className="pointer-events-auto absolute right-2 top-2 z-20 rounded-lg bg-white/95 p-1.5 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-30"
+						aria-label={t("orgDashboard.removeWidget", { widget: title })}
+					>
+						<TrashIcon />
+					</button>
+				</>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -1,14 +1,4 @@
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type CSSProperties,
-	type KeyboardEvent,
-	type PointerEvent as ReactPointerEvent,
-	type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrgAppContext } from "../../../layouts/OrgAppLayout";
@@ -16,7 +6,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import { useEditModeQuickActions } from "../../../hooks/useEditModeQuickActions";
 import { dispatchToast } from "../../../lib/toastBus";
 import { getApiErrorMessage } from "../../../lib/apiError";
-import { PlusIcon, TrashIcon } from "../../../components/QuickActionIcons";
+import { PlusIcon } from "../../../components/QuickActionIcons";
 import EmptyState from "../../../components/EmptyState";
 import AddWidgetModal from "./AddWidgetModal";
 import CalendarWidget from "./CalendarWidget";
@@ -26,6 +16,8 @@ import SettingsWidget from "./SettingsWidget";
 import CreateOpportunityWidget from "./CreateOpportunityWidget";
 import QuickCheckInWidget from "./QuickCheckInWidget";
 import SettingsIconWidget from "./SettingsIconWidget";
+import EditableWidgetTile from "./EditableWidgetTile";
+import { cellInRect, useWidgetPlacement } from "./useWidgetPlacement";
 import {
 	DEFAULT_LAYOUT,
 	GRID_COLUMNS,
@@ -34,69 +26,12 @@ import {
 	WIDGET_KEYS,
 	classifyWidth,
 	compactLayout,
-	isValidPlacement,
 	placeNewWidget,
 	sanitizeWidgetKey,
-	settlePlacement,
 	type PlacedWidget,
 	type WidgetKey,
 	type WidgetSizeClass,
 } from "./widgetCatalog";
-
-// A single grid cell, 1-based - the unit both the corner-to-corner mouse/
-// touch flow and the keyboard flow move a cursor around in before locking
-// it as one of a placement's two corners (see startPlacing/handleAdvance
-// below).
-interface Cell {
-	col: number;
-	row: number;
-}
-
-// A real pointer drag (#16) in progress on one widget's grip (move) or
-// resize handle. `origRect` is that widget's position when the drag
-// started; `currentRect` is the live, cell-snapped position/size under the
-// pointer right now (authoritative - dragPreview state below just mirrors it
-// for rendering). colPx/rowPx convert pixel deltas to grid cells, measured
-// off the widget's own rendered tile at drag start rather than the grid
-// container, so it stays correct at any viewport width. `moved` gates
-// whether releasing the pointer counts as an actual drag (commit) or a
-// plain click (fall through to the existing click-click-click flow via
-// handleAdvance).
-interface DragSession {
-	key: WidgetKey;
-	mode: "move" | "resize";
-	startClientX: number;
-	startClientY: number;
-	colPx: number;
-	rowPx: number;
-	origRect: PlacedWidget;
-	currentRect: PlacedWidget;
-	moved: boolean;
-}
-
-// How far the pointer has to travel from its down-position before a
-// grip/resize-handle press counts as a drag rather than a click - keeps a
-// slightly-jittery tap/click from being misread as an accidental 1-cell move.
-const DRAG_THRESHOLD_PX = 4;
-
-function normalizeRect(a: Cell, b: Cell, widgetKey: WidgetKey): PlacedWidget {
-	return {
-		widgetKey,
-		x: Math.min(a.col, b.col),
-		y: Math.min(a.row, b.row),
-		width: Math.abs(a.col - b.col) + 1,
-		height: Math.abs(a.row - b.row) + 1,
-	};
-}
-
-function cellInRect(col: number, row: number, rect: PlacedWidget): boolean {
-	return (
-		col >= rect.x &&
-		col < rect.x + rect.width &&
-		row >= rect.y &&
-		row < rect.y + rect.height
-	);
-}
 
 // Matches Tailwind's default `lg` breakpoint, which is also where the
 // widget grid switches from a single stacked column to the real 8-column
@@ -114,242 +49,6 @@ function useIsLargeViewport() {
 		return () => mql.removeEventListener("change", handler);
 	}, []);
 	return isLarge;
-}
-
-function GripIcon() {
-	return (
-		<svg
-			className="h-4 w-4"
-			viewBox="0 0 16 16"
-			fill="currentColor"
-			aria-hidden="true"
-		>
-			<circle cx="5" cy="3" r="1.25" />
-			<circle cx="11" cy="3" r="1.25" />
-			<circle cx="5" cy="8" r="1.25" />
-			<circle cx="11" cy="8" r="1.25" />
-			<circle cx="5" cy="13" r="1.25" />
-			<circle cx="11" cy="13" r="1.25" />
-		</svg>
-	);
-}
-
-function ResizeHandleIcon() {
-	return (
-		<svg
-			className="h-3.5 w-3.5"
-			viewBox="0 0 16 16"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			aria-hidden="true"
-		>
-			<path d="M13 3 3 13M13 8 8 13" />
-		</svg>
-	);
-}
-
-function EditableWidgetTile({
-	widgetKey,
-	gridStyle,
-	editing,
-	showPlacementControls,
-	isPlacing,
-	hasAnchor,
-	placingDisabled,
-	isCornerFlowActive,
-	onAdvance,
-	onArrowKeyDown,
-	onRemove,
-	onGripPointerDown,
-	onResizePointerDown,
-	children,
-}: {
-	widgetKey: WidgetKey;
-	gridStyle?: CSSProperties;
-	editing: boolean;
-	showPlacementControls: boolean;
-	isPlacing: boolean;
-	hasAnchor: boolean;
-	placingDisabled: boolean;
-	// Whether the click-click-click/keyboard corner flow specifically (not a
-	// real pointer drag, #16) is what's active for this widget - `isPlacing`
-	// alone can't tell the two apart (a drag sets it too, for the ring
-	// highlight below), and `hasAnchor`/hasAnchor's "pick a corner" wording
-	// would be actively wrong read out mid-drag if used for that.
-	isCornerFlowActive: boolean;
-	onAdvance: () => void;
-	onArrowKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
-	onRemove: () => void;
-	onGripPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
-	onResizePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
-	children: ReactNode;
-}) {
-	const { t } = useTranslation();
-	const catalogEntry = WIDGET_CATALOG[widgetKey];
-	const title = t(catalogEntry.titleKey);
-	const moveLabel = !isCornerFlowActive
-		? t("orgDashboard.moveOrResize", { widget: title })
-		: hasAnchor
-			? t("orgDashboard.placementPickEndCorner", { widget: title })
-			: t("orgDashboard.placementPickStartCorner", { widget: title });
-
-	return (
-		<div
-			data-testid={`widget-tile-${widgetKey}`}
-			style={gridStyle}
-			// No z-index here on purpose: this div is `position: relative` (for
-			// the absolutely-positioned remove button and the tile itself acting
-			// as the drag-to-move surface) but must NOT also get a z-index,
-			// because that would give it its own stacking context - any modal a
-			// widget renders inside itself (e.g. CreateOpportunityWidget's
-			// wizard) would then be scoped to THIS tile's stacking order instead
-			// of the page's, so a later sibling tile (also positioned) could
-			// paint over the modal despite its own z-[2000] and swallow clicks
-			// meant for it.
-			//
-			// The whole tile is the primary press-and-drag-to-move target while
-			// editing (not just a small grip icon) - dashboard-builder UIs that
-			// make organizers hunt for a tiny handle before they can reposition
-			// anything are exactly the friction this is meant to remove. That
-			// means the tile opts INTO pointer events here (rather than passing
-			// clicks through to the grid-guide backdrop beneath, as it used to) -
-			// but only while NO placement is active at all anywhere on the
-			// board (!isPlacing && !placingDisabled, i.e. activeKey === null).
-			// Once ANY widget's placement is active (real drag or the
-			// click-click-click flow), completing it very often means clicking
-			// a backdrop cell that falls inside another widget's current
-			// footprint - that's the whole point of #18 (an overlapping
-			// placement displaces what's in the way instead of being
-			// rejected), so every OTHER tile must let those clicks through
-			// too, not just the one actually being placed. A real drag
-			// already committed to via document-level pointermove/pointerup
-			// listeners isn't affected by tiles losing pointer-events
-			// mid-drag - only where a NEW press lands is.
-			onPointerDown={
-				editing && showPlacementControls && !placingDisabled && !isPlacing
-					? onGripPointerDown
-					: undefined
-			}
-			className={`relative h-full ${
-				editing && showPlacementControls && !isPlacing && !placingDisabled
-					? "cursor-grab touch-none active:cursor-grabbing"
-					: editing
-						? "pointer-events-none"
-						: ""
-			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
-		>
-			<div inert={editing} className={`h-full ${editing ? "opacity-60" : ""}`}>
-				{children}
-			</div>
-			{editing && (
-				<>
-					{showPlacementControls && (
-						// Still the entry point into the click-click-click
-						// corner-to-corner flow (onClick) and its accessible
-						// keyboard path (onKeyDown's arrow keys/Enter, #17) - the
-						// whole tile above now also starts a real pointer drag
-						// (#16) on its own, so this button's own onPointerDown
-						// would otherwise fire a second, redundant drag-start for
-						// the exact same press; stopPropagation keeps it to one.
-						//
-						// Mouse hit-testing only (#830 follow-up), not pointer-
-						// events-none outright: while the click-click-click corner
-						// flow is active for this widget with no anchor picked yet,
-						// its tile has collapsed to a 1x1 preview box at its own
-						// current top-left cell (see previewRect/normalizeRect
-						// (cursor, cursor, ...) below), putting this centered
-						// button almost exactly on top of the very backdrop cell
-						// the next click needs to land on - so it stops claiming
-						// mouse clicks for that one narrow window. Gated on
-						// isCornerFlowActive specifically, not the broader
-						// isPlacing (which a fresh press's own onPointerDown/
-						// startDrag call above already flips true, transiently,
-						// before the browser has even dispatched this SAME click's
-						// "click" event) - isCornerFlowActive only reflects
-						// placingKey, set by onAdvance below, which only runs once
-						// the click event actually fires - so a fresh press can
-						// never self-disable its own click via this class.
-						// Keyboard Enter/Space activation is untouched regardless
-						// (pointer-events doesn't gate that), so the accessible
-						// path this button exists for - not requiring pointer
-						// precision on a tiny backdrop cell - still works exactly
-						// the same via a focused Enter press.
-						<button
-							type="button"
-							onClick={onAdvance}
-							onKeyDown={onArrowKeyDown}
-							onPointerDown={(e) => {
-								e.stopPropagation();
-								onGripPointerDown(e);
-							}}
-							disabled={placingDisabled}
-							className={`absolute left-1/2 top-2 z-30 -translate-x-1/2 cursor-pointer touch-none rounded-lg bg-white p-1.5 text-gray-600 shadow-md ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 ${isCornerFlowActive && !hasAnchor ? "pointer-events-none" : "pointer-events-auto"} ${isPlacing ? "ring-2 ring-brand-500" : ""}`}
-							aria-label={moveLabel}
-						>
-							<GripIcon />
-						</button>
-					)}
-					{showPlacementControls && !isPlacing && (
-						// Pure mouse/touch drag-to-resize affordance (#16) - the
-						// existing grip button + arrow keys already cover resizing
-						// accessibly via the two-corner flow, so this one is taken out
-						// of the tab order and hidden from assistive tech (#17) rather
-						// than exposing a second, keyboard-inert control for the same
-						// capability. stopPropagation is required here, not just an
-						// optimization - without it, the tile's own move-drag handler
-						// (above) would also see this same press and immediately
-						// overwrite the resize session with a move session.
-						//
-						// Hidden entirely while THIS widget is being placed (#830
-						// follow-up): starting a placement collapses the tile to a
-						// 1x1 preview box at its own current top-left cell (see
-						// previewRect/normalizeRect(cursor, cursor, ...) below) until
-						// a first corner is picked - with the tile that small, this
-						// handle would otherwise sit almost exactly on top of the
-						// very backdrop cell the corner-to-corner flow needs the
-						// next click to land on. Resizing mid-placement isn't a
-						// meaningful action anyway.
-						//
-						// A dedicated right-edge (width-only) and bottom-edge
-						// (height-only) handle pair briefly existed alongside this
-						// one (#830) but got reverted (#783 review) - on top of the
-						// existing grip/corner-resize/remove trio, two more
-						// permanently-visible controls left too little bare tile
-						// surface to grab-and-drag on the smaller widget sizes,
-						// which the organizer's feedback described as "you added
-						// more buttons, I can't move anything else - it's just not
-						// working" rather than as an improvement.
-						<button
-							type="button"
-							data-testid="widget-resize-handle-corner"
-							tabIndex={-1}
-							aria-hidden="true"
-							onPointerDown={(e) => {
-								e.stopPropagation();
-								onResizePointerDown(e);
-							}}
-							disabled={placingDisabled}
-							className="pointer-events-auto absolute bottom-2 right-2 z-20 cursor-nwse-resize touch-none rounded-lg bg-white/95 p-1 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30"
-						>
-							<ResizeHandleIcon />
-						</button>
-					)}
-					<button
-						type="button"
-						onPointerDown={(e) => e.stopPropagation()}
-						onClick={onRemove}
-						disabled={placingDisabled}
-						className="pointer-events-auto absolute right-2 top-2 z-20 rounded-lg bg-white/95 p-1.5 text-gray-500 shadow-sm ring-1 ring-gray-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-30"
-						aria-label={t("orgDashboard.removeWidget", { widget: title })}
-					>
-						<TrashIcon />
-					</button>
-				</>
-			)}
-		</div>
-	);
 }
 
 export default function OrgDashboardPage() {
@@ -376,34 +75,7 @@ export default function OrgDashboardPage() {
 	const [saving, setSaving] = useState(false);
 	const [showAddWidgetModal, setShowAddWidgetModal] = useState(false);
 
-	// Corner-to-corner placement state (#782): at most one widget is being
-	// placed at a time. `cursor` is the grid cell the pointer is hovering (or
-	// the keyboard cursor last moved to); `anchor` is the first corner once
-	// locked in (by a click/tap or an Enter/Space press) - once both corners
-	// are known the placement commits. Mouse/touch and keyboard both drive
-	// this same state, just through different inputs (see handleAdvance vs
-	// handleCellClick vs handleArrowKeyDown).
-	const [placingKey, setPlacingKey] = useState<WidgetKey | null>(null);
-	const [anchor, setAnchor] = useState<Cell | null>(null);
-	const [cursor, setCursor] = useState<Cell | null>(null);
-
-	// Real pointer drag (#16) - a second, independent way to reposition a
-	// widget alongside the click-click-click/keyboard flow above. `dragActive`
-	// only exists to (de)register the document-level pointermove/pointerup
-	// listeners at the right time; the session's actual live data lives in
-	// dragSessionRef (a ref, not state, since pointermove fires far more often
-	// than a re-render is useful for) and dragPreview mirrors just enough of
-	// it to render the live preview + backdrop tint.
-	const [dragActive, setDragActive] = useState(false);
-	const [dragPreview, setDragPreview] = useState<PlacedWidget | null>(null);
-	const dragSessionRef = useRef<DragSession | null>(null);
-	// Set to the widget key a drag just committed via a real pointer move, so
-	// the `click` event a browser still fires right after pointerup on THAT
-	// widget's grip doesn't also run handleAdvance and start an unwanted
-	// click-click-click placement. Keyed rather than a plain flag so a stray
-	// click landing on a *different* widget's grip right after (pointerup can
-	// land anywhere) doesn't have its own click wrongly swallowed too.
-	const suppressNextAdvanceRef = useRef<WidgetKey | null>(null);
+	const placement = useWidgetPlacement({ draftLayout, setDraftLayout });
 
 	useEffect(() => {
 		api
@@ -462,217 +134,6 @@ export default function OrgDashboardPage() {
 		[navigate, organizationId],
 	);
 
-	function cancelPlacing() {
-		setPlacingKey(null);
-		setAnchor(null);
-		setCursor(null);
-	}
-
-	function startPlacing(key: WidgetKey) {
-		const current = (draftLayout ?? []).find((w) => w.widgetKey === key);
-		if (!current) return;
-		setPlacingKey(key);
-		setAnchor(null);
-		setCursor({ col: current.x, row: current.y });
-	}
-
-	// Bounds/min-size violations still hard-reject (there's nowhere to push a
-	// widget that doesn't fit on the grid at all). An overlap with another
-	// widget no longer does (#18) - it displaces whatever's in the way
-	// instead, then compacts the result so that displacement doesn't leave a
-	// gap of its own further up.
-	function commitPlacement(rect: PlacedWidget) {
-		if (!isValidPlacement(rect)) {
-			dispatchToast("error", t("orgDashboard.placementInvalid"));
-			cancelPlacing();
-			return;
-		}
-		setDraftLayout((prev) => {
-			const others = (prev ?? []).filter((w) => w.widgetKey !== rect.widgetKey);
-			return settlePlacement(rect, others);
-		});
-		cancelPlacing();
-	}
-
-	// Drives the Move/Resize button - a mouse click, or a keyboard Enter/
-	// Space on the focused button (both fire a native `click` event), always
-	// advance this same state machine: not placing yet -> start placing;
-	// placing with no corner locked -> lock the current cursor as the first
-	// corner; placing with a corner already locked -> commit using the
-	// cursor as the second corner. Skipped once for the synthetic click that
-	// follows a real pointer drag (#16) - that drag already committed via
-	// startDrag's own pointerup handler.
-	function handleAdvance(key: WidgetKey) {
-		if (suppressNextAdvanceRef.current === key) {
-			suppressNextAdvanceRef.current = null;
-			return;
-		}
-		if (placingKey !== key) {
-			startPlacing(key);
-			return;
-		}
-		if (!cursor) return;
-		if (!anchor) {
-			setAnchor(cursor);
-			return;
-		}
-		commitPlacement(normalizeRect(anchor, cursor, key));
-	}
-
-	// A click/tap directly on a grid guide cell is the mouse/touch equivalent
-	// of the keyboard's arrow-keys-then-Enter: it moves the cursor there AND
-	// immediately locks/commits, since there's no separate "hover" step on
-	// touch. Mouse users additionally get a live preview via onPointerEnter
-	// (handleCellHover) before they click.
-	function handleCellClick(cell: Cell) {
-		if (!placingKey) return;
-		setCursor(cell);
-		if (!anchor) {
-			setAnchor(cell);
-			return;
-		}
-		commitPlacement(normalizeRect(anchor, cell, placingKey));
-	}
-
-	function handleCellHover(cell: Cell) {
-		if (!placingKey) return;
-		setCursor(cell);
-	}
-
-	function handleArrowKeyDown(
-		event: KeyboardEvent<HTMLButtonElement>,
-		key: WidgetKey,
-	) {
-		if (placingKey !== key || !cursor) return;
-		switch (event.key) {
-			case "ArrowUp":
-				event.preventDefault();
-				setCursor({ col: cursor.col, row: Math.max(1, cursor.row - 1) });
-				break;
-			case "ArrowDown":
-				event.preventDefault();
-				setCursor({
-					col: cursor.col,
-					row: Math.min(GRID_MAX_ROWS, cursor.row + 1),
-				});
-				break;
-			case "ArrowLeft":
-				event.preventDefault();
-				setCursor({ col: Math.max(1, cursor.col - 1), row: cursor.row });
-				break;
-			case "ArrowRight":
-				event.preventDefault();
-				setCursor({
-					col: Math.min(GRID_COLUMNS, cursor.col + 1),
-					row: cursor.row,
-				});
-				break;
-			case "Escape":
-				event.preventDefault();
-				cancelPlacing();
-				break;
-		}
-	}
-
-	// Starts a real pointer drag (#16) on a widget's tile (move, from
-	// anywhere on it) or resize handle. Measures cell size off the widget's
-	// OWN rendered tile rather than the grid container, so it stays correct
-	// regardless of viewport width. A plain click/tap (pointer released
-	// before moving past DRAG_THRESHOLD_PX) is left alone here - a press on
-	// the grip button specifically still falls through to its own onClick
-	// (handleAdvance) exactly as before; the tile itself has no click
-	// handler to fall through to, so a plain click anywhere else on it is
-	// simply a no-op, same as before the whole tile became draggable.
-	function startDrag(
-		event: ReactPointerEvent<HTMLElement>,
-		key: WidgetKey,
-		mode: "move" | "resize",
-	) {
-		if (event.pointerType === "mouse" && event.button !== 0) return;
-		const widget = (draftLayout ?? []).find((w) => w.widgetKey === key);
-		const tile = event.currentTarget.closest<HTMLElement>(
-			`[data-testid="widget-tile-${key}"]`,
-		);
-		if (!widget || !tile) return;
-		const box = tile.getBoundingClientRect();
-		// A tile mid-layout (just resized, just re-rendered) can momentarily
-		// measure as 0x0 in a real browser - dividing by that produces
-		// Infinity/NaN deltas for the rest of the drag. Bail out rather than
-		// starting a session on a bad measurement; the user's next press
-		// gets a fresh, presumably-settled measurement.
-		if (box.width <= 0 || box.height <= 0) return;
-		dragSessionRef.current = {
-			key,
-			mode,
-			startClientX: event.clientX,
-			startClientY: event.clientY,
-			colPx: box.width / widget.width,
-			rowPx: box.height / widget.height,
-			origRect: widget,
-			currentRect: widget,
-			moved: false,
-		};
-		setDragPreview(widget);
-		setDragActive(true);
-	}
-
-	useEffect(() => {
-		if (!dragActive) return;
-
-		function handlePointerMove(event: globalThis.PointerEvent) {
-			const session = dragSessionRef.current;
-			if (!session) return;
-			const deltaX = event.clientX - session.startClientX;
-			const deltaY = event.clientY - session.startClientY;
-			if (
-				Math.abs(deltaX) > DRAG_THRESHOLD_PX ||
-				Math.abs(deltaY) > DRAG_THRESHOLD_PX
-			) {
-				session.moved = true;
-			}
-			const deltaCol = Math.round(deltaX / session.colPx);
-			const deltaRow = Math.round(deltaY / session.rowPx);
-			const nextRect: PlacedWidget =
-				session.mode === "move"
-					? {
-							...session.origRect,
-							x: Math.max(1, session.origRect.x + deltaCol),
-							y: Math.max(1, session.origRect.y + deltaRow),
-						}
-					: {
-							...session.origRect,
-							width: Math.max(1, session.origRect.width + deltaCol),
-							height: Math.max(1, session.origRect.height + deltaRow),
-						};
-			session.currentRect = nextRect;
-			setDragPreview(nextRect);
-		}
-
-		function endDrag() {
-			const session = dragSessionRef.current;
-			dragSessionRef.current = null;
-			setDragActive(false);
-			setDragPreview(null);
-			if (session?.moved) {
-				suppressNextAdvanceRef.current = session.key;
-				commitPlacement(session.currentRect);
-			}
-		}
-
-		document.addEventListener("pointermove", handlePointerMove);
-		document.addEventListener("pointerup", endDrag);
-		document.addEventListener("pointercancel", endDrag);
-		return () => {
-			document.removeEventListener("pointermove", handlePointerMove);
-			document.removeEventListener("pointerup", endDrag);
-			document.removeEventListener("pointercancel", endDrag);
-		};
-		// commitPlacement/cancelPlacing close over draftLayout - re-running
-		// this setup on every draftLayout change would drop mid-drag listeners.
-		// dragActive is the only thing that should ever (re)register them.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [dragActive]);
-
 	async function handleSave() {
 		if (!draftLayout) return;
 		setSaving(true);
@@ -689,7 +150,7 @@ export default function OrgDashboardPage() {
 			setSavedLayout(draftLayout);
 			setEditing(false);
 			setDraftLayout(null);
-			cancelPlacing();
+			placement.cancelPlacing();
 		} catch (e) {
 			dispatchToast("error", getApiErrorMessage(e, t("error.serverError")));
 		} finally {
@@ -698,7 +159,7 @@ export default function OrgDashboardPage() {
 	}
 
 	function handleCancel() {
-		cancelPlacing();
+		placement.cancelPlacing();
 		setEditing(false);
 		setDraftLayout(null);
 	}
@@ -745,14 +206,14 @@ export default function OrgDashboardPage() {
 	});
 
 	function handleRemoveWidget(key: WidgetKey) {
-		const wasPlacing = placingKey === key;
+		const wasPlacing = placement.placingKey === key;
 		// #14: closes whatever gap removing this widget just left instead of
 		// leaving the rest of the layout sitting where it was.
 		setDraftLayout((prev) =>
 			compactLayout((prev ?? []).filter((w) => w.widgetKey !== key)),
 		);
 		if (wasPlacing) {
-			cancelPlacing();
+			placement.cancelPlacing();
 			// Removing the widget currently being placed unmounts the very
 			// button that had focus (its whole tile disappears), dropping
 			// focus to <body> with nothing to restore it - move it somewhere
@@ -831,18 +292,8 @@ export default function OrgDashboardPage() {
 	// empty state rather than silently falling back to the default set.
 	const isEmpty = layout.length === 0;
 
-	// The widget currently being interactively positioned, however it got
-	// there - the click-click-click/keyboard corner flow (placingKey) or a
-	// real pointer drag (dragPreview, #16). previewRect is that widget's
-	// live candidate rect either way; previewValid only reflects the hard
-	// bounds/min-size constraints (#18: overlap is no longer one of them).
-	const activeKey = dragPreview?.widgetKey ?? placingKey;
-	const previewRect = useMemo(() => {
-		if (dragPreview) return dragPreview;
-		if (!placingKey || !cursor) return null;
-		return normalizeRect(anchor ?? cursor, cursor, placingKey);
-	}, [dragPreview, placingKey, anchor, cursor]);
-	const previewValid = previewRect ? isValidPlacement(previewRect) : false;
+	const { activeKey, previewRect, previewValid, placingKey, anchor, cursor } =
+		placement;
 
 	const contentRows = layout.length
 		? Math.max(1, ...layout.map((w) => w.y + w.height - 1))
@@ -923,10 +374,14 @@ export default function OrgDashboardPage() {
 							data-testid="dashboard-grid-guide-cell"
 							aria-hidden="true"
 							onClick={
-								placingKey ? () => handleCellClick({ col, row }) : undefined
+								placingKey
+									? () => placement.handleCellClick({ col, row })
+									: undefined
 							}
 							onPointerEnter={
-								placingKey ? () => handleCellHover({ col, row }) : undefined
+								placingKey
+									? () => placement.handleCellHover({ col, row })
+									: undefined
 							}
 							className={`-m-1 rounded-md ${tint} ${placingKey ? "cursor-pointer" : "pointer-events-none"}`}
 							style={{ gridColumn: col, gridRow: row }}
@@ -965,12 +420,16 @@ export default function OrgDashboardPage() {
 						hasAnchor={isPlacingThis && anchor !== null}
 						isCornerFlowActive={placingKey === widget.widgetKey}
 						placingDisabled={activeKey !== null && !isPlacingThis}
-						onAdvance={() => handleAdvance(widget.widgetKey)}
-						onArrowKeyDown={(e) => handleArrowKeyDown(e, widget.widgetKey)}
+						onAdvance={() => placement.handleAdvance(widget.widgetKey)}
+						onArrowKeyDown={(e) =>
+							placement.handleArrowKeyDown(e, widget.widgetKey)
+						}
 						onRemove={() => handleRemoveWidget(widget.widgetKey)}
-						onGripPointerDown={(e) => startDrag(e, widget.widgetKey, "move")}
+						onGripPointerDown={(e) =>
+							placement.startDrag(e, widget.widgetKey, "move")
+						}
 						onResizePointerDown={(e) =>
-							startDrag(e, widget.widgetKey, "resize")
+							placement.startDrag(e, widget.widgetKey, "resize")
 						}
 					>
 						{renderWidget(widget.widgetKey, sizeClass)}
@@ -1011,7 +470,7 @@ export default function OrgDashboardPage() {
 					immediately), so this is their only way to back out. */}
 					<button
 						type="button"
-						onClick={cancelPlacing}
+						onClick={placement.cancelPlacing}
 						className="shrink-0 rounded-lg px-2 py-1 text-xs font-semibold text-brand-800 hover:bg-brand-100"
 					>
 						{t("common.cancel")}

--- a/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
@@ -1,0 +1,367 @@
+import {
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type Dispatch,
+	type KeyboardEvent,
+	type PointerEvent as ReactPointerEvent,
+	type SetStateAction,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { dispatchToast } from "../../../lib/toastBus";
+import {
+	GRID_COLUMNS,
+	GRID_MAX_ROWS,
+	isValidPlacement,
+	settlePlacement,
+	type PlacedWidget,
+	type WidgetKey,
+} from "./widgetCatalog";
+
+// A single grid cell, 1-based - the unit both the corner-to-corner mouse/
+// touch flow and the keyboard flow move a cursor around in before locking
+// it as one of a placement's two corners (see startPlacing/handleAdvance
+// below).
+interface Cell {
+	col: number;
+	row: number;
+}
+
+// A real pointer drag (#16) in progress on one widget's grip (move) or
+// resize handle. `origRect` is that widget's position when the drag
+// started; `currentRect` is the live, cell-snapped position/size under the
+// pointer right now (authoritative - dragPreview state below just mirrors it
+// for rendering). colPx/rowPx convert pixel deltas to grid cells, measured
+// off the widget's own rendered tile at drag start rather than the grid
+// container, so it stays correct at any viewport width. `moved` gates
+// whether releasing the pointer counts as an actual drag (commit) or a
+// plain click (fall through to the existing click-click-click flow via
+// handleAdvance).
+interface DragSession {
+	key: WidgetKey;
+	mode: "move" | "resize";
+	startClientX: number;
+	startClientY: number;
+	colPx: number;
+	rowPx: number;
+	origRect: PlacedWidget;
+	currentRect: PlacedWidget;
+	moved: boolean;
+}
+
+// How far the pointer has to travel from its down-position before a
+// grip/resize-handle press counts as a drag rather than a click - keeps a
+// slightly-jittery tap/click from being misread as an accidental 1-cell move.
+const DRAG_THRESHOLD_PX = 4;
+
+function normalizeRect(a: Cell, b: Cell, widgetKey: WidgetKey): PlacedWidget {
+	return {
+		widgetKey,
+		x: Math.min(a.col, b.col),
+		y: Math.min(a.row, b.row),
+		width: Math.abs(a.col - b.col) + 1,
+		height: Math.abs(a.row - b.row) + 1,
+	};
+}
+
+export function cellInRect(
+	col: number,
+	row: number,
+	rect: PlacedWidget,
+): boolean {
+	return (
+		col >= rect.x &&
+		col < rect.x + rect.width &&
+		row >= rect.y &&
+		row < rect.y + rect.height
+	);
+}
+
+interface UseWidgetPlacementOptions {
+	draftLayout: PlacedWidget[] | null;
+	setDraftLayout: Dispatch<SetStateAction<PlacedWidget[] | null>>;
+}
+
+// Owns widget repositioning/resizing across all three input modalities the
+// dashboard's edit mode supports: a real pointer drag on a widget's tile or
+// resize handle (#16, mouse/touch), the click-click-click corner-to-corner
+// flow (mouse/touch tap on a grid-guide cell), and its keyboard equivalent
+// (arrow keys + Enter/Space on the Move/Resize button, #17). All three
+// funnel into the same `placingKey`/`anchor`/`cursor`/commitPlacement state
+// machine below so OrgDashboardPage itself only has to wire up input events
+// to the handlers this hook returns.
+export function useWidgetPlacement({
+	draftLayout,
+	setDraftLayout,
+}: UseWidgetPlacementOptions) {
+	const { t } = useTranslation();
+
+	// Corner-to-corner placement state (#782): at most one widget is being
+	// placed at a time. `cursor` is the grid cell the pointer is hovering (or
+	// the keyboard cursor last moved to); `anchor` is the first corner once
+	// locked in (by a click/tap or an Enter/Space press) - once both corners
+	// are known the placement commits. Mouse/touch and keyboard both drive
+	// this same state, just through different inputs (see handleAdvance vs
+	// handleCellClick vs handleArrowKeyDown).
+	const [placingKey, setPlacingKey] = useState<WidgetKey | null>(null);
+	const [anchor, setAnchor] = useState<Cell | null>(null);
+	const [cursor, setCursor] = useState<Cell | null>(null);
+
+	// Real pointer drag (#16) - a second, independent way to reposition a
+	// widget alongside the click-click-click/keyboard flow above. `dragActive`
+	// only exists to (de)register the document-level pointermove/pointerup
+	// listeners at the right time; the session's actual live data lives in
+	// dragSessionRef (a ref, not state, since pointermove fires far more often
+	// than a re-render is useful for) and dragPreview mirrors just enough of
+	// it to render the live preview + backdrop tint.
+	const [dragActive, setDragActive] = useState(false);
+	const [dragPreview, setDragPreview] = useState<PlacedWidget | null>(null);
+	const dragSessionRef = useRef<DragSession | null>(null);
+	// Set to the widget key a drag just committed via a real pointer move, so
+	// the `click` event a browser still fires right after pointerup on THAT
+	// widget's grip doesn't also run handleAdvance and start an unwanted
+	// click-click-click placement. Keyed rather than a plain flag so a stray
+	// click landing on a *different* widget's grip right after (pointerup can
+	// land anywhere) doesn't have its own click wrongly swallowed too.
+	const suppressNextAdvanceRef = useRef<WidgetKey | null>(null);
+
+	function cancelPlacing() {
+		setPlacingKey(null);
+		setAnchor(null);
+		setCursor(null);
+	}
+
+	function startPlacing(key: WidgetKey) {
+		const current = (draftLayout ?? []).find((w) => w.widgetKey === key);
+		if (!current) return;
+		setPlacingKey(key);
+		setAnchor(null);
+		setCursor({ col: current.x, row: current.y });
+	}
+
+	// Bounds/min-size violations still hard-reject (there's nowhere to push a
+	// widget that doesn't fit on the grid at all). An overlap with another
+	// widget no longer does (#18) - it displaces whatever's in the way
+	// instead, then compacts the result so that displacement doesn't leave a
+	// gap of its own further up.
+	function commitPlacement(rect: PlacedWidget) {
+		if (!isValidPlacement(rect)) {
+			dispatchToast("error", t("orgDashboard.placementInvalid"));
+			cancelPlacing();
+			return;
+		}
+		setDraftLayout((prev) => {
+			const others = (prev ?? []).filter((w) => w.widgetKey !== rect.widgetKey);
+			return settlePlacement(rect, others);
+		});
+		cancelPlacing();
+	}
+
+	// Drives the Move/Resize button - a mouse click, or a keyboard Enter/
+	// Space on the focused button (both fire a native `click` event), always
+	// advance this same state machine: not placing yet -> start placing;
+	// placing with no corner locked -> lock the current cursor as the first
+	// corner; placing with a corner already locked -> commit using the
+	// cursor as the second corner. Skipped once for the synthetic click that
+	// follows a real pointer drag (#16) - that drag already committed via
+	// startDrag's own pointerup handler.
+	function handleAdvance(key: WidgetKey) {
+		if (suppressNextAdvanceRef.current === key) {
+			suppressNextAdvanceRef.current = null;
+			return;
+		}
+		if (placingKey !== key) {
+			startPlacing(key);
+			return;
+		}
+		if (!cursor) return;
+		if (!anchor) {
+			setAnchor(cursor);
+			return;
+		}
+		commitPlacement(normalizeRect(anchor, cursor, key));
+	}
+
+	// A click/tap directly on a grid guide cell is the mouse/touch equivalent
+	// of the keyboard's arrow-keys-then-Enter: it moves the cursor there AND
+	// immediately locks/commits, since there's no separate "hover" step on
+	// touch. Mouse users additionally get a live preview via onPointerEnter
+	// (handleCellHover) before they click.
+	function handleCellClick(cell: Cell) {
+		if (!placingKey) return;
+		setCursor(cell);
+		if (!anchor) {
+			setAnchor(cell);
+			return;
+		}
+		commitPlacement(normalizeRect(anchor, cell, placingKey));
+	}
+
+	function handleCellHover(cell: Cell) {
+		if (!placingKey) return;
+		setCursor(cell);
+	}
+
+	function handleArrowKeyDown(
+		event: KeyboardEvent<HTMLButtonElement>,
+		key: WidgetKey,
+	) {
+		if (placingKey !== key || !cursor) return;
+		switch (event.key) {
+			case "ArrowUp":
+				event.preventDefault();
+				setCursor({ col: cursor.col, row: Math.max(1, cursor.row - 1) });
+				break;
+			case "ArrowDown":
+				event.preventDefault();
+				setCursor({
+					col: cursor.col,
+					row: Math.min(GRID_MAX_ROWS, cursor.row + 1),
+				});
+				break;
+			case "ArrowLeft":
+				event.preventDefault();
+				setCursor({ col: Math.max(1, cursor.col - 1), row: cursor.row });
+				break;
+			case "ArrowRight":
+				event.preventDefault();
+				setCursor({
+					col: Math.min(GRID_COLUMNS, cursor.col + 1),
+					row: cursor.row,
+				});
+				break;
+			case "Escape":
+				event.preventDefault();
+				cancelPlacing();
+				break;
+		}
+	}
+
+	// Starts a real pointer drag (#16) on a widget's tile (move, from
+	// anywhere on it) or resize handle. Measures cell size off the widget's
+	// OWN rendered tile rather than the grid container, so it stays correct
+	// regardless of viewport width. A plain click/tap (pointer released
+	// before moving past DRAG_THRESHOLD_PX) is left alone here - a press on
+	// the grip button specifically still falls through to its own onClick
+	// (handleAdvance) exactly as before; the tile itself has no click
+	// handler to fall through to, so a plain click anywhere else on it is
+	// simply a no-op, same as before the whole tile became draggable.
+	function startDrag(
+		event: ReactPointerEvent<HTMLElement>,
+		key: WidgetKey,
+		mode: "move" | "resize",
+	) {
+		if (event.pointerType === "mouse" && event.button !== 0) return;
+		const widget = (draftLayout ?? []).find((w) => w.widgetKey === key);
+		const tile = event.currentTarget.closest<HTMLElement>(
+			`[data-testid="widget-tile-${key}"]`,
+		);
+		if (!widget || !tile) return;
+		const box = tile.getBoundingClientRect();
+		// A tile mid-layout (just resized, just re-rendered) can momentarily
+		// measure as 0x0 in a real browser - dividing by that produces
+		// Infinity/NaN deltas for the rest of the drag. Bail out rather than
+		// starting a session on a bad measurement; the user's next press
+		// gets a fresh, presumably-settled measurement.
+		if (box.width <= 0 || box.height <= 0) return;
+		dragSessionRef.current = {
+			key,
+			mode,
+			startClientX: event.clientX,
+			startClientY: event.clientY,
+			colPx: box.width / widget.width,
+			rowPx: box.height / widget.height,
+			origRect: widget,
+			currentRect: widget,
+			moved: false,
+		};
+		setDragPreview(widget);
+		setDragActive(true);
+	}
+
+	useEffect(() => {
+		if (!dragActive) return;
+
+		function handlePointerMove(event: globalThis.PointerEvent) {
+			const session = dragSessionRef.current;
+			if (!session) return;
+			const deltaX = event.clientX - session.startClientX;
+			const deltaY = event.clientY - session.startClientY;
+			if (
+				Math.abs(deltaX) > DRAG_THRESHOLD_PX ||
+				Math.abs(deltaY) > DRAG_THRESHOLD_PX
+			) {
+				session.moved = true;
+			}
+			const deltaCol = Math.round(deltaX / session.colPx);
+			const deltaRow = Math.round(deltaY / session.rowPx);
+			const nextRect: PlacedWidget =
+				session.mode === "move"
+					? {
+							...session.origRect,
+							x: Math.max(1, session.origRect.x + deltaCol),
+							y: Math.max(1, session.origRect.y + deltaRow),
+						}
+					: {
+							...session.origRect,
+							width: Math.max(1, session.origRect.width + deltaCol),
+							height: Math.max(1, session.origRect.height + deltaRow),
+						};
+			session.currentRect = nextRect;
+			setDragPreview(nextRect);
+		}
+
+		function endDrag() {
+			const session = dragSessionRef.current;
+			dragSessionRef.current = null;
+			setDragActive(false);
+			setDragPreview(null);
+			if (session?.moved) {
+				suppressNextAdvanceRef.current = session.key;
+				commitPlacement(session.currentRect);
+			}
+		}
+
+		document.addEventListener("pointermove", handlePointerMove);
+		document.addEventListener("pointerup", endDrag);
+		document.addEventListener("pointercancel", endDrag);
+		return () => {
+			document.removeEventListener("pointermove", handlePointerMove);
+			document.removeEventListener("pointerup", endDrag);
+			document.removeEventListener("pointercancel", endDrag);
+		};
+		// commitPlacement/cancelPlacing close over draftLayout - re-running
+		// this setup on every draftLayout change would drop mid-drag listeners.
+		// dragActive is the only thing that should ever (re)register them.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [dragActive]);
+
+	// The widget currently being interactively positioned, however it got
+	// there - the click-click-click/keyboard corner flow (placingKey) or a
+	// real pointer drag (dragPreview, #16). previewRect is that widget's
+	// live candidate rect either way; previewValid only reflects the hard
+	// bounds/min-size constraints (#18: overlap is no longer one of them).
+	const activeKey = dragPreview?.widgetKey ?? placingKey;
+	const previewRect = useMemo(() => {
+		if (dragPreview) return dragPreview;
+		if (!placingKey || !cursor) return null;
+		return normalizeRect(anchor ?? cursor, cursor, placingKey);
+	}, [dragPreview, placingKey, anchor, cursor]);
+	const previewValid = previewRect ? isValidPlacement(previewRect) : false;
+
+	return {
+		placingKey,
+		anchor,
+		cursor,
+		activeKey,
+		previewRect,
+		previewValid,
+		cancelPlacing,
+		handleAdvance,
+		handleCellClick,
+		handleCellHover,
+		handleArrowKeyDown,
+		startDrag,
+	};
+}


### PR DESCRIPTION
index.tsx packed a 13-variable state machine driving drag, keyboard, and click/touch placement of dashboard widgets into a single 1,033-line component. Split it into useWidgetPlacement (the placement state machine and its handlers) and EditableWidgetTile (the presentational tile), leaving index.tsx to orchestrate layout/save state and wire the two together.

Fixes #867