### PR TITLE
fix: add Content-Security-Policy header to frontend nginx.conf

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -166,6 +166,6 @@ Automated axe-core checks run in the Playwright visual tests (`backend/tests/Vis
 
 ## Production
 
-Static files in `dist/` served by nginx. `nginx.conf` handles SPA routing via `try_files $uri /index.html`.
+Static files in `dist/` served by nginx. `nginx.conf.template` handles SPA routing via `try_files $uri /index.html`; `docker-entrypoint.d/99-runtime-config.sh` renders it (and `config.js`) into their final form at container start via `envsubst`, filling in the Content-Security-Policy's `connect-src`/`frame-src` origins from the same `VITE_API_URL`/`VITE_KEYCLOAK_AUTHORITY_URL` env vars used for runtime config, so one image works across environments.
 
 **Important:** CORS must be configured on the backend to allow the frontend origin, since API calls are now cross-origin (no server-side proxy).

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,7 @@ RUN VITE_KEYCLOAK_AUTHORITY_URL=$VITE_KEYCLOAK_AUTHORITY_URL \
 
 FROM nginx:alpine AS runtime
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
 COPY docker-entrypoint.d/99-runtime-config.sh /docker-entrypoint.d/99-runtime-config.sh
 RUN chmod +x /docker-entrypoint.d/99-runtime-config.sh
 EXPOSE 80

--- a/frontend/docker-entrypoint.d/99-runtime-config.sh
+++ b/frontend/docker-entrypoint.d/99-runtime-config.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Substitutes runtime env vars into config.js at container start, so a single
-# image can be deployed to any environment (build once, deploy anywhere).
+# Substitutes runtime env vars into config.js and the nginx CSP header at
+# container start, so a single image can be deployed to any environment
+# (build once, deploy anywhere).
 set -eu
 
 config="/usr/share/nginx/html/config.js"
@@ -13,3 +14,25 @@ if [ -f "$config" ]; then
 	# return 403 without world-readable perms.
 	chmod 644 "$config"
 fi
+
+# The Content-Security-Policy's connect-src/frame-src need the backend API
+# and Keycloak origins (scheme+host, no path), derived from the same env vars
+# as config.js above rather than hardcoded, so a fork or a second deployment
+# target isn't silently locked to this repo's staging domains.
+: "${VITE_API_URL:=http://localhost:5000}"
+: "${VITE_KEYCLOAK_AUTHORITY_URL:=http://localhost:8080/realms/einsatzbereit}"
+
+url_origin() {
+	proto="${1%%://*}"
+	rest="${1#*://}"
+	host="${rest%%/*}"
+	printf '%s://%s' "$proto" "$host"
+}
+
+CSP_API_ORIGIN="$(url_origin "$VITE_API_URL")"
+CSP_KEYCLOAK_ORIGIN="$(url_origin "$VITE_KEYCLOAK_AUTHORITY_URL")"
+export CSP_API_ORIGIN CSP_KEYCLOAK_ORIGIN
+
+envsubst '${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN}' \
+	< /etc/nginx/nginx.conf.template \
+	> /etc/nginx/conf.d/default.conf

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -15,6 +15,7 @@ server {
 	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 	add_header Strict-Transport-Security "max-age=31536000" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.tile.openstreetmap.org; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN} https://nominatim.openstreetmap.org; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
 
 	location / {
 		try_files $uri $uri/ /index.html;
@@ -28,6 +29,7 @@ server {
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.tile.openstreetmap.org; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN} https://nominatim.openstreetmap.org; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
 	}
 
 	location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
@@ -39,6 +41,7 @@ server {
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.tile.openstreetmap.org; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN} https://nominatim.openstreetmap.org; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
 	}
 
 	location = /index.html {
@@ -49,5 +52,6 @@ server {
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.tile.openstreetmap.org; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN} https://nominatim.openstreetmap.org; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
 	}
 }


### PR DESCRIPTION
## Summary

Closes #807.

`frontend/nginx.conf` set a solid set of hardening headers on every location block but had no `Content-Security-Policy`. Since OIDC session tokens live in `localStorage` (`frontend/src/main.tsx`, `frontend/src/lib/keycloakRegistration.ts` - deliberate, for Playwright `storageState` capture), a CSP is the last line of defense against token exfiltration if an XSS vector is ever introduced.

### Policy

Traced every origin the SPA actually loads from before writing the policy, rather than guessing:

- `script-src 'self'` - no inline scripts in `index.html`; `vite-plugin-pwa`'s default `injectRegister: 'auto'` (unused `virtual:pwa-register` import) emits an external same-origin `/registerSW.js`, not inline.
- `style-src 'self' 'unsafe-inline'` - Tailwind's compiled stylesheet is same-origin, but React `style={{...}}` props (`CalendarWidget.tsx`, `OrgDashboardPage/index.tsx`, `HomePage.tsx`, `ImprintPage.tsx`, `PrivacyPolicyPage.tsx`) and Leaflet's inline marker-positioning styles need `unsafe-inline`.
- `img-src 'self' https://*.tile.openstreetmap.org` - map tiles (`SingleMarkerMap.tsx`); no `data:` URI image usage anywhere in `src/`, so left out.
- `connect-src 'self' <api-origin> <keycloak-origin> https://nominatim.openstreetmap.org` - backend API calls, Keycloak OIDC discovery/token/userinfo endpoints, and the city-autocomplete geocoder (`useCitySuggestions.ts`).
- `frame-src <keycloak-origin>` - `automaticSilentRenew: true` can fall back to an iframe-based silent renew against the Keycloak authority.
- `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'` - no plugins/objects, no base-tag or form-based redirect surface to restrict beyond same-origin.

### Build once, deploy anywhere

`nginx.conf` becomes `nginx.conf.template`. `docker-entrypoint.d/99-runtime-config.sh` now also derives `CSP_API_ORIGIN`/`CSP_KEYCLOAK_ORIGIN` (scheme+host only) from the same `VITE_API_URL`/`VITE_KEYCLOAK_AUTHORITY_URL` env vars `config.js` already uses, and renders the template into `/etc/nginx/conf.d/default.conf` via `envsubst` at container start - so `connect-src`/`frame-src` stay correct across environments instead of hardcoding this repo's staging domains (`api.maik-hasler.de`, `login.maik-hasler.de`) into the image.

## Test plan

- [x] `/self-review` run against the diff (report-only, no domain-specific subagent applied - no backend/EF/API/i18n/`.tsx` changes)
- [x] Simulated the `envsubst` render locally (Python regex stand-in - neither `envsubst` nor Docker is available in this sandbox) against representative staging values to confirm only `${CSP_API_ORIGIN}`/`${CSP_KEYCLOAK_ORIGIN}` get substituted and nginx's own `$uri` token is untouched
- [x] CI green, merged
- [x] Release candidate `v1.0.0-rc.322` built, pushed to GHCR, and deployed to staging - `publish.yml`'s post-deploy health gate (runs on GitHub's own runner) passed
- [ ] Browser-level live verification (login flow, map widget, city autocomplete, CSP console-violation check) - **blocked**, see below
- [ ] Durable regression test in `backend/tests/VisualTests/` - **not applicable**, see below

## Live verification

**Blocked, not skipped.** The session driving this PR has an egress policy that denies both `api.maik-hasler.de` and `einsatzbereit.maik-hasler.de` (confirmed via the sandbox's proxy diagnostics: `connect_rejected`/403 on CONNECT for both hosts, for both `curl` and a proxied Playwright browser launch). The proxy's own guidance is explicit: don't retry or route around a policy denial, report it - so no browser-based check of the live CSP header, login flow, map widget, or city autocomplete was performed from this session.

What *is* confirmed: `publish.yml`'s `Deploy to Staging` job's `Post-deploy health gate` step passed on GitHub's own runner (unaffected by this session's network policy), so the container is up and healthy.

**Step 7 (TUnit test) does not apply to this fix**, for an architectural reason rather than an oversight: `backend/src/Aspire/AppHost/AppHost.cs` runs the frontend via `AddViteApp` (Vite's dev server) for the local Aspire stack that `VisualTests` exercises - it never runs the built nginx Docker image. The `Content-Security-Policy` header only exists on `nginx.conf.template`, rendered inside that production container. A Playwright test against the Aspire stack would never observe this header regardless of whether the fix is correct, so no such test was added rather than adding one that can't actually fail.

Someone with unrestricted network access (or a future session with staging in its egress allowlist) should complete the browser-level check against `https://einsatzbereit.maik-hasler.de` before fully trusting this in production: confirm the `Content-Security-Policy` response header is present with the expected directives, and that login, the map widget, and city autocomplete all still work with no CSP violations in the browser console.
