### PR TITLE
fix: add pull_request trigger to docs.yml so broken docs fail CI before merge

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -31,9 +31,11 @@
 - **No E2E job** - E2E lives in backend `tests/VisualTests/` (run by `dotnet.yml`)
 
 ### `docs.yml`
-- **Trigger:** `docs/**` path filter or manual
-- **Jobs:** build AsciiDoc → deploy to GitHub Pages
+- **Trigger:** `docs/**` path filter, push/PR to main, or manual
+- **Jobs:** build AsciiDoc (`build`) -> deploy to GitHub Pages (`deploy`, `needs: build`)
+- `deploy` is gated with `if: github.event_name == 'push'` so PRs only build and never deploy
 - Uses `tonynv/asciidoctor-action` with `asciidoctor-diagram` for PlantUML
+- `build` uses a per-ref concurrency group (`docs-build-${{ github.ref }}`) separate from `deploy`'s `pages` group, so a PR build can't cancel an in-progress production deployment
 
 ## Publish Workflows (tag-triggered)
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,13 +18,12 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: docs-build-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -59,7 +63,11 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
docs.yml only ran on push to main, unlike dotnet.yml/frontend.yml, so a broken AsciiDoc file (bad syntax, missing image, malformed PlantUML) went undetected until after merging to main. Mirror the pull_request trigger pattern from the other path-filtered workflows and gate the deploy job to push events only. Split concurrency into a per-ref group for build and a separate pages group for deploy so a PR build can no longer cancel an in-progress production deployment (previously both shared one workflow-level group, safe only because deploy had no PR trigger to race against).

Fixes #804