### PR TITLE
fix: left-align org profile/members/settings body under heading

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -245,18 +245,24 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task PublicProfilePage_ContentIsCenteredWithinMain()
+	public async Task PublicProfilePage_ContentIsLeftAlignedUnderHeading()
 	{
-		// Regression for #694: OrganizationProfileView's content wrapper
-		// (`max-w-2xl`) had no `mx-auto`, so it hugged the left edge of <main>
-		// instead of being centered like every other page.
+		// Regression for #766: OrganizationProfileView's content wrapper had
+		// `mx-auto`, so it centered itself against the whole page instead of
+		// sitting flush under the left-aligned heading above it - a dead
+		// column on wide viewports. This reverses the `mx-auto` #694 added
+		// for the opposite problem (the wrapper hugging the left edge with no
+		// centering at all); left-aligning was the chosen fix direction over
+		// centering the heading to match, for consistency with the rest of
+		// the org app shell (Opportunities tab, dashboard, breadcrumb bar),
+		// none of which centers a content block.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await CreateOrganizationAsync("Visual694 Centering");
+		await CreateOrganizationAsync("Visual766 LeftAlign");
 
 		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
 		match.Success.Should().BeTrue();
@@ -265,7 +271,47 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync($"{origin}/organizations/{organizationId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertMaxWidthContentCenteredAsync("Organization profile page");
+		await AssertMaxWidthContentLeftAlignedAsync("Organization profile page");
+	}
+
+	[Test]
+	public async Task SettingsPage_ContentIsLeftAlignedWithinMain()
+	{
+		// Regression for #766: OrgSettingsPage wraps its content in its own
+		// separate `mx-auto max-w-2xl` div - independent of
+		// OrganizationProfileView's own wrapper - which produced the same
+		// dead-column effect. This is the page shown in the issue's primary
+		// repro steps.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual766 Settings");
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Edit settings" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Danger Zone" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await AssertMaxWidthContentLeftAlignedAsync("Organization settings page");
+	}
+
+	[Test]
+	public async Task MembersPage_ContentIsLeftAlignedWithinMain()
+	{
+		// Regression for #766: OrgMembersPage's content wrapper had
+		// `mx-auto`, independently centering it against the whole page.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual766 Members");
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "members" }).ClickAsync();
+		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await AssertMaxWidthContentLeftAlignedAsync("Organization members page");
 	}
 
 	private async Task<string> CreateOrganizationAsync(string namePrefix)

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -177,6 +177,11 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await Expect(Page.GetByText(skill)).ToBeVisibleAsync();
 		await Expect(Page.GetByText("Preferred contact channel")).ToBeVisibleAsync();
+
+		// Regression for #766: this bio/skills/contact wrapper had `mx-auto`,
+		// centering it independently of the left-aligned avatar/name row
+		// above it - a dead column on wide viewports.
+		await AssertMaxWidthContentLeftAlignedAsync("Public user profile page");
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -73,4 +73,33 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 		Math.Abs(leftGap - rightGap).Should().BeLessThan(2,
 			$"{label}: .max-w-2xl content should be horizontally centered within <main>");
 	}
+
+	/// <summary>
+	/// Asserts the page's `.max-w-2xl` content wrapper inside `&lt;main&gt;` sits
+	/// flush against the left edge, i.e. it is left-aligned rather than centered
+	/// via `mx-auto`. See #766.
+	/// </summary>
+	protected async Task AssertMaxWidthContentLeftAlignedAsync(string label)
+	{
+		var main = Page.Locator("main");
+		await Expect(main).ToBeVisibleAsync();
+		var container = main.Locator(".max-w-2xl").First;
+		await Expect(container).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var mainBox = await main.BoundingBoxAsync();
+		var containerBox = await container.BoundingBoxAsync();
+		mainBox.Should().NotBeNull();
+		containerBox.Should().NotBeNull();
+
+		// BoundingBoxAsync returns <main>'s border box, which includes its own
+		// (symmetric) horizontal padding - net that out so a left-aligned child
+		// is expected to sit at <main>'s padded content edge, not at X=0.
+		var mainPaddingLeft = await main.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).paddingLeft)");
+
+		var leftGap = containerBox!.X - mainBox!.X - mainPaddingLeft;
+
+		Math.Abs(leftGap).Should().BeLessThan(2,
+			$"{label}: .max-w-2xl content should sit flush against <main>'s left padding edge, not be centered");
+	}
 }

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -75,7 +75,7 @@ export default function OrganizationProfileView({
 				{actions}
 			</div>
 
-			<div className="mx-auto max-w-2xl">
+			<div className="max-w-2xl">
 				{beforeContent}
 
 				{description && (

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -80,7 +80,7 @@ export default function UserProfilePage() {
 				profile.skills.length > 0 ||
 				profile.languages.length > 0 ||
 				profile.preferredContact) && (
-				<div className="mx-auto mb-8 max-w-2xl space-y-5">
+				<div className="mb-8 max-w-2xl space-y-5">
 					<ProfileFieldsView
 						bio={profile.bio}
 						skills={profile.skills}

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -134,7 +134,7 @@ export default function OrgMembersPage() {
 
 	return (
 		<div>
-			<div className="mx-auto max-w-2xl">
+			<div className="max-w-2xl">
 				{successMessage && (
 					<div className="mb-4 rounded-xl bg-green-50 px-4 py-3 text-sm text-green-700">
 						{successMessage}

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -180,7 +180,7 @@ export default function OrgSettingsPage() {
 
 	return (
 		<div>
-			<div className="mx-auto max-w-2xl">
+			<div className="max-w-2xl">
 				{!editing && (
 					<OrganizationProfileView
 						name={org.name}


### PR DESCRIPTION
## Summary

Fixes #766. Org Settings, org Members, and any user's public profile each wrapped their body content in `mx-auto max-w-2xl`, centering it independently of the left-aligned heading above it - leaving a dead column on the left and unused margin on the right on viewports wider than ~900px.

Per the two directions the issue laid out (design call), went with **left-aligning the body to match the heading** rather than centering the heading to match the body: nothing else in the org app shell (Opportunities tab, dashboard widgets, breadcrumb bar) centers a content block - everything flows left - so centering just these three pages would be a one-off pattern. `max-w-2xl` is kept (not dropped) to preserve reading-width prose, just anchored left instead of centered.

- `frontend/src/components/OrganizationProfileView.tsx` - drop `mx-auto` on the body wrapper (feeds the public org profile page and, via edit mode, the Settings tab)
- `frontend/src/pages/app/OrgMembersPage.tsx` - drop `mx-auto` on the body wrapper
- `frontend/src/pages/UserProfilePage.tsx` - drop `mx-auto` on the bio/skills/contact wrapper
- `frontend/src/pages/app/OrgSettingsPage.tsx` - drop `mx-auto` on its own separate outer wrapper (not named in the issue, but wraps the entire `OrganizationProfileView` independently - without this the Settings tab, the issue's primary repro case, would still show the bug after the other three fixes)

## Test plan

- [x] `pnpm check` (tsc --noEmit) - clean
- [x] `pnpm lint` (zero warnings) - clean
- [x] `pnpm format:write` - no changes
- [x] `/self-review` + `a11y-check` subagent - pure visual reflow, no a11y surface, all four pages already covered in `AccessibilityTests.cs`
- [ ] Live verification on staging (see below, added once the RC deploys)

## Live verification

_Pending - will update once the release candidate deploys to staging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC9N4omdjQ9yn4WDg6Mssy)_