### PR TITLE
docs: document per-organization membership check in arc42 authorizati…

### DIFF
--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -33,6 +33,12 @@ Role-based access control is enforced at the API endpoint level using ASP.NET Co
 |Full administrative access
 |===
 
+*Per-organization membership:*
+
+The `organisator` role in the JWT only proves the user organizes *some* organization, not which one. "Own organization" access is gated by a separate, local `organization_membership` table (`organization_id`, `user_id`, `role`), not by anything in the token. `OwnershipGuard.EnsureIsOrganizerAsync` checks this table on every org-modifying endpoint and returns `403 Forbidden` (`Organization.NotOrganizer`) when the requesting user has no membership row for that organization. There is no Keycloak fallback at request time - Keycloak is the source of truth for who organizes an organization, but the request-time guard only ever reads the local table.
+
+Membership rows are written when a user is added to an organization, and once at startup by an idempotent backfill that pulls existing organizer members from Keycloak for any organization that predates the table and has no membership rows yet. The backfill runs after migrations on every startup path (development and staging), so a fresh deploy against pre-existing data does not lock out its existing organizers.
+
 *Token handling in the frontend:*
 
 Access and refresh tokens are stored in `localStorage` via the OIDC client's `WebStorageStateStore`, so the session survives a page reload. The refresh token is used to obtain new access tokens silently when the access token expires.


### PR DESCRIPTION
…on chapter

The organisator role in the JWT only says a user organizes some organization; "own organization" access is gated separately by the local organization_membership table via OwnershipGuard, with no Keycloak fallback at request time. This mechanism was undocumented despite a prior production incident (#702) hinging on it.

Fixes #863