### PR TITLE
fix: translate backend API error messages instead of showing raw English text

### DIFF
--- a/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
+++ b/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
@@ -1,0 +1,98 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1250: getApiErrorMessage() (frontend/src/lib/apiError.ts)
+/// used to prefer the server's raw ProblemDetails.Detail - always English,
+/// see ResultFailureExceptionHandler - over the caller-supplied,
+/// already-localized fallback string. A German volunteer entering a wrong
+/// check-in PIN therefore saw the backend's raw "Invalid PIN." instead of the
+/// translated checkIn.invalidPin fallback ("Falsche PIN. Bitte erneut
+/// versuchen."). Fixed by mapping the ProblemDetails errorCode extension to
+/// an apiError.&lt;errorCode&gt; translation key first, only falling back to
+/// the caller's string when no such key exists - server text is never
+/// rendered to the user.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class LocalizedCheckInPinErrorTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task CheckInModal_ShowsGermanTranslatedInvalidPinMessage_NotRawEnglishServerText()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"LocalizedPinError Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		const string pin = "482170";
+		var oppTitle = $"LocalizedPinError Opportunity {suffix}";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by LocalizedCheckInPinErrorTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "PINCode",
+			checkInPin = pin,
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "IndividualContact", message = "Ready to help with LocalizedCheckInPinErrorTests." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		// Only a Confirmed engagement's "Check in" button renders (ActivitySection.tsx).
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Switch to German only after signing in - FastSignInAsync itself waits on
+		// the English "User menu" aria-label (see OrgDashboardWidgetsTests).
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch language" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Option, new() { Name = "Deutsch" }).ClickAsync();
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await row.GetByRole(AriaRole.Button, new() { Name = "Einchecken" }).ClickAsync();
+
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+
+		await dialog.Locator("#pin-input").FillAsync("000000");
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Bestätigen" }).ClickAsync();
+
+		await Expect(dialog.GetByText("Falsche PIN. Bitte erneut versuchen."))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// The bug this guards against: the raw English backend detail text
+		// must never be rendered to the user, regardless of locale.
+		await Expect(dialog.GetByText("Invalid PIN.")).Not.ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -1,17 +1,28 @@
+import i18next from "../i18n";
+
 /**
  * Extracts a human-readable message from a rejected API call.
  *
  * The NSwag client throws the raw ProblemDetails object (`{ title, status,
- * detail }`) for error responses, which has no `.message` property. Reading
- * `err.message` there yields `undefined`, which previously left error state
- * falsy and made pages render their empty state instead of the error (see #349).
+ * detail, errorCode }`) for error responses. `detail`/`title` are always
+ * English (server-side `Error.Description` text) - see #1250 - so they are
+ * never shown to the user, only logged for debugging. `errorCode` (set by
+ * ResultFailureExceptionHandler for every Result-pattern failure) is looked
+ * up as an `apiError.<errorCode>` translation key; if that key doesn't
+ * exist (unmapped code, or a rejection with no errorCode at all, e.g. a
+ * network failure), the caller-supplied, already-localized `fallback` is
+ * used instead.
  */
 export function getApiErrorMessage(err: unknown, fallback: string): string {
 	if (err && typeof err === "object") {
-		const o = err as { detail?: unknown; title?: unknown; message?: unknown };
-		if (typeof o.detail === "string" && o.detail.trim()) return o.detail;
-		if (typeof o.title === "string" && o.title.trim()) return o.title;
-		if (typeof o.message === "string" && o.message.trim()) return o.message;
+		const o = err as { detail?: unknown; errorCode?: unknown };
+		if (typeof o.detail === "string" && o.detail.trim()) {
+			console.error("[API] error detail (not shown to user):", o.detail);
+		}
+		if (typeof o.errorCode === "string" && o.errorCode.trim()) {
+			const key = `apiError.${o.errorCode}`;
+			if (i18next.exists(key)) return i18next.t(key);
+		}
 	}
 	return fallback;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -859,6 +859,130 @@
       "eventFillState": "{{booked}} / {{max}} gebucht",
       "eventManageApplications": "Bewerbungen verwalten",
       "createOpportunity": "Einsatz erstellen"
+    },
+    "apiError": {
+      "AchievementId": {
+        "Empty": "AchievementId darf nicht leer sein."
+      },
+      "NotificationId": {
+        "Empty": "NotificationId darf nicht leer sein."
+      },
+      "EngagementId": {
+        "Empty": "EngagementId darf nicht leer sein."
+      },
+      "VolunteerOpportunityId": {
+        "Empty": "VolunteerOpportunityId darf nicht leer sein."
+      },
+      "OrganizationId": {
+        "Empty": "OrganizationId darf nicht leer sein."
+      },
+      "OrganizationInvitationId": {
+        "Empty": "OrganizationInvitationId darf nicht leer sein."
+      },
+      "OrganizationMembershipId": {
+        "Empty": "OrganizationMembershipId darf nicht leer sein."
+      },
+      "OrganizationDashboardLayoutId": {
+        "Empty": "OrganizationDashboardLayoutId darf nicht leer sein."
+      },
+      "TimeSlotId": {
+        "Empty": "TimeSlotId darf nicht leer sein."
+      },
+      "UserId": {
+        "Empty": "UserId darf nicht leer sein."
+      },
+      "UserStreakId": {
+        "Empty": "UserStreakId darf nicht leer sein."
+      },
+      "User": {
+        "InvalidId": "Ungültiger Benutzer."
+      },
+      "Users": {
+        "CannotModifyServiceAccount": "Das interne Service-Konto des Systems kann nicht geändert werden.",
+        "CannotDisableSelf": "Du kannst dein eigenes Konto nicht sperren.",
+        "CannotDemoteSelf": "Du kannst dir nicht selbst die Admin-Rechte entziehen."
+      },
+      "Address": {
+        "StreetRequired": "Straße darf nicht leer sein.",
+        "HouseNumberRequired": "Hausnummer darf nicht leer sein.",
+        "ZipCodeInvalid": "Die Postleitzahl muss genau 5 Zeichen lang sein.",
+        "CityRequired": "Stadt darf nicht leer sein.",
+        "LatitudeOutOfRange": "Der Breitengrad muss zwischen -90 und 90 liegen.",
+        "LongitudeOutOfRange": "Der Längengrad muss zwischen -180 und 180 liegen."
+      },
+      "Organization": {
+        "NameRequired": "Name darf nicht leer sein.",
+        "NameTooLong": "Der Name der Organisation darf 100 Zeichen nicht überschreiten.",
+        "AlreadyVerified": "Die Organisation ist bereits verifiziert.",
+        "NotVerified": "Die Organisation ist nicht verifiziert.",
+        "NotFound": "Organisation nicht gefunden.",
+        "MultipleMembers": "Nur das letzte verbleibende Mitglied kann die Organisation löschen. Entferne zuerst die anderen Mitglieder.",
+        "HasBlockingOpportunities": "Diese Organisation hat noch Bedarfe mit zukünftigen Zeitslots oder aktiven Engagements. Bitte löse das zuerst auf.",
+        "SoleOrganizer": "Du bist der einzige Organisator dieser Organisation. Lösche stattdessen die Organisation, wenn du sie schließen möchtest.",
+        "NotOrganizer": "Du hast keine Berechtigung, diese Ressource zu ändern."
+      },
+      "OrganizationInvitation": {
+        "NotPending": "Die Einladung ist nicht mehr ausstehend.",
+        "NotFound": "Einladung nicht gefunden.",
+        "NotRecipient": "Du bist nicht der Empfänger dieser Einladung.",
+        "WrongOrganization": "Diese Einladung gehört nicht zu dieser Organisation.",
+        "NotDeclined": "Nur abgelehnte Einladungen können verworfen werden.",
+        "AlreadyMember": "Der Benutzer ist bereits Mitglied dieser Organisation.",
+        "AlreadyInvited": "Für diesen Benutzer besteht bereits eine ausstehende Einladung."
+      },
+      "VolunteerOpportunity": {
+        "InvalidCheckInPin": "Die Check-in-PIN muss 4 bis 6 Ziffern haben.",
+        "TitleTooLong": "Der Titel darf 200 Zeichen nicht überschreiten.",
+        "DescriptionTooLong": "Die Beschreibung darf 5000 Zeichen nicht überschreiten.",
+        "WaitlistMustStartAsDraft": "Ein Bedarf mit Warteliste muss zunächst als Entwurf angelegt werden und kann erst nach Hinzufügen mindestens eines Zeitslots veröffentlicht werden.",
+        "TitleRequired": "Titel darf nicht leer sein.",
+        "DescriptionRequired": "Beschreibung darf nicht leer sein.",
+        "AddressRequired": "Für Vor-Ort-Bedarfe ist eine Adresse erforderlich.",
+        "AlreadyPublished": "Der Bedarf ist bereits veröffentlicht.",
+        "WaitlistRequiresTimeSlot": "Ein Bedarf mit Warteliste benötigt mindestens einen Zeitslot, bevor er veröffentlicht werden kann.",
+        "BannerImageUrlRequired": "Die URL des Bannerbilds darf nicht leer sein.",
+        "TimeSlotNotAllowed": "Zeitslots können nur zu Bedarfen mit Teilnahmeart „Warteliste“ hinzugefügt werden.",
+        "TimeSlotNotFound": "Zeitslot nicht gefunden.",
+        "NotFound": "Bedarf nicht gefunden.",
+        "ParticipationTypeLocked": "Die Teilnahmeart kann nicht geändert werden, solange aktive Engagements bestehen.",
+        "TimeSlotCapacityBelowActive": "Die Kapazität kann nicht unter die Anzahl der aktuell aktiven Anmeldungen gesenkt werden.",
+        "TimeSlotHasActiveEngagements": "Ein Zeitslot mit aktiven Anmeldungen kann nicht gelöscht werden. Sage zuerst die betroffenen Anmeldungen ab."
+      },
+      "TimeSlot": {
+        "StartMustBeFuture": "Das Startdatum muss in der Zukunft liegen.",
+        "EndMustBeAfterStart": "Das Enddatum muss nach dem Startdatum liegen.",
+        "MaxParticipantsMustBePositive": "Die maximale Teilnehmerzahl muss größer als null sein."
+      },
+      "Engagement": {
+        "MessageRequired": "Bei einer Interessensbekundung per Einzelkontakt ist eine Nachricht erforderlich.",
+        "NotPending": "Nur ausstehende Engagements können bestätigt werden.",
+        "AlreadyTerminated": "Dieses Engagement wurde bereits beendet.",
+        "CheckedIn": "Ein bereits eingechecktes Engagement kann nicht mehr zurückgezogen werden.",
+        "NotTerminated": "Nur zurückgezogene oder abgesagte Engagements können reaktiviert werden.",
+        "NotConfirmed": "Nur bestätigte Engagements können eingecheckt werden.",
+        "NotCheckedIn": "Feedback kann nur für eingecheckte Engagements abgegeben werden.",
+        "FeedbackAlreadySubmitted": "Für dieses Engagement wurde bereits Feedback abgegeben.",
+        "RatingOutOfRange": "Die Bewertung muss zwischen 1 und 5 liegen.",
+        "CommentTooLong": "Der Kommentar darf 500 Zeichen nicht überschreiten.",
+        "NotFound": "Engagement nicht gefunden.",
+        "NotOwner": "Du kannst nur deine eigenen Engagements verwalten.",
+        "AlreadySignedUp": "Du bist für diesen Bedarf bereits angemeldet.",
+        "TimeSlotNotInOpportunity": "Der ausgewählte Zeitslot gehört nicht zu diesem Bedarf.",
+        "TimeSlotFull": "Dieser Zeitslot hat seine Kapazität erreicht und kann keine weiteren Anmeldungen annehmen.",
+        "InvalidPin": "Falsche PIN. Bitte erneut versuchen.",
+        "CheckInLocked": "Zu viele fehlgeschlagene PIN-Versuche. Bitte versuche es später erneut."
+      },
+      "DashboardLayout": {
+        "InvalidWidgetKey": "Unbekanntes Widget.",
+        "DuplicateWidget": "Ein Widget ist mehrfach platziert.",
+        "InvalidPlacement": "Ein Widget hat eine ungültige Position im Raster.",
+        "OverlappingPlacement": "Zwei Widgets überlappen sich im Raster."
+      },
+      "FileUpload": {
+        "Empty": "Das Bild darf nicht leer sein.",
+        "TooLarge": "Das Bild darf 2 MB nicht überschreiten.",
+        "InvalidContentType": "Das Bild muss im Format JPEG, PNG oder WebP vorliegen."
+      }
     }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -859,6 +859,130 @@
       "eventFillState": "{{booked}} / {{max}} booked",
       "eventManageApplications": "Manage applications",
       "createOpportunity": "Create opportunity"
+    },
+    "apiError": {
+      "AchievementId": {
+        "Empty": "AchievementId must not be empty."
+      },
+      "NotificationId": {
+        "Empty": "NotificationId must not be empty."
+      },
+      "EngagementId": {
+        "Empty": "EngagementId must not be empty."
+      },
+      "VolunteerOpportunityId": {
+        "Empty": "VolunteerOpportunityId must not be empty."
+      },
+      "OrganizationId": {
+        "Empty": "OrganizationId must not be empty."
+      },
+      "OrganizationInvitationId": {
+        "Empty": "OrganizationInvitationId must not be empty."
+      },
+      "OrganizationMembershipId": {
+        "Empty": "OrganizationMembershipId must not be empty."
+      },
+      "OrganizationDashboardLayoutId": {
+        "Empty": "OrganizationDashboardLayoutId must not be empty."
+      },
+      "TimeSlotId": {
+        "Empty": "TimeSlotId must not be empty."
+      },
+      "UserId": {
+        "Empty": "UserId must not be empty."
+      },
+      "UserStreakId": {
+        "Empty": "UserStreakId must not be empty."
+      },
+      "User": {
+        "InvalidId": "Invalid user."
+      },
+      "Users": {
+        "CannotModifyServiceAccount": "The backend's own service account cannot be modified.",
+        "CannotDisableSelf": "You cannot block your own account.",
+        "CannotDemoteSelf": "You cannot remove your own admin access."
+      },
+      "Address": {
+        "StreetRequired": "Street must not be empty.",
+        "HouseNumberRequired": "House number must not be empty.",
+        "ZipCodeInvalid": "Zip code must be exactly 5 characters.",
+        "CityRequired": "City must not be empty.",
+        "LatitudeOutOfRange": "Latitude must be between -90 and 90.",
+        "LongitudeOutOfRange": "Longitude must be between -180 and 180."
+      },
+      "Organization": {
+        "NameRequired": "Name must not be empty.",
+        "NameTooLong": "Organization name must not exceed 100 characters.",
+        "AlreadyVerified": "Organization is already verified.",
+        "NotVerified": "Organization is not verified.",
+        "NotFound": "Organization not found.",
+        "MultipleMembers": "Only the organization's sole remaining member can delete it. Remove the other members first.",
+        "HasBlockingOpportunities": "This organization has opportunities with future time slots or active engagements. Resolve or cancel these first.",
+        "SoleOrganizer": "You are the only organizer of this organization. Delete the organization instead of leaving it.",
+        "NotOrganizer": "You do not have permission to modify this resource."
+      },
+      "OrganizationInvitation": {
+        "NotPending": "Invitation is not pending.",
+        "NotFound": "Invitation not found.",
+        "NotRecipient": "You are not the recipient of this invitation.",
+        "WrongOrganization": "Invitation does not belong to this organization.",
+        "NotDeclined": "Only declined invitations can be dismissed.",
+        "AlreadyMember": "User is already a member of this organization.",
+        "AlreadyInvited": "A pending invitation already exists for this user."
+      },
+      "VolunteerOpportunity": {
+        "InvalidCheckInPin": "Check-in PIN must be 4 to 6 digits.",
+        "TitleTooLong": "Title must not exceed 200 characters.",
+        "DescriptionTooLong": "Description must not exceed 5000 characters.",
+        "WaitlistMustStartAsDraft": "A Waitlist opportunity must be created as a draft and published after adding at least one time slot.",
+        "TitleRequired": "Title must not be empty.",
+        "DescriptionRequired": "Description must not be empty.",
+        "AddressRequired": "Address is required for non-remote opportunities.",
+        "AlreadyPublished": "Opportunity is already published.",
+        "WaitlistRequiresTimeSlot": "A Waitlist opportunity must have at least one time slot before it can be published.",
+        "BannerImageUrlRequired": "Banner image URL must not be empty.",
+        "TimeSlotNotAllowed": "Time slots can only be added to opportunities with Waitlist participation type.",
+        "TimeSlotNotFound": "Time slot not found.",
+        "NotFound": "Volunteer opportunity not found.",
+        "ParticipationTypeLocked": "Participation type cannot be changed while active engagements exist.",
+        "TimeSlotCapacityBelowActive": "Cannot reduce capacity below the current number of active sign-ups.",
+        "TimeSlotHasActiveEngagements": "Cannot delete a time slot that has active sign-ups. Cancel the affected engagements first."
+      },
+      "TimeSlot": {
+        "StartMustBeFuture": "Start date must be in the future.",
+        "EndMustBeAfterStart": "End date must be after start date.",
+        "MaxParticipantsMustBePositive": "Max participants must be greater than zero."
+      },
+      "Engagement": {
+        "MessageRequired": "A message is required when expressing interest via individual contact.",
+        "NotPending": "Only pending engagements can be confirmed.",
+        "AlreadyTerminated": "Engagement is already terminated.",
+        "CheckedIn": "A checked-in engagement can no longer be withdrawn.",
+        "NotTerminated": "Only withdrawn or cancelled engagements can be reactivated.",
+        "NotConfirmed": "Only confirmed engagements can be checked in.",
+        "NotCheckedIn": "Feedback can only be submitted for checked-in engagements.",
+        "FeedbackAlreadySubmitted": "Feedback has already been submitted for this engagement.",
+        "RatingOutOfRange": "Rating must be between 1 and 5.",
+        "CommentTooLong": "Comment must not exceed 500 characters.",
+        "NotFound": "Engagement not found.",
+        "NotOwner": "You can only manage your own engagements.",
+        "AlreadySignedUp": "You are already signed up for this opportunity.",
+        "TimeSlotNotInOpportunity": "The selected time slot does not belong to this opportunity.",
+        "TimeSlotFull": "This time slot has reached its capacity and cannot accept more sign-ups.",
+        "InvalidPin": "Invalid PIN. Please try again.",
+        "CheckInLocked": "Too many failed PIN attempts. Try again later."
+      },
+      "DashboardLayout": {
+        "InvalidWidgetKey": "Unknown widget.",
+        "DuplicateWidget": "A widget is placed more than once.",
+        "InvalidPlacement": "A widget has an invalid grid placement.",
+        "OverlappingPlacement": "Two widgets overlap on the grid."
+      },
+      "FileUpload": {
+        "Empty": "The image must not be empty.",
+        "TooLarge": "The image must not exceed 2 MB.",
+        "InvalidContentType": "The image must be a JPEG, PNG or WebP image."
+      }
     }
   }
 }


### PR DESCRIPTION
getApiErrorMessage() preferred the server's raw ProblemDetails.detail/title (always English) over the caller-supplied, already-localized fallback, so German users saw untranslated backend text (and sometimes a bare error-type prefix like "Conflict"). It now maps the ProblemDetails errorCode extension to an apiError.<errorCode> translation key first, falling back to the caller's string only when no such key exists; raw server detail is logged for debugging but never rendered to the user.

Adds apiError.* keys to en.json/de.json for all ~80 distinct Result-pattern error codes, and a VisualTests regression test covering the check-in wrong-PIN example from the issue.

Fixes #1250