### PR TITLE
feat: add Grafana, Prometheus, and Loki monitoring stack to staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,14 @@
 # to the host on each RC deploy - you do not place this file by hand.
 # Required secrets in the `staging` GitHub Environment:
 #   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD,
-#   MINIO_ROOT_USER, MINIO_ROOT_PASSWORD
+#   MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, GRAFANA_ADMIN_PASSWORD (GRAFANA_ADMIN_USER optional)
 # (Plus deploy creds: STAGING_SSH_KEY/HOST/USER, GHCR_USERNAME, GHCR_TOKEN.)
 #
 # Traefik runs as a separate host-level container (shared across projects on
 # the same Hetzner box) - its ACME and dashboard auth secrets live with that
-# stack, not here.
+# stack, not here. Grafana is routed the same way at grafana.maik-hasler.de,
+# so that DNS record has to exist and point at the staging host before the
+# route resolves, same as the other *.maik-hasler.de subdomains below.
 
 # PostgreSQL credentials. Used by Postgres, Keycloak, and the backend.
 POSTGRES_USER=postgres
@@ -21,3 +23,7 @@ KEYCLOAK_ADMIN_PASSWORD=change-me
 # MinIO root credentials. Used by MinIO and the backend's Storage__AccessKey/SecretKey.
 MINIO_ROOT_USER=change-me
 MINIO_ROOT_PASSWORD=change-me
+
+# Grafana admin login. GRAFANA_ADMIN_USER defaults to "admin" if unset.
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me

--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,11 @@ MINIO_ROOT_USER=change-me
 MINIO_ROOT_PASSWORD=change-me
 
 # Grafana admin login. GRAFANA_ADMIN_USER defaults to "admin" if unset.
+# These only apply the FIRST time Grafana boots against an empty
+# grafana_data volume - this is Grafana's own documented behavior, not
+# something this repo controls. Changing GRAFANA_ADMIN_PASSWORD after that
+# has no effect on the live account; recover via
+# `.github/workflows/reset-staging.yml` (wipes grafana_data along with
+# Postgres/MinIO) if you ever need to change it post-bootstrap.
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-me

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -450,6 +450,24 @@ jobs:
               img="ghcr.io/maik-hasler/einsatzbereit-${svc}"
               docker tag "${img}:staging" "${img}:staging-previous" 2>/dev/null || true
             done
+            # One-time remediation for the first Grafana rollout: Grafana only
+            # applies GF_SECURITY_ADMIN_USER/PASSWORD on a completely empty
+            # data volume, and it already bootstrapped once (with whatever
+            # secret value existed at the time) during the initial deploy
+            # attempt that later failed on an unrelated loki healthcheck bug.
+            # A changed GRAFANA_ADMIN_PASSWORD since then silently doesn't
+            # take effect. Wipe just the grafana volume, once, guarded by a
+            # marker file so this never repeats and never touches
+            # Postgres/MinIO. Remove this block entirely once confirmed fixed
+            # - it is not meant to be a permanent step (it would wipe
+            # dashboards on every future deploy otherwise).
+            if [ ! -f .grafana-admin-bootstrap-reset-done ]; then
+              echo "One-time: resetting grafana_data so admin credentials re-bootstrap from current secrets..."
+              docker compose stop grafana 2>/dev/null || true
+              docker compose rm -f grafana 2>/dev/null || true
+              docker volume rm einsatzbereit_grafana_data 2>/dev/null || true
+              touch .grafana-admin-bootstrap-reset-done
+            fi
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune --force || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -344,6 +344,8 @@ jobs:
           KEYCLOAK_BACKEND_SECRET: ${{ secrets.KEYCLOAK_BACKEND_SECRET }}
           MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
           MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+          GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
         run: |
           umask 077
           # Wrap each value in double quotes and escape \ and " so secrets that
@@ -363,6 +365,8 @@ jobs:
             printf 'KEYCLOAK_BACKEND_SECRET="%s"\n' "$(escape "$KEYCLOAK_BACKEND_SECRET")"
             printf 'MINIO_ROOT_USER="%s"\n' "$(escape "$MINIO_ROOT_USER")"
             printf 'MINIO_ROOT_PASSWORD="%s"\n' "$(escape "$MINIO_ROOT_PASSWORD")"
