### PR TITLE
fix: restore focus to triggering control when modal closes

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -38,6 +38,18 @@ export default function Modal({
 		scope?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
 	}, [initialFocusRef]);
 
+	// Restore focus to whatever triggered the modal once it unmounts (close),
+	// per the WAI-ARIA Dialog pattern - otherwise focus falls back to <body>.
+	useEffect(() => {
+		const trigger =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
+		return () => {
+			if (trigger?.isConnected) trigger.focus();
+		};
+	}, []);
+
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
 			if (suspended) return;


### PR DESCRIPTION
Modal.tsx moved focus into the dialog on open but never restored it, leaving keyboard users stranded at <body> after close. Capture document.activeElement on mount and refocus it in the effect's cleanup (unmount = close), per the WAI-ARIA Dialog pattern.

Fixes #799