### PR TITLE
fix: correct misleading header-close-button comment in opportunity wizard

### DIFF
--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -572,7 +572,10 @@ export default function CreateVolunteerOpportunityModal({
 				suspended={showDiscardConfirm}
 				initialFocusRef={bodyRef}
 			>
-				{/* Plain header, matching the app's other modals. */}
+				{/* Unlike the app's other (single-step) modals, this one is a multi-step
+				wizard - the footer's "Back"/"Cancel" button changes meaning across
+				steps, so this is the only modal with a dedicated header close (X)
+				button giving a step-independent way out. */}
 				<div className="flex items-center justify-between gap-4 border-b border-gray-100 px-6 py-4">
 					<h2
 						id="create-opportunity-dialog-title"


### PR DESCRIPTION
CreateVolunteerOpportunityModal's header X close button is intentional (the only modal that needs a step-independent way out of a multi-step wizard), but the comment falsely claimed it matches every other modal's header - none of which have one.

Closes #850