### PR TITLE
fix: stack name/email above status and actions on mobile admin user list

### DIFF
--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using AwesomeAssertions;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -15,6 +16,8 @@ namespace VisualTests;
 public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	private const string Realm = "einsatzbereit";
+	private const int MobileWidth = 390;
+	private const int MobileHeight = 844;
 
 	[Test]
 	public async Task AdministrationPage_BlockAndPromote_UpdatesRowState()
@@ -44,6 +47,53 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await row.GetByRole(AriaRole.Button, new() { Name = "Promote to admin" }).ClickAsync();
 			await Expect(row.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = "Remove admin" })).ToBeVisibleAsync();
+		}
+		finally
+		{
+			await DeleteKeycloakUserAsync(keycloak, userId);
+		}
+	}
+
+	[Test]
+	public async Task AdministrationPage_MobileViewport_UserRowStacksNameAboveActions()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (username, userId) = await CreateDisposableUserAsync(keycloak);
+		try
+		{
+			await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+			await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+			await Page.GotoAsync($"{origin}/administration");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			await Page.Locator("#admin-user-search").FillAsync(username);
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
+
+			var row = Page.Locator("tr").Filter(new() { HasTextString = username });
+			await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+			var nameCell = row.Locator("p").First;
+			var nameBox = await nameCell.BoundingBoxAsync();
+			nameBox.Should().NotBeNull("Could not get bounding box for the user name");
+
+			var blockButton = row.GetByRole(AriaRole.Button, new() { Name = "Block" });
+			await Expect(blockButton).ToBeVisibleAsync();
+			var blockBox = await blockButton.BoundingBoxAsync();
+			blockBox.Should().NotBeNull("Could not get bounding box for the Block button");
+
+			// Regression #813: on narrow viewports the name/email cell used to shrink
+			// to a sliver next to the still-full-width status badge and action
+			// buttons instead of wrapping onto its own line above them.
+			nameBox!.Width.Should().BeGreaterThan(
+				200f,
+				$"Name cell width ({nameBox.Width:F0}px) should span most of the {MobileWidth}px viewport, not be compressed next to the action buttons");
+
+			blockBox!.Y.Should().BeGreaterThanOrEqualTo(
+				nameBox.Y + nameBox.Height,
+				"Block button should stack below the name/email text on narrow viewports, not sit beside it");
 		}
 		finally
 		{

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -64,8 +64,11 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		var (username, userId) = await CreateDisposableUserAsync(keycloak);
 		try
 		{
-			await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+			// LoginAsync's "Sign in" button is CSS-hidden below the md breakpoint
+			// (it moves into the mobile burger menu), so sign in at desktop size
+			// first and only shrink afterwards - see OrganizationDashboardNavLinkTests.
 			await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+			await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 			await Page.GotoAsync($"{origin}/administration");
 			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -339,7 +339,7 @@ function UsersSection() {
 									return (
 										<tr
 											key={row.id}
-											className="flex flex-wrap items-center gap-3 px-4 py-3"
+											className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:flex-wrap sm:items-center"
 										>
 											<td className="min-w-0 flex-1">
 												<p className="truncate font-medium text-gray-900">
@@ -354,9 +354,9 @@ function UsersSection() {
 													{row.username} &middot; {row.email}
 												</p>
 											</td>
-											<td className="shrink-0">
+											<td className="flex items-center justify-between gap-3 sm:shrink-0 sm:justify-end">
 												<span
-													className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+													className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
 														row.enabled
 															? "bg-green-50 text-green-700"
 															: "bg-red-50 text-red-700"
@@ -366,43 +366,45 @@ function UsersSection() {
 														? t("administration.users.statusActive")
 														: t("administration.users.statusBlocked")}
 												</span>
-											</td>
-											<td className="flex shrink-0 items-center gap-2">
-												{isSelf ? (
-													<span
-														className="text-xs text-gray-500"
-														title={t(
-															"administration.users.selfActionDisabledHint",
-														)}
-													>
-														{t("administration.users.selfActionDisabledHint")}
-													</span>
-												) : (
-													<>
-														<button
-															type="button"
-															disabled={isPending}
-															onClick={() =>
-																void toggleEnabled(row.id, !row.enabled)
-															}
-															className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+												<div className="flex shrink-0 items-center gap-2">
+													{isSelf ? (
+														<span
+															className="text-xs text-gray-500"
+															title={t(
+																"administration.users.selfActionDisabledHint",
+															)}
 														>
-															{row.enabled
-																? t("administration.users.block")
-																: t("administration.users.unblock")}
-														</button>
-														<button
-															type="button"
-															disabled={isPending}
-															onClick={() => void toggleAdmin(row.id, !isAdmin)}
-															className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
-														>
-															{isAdmin
-																? t("administration.users.demote")
-																: t("administration.users.promote")}
-														</button>
-													</>
-												)}
+															{t("administration.users.selfActionDisabledHint")}
+														</span>
+													) : (
+														<>
+															<button
+																type="button"
+																disabled={isPending}
+																onClick={() =>
+																	void toggleEnabled(row.id, !row.enabled)
+																}
+																className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+															>
+																{row.enabled
+																	? t("administration.users.block")
+																	: t("administration.users.unblock")}
+															</button>
+															<button
+																type="button"
+																disabled={isPending}
+																onClick={() =>
+																	void toggleAdmin(row.id, !isAdmin)
+																}
+																className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+															>
+																{isAdmin
+																	? t("administration.users.demote")
+																	: t("administration.users.promote")}
+															</button>
+														</>
+													)}
+												</div>
 											</td>
 										</tr>
 									);


### PR DESCRIPTION
Admin user rows compressed name/email to a sliver on narrow viewports while the status badge and Block/Promote buttons stayed full width, risking an admin acting on the wrong account. The row now stacks name/email above status+actions below the sm breakpoint instead of letting flex-1/min-w-0 shrink the text arbitrarily.

Fixes #813