### PR TITLE
fix: make achievement badge tooltips keyboard-accessible, cover /achievements in a11y tests

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -198,6 +198,37 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		AssertNoViolations(result);
 	}
 
+	[Test]
+	public async Task UserAchievementsPage_HasNoSeriousA11yViolations()
+	{
+		// #800: /users/{userId}/achievements was never visited by any a11y
+		// test, despite being a major user-facing page (BadgeGrid's badge
+		// cards + hover/focus tooltips).
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		var userId = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.profile?.sub) return entry.profile.sub;
+				}
+			}
+			return null;
+		}");
+		if (userId is null)
+			return; // could not resolve the logged-in user's id, skip
+
+		await Page.GotoAsync($"{origin}/users/{userId}/achievements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
 	// Olaf's seed data always organizes at least one org, so the home page's
 	// "Organization overview" CTA always resolves straight to a dashboard.
 	private async Task<bool> NavigateToOrgAppDashboardAsOlafAsync(Uri frontend)

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -37,14 +37,18 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 	const typeName = isEarned ? typeLabel(earned.type) : typeLabel(catalog.type);
 	const icon = TYPE_ICON[typeName] ?? "🏅";
 	const tooltipId = `badge-tooltip-${catalog.key}`;
+	const nameId = `badge-name-${catalog.key}`;
 
 	return (
 		<div
-			className={`group relative flex flex-col items-center rounded-xl border p-4 text-center transition-all ${
+			className={`group relative flex flex-col items-center rounded-xl border p-4 text-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 ${
 				isEarned
 					? "border-brand-200 bg-white shadow-sm hover:shadow-md"
 					: "border-gray-100 bg-gray-50"
 			}`}
+			tabIndex={isHidden ? undefined : 0}
+			role={isHidden ? undefined : "group"}
+			aria-labelledby={!isHidden ? nameId : undefined}
 			aria-describedby={!isHidden ? tooltipId : undefined}
 		>
 			<div
@@ -55,6 +59,7 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 				{isHidden ? "?" : icon}
 			</div>
 			<p
+				id={nameId}
 				className={`text-sm font-semibold leading-snug ${
 					isEarned ? "text-gray-900" : "text-gray-500"
 				}`}
@@ -83,7 +88,7 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 				<div
 					id={tooltipId}
 					role="tooltip"
-					className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block"
+					className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block group-focus:block"
 				>
 					<p className="font-semibold">
 						{t(`achievements.badges.${catalog.key}.name`, {


### PR DESCRIPTION
Badge cards in BadgeGrid only revealed their tooltip on CSS :hover and had no tabIndex, so keyboard users could never reach the badge type/description text. Cards are now focusable with a visible focus ring, the tooltip also shows on :focus, and aria-labelledby/aria-describedby give the focused card a name and description.

Also adds the missing HasNoSeriousA11yViolations coverage for /users/{userId}/achievements, which no axe test ever visited.

Fixes #800