+            printf 'GRAFANA_ADMIN_USER="%s"\n' "$(escape "$GRAFANA_ADMIN_USER")"
+            printf 'GRAFANA_ADMIN_PASSWORD="%s"\n' "$(escape "$GRAFANA_ADMIN_PASSWORD")"
           } > .env
 
       - name: Copy compose file and .env

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -450,24 +450,6 @@ jobs:
               img="ghcr.io/maik-hasler/einsatzbereit-${svc}"
               docker tag "${img}:staging" "${img}:staging-previous" 2>/dev/null || true
             done
-            # One-time remediation for the first Grafana rollout: Grafana only
-            # applies GF_SECURITY_ADMIN_USER/PASSWORD on a completely empty
-            # data volume, and it already bootstrapped once (with whatever
-            # secret value existed at the time) during the initial deploy
-            # attempt that later failed on an unrelated loki healthcheck bug.
-            # A changed GRAFANA_ADMIN_PASSWORD since then silently doesn't
-            # take effect. Wipe just the grafana volume, once, guarded by a
-            # marker file so this never repeats and never touches
-            # Postgres/MinIO. Remove this block entirely once confirmed fixed
-            # - it is not meant to be a permanent step (it would wipe
-            # dashboards on every future deploy otherwise).
-            if [ ! -f .grafana-admin-bootstrap-reset-done ]; then
-              echo "One-time: resetting grafana_data so admin credentials re-bootstrap from current secrets..."
-              docker compose stop grafana 2>/dev/null || true
-              docker compose rm -f grafana 2>/dev/null || true
-              docker volume rm einsatzbereit_grafana_data 2>/dev/null || true
-              touch .grafana-admin-bootstrap-reset-done
-            fi
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune --force || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -466,7 +466,7 @@ jobs:
           ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
             set +e
             cd /opt/einsatzbereit
-            for svc in backend keycloak postgres; do
+            for svc in backend keycloak postgres prometheus node-exporter grafana loki alloy; do
               echo "::group::docker inspect ${svc} (state)"
               docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Health={{if .State.Health}}{{.State.Health.Status}}{{end}}' "${svc}" 2>&1 || true
               echo "::endgroup::"

--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -45,10 +45,14 @@ jobs:
 
             # postgres_data holds both the "einsatzbereit" and "keycloak" databases
             # (single Postgres instance, see docker-compose.yml). minio_data holds
-            # uploaded files. postgres_backups is deliberately NOT removed - it is
+            # uploaded files. grafana_data holds Grafana's own admin account -
+            # GF_SECURITY_ADMIN_USER/PASSWORD only apply on a completely empty
+            # volume, so it has to be wiped here too or a changed
+            # GRAFANA_ADMIN_PASSWORD secret silently stops matching the live
+            # account. postgres_backups is deliberately NOT removed - it is
             # the safety net if this reset needs to be walked back.
-            echo "Removing data volumes (postgres_data, minio_data)..."
-            docker volume rm einsatzbereit_postgres_data einsatzbereit_minio_data
+            echo "Removing data volumes (postgres_data, minio_data, grafana_data)..."
+            docker volume rm einsatzbereit_postgres_data einsatzbereit_minio_data einsatzbereit_grafana_data
 
             # No `docker compose pull` here on purpose: we restart with whatever
             # images are already cached locally, i.e. the exact same tags/versions
@@ -79,7 +83,7 @@ jobs:
           ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
             set +e
             cd /opt/einsatzbereit
