### PR TITLE
fix: reject PIN check-in when opportunity has no PIN configured

### DIFF
--- a/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
+++ b/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
@@ -4,6 +4,7 @@ using Application.Common.Persistence;
 using Application.Common.RateLimiting;
 using Domain.Engagements;
 using Domain.Primitives;
+using Domain.VolunteerOpportunities;
 
 namespace Application.Engagements.CheckInWithPin.v1;
 
@@ -33,7 +34,16 @@ internal sealed class CheckInWithPinCommandHandler(
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(engagement.OpportunityId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", "Opportunity not found."));
 
-		if (opportunity.CheckInPin != request.Pin)
+		// CheckInPin is only ever populated for PINCode opportunities - every other
+		// CheckInMethod leaves it null, which would otherwise let a null request.Pin
+		// (an empty JSON body) pass a plain `!=` comparison as "null == null" (#1139).
+		if (opportunity.CheckInMethod != CheckInMethod.PINCode)
+			throw new ResultFailureException(Error.Conflict("Engagement.CheckInMethodNotPin", "This opportunity does not use PIN check-in."));
+
+		if (string.IsNullOrWhiteSpace(request.Pin))
+			throw new ResultFailureException(Error.Validation("Engagement.PinRequired", "PIN is required."));
+
+		if (!string.Equals(opportunity.CheckInPin, request.Pin, StringComparison.Ordinal))
 		{
 			await attemptLimiter.RegisterFailedAttemptAsync(request.EngagementId, cancellationToken);
 			throw new ResultFailureException(Error.Validation("Engagement.InvalidPin", "Invalid PIN."));

--- a/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
@@ -139,6 +139,92 @@ public class CheckInWithPinCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage($"*{engagementId.Value}*");
 	}
 
+	[Test]
+	[Arguments(null)]
+	[Arguments("")]
+	[Arguments("   ")]
+	public async Task Handle_ShouldThrowValidation_WhenPinIsNullOrWhitespace_OnNonPinOpportunity(
+		string? submittedPin,
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1139: a "None"/"QRCode"/"Manual" opportunity never sets
+		// CheckInPin, so it stays null. Before this fix, submitting an empty body
+		// (deserializing Pin as null) made `opportunity.CheckInPin != request.Pin`
+		// compare null to null and pass, checking the volunteer in without any PIN.
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var opportunity = CreateNonPinOpportunity(CheckInMethod.None);
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInWithPinCommand(engagementId, submittedPin!, owner);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*does not use PIN check-in*");
+		await _attemptLimiter.DidNotReceive().RegisterFailedAttemptAsync(Arg.Any<EngagementId>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	[Arguments(CheckInMethod.QRCode)]
+	[Arguments(CheckInMethod.Manual)]
+	public async Task Handle_ShouldThrowConflict_WhenOpportunityDoesNotUsePinCheckIn(
+		CheckInMethod checkInMethod,
+		CancellationToken cancellationToken)
+	{
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var opportunity = CreateNonPinOpportunity(checkInMethod);
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInWithPinCommand(engagementId, CorrectPin, owner);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*does not use PIN check-in*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowValidation_WhenPinIsNullOrWhitespace_OnPinOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var engagementId = EngagementId.New();
+		var owner = UserId.New();
+		var opportunity = CreatePinOpportunity();
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, owner, TimeSlotId.New());
+		engagement.Confirm();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		var command = new CheckInWithPinCommand(engagementId, "", owner);
+
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*PIN is required*");
+		await _attemptLimiter.DidNotReceive().RegisterFailedAttemptAsync(Arg.Any<EngagementId>(), Arg.Any<CancellationToken>());
+	}
+
+	private VolunteerOpportunity CreateNonPinOpportunity(CheckInMethod checkInMethod) =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId,
+			"Test",
+			"Test",
+			false,
+			DefaultAddress,
+			Occurrence.OneTime,
+			ParticipationType.Waitlist,
+			checkInMethod,
+			_pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
 	private VolunteerOpportunity CreatePinOpportunity() =>
 		VolunteerOpportunity.Create(
 			DefaultOrgId,

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -386,6 +386,63 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task CheckInWithPin_ShouldReturn409_WhenOpportunityDoesNotUsePinCheckIn(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1139: a "None" (or QRCode/Manual) opportunity never sets
+		// a CheckInPin, so it stays null server-side. Posting a check-in with a
+		// blank/empty PIN must be rejected outright, not accidentally accepted
+		// because "null equals null".
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, "None", cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "Ready to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		var act = () => veraClient.CheckInWithPinAsync(
+			engagement.Id,
+			new CheckInWithPinRequest { Pin = "" },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+
+		var myEngagements = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: false, cancellationToken);
+		myEngagements.Items.Single().IsCheckedIn.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task CheckInWithPin_ShouldReturn400_WhenPinIsEmpty_OnPinCodeOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, "PINCode", cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "Ready to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		var act = () => veraClient.CheckInWithPinAsync(
+			engagement.Id,
+			new CheckInWithPinRequest { Pin = "" },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
 	public async Task GetVolunteerOpportunityDetails_ShouldNotExposeCheckInPin(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -413,7 +413,9 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var exception = await act.Should().ThrowAsync<ApiException>();
 		exception.Which.StatusCode.Should().Be(409);
 
-		var myEngagements = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: false, cancellationToken);
+		// Confirmed + not-checked-in + opportunity still exists stays in the
+		// upcoming bucket (EngagementReadRepository.cs), not past.
+		var myEngagements = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: true, cancellationToken);
 		myEngagements.Items.Single().IsCheckedIn.Should().BeFalse();
 	}
 


### PR DESCRIPTION
CheckInPin is only set for PINCode opportunities, so it stays null for None/QRCode/Manual. A null request.Pin (empty JSON body) made the plain != comparison pass as "null == null", letting a volunteer self-check-in without any PIN on those opportunities. Reject non-PINCode opportunities outright and require a non-blank Pin before comparing.

Closes #1139