### PR TITLE
fix: keep org switcher name legible on mobile for orgs sharing an initial

### DIFF
--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Microsoft.Playwright;
 
@@ -65,5 +66,43 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 			.ToBeVisibleAsync();
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }))
 			.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task MobileHeader_OrgSwitcherName_StaysLegibleForOrgsSharingAnInitial()
+	{
+		// #809: olaf organizes "Fairview Red Cross" and "Fairview Animal Welfare
+		// Association" - two names sharing both a first letter and a "Fairview "
+		// prefix. The switcher's name span used to collapse to almost nothing on
+		// phone widths (the brand wordmark plus the mobile bell/hamburger left it
+		// no room), rendering as just "F.." for both - indistinguishable. Fixed by
+		// cropping the header wordmark to its icon mark on mobile whenever the org
+		// switcher is present (frees the width the name needs) plus a min-width
+		// floor on the name span itself (OrganizationSwitcher.tsx).
+		var frontend = Fixture.GetEndpoint("frontend");
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend);
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+
+		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
+		await switcherBtn.ClickAsync();
+
+		var animalWelfareRow = Page.GetByTestId("org-switch-row")
+			.Filter(new() { HasText = "Fairview Animal Welfare Association" });
+		if (await animalWelfareRow.CountAsync() == 0)
+			return; // seed data changed - nothing to compare against
+
+		await animalWelfareRow.ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
+
+		// The name span's rendered box, not its (untruncated-by-CSS) text content,
+		// is what actually regresses - assert on the box width so a truncated
+		// render is caught even though the DOM text is always the full name.
+		var nameSpan = Page.GetByTestId("org-switcher-current-name");
+		var box = await nameSpan.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Width.Should().BeGreaterThan(60,
+			"the org name must keep enough width on mobile to show more than just its "
+			+ "first letter - it previously rendered at ~0px wide here");
 	}
 }

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -133,12 +133,19 @@ export default function Header({
 					<div
 						className={`flex items-center justify-between h-16 ${orgSwitcher ? "gap-3 sm:gap-4" : ""}`}
 					>
-						{/* Brand */}
-						<Link to="/" className="flex shrink-0 items-center">
+						{/* Brand. When the org switcher is present, the wordmark is
+						cropped to just its icon mark below the `sm` breakpoint - the
+						full wordmark plus the switcher plus the mobile bell/hamburger
+						don't fit a phone-width viewport with enough room left for the
+						org name to stay legible (#809). */}
+						<Link
+							to="/"
+							className={`flex shrink-0 items-center ${orgSwitcher ? "w-8 overflow-hidden sm:w-auto sm:overflow-visible" : ""}`}
+						>
 							<img
 								src="/logo.svg"
 								alt={t("brand.name")}
-								className={`h-8 transition-all duration-300 ${isTransparent ? "brightness-0 invert" : ""}`}
+								className={`h-8 w-auto max-w-none shrink-0 transition-all duration-300 ${isTransparent ? "brightness-0 invert" : ""}`}
 							/>
 						</Link>
 

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -75,7 +75,10 @@ export default function OrganizationSwitcher({
 							data-initial={(currentOrg?.name ?? "?").charAt(0).toUpperCase()}
 						/>
 					)}
-					<span className="min-w-0 max-w-[200px] flex-1 truncate">
+					<span
+						data-testid="org-switcher-current-name"
+						className="min-w-[6rem] max-w-[200px] flex-1 truncate"
+					>
 						{currentOrg?.name ?? t("organization.selectPlaceholder")}
 					</span>
 					<svg


### PR DESCRIPTION
The switcher's name span could compress to almost nothing on phone widths (the full header wordmark plus the mobile bell/hamburger left it no room), rendering as just "F.." regardless of which org was active - indistinguishable when two orgs share a first letter (e.g. olaf's "Fairview Red Cross" vs "Fairview Animal Welfare Association").

Crop the header wordmark to its icon mark on mobile whenever the org switcher is present, freeing the width the name needs, and add a min-width floor on the name span itself as a safety net.

Fixes #809