### PR TITLE
fix: unify inline error messaging into shared ErrorBanner component

### DIFF
--- a/backend/tests/IntegrationTests/OutboxTests.cs
+++ b/backend/tests/IntegrationTests/OutboxTests.cs
@@ -52,10 +52,14 @@ public class OutboxTests(IntegrationTestFixture fixture)
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
 
+		// OutboxProcessorJob polls every 5s (PollInterval in OutboxProcessorJob.cs); a
+		// 30s budget gives it several cycles to run so a slow/loaded CI runner delaying
+		// one tick doesn't flake the test, while still failing fast if dispatch is
+		// actually broken.
 		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
-			EngagementCheckedInDomainEventType, TimeSpan.FromSeconds(15));
+			EngagementCheckedInDomainEventType, TimeSpan.FromSeconds(30));
 
-		processed.Should().BeTrue("OutboxProcessorJob should dispatch the message to EngagementCheckedInAuditLogHandler within its poll interval");
+		processed.Should().BeTrue("OutboxProcessorJob should dispatch the message to EngagementCheckedInAuditLogHandler within a few poll cycles");
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────────

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -129,7 +129,7 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 		var secondSignUpResponse = await secondSignUpResponseTask;
 		secondSignUpResponse.Status.Should().Be(409);
 
-		var errorText = await page2.Locator("p.text-red-600").First.TextContentAsync();
+		var errorText = await page2.GetByRole(AriaRole.Alert).First.TextContentAsync();
 		errorText.Should().NotBeNullOrEmpty();
 		errorText.Should().NotContain("Unknown error");
 		errorText.Should().Contain("already signed up");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
+import ErrorBanner from "./components/ErrorBanner";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
@@ -65,9 +66,9 @@ function CallbackPage() {
 	if (auth.error) {
 		return (
 			<div className="flex min-h-screen items-center justify-center">
-				<span className="text-red-600">
-					{t("auth.authError", { message: auth.error.message })}
-				</span>
+				<ErrorBanner
+					message={t("auth.authError", { message: auth.error.message })}
+				/>
 			</div>
 		);
 	}

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -7,6 +7,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
 import Button from "./Button";
+import ErrorBanner from "./ErrorBanner";
 
 interface CheckInModalProps {
 	engagementId: string;
@@ -72,11 +73,7 @@ export default function CheckInModal({
 				</div>
 			)}
 
-			{loadError && (
-				<p className="text-sm text-red-600" role="alert">
-					{t("checkIn.loadError")}
-				</p>
-			)}
+			{loadError && <ErrorBanner message={t("checkIn.loadError")} />}
 
 			{details && !success && checkInMethod === "QRCode" && (
 				<div className="flex flex-col items-center gap-4">
@@ -115,7 +112,7 @@ export default function CheckInModal({
 								className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
 							/>
 						</div>
-						{error && <p className="text-sm text-red-600">{error}</p>}
+						{error && <ErrorBanner message={error} />}
 						<Button
 							type="submit"
 							disabled={submitting || pin.length < 4}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import Modal from "./Modal";
+import ErrorBanner from "./ErrorBanner";
 
 interface Props {
 	title: string;
@@ -36,7 +37,7 @@ export default function ConfirmDialog({
 			</h2>
 			<p className="mt-2 text-sm text-gray-600">{message}</p>
 
-			{error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+			{error && <ErrorBanner message={error} className="mt-3" />}
 
 			<div className="mt-5 flex justify-end gap-3">
 				<button

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -6,6 +6,7 @@ import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { getApiErrorMessage } from "../lib/apiError";
 import Modal from "./Modal";
 import Button from "./Button";
+import ErrorBanner from "./ErrorBanner";
 
 interface Props {
 	onClose: () => void;
@@ -290,7 +291,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						</div>
 					</fieldset>
 
-					{error && <p className="text-sm text-red-600">{error}</p>}
+					{error && <ErrorBanner message={error} />}
 				</div>
 
 				<div className="flex justify-end gap-2 border-t border-gray-100 px-6 py-4">

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -4,6 +4,7 @@ import { Controller } from "react-hook-form";
 import type { Control } from "react-hook-form";
 import Dropdown from "../Dropdown";
 import TagsInput from "../TagsInput";
+import ErrorBanner from "../ErrorBanner";
 import { formatDateTime } from "../../lib/format";
 import type { OpportunityFormValues } from "./schema";
 
@@ -331,14 +332,12 @@ export default function DetailsStep({
 			)}
 
 			{error && (
-				<p
+				<ErrorBanner
 					ref={errorRef}
-					role="alert"
+					message={error}
 					tabIndex={-1}
-					className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700 focus:outline-none"
-				>
-					{error}
-				</p>
+					className="focus:outline-none"
+				/>
 			)}
 		</div>
 	);

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes } from "react";
+
+interface Props extends Omit<
+	HTMLAttributes<HTMLParagraphElement>,
+	"className"
+> {
+	message: string;
+	className?: string;
+}
+
+// Single shared style for an inline "action failed" message - the box every
+// page's error state should share (see issue #853: pages alternated between
+// a bare red line and a boxed banner, with different border radii, for the
+// same state).
+const BASE_CLASSES = "rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700";
+
+const ErrorBanner = forwardRef<HTMLParagraphElement, Props>(
+	({ message, className = "", ...rest }, ref) => (
+		<p
+			ref={ref}
+			role="alert"
+			className={[BASE_CLASSES, className].filter(Boolean).join(" ")}
+			{...rest}
+		>
+			{message}
+		</p>
+	),
+);
+ErrorBanner.displayName = "ErrorBanner";
+
+export default ErrorBanner;

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -4,6 +4,7 @@ import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
+import ErrorBanner from "./ErrorBanner";
 
 declare global {
 	class BarcodeDetector {
@@ -144,13 +145,13 @@ export default function QRScannerModal({
 			)}
 
 			{supported === false && (
-				<p className="text-sm text-red-600">{t("checkIn.qrNotSupported")}</p>
+				<ErrorBanner message={t("checkIn.qrNotSupported")} />
 			)}
 
 			{supported === true && !success && (
 				<>
 					{cameraError ? (
-						<p className="text-sm text-red-600">{cameraError}</p>
+						<ErrorBanner message={cameraError} />
 					) : (
 						<div className="relative overflow-hidden rounded-lg bg-black">
 							<video
@@ -169,11 +170,7 @@ export default function QRScannerModal({
 							</div>
 						</div>
 					)}
-					{scanError && (
-						<p className="mt-2 text-sm text-red-600" role="alert">
-							{scanError}
-						</p>
-					)}
+					{scanError && <ErrorBanner message={scanError} className="mt-2" />}
 					{!cameraError && !scanError && (
 						<p className="mt-3 text-sm text-gray-500">
 							{t("checkIn.qrScanHint")}

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -8,6 +8,7 @@ import { textareaClass } from "../lib/formClasses";
 import Dropdown from "./Dropdown";
 import Modal from "./Modal";
 import Button from "./Button";
+import ErrorBanner from "./ErrorBanner";
 
 interface Props {
 	opportunityId: string;
@@ -135,7 +136,7 @@ export default function SignUpModal({
 					</div>
 				)}
 
-				{error && <p className="text-sm text-red-600">{error}</p>}
+				{error && <ErrorBanner message={error} />}
 
 				<div className="flex justify-end gap-2">
 					<button

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Button from "./Button";
+import ErrorBanner from "./ErrorBanner";
 
 interface SubmitFeedbackModalProps {
 	engagementId: string;
@@ -117,7 +118,7 @@ export default function SubmitFeedbackModal({
 					</p>
 				</div>
 
-				{error && <p className="text-sm text-red-600">{error}</p>}
+				{error && <ErrorBanner message={error} />}
 
 				<div className="flex gap-3">
 					<button

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
 import EmptyState from "../EmptyState";
 import Skeleton from "../Skeleton";
+import ErrorBanner from "../ErrorBanner";
 import OpportunityListItem from "./OpportunityListItem";
 
 export default function OpportunityResultsList({
@@ -47,9 +48,10 @@ export default function OpportunityResultsList({
 				</div>
 			)}
 			{error && (
-				<p className="text-red-600" data-testid="opportunities-error">
-					{t("opportunities.error", { message: error })}
-				</p>
+				<ErrorBanner
+					message={t("opportunities.error", { message: error })}
+					data-testid="opportunities-error"
+				/>
 			)}
 
 			{!error && (

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -12,6 +12,7 @@ import { usePageToolbar } from "../contexts/ToolbarContext";
 import Spinner from "../components/Spinner";
 import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
+import ErrorBanner from "../components/ErrorBanner";
 
 const PAGE_SIZE = 10;
 
@@ -123,7 +124,7 @@ function OrganizationsSection() {
 			</div>
 		);
 	}
-	if (error) return <p className="text-red-600">{error}</p>;
+	if (error) return <ErrorBanner message={error} />;
 	if (rows.length === 0)
 		return (
 			<EmptyState title={t("administration.organizations.noOrganizations")} />
@@ -318,7 +319,7 @@ function UsersSection() {
 					<Spinner label={t("administration.users.loading")} />
 				</div>
 			) : error ? (
-				<p className="text-red-600">{error}</p>
+				<ErrorBanner message={error} />
 			) : rows.length === 0 ? (
 				<EmptyState title={t("administration.users.noUsers")} />
 			) : (

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -13,6 +13,7 @@ import EmptyState from "../components/EmptyState";
 import QRScannerModal from "../components/QRScannerModal";
 import Spinner from "../components/Spinner";
 import Button from "../components/Button";
+import ErrorBanner from "../components/ErrorBanner";
 import NotFoundPage from "./NotFoundPage";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -228,9 +229,9 @@ export default function EngagementManagementPage() {
 				</div>
 			)}
 			{error && (
-				<p className="text-red-600">
-					{t("engagementManagement.error", { message: error })}
-				</p>
+				<ErrorBanner
+					message={t("engagementManagement.error", { message: error })}
+				/>
 			)}
 
 			{!loading && !error && engagements.length === 0 && (

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { PublicOrganizationProfileResponse } from "../client/api-client";
 import OrganizationProfileView from "../components/OrganizationProfileView";
 import Spinner from "../components/Spinner";
+import ErrorBanner from "../components/ErrorBanner";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatOccurrence, formatParticipationType } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -43,11 +44,7 @@ export default function OrganizationProfilePage() {
 			</div>
 		);
 	if (error)
-		return (
-			<p className="text-red-600">
-				{t("orgProfile.error", { message: error })}
-			</p>
-		);
+		return <ErrorBanner message={t("orgProfile.error", { message: error })} />;
 	if (!profile)
 		return <p className="text-gray-500">{t("orgProfile.notFound")}</p>;
 

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -9,6 +9,7 @@ import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
+import ErrorBanner from "../components/ErrorBanner";
 
 const PAGE_SIZE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -105,9 +106,9 @@ export default function OrganizationsPage() {
 						))}
 					</div>
 				) : error ? (
-					<p className="text-red-600">
-						{t("organizationsPage.error", { message: error })}
-					</p>
+					<ErrorBanner
+						message={t("organizationsPage.error", { message: error })}
+					/>
 				) : items.length === 0 ? (
 					<EmptyState
 						title={

--- a/frontend/src/pages/ProfileOverviewPage/AchievementsSection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/AchievementsSection.tsx
@@ -7,6 +7,7 @@ import type {
 import { useApiClient } from "../../hooks/useApiClient";
 import { getApiErrorMessage } from "../../lib/apiError";
 import BadgeGrid from "../../components/BadgeGrid";
+import ErrorBanner from "../../components/ErrorBanner";
 
 export default function AchievementsSection() {
 	const api = useApiClient();
@@ -34,9 +35,7 @@ export default function AchievementsSection() {
 				{t("achievements.badgesTitle")}
 			</h2>
 			{error ? (
-				<p className="text-sm text-red-600">
-					{t("achievements.error", { message: error })}
-				</p>
+				<ErrorBanner message={t("achievements.error", { message: error })} />
 			) : (
 				<BadgeGrid earned={achievements} catalog={catalog} loading={loading} />
 			)}

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -17,6 +17,7 @@ import EmptyState from "../../components/EmptyState";
 import SubmitFeedbackModal from "../../components/SubmitFeedbackModal";
 import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
+import ErrorBanner from "../../components/ErrorBanner";
 
 const ENGAGEMENTS_PAGE_SIZE = 10;
 
@@ -169,11 +170,11 @@ export default function ActivitySection() {
 
 	return (
 		<section id="activity" className="mb-6">
-			{invitationsError && <p className="text-red-600">{invitationsError}</p>}
+			{invitationsError && (
+				<ErrorBanner message={invitationsError} className="mb-4" />
+			)}
 			{invitationActionError && (
-				<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-					{invitationActionError}
-				</div>
+				<ErrorBanner message={invitationActionError} className="mb-4" />
 			)}
 			{!invitationsLoading && invitations.length > 0 && (
 				<div className="mb-6">
@@ -289,9 +290,9 @@ export default function ActivitySection() {
 				</div>
 			)}
 			{engagementsError && (
-				<p className="text-red-600">
-					{t("myEngagements.error", { message: engagementsError })}
-				</p>
+				<ErrorBanner
+					message={t("myEngagements.error", { message: engagementsError })}
+				/>
 			)}
 
 			{!engagementsLoading &&

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -11,6 +11,7 @@ import { inputClass, textareaClass } from "../../lib/formClasses";
 import Dropdown from "../../components/Dropdown";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
 import Skeleton from "../../components/Skeleton";
+import ErrorBanner from "../../components/ErrorBanner";
 import AchievementsSection from "./AchievementsSection";
 import ActivitySection from "./ActivitySection";
 import DangerZoneCard from "./DangerZoneCard";
@@ -269,9 +270,7 @@ export default function ProfileOverviewPage() {
 			{!profileLoading && (
 				<>
 					{profileError && (
-						<div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-							{profileError}
-						</div>
+						<ErrorBanner message={profileError} className="mb-4" />
 					)}
 					{successMessage && (
 						<div className="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">

--- a/frontend/src/pages/UserAchievementsPage.tsx
+++ b/frontend/src/pages/UserAchievementsPage.tsx
@@ -7,6 +7,7 @@ import type {
 	BadgeCatalogEntry,
 } from "../client/api-client";
 import BadgeGrid from "../components/BadgeGrid";
+import ErrorBanner from "../components/ErrorBanner";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { runtimeConfig } from "../lib/runtimeConfig";
@@ -56,9 +57,7 @@ export default function UserAchievementsPage() {
 
 	if (error) {
 		return (
-			<p className="text-sm text-red-600">
-				{t("achievements.error", { message: error })}
-			</p>
+			<ErrorBanner message={t("achievements.error", { message: error })} />
 		);
 	}
 

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -9,6 +9,7 @@ import type {
 import BadgeGrid from "../components/BadgeGrid";
 import ProfileFieldsView from "../components/ProfileFieldsView";
 import Spinner from "../components/Spinner";
+import ErrorBanner from "../components/ErrorBanner";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
@@ -46,7 +47,7 @@ export default function UserProfilePage() {
 				<Spinner label={t("userProfile.loading")} />
 			</div>
 		);
-	if (error) return <p className="text-red-600">{error}</p>;
+	if (error) return <ErrorBanner message={error} />;
 	if (!profile)
 		return <p className="text-gray-500">{t("userProfile.notFound")}</p>;
 

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -18,6 +18,7 @@ import ConfirmDialog from "../components/ConfirmDialog";
 import Button from "../components/Button";
 import SingleMarkerMap from "../components/SingleMarkerMap";
 import Skeleton from "../components/Skeleton";
+import ErrorBanner from "../components/ErrorBanner";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
@@ -162,9 +163,7 @@ export default function VolunteerOpportunityDetailPage() {
 		);
 	if (error)
 		return (
-			<p className="text-red-600">
-				{t("opportunities.error", { message: error })}
-			</p>
+			<ErrorBanner message={t("opportunities.error", { message: error })} />
 		);
 	if (!opportunity)
 		return <p className="text-gray-500">{t("opportunities.notFound")}</p>;

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -11,6 +11,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import Modal from "../../../components/Modal";
 import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
+import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "./useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -157,9 +158,9 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 				</div>
 			)}
 			{calError && (
-				<p className="text-red-600">
-					{t("orgOverview.calendarError", { message: calError })}
-				</p>
+				<ErrorBanner
+					message={t("orgOverview.calendarError", { message: calError })}
+				/>
 			)}
 			{!calLoading && !calError && (
 				<div className="rbc-container h-full">
@@ -243,9 +244,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 								<span className="text-sm text-gray-500">{pickerColor}</span>
 							</div>
 						</div>
-						{colorSaveError && (
-							<p className="text-sm text-red-600">{colorSaveError}</p>
-						)}
+						{colorSaveError && <ErrorBanner message={colorSaveError} />}
 						<div className="flex flex-col gap-2">
 							<div className="flex gap-4">
 								<Link

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -10,6 +10,7 @@ import { getApiErrorMessage } from "../../../lib/apiError";
 import QRScannerModal from "../../../components/QRScannerModal";
 import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
+import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "./useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -70,7 +71,7 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 			{opportunities === null && !error && (
 				<Spinner label={t("orgDashboard.loading")} size="sm" />
 			)}
-			{error && <p className="text-sm text-red-600">{error}</p>}
+			{error && <ErrorBanner message={error} />}
 			{opportunities !== null && !error && opportunities.length === 0 && (
 				<p className="text-sm text-gray-500">
 					{t("orgDashboard.quickCheckInNoOpportunities")}

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
+import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
@@ -46,7 +47,7 @@ function ToDoWidget({ organizationId, size }: Props) {
 			title={t("orgDashboard.todoWidgetTitle")}
 		>
 			{loading && <Spinner label={t("orgDashboard.loading")} />}
-			{!loading && error && <p className="text-sm text-red-600">{error}</p>}
+			{!loading && error && <ErrorBanner message={error} />}
 			{!loading && !error && kpis && (
 				// Side by side once there's room for two columns to breathe;
 				// stacked when the widget only got a narrow slice of the grid

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
+import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "./useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -91,11 +92,7 @@ function UpcomingOpportunitiesWidget({
 			{items === null && !error && (
 				<Spinner label={t("orgDashboard.upcomingLoading")} />
 			)}
-			{error && (
-				<p className="text-sm text-red-600">
-					{t("orgDashboard.upcomingError")}
-				</p>
-			)}
+			{error && <ErrorBanner message={t("orgDashboard.upcomingError")} />}
 			{items !== null && !error && items.length === 0 && (
 				<p className="text-sm text-gray-500">
 					{t("orgDashboard.upcomingEmpty")}

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -12,6 +12,7 @@ import { inputClass } from "../../lib/formClasses";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import Button from "../../components/Button";
+import ErrorBanner from "../../components/ErrorBanner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 export default function OrgMembersPage() {
@@ -141,9 +142,7 @@ export default function OrgMembersPage() {
 					</div>
 				)}
 				{settingsError && (
-					<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
-						{settingsError}
-					</div>
+					<ErrorBanner message={settingsError} className="mb-4" />
 				)}
 
 				<div className="mb-6">

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -13,6 +13,7 @@ import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
 import Spinner from "../../components/Spinner";
 import Button from "../../components/Button";
+import ErrorBanner from "../../components/ErrorBanner";
 import { PlusIcon } from "../../components/QuickActionIcons";
 import { useQuickActions } from "../../contexts/QuickActionsContext";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
@@ -282,9 +283,9 @@ export default function OrgOpportunitiesPage() {
 			)}
 
 			{error && (
-				<p className="text-red-600">
-					{t("orgOpportunities.error", { message: error })}
-				</p>
+				<ErrorBanner
+					message={t("orgOpportunities.error", { message: error })}
+				/>
 			)}
 
 			{items !== null && !error && items.length === 0 && (

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -7,6 +7,7 @@ import { inputClass, labelClass } from "../../lib/formClasses";
 import { getApiErrorMessage } from "../../lib/apiError";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import OrganizationProfileView from "../../components/OrganizationProfileView";
+import ErrorBanner from "../../components/ErrorBanner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const MAX_LOGO_BYTES = 2 * 1024 * 1024;
@@ -209,9 +210,7 @@ export default function OrgSettingsPage() {
 									</div>
 								)}
 								{settingsError && (
-									<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
-										{settingsError}
-									</div>
+									<ErrorBanner message={settingsError} className="mb-4" />
 								)}
 							</>
 						}
@@ -238,9 +237,7 @@ export default function OrgSettingsPage() {
 				{editing && (
 					<>
 						{settingsError && (
-							<div className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
-								{settingsError}
-							</div>
+							<ErrorBanner message={settingsError} className="mb-4" />
 						)}
 
 						<form ref={formRef} onSubmit={handleSave} className="space-y-5">


### PR DESCRIPTION
Pages alternated between a bare red text line and an ad-hoc bg-red-50 box (with varying border radii) for the same "action failed" state, since no page shared a component for it. Introduces ErrorBanner (role=alert, forwardRef for DetailsStep's existing focus-management use case) and swaps it in everywhere that pattern occurred, leaving field-level input validation text untouched as a distinct pattern.

Closes #853