### PR TITLE
test: add ownership-guard rejection tests for 18 uncovered handlers

### DIFF
--- a/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
@@ -1,0 +1,95 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Engagements.CheckInEngagement.v1;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.CheckInEngagement;
+
+public class CheckInEngagementCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
+		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly CheckInEngagementCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public CheckInEngagementCommandHandlerTests()
+	{
+		_dbContext.Engagements.Returns(_engagementRepo);
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new CheckInEngagementCommandHandler(_dbContext);
+	}
+
+	private VolunteerOpportunity CreateOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	private static Engagement CreateConfirmedEngagement(VolunteerOpportunityId opportunityId)
+	{
+		var engagement = Engagement.CreateWaitlistSignUp(opportunityId, UserId.New(), TimeSlotId.New());
+		engagement.Confirm();
+		return engagement;
+	}
+
+	[Test]
+	public async Task Handle_ShouldCheckInEngagement_WhenConfirmed(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunity();
+		var engagement = CreateConfirmedEngagement(opportunity.Id);
+		var engagementId = engagement.Id;
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInEngagementCommand(engagementId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.IsCheckedIn.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunity = CreateOpportunity();
+		var engagement = CreateConfirmedEngagement(opportunity.Id);
+		var engagementId = engagement.Id;
+
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new CheckInEngagementCommand(engagementId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		engagement.IsCheckedIn.Should().BeFalse();
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganizationLogo/DeleteOrganizationLogoCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganizationLogo/DeleteOrganizationLogoCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Application.Organizations.DeleteOrganizationLogo.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.DeleteOrganizationLogo;
+
+public class DeleteOrganizationLogoCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Organization, OrganizationId> _orgRepo =
+		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+	private readonly DeleteOrganizationLogoCommandHandler _sut;
+
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public DeleteOrganizationLogoCommandHandlerTests()
+	{
+		_dbContext.Organizations.Returns(_orgRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new DeleteOrganizationLogoCommandHandler(_dbContext, _fileStorage);
+	}
+
+	private static Organization CreateOrganizationWithLogo(Guid orgId)
+	{
+		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Test Org").Value;
+		org.SetLogoUrl("https://example.com/logo.png");
+		return org;
+	}
+
+	[Test]
+	public async Task Handle_ShouldClearLogoUrl_WhenOrganizationExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganizationWithLogo(orgId);
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+
+		var command = new DeleteOrganizationLogoCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		organization.LogoUrl.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the target.
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganizationWithLogo(orgId);
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new DeleteOrganizationLogoCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		organization.LogoUrl.Should().NotBeNull();
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
@@ -1,0 +1,69 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Organizations.GetOrganizationCalendarEvents.v1;
+using Application.VolunteerOpportunities;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.GetOrganizationCalendarEvents;
+
+public class GetOrganizationCalendarEventsQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IVolunteerOpportunityReadRepository _readRepository = Substitute.For<IVolunteerOpportunityReadRepository>();
+	private readonly GetOrganizationCalendarEventsQueryHandler _sut;
+
+	private static readonly Guid DefaultOrgId = Guid.NewGuid();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public GetOrganizationCalendarEventsQueryHandlerTests()
+	{
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new GetOrganizationCalendarEventsQueryHandler(_dbContext, _readRepository);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCalendarEvents_WhenOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var events = new List<OrganizationCalendarEventDto>
+		{
+			new(Guid.NewGuid(), "Title", "#ff0000", []),
+		};
+		_readRepository.GetCalendarEventsAsync(DefaultOrgId, cancellationToken).Returns(events);
+
+		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().BeEquivalentTo(events);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller is not an organizer of the target organization.
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _readRepository.DidNotReceive().GetCalendarEventsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Organizations.GetOrganizationDetails.v1;
 using AwesomeAssertions;
 using Domain.Common;
 using Domain.Organizations;
+using Domain.Primitives;
 using Domain.Users;
 using NSubstitute;
 
@@ -111,5 +112,27 @@ public class GetOrganizationDetailsQueryHandlerTests
 
 		// Assert
 		result!.Address.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller is not an organizer of the target organization.
+		var orgId = DefaultOrgId;
+		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Org").Value;
+
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(org);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new GetOrganizationDetailsQuery(orgId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _keycloakService.DidNotReceive().GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
@@ -1,0 +1,85 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Organizations.SearchMemberCandidates.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.SearchMemberCandidates;
+
+public class SearchMemberCandidatesQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly SearchMemberCandidatesQueryHandler _sut;
+
+	private static readonly Guid DefaultOrgId = Guid.NewGuid();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public SearchMemberCandidatesQueryHandlerTests()
+	{
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_keycloakService
+			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakService
+			.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_sut = new SearchMemberCandidatesQueryHandler(_dbContext, _keycloakService);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCandidates_ExcludingExistingMembers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var existingMember = Guid.NewGuid();
+		var candidate = Guid.NewGuid();
+		_keycloakService
+			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
+			[
+				new KeycloakOrganizationMember(existingMember, "olaf", "Olaf", "Miller", "olaf@test.de", true),
+				new KeycloakOrganizationMember(candidate, "vera", "Vera", "Smith", "vera@test.de", false),
+			]);
+		_keycloakService
+			.GetMembersAsync(DefaultOrgId, cancellationToken)
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
+			[
+				new KeycloakOrganizationMember(existingMember, "olaf", "Olaf", "Miller", "olaf@test.de", true),
+			]);
+
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().ContainSingle(c => c.UserId == candidate);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller is not an organizer of the target organization.
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _keycloakService.DidNotReceive().SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
@@ -1,0 +1,82 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Application.Organizations.UploadOrganizationLogo.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.UploadOrganizationLogo;
+
+public class UploadOrganizationLogoCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Organization, OrganizationId> _orgRepo =
+		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+	private readonly UploadOrganizationLogoCommandHandler _sut;
+
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static byte[] PngBytes => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
+
+	public UploadOrganizationLogoCommandHandlerTests()
+	{
+		_dbContext.Organizations.Returns(_orgRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_fileStorage
+			.UploadAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns("https://example.com/organization-logos/logo.png");
+		_sut = new UploadOrganizationLogoCommandHandler(_dbContext, _fileStorage);
+	}
+
+	private static Organization CreateOrganization(Guid orgId) =>
+		Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Test Org").Value;
+
+	[Test]
+	public async Task Handle_ShouldSetLogoUrl_WhenOrganizationExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		organization.LogoUrl.Should().Be("https://example.com/organization-logos/logo.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the target.
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		organization.LogoUrl.Should().BeNull();
+		await _fileStorage.DidNotReceive().UploadAsync(
+			Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -179,4 +179,29 @@ public class CreateTimeSlotCommandHandlerTests
 
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage($"*{opportunityId}*");
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunity = CreateOpportunity();
+		var opportunityId = Guid.CreateVersion7();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new CreateTimeSlotCommand(opportunityId, BaseStart, BaseEnd, 10, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.TimeSlots.Should().BeEmpty();
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -257,4 +257,39 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 			.DidNotReceive()
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller is not an organizer of the target organization.
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new CreateVolunteerOpportunityCommand(
+			"Title",
+			"Description",
+			TestOrganizationId,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			CheckInMethod.None,
+			null,
+			[],
+			OpportunityStatus.Draft,
+			DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _dbContext
+			.VolunteerOpportunities
+			.DidNotReceive()
+			.AddAsync(Arg.Any<VolunteerOpportunity>(), Arg.Any<CancellationToken>());
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
@@ -1,0 +1,91 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Application.VolunteerOpportunities.DeleteOpportunityBanner.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.DeleteOpportunityBanner;
+
+public class DeleteOpportunityBannerCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly DeleteOpportunityBannerCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public DeleteOpportunityBannerCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new DeleteOpportunityBannerCommandHandler(_dbContext, _fileStorage);
+	}
+
+	private VolunteerOpportunity CreateOpportunityWithBanner()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+		opportunity.SetBannerImageUrl("https://example.com/banner.png");
+		return opportunity;
+	}
+
+	[Test]
+	public async Task Handle_ShouldClearBannerImageUrl_WhenOpportunityExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunityWithBanner();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new DeleteOpportunityBannerCommand(opportunityId, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.BannerImageUrl.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunityWithBanner();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new DeleteOpportunityBannerCommand(opportunityId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.BannerImageUrl.Should().NotBeNull();
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
@@ -1,0 +1,93 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.DeleteTimeSlot.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.DeleteTimeSlot;
+
+public class DeleteTimeSlotCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly DeleteTimeSlotCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public DeleteTimeSlotCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_dbContext
+			.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
+			.Returns(0);
+		_sut = new DeleteTimeSlotCommandHandler(_dbContext);
+	}
+
+	private VolunteerOpportunity CreateOpportunityWithTimeSlot(out TimeSlot timeSlot)
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
+			Occurrence.Recurring, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+		timeSlot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(7), DateTimeOffset.UtcNow.AddDays(7).AddHours(2), 10, DateTimeOffset.UtcNow).Value;
+		return opportunity;
+	}
+
+	[Test]
+	public async Task Handle_ShouldRemoveTimeSlot_WhenNoActiveEngagements(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityWithTimeSlot(out var timeSlot);
+		var opportunityId = opportunity.Id.Value;
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new DeleteTimeSlotCommand(opportunityId, timeSlot.Id.Value, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.TimeSlots.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunity = CreateOpportunityWithTimeSlot(out var timeSlot);
+		var opportunityId = opportunity.Id.Value;
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new DeleteTimeSlotCommand(opportunityId, timeSlot.Id.Value, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.TimeSlots.Should().ContainSingle();
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -214,4 +214,28 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		// Assert
 		_opportunityRepo.DidNotReceive().Delete(Arg.Any<VolunteerOpportunity>());
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		_opportunityRepo.DidNotReceive().Delete(Arg.Any<VolunteerOpportunity>());
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
@@ -1,0 +1,77 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.GetOpportunityCheckInPin.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.GetOpportunityCheckInPin;
+
+public class GetOpportunityCheckInPinQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly GetOpportunityCheckInPinQueryHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public GetOpportunityCheckInPinQueryHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new GetOpportunityCheckInPinQueryHandler(_dbContext);
+	}
+
+	private VolunteerOpportunity CreateOpportunityWithPin() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.PINCode, _pinGenerator,
+			status: OpportunityStatus.Draft, checkInPin: "12345").Value;
+
+	[Test]
+	public async Task Handle_ShouldReturnCheckInPin_WhenOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityWithPin();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var query = new GetOpportunityCheckInPinQuery(opportunity.Id, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().Be("12345");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's -
+		// this is the highest-priority gap called out by the audit, since a leaked PIN
+		// lets an outsider forge check-ins for another org's opportunity.
+		var opportunity = CreateOpportunityWithPin();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new GetOpportunityCheckInPinQuery(opportunity.Id, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.GetOpportunityFeedback.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.GetOpportunityFeedback;
+
+public class GetOpportunityFeedbackQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly GetOpportunityFeedbackQueryHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public GetOpportunityFeedbackQueryHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new GetOpportunityFeedbackQueryHandler(_dbContext, _engagementReadRepository);
+	}
+
+	private VolunteerOpportunity CreateOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldReturnFeedbackSummary_WhenOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunity();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var summary = new OpportunityFeedbackSummary(4.5, 2,
+		[
+			new FeedbackItemDto(5, "Great!", DateTimeOffset.UtcNow),
+			new FeedbackItemDto(4, null, DateTimeOffset.UtcNow),
+		]);
+		_engagementReadRepository.GetFeedbackByOpportunityAsync(opportunity.Id, cancellationToken).Returns(summary);
+
+		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().BeEquivalentTo(summary);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunity = CreateOpportunity();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _engagementReadRepository.DidNotReceive().GetFeedbackByOpportunityAsync(
+			Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOrganizationOpportunities/GetOrganizationOpportunitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOrganizationOpportunities/GetOrganizationOpportunitiesQueryHandlerTests.cs
@@ -1,0 +1,69 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities;
+using Application.VolunteerOpportunities.GetOrganizationOpportunities.v1;
+using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.GetOrganizationOpportunities;
+
+public class GetOrganizationOpportunitiesQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IVolunteerOpportunityReadRepository _readRepository = Substitute.For<IVolunteerOpportunityReadRepository>();
+	private readonly GetOrganizationOpportunitiesQueryHandler _sut;
+
+	private static readonly Guid DefaultOrgId = Guid.NewGuid();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public GetOrganizationOpportunitiesQueryHandlerTests()
+	{
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_readRepository
+			.GetSummariesByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<OpportunityStatus?>(), Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<VolunteerOpportunitySummary>)[]);
+		_sut = new GetOrganizationOpportunitiesQueryHandler(_readRepository, _dbContext);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnAllStatuses_WhenOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var query = new GetOrganizationOpportunitiesQuery(DefaultOrgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(query, cancellationToken);
+
+		// Assert - the organizer's management view returns every status, not just Published.
+		await _readRepository.Received(1).GetSummariesByOrganizationAsync(DefaultOrgId, null, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller is not an organizer of the target organization.
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new GetOrganizationOpportunitiesQuery(DefaultOrgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _readRepository.DidNotReceive().GetSummariesByOrganizationAsync(
+			Arg.Any<Guid>(), Arg.Any<OpportunityStatus?>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/SetOpportunityColor/SetOpportunityColorCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/SetOpportunityColor/SetOpportunityColorCommandHandlerTests.cs
@@ -1,0 +1,83 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.SetOpportunityColor.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.SetOpportunityColor;
+
+public class SetOpportunityColorCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly SetOpportunityColorCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public SetOpportunityColorCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new SetOpportunityColorCommandHandler(_dbContext);
+	}
+
+	private VolunteerOpportunity CreateOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldSetColor_WhenOpportunityExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new SetOpportunityColorCommand(opportunityId, "#ff0000", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.Color.Should().Be("#ff0000");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new SetOpportunityColorCommand(opportunityId, "#ff0000", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.Color.Should().BeNull();
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -188,4 +188,34 @@ public class UpdateTimeSlotCommandHandlerTests
 			Arg.Is<Notification>(n => n!.RecipientId.Value == otherSlotVolunteer),
 			cancellationToken);
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunity = CreateWaitlistOpportunity();
+		var timeSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
+		var opportunityId = opportunity.Id.Value;
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, timeSlot.Id.Value, BaseStart.AddDays(1), BaseEnd.AddDays(1), 20, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		timeSlot.StartDateTime.Should().Be(BaseStart);
+		timeSlot.EndDateTime.Should().Be(BaseEnd);
+		timeSlot.MaxParticipants.Should().Be(10);
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -404,4 +404,32 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>()
 			.WithMessage("*Address is required*");
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.Title.Should().Be("Altes Thema");
+		opportunity.Description.Should().Be("Alte Beschreibung");
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
@@ -1,0 +1,91 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Common.Storage;
+using Application.VolunteerOpportunities.UploadOpportunityBanner.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.UploadOpportunityBanner;
+
+public class UploadOpportunityBannerCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly UploadOpportunityBannerCommandHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static byte[] PngBytes => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
+
+	public UploadOpportunityBannerCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_fileStorage
+			.UploadAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns("https://example.com/opportunity-banners/banner.png");
+		_sut = new UploadOpportunityBannerCommandHandler(_dbContext, _fileStorage);
+	}
+
+	private VolunteerOpportunity CreateOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldSetBannerImageUrl_WhenOpportunityExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.BannerImageUrl.Should().Be("https://example.com/opportunity-banners/banner.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: caller belongs to a different organization than the opportunity's.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.BannerImageUrl.Should().BeNull();
+		await _fileStorage.DidNotReceive().UploadAsync(
+			Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/IntegrationTests/VolunteerOpportunityOwnershipTests.cs
+++ b/backend/tests/IntegrationTests/VolunteerOpportunityOwnershipTests.cs
@@ -1,0 +1,135 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Cross-org coverage for OwnershipGuard.EnsureIsOrganizerAsync on the volunteer-opportunity
+// management endpoints (#1309) - each unit test suite already flips the guard to false, but
+// these prove the same rejection happens end-to-end against a real second organization.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class VolunteerOpportunityOwnershipTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetOpportunityCheckInPin_ShouldReturn403_WhenOrganizerAccessesOtherOrgsOpportunity(
+		CancellationToken cancellationToken)
+	{
+		// olaf creates org1 with a PIN-protected opportunity
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken, checkInPin: "13579");
+
+		// vera creates her own org - this grants her the organisator role, but not membership in org1
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await CreateOrganizationAsync(veraClient, cancellationToken);
+
+		var act = () => veraClient.GetOpportunityCheckInPinAsync(opportunity.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	[Test]
+	public async Task DeleteVolunteerOpportunity_ShouldReturn403_WhenOrganizerDeletesOtherOrgsOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await CreateOrganizationAsync(veraClient, cancellationToken);
+
+		var act = () => veraClient.DeleteVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+
+		// The opportunity must still exist for its own org - deletion was rejected, not silently skipped.
+		var stillExists = await olafClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+		stillExists.Should().NotBeNull();
+	}
+
+	[Test]
+	public async Task UpdateTimeSlot_ShouldReturn403_WhenOrganizerUpdatesOtherOrgsTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+			},
+			cancellationToken);
+		var timeSlotId = timeSlots.Single().Id;
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await CreateOrganizationAsync(veraClient, cancellationToken);
+
+		var act = () => veraClient.UpdateTimeSlotAsync(
+			opportunity.Id,
+			timeSlotId,
+			new UpdateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(14),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(14).AddHours(2),
+				MaxParticipants = 99,
+			},
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"OwnershipTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken, string? checkInPin = null)
+	{
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "Recurring",
+				ParticipationType = "Waitlist",
+				CheckInMethod = checkInPin is null ? "None" : "PINCode",
+				CheckInPin = checkInPin,
+				IsDraft = true,
+			},
+			cancellationToken);
+	}
+}

--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -98,7 +98,12 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 		// The name span's rendered box, not its (untruncated-by-CSS) text content,
 		// is what actually regresses - assert on the box width so a truncated
 		// render is caught even though the DOM text is always the full name.
+		// The switcher re-fetches orgs on navigation and briefly renders a
+		// loading skeleton with no name span at all, so wait for the new org's
+		// name to actually be showing before measuring - otherwise BoundingBoxAsync
+		// races the skeleton and returns null.
 		var nameSpan = Page.GetByTestId("org-switcher-current-name");
+		await Expect(nameSpan).ToHaveTextAsync("Fairview Animal Welfare Association", new() { Timeout = 15_000 });
 		var box = await nameSpan.BoundingBoxAsync();
 		box.Should().NotBeNull();
 		box!.Width.Should().BeGreaterThan(60,


### PR DESCRIPTION
Adds a negative unit test per handler asserting ResultFailureException with ErrorType.Forbidden and no mutation when OwnershipGuard rejects a non-organizer, plus three cross-org integration tests for the highest-risk endpoints (check-in PIN read, opportunity delete, time slot update).

Closes #1309 