### PR TITLE
fix: render SMTP secrets in reset-staging.yml too

### DIFF
--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -50,6 +50,12 @@ jobs:
           KEYCLOAK_BACKEND_SECRET: ${{ secrets.KEYCLOAK_BACKEND_SECRET }}
           MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
           MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SMTP_FROM_ADDRESS: ${{ secrets.SMTP_FROM_ADDRESS }}
+          SMTP_FROM_NAME: ${{ secrets.SMTP_FROM_NAME }}
           GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
         run: |
@@ -68,6 +74,12 @@ jobs:
             printf 'KEYCLOAK_BACKEND_SECRET="%s"\n' "$(escape "$KEYCLOAK_BACKEND_SECRET")"
             printf 'MINIO_ROOT_USER="%s"\n' "$(escape "$MINIO_ROOT_USER")"
             printf 'MINIO_ROOT_PASSWORD="%s"\n' "$(escape "$MINIO_ROOT_PASSWORD")"
+            printf 'SMTP_HOST="%s"\n' "$(escape "$SMTP_HOST")"
+            printf 'SMTP_PORT="%s"\n' "$(escape "$SMTP_PORT")"
+            printf 'SMTP_USERNAME="%s"\n' "$(escape "$SMTP_USERNAME")"
+            printf 'SMTP_PASSWORD="%s"\n' "$(escape "$SMTP_PASSWORD")"
+            printf 'SMTP_FROM_ADDRESS="%s"\n' "$(escape "$SMTP_FROM_ADDRESS")"
+            printf 'SMTP_FROM_NAME="%s"\n' "$(escape "$SMTP_FROM_NAME")"
             printf 'GRAFANA_ADMIN_USER="%s"\n' "$(escape "$GRAFANA_ADMIN_USER")"
             printf 'GRAFANA_ADMIN_PASSWORD="%s"\n' "$(escape "$GRAFANA_ADMIN_PASSWORD")"
           } > .env


### PR DESCRIPTION
## Summary

Follow-up to #1417. That PR added a "Render .env" step to `reset-staging.yml`, matching whatever secrets were on `main` at the time - which didn't yet include `SMTP_*` (still pending in #1415).

The `docker-compose.yml` actually running on staging right now (deployed from the `claude/smtp-server-issues-4x8rml` branch, ahead of `main`) already requires `SMTP_HOST`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`/`SMTP_FROM_ADDRESS`/`SMTP_FROM_NAME`. Running "Reset Staging" against that reality fails outright:

```
error while interpolating services.keycloak.environment.KC_SMTP_FROM: required variable SMTP_FROM_ADDRESS is missing a value: set SMTP_FROM_ADDRESS in .env
```

## Fix

Extends the same "Render .env" step with the same six SMTP secrets already rendered in `publish.yml`.

## Note on sequencing

`main`'s own `docker-compose.yml` doesn't reference `SMTP_*` yet (that lands with #1415) - so right now this just renders six additional secrets into `.env` that nothing on `main` consumes yet. Harmless (they sit unused until #1415 merges), but it's what keeps `reset-staging.yml` matching what's actually deployed on staging in the meantime, and needs no further changes once #1415 lands.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` - YAML parses cleanly.
- Same as #1417: this is a `workflow_dispatch`-only workflow with a destructive confirmation gate, so I did not trigger it myself.

---
_Generated by [Claude Code](https://claude.ai/code/session_014axBH1kfsSXMBBFV16b3p7)_