-            for svc in backend keycloak postgres minio; do
+            for svc in backend keycloak postgres minio grafana; do
               echo "::group::docker inspect ${svc} (state)"
               docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Health={{if .State.Health}}{{.State.Health.Status}}{{end}}' "${svc}" 2>&1 || true
               echo "::endgroup::"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,20 +222,137 @@ services:
       - traefik.http.routers.frontend.tls.certresolver=myresolver
       - traefik.http.services.frontend.loadbalancer.server.port=80
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    volumes:
+      - prometheus_data:/prometheus
+    configs:
+      - source: prometheus-config
+        target: /etc/prometheus/prometheus.yml
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:9090/-/healthy || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # Host-level metrics only (CPU/memory/disk/network), read-only mounts, no
+  # privileged mode. Deliberately not pairing this with cAdvisor for
+  # per-container metrics - cAdvisor needs the Docker socket and broad host
+  # access, which is too invasive for a box shared with other projects.
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 64m
+          cpus: "0.10"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/rootfs
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    networks:
+      - proxy
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env}
+      GF_SERVER_ROOT_URL: https://grafana.maik-hasler.de
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    configs:
+      - source: grafana-datasources
+        target: /etc/grafana/provisioning/datasources/prometheus.yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.grafana.rule=Host(`grafana.maik-hasler.de`)
+      - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.http.routers.grafana.tls=true
+      - traefik.http.routers.grafana.tls.certresolver=myresolver
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+
 networks:
   proxy:
     name: proxy
     external: true
   db:
     name: einsatzbereit-db
+  monitoring:
+    name: einsatzbereit-monitoring
 
 volumes:
   postgres_data:
   postgres_backups:
   minio_data:
+  prometheus_data:
+  grafana_data:
 
 configs:
   postgres-init:
     content: |
       SELECT 'CREATE DATABASE einsatzbereit' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'einsatzbereit')\gexec
       SELECT 'CREATE DATABASE keycloak' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'keycloak')\gexec
+  prometheus-config:
+    content: |
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+
+      scrape_configs:
+        - job_name: prometheus
+          static_configs:
+            - targets: ["localhost:9090"]
+
+        - job_name: node-exporter
+          static_configs:
+            - targets: ["node-exporter:9100"]
+  grafana-datasources:
+    content: |
+      apiVersion: 1
+
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          url: http://prometheus:9090
+          isDefault: true
+          editable: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,6 +310,59 @@ services:
       - traefik.http.routers.grafana.tls.certresolver=myresolver
       - traefik.http.services.grafana.loadbalancer.server.port=3000
 
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    volumes:
+      - loki_data:/loki
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # Ships container logs to Loki. Uses the Docker API (read-only socket mount)
+  # to discover containers and stream their logs, rather than tailing
+  # /var/lib/docker/containers directly - this is the standard, well-tested
+  # pattern Grafana documents for Alloy/Promtail + Docker. This is a narrower
+  # grant than cAdvisor's (list containers + read their logs, not full host
+  # filesystem + cgroup access), but a leaked docker.sock is still
+  # effectively host-level access - worth knowing, not a reason to avoid it
+  # for a single-purpose, Grafana-maintained log shipper.
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.15"
+    depends_on:
+      loki:
+        condition: service_healthy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alloy_data:/var/lib/alloy/data
+    configs:
+      - source: alloy-config
+        target: /etc/alloy/config.alloy
+    command:
+      - run
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+
 networks:
   proxy:
     name: proxy
@@ -325,6 +378,8 @@ volumes:
   minio_data:
   prometheus_data:
   grafana_data:
+  loki_data:
+  alloy_data:
 
 configs:
   postgres-init:
@@ -356,3 +411,37 @@ configs:
           url: http://prometheus:9090
           isDefault: true
           editable: false
+        - name: Loki
+          type: loki
+          access: proxy
+          url: http://loki:3100
+          editable: false
+  alloy-config:
+    content: |
+      discovery.docker "containers" {
+        host = "unix:///var/run/docker.sock"
+      }
+
+      discovery.relabel "containers" {
+        targets = discovery.docker.containers.targets
+
+        rule {
+          source_labels = ["__meta_docker_container_name"]
+          regex         = "/(.*)"
+          target_label  = "container"
+        }
+      }
+
+      loki.source.docker "default" {
+        host          = "unix:///var/run/docker.sock"
+        targets       = discovery.docker.containers.targets
+        labels        = {"job" = "docker"}
+        relabel_rules = discovery.relabel.containers.rules
+        forward_to    = [loki.write.default.receiver]
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki:3100/loki/api/v1/push"
+        }
+      }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,10 +228,13 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    # Only 2 scrape targets (itself + node-exporter), so a low ceiling is
+    # plenty - trimmed down from 256m to leave more host headroom on a
+    # memory-constrained box (staging runs on a 4GB VM).
     deploy:
       resources:
         limits:
-          memory: 256m
+          memory: 128m
           cpus: "0.25"
     volumes:
       - prometheus_data:/prometheus
@@ -258,7 +261,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 64m
+          memory: 32m
           cpus: "0.10"
     volumes:
       - /proc:/host/proc:ro
@@ -316,10 +319,14 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    # Now scoped to just this stack's own ~6 containers (see alloy's
+    # discovery filter below), so log volume is small - trimmed down from
+    # 256m to leave more host headroom on a memory-constrained box
+    # (staging runs on a 4GB VM).
     deploy:
       resources:
         limits:
-          memory: 256m
+          memory: 160m
           cpus: "0.25"
     volumes:
       - loki_data:/loki
@@ -347,7 +354,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128m
+          memory: 96m
           cpus: "0.15"
     # Plain depends_on (wait for container start, not health): Alloy's Loki
     # writer retries and buffers on its own, so it doesn't need Loki to be

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,8 +323,15 @@ services:
           cpus: "0.25"
     volumes:
       - loki_data:/loki
+    # Exec-form CMD (not CMD-SHELL) so this doesn't also depend on a shell
+    # existing in the image - only on wget, which is what actually mattered
+    # here (see the deploy failure this fixed: alloy's hard `service_healthy`
+    # dependency on this healthcheck took the whole app deploy down with it
+    # when the check itself turned out to be wrong, not Loki). Nothing gates
+    # on this anymore (see alloy's depends_on below), so a wrong guess here
+    # is now cosmetic (shows "unhealthy" in `docker ps`), not deploy-blocking.
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3100/ready || exit 1"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3100/ready"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -349,9 +356,13 @@ services:
         limits:
           memory: 128m
           cpus: "0.15"
+    # Plain depends_on (wait for container start, not health): Alloy's Loki
+    # writer retries and buffers on its own, so it doesn't need Loki to be
+    # fully ready first. Deliberately not `condition: service_healthy` -
+    # observability's own startup issues should never be able to block or
+    # roll back the application deploy the way this one did.
     depends_on:
-      loki:
-        condition: service_healthy
+      - loki
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - alloy_data:/var/lib/alloy/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,19 +323,12 @@ services:
           cpus: "0.25"
     volumes:
       - loki_data:/loki
-    # Exec-form CMD (not CMD-SHELL) so this doesn't also depend on a shell
-    # existing in the image - only on wget, which is what actually mattered
-    # here (see the deploy failure this fixed: alloy's hard `service_healthy`
-    # dependency on this healthcheck took the whole app deploy down with it
-    # when the check itself turned out to be wrong, not Loki). Nothing gates
-    # on this anymore (see alloy's depends_on below), so a wrong guess here
-    # is now cosmetic (shows "unhealthy" in `docker ps`), not deploy-blocking.
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3100/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 15s
+    # No Docker healthcheck: confirmed on staging that grafana/loki has
+    # neither wget nor a shell, so CMD-SHELL and exec-form CMD wget both
+    # fail regardless of whether Loki itself is fine - `docker ps` showed
+    # "unhealthy" even while Loki's own logs proved it was serving queries
+    # successfully. Nothing depends on this healthcheck (see alloy's
+    # depends_on below), so leaving it out is honest instead of misleading.
 
   # Ships container logs to Loki. Uses the Docker API (read-only socket mount)
   # to discover containers and stream their logs, rather than tailing
@@ -435,6 +428,21 @@ configs:
 
       discovery.relabel "containers" {
         targets = discovery.docker.containers.targets
+
+        # This host runs other projects behind the same shared Traefik
+        # (see this file's top comment) - without this filter Alloy
+        # discovers every container on the box, not just this stack's,
+        # and tries to ship their logs too. Besides leaking unrelated
+        # projects' log data into this stack's Loki, a long-running
+        # container discovered for the first time gets its full log
+        # backlog tailed, which Loki correctly rejects as "too old" and
+        # drops the whole batch over - taking this stack's own log lines
+        # down with it.
+        rule {
+          source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+          regex         = "einsatzbereit"
+          action        = "keep"
+        }
 
         rule {
           source_labels = ["__meta_docker_container_name"]

--- a/docs/Architecture/images/deployment-staging.puml
+++ b/docs/Architecture/images/deployment-staging.puml
@@ -33,16 +33,31 @@ Deployment_Node(host, "Staging Host (VM)", "Docker Compose") {
 	Deployment_Node(bk_node, "db-backup", "postgres-backup-local:18") {
 		Container(bk, "Daily backups", "retention 7d / 4w / 6m")
 	}
+
+	Deployment_Node(gf_node, "grafana", "grafana/grafana") {
+		Container(gf, "Dashboards", "Grafana", "grafana.maik-hasler.de")
+	}
+
+	Deployment_Node(pr_node, "prometheus", "prom/prometheus") {
+		Container(pr, "Metrics store", "Prometheus", "internal only")
+	}
+
+	Deployment_Node(ne_node, "node-exporter", "prom/node-exporter") {
+		Container(ne, "Host metrics", "node_exporter", "internal only")
+	}
 }
 
 Rel(traefik, fe, "HTTPS")
 Rel(traefik, be, "HTTPS")
 Rel(traefik, kc, "HTTPS")
 Rel(traefik, mo, "HTTPS")
+Rel(traefik, gf, "HTTPS")
 Rel(be, pg, "SQL / EF Core")
 Rel(be, kc, "JWKS + Admin API")
 Rel(be, mo, "S3 API")
 Rel(kc, pg, "Realm data")
 Rel(bk, pg, "pg_dump")
+Rel(gf, pr, "PromQL queries")
+Rel(pr, ne, "scrape /metrics")
 
 @enduml

--- a/docs/Architecture/images/deployment-staging.puml
+++ b/docs/Architecture/images/deployment-staging.puml
@@ -45,6 +45,14 @@ Deployment_Node(host, "Staging Host (VM)", "Docker Compose") {
 	Deployment_Node(ne_node, "node-exporter", "prom/node-exporter") {
 		Container(ne, "Host metrics", "node_exporter", "internal only")
 	}
+
+	Deployment_Node(lo_node, "loki", "grafana/loki") {
+		Container(lo, "Log store", "Loki", "internal only")
+	}
+
+	Deployment_Node(al_node, "alloy", "grafana/alloy") {
+		Container(al, "Log shipper", "Grafana Alloy", "internal only")
+	}
 }
 
 Rel(traefik, fe, "HTTPS")
@@ -58,6 +66,8 @@ Rel(be, mo, "S3 API")
 Rel(kc, pg, "Realm data")
 Rel(bk, pg, "pg_dump")
 Rel(gf, pr, "PromQL queries")
+Rel(gf, lo, "LogQL queries")
 Rel(pr, ne, "scrape /metrics")
+Rel(al, lo, "push logs")
 
 @enduml

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -158,7 +158,7 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Grafana
 |`grafana/grafana`
 |`grafana.maik-hasler.de`
-|Dashboards; only datasource is Prometheus
+|Dashboards; datasources are Prometheus (metrics) and Loki (logs)
 
 |Prometheus
 |`prom/prometheus`
@@ -170,6 +170,16 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |internal only
 |Host-level CPU/memory/disk/network metrics, read-only mounts, no privileged mode
 
+|Loki
+|`grafana/loki`
+|internal only
+|Log store; receives pushes from Alloy, not exposed via Traefik
+
+|Alloy
+|`grafana/alloy`
+|internal only
+|Ships container logs to Loki; discovers containers via a read-only Docker socket mount
+
 |Traefik
 |host-level (shared)
 |`*.maik-hasler.de`
@@ -178,4 +188,4 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 
 Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`). The deploy is health-gated (backend `/alive` and `/health`) and rolls back to the previous images on failure.
 
-Prometheus and node-exporter are metrics only, not logs - they sit on an internal-only `monitoring` Docker network with no Traefik route, since Prometheus has no built-in auth and would leak all scraped labels if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`). Centralized log aggregation (a Loki + Promtail stack) and per-container metrics (cAdvisor, which needs Docker socket access and broad host mounts) were deliberately left out of this pass; both are natural follow-ups if the host-level view here proves insufficient.
+Prometheus, node-exporter, and Loki sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics or log content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads both Prometheus (metrics) and Loki (logs) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient.

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -155,6 +155,21 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |`storage.maik-hasler.de`
 |S3-compatible object storage
 
+|Grafana
+|`grafana/grafana`
+|`grafana.maik-hasler.de`
+|Dashboards; only datasource is Prometheus
+
+|Prometheus
+|`prom/prometheus`
+|internal only
+|Metrics store; scrapes node-exporter, not exposed via Traefik
+
+|node-exporter
+|`prom/node-exporter`
+|internal only
+|Host-level CPU/memory/disk/network metrics, read-only mounts, no privileged mode
+
 |Traefik
 |host-level (shared)
 |`*.maik-hasler.de`
@@ -162,3 +177,5 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |===
 
 Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`). The deploy is health-gated (backend `/alive` and `/health`) and rolls back to the previous images on failure.
+
+Prometheus and node-exporter are metrics only, not logs - they sit on an internal-only `monitoring` Docker network with no Traefik route, since Prometheus has no built-in auth and would leak all scraped labels if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`). Centralized log aggregation (a Loki + Promtail stack) and per-container metrics (cAdvisor, which needs Docker socket access and broad host mounts) were deliberately left out of this pass; both are natural follow-ups if the host-level view here proves insufficient.


### PR DESCRIPTION
## Summary

- Adds a monitoring stack to `docker-compose.yml` for staging:
  - **Prometheus** + **node-exporter** - host-level metrics (CPU/memory/disk/network).
  - **Loki** + **Grafana Alloy** - log aggregation. Alloy discovers containers via a read-only Docker socket mount and ships their logs to Loki.
  - **Grafana** - the dashboard on top, provisioned on startup with both Prometheus and Loki as datasources (no manual click-through needed after deploy).
- Grafana is routed publicly via Traefik at `grafana.maik-hasler.de`, gated by its own admin login. Prometheus, node-exporter, and Loki sit on a new internal-only `monitoring` Docker network with no Traefik route - none of them has built-in auth, so exposing them would leak scraped metrics/log content to the internet.
- Wires the new `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD` secrets through `deploy-staging`'s "Render .env" step, and documents them in `.env.example`.
- Updates the arc42 deployment view (`docs/Architecture/images/deployment-staging.puml` + `07_deployment_view.adoc`) with all five new nodes.

### Scope decisions (see PR discussion for the "why")

- **Not adding cAdvisor** (per-container CPU/memory breakdown). It needs Docker socket access *and* broad host filesystem/cgroup mounts, which is more invasive than warranted for a first pass on a host shared with other projects. node-exporter alone covers "is the host healthy."
- **Alloy does use a read-only Docker socket mount** to discover containers and stream logs - the standard, well-documented pattern for Docker-aware log shippers. This is a narrower grant than cAdvisor's (list containers + read logs, not full host access), but worth being explicit about: a compromised container with socket access still has effective host-level reach. Documented in `07_deployment_view.adoc`.
- **No app-level metrics/logs yet** (structured request logs or metrics instrumentation from the .NET backend itself, beyond its existing stdout going through Alloy). That would need `prometheus-net`/OpenTelemetry work in the backend - a separate, bigger change.

## Required setup

1. **GitHub Environment secret** (`staging` environment): `GRAFANA_ADMIN_PASSWORD` (required). `GRAFANA_ADMIN_USER` optional, defaults to `admin`. *(Confirmed done by repo owner.)*
2. **DNS**: `grafana.maik-hasler.de` pointing at the staging host, same as the other `*.maik-hasler.de` subdomains. *(Confirmed done by repo owner.)*

No new secrets needed for Loki/Alloy - neither takes credentials.

## Test plan

- [x] `docker compose config` validated locally against a dummy `.env` (all required vars) after each change - no interpolation or schema errors.
- [x] No tabs introduced in `.yml` files, no Unicode dashes anywhere in the diff (CI's `lint.yml`/`editorconfig` checks).
- [x] CI green on this PR.
- [ ] Live verification on staging after an RC deploy (see below).

## Live verification

Pending - will cut a release candidate and update this section once `deploy-staging` succeeds and Grafana/Prometheus/Loki are confirmed reachable and showing data.
