### PR TITLE
chore: remove unused System.IdentityModel.Tokens.Jwt package pin

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -47,7 +47,6 @@
 		<PackageVersion Include="NetArchTest.Rules" Version="[1.3.2]" />
 		<PackageVersion Include="NSubstitute" Version="[6.0.0]" />
 		<PackageVersion Include="Respawn" Version="[7.0.0]" />
-		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="[8.21.0]" />
 		<PackageVersion Include="TUnit" Version="[1.61.38]" />
 		<PackageVersion Include="TUnit.Playwright" Version="[1.61.38]" />
 	</ItemGroup>


### PR DESCRIPTION
No project references it; Renovate kept opening version-bump PRs for dead weight (#842).

Closes #842