### PR TITLE
feat: let organizers edit an existing time slot, notify only its registrants

### DIFF
--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -13,21 +13,24 @@ internal static class OpportunityNotificationHelper
 
 	/// <summary>
 	/// Creates a notification of the given kind for every distinct volunteer who
-	/// has an active (pending or confirmed) engagement on the opportunity. The
-	/// opportunity id is used as the related entity id.
+	/// has an active (pending or confirmed) engagement on the opportunity, or -
+	/// when <paramref name="timeSlotId"/> is given - only those engaged on that
+	/// specific time slot. The opportunity id is used as the related entity id.
 	/// </summary>
 	public static async Task NotifyActiveVolunteersAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
 		VolunteerOpportunityId opportunityId,
 		NotificationKind kind,
-		CancellationToken cancellationToken)
+		CancellationToken cancellationToken,
+		TimeSlotId? timeSlotId = null)
 	{
 		var engagements = await engagementReadRepository.GetByOpportunityAsync(
 			opportunityId, cancellationToken);
 
 		var volunteerIds = engagements
 			.Where(e => ActiveStatuses.Contains(e.Status) && e.VolunteerId is not null)
+			.Where(e => timeSlotId is null || e.TimeSlotId == timeSlotId.Value.Value)
 			.Select(e => e.VolunteerId!.Value)
 			.Distinct();
 

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -45,13 +45,16 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			request.MaxParticipants,
 			DateTimeOffset.UtcNow).ThrowIfFailure();
 
-		// Notify volunteers with an active engagement that a time slot changed (#406).
+		// Notify volunteers with an active engagement on this time slot that it
+		// changed (#406) - scoped to the slot itself, not every volunteer on the
+		// opportunity, so editing one slot doesn't spam registrants of others (#811).
 		await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
 			dbContext,
 			engagementReadRepository,
 			opportunityId,
 			NotificationKind.OpportunityUpdated,
-			cancellationToken);
+			cancellationToken,
+			timeSlotId);
 
 		return true;
 	}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -1,0 +1,191 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.UpdateTimeSlot.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.UpdateTimeSlot;
+
+public class UpdateTimeSlotCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly UpdateTimeSlotCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static readonly Address DefaultAddress = Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value;
+	private static readonly DateTimeOffset BaseStart = DateTimeOffset.UtcNow.AddDays(7);
+	private static readonly DateTimeOffset BaseEnd = DateTimeOffset.UtcNow.AddDays(7).AddHours(2);
+
+	public UpdateTimeSlotCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_dbContext
+			.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
+			.Returns(0);
+		_engagementReadRepository
+			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository);
+	}
+
+	private VolunteerOpportunity CreateWaitlistOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress,
+			Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldUpdateTimeSlot_WhenValid(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateWaitlistOpportunity();
+		var timeSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
+		var opportunityId = opportunity.Id.Value;
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var newStart = BaseStart.AddDays(1);
+		var newEnd = BaseEnd.AddDays(1);
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, timeSlot.Id.Value, newStart, newEnd, 20, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		timeSlot.StartDateTime.Should().Be(newStart);
+		timeSlot.EndDateTime.Should().Be(newEnd);
+		timeSlot.MaxParticipants.Should().Be(20);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns((VolunteerOpportunity?)null);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, Guid.CreateVersion7(), BaseStart, BaseEnd, 10, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage($"*{opportunityId}*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenTimeSlotNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateWaitlistOpportunity();
+		var opportunityId = opportunity.Id.Value;
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, Guid.CreateVersion7(), BaseStart, BaseEnd, 10, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*not found*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenCapacityReducedBelowActiveEngagements(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateWaitlistOpportunity();
+		var timeSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
+		var opportunityId = opportunity.Id.Value;
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		_dbContext
+			.CountActiveEngagementsForTimeSlotAsync(timeSlot.Id, cancellationToken)
+			.Returns(5);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, timeSlot.Id.Value, BaseStart, BaseEnd, 3, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*5*");
+		timeSlot.MaxParticipants.Should().Be(10);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotifyOnlyVolunteersOnTheEditedSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateWaitlistOpportunity();
+		var editedSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
+		var otherSlot = opportunity.AddTimeSlot(BaseStart.AddDays(2), BaseEnd.AddDays(2), 10, DateTimeOffset.UtcNow).Value;
+		var opportunityId = opportunity.Id.Value;
+		var editedSlotVolunteer = Guid.NewGuid();
+		var otherSlotVolunteer = Guid.NewGuid();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		_engagementReadRepository
+			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(
+			[
+				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", editedSlotVolunteer, editedSlot.Id.Value, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
+				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", otherSlotVolunteer, otherSlot.Id.Value, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
+			]);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, editedSlot.Id.Value, BaseStart.AddHours(1), BaseEnd.AddHours(1), 10, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == editedSlotVolunteer),
+			cancellationToken);
+		await _notifRepo.DidNotReceive().AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId.Value == otherSlotVolunteer),
+			cancellationToken);
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -13,7 +13,15 @@ interface TimeSlotRow {
 	startDateTime: string;
 	endDateTime: string;
 	maxParticipants: number;
+	bookedCount: number;
 	persisted: boolean;
+}
+
+interface EditingSlot {
+	id: string;
+	startDateTime: string;
+	endDateTime: string;
+	maxParticipants: number;
 }
 
 interface Props {
@@ -25,6 +33,12 @@ interface Props {
 	removingSlotId: string | null;
 	onRemoveExistingSlot: (id: string) => void;
 	onRemovePendingSlot: (id: string) => void;
+	editingSlot: EditingSlot | null;
+	onStartEditSlot: (slot: TimeSlotRow) => void;
+	onEditingSlotChange: (slot: EditingSlot) => void;
+	onCancelEditSlot: () => void;
+	onSaveEditSlot: (bookedCount: number) => void;
+	updatingSlotId: string | null;
 	newSlot: {
 		startDateTime: string;
 		endDateTime: string;
@@ -77,6 +91,12 @@ export default function DetailsStep({
 	removingSlotId,
 	onRemoveExistingSlot,
 	onRemovePendingSlot,
+	editingSlot,
+	onStartEditSlot,
+	onEditingSlotChange,
+	onCancelEditSlot,
+	onSaveEditSlot,
+	updatingSlotId,
 	newSlot,
 	onNewSlotChange,
 	slotError,
@@ -159,32 +179,150 @@ export default function DetailsStep({
 						<p className="text-xs text-gray-400">{t("timeSlots.noSlots")}</p>
 					) : (
 						<ul className="mb-3 space-y-2">
-							{allTimeSlots.map((slot) => (
-								<li
-									key={slot.id}
-									className="flex items-center justify-between rounded-lg bg-white px-3 py-2 text-sm shadow-sm"
-								>
-									<span className="text-gray-700">
-										{formatDateTime(slot.startDateTime, i18n.language)} -{" "}
-										{formatDateTime(slot.endDateTime, i18n.language)} (
-										{slot.maxParticipants})
-									</span>
-									<button
-										type="button"
-										disabled={slot.persisted && removingSlotId === slot.id}
-										onClick={() =>
-											slot.persisted
-												? onRemoveExistingSlot(slot.id)
-												: onRemovePendingSlot(slot.id)
-										}
-										className="ml-2 text-xs text-red-600 hover:underline disabled:opacity-50"
+							{allTimeSlots.map((slot) =>
+								editingSlot?.id === slot.id ? (
+									<li
+										key={slot.id}
+										className="rounded-lg bg-white px-3 py-2 text-sm shadow-sm"
 									>
-										{slot.persisted && removingSlotId === slot.id
-											? t("timeSlots.removing")
-											: t("timeSlots.removeButton")}
-									</button>
-								</li>
-							))}
+										<div className="space-y-2">
+											{slot.bookedCount > 0 && (
+												<p className="text-xs text-amber-600">
+													{t("timeSlots.bookedCount", {
+														count: slot.bookedCount,
+													})}
+												</p>
+											)}
+											<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+												<div>
+													<label
+														htmlFor={`edit-slot-start-${slot.id}`}
+														className="mb-1 block text-xs font-medium text-gray-600"
+													>
+														{t("timeSlots.fieldStart")}
+													</label>
+													<input
+														id={`edit-slot-start-${slot.id}`}
+														type="datetime-local"
+														value={editingSlot.startDateTime}
+														onChange={(e) =>
+															onEditingSlotChange({
+																...editingSlot,
+																startDateTime: e.target.value,
+															})
+														}
+														className={dateInputClass}
+													/>
+												</div>
+												<div>
+													<label
+														htmlFor={`edit-slot-end-${slot.id}`}
+														className="mb-1 block text-xs font-medium text-gray-600"
+													>
+														{t("timeSlots.fieldEnd")}
+													</label>
+													<input
+														id={`edit-slot-end-${slot.id}`}
+														type="datetime-local"
+														value={editingSlot.endDateTime}
+														onChange={(e) =>
+															onEditingSlotChange({
+																...editingSlot,
+																endDateTime: e.target.value,
+															})
+														}
+														className={dateInputClass}
+													/>
+												</div>
+											</div>
+											<div>
+												<label
+													htmlFor={`edit-slot-max-${slot.id}`}
+													className="mb-1 block text-xs font-medium text-gray-600"
+												>
+													{t("timeSlots.fieldMaxParticipants")}
+												</label>
+												<input
+													id={`edit-slot-max-${slot.id}`}
+													type="number"
+													min={1}
+													value={editingSlot.maxParticipants}
+													onChange={(e) =>
+														onEditingSlotChange({
+															...editingSlot,
+															maxParticipants:
+																parseInt(e.target.value, 10) || 1,
+														})
+													}
+													className="w-24 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+												/>
+											</div>
+											<div className="flex justify-end gap-3">
+												<button
+													type="button"
+													onClick={onCancelEditSlot}
+													className="text-xs text-gray-500 hover:underline"
+												>
+													{t("timeSlots.cancelEditButton")}
+												</button>
+												<button
+													type="button"
+													disabled={updatingSlotId === slot.id}
+													onClick={() => onSaveEditSlot(slot.bookedCount)}
+													className="rounded-lg border border-brand-200 bg-white px-3 py-1.5 text-xs font-semibold text-brand-700 transition hover:bg-brand-50 disabled:opacity-50"
+												>
+													{updatingSlotId === slot.id
+														? t("timeSlots.editing")
+														: t("timeSlots.saveButton")}
+												</button>
+											</div>
+										</div>
+									</li>
+								) : (
+									<li
+										key={slot.id}
+										className="flex items-center justify-between rounded-lg bg-white px-3 py-2 text-sm shadow-sm"
+									>
+										<span className="text-gray-700">
+											{formatDateTime(slot.startDateTime, i18n.language)} -{" "}
+											{formatDateTime(slot.endDateTime, i18n.language)} (
+											{slot.maxParticipants})
+											{slot.bookedCount > 0 && (
+												<span className="ml-2 text-xs text-gray-400">
+													{t("timeSlots.bookedCount", {
+														count: slot.bookedCount,
+													})}
+												</span>
+											)}
+										</span>
+										<span className="ml-2 flex shrink-0 items-center gap-3">
+											{slot.persisted && (
+												<button
+													type="button"
+													onClick={() => onStartEditSlot(slot)}
+													className="text-xs text-brand-700 hover:underline"
+												>
+													{t("timeSlots.editButton")}
+												</button>
+											)}
+											<button
+												type="button"
+												disabled={slot.persisted && removingSlotId === slot.id}
+												onClick={() =>
+													slot.persisted
+														? onRemoveExistingSlot(slot.id)
+														: onRemovePendingSlot(slot.id)
+												}
+												className="text-xs text-red-600 hover:underline disabled:opacity-50"
+											>
+												{slot.persisted && removingSlotId === slot.id
+													? t("timeSlots.removing")
+													: t("timeSlots.removeButton")}
+											</button>
+										</span>
+									</li>
+								),
+							)}
 						</ul>
 					)}
 

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -89,6 +89,22 @@ interface PendingTimeSlot {
 	maxParticipants: number;
 }
 
+interface EditingSlot {
+	id: string;
+	startDateTime: string;
+	endDateTime: string;
+	maxParticipants: number;
+}
+
+/** Converts a Date (or ISO string) to the `YYYY-MM-DDTHH:mm` value a
+ * `datetime-local` input expects, in the viewer's local time. */
+function toDatetimeLocalValue(value: Date | string): string {
+	const date = value instanceof Date ? value : new Date(value);
+	return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+		.toISOString()
+		.slice(0, 16);
+}
+
 const DEFAULT_VALUES: OpportunityFormValues = {
 	title: "",
 	description: "",
@@ -192,6 +208,11 @@ export default function CreateVolunteerOpportunityModal({
 	const [slotError, setSlotError] = useState<string | null>(null);
 	const [removingSlotId, setRemovingSlotId] = useState<string | null>(null);
 	const [addingSlot, setAddingSlot] = useState(false);
+	const [editingSlot, setEditingSlot] = useState<EditingSlot | null>(null);
+	const [updatingSlotId, setUpdatingSlotId] = useState<string | null>(null);
+	const [pendingSlotEdit, setPendingSlotEdit] = useState<
+		(EditingSlot & { bookedCount: number }) | null
+	>(null);
 	const [recurrenceFrequency, setRecurrenceFrequency] = useState("Weekly");
 	const [recurrenceCount, setRecurrenceCount] = useState(1);
 
@@ -402,6 +423,69 @@ export default function CreateVolunteerOpportunityModal({
 		}
 	}
 
+	function handleStartEditSlot(slot: {
+		id: string;
+		startDateTime: string;
+		endDateTime: string;
+		maxParticipants: number;
+	}) {
+		setSlotError(null);
+		setEditingSlot({
+			id: slot.id,
+			startDateTime: toDatetimeLocalValue(slot.startDateTime),
+			endDateTime: toDatetimeLocalValue(slot.endDateTime),
+			maxParticipants: slot.maxParticipants,
+		});
+	}
+
+	async function applySlotEdit(edit: EditingSlot) {
+		if (!initialOpportunity) return;
+		setUpdatingSlotId(edit.id);
+		setSlotError(null);
+		try {
+			await api.updateTimeSlot(initialOpportunity.id, edit.id, {
+				startDateTime: new Date(edit.startDateTime),
+				endDateTime: new Date(edit.endDateTime),
+				maxParticipants: edit.maxParticipants,
+			});
+			setExistingSlots((prev) =>
+				prev.map((s) =>
+					s.id === edit.id
+						? {
+								...s,
+								startDateTime: new Date(edit.startDateTime),
+								endDateTime: new Date(edit.endDateTime),
+								maxParticipants: edit.maxParticipants,
+							}
+						: s,
+				),
+			);
+			setEditingSlot(null);
+		} catch {
+			setSlotError(t("timeSlots.editError"));
+		} finally {
+			setUpdatingSlotId(null);
+			setPendingSlotEdit(null);
+		}
+	}
+
+	function handleRequestSaveEditSlot(bookedCount: number) {
+		if (!editingSlot) return;
+		if (!editingSlot.startDateTime || !editingSlot.endDateTime) return;
+		const start = new Date(editingSlot.startDateTime);
+		const end = new Date(editingSlot.endDateTime);
+		if (end <= start) {
+			setSlotError(t("timeSlots.editError"));
+			return;
+		}
+		setSlotError(null);
+		if (bookedCount > 0) {
+			setPendingSlotEdit({ ...editingSlot, bookedCount });
+		} else {
+			void applySlotEdit(editingSlot);
+		}
+	}
+
 	const submit = async (asDraft: boolean) => {
 		if (!asDraft) {
 			// Walk the steps in order and stop at the first one that fails -
@@ -557,9 +641,14 @@ export default function CreateVolunteerOpportunityModal({
 						? s.endDateTime.toISOString()
 						: String(s.endDateTime),
 				maxParticipants: s.maxParticipants,
+				bookedCount: s.bookedCount,
 				persisted: true as const,
 			}))
-		: pendingSlots.map((s) => ({ ...s, persisted: false as const }));
+		: pendingSlots.map((s) => ({
+				...s,
+				bookedCount: 0,
+				persisted: false as const,
+			}));
 
 	return (
 		<>
@@ -569,7 +658,7 @@ export default function CreateVolunteerOpportunityModal({
 				maxWidth="max-w-xl"
 				className="flex min-w-0 flex-col overflow-hidden rounded-2xl bg-white shadow-2xl"
 				backdropClassName="bg-black/60 backdrop-blur-sm"
-				suspended={showDiscardConfirm}
+				suspended={showDiscardConfirm || pendingSlotEdit !== null}
 				initialFocusRef={bodyRef}
 			>
 				{/* Unlike the app's other (single-step) modals, this one is a multi-step
@@ -687,6 +776,12 @@ export default function CreateVolunteerOpportunityModal({
 							removingSlotId={removingSlotId}
 							onRemoveExistingSlot={(id) => void handleRemoveExistingSlot(id)}
 							onRemovePendingSlot={handleRemovePendingSlot}
+							editingSlot={editingSlot}
+							onStartEditSlot={handleStartEditSlot}
+							onEditingSlotChange={setEditingSlot}
+							onCancelEditSlot={() => setEditingSlot(null)}
+							onSaveEditSlot={handleRequestSaveEditSlot}
+							updatingSlotId={updatingSlotId}
 							newSlot={newSlot}
 							onNewSlotChange={setNewSlot}
 							slotError={slotError}
@@ -767,6 +862,19 @@ export default function CreateVolunteerOpportunityModal({
 						onClose();
 					}}
 					onClose={() => setShowDiscardConfirm(false)}
+				/>
+			)}
+
+			{pendingSlotEdit && (
+				<ConfirmDialog
+					title={t("confirmDialog.editTimeSlot.title")}
+					message={t("confirmDialog.editTimeSlot.message", {
+						count: pendingSlotEdit.bookedCount,
+					})}
+					confirmLabel={t("confirmDialog.editTimeSlot.confirm")}
+					loading={updatingSlotId === pendingSlotEdit.id}
+					onConfirm={() => void applySlotEdit(pendingSlotEdit)}
+					onClose={() => setPendingSlotEdit(null)}
 				/>
 			)}
 		</>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -266,12 +266,18 @@
       "fieldMaxParticipants": "Max. Teilnehmer",
       "addButton": "Hinzufügen",
       "adding": "Wird hinzugefügt…",
+      "editButton": "Bearbeiten",
+      "editing": "Wird gespeichert…",
+      "saveButton": "Speichern",
+      "cancelEditButton": "Abbrechen",
       "removeButton": "Entfernen",
       "removing": "…",
       "noSlots": "Noch keine Zeitslots hinzugefügt.",
       "requiredForPublish": "Ein Zeitslots-Einsatz muss mindestens einen Zeitslot haben, bevor er veröffentlicht werden kann.",
       "addError": "Zeitslot konnte nicht hinzugefügt werden.",
       "removeError": "Zeitslot konnte nicht entfernt werden.",
+      "editError": "Zeitslot konnte nicht aktualisiert werden.",
+      "bookedCount": "{{count}} angemeldet",
       "recurrenceFrequency": "Wiederholungsrhythmus",
       "recurrenceWeekly": "Wöchentlich",
       "recurrenceMonthly": "Monatlich",
@@ -626,6 +632,13 @@
         "title": "Engagement absagen?",
         "message": "Möchtest du dieses Engagement wirklich absagen? Der Freiwillige wird informiert.",
         "confirm": "Ja, absagen"
+      },
+      "editTimeSlot": {
+        "title": "Zeitslot bearbeiten?",
+        "message": "{{count}} Personen sind für diesen Zeitslot angemeldet und werden über die Änderung benachrichtigt, damit sie entscheiden können, ob sie weiterhin teilnehmen möchten.",
+        "message_one": "{{count}} Person ist für diesen Zeitslot angemeldet und wird über die Änderung benachrichtigt, damit sie entscheiden kann, ob sie weiterhin teilnehmen möchte.",
+        "message_other": "{{count}} Personen sind für diesen Zeitslot angemeldet und werden über die Änderung benachrichtigt, damit sie entscheiden können, ob sie weiterhin teilnehmen möchten.",
+        "confirm": "Ja, speichern"
       },
       "leaveOrganization": {
         "title": "Organisation verlassen?",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -266,12 +266,18 @@
       "fieldMaxParticipants": "Max. participants",
       "addButton": "Add",
       "adding": "Adding…",
+      "editButton": "Edit",
+      "editing": "Saving…",
+      "saveButton": "Save",
+      "cancelEditButton": "Cancel",
       "removeButton": "Remove",
       "removing": "…",
       "noSlots": "No time slots added yet.",
       "requiredForPublish": "A Scheduled slots opportunity must have at least one time slot before it can be published.",
       "addError": "Could not add time slot.",
       "removeError": "Could not remove time slot.",
+      "editError": "Could not update time slot.",
+      "bookedCount": "{{count}} signed up",
       "recurrenceFrequency": "Frequency",
       "recurrenceWeekly": "Weekly",
       "recurrenceMonthly": "Monthly",
@@ -626,6 +632,13 @@
         "title": "Cancel engagement?",
         "message": "Are you sure you want to cancel this engagement? The volunteer will be informed.",
         "confirm": "Yes, cancel"
+      },
+      "editTimeSlot": {
+        "title": "Edit time slot?",
+        "message": "{{count}} people are signed up for this time slot and will be notified of the change so they can decide whether to still participate.",
+        "message_one": "{{count}} person is signed up for this time slot and will be notified of the change so they can decide whether to still participate.",
+        "message_other": "{{count}} people are signed up for this time slot and will be notified of the change so they can decide whether to still participate.",
+        "confirm": "Yes, save changes"
       },
       "leaveOrganization": {
         "title": "Leave organization?",


### PR DESCRIPTION
Wires the frontend up to the previously-unused UpdateTimeSlot endpoint: adds an inline edit form (start/end/capacity) to the time-slot list in CreateVolunteerOpportunityModal, with a confirmation step warning the organizer that signed-up volunteers will be notified so they can decide whether to still participate.

The backend already notified volunteers on every slot edit (#406), but fanned the notification out to every active volunteer on the opportunity instead of just the edited slot's registrants - editing one slot spammed everyone else too. Scoped OpportunityNotificationHelper's fan-out to the affected time slot.

Fixes #811