### PR TITLE
fix: pin CI Keycloak test container to 26.7.0 to match shipped Docker…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.6.1
+          docker pull quay.io/keycloak/keycloak:26.7.0
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 
@@ -169,7 +169,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.6.1
+          docker pull quay.io/keycloak/keycloak:26.7.0
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.6.1
+          docker pull quay.io/keycloak/keycloak:26.7.0
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.6.1
+          docker pull quay.io/keycloak/keycloak:26.7.0
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -69,7 +69,7 @@ File.WriteAllText(
 	Path.Combine(keycloakRealmImportPath, "einsatzbereit-realm.json"),
 	localRealm.ToJsonString());
 
-var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.6.1")
+var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.7.0")
 	.WithEnvironment("KC_DB", "dev-file")
 	.WithBindMount(keycloakRealmImportPath, "/opt/keycloak/data/import", isReadOnly: true)
 	.WithBindMount(keycloakThemePath, "/opt/keycloak/themes/einsatzbereit", isReadOnly: true)


### PR DESCRIPTION
…file

Aspire AppHost (used by IntegrationTests and VisualTests) and the CI pre-pull steps in dotnet.yml/publish.yml were still on Keycloak 26.6.1, while keycloak/Dockerfile builds and ships 26.7.0. Regressions specific to 26.7.0 could pass CI but fail in staging/production.

Closes #830 