### PR TITLE
fix: remove eight more orphaned pre-restructure org routes

### DIFF
--- a/backend/tests/VisualTests/OrgAppRestructureTests.cs
+++ b/backend/tests/VisualTests/OrgAppRestructureTests.cs
@@ -130,10 +130,12 @@ public class OrgAppRestructureTests(AspireFixture fixture) : VisualTestBase(fixt
 	}
 
 	[Test]
-	public async Task LegacyOrganizationDashboardUrl_RedirectsIntoAppShell()
+	public async Task LegacyOrganizationDashboardUrl_NoLongerRoutes_FallsThroughToNotFound()
 	{
-		// Pre-restructure bookmarks/links to /organizations/{id}/dashboard must
-		// still land the user in the right place, under /app now.
+		// #844: the pre-restructure /organizations/{id}/dashboard redirect had
+		// no in-app link pointing at it (only /app/{id}/dashboard is ever
+		// linked) and was removed - a direct visit now falls through to the
+		// catch-all NotFoundPage, same as the /app legacy entry above.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -145,6 +147,10 @@ public class OrgAppRestructureTests(AspireFixture fixture) : VisualTestBase(fixt
 		var organizationId = match.Groups[1].Value;
 
 		await Page.GotoAsync($"{origin}/organizations/{organizationId}/dashboard");
-		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page).ToHaveURLAsync($"{origin}/organizations/{organizationId}/dashboard");
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Page not found" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
 	}
 }

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -102,10 +102,6 @@ Routes declared in `src/App.tsx`. Add new routes there.
 <Route path="/secure" element={<ProtectedRoute><SecurePage /></ProtectedRoute>} />
 ```
 
-Current protected routes:
-
-- `/organizations/:organizationId/settings` → `OrganizationSettingsPage` (requires `organisator`)
-
 **Note:** New API methods become available in `useApiClient()` only after running `dotnet build` in `backend/` (NSwag regenerates `src/client/api-client.ts`). During development, new page code may use `(api as any)` until the client is regenerated.
 
 ## Scripts

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import {
 	Navigate,
 	Outlet,
 	useOutletContext,
-	useParams,
 } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
@@ -29,11 +28,6 @@ import OrgOpportunitiesPage from "./pages/app/OrgOpportunitiesPage";
 import OrgMembersPage from "./pages/app/OrgMembersPage";
 import OrgSettingsPage from "./pages/app/OrgSettingsPage";
 
-function OrgAppRedirect({ tab }: { tab: string }) {
-	const { organizationId } = useParams<{ organizationId: string }>();
-	return <Navigate to={`/app/${organizationId}/${tab}`} replace />;
-}
-
 // A bare <Outlet /> element (no `context` prop) starts a brand new outlet
 // context of its own - it does NOT transparently forward whatever an
 // ancestor <Outlet context={...}> (OrgAppLayout's) already provided. Without
@@ -43,21 +37,6 @@ function OrgAppRedirect({ tab }: { tab: string }) {
 function OrgAppOutletRelay() {
 	const context = useOutletContext<OrgAppContext>();
 	return <Outlet context={context} />;
-}
-
-// Pre-#9 bookmarks to a specific opportunity's engagement management page
-// need their :opportunityId preserved, unlike OrgAppRedirect's fixed tab path.
-function OrgAppEngagementsRedirect() {
-	const { organizationId, opportunityId } = useParams<{
-		organizationId: string;
-		opportunityId: string;
-	}>();
-	return (
-		<Navigate
-			to={`/app/${organizationId}/dashboard/opportunities/${opportunityId}/engagements`}
-			replace
-		/>
-	);
 }
 
 function CallbackPage() {
@@ -109,28 +88,6 @@ export default function App() {
 					<Route path="members" element={<OrgMembersPage />} />
 					<Route path="settings" element={<OrgSettingsPage />} />
 				</Route>
-				{/* Old tab key: the "Engagements" tab is now the Opportunities hub - keep old bookmarks working. */}
-				<Route
-					path="engagements"
-					element={<OrgAppRedirect tab="dashboard/opportunities" />}
-				/>
-				{/* Pre-#9 bookmarks: these three lived flat under /app/:organizationId/... before opportunities/members/settings were nested under /dashboard. */}
-				<Route
-					path="opportunities"
-					element={<OrgAppRedirect tab="dashboard/opportunities" />}
-				/>
-				<Route
-					path="opportunities/:opportunityId/engagements"
-					element={<OrgAppEngagementsRedirect />}
-				/>
-				<Route
-					path="members"
-					element={<OrgAppRedirect tab="dashboard/members" />}
-				/>
-				<Route
-					path="settings"
-					element={<OrgAppRedirect tab="dashboard/settings" />}
-				/>
 			</Route>
 			<Route element={<AppLayout />}>
 				<Route path="/" element={<HomePage />} />
@@ -155,19 +112,6 @@ export default function App() {
 							<ProfileOverviewPage />
 						</ProtectedRoute>
 					}
-				/>
-				{/* Pre-restructure bookmarks: org dashboard/settings/engagements used to live here, nested in the main site shell - now their own app context. */}
-				<Route
-					path="/organizations/:organizationId/dashboard"
-					element={<OrgAppRedirect tab="dashboard" />}
-				/>
-				<Route
-					path="/organizations/:organizationId/settings"
-					element={<OrgAppRedirect tab="dashboard/settings" />}
-				/>
-				<Route
-					path="/organizations/:organizationId/engagements"
-					element={<OrgAppRedirect tab="dashboard/opportunities" />}
 				/>
 				<Route
 					path="/users/:userId/achievements"


### PR DESCRIPTION
/app/:organizationId/{engagements,opportunities,opportunities/:id/engagements, members,settings} and /organizations/:organizationId/{dashboard,settings, engagements} redirect-only routes had no in-app link pointing at them - only the nested /app/:id/dashboard/... form is ever linked. Same bookmark-compat pattern as #843, where the owner's call was removal over indefinite retention: dropped the routes plus the now-unused OrgAppRedirect/ OrgAppEngagementsRedirect helpers, and repointed OrgAppRestructureTests' legacy-dashboard-redirect test to assert the NotFound fallthrough instead.

Closes #844