### PR TITLE
fix: declare explicit AllowAnonymous on public achievement endpoints …

### DIFF
--- a/backend/src/Api/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogEndpoint.cs
+++ b/backend/src/Api/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogEndpoint.cs
@@ -16,6 +16,7 @@ internal sealed class GetBadgeCatalogEndpoint
 			.WithTags("Achievements")
 			.Produces<List<BadgeCatalogEntry>>()
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 

--- a/backend/src/Api/Achievements/GetUserAchievements/v1/GetUserAchievementsEndpoint.cs
+++ b/backend/src/Api/Achievements/GetUserAchievements/v1/GetUserAchievementsEndpoint.cs
@@ -18,6 +18,7 @@ internal sealed class GetUserAchievementsEndpoint
 			.WithTags("Achievements")
 			.Produces<List<AchievementSummary>>()
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 

--- a/backend/tests/ArchitectureTests/AuthorizationConventionTests.cs
+++ b/backend/tests/ArchitectureTests/AuthorizationConventionTests.cs
@@ -1,0 +1,23 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authorization;
+
+namespace ArchitectureTests;
+
+public sealed class AuthorizationConventionTests
+{
+	[Test]
+	public void AllEndpoints_ShouldDeclareAnExplicitAuthorizationDecision()
+	{
+		var app = EndpointTestHelper.BuildMinimalAppWithAllEndpoints();
+
+		var endpointsWithoutAuthorizationMetadata = EndpointTestHelper.GetAllRouteEndpoints(app)
+			.Where(e => !e.Metadata.OfType<IAllowAnonymous>().Any()
+				&& !e.Metadata.OfType<IAuthorizeData>().Any())
+			.Select(e => e.RoutePattern.RawText)
+			.ToList();
+
+		endpointsWithoutAuthorizationMetadata.Should().BeEmpty(
+			"every endpoint must call RequireAuthorization(...) or AllowAnonymous() explicitly - " +
+			"omitting both leaves it anonymously reachable by accident");
+	}
+}

--- a/backend/tests/ArchitectureTests/EndpointTestHelper.cs
+++ b/backend/tests/ArchitectureTests/EndpointTestHelper.cs
@@ -1,0 +1,57 @@
+using Api.Common.Endpoints;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ArchitectureTests;
+
+internal static class EndpointTestHelper
+{
+	public static WebApplication BuildMinimalAppWithAllEndpoints()
+	{
+		var builder = WebApplication.CreateBuilder();
+
+		builder.Services
+			.AddApiVersioning(options =>
+			{
+				options.DefaultApiVersion = new ApiVersion(1);
+				options.AssumeDefaultVersionWhenUnspecified = true;
+				options.ApiVersionReader = new UrlSegmentApiVersionReader();
+			})
+			.AddApiExplorer(options => options.GroupNameFormat = "'v'V");
+
+		builder.Services.AddAuthentication();
+		builder.Services.AddAuthorization();
+		builder.Services.AddRateLimiter(_ => { });
+
+		// AddEndpoints() uses Assembly.GetExecutingAssembly(), which is ArchitectureTests here.
+		// Manually register all IEndpoint implementations from the Api assembly instead.
+		var endpointTypes = AssemblyAnchors.PresentationLayer.GetTypes()
+			.Where(t => t is { IsClass: true, IsAbstract: false }
+				&& typeof(IEndpoint).IsAssignableFrom(t));
+
+		foreach (var type in endpointTypes)
+			builder.Services.AddTransient(typeof(IEndpoint), type);
+
+		var app = builder.Build();
+
+		var versionSet = app.NewApiVersionSet()
+			.HasApiVersion(new ApiVersion(1))
+			.ReportApiVersions()
+			.Build();
+
+		var group = app.MapGroup("v{version:apiVersion}").WithApiVersionSet(versionSet);
+
+		foreach (var endpoint in app.Services.GetRequiredService<IEnumerable<IEndpoint>>())
+			endpoint.MapEndpoint(group);
+
+		return app;
+	}
+
+	public static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
+		((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(ds => ds.Endpoints)
+			.OfType<RouteEndpoint>()
+			.ToList();
+}

--- a/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RateLimitingConventionTests.cs
@@ -1,10 +1,6 @@
-using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
-using Asp.Versioning;
 using AwesomeAssertions;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace ArchitectureTests;
 
@@ -13,9 +9,9 @@ public sealed class RateLimitingConventionTests
 	[Test]
 	public void AllEndpoints_ShouldHaveRateLimitingPolicyApplied()
 	{
-		var app = BuildMinimalAppWithAllEndpoints();
+		var app = EndpointTestHelper.BuildMinimalAppWithAllEndpoints();
 
-		var endpointsWithoutRateLimiting = GetAllRouteEndpoints(app)
+		var endpointsWithoutRateLimiting = EndpointTestHelper.GetAllRouteEndpoints(app)
 			.Where(e => GetRateLimitingPolicyName(e) is null)
 			.Select(e => e.RoutePattern.RawText)
 			.ToList();
@@ -29,9 +25,9 @@ public sealed class RateLimitingConventionTests
 	{
 		var knownPolicies = new[] { RateLimitingPolicies.Read, RateLimitingPolicies.Write };
 
-		var app = BuildMinimalAppWithAllEndpoints();
+		var app = EndpointTestHelper.BuildMinimalAppWithAllEndpoints();
 
-		var endpointsWithUnknownPolicy = GetAllRouteEndpoints(app)
+		var endpointsWithUnknownPolicy = EndpointTestHelper.GetAllRouteEndpoints(app)
 			.Select(e => new { Route = e.RoutePattern.RawText, Policy = GetRateLimitingPolicyName(e) })
 			.Where(e => e.Policy is not null && !knownPolicies.Contains(e.Policy))
 			.Select(e => $"{e.Route} uses unknown policy '{e.Policy}'")
@@ -47,52 +43,5 @@ public sealed class RateLimitingConventionTests
 			.FirstOrDefault(m => m.GetType().Name == "EnableRateLimitingAttribute");
 
 		return attr?.GetType().GetProperty("PolicyName")?.GetValue(attr) as string;
-	}
-
-	private static IReadOnlyList<RouteEndpoint> GetAllRouteEndpoints(WebApplication app) =>
-		((IEndpointRouteBuilder)app).DataSources
-			.SelectMany(ds => ds.Endpoints)
-			.OfType<RouteEndpoint>()
-			.ToList();
-
-	private static WebApplication BuildMinimalAppWithAllEndpoints()
-	{
-		var builder = WebApplication.CreateBuilder();
-
-		builder.Services
-			.AddApiVersioning(options =>
-			{
-				options.DefaultApiVersion = new ApiVersion(1);
-				options.AssumeDefaultVersionWhenUnspecified = true;
-				options.ApiVersionReader = new UrlSegmentApiVersionReader();
-			})
-			.AddApiExplorer(options => options.GroupNameFormat = "'v'V");
-
-		builder.Services.AddAuthentication();
-		builder.Services.AddAuthorization();
-		builder.Services.AddRateLimiter(_ => { });
-
-		// AddEndpoints() uses Assembly.GetExecutingAssembly(), which is ArchitectureTests here.
-		// Manually register all IEndpoint implementations from the Api assembly instead.
-		var endpointTypes = AssemblyAnchors.PresentationLayer.GetTypes()
-			.Where(t => t is { IsClass: true, IsAbstract: false }
-				&& typeof(IEndpoint).IsAssignableFrom(t));
-
-		foreach (var type in endpointTypes)
-			builder.Services.AddTransient(typeof(IEndpoint), type);
-
-		var app = builder.Build();
-
-		var versionSet = app.NewApiVersionSet()
-			.HasApiVersion(new ApiVersion(1))
-			.ReportApiVersions()
-			.Build();
-
-		var group = app.MapGroup("v{version:apiVersion}").WithApiVersionSet(versionSet);
-
-		foreach (var endpoint in app.Services.GetRequiredService<IEnumerable<IEndpoint>>())
-			endpoint.MapEndpoint(group);
-
-		return app;
 	}
 }


### PR DESCRIPTION
…(#854)

GetUserAchievementsEndpoint and GetBadgeCatalogEndpoint carried no authorization metadata at all, making them anonymously reachable purely by omission rather than by an explicit decision. Both serve public data, so add .AllowAnonymous() to match the codebase's convention for public endpoints.

Add AuthorizationConventionTests to catch this class of bug going forward: builds a real WebApplication with every IEndpoint mapped and asserts each resulting RouteEndpoint carries either IAllowAnonymous or IAuthorizeData metadata. Extracted the shared WebApplication-building helper (previously duplicated in RateLimitingConventionTests) into EndpointTestHelper so both convention tests reuse one implementation.

Closes #854