### PR TITLE
fix: unify primary CTA button styling into shared Button component (#…

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,67 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { Link, type LinkProps } from "react-router";
+
+const SIZE_CLASSES = {
+	sm: "px-3 py-1.5 text-xs",
+	md: "px-4 py-2 text-sm",
+	lg: "px-6 py-3 text-base",
+} as const;
+
+type Size = keyof typeof SIZE_CLASSES;
+
+// Solid brand-color primary CTA - the single style every "call to action"
+// button/link in the app should share (see issue #846: four different
+// border-radius values across primary buttons before this existed).
+const BASE_CLASSES =
+	"inline-flex items-center justify-center gap-1.5 rounded-xl bg-brand-700 font-semibold text-white transition-colors hover:bg-brand-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+interface CommonProps {
+	size?: Size;
+	fullWidth?: boolean;
+	className?: string;
+	children: ReactNode;
+}
+
+type ButtonAsButton = CommonProps &
+	Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> & {
+		to?: undefined;
+	};
+
+type ButtonAsLink = CommonProps & Omit<LinkProps, "className">;
+
+type ButtonProps = ButtonAsButton | ButtonAsLink;
+
+export default function Button(props: ButtonProps) {
+	const {
+		size = "md",
+		fullWidth = false,
+		className = "",
+		children,
+		...rest
+	} = props;
+	const classes = [
+		BASE_CLASSES,
+		SIZE_CLASSES[size],
+		fullWidth && "w-full",
+		className,
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	if ("to" in rest && rest.to !== undefined) {
+		return (
+			<Link className={classes} {...(rest as Omit<LinkProps, "className">)}>
+				{children}
+			</Link>
+		);
+	}
+
+	return (
+		<button
+			className={classes}
+			{...(rest as Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className">)}
+		>
+			{children}
+		</button>
+	);
+}

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -6,6 +6,7 @@ import { getApiErrorMessage } from "../lib/apiError";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
+import Button from "./Button";
 
 interface CheckInModalProps {
 	engagementId: string;
@@ -115,13 +116,13 @@ export default function CheckInModal({
 							/>
 						</div>
 						{error && <p className="text-sm text-red-600">{error}</p>}
-						<button
+						<Button
 							type="submit"
 							disabled={submitting || pin.length < 4}
-							className="w-full rounded-md bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+							fullWidth
 						>
 							{submitting ? t("checkIn.submitting") : t("checkIn.submitPin")}
-						</button>
+						</Button>
 					</form>
 				</div>
 			)}

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -5,6 +5,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { getApiErrorMessage } from "../lib/apiError";
 import Modal from "./Modal";
+import Button from "./Button";
 
 interface Props {
 	onClose: () => void;
@@ -301,14 +302,9 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					>
 						{t("organization.cancel")}
 					</button>
-					<button
-						type="submit"
-						disabled={loading}
-						data-testid="modal-submit"
-						className="rounded-xl bg-brand-700 px-4 py-2 text-sm text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
-					>
+					<Button type="submit" disabled={loading} data-testid="modal-submit">
 						{loading ? t("organization.creating") : t("organization.submit")}
-					</button>
+					</Button>
 				</div>
 			</form>
 		</Modal>

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -14,6 +14,7 @@ import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
 import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
+import Button from "../Button";
 import { Stepper } from "./shared";
 import BasicsStep from "./BasicsStep";
 import LocationStep from "./LocationStep";
@@ -726,21 +727,19 @@ export default function CreateVolunteerOpportunityModal({
 							</button>
 						)}
 						{step < TOTAL_STEPS ? (
-							<button
+							<Button
 								type="button"
 								data-testid="modal-next"
 								onClick={() => void handleNext()}
-								className="rounded-xl bg-brand-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-800"
 							>
 								{t("createOpportunity.next")}
-							</button>
+							</Button>
 						) : (
-							<button
+							<Button
 								type="button"
 								disabled={submitting !== null}
 								data-testid="modal-submit"
 								onClick={() => void submit(false)}
-								className="rounded-xl bg-brand-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-800 disabled:opacity-40"
 							>
 								{submitting === "publish"
 									? isEditMode
@@ -749,7 +748,7 @@ export default function CreateVolunteerOpportunityModal({
 									: isEditMode
 										? t("createOpportunity.save")
 										: t("createOpportunity.publish")}
-							</button>
+							</Button>
 						)}
 					</div>
 				</div>

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,3 +1,5 @@
+import Button from "./Button";
+
 interface Props {
 	title: string;
 	message?: string;
@@ -13,12 +15,9 @@ export default function EmptyState({ title, message, action }: Props) {
 			<p className="font-medium text-gray-900">{title}</p>
 			{message && <p className="mt-1 text-sm text-gray-500">{message}</p>}
 			{action && (
-				<button
-					onClick={action.onClick}
-					className="mt-4 rounded-md bg-brand-700 px-4 py-2 text-sm text-white hover:bg-brand-800"
-				>
+				<Button onClick={action.onClick} className="mt-4">
 					{action.label}
-				</button>
+				</Button>
 			)}
 		</div>
 	);

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -7,6 +7,7 @@ import { getApiErrorMessage } from "../lib/apiError";
 import { textareaClass } from "../lib/formClasses";
 import Dropdown from "./Dropdown";
 import Modal from "./Modal";
+import Button from "./Button";
 
 interface Props {
 	opportunityId: string;
@@ -144,13 +145,12 @@ export default function SignUpModal({
 					>
 						{t("signUp.cancel")}
 					</button>
-					<button
+					<Button
 						type="submit"
 						disabled={submitting || (isWaitlist && timeSlots.length === 0)}
-						className="rounded-xl bg-brand-700 px-4 py-2 text-sm text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
 					>
 						{submitting ? t("signUp.submitting") : t("signUp.submit")}
-					</button>
+					</Button>
 				</div>
 			</form>
 		</Modal>

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
+import Button from "./Button";
 
 interface SubmitFeedbackModalProps {
 	engagementId: string;
@@ -126,13 +127,13 @@ export default function SubmitFeedbackModal({
 					>
 						{t("feedback.cancel")}
 					</button>
-					<button
+					<Button
 						type="submit"
 						disabled={submitting || rating === 0}
-						className="flex-1 rounded-md bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+						className="flex-1"
 					>
 						{submitting ? t("feedback.submitting") : t("feedback.submit")}
-					</button>
+					</Button>
 				</div>
 			</form>
 		</Modal>

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -16,6 +16,7 @@ import {
 } from "../contexts/QuickActionsContext";
 import Header from "../components/Header/Header";
 import Spinner from "../components/Spinner";
+import Button from "../components/Button";
 
 export interface OrgAppContext {
 	org: OrganizationDetailsResponse;
@@ -166,12 +167,7 @@ export default function OrgAppLayout() {
 				<h1 className="text-xl font-semibold text-gray-900">
 					{t("orgApp.notAuthorized")}
 				</h1>
-				<Link
-					to="/"
-					className="rounded-lg bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800"
-				>
-					{t("orgApp.backToSite")}
-				</Link>
+				<Button to="/">{t("orgApp.backToSite")}</Button>
 			</div>
 		);
 	}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -11,6 +11,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import Spinner from "../components/Spinner";
 import EmptyState from "../components/EmptyState";
+import Button from "../components/Button";
 
 const PAGE_SIZE = 10;
 
@@ -164,14 +165,14 @@ function OrganizationsSection() {
 											{t("administration.organizations.unverify")}
 										</button>
 									) : (
-										<button
+										<Button
 											type="button"
 											disabled={toggling === row.id}
 											onClick={() => void toggleVerified(row.id, true)}
-											className="rounded-lg bg-brand-700 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
+											size="sm"
 										>
 											{t("administration.organizations.verify")}
-										</button>
+										</Button>
 									)}
 								</td>
 							</tr>
@@ -305,12 +306,7 @@ function UsersSection() {
 						className={inputClass}
 					/>
 				</div>
-				<button
-					type="submit"
-					className="rounded-lg bg-brand-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-800"
-				>
-					{t("administration.users.searchButton")}
-				</button>
+				<Button type="submit">{t("administration.users.searchButton")}</Button>
 			</form>
 
 			<p className="mb-4 text-xs text-gray-500">

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -12,6 +12,7 @@ import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import QRScannerModal from "../components/QRScannerModal";
 import Spinner from "../components/Spinner";
+import Button from "../components/Button";
 import NotFoundPage from "./NotFoundPage";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -196,11 +197,7 @@ export default function EngagementManagementPage() {
 
 			{showQrScanner && (
 				<div className="mb-6">
-					<button
-						type="button"
-						onClick={() => setQrScannerOpen(true)}
-						className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-800"
-					>
+					<Button type="button" onClick={() => setQrScannerOpen(true)}>
 						<svg
 							className="h-4 w-4"
 							fill="none"
@@ -221,7 +218,7 @@ export default function EngagementManagementPage() {
 							/>
 						</svg>
 						{t("checkIn.qrScanButton")}
-					</button>
+					</Button>
 				</div>
 			)}
 
@@ -339,15 +336,15 @@ export default function EngagementManagementPage() {
 									{e.status === "Confirmed" && (
 										<div className="flex gap-2">
 											{showManualCheckIn && !e.isCheckedIn && (
-												<button
+												<Button
 													onClick={() => handleCheckIn(e.id)}
 													disabled={checkingIn === e.id}
-													className="rounded-xl bg-brand-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800 disabled:opacity-50"
+													size="sm"
 												>
 													{checkingIn === e.id
 														? t("checkIn.markingCheckedIn")
 														: t("checkIn.markCheckedIn")}
-												</button>
+												</Button>
 											)}
 											<button
 												onClick={() => setConfirmCancelId(e.id)}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useSearchParams } from "react-router";
 import type { OrganizationSummaryDto } from "../client/api-client";
 import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList/VolunteerOpportunitiesList";
 import CreateOrganizationModal from "../components/CreateOrganizationModal";
+import Button from "../components/Button";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { signinLocaleArgs } from "../lib/authLocale";
@@ -484,13 +485,14 @@ export default function HomePage() {
 							{t("landing.orgsTeaserDesc")}
 						</p>
 					</div>
-					<Link
+					<Button
 						to="/organizations"
 						data-testid="organizations-teaser-cta"
-						className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-brand-700 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-800"
+						size="lg"
+						className="shadow-sm shrink-0"
 					>
 						{t("landing.orgsTeaserCta")}
-					</Link>
+					</Button>
 				</div>
 			</section>
 

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,7 +1,7 @@
-import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import PageEaten from "../assets/page-eaten.svg?react";
 import { usePageTitle } from "../hooks/usePageTitle";
+import Button from "../components/Button";
 
 export default function NotFoundPage() {
 	const { t } = useTranslation();
@@ -19,12 +19,9 @@ export default function NotFoundPage() {
 
 				<p className="mb-8 text-black">{t("notFound.description")}</p>
 
-				<Link
-					to="/"
-					className="inline-flex items-center gap-2 rounded-full bg-brand-700 px-6 py-3 text-sm font-medium text-white shadow-lg hover:bg-brand-800"
-				>
+				<Button to="/" size="lg" className="shadow-lg">
 					{t("notFound.backHome")}
-				</Link>
+				</Button>
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -16,6 +16,7 @@ import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
 import SubmitFeedbackModal from "../../components/SubmitFeedbackModal";
 import Skeleton from "../../components/Skeleton";
+import Button from "../../components/Button";
 
 const ENGAGEMENTS_PAGE_SIZE = 10;
 
@@ -199,18 +200,18 @@ export default function ActivitySection() {
 										</p>
 									</div>
 									<div className="flex shrink-0 gap-2">
-										<button
+										<Button
 											type="button"
 											onClick={() => handleAcceptInvitation(inv.id)}
 											disabled={
 												acceptingId === inv.id || decliningId === inv.id
 											}
-											className="rounded-md bg-brand-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+											size="sm"
 										>
 											{acceptingId === inv.id
 												? t("invitations.accepting")
 												: t("invitations.accept")}
-										</button>
+										</Button>
 										<button
 											type="button"
 											onClick={() => handleDeclineInvitation(inv.id)}
@@ -384,12 +385,9 @@ export default function ActivitySection() {
 									{e.status === "Confirmed" &&
 										!e.isCheckedIn &&
 										e.opportunityTitle && (
-											<button
-												onClick={() => setCheckInEngagement(e)}
-												className="rounded-lg bg-brand-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800"
-											>
+											<Button onClick={() => setCheckInEngagement(e)} size="sm">
 												{t("checkIn.buttonLabel")}
-											</button>
+											</Button>
 										)}
 									{e.isCheckedIn && !e.hasFeedback && (
 										<button

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "../lib/format";
 import SignUpModal from "../components/SignUpModal";
 import ConfirmDialog from "../components/ConfirmDialog";
+import Button from "../components/Button";
 import SingleMarkerMap from "../components/SingleMarkerMap";
 import Skeleton from "../components/Skeleton";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -467,15 +468,16 @@ export default function VolunteerOpportunityDetailPage() {
 									: t("opportunities.spotsLeft", { count: spotsLeft })}
 						</p>
 					)}
-					<button
+					<Button
 						onClick={() => setShowSignUp(true)}
 						disabled={isFull}
-						className="w-full rounded-xl bg-brand-700 px-6 py-3.5 text-base font-semibold text-white transition hover:bg-brand-800 disabled:cursor-not-allowed disabled:opacity-50"
+						fullWidth
+						size="lg"
 					>
 						{opportunity.participationType === "Waitlist"
 							? t("opportunities.joinWaitlist")
 							: t("opportunities.expressInterest")}
-					</button>
+					</Button>
 				</div>
 			)}
 

--- a/frontend/src/pages/app/OrgDashboardPage/AddWidgetModal.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/AddWidgetModal.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import Modal from "../../../components/Modal";
+import Button from "../../../components/Button";
 import { WIDGET_CATALOG, type WidgetKey } from "./widgetCatalog";
 
 const WIDGET_DESC_KEY: Record<WidgetKey, string> = {
@@ -161,14 +162,9 @@ export default function AddWidgetModal({
 			</div>
 
 			<div className="flex justify-end border-t border-gray-100 px-6 py-4">
-				<button
-					type="button"
-					onClick={onClose}
-					data-testid="add-widget-done"
-					className="rounded-xl bg-brand-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-800"
-				>
+				<Button type="button" onClick={onClose} data-testid="add-widget-done">
 					{t("orgDashboard.addWidgetDone")}
-				</button>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -10,6 +10,7 @@ import type { OrganizationCalendarEventDto } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Modal from "../../../components/Modal";
 import Spinner from "../../../components/Spinner";
+import Button from "../../../components/Button";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "./useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -270,16 +271,16 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 								>
 									{t("createOpportunity.cancel")}
 								</button>
-								<button
+								<Button
 									type="button"
 									disabled={savingColor}
 									onClick={handleColorSave}
-									className="rounded-md bg-brand-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-50"
+									size="sm"
 								>
 									{savingColor
 										? t("orgOverview.eventColorSaving")
 										: t("orgOverview.eventColorSave")}
-								</button>
+								</Button>
 							</div>
 						</div>
 					</div>

--- a/frontend/src/pages/app/OrgDashboardPage/CreateOpportunityWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CreateOpportunityWidget.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import CreateVolunteerOpportunityModal from "../../../components/CreateVolunteerOpportunityModal";
+import Button from "../../../components/Button";
 import WidgetCard from "./WidgetCard";
 import type { WidgetSizeClass } from "./widgetCatalog";
 import { PlusIcon } from "../../../components/QuickActionIcons";
@@ -32,15 +33,16 @@ function CreateOpportunityWidget({ organizationId, onCreated, size }: Props) {
 					{t("orgDashboard.createOpportunityWidgetDesc")}
 				</p>
 			)}
-			<button
+			<Button
 				type="button"
 				onClick={() => setShowCreateModal(true)}
 				data-testid="create-opportunity-btn"
-				className={`inline-flex w-full items-center justify-center gap-1.5 rounded-xl bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-800 focus:outline-none ${compact ? "" : "mt-4"}`}
+				fullWidth
+				className={`shadow-sm ${compact ? "" : "mt-4"}`}
 			>
 				{compact && <PlusIcon />}
 				{t("orgOverview.createOpportunity")}
-			</button>
+			</Button>
 
 			{showCreateModal && (
 				<CreateVolunteerOpportunityModal

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -9,6 +9,7 @@ import { dispatchToast } from "../../../lib/toastBus";
 import { getApiErrorMessage } from "../../../lib/apiError";
 import QRScannerModal from "../../../components/QRScannerModal";
 import Spinner from "../../../components/Spinner";
+import Button from "../../../components/Button";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "./useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -104,17 +105,17 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 							))}
 						</select>
 					</div>
-					<button
+					<Button
 						type="button"
 						onClick={() => void startScanning()}
 						disabled={loadingEngagements}
 						data-testid="quick-checkin-scan-btn"
-						className={`inline-flex items-center justify-center gap-1.5 rounded-xl bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-800 focus:outline-none disabled:opacity-50 ${size !== "compact" ? "shrink-0" : "w-full"}`}
+						className={`shadow-sm ${size !== "compact" ? "shrink-0" : "w-full"}`}
 					>
 						{loadingEngagements
 							? t("orgDashboard.loading")
 							: t("orgDashboard.quickCheckInOpenScanner")}
-					</button>
+					</Button>
 				</div>
 			)}
 

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -11,6 +11,7 @@ import { getApiErrorMessage } from "../../lib/apiError";
 import { inputClass } from "../../lib/formClasses";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
+import Button from "../../components/Button";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 export default function OrgMembersPage() {
@@ -182,13 +183,14 @@ export default function OrgMembersPage() {
 											{candidate.email}
 										</p>
 									</div>
-									<button
+									<Button
 										type="button"
 										onClick={() => handleInviteMember(candidate.userId)}
-										className="ml-3 shrink-0 rounded-xl bg-brand-700 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-800"
+										size="sm"
+										className="ml-3 shrink-0"
 									>
 										{t("orgSettings.invite")}
-									</button>
+									</Button>
 								</li>
 							))}
 						</ul>

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -12,6 +12,7 @@ import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpp
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
 import Spinner from "../../components/Spinner";
+import Button from "../../components/Button";
 import { PlusIcon } from "../../components/QuickActionIcons";
 import { useQuickActions } from "../../contexts/QuickActionsContext";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
@@ -230,17 +231,17 @@ export default function OrgOpportunitiesPage() {
 							{t("opportunities.delete")}
 						</button>
 						{isDraft ? (
-							<button
+							<Button
 								type="button"
 								onClick={() => void publish(item.id)}
 								disabled={publishingId === item.id}
 								data-testid="opportunity-publish"
-								className="rounded-lg bg-brand-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-800 disabled:opacity-50"
+								size="sm"
 							>
 								{publishingId === item.id
 									? t("opportunities.publishing")
 									: t("opportunities.publish")}
-							</button>
+							</Button>
 						) : (
 							<Link
 								to={`/app/${organizationId}/dashboard/opportunities/${item.id}/engagements`}


### PR DESCRIPTION
…846)

Primary call-to-action buttons were hand-styled across ~20 files with four different border-radius values (rounded-md/lg/xl/full) and no shared component. Adds components/Button.tsx (solid brand style, size sm/md/lg, fullWidth, polymorphic to/onClick for Link vs button) and migrates every solid-brand primary CTA to it.

Closes #846