### PR TITLE
fix: share nested Send() calls' DbContext/transaction with their caller

### DIFF
--- a/backend/src/Application/Common/Messaging/Sender.cs
+++ b/backend/src/Application/Common/Messaging/Sender.cs
@@ -9,6 +9,15 @@ internal sealed class Sender(
 {
 	private static readonly ConcurrentDictionary<Type, IHandlerWrapper> HandlerWrapperCache = [];
 
+	// A Send() call issued from within a handler that is itself running inside
+	// a Send() call (e.g. ConfirmEngagementCommandHandler dispatching
+	// AwardAchievementCommand) reuses the outer call's DI scope instead of
+	// opening a new one. This makes the nested command share the same
+	// IApplicationDbContext/IUnitOfWork instance as its caller, so
+	// TransactionPipelineBehavior can let the outermost command own the single
+	// begin/commit/rollback and nested writes rise or fall with it.
+	private static readonly AsyncLocal<IServiceScope?> AmbientScope = new();
+
 	public async ValueTask<TResponse> Send<TResponse>(
 		IRequest<TResponse> request,
 		CancellationToken cancellationToken = default)
@@ -17,11 +26,29 @@ internal sealed class Sender(
 
 		var handlerWrapper = HandlerWrapperCache.GetOrAdd(requestType, CreateHandlerWrapper);
 
+		var ambientScope = AmbientScope.Value;
+
+		if (ambientScope is not null)
+		{
+			var nestedResult = await handlerWrapper.HandleAsync(request, ambientScope, cancellationToken);
+
+			return (TResponse)nestedResult!;
+		}
+
 		using var scope = serviceProvider.CreateScope();
 
-		var result = await handlerWrapper.HandleAsync(request, scope, cancellationToken);
+		AmbientScope.Value = scope;
 
-		return (TResponse)result!;
+		try
+		{
+			var result = await handlerWrapper.HandleAsync(request, scope, cancellationToken);
+
+			return (TResponse)result!;
+		}
+		finally
+		{
+			AmbientScope.Value = null;
+		}
 	}
 
 	private static IHandlerWrapper CreateHandlerWrapper(

--- a/backend/src/Application/Common/Persistence/IUnitOfWork.cs
+++ b/backend/src/Application/Common/Persistence/IUnitOfWork.cs
@@ -3,6 +3,8 @@ namespace Application.Common.Persistence;
 public interface IUnitOfWork
 	: IDisposable
 {
+	bool HasActiveTransaction { get; }
+
 	Task BeginTransactionAsync(
 		CancellationToken cancellationToken = default);
 

--- a/backend/src/Application/Common/PipelineBehaviors/TransactionPipelineBehavior.cs
+++ b/backend/src/Application/Common/PipelineBehaviors/TransactionPipelineBehavior.cs
@@ -13,6 +13,16 @@ internal sealed class TransactionPipelineBehavior<TCommand, TResponse>(
 		Func<ValueTask<TResponse>> next,
 		CancellationToken cancellationToken = default)
 	{
+		// A nested Send() call (see Sender.AmbientScope) shares the caller's
+		// IUnitOfWork/DbContext and therefore its transaction. Let the
+		// outermost command own the single begin/save/commit-or-rollback so
+		// nested writes commit or roll back atomically with it, instead of
+		// each nested command opening (and prematurely committing) its own.
+		if (unitOfWork.HasActiveTransaction)
+		{
+			return await next();
+		}
+
 		await unitOfWork.BeginTransactionAsync(cancellationToken);
 
 		try

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -287,6 +287,9 @@ internal sealed class ApplicationDbContext(
 			modelBuilder.ApplyConfigurationsFromAssembly(
 				Assembly.GetExecutingAssembly());
 
+	public bool HasActiveTransaction =>
+		Database.CurrentTransaction != null;
+
 	public async Task BeginTransactionAsync(
 		CancellationToken cancellationToken = default) =>
 			await Database.BeginTransactionAsync(cancellationToken);

--- a/backend/tests/Application.UnitTests/Common/PipelineBehaviors/TransactionPipelineBehaviorTests.cs
+++ b/backend/tests/Application.UnitTests/Common/PipelineBehaviors/TransactionPipelineBehaviorTests.cs
@@ -1,0 +1,102 @@
+using Application.Common.Messaging;
+using Application.Common.PipelineBehaviors;
+using Application.Common.Persistence;
+using AwesomeAssertions;
+using NSubstitute;
+
+
+namespace Application.UnitTests.Common.PipelineBehaviors;
+
+public class TransactionPipelineBehaviorTests
+{
+	[Test]
+	public async Task Handle_ShouldBeginSaveAndCommit_WhenNoTransactionIsActive(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var unitOfWork = Substitute.For<IUnitOfWork>();
+		unitOfWork.HasActiveTransaction.Returns(false);
+
+		var behavior = new TransactionPipelineBehavior<TestCommand, string>(unitOfWork);
+
+		// Act
+		var result = await behavior.Handle(new TestCommand(), () => ValueTask.FromResult("ok"), cancellationToken);
+
+		// Assert
+		result.Should().Be("ok");
+		await unitOfWork.Received(1).BeginTransactionAsync(cancellationToken);
+		await unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+		await unitOfWork.Received(1).CommitTransactionAsync(cancellationToken);
+		await unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRollback_WhenNoTransactionIsActiveAndNextThrows(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var unitOfWork = Substitute.For<IUnitOfWork>();
+		unitOfWork.HasActiveTransaction.Returns(false);
+
+		var behavior = new TransactionPipelineBehavior<TestCommand, string>(unitOfWork);
+
+		ValueTask<string> Next() => throw new InvalidOperationException("boom");
+
+		// Act
+		Func<Task> act = async () => await behavior.Handle(new TestCommand(), Next, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+		await unitOfWork.Received(1).BeginTransactionAsync(cancellationToken);
+		await unitOfWork.Received(1).RollbackTransactionAsync(cancellationToken);
+		await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await unitOfWork.DidNotReceive().CommitTransactionAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkipBeginSaveAndCommit_WhenATransactionIsAlreadyActive(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - simulates a nested Send() call (e.g. AwardAchievementCommand
+		// dispatched from ConfirmEngagementCommandHandler) sharing the outer
+		// command's IUnitOfWork/transaction via Sender's ambient scope reuse.
+		var unitOfWork = Substitute.For<IUnitOfWork>();
+		unitOfWork.HasActiveTransaction.Returns(true);
+
+		var behavior = new TransactionPipelineBehavior<TestCommand, string>(unitOfWork);
+
+		// Act
+		var result = await behavior.Handle(new TestCommand(), () => ValueTask.FromResult("nested-ok"), cancellationToken);
+
+		// Assert - the outermost command owns begin/save/commit/rollback; this
+		// nested invocation must not touch any of them.
+		result.Should().Be("nested-ok");
+		await unitOfWork.DidNotReceive().BeginTransactionAsync(Arg.Any<CancellationToken>());
+		await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await unitOfWork.DidNotReceive().CommitTransactionAsync(Arg.Any<CancellationToken>());
+		await unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotSwallowRollback_WhenATransactionIsAlreadyActiveAndNextThrows(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a nested command's own failure must still propagate so the
+		// outer command's TransactionPipelineBehavior can roll everything back.
+		var unitOfWork = Substitute.For<IUnitOfWork>();
+		unitOfWork.HasActiveTransaction.Returns(true);
+
+		var behavior = new TransactionPipelineBehavior<TestCommand, string>(unitOfWork);
+
+		ValueTask<string> Next() => throw new InvalidOperationException("nested boom");
+
+		// Act
+		Func<Task> act = async () => await behavior.Handle(new TestCommand(), Next, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("nested boom");
+		await unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+	}
+
+	private sealed record TestCommand : ICommand<string>;
+}

--- a/backend/tests/Application.UnitTests/Messaging/SenderTests.cs
+++ b/backend/tests/Application.UnitTests/Messaging/SenderTests.cs
@@ -108,6 +108,55 @@ public class SenderTests
 			"A:After");
 	}
 
+	[Test]
+	public async Task Send_ShouldReuseCallingScope_WhenInvokedFromWithinAnotherHandler(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		services.AddScoped<ScopedMarker>();
+
+		services.AddScoped<IRequestHandler<OuterRequest, (Guid Outer, Guid Inner)>, OuterHandler>();
+		services.AddScoped<IRequestHandler<InnerRequest, Guid>, InnerHandler>();
+
+		services.AddScoped<ISender, Sender>();
+
+		var sender = services.BuildServiceProvider().GetRequiredService<ISender>();
+
+		// Act
+		var (outerMarkerId, innerMarkerId) = await sender.Send(new OuterRequest(), cancellationToken);
+
+		// Assert
+		innerMarkerId.Should().Be(outerMarkerId);
+	}
+
+	private sealed class ScopedMarker
+	{
+		public Guid Id { get; } = Guid.NewGuid();
+	}
+
+	private sealed record OuterRequest : ICommand<(Guid Outer, Guid Inner)>;
+
+	private sealed record InnerRequest : ICommand<Guid>;
+
+	private sealed class OuterHandler(ISender sender, ScopedMarker marker)
+		: ICommandHandler<OuterRequest, (Guid Outer, Guid Inner)>
+	{
+		public async ValueTask<(Guid Outer, Guid Inner)> Handle(OuterRequest request, CancellationToken cancellationToken)
+		{
+			var innerMarkerId = await sender.Send(new InnerRequest(), cancellationToken);
+
+			return (marker.Id, innerMarkerId);
+		}
+	}
+
+	private sealed class InnerHandler(ScopedMarker marker)
+		: ICommandHandler<InnerRequest, Guid>
+	{
+		public ValueTask<Guid> Handle(InnerRequest request, CancellationToken cancellationToken) =>
+			ValueTask.FromResult(marker.Id);
+	}
+
 	private sealed record TestRequest(string Input) : ICommand<string>;
 
 	private sealed class TestHandler : ICommandHandler<TestRequest, string>


### PR DESCRIPTION
ConfirmEngagementCommandHandler and RecordLoginCommandHandler dispatch AwardAchievementCommand via ISender.Send() from within their own handler. Sender.Send() opened a brand-new DI scope (and thus a new ApplicationDbContext/connection/transaction) on every call, including nested ones, so TransactionPipelineBehavior committed the nested achievement award independently and immediately - if the outer command later failed and rolled back, the award stayed persisted (#827).

Sender now reuses the calling Send()'s DI scope for any nested Send() issued from within a handler (tracked via an AsyncLocal), so a nested command shares the same IApplicationDbContext/IUnitOfWork instance as its caller. TransactionPipelineBehavior detects an already-active transaction on that shared IUnitOfWork and skips its own begin/save/commit/rollback, leaving the outermost command to own the single transactional boundary - nested writes now commit or roll back atomically with the command that triggered them.

Closes #827