### PR TITLE
fix: unify cancel/close button styling across modal dialogs

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -9,13 +9,25 @@ const SIZE_CLASSES = {
 
 type Size = keyof typeof SIZE_CLASSES;
 
-// Solid brand-color primary CTA - the single style every "call to action"
-// button/link in the app should share (see issue #846: four different
-// border-radius values across primary buttons before this existed).
+// Shared shape/behavior every button/link in the app should share (see
+// issue #846: four different border-radius values across primary buttons
+// before this existed).
 const BASE_CLASSES =
-	"inline-flex items-center justify-center gap-1.5 rounded-xl bg-brand-700 font-semibold text-white transition-colors hover:bg-brand-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+	"inline-flex items-center justify-center gap-1.5 rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+// primary: solid brand-color CTA. secondary: borderless cancel/close action -
+// the single style every modal's cancel/close button should share (see
+// issue #847: three different visual treatments for the same action before
+// this existed).
+const VARIANT_CLASSES = {
+	primary: "bg-brand-700 font-semibold text-white hover:bg-brand-800",
+	secondary: "text-gray-600 hover:bg-gray-100",
+} as const;
+
+type Variant = keyof typeof VARIANT_CLASSES;
 
 interface CommonProps {
+	variant?: Variant;
 	size?: Size;
 	fullWidth?: boolean;
 	className?: string;
@@ -33,6 +45,7 @@ type ButtonProps = ButtonAsButton | ButtonAsLink;
 
 export default function Button(props: ButtonProps) {
 	const {
+		variant = "primary",
 		size = "md",
 		fullWidth = false,
 		className = "",
@@ -41,6 +54,7 @@ export default function Button(props: ButtonProps) {
 	} = props;
 	const classes = [
 		BASE_CLASSES,
+		VARIANT_CLASSES[variant],
 		SIZE_CLASSES[size],
 		fullWidth && "w-full",
 		className,

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -143,13 +143,15 @@ export default function CheckInModal({
 				</p>
 			)}
 
-			<button
+			<Button
 				type="button"
+				variant="secondary"
 				onClick={onClose}
-				className="mt-5 w-full rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+				fullWidth
+				className="mt-5"
 			>
 				{t("checkIn.close")}
-			</button>
+			</Button>
 		</Modal>
 	);
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import Modal from "./Modal";
+import Button from "./Button";
 
 interface Props {
 	title: string;
@@ -39,13 +40,14 @@ export default function ConfirmDialog({
 			{error && <p className="mt-3 text-sm text-red-600">{error}</p>}
 
 			<div className="mt-5 flex justify-end gap-3">
-				<button
+				<Button
+					type="button"
+					variant="secondary"
 					onClick={onClose}
 					disabled={loading}
-					className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
 				>
 					{t("confirmDialog.keep")}
-				</button>
+				</Button>
 				<button
 					onClick={onConfirm}
 					disabled={loading}

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -294,14 +294,14 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 				</div>
 
 				<div className="flex justify-end gap-2 border-t border-gray-100 px-6 py-4">
-					<button
+					<Button
 						type="button"
+						variant="secondary"
 						onClick={onClose}
 						data-testid="modal-cancel"
-						className="rounded-xl px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100"
 					>
 						{t("organization.cancel")}
-					</button>
+					</Button>
 					<Button type="submit" disabled={loading} data-testid="modal-submit">
 						{loading ? t("organization.creating") : t("organization.submit")}
 					</Button>

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -4,6 +4,7 @@ import type { EngagementSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
+import Button from "./Button";
 
 declare global {
 	class BarcodeDetector {
@@ -193,13 +194,15 @@ export default function QRScannerModal({
 				</p>
 			)}
 
-			<button
+			<Button
 				type="button"
+				variant="secondary"
 				onClick={onClose}
-				className="mt-5 w-full rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+				fullWidth
+				className="mt-5"
 			>
 				{t("checkIn.close")}
-			</button>
+			</Button>
 		</Modal>
 	);
 }

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -138,13 +138,9 @@ export default function SignUpModal({
 				{error && <p className="text-sm text-red-600">{error}</p>}
 
 				<div className="flex justify-end gap-2">
-					<button
-						type="button"
-						onClick={onClose}
-						className="rounded-xl px-4 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100"
-					>
+					<Button type="button" variant="secondary" onClick={onClose}>
 						{t("signUp.cancel")}
-					</button>
+					</Button>
 					<Button
 						type="submit"
 						disabled={submitting || (isWaitlist && timeSlots.length === 0)}

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -120,13 +120,14 @@ export default function SubmitFeedbackModal({
 				{error && <p className="text-sm text-red-600">{error}</p>}
 
 				<div className="flex gap-3">
-					<button
+					<Button
 						type="button"
+						variant="secondary"
 						onClick={onClose}
-						className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+						className="flex-1"
 					>
 						{t("feedback.cancel")}
-					</button>
+					</Button>
 					<Button
 						type="submit"
 						disabled={submitting || rating === 0}


### PR DESCRIPTION
ConfirmDialog, SignUpModal, and SubmitFeedbackModal each used a different visual treatment for the same cancel/close action; CheckInModal, QRScannerModal, and CreateOrganizationModal had the same problem. Extend Button.tsx with a "secondary" variant (the borderless rounded-xl treatment already used in two of the six) and reuse it everywhere instead.

Closes #847