### PR TITLE
fix: surface expired sessions instead of silently discarding every 401

### DIFF
--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// Regression for #1219: handleErrorResponse used to silently discard every
+	// 401 ("if (response.status === 401) { return; }"), leaving a
+	// logged-in-looking UI - avatar, notification bell still rendered - where
+	// every authenticated API call quietly failed. A 401 on a request that
+	// carried a bearer token now means the Keycloak session behind it is no
+	// longer valid, so the app must send the user back through sign-in instead
+	// of pretending nothing happened.
+	[Test]
+	public async Task AuthenticatedRequest_Returns401_RedirectsToKeycloakSignIn()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		await MockAllV1GetRequestsAsUnauthorizedAsync();
+
+		// Force the header + home page effects to remount and re-fire their
+		// concurrent authenticated requests against the mocked 401 above.
+		await Page.ReloadAsync();
+
+		// Same tolerant wait as AuthGuardTests.MyEngagements_Anonymous_RedirectsToKeycloak -
+		// wait on the Keycloak login form rather than an exact URL, which is race-prone
+		// against the JS-driven redirect.
+		await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+		await Expect(Page).ToHaveURLAsync(new Regex(@"/realms/einsatzbereit/protocol/openid-connect/auth"));
+	}
+
+	[Test]
+	public async Task AuthenticatedRequest_Returns401_ShowsSessionExpiredToast()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		await MockAllV1GetRequestsAsUnauthorizedAsync();
+
+		// Hold the sign-in redirect at the network layer instead of letting it
+		// navigate away: aborting a cross-origin top-level navigation before any
+		// response arrives makes Chromium cancel it and stay on the current
+		// document, rather than swapping documents. That keeps the SPA (and its
+		// toast) on screen long enough to assert, instead of racing the redirect.
+		await Page.RouteAsync(
+			"**/realms/einsatzbereit/protocol/openid-connect/auth**",
+			route => route.AbortAsync());
+
+		await Page.ReloadAsync();
+
+		var sessionExpiredToast = Page.GetByRole(AriaRole.Alert)
+			.Filter(new() { HasTextString = "session has expired" });
+		await Expect(sessionExpiredToast).ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	// Edge case: an anonymous visitor's public, tokenless requests (e.g. the
+	// home page's opportunity listing) can also 401 (auth required, none
+	// given) - that is just "not logged in", not a session expiring, and must
+	// not trigger the toast/redirect above. Guarded by handleErrorResponse's
+	// hadAccessToken check in api-instance.ts.
+	[Test]
+	public async Task AnonymousRequest_Returns401_DoesNotShowToastOrRedirect()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await MockAllV1GetRequestsAsUnauthorizedAsync();
+
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var sessionExpiredToast = Page.GetByRole(AriaRole.Alert)
+			.Filter(new() { HasTextString = "session has expired" });
+		await Expect(sessionExpiredToast).Not.ToBeVisibleAsync();
+
+		Page.Url.Should().StartWith(frontend.ToString());
+	}
+
+	private async Task MockAllV1GetRequestsAsUnauthorizedAsync()
+	{
+		await Page.RouteAsync("**/v1/**", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			// The frontend and backend are cross-origin in this test environment,
+			// so a mocked response still needs an Access-Control-Allow-Origin
+			// header - the browser enforces CORS on fulfilled responses just as
+			// it would on a real one, and without it fetch() rejects before the
+			// app's response-handling code (and thus the toast/redirect) ever runs.
+			await route.FulfillAsync(new()
+			{
+				Status = 401,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.2\",\"status\":401}",
+			});
+		});
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
+import { useSessionExpiryHandler } from "./hooks/useSessionExpiryHandler";
 import ErrorBanner from "./components/ErrorBanner";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
@@ -59,6 +60,7 @@ function CallbackPage() {
 }
 
 export default function App() {
+	useSessionExpiryHandler();
 	return (
 		<Routes>
 			<Route path="/callback" element={<CallbackPage />} />

--- a/frontend/src/client/api-instance.ts
+++ b/frontend/src/client/api-instance.ts
@@ -1,12 +1,23 @@
 import { dispatchToast } from "../lib/toastBus";
+import { notifySessionExpired } from "../lib/sessionExpiryBus";
 import { runtimeConfig } from "../lib/runtimeConfig";
 import { EinsatzbereitApi } from "./api-client";
 import i18next from "../i18n";
 
-async function handleErrorResponse(response: Response): Promise<void> {
+async function handleErrorResponse(
+	response: Response,
+	hadAccessToken: boolean,
+): Promise<void> {
 	if (response.ok) return;
 
 	if (response.status === 401) {
+		// A 401 without a token just means "not logged in" (e.g. anonymous
+		// browsing) - expected, not a session expiring. Only a 401 on a
+		// request that *did* carry a bearer token means the Keycloak session
+		// backing it is no longer valid.
+		if (hadAccessToken) {
+			notifySessionExpired();
+		}
 		return;
 	}
 
@@ -40,7 +51,7 @@ export function createApiClient(accessToken?: string): EinsatzbereitApi {
 					"X-Timezone": Intl.DateTimeFormat().resolvedOptions().timeZone,
 				},
 			});
-			await handleErrorResponse(response);
+			await handleErrorResponse(response, Boolean(accessToken));
 			return response;
 		},
 	});

--- a/frontend/src/hooks/useSessionExpiryHandler.ts
+++ b/frontend/src/hooks/useSessionExpiryHandler.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useAuth } from "react-oidc-context";
+import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router";
+import { dispatchToast } from "../lib/toastBus";
+import { subscribeSessionExpired } from "../lib/sessionExpiryBus";
+import { signinLocaleArgs } from "../lib/authLocale";
+
+/**
+ * Reacts to a Keycloak session going invalid while the UI still looks
+ * logged in - either reactively (an API call came back 401, reported via
+ * sessionExpiryBus) or proactively (react-oidc-context's automaticSilentRenew
+ * failed in the background, e.g. the SSO session was revoked server-side).
+ * Shows a toast and redirects to sign-in, preserving the current location
+ * so the user lands back where they were after re-authenticating.
+ */
+export function useSessionExpiryHandler() {
+	const auth = useAuth();
+	const { t } = useTranslation();
+	const location = useLocation();
+	const handledRef = useRef(false);
+	const locationRef = useRef(location);
+	locationRef.current = location;
+
+	useEffect(() => {
+		handledRef.current = false;
+	}, [auth.isAuthenticated]);
+
+	useEffect(() => {
+		function handleExpiry() {
+			// Several concurrent API calls (or a bus event racing a silent-renew
+			// failure) can all report expiry around the same time - only act once.
+			if (handledRef.current) return;
+			handledRef.current = true;
+
+			dispatchToast("error", t("error.sessionExpired"));
+			void auth.signinRedirect({
+				...signinLocaleArgs(),
+				state: {
+					returnTo: locationRef.current.pathname + locationRef.current.search,
+				},
+			});
+		}
+
+		const unsubscribeBus = subscribeSessionExpired(handleExpiry);
+		const unsubscribeSilentRenewError =
+			auth.events.addSilentRenewError(handleExpiry);
+
+		return () => {
+			unsubscribeBus();
+			unsubscribeSilentRenewError();
+		};
+	}, [auth, t]);
+}

--- a/frontend/src/lib/sessionExpiryBus.ts
+++ b/frontend/src/lib/sessionExpiryBus.ts
@@ -1,0 +1,15 @@
+type Listener = () => void;
+
+const listeners: Listener[] = [];
+
+export function subscribeSessionExpired(listener: Listener): () => void {
+	listeners.push(listener);
+	return () => {
+		const idx = listeners.indexOf(listener);
+		if (idx !== -1) listeners.splice(idx, 1);
+	};
+}
+
+export function notifySessionExpired(): void {
+	listeners.forEach((l) => l());
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -760,6 +760,7 @@
     },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",
+      "sessionExpired": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
       "serverError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.",
       "boundaryTitle": "Etwas ist schiefgelaufen",
       "boundaryMessage": "Ein unerwarteter Fehler ist aufgetreten. Du kannst zurück navigieren oder die Seite neu laden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -760,6 +760,7 @@
     },
     "error": {
       "forbidden": "You do not have permission to do this.",
+      "sessionExpired": "Your session has expired. Please sign in again.",
       "serverError": "An unexpected error occurred. Please try again later.",
       "boundaryTitle": "Something went wrong",
       "boundaryMessage": "An unexpected error occurred. You can try going back or reloading the page.",


### PR DESCRIPTION
handleErrorResponse dropped every 401 unconditionally, leaving a logged-in-looking UI (avatar, notification bell) where authenticated API calls silently failed once a Keycloak session expired. Now a 401 on a request that carried a bearer token notifies a new session-expiry bus; a top-level hook shows a toast and redirects to sign-in, preserving the current location, and also reacts proactively to
react-oidc-context's silent-renew failures. A 401 with no token (plain anonymous browsing) is left alone.

Closes #1219 