### PR TITLE
fix: sync root AGENTS.md stack-version claims with actual pinned versions

### DIFF
--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 # Install .NET 10 SDK if dotnet is not on PATH
 if ! command -v dotnet &>/dev/null; then
-	echo "[SessionStart] dotnet not found - installing .NET SDK 10.0.300..."
+	DOTNET_SDK_VERSION=$(grep -o '"version": *"[^"]*"' backend/global.json | head -1 | sed -E 's/.*"([0-9.]+)".*/\1/')
+	echo "[SessionStart] dotnet not found - installing .NET SDK $DOTNET_SDK_VERSION..."
 	curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
 	chmod +x /tmp/dotnet-install.sh
-	/tmp/dotnet-install.sh --version 10.0.300 --install-dir "$HOME/.dotnet"
+	/tmp/dotnet-install.sh --version "$DOTNET_SDK_VERSION" --install-dir "$HOME/.dotnet"
 	export PATH="$HOME/.dotnet:$PATH"
 	echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ einsatzbereit/
 
 | | |
 |---|---|
-| Backend | .NET 10 (SDK 10.0.300, see `backend/global.json`), EF Core 9, PostgreSQL 18 |
+| Backend | .NET 10 (SDK 10.0.302, see `backend/global.json`), EF Core 10, PostgreSQL 18 |
 | Auth | Keycloak 26.7.0 (OIDC, JWT) |
-| Frontend | Vite SPA, React 19, React Router v7, Tailwind CSS 4 |
+| Frontend | Vite SPA, React 19, React Router v8, Tailwind CSS 4 |
 | API client | NSwag-generated - **never hand-edit** `api-client.ts` |
 | Tests (BE) | TUnit, Aspire.Hosting.Testing, Respawn, NetArchTest |
 | Tests (FE) | E2E lives in backend `tests/VisualTests/` (TUnit.Playwright + Aspire) |
@@ -28,7 +28,7 @@ einsatzbereit/
 
 ## Development Setup
 
-Required: .NET SDK **10.0.300** (enforced via `backend/global.json`).
+Required: .NET SDK **10.0.302** (enforced via `backend/global.json`).
 
 ```bash
 dotnet run --project backend/src/Aspire/AppHost
@@ -98,10 +98,11 @@ edit on your own initiative):
   once before ending a turn if backend/frontend source changed, blocking
   only on an actual failure (capped at 2 blocks per session so it fails
   open rather than risk a loop) - a safety net since this routine has no
-  human review before a PR goes out. The `SessionStart` hook installs .NET
-  SDK **10.0.300** automatically via `dotnet-install.sh` in Claude Code
-  web/cloud sessions if `dotnet` is not already on `PATH` (see this file's
-  Development Setup for the SDK requirement itself).
+  human review before a PR goes out. The `SessionStart` hook installs the
+  .NET SDK version pinned in `backend/global.json` automatically via
+  `dotnet-install.sh` in Claude Code web/cloud sessions if `dotnet` is not
+  already on `PATH` (see this file's Development Setup for the SDK
+  requirement itself).
 - **Plugins** - the `dotnet/skills` marketplace (`dotnet-aspnetcore`,
   `dotnet-test`, `dotnet-nuget`, `dotnet-data`) plus `csharp-lsp`,
   `typescript-lsp`, and `playwright` (live browser control) are enabled in

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -165,7 +165,7 @@ Because dispatch now happens in a fresh scope after commit (not inline inside th
 
 ## Database
 
-- PostgreSQL 18, EF Core 9, `UseSnakeCaseNamingConvention()`
+- PostgreSQL 18, EF Core 10, `UseSnakeCaseNamingConvention()`
 - Migrations in `Infrastructure/Persistence/Migrations/`
 - Add migration: `dotnet ef migrations add <Name> -p src/Infrastructure -s src/Api`
 - Apply migrations: runs automatically on startup in Development; `dotnet ef database update` otherwise

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-Vite SPA. React Router v7 for routing. Client-side OIDC via `react-oidc-context`. Static files served by nginx in production.
+Vite SPA. React Router v8 for routing. Client-side OIDC via `react-oidc-context`. Static files served by nginx in production.
 
 ```
 src/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Frontend
 
-Vite SPA - React 19, React Router v7, Tailwind CSS 4, react-oidc-context (Keycloak PKCE).
+Vite SPA - React 19, React Router v8, Tailwind CSS 4, react-oidc-context (Keycloak PKCE).
 
 ## Commands
 


### PR DESCRIPTION
SDK, EF Core, and React Router doc claims had drifted from global.json, Directory.Packages.props, and package.json. The Keycloak prod/local split this issue also flagged was already resolved by #930 (AppHost now pins 26.7.0 to match the Dockerfile), so no decision was needed there.

Also stop session-start.sh from hardcoding the SDK version - it now reads it from backend/global.json so this can't drift again.

Closes #801