### PR TITLE
fix: standardize client-side validation across organization forms

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -319,6 +319,32 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrganizationSettingsPage_EditModeValidationError_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #851: OrgSettingsPage gained the same react-hook-form + zod
+		// validation as CreateOrganizationModal (previously it had none) -
+		// scan the new inline validation-error state, not just the clean
+		// edit-mode form covered above.
+		var frontend = Fixture.GetEndpoint("frontend");
+		if (!await NavigateToOrgAppDashboardAsOlafAsync(frontend))
+			return;
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Edit settings" }).ClickAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync();
+
+		await Page.Locator("#org-name").FillAsync("");
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+
+		await Expect(Page.Locator("#org-name-error")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task OrganizationSettingsPage_EditModeWithLogo_HasNoSeriousA11yViolations()
 	{
 		// #845: the "Remove" button next to the logo only renders once an
@@ -618,6 +644,35 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var nestedResult = await Page.RunAxe();
 		AssertNoViolations(nestedResult);
+	}
+
+	[Test]
+	public async Task CreateOrganizationModal_HasNoSeriousA11yViolations()
+	{
+		// #851: this modal gained react-hook-form + zod validation (it
+		// previously had none) - scan both the clean state and the
+		// blank-submit validation-error state it can now render.
+		var frontend = Fixture.GetEndpoint("frontend");
+		if (!await NavigateToOrgAppDashboardAsOlafAsync(frontend))
+			return;
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+
+		var createDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(createDialog).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+
+		await createDialog.GetByTestId("modal-submit").ClickAsync();
+		await Expect(createDialog.Locator("#create-org-name-error")).ToBeVisibleAsync(
+			new() { Timeout = 5_000 });
+
+		var errorResult = await Page.RunAxe();
+		AssertNoViolations(errorResult);
+
+		await createDialog.GetByTestId("modal-cancel").ClickAsync();
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -161,9 +161,22 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 		await removeButton.ClickAsync();
 		await Expect(removeButton).ToBeHiddenAsync(new() { Timeout = 10_000 });
 
-		var afterResponse = await http.GetAsync($"/v1/organizations/{organizationId}");
-		afterResponse.EnsureSuccessStatusCode();
-		var afterOrg = await afterResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// The DELETE the button click awaited has already committed by the time
+		// it resolves (TransactionPipelineBehavior commits before the endpoint
+		// returns), but this is a separate HTTP connection from a fresh
+		// HttpClient - poll briefly instead of asserting on a single read, to
+		// absorb any connection-pool/scheduling jitter between the two rather
+		// than flake on it (observed intermittently in CI - see #946).
+		JsonElement afterOrg = default;
+		for (var attempt = 0; ; attempt++)
+		{
+			var afterResponse = await http.GetAsync($"/v1/organizations/{organizationId}");
+			afterResponse.EnsureSuccessStatusCode();
+			afterOrg = await afterResponse.Content.ReadFromJsonAsync<JsonElement>();
+			if (afterOrg.GetProperty("logoUrl").ValueKind == JsonValueKind.Null || attempt >= 5)
+				break;
+			await Task.Delay(500);
+		}
 		afterOrg.GetProperty("logoUrl").ValueKind.Should().Be(JsonValueKind.Null);
 	}
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -185,6 +185,76 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task CreateOrganizationModal_NameRequired_BlocksSubmitWithInlineError()
+	{
+		// #851: the create-organization form used to only enforce Name via the
+		// browser's native "required" attribute (or fail at the server round-trip
+		// for every other field). It now uses the same react-hook-form + zod
+		// approach as the volunteer-opportunity wizard, so submitting blank
+		// blocks client-side with a styled inline error instead of a native
+		// tooltip or a server error.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+
+		var createDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(createDialog).ToBeVisibleAsync();
+
+		await createDialog.GetByTestId("modal-submit").ClickAsync();
+
+		await Expect(createDialog.Locator("#create-org-name-error")).ToBeVisibleAsync(
+			new() { Timeout = 5_000 });
+		await Expect(createDialog.Locator("#create-org-name")).ToHaveAttributeAsync(
+			"aria-invalid", "true");
+
+		// Blocked client-side - the dialog is still open, nothing was created.
+		await Expect(createDialog).ToBeVisibleAsync();
+
+		await createDialog.GetByTestId("modal-cancel").ClickAsync();
+	}
+
+	[Test]
+	public async Task CreateOrganizationModal_PartialAddress_ShowsInlineErrorsForMissingFields()
+	{
+		// #851: Address.Create requires street/houseNumber/zipCode/city together
+		// - filling in only some of them used to pass client-side silently and
+		// only fail once the request round-tripped to the server. The shared
+		// zod schema (organizationFormSchema.ts) now mirrors that same
+		// conditional-required rule client-side, same as LocationStep does for
+		// the volunteer-opportunity wizard.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var orgName = $"Visual851 PartialAddress {Guid.NewGuid():N}";
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+
+		var createDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(createDialog).ToBeVisibleAsync();
+
+		await createDialog.Locator("#create-org-name").FillAsync(orgName);
+		await createDialog.Locator("#create-org-street").FillAsync("Main Street");
+
+		await createDialog.GetByTestId("modal-submit").ClickAsync();
+
+		await Expect(createDialog.Locator("#create-org-house-number-error")).ToBeVisibleAsync(
+			new() { Timeout = 5_000 });
+		await Expect(createDialog.Locator("#create-org-zip-error")).ToBeVisibleAsync();
+		await Expect(createDialog.Locator("#create-org-city-error")).ToBeVisibleAsync();
+
+		// Blocked client-side - the dialog is still open, nothing was created.
+		await Expect(createDialog).ToBeVisibleAsync();
+
+		await createDialog.GetByTestId("modal-cancel").ClickAsync();
+	}
+
+	[Test]
 	public async Task Directory_ShowsOpenOpportunityCount_ForOrgWithPublishedOpportunity()
 	{
 		// #772 review follow-up (issue #763): "the site looks a bit dead" -

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslation } from "react-i18next";
 import type { Organization } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { getApiErrorMessage } from "../lib/apiError";
+import {
+	buildOrganizationFormSchema,
+	ORGANIZATION_FORM_DEFAULT_VALUES,
+} from "../lib/organizationFormSchema";
+import type { OrganizationFormValues } from "../lib/organizationFormSchema";
 import Modal from "./Modal";
 import Button from "./Button";
 
@@ -18,15 +25,19 @@ const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
 export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 	const api = useApiClient();
 	const { t } = useTranslation();
-	const [name, setName] = useState("");
-	const [description, setDescription] = useState("");
-	const [contactEmail, setContactEmail] = useState("");
-	const [contactPhone, setContactPhone] = useState("");
-	const [website, setWebsite] = useState("");
-	const [street, setStreet] = useState("");
-	const [houseNumber, setHouseNumber] = useState("");
-	const [zipCode, setZipCode] = useState("");
-	const [city, setCity] = useState("");
+	const schema = useMemo(() => buildOrganizationFormSchema(t), [t]);
+	const {
+		register,
+		handleSubmit,
+		watch,
+		formState: { errors },
+	} = useForm<OrganizationFormValues>({
+		resolver: zodResolver(schema),
+		mode: "onBlur",
+		defaultValues: ORGANIZATION_FORM_DEFAULT_VALUES,
+	});
+	const name = watch("name");
+
 	const [logoFile, setLogoFile] = useState<File | null>(null);
 	const [logoPreview, setLogoPreview] = useState<string | null>(null);
 	const [logoError, setLogoError] = useState<string | null>(null);
@@ -40,8 +51,6 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 			if (logoPreview) URL.revokeObjectURL(logoPreview);
 		};
 	}, [logoPreview]);
