### PR TITLE
fix: update arc42 docs to reflect parallel CI jobs from #773 (#861)

### DIFF
--- a/docs/Architecture/images/deployment-cicd.puml
+++ b/docs/Architecture/images/deployment-cicd.puml
@@ -12,7 +12,7 @@ participant "Staging host\n(Docker Compose)" as staging
 
 dev -> github: Push commit or open PR
 github -> ci: Trigger workflows
-ci -> ci: Backend (dotnet.yml): build, then\nUnit + Architecture + Integration + Visual tests\n(Integration/Visual boot the Aspire stack)
+ci -> ci: Backend (dotnet.yml): format-check + fast-tests + integration-tests + visual-tests\nrun as 4 parallel jobs, no needs between them\n(integration-tests/visual-tests boot the Aspire stack)
 ci -> ci: Frontend (frontend.yml): lint + build
 ci -> ci: Lint (lint.yml): ASCII dashes + EditorConfig
 

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -72,12 +72,13 @@ The CI/CD pipeline runs on GitHub Actions and covers three concerns: quality gat
 
 ==== Quality Gate (on every push / PR to `main`)
 
-The backend workflow (`dotnet.yml`) runs `dotnet build`, then four test projects sequentially via `dotnet run`:
+The backend workflow (`dotnet.yml`) runs four independent jobs in parallel (no `needs` between them), each doing its own `dotnet build` via `dotnet run`:
 
-* `Application.UnitTests` and `ArchitectureTests` - fast, no containers.
-* `IntegrationTests` and `VisualTests` - both boot the Aspire AppHost stack (the same stack as local development) under Docker; `VisualTests` adds Playwright end-to-end checks.
+* `format-check` - verifies `dotnet format`.
+* `fast-tests` - `Application.UnitTests` and `ArchitectureTests`, no containers.
+* `integration-tests` and `visual-tests` - both boot the Aspire AppHost stack (the same stack as local development) under Docker; `visual-tests` adds Playwright end-to-end checks.
 
-A parallel `format-check` job verifies `dotnet format`. The frontend workflow (`frontend.yml`) runs lint, i18n key-parity, type-check, and build; `lint.yml` enforces ASCII dashes and EditorConfig. Typical `dotnet.yml` runtime is about 10 minutes, dominated by `VisualTests` - see TDR-2.
+The frontend workflow (`frontend.yml`) runs lint, i18n key-parity, type-check, and build; `lint.yml` enforces ASCII dashes and EditorConfig. Typical `dotnet.yml` critical-path runtime is about 6 minutes, down from ~10 minutes before the jobs were split into parallel jobs in issue #773 - `visual-tests` remains the longest-running job - see TDR-2.
 
 The architecture docs build (`docs.yml`) is a separate, main-branch-only deployment to GitHub Pages, not a pull-request gate.
 

--- a/docs/Architecture/src/10_quality_requirements.adoc
+++ b/docs/Architecture/src/10_quality_requirements.adoc
@@ -97,7 +97,7 @@ include::../images/quality-tree.puml[]
 
 |QS-3.4
 |A contributor opens a pull request.
-|The backend CI quality gate (`dotnet.yml`) returns a pass/fail verdict within about 10 minutes, keeping the contribution feedback loop short. See TDR-2.
+|The backend CI quality gate (`dotnet.yml`) returns a pass/fail verdict within about 6 minutes via three parallel test jobs, keeping the contribution feedback loop short. See TDR-2.
 |===
 
 ==== Usability

--- a/docs/Architecture/src/11_technical_risks.adoc
+++ b/docs/Architecture/src/11_technical_risks.adoc
@@ -20,9 +20,9 @@ The following table lists the relevant risks and technical debts. Each risk or t
 
 |2
 |CI Pipeline Performance
-|Slow, steadily growing backend CI pipeline dominated by end-to-end tests.
+|Steadily growing backend CI pipeline dominated by end-to-end tests; critical path cut from ~10 min to ~6 min by splitting into parallel jobs (#773), full resolution still pending.
 |Low-Medium
-|Analyzed
+|In Progress
 |2026-07-18
 |link:TDRs/2_slow_ci_pipeline.html[Slow CI Pipeline]
 


### PR DESCRIPTION
Chapters 7, 10 and 11 still described dotnet.yml as one sequential ~10-minute job. It was split into parallel jobs (format-check, fast-tests, integration-tests, visual-tests) with critical path ~6 minutes; update the deployment view, quality scenario, and technical risk table (plus the CI/CD sequence diagram) to match.

Closes #861