### PR TITLE
fix: use shared inputClass for organizations search input

### DIFF
--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -156,7 +156,7 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GetByTestId("quick-action-edit").ClickAsync();
 		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync();
 
-		var removeButton = Page.GetByRole(AriaRole.Button, new() { Name = "Remove" });
+		var removeButton = Page.GetByTestId("logo-remove");
 		await Expect(removeButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await removeButton.ClickAsync();
 		await Expect(removeButton).ToBeHiddenAsync(new() { Timeout = 10_000 });

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -7,6 +7,7 @@ import { useLoadMore } from "../hooks/useLoadMore";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
+import { inputClass } from "../lib/formClasses";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
 
@@ -82,7 +83,7 @@ export default function OrganizationsPage() {
 					value={searchInput}
 					onChange={(e) => handleSearchInputChange(e.target.value)}
 					placeholder={t("organizationsPage.searchPlaceholder")}
-					className="w-full max-w-md rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+					className={`${inputClass} max-w-md`}
 				/>
 			</div>
 

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -282,6 +282,7 @@ export default function OrgSettingsPage() {
 											{logoUrl && (
 												<button
 													type="button"
+													data-testid="logo-remove"
 													onClick={handleRemoveLogo}
 													disabled={uploadingLogo || removingLogo}
 													className="text-sm font-medium text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50"


### PR DESCRIPTION
OrganizationsPage hand-rolled the search input's border/focus-ring styling instead of using formClasses.ts, giving it a different focus ring than every other text input in the app.

Closes #849