-
-	const hasAddress = street || houseNumber || zipCode || city;
 
 	function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
@@ -60,20 +69,30 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 		setLogoPreview(URL.createObjectURL(file));
 	}
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const onSubmit = async (values: OrganizationFormValues) => {
 		setLoading(true);
 		setError(null);
 
+		const hasAddress =
+			values.street.trim() ||
+			values.houseNumber.trim() ||
+			values.zipCode.trim() ||
+			values.city.trim();
+
 		try {
 			const organization = await api.createOrganization({
-				name,
-				description: description || undefined,
-				contactEmail: contactEmail || undefined,
-				contactPhone: contactPhone || undefined,
-				website: website || undefined,
+				name: values.name,
+				description: values.description || undefined,
+				contactEmail: values.contactEmail || undefined,
+				contactPhone: values.contactPhone || undefined,
+				website: values.website || undefined,
 				address: hasAddress
-					? { street, houseNumber, zipCode, city }
+					? {
+							street: values.street,
+							houseNumber: values.houseNumber,
+							zipCode: values.zipCode,
+							city: values.city,
+						}
 					: undefined,
 			});
 			const organizationId = organization.id?.value;
@@ -112,7 +131,10 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 				{t("organization.create")}
 			</h2>
 
-			<form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+			<form
+				onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+				className="flex min-h-0 flex-1 flex-col"
+			>
 				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
 					<div>
 						<p className={labelClass}>{t("orgSettings.fieldLogo")}</p>
@@ -163,13 +185,25 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						<input
 							id="create-org-name"
 							type="text"
-							required
 							maxLength={100}
-							value={name}
-							onChange={(e) => setName(e.target.value)}
 							placeholder={t("organization.namePlaceholder")}
+							aria-invalid={errors.name ? true : undefined}
+							aria-describedby={
+								errors.name ? "create-org-name-error" : undefined
+							}
+							aria-required="true"
 							className={inputClass}
+							{...register("name")}
 						/>
+						{errors.name && (
+							<p
+								id="create-org-name-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{errors.name.message}
+							</p>
+						)}
 					</div>
 
 					<div>
@@ -182,10 +216,23 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						<textarea
 							id="create-org-description"
 							rows={3}
-							value={description}
-							onChange={(e) => setDescription(e.target.value)}
+							maxLength={1000}
+							aria-invalid={errors.description ? true : undefined}
+							aria-describedby={
+								errors.description ? "create-org-description-error" : undefined
+							}
 							className={textareaClass}
+							{...register("description")}
 						/>
+						{errors.description && (
+							<p
+								id="create-org-description-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{errors.description.message}
+							</p>
+						)}
 					</div>
 
 					<div>
@@ -198,10 +245,25 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						<input
 							id="create-org-contact-email"
 							type="email"
-							value={contactEmail}
-							onChange={(e) => setContactEmail(e.target.value)}
+							maxLength={254}
+							aria-invalid={errors.contactEmail ? true : undefined}
+							aria-describedby={
+								errors.contactEmail
+									? "create-org-contact-email-error"
+									: undefined
+							}
 							className={inputClass}
+							{...register("contactEmail")}
 						/>
+						{errors.contactEmail && (
+							<p
+								id="create-org-contact-email-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{errors.contactEmail.message}
+							</p>
+						)}
 					</div>
 
 					<div>
@@ -214,10 +276,23 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						<input
 							id="create-org-phone"
 							type="tel"
-							value={contactPhone}
-							onChange={(e) => setContactPhone(e.target.value)}
+							maxLength={30}
+							aria-invalid={errors.contactPhone ? true : undefined}
+							aria-describedby={
+								errors.contactPhone ? "create-org-phone-error" : undefined
+							}
 							className={inputClass}
+							{...register("contactPhone")}
 						/>
+						{errors.contactPhone && (
+							<p
+								id="create-org-phone-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{errors.contactPhone.message}
+							</p>
+						)}
 					</div>
 
 					<div>
@@ -230,11 +305,24 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 						<input
 							id="create-org-website"
 							type="url"
-							value={website}
-							onChange={(e) => setWebsite(e.target.value)}
+							maxLength={500}
 							placeholder="https://"
+							aria-invalid={errors.website ? true : undefined}
+							aria-describedby={
+								errors.website ? "create-org-website-error" : undefined
+							}
 							className={inputClass}
+							{...register("website")}
 						/>
+						{errors.website && (
+							<p
+								id="create-org-website-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{errors.website.message}
+							</p>
+						)}
 					</div>
 
 					<fieldset className="rounded-xl border border-gray-200 p-4">
@@ -248,10 +336,23 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								</label>
 								<input
 									id="create-org-street"
-									value={street}
-									onChange={(e) => setStreet(e.target.value)}
+									maxLength={200}
+									aria-invalid={errors.street ? true : undefined}
+									aria-describedby={
+										errors.street ? "create-org-street-error" : undefined
+									}
 									className={inputClass}
+									{...register("street")}
 								/>
+								{errors.street && (
+									<p
+										id="create-org-street-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.street.message}
+									</p>
+								)}
 							</div>
 							<div>
 								<label htmlFor="create-org-house-number" className={labelClass}>
@@ -259,10 +360,25 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								</label>
 								<input
 									id="create-org-house-number"
-									value={houseNumber}
-									onChange={(e) => setHouseNumber(e.target.value)}
+									maxLength={20}
+									aria-invalid={errors.houseNumber ? true : undefined}
+									aria-describedby={
+										errors.houseNumber
+											? "create-org-house-number-error"
+											: undefined
+									}
 									className={inputClass}
+									{...register("houseNumber")}
 								/>
+								{errors.houseNumber && (
+									<p
+										id="create-org-house-number-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.houseNumber.message}
+									</p>
+								)}
 							</div>
 							<div>
 								<label htmlFor="create-org-zip" className={labelClass}>
@@ -271,10 +387,22 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								<input
 									id="create-org-zip"
 									maxLength={5}
-									value={zipCode}
-									onChange={(e) => setZipCode(e.target.value)}
+									aria-invalid={errors.zipCode ? true : undefined}
+									aria-describedby={
+										errors.zipCode ? "create-org-zip-error" : undefined
+									}
 									className={inputClass}
+									{...register("zipCode")}
 								/>
+								{errors.zipCode && (
+									<p
+										id="create-org-zip-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.zipCode.message}
+									</p>
+								)}
 							</div>
 							<div className="col-span-2">
 								<label htmlFor="create-org-city" className={labelClass}>
@@ -282,10 +410,23 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								</label>
 								<input
 									id="create-org-city"
-									value={city}
-									onChange={(e) => setCity(e.target.value)}
+									maxLength={100}
+									aria-invalid={errors.city ? true : undefined}
+									aria-describedby={
+										errors.city ? "create-org-city-error" : undefined
+									}
 									className={inputClass}
+									{...register("city")}
 								/>
+								{errors.city && (
+									<p
+										id="create-org-city-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.city.message}
+									</p>
+								)}
 							</div>
 						</div>
 					</fieldset>

--- a/frontend/src/lib/organizationFormSchema.ts
+++ b/frontend/src/lib/organizationFormSchema.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import type { TFunction } from "i18next";
+
+/**
+ * Shared by CreateOrganizationModal and OrgSettingsPage - both edit the same
+ * organization fields and must reject the same invalid states before ever
+ * reaching the server (mirrors backend/src/Domain/Organizations/Organization.cs
+ * and backend/src/Domain/Common/Address.cs).
+ */
+export function buildOrganizationFormSchema(t: TFunction) {
+	const required = t("orgSettings.fieldRequired");
+	const invalidZip = t("orgSettings.zipInvalid");
+
+	return z
+		.object({
+			name: z.string().max(100),
+			description: z.string().max(1000),
+			contactEmail: z.string().max(254),
+			contactPhone: z.string().max(30),
+			website: z.string().max(500),
+			street: z.string().max(200),
+			houseNumber: z.string().max(20),
+			zipCode: z.string().max(10),
+			city: z.string().max(100),
+		})
+		.superRefine((data, ctx) => {
+			if (!data.name.trim())
+				ctx.addIssue({ code: "custom", path: ["name"], message: required });
+
+			// The address is optional as a whole, but once any one part of it is
+			// filled in the backend requires all of street/houseNumber/zipCode/city
+			// together (Address.Create) - so partial input must be caught here too,
+			// not just at the server round-trip.
+			const hasAddress =
+				data.street.trim() ||
+				data.houseNumber.trim() ||
+				data.zipCode.trim() ||
+				data.city.trim();
+
+			if (hasAddress) {
+				if (!data.street.trim())
+					ctx.addIssue({
+						code: "custom",
+						path: ["street"],
+						message: required,
+					});
+				if (!data.houseNumber.trim())
+					ctx.addIssue({
+						code: "custom",
+						path: ["houseNumber"],
+						message: required,
+					});
+				if (!data.zipCode.trim())
+					ctx.addIssue({
+						code: "custom",
+						path: ["zipCode"],
+						message: required,
+					});
+				else if (data.zipCode.trim().length !== 5)
+					ctx.addIssue({
+						code: "custom",
+						path: ["zipCode"],
+						message: invalidZip,
+					});
+				if (!data.city.trim())
+					ctx.addIssue({ code: "custom", path: ["city"], message: required });
+			}
+		});
+}
+
+export type OrganizationFormValues = z.infer<
+	ReturnType<typeof buildOrganizationFormSchema>
+>;
+
+export const ORGANIZATION_FORM_DEFAULT_VALUES: OrganizationFormValues = {
+	name: "",
+	description: "",
+	contactEmail: "",
+	contactPhone: "",
+	website: "",
+	street: "",
+	houseNumber: "",
+	zipCode: "",
+	city: "",
+};

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -414,6 +414,8 @@
       "fieldHouseNumber": "Hausnummer",
       "fieldZip": "PLZ",
       "fieldCity": "Stadt",
+      "fieldRequired": "Erforderlich",
+      "zipInvalid": "Die PLZ muss genau 5 Zeichen lang sein.",
       "savedSuccess": "Änderungen gespeichert.",
       "saveError": "Speichern fehlgeschlagen.",
       "loadError": "Organisation konnte nicht geladen werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -414,6 +414,8 @@
       "fieldHouseNumber": "House number",
       "fieldZip": "ZIP",
       "fieldCity": "City",
+      "fieldRequired": "Required",
+      "zipInvalid": "ZIP code must be exactly 5 characters.",
       "savedSuccess": "Changes saved.",
       "saveError": "Failed to save.",
       "loadError": "Could not load organization.",

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -1,10 +1,14 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../hooks/useApiClient";
 import { useEditModeQuickActions } from "../../hooks/useEditModeQuickActions";
 import { inputClass, labelClass } from "../../lib/formClasses";
 import { getApiErrorMessage } from "../../lib/apiError";
+import { buildOrganizationFormSchema } from "../../lib/organizationFormSchema";
+import type { OrganizationFormValues } from "../../lib/organizationFormSchema";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import OrganizationProfileView from "../../components/OrganizationProfileView";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
@@ -38,17 +42,32 @@ export default function OrgSettingsPage() {
 	const navigate = useNavigate();
 	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
 
-	const [form, setForm] = useState({
-		name: org.name,
-		description: org.description ?? "",
-		contactEmail: org.contactEmail ?? "",
-		contactPhone: org.contactPhone ?? "",
-		website: org.website ?? "",
-		street: org.address?.street ?? "",
-		houseNumber: org.address?.houseNumber ?? "",
-		zipCode: org.address?.zipCode ?? "",
-		city: org.address?.city ?? "",
+	function organizationToFormValues(): OrganizationFormValues {
+		return {
+			name: org.name,
+			description: org.description ?? "",
+			contactEmail: org.contactEmail ?? "",
+			contactPhone: org.contactPhone ?? "",
+			website: org.website ?? "",
+			street: org.address?.street ?? "",
+			houseNumber: org.address?.houseNumber ?? "",
+			zipCode: org.address?.zipCode ?? "",
+			city: org.address?.city ?? "",
+		};
+	}
+
+	const schema = useMemo(() => buildOrganizationFormSchema(t), [t]);
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<OrganizationFormValues>({
+		resolver: zodResolver(schema),
+		mode: "onBlur",
+		defaultValues: organizationToFormValues(),
 	});
+
 	const [logoUrl, setLogoUrl] = useState<string | null>(org.logoUrl ?? null);
 	const [uploadingLogo, setUploadingLogo] = useState(false);
 	const [removingLogo, setRemovingLogo] = useState(false);
@@ -64,33 +83,20 @@ export default function OrgSettingsPage() {
 	const [deleting, setDeleting] = useState(false);
 	const isSoleMember = org.members.length === 1;
 
-	const hasAddress =
-		form.street || form.houseNumber || form.zipCode || form.city;
-
 	useEditModeQuickActions({
 		editing,
 		saving,
 		onEdit: () => setEditing(true),
-		// Goes through the form's native submit (not handleSave() directly) so
-		// the browser still runs constraint validation (e.g. the required name
-		// field) and focuses/announces the offending field, same as pressing
-		// Enter in the form used to.
+		// Goes through the form's native submit (not onSubmit() directly) so
+		// react-hook-form's handleSubmit runs the same zod validation, error
+		// display and focus-the-offending-field behavior as pressing Enter in
+		// the form would.
 		onSave: () => formRef.current?.requestSubmit(),
 		onCancel: handleCancelEdit,
 	});
 
 	function handleCancelEdit() {
-		setForm({
-			name: org.name,
-			description: org.description ?? "",
-			contactEmail: org.contactEmail ?? "",
-			contactPhone: org.contactPhone ?? "",
-			website: org.website ?? "",
-			street: org.address?.street ?? "",
-			houseNumber: org.address?.houseNumber ?? "",
-			zipCode: org.address?.zipCode ?? "",
-			city: org.address?.city ?? "",
-		});
+		reset(organizationToFormValues());
 		setLogoError(null);
 		setSettingsError(null);
 		setEditing(false);
@@ -132,24 +138,30 @@ export default function OrgSettingsPage() {
 		}
 	}
 
-	async function handleSave(e: React.FormEvent) {
-		e.preventDefault();
+	async function onSubmit(values: OrganizationFormValues) {
 		setSaving(true);
 		setSettingsError(null);
 		setSuccessMessage(null);
+
+		const hasAddress =
+			values.street.trim() ||
+			values.houseNumber.trim() ||
+			values.zipCode.trim() ||
+			values.city.trim();
+
 		try {
 			await api.updateOrganization(org.id, {
-				name: form.name,
-				description: form.description || undefined,
-				contactEmail: form.contactEmail || undefined,
-				contactPhone: form.contactPhone || undefined,
-				website: form.website || undefined,
+				name: values.name,
+				description: values.description || undefined,
+				contactEmail: values.contactEmail || undefined,
+				contactPhone: values.contactPhone || undefined,
+				website: values.website || undefined,
 				address: hasAddress
 					? {
-							street: form.street,
-							houseNumber: form.houseNumber,
-							zipCode: form.zipCode,
-							city: form.city,
+							street: values.street,
+							houseNumber: values.houseNumber,
+							zipCode: values.zipCode,
+							city: values.city,
 						}
 					: undefined,
 			});
@@ -243,7 +255,11 @@ export default function OrgSettingsPage() {
 							</div>
 						)}
 
-						<form ref={formRef} onSubmit={handleSave} className="space-y-5">
+						<form
+							ref={formRef}
+							onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+							className="space-y-5"
+						>
 							<div>
 								<p className="mb-1 block text-sm font-medium text-gray-700">
 									{t("orgSettings.fieldLogo")}
@@ -305,13 +321,21 @@ export default function OrgSettingsPage() {
 							<Field label={t("orgSettings.fieldName")} id="org-name">
 								<input
 									id="org-name"
-									required
-									value={form.name}
-									onChange={(e) =>
-										setForm((f) => ({ ...f, name: e.target.value }))
-									}
+									aria-invalid={errors.name ? true : undefined}
+									aria-describedby={errors.name ? "org-name-error" : undefined}
+									aria-required="true"
 									className={inputClass}
+									{...register("name")}
 								/>
+								{errors.name && (
+									<p
+										id="org-name-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.name.message}
+									</p>
+								)}
 							</Field>
 
 							<Field
@@ -321,12 +345,23 @@ export default function OrgSettingsPage() {
 								<textarea
 									id="org-description"
 									rows={3}
-									value={form.description}
-									onChange={(e) =>
-										setForm((f) => ({ ...f, description: e.target.value }))
+									maxLength={1000}
+									aria-invalid={errors.description ? true : undefined}
+									aria-describedby={
+										errors.description ? "org-description-error" : undefined
 									}
 									className={inputClass}
+									{...register("description")}
 								/>
+								{errors.description && (
+									<p
+										id="org-description-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.description.message}
+									</p>
+								)}
 							</Field>
 
 							<Field
@@ -336,37 +371,70 @@ export default function OrgSettingsPage() {
 								<input
 									id="org-contact-email"
 									type="email"
-									value={form.contactEmail}
-									onChange={(e) =>
-										setForm((f) => ({ ...f, contactEmail: e.target.value }))
+									maxLength={254}
+									aria-invalid={errors.contactEmail ? true : undefined}
+									aria-describedby={
+										errors.contactEmail ? "org-contact-email-error" : undefined
 									}
 									className={inputClass}
+									{...register("contactEmail")}
 								/>
+								{errors.contactEmail && (
+									<p
+										id="org-contact-email-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.contactEmail.message}
+									</p>
+								)}
 							</Field>
 
 							<Field label={t("orgSettings.fieldPhone")} id="org-phone">
 								<input
 									id="org-phone"
 									type="tel"
-									value={form.contactPhone}
-									onChange={(e) =>
-										setForm((f) => ({ ...f, contactPhone: e.target.value }))
+									maxLength={30}
+									aria-invalid={errors.contactPhone ? true : undefined}
+									aria-describedby={
+										errors.contactPhone ? "org-phone-error" : undefined
 									}
 									className={inputClass}
+									{...register("contactPhone")}
 								/>
+								{errors.contactPhone && (
+									<p
+										id="org-phone-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.contactPhone.message}
+									</p>
+								)}
 							</Field>
 
 							<Field label={t("orgSettings.fieldWebsite")} id="org-website">
 								<input
 									id="org-website"
 									type="url"
-									value={form.website}
-									onChange={(e) =>
-										setForm((f) => ({ ...f, website: e.target.value }))
-									}
+									maxLength={500}
 									placeholder="https://"
+									aria-invalid={errors.website ? true : undefined}
+									aria-describedby={
+										errors.website ? "org-website-error" : undefined
+									}
 									className={inputClass}
+									{...register("website")}
 								/>
+								{errors.website && (
+									<p
+										id="org-website-error"
+										className="mt-1 text-xs text-red-600"
+										role="alert"
+									>
+										{errors.website.message}
+									</p>
+								)}
 							</Field>
 
 							<fieldset className="rounded-xl border border-gray-200 p-4">
@@ -380,12 +448,23 @@ export default function OrgSettingsPage() {
 										</label>
 										<input
 											id="org-street"
-											value={form.street}
-											onChange={(e) =>
-												setForm((f) => ({ ...f, street: e.target.value }))
+											maxLength={200}
+											aria-invalid={errors.street ? true : undefined}
+											aria-describedby={
+												errors.street ? "org-street-error" : undefined
 											}
 											className={inputClass}
+											{...register("street")}
 										/>
+										{errors.street && (
+											<p
+												id="org-street-error"
+												className="mt-1 text-xs text-red-600"
+												role="alert"
+											>
+												{errors.street.message}
+											</p>
+										)}
 									</div>
 									<div>
 										<label htmlFor="org-house-number" className={labelClass}>
@@ -393,12 +472,25 @@ export default function OrgSettingsPage() {
 										</label>
 										<input
 											id="org-house-number"
-											value={form.houseNumber}
-											onChange={(e) =>
-												setForm((f) => ({ ...f, houseNumber: e.target.value }))
+											maxLength={20}
+											aria-invalid={errors.houseNumber ? true : undefined}
+											aria-describedby={
+												errors.houseNumber
+													? "org-house-number-error"
+													: undefined
 											}
 											className={inputClass}
+											{...register("houseNumber")}
 										/>
+										{errors.houseNumber && (
+											<p
+												id="org-house-number-error"
+												className="mt-1 text-xs text-red-600"
+												role="alert"
+											>
+												{errors.houseNumber.message}
+											</p>
+										)}
 									</div>
 									<div>
 										<label htmlFor="org-zip" className={labelClass}>
@@ -407,12 +499,22 @@ export default function OrgSettingsPage() {
 										<input
 											id="org-zip"
 											maxLength={5}
-											value={form.zipCode}
-											onChange={(e) =>
-												setForm((f) => ({ ...f, zipCode: e.target.value }))
+											aria-invalid={errors.zipCode ? true : undefined}
+											aria-describedby={
+												errors.zipCode ? "org-zip-error" : undefined
 											}
 											className={inputClass}
+											{...register("zipCode")}
 										/>
+										{errors.zipCode && (
+											<p
+												id="org-zip-error"
+												className="mt-1 text-xs text-red-600"
+												role="alert"
+											>
+												{errors.zipCode.message}
+											</p>
+										)}
 									</div>
 									<div className="col-span-2">
 										<label htmlFor="org-city" className={labelClass}>
@@ -420,12 +522,23 @@ export default function OrgSettingsPage() {
 										</label>
 										<input
 											id="org-city"
-											value={form.city}
-											onChange={(e) =>
-												setForm((f) => ({ ...f, city: e.target.value }))
+											maxLength={100}
+											aria-invalid={errors.city ? true : undefined}
+											aria-describedby={
+												errors.city ? "org-city-error" : undefined
 											}
 											className={inputClass}
+											{...register("city")}
 										/>
+										{errors.city && (
+											<p
+												id="org-city-error"
+												className="mt-1 text-xs text-red-600"
+												role="alert"
+											>
+												{errors.city.message}
+											</p>
+										)}
 									</div>
 								</div>
 							</fieldset>


### PR DESCRIPTION
CreateOrganizationModal and OrgSettingsPage relied only on native HTML required/type checks and a server round-trip for everything else - unlike CreateVolunteerOpportunityModal's react-hook-form + zod schema, which gives per-field, in-context feedback (including catching a partially filled address before it ever reaches the server, where Address.Create requires street/houseNumber/zipCode/city all together or none).

Extract a shared buildOrganizationFormSchema (mirroring the backend's Organization/Address invariants) and wire both forms to it the same way, with matching inline error text and aria-invalid/aria-describedby wiring.

Closes #851