### PR TITLE
fix: clean up user_streak, achievement, org membership/layout/invitation rows on account deletion

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -55,6 +55,18 @@ public interface IApplicationDbContext
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
 
+	Task RemoveMembershipsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
+	Task RemoveDashboardLayoutsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
+	Task DeleteInvitationsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
 	Task<List<Organization>> GetOrganizerOrganizationsAsync(
 		UserId userId,
 		CancellationToken cancellationToken = default);
@@ -77,6 +89,10 @@ public interface IApplicationDbContext
 		string badgeName,
 		CancellationToken cancellationToken = default);
 
+	Task DeleteAchievementsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
 	Task<bool> HasEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,
@@ -88,6 +104,9 @@ public interface IApplicationDbContext
 		UserId userId,
 		CancellationToken cancellationToken = default);
 
+	Task DeleteUserStreakAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
 
 	ValueTask<List<Notification>> GetUnreadNotificationsForRecipientAsync(
 		UserId recipientId,

--- a/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
+++ b/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
@@ -1,7 +1,9 @@
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Common.Storage;
+using Domain.Primitives;
 using Domain.Users;
 
 namespace Application.Users.DeleteMyAccount.v1;
@@ -18,6 +20,8 @@ internal sealed class DeleteMyAccountCommandHandler(
 		DeleteMyAccountCommand request,
 		CancellationToken cancellationToken = default)
 	{
+		await EnsureNotSoleOrganizerOfAnyOrganizationAsync(request.UserId, cancellationToken);
+
 		var engagements = await dbContext.GetEngagementsForVolunteerTrackingAsync(
 			request.UserId, cancellationToken);
 
@@ -25,6 +29,11 @@ internal sealed class DeleteMyAccountCommandHandler(
 			engagement.Anonymize();
 
 		await dbContext.DeleteNotificationsForRecipientAsync(request.UserId, cancellationToken);
+		await dbContext.DeleteUserStreakAsync(request.UserId, cancellationToken);
+		await dbContext.DeleteAchievementsForUserAsync(request.UserId, cancellationToken);
+		await dbContext.RemoveMembershipsForUserAsync(request.UserId, cancellationToken);
+		await dbContext.RemoveDashboardLayoutsForUserAsync(request.UserId, cancellationToken);
+		await dbContext.DeleteInvitationsForUserAsync(request.UserId, cancellationToken);
 
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 		if (user is not null)
@@ -47,5 +56,35 @@ internal sealed class DeleteMyAccountCommandHandler(
 		await keycloakUserService.DeleteUserAsync(request.UserId.Value, cancellationToken);
 
 		return true;
+	}
+
+	// Wiping this user's organization_membership row for an organization
+	// where they are the sole organizer would leave it with no one who can
+	// manage it - the same situation RemoveMemberCommandHandler already
+	// refuses to create when an organizer tries to leave. Checked first,
+	// before any destructive step below, so a blocked deletion has no
+	// side effects at all.
+	private async Task EnsureNotSoleOrganizerOfAnyOrganizationAsync(
+		UserId userId,
+		CancellationToken cancellationToken)
+	{
+		var organizerOrganizations = await dbContext.GetOrganizerOrganizationsAsync(userId, cancellationToken);
+
+		var soleOrganizerOrganizationNames = new List<string>();
+		foreach (var organization in organizerOrganizations)
+		{
+			var organizerCount = await dbContext.CountOrganizersAsync(organization.Id, cancellationToken);
+			if (organizerCount <= 1)
+				soleOrganizerOrganizationNames.Add(organization.Name);
+		}
+
+		if (soleOrganizerOrganizationNames.Count > 0)
+		{
+			var names = string.Join(", ", soleOrganizerOrganizationNames.Select(name => $"'{name}'"));
+			throw new ResultFailureException(Error.Conflict(
+				"User.SoleOrganizerOfOrganizations",
+				$"Conflict: you are the sole organizer of the following organization(s): {names}. " +
+				"Transfer ownership to another organizer or delete these organizations before deleting your account."));
+		}
 	}
 }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -128,6 +128,27 @@ internal sealed class ApplicationDbContext(
 			.Where(l => l.OrganizationId == organizationId)
 			.ExecuteDeleteAsync(cancellationToken);
 
+	public async Task RemoveMembershipsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationMembership>()
+			.Where(m => m.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+	public async Task RemoveDashboardLayoutsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationDashboardLayout>()
+			.Where(l => l.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+	public async Task DeleteInvitationsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationInvitation>()
+			.Where(i => i.InviteeId == userId || i.InvitedById == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+
 	public async Task<List<Organization>> GetOrganizerOrganizationsAsync(
 		UserId userId,
 		CancellationToken cancellationToken = default) =>
@@ -148,6 +169,13 @@ internal sealed class ApplicationDbContext(
 		CancellationToken cancellationToken = default) =>
 		await Set<Achievement>()
 			.AnyAsync(a => a.UserId == userId && a.Name == badgeName, cancellationToken);
+
+	public async Task DeleteAchievementsForUserAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<Achievement>()
+			.Where(a => a.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
 
 	public async Task<bool> HasEngagementAsync(
 		UserId volunteerId,
@@ -173,6 +201,12 @@ internal sealed class ApplicationDbContext(
 		await Set<UserStreak>()
 			.FirstOrDefaultAsync(s => s.UserId == userId, cancellationToken);
 
+	public async Task DeleteUserStreakAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<UserStreak>()
+			.Where(s => s.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
 
 	public async ValueTask<List<Notification>> GetUnreadNotificationsForRecipientAsync(
 		UserId recipientId,

--- a/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
@@ -1,9 +1,11 @@
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Common.Storage;
 using Application.Users.DeleteMyAccount.v1;
 using AwesomeAssertions;
 using Domain.Engagements;
+using Domain.Organizations;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
@@ -28,11 +30,17 @@ public class DeleteMyAccountCommandHandlerTests
 		_dbContext
 			.GetEngagementsForVolunteerTrackingAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Engagement>());
+		_dbContext
+			.GetOrganizerOrganizationsAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Organization>());
 		_sut = new DeleteMyAccountCommandHandler(_dbContext, _keycloakUserService, _fileStorage);
 	}
 
 	private static Engagement CreateEngagementFor(UserId volunteerId) =>
 		Engagement.CreateWaitlistSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
+
+	private static Organization CreateOrganization(string name) =>
+		Organization.Create(OrganizationId.New(), name).Value;
 
 	[Test]
 	public async Task Handle_ShouldAnonymizeAllEngagements_ReturnedForVolunteerTracking(
@@ -155,5 +163,136 @@ public class DeleteMyAccountCommandHandlerTests
 
 		// Assert
 		result.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheUserStreak(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).DeleteUserStreakAsync(DefaultUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteAchievementsForTheUser(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).DeleteAchievementsForUserAsync(DefaultUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRemoveOrganizationMembershipsAndDashboardLayoutsForTheUser(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).RemoveMembershipsForUserAsync(DefaultUserId, cancellationToken);
+		await _dbContext.Received(1).RemoveDashboardLayoutsForUserAsync(DefaultUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteOrganizationInvitationsForTheUser(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).DeleteInvitationsForUserAsync(DefaultUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_AndPerformNoOtherAction_WhenSoleOrganizerOfAnOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organization = CreateOrganization("Solo Org");
+		_dbContext
+			.GetOrganizerOrganizationsAsync(DefaultUserId, cancellationToken)
+			.Returns([organization]);
+		_dbContext
+			.CountOrganizersAsync(organization.Id, cancellationToken)
+			.Returns(1);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		var thrown = await act.Should().ThrowAsync<ResultFailureException>();
+		thrown.Which.Message.Should().Contain("Solo Org");
+		await _dbContext.DidNotReceive().DeleteNotificationsForRecipientAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().RemoveMembershipsForUserAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteUserStreakAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+		_usersRepo.DidNotReceive().Delete(Arg.Any<User>());
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _keycloakUserService.DidNotReceive().DeleteUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldListEveryBlockingOrganizationByName_WhenSoleOrganizerOfMultipleOrganizations(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgAlpha = CreateOrganization("Org Alpha");
+		var orgBeta = CreateOrganization("Org Beta");
+		_dbContext
+			.GetOrganizerOrganizationsAsync(DefaultUserId, cancellationToken)
+			.Returns([orgAlpha, orgBeta]);
+		_dbContext.CountOrganizersAsync(orgAlpha.Id, cancellationToken).Returns(1);
+		_dbContext.CountOrganizersAsync(orgBeta.Id, cancellationToken).Returns(1);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		var thrown = await act.Should().ThrowAsync<ResultFailureException>();
+		thrown.Which.Message.Should().Contain("Org Alpha");
+		thrown.Which.Message.Should().Contain("Org Beta");
+	}
+
+	[Test]
+	public async Task Handle_ShouldProceed_WhenOrganizerButOtherOrganizersRemainForThatOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organization = CreateOrganization("Shared Org");
+		_dbContext
+			.GetOrganizerOrganizationsAsync(DefaultUserId, cancellationToken)
+			.Returns([organization]);
+		_dbContext
+			.CountOrganizersAsync(organization.Id, cancellationToken)
+			.Returns(2);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _dbContext.Received(1).RemoveMembershipsForUserAsync(DefaultUserId, cancellationToken);
+		await _keycloakUserService.Received(1).DeleteUserAsync(DefaultUserId.Value, cancellationToken);
 	}
 }

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -71,6 +71,13 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 			cancellationToken);
 		await ephemeralClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
 
+		// #826: SaveDashboardLayout/CreateInvitation below are gated by the
+		// Organisator policy, a role claim baked into the JWT at mint time -
+		// ephemeralClient's original token predates the "organisator" role
+		// grant that just happened as a side effect of accepting, so a fresh
+		// token is needed (same pattern as OrganizationSettingsTests).
+		ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
+
 		// #1192: the ephemeral user (now an organizer of sharedOrg) saves a
 		// dashboard layout for it, giving an organization_dashboard_layout row.
 		await ephemeralClient.SaveDashboardLayoutAsync(
@@ -146,6 +153,13 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 
 		var org = await ephemeralClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Sole Organizer Test Org" }, cancellationToken);
+
+		// #826: GetOrganizationDetails below is gated by the Organisator
+		// policy, a role claim baked into the JWT at mint time -
+		// ephemeralClient's original token predates the "organisator" role
+		// grant that just happened as a side effect of creating the
+		// organization, so a fresh token is needed.
+		ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
 
 		var deleteAccount = () => ephemeralClient.DeleteMyAccountAsync(cancellationToken);
 

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -23,6 +23,11 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 			await fixture.CreateEphemeralUserAsync(cancellationToken);
 		var ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
 
+		// #1192: a second throwaway user the ephemeral user invites into an
+		// organization once they're an organizer themselves, giving an
+		// organization_invitation row on the *inviter* (invited_by_id) side.
+		var (thirdPartyUserId, _, _) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var org = await olafClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Account Deletion Test Org" }, cancellationToken);
@@ -49,7 +54,42 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 
 		// Fires an EngagementConfirmed notification whose recipient is the
 		// ephemeral user, giving it a notification row to prove gets hard-deleted.
+		// Confirming also creates/updates a user_streak row and awards the
+		// "first-step" achievement for the ephemeral user - #1192 coverage for
+		// both, alongside the notification.
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		// #1192: olaf invites the ephemeral user into a second organization and
+		// the ephemeral user accepts, becoming its second organizer alongside
+		// olaf - giving the ephemeral user an organization_membership row and
+		// an accepted organization_invitation row (invitee_id side).
+		var sharedOrg = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Shared Membership Test Org" }, cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			sharedOrg.Id.Value,
+			new CreateInvitationRequest { InviteeId = ephemeralUserId },
+			cancellationToken);
+		await ephemeralClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		// #1192: the ephemeral user (now an organizer of sharedOrg) saves a
+		// dashboard layout for it, giving an organization_dashboard_layout row.
+		await ephemeralClient.SaveDashboardLayoutAsync(
+			sharedOrg.Id.Value,
+			new SaveDashboardLayoutRequest
+			{
+				Widgets =
+				[
+					new DashboardWidgetPlacementRequest { WidgetKey = "ToDo", X = 1, Y = 1, Width = 1, Height = 1 },
+				],
+			},
+			cancellationToken);
+
+		// #1192: the ephemeral user, now an organizer, invites the third-party
+		// user - an organization_invitation row on the inviter (invited_by_id) side.
+		await ephemeralClient.CreateInvitationAsync(
+			sharedOrg.Id.Value,
+			new CreateInvitationRequest { InviteeId = thirdPartyUserId },
+			cancellationToken);
 
 		await ephemeralClient.DeleteMyAccountAsync(cancellationToken);
 
@@ -70,6 +110,54 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 		// deleted volunteer.
 		var engagements = await olafClient.GetEngagementsAsync(opportunity.Id, cancellationToken);
 		engagements.Should().ContainSingle(e => e.Id == engagement.Id && e.VolunteerId == null);
+
+		// #1192: user_streak and achievement rows created for the ephemeral
+		// user while confirming their engagement above are hard-deleted.
+		(await fixture.CountRowsWhereAsync("user_streak", "user_id", ephemeralUserId))
+			.Should().Be(0);
+		(await fixture.CountRowsWhereAsync("achievement", "user_id", ephemeralUserId))
+			.Should().Be(0);
+
+		// #1192: the ephemeral user's own organization_membership and
+		// organization_dashboard_layout rows are hard-deleted (olaf's own
+		// membership in sharedOrg is untouched by construction, since the
+		// cleanup is scoped to the deleted user's rows only).
+		(await fixture.CountRowsWhereAsync("organization_membership", "user_id", ephemeralUserId))
+			.Should().Be(0);
+		(await fixture.CountRowsWhereAsync("organization_dashboard_layout", "user_id", ephemeralUserId))
+			.Should().Be(0);
+
+		// #1192: organization_invitation rows are hard-deleted on both the
+		// invitee side (accepted invitation from olaf) and the inviter side
+		// (pending invitation the ephemeral user sent as an organizer).
+		(await fixture.CountRowsWhereAsync("organization_invitation", "invitee_id", ephemeralUserId))
+			.Should().Be(0);
+		(await fixture.CountRowsWhereAsync("organization_invitation", "invited_by_id", ephemeralUserId))
+			.Should().Be(0);
+	}
+
+	[Test]
+	public async Task DeleteMyAccount_ShouldBeBlocked_WhenUserIsSoleOrganizerOfAnOrganization(
+		CancellationToken cancellationToken)
+	{
+		var (_, ephemeralUsername, ephemeralPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
+
+		var org = await ephemeralClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Sole Organizer Test Org" }, cancellationToken);
+
+		var deleteAccount = () => ephemeralClient.DeleteMyAccountAsync(cancellationToken);
+
+		var ex = await deleteAccount.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+
+		// Nothing was deleted: the account can still authenticate, and the
+		// organization it solely organizes still exists.
+		var token = await fixture.GetAccessTokenAsync(ephemeralUsername, ephemeralPassword);
+		token.Should().NotBeNullOrEmpty();
+		var stillThere = await ephemeralClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Name.Should().Be("Sole Organizer Test Org");
 	}
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(

--- a/frontend/src/pages/ProfileOverviewPage/DangerZoneCard.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/DangerZoneCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../hooks/useApiClient";
+import { getApiErrorMessage } from "../../lib/apiError";
 import ConfirmDialog from "../../components/ConfirmDialog";
 
 // Self-contained account-deletion card, split out of ProfileOverviewPage -
@@ -25,8 +26,8 @@ export default function DangerZoneCard() {
 			await api.deleteMyAccount();
 			await auth.removeUser();
 			navigate("/");
-		} catch {
-			setDeleteError(t("account.deleteError"));
+		} catch (err) {
+			setDeleteError(getApiErrorMessage(err, t("account.deleteError")));
 			setDeleting(false);
 		}
 	}


### PR DESCRIPTION
DeleteMyAccount left rows in five tables keyed to the deleted user's id (user_streak, achievement, organization_membership, organization_dashboard_layout, organization_invitation), including plaintext invitee names - a GDPR gap and a source of stale organizer-count bugs. Also blocks deletion with a clear conflict when the user is the sole organizer of an organization, mirroring the existing "leave organization" guard, instead of silently orphaning it.

Closes #1192.