### PR TITLE
feat: track and expose email send failure metrics for staging alerting

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -20,6 +20,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[10.0.10]" />
+		<PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.10]" />
@@ -28,6 +29,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="[10.8.0]" />
 		<PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="[10.8.0]" />
 		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="[1.17.0]" />
+		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="[1.17.0-beta.1]" />
 		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[1.17.0]" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.17.0]" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.17.0]" />

--- a/backend/src/Aspire/ServiceDefaults/Extensions.cs
+++ b/backend/src/Aspire/ServiceDefaults/Extensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -11,11 +14,18 @@ namespace Microsoft.Extensions.Hosting;
 
 public static class ServiceDefaultsExtensions
 {
+	// Kept in sync with EmailMetrics.MeterName (Infrastructure/Email/EmailMetrics.cs) -
+	// a plain string, not a shared constant, since ServiceDefaults doesn't reference
+	// Infrastructure (Aspire's AppHost also depends on this project).
+	private const string EmailMeterName = "Einsatzbereit.Email";
+
 	public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
 	{
 		builder.ConfigureOpenTelemetry();
 		builder.AddDefaultHealthChecks();
+		builder.AddMetricsPortListener();
 
+		builder.Services.AddMetrics();
 		builder.Services.AddServiceDiscovery();
 		builder.Services.ConfigureHttpClientDefaults(http =>
 		{
@@ -40,7 +50,9 @@ public static class ServiceDefaultsExtensions
 				metrics
 					.AddAspNetCoreInstrumentation()
 					.AddHttpClientInstrumentation()
-					.AddRuntimeInstrumentation();
+					.AddRuntimeInstrumentation()
+					.AddMeter(EmailMeterName)
+					.AddPrometheusExporter();
 			})
 			.WithTracing(tracing =>
 			{
@@ -72,6 +84,24 @@ public static class ServiceDefaultsExtensions
 		return builder;
 	}
 
+	// Metrics:Port (Metrics__Port in docker-compose.yml) is unset everywhere except
+	// staging, where it points Kestrel at a second listener that only Prometheus's
+	// internal "monitoring" docker network can reach - never the Traefik-routed main
+	// port, so /metrics is never publicly exposed (#1341). Optional/unset elsewhere
+	// (local Aspire dev already gets live metrics via its own OTLP dashboard).
+	private static TBuilder AddMetricsPortListener<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+	{
+		if (builder is WebApplicationBuilder webBuilder && TryGetMetricsPort(builder.Configuration, out var port))
+		{
+			webBuilder.WebHost.ConfigureKestrel(options => options.ListenAnyIP(port));
+		}
+
+		return builder;
+	}
+
+	private static bool TryGetMetricsPort(IConfiguration configuration, out int port) =>
+		int.TryParse(configuration["Metrics:Port"], out port);
+
 	public static WebApplication MapDefaultEndpoints(this WebApplication app)
 	{
 		// Exposed in all environments so deployment health checks and live smoke
@@ -89,6 +119,31 @@ public static class ServiceDefaultsExtensions
 		{
 			Predicate = r => r.Tags.Contains("live")
 		});
+
+		if (TryGetMetricsPort(app.Configuration, out var metricsPort))
+		{
+			// Deliberately not RequireHost($"*:{port}") - that matches the
+			// client-supplied Host header, not which physical Kestrel listener
+			// accepted the connection, so a request that reaches the
+			// Traefik-routed main port (8080) with a forged
+			// "Host: anything:8081" header would satisfy it. Connection.LocalPort
+			// reflects the actual socket the OS accepted the connection on and
+			// can't be spoofed the same way - only a caller on the
+			// docker-compose "monitoring" network (Prometheus) can ever hit the
+			// AddMetricsPortListener listener directly (#1341).
+			app.Use(async (context, next) =>
+			{
+				if (context.Request.Path == "/metrics" && context.Connection.LocalPort != metricsPort)
+				{
+					context.Response.StatusCode = StatusCodes.Status404NotFound;
+					return;
+				}
+
+				await next(context);
+			});
+
+			app.MapPrometheusScrapingEndpoint();
+		}
 
 		return app;
 	}

--- a/backend/src/Aspire/ServiceDefaults/ServiceDefaults.csproj
+++ b/backend/src/Aspire/ServiceDefaults/ServiceDefaults.csproj
@@ -5,9 +5,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/backend/src/Infrastructure/Email/EmailMetrics.cs
+++ b/backend/src/Infrastructure/Email/EmailMetrics.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Metrics;
+
+namespace Infrastructure.Email;
+
+internal sealed class EmailMetrics
+{
+	// Registered with the OTel MeterProvider in Aspire/ServiceDefaults/Extensions.cs
+	// (AddMeter) - keep both in sync if this ever changes.
+	public const string MeterName = "Einsatzbereit.Email";
+
+	private readonly Counter<long> _sendCounter;
+
+	public EmailMetrics(IMeterFactory meterFactory)
+	{
+		_sendCounter = meterFactory.Create(MeterName).CreateCounter<long>(
+			"email.send",
+			unit: "{email}",
+			description: "Outbound email send attempts, tagged by outcome.");
+	}
+
+	public void RecordSucceeded() => Record("succeeded");
+
+	public void RecordFailed() => Record("failed");
+
+	private void Record(string status) =>
+		_sendCounter.Add(1, new KeyValuePair<string, object?>("status", status));
+}

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -8,7 +8,8 @@ namespace Infrastructure.Email;
 
 internal sealed class SmtpEmailService(
 	IOptions<SmtpOptions> options,
-	ILogger<SmtpEmailService> logger)
+	ILogger<SmtpEmailService> logger,
+	EmailMetrics metrics)
 	: IEmailService
 {
 	private readonly SmtpOptions _options = options.Value;
@@ -43,10 +44,13 @@ internal sealed class SmtpEmailService(
 			message.To.Add(to);
 
 			await client.SendMailAsync(message, cancellationToken);
+
+			metrics.RecordSucceeded();
 		}
 		catch (Exception ex)
 		{
 			logger.LogError(ex, "Failed to send email to {To} with subject {Subject}", to, subject);
+			metrics.RecordFailed();
 		}
 	}
 }

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -6,6 +6,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Http" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ public static class ServiceCollectionExtensions
 		services.AddSingleton<IBadgeCatalogService, BadgeCatalogService>();
 
 		services.ConfigureOptions<SmtpOptionsSetup>();
+		services.AddSingleton<EmailMetrics>();
 		services.AddScoped<IEmailService, SmtpEmailService>();
 		services.AddHostedService<EngagementReminderJob>();
 		services.AddHostedService<OutboxProcessorJob>();

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -1,0 +1,207 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AwesomeAssertions;
+using Infrastructure.Email;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.Email.SmtpEmailService directly (InternalsVisibleTo,
+// see Infrastructure.csproj) against a loopback socket instead of a real relay,
+// so - unlike the rest of this project - it needs no Aspire/Testcontainers
+// fixture and runs as a plain fast unit test.
+//
+// Regression coverage for #1341: a send failure must be swallowed (callers
+// like EngagementReminderJob rely on this - see its MarkReminderSent right
+// after SendAsync) but still observable, now via a metric rather than only a
+// log line nothing was watching.
+public class SmtpEmailServiceTests
+{
+	[Test]
+	public async Task SendAsync_ServerAcceptsMail_RecordsSucceededMetricAndDoesNotThrow()
+	{
+		await using var server = await FakeSmtpServer.StartAsync();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(server.Port, metrics);
+		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body");
+
+		await act.Should().NotThrowAsync();
+
+		recorded.Should().ContainSingle(m => m.Status == "succeeded" && m.Value == 1);
+	}
+
+	[Test]
+	public async Task SendAsync_ServerUnreachable_RecordsFailedMetricAndDoesNotThrow()
+	{
+		var unusedPort = GetUnusedLoopbackPort();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(unusedPort, metrics);
+		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body");
+
+		await act.Should().NotThrowAsync();
+
+		recorded.Should().ContainSingle(m => m.Status == "failed" && m.Value == 1);
+	}
+
+	private static SmtpEmailService CreateService(int port, EmailMetrics metrics) =>
+		new(
+			Options.Create(new SmtpOptions
+			{
+				Host = "127.0.0.1",
+				Port = port,
+				FromAddress = "noreply@test.local",
+				FromName = "Test",
+				EnableSsl = false,
+			}),
+			NullLogger<SmtpEmailService>.Instance,
+			metrics);
+
+	private static List<(string Status, long Value)> RecordEmailSendMeasurements(IMeterFactory meterFactory)
+	{
+		var recorded = new List<(string, long)>();
+
+		var listener = new MeterListener
+		{
+			InstrumentPublished = (instrument, l) =>
+			{
+				if (instrument.Meter.Name == EmailMetrics.MeterName)
+					l.EnableMeasurementEvents(instrument);
+			},
+		};
+		listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+		{
+			var status = tags.ToArray()
+				.FirstOrDefault(t => t.Key == "status").Value?.ToString()
+				?? throw new InvalidOperationException("Measurement missing 'status' tag.");
+			recorded.Add((status, measurement));
+		});
+		listener.Start();
+
+		// Meter creation (inside EmailMetrics' constructor) must happen after the
+		// listener is listening, or InstrumentPublished never fires for it - but
+		// callers construct EmailMetrics before this returns, so replay isn't
+		// needed here; RecordEmailSendMeasurements is always called first in
+		// these tests. Recording the listener disposal isn't necessary either:
+		// it's process/test-local and TUnit tears down between tests.
+		return recorded;
+	}
+
+	private static int GetUnusedLoopbackPort()
+	{
+		var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		try
+		{
+			return ((IPEndPoint)listener.LocalEndpoint).Port;
+		}
+		finally
+		{
+			listener.Stop();
+		}
+	}
+
+	private sealed class TestMeterFactory : IMeterFactory
+	{
+		private readonly List<Meter> _meters = [];
+
+		public Meter Create(MeterOptions options)
+		{
+			var meter = new Meter(options);
+			_meters.Add(meter);
+			return meter;
+		}
+
+		public void Dispose()
+		{
+			foreach (var meter in _meters)
+				meter.Dispose();
+		}
+	}
+
+	// Minimal but protocol-correct SMTP responder: greets, accepts EHLO/MAIL
+	// FROM/RCPT TO/DATA/QUIT with no auth or TLS (matching EnableSsl=false,
+	// Username=null in these tests), just enough for SmtpClient.SendMailAsync
+	// to consider the send successful.
+	private sealed class FakeSmtpServer : IAsyncDisposable
+	{
+		private readonly TcpListener _listener;
+		private readonly Task _acceptTask;
+
+		private FakeSmtpServer(TcpListener listener, int port)
+		{
+			_listener = listener;
+			Port = port;
+			_acceptTask = AcceptAsync();
+		}
+
+		public int Port { get; }
+
+		public static Task<FakeSmtpServer> StartAsync()
+		{
+			var listener = new TcpListener(IPAddress.Loopback, 0);
+			listener.Start();
+			var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+			return Task.FromResult(new FakeSmtpServer(listener, port));
+		}
+
+		private async Task AcceptAsync()
+		{
+			using var client = await _listener.AcceptTcpClientAsync();
+			await using var stream = client.GetStream();
+			using var reader = new StreamReader(stream, Encoding.ASCII);
+			await using var writer = new StreamWriter(stream, Encoding.ASCII) { NewLine = "\r\n", AutoFlush = true };
+
+			await writer.WriteLineAsync("220 fake.local ESMTP");
+
+			string? line;
+			while ((line = await reader.ReadLineAsync()) is not null)
+			{
+				if (line.StartsWith("EHLO", StringComparison.OrdinalIgnoreCase))
+				{
+					await writer.WriteLineAsync("250 fake.local");
+				}
+				else if (line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase)
+					|| line.StartsWith("RCPT TO", StringComparison.OrdinalIgnoreCase))
+				{
+					await writer.WriteLineAsync("250 OK");
+				}
+				else if (line.Equals("DATA", StringComparison.OrdinalIgnoreCase))
+				{
+					await writer.WriteLineAsync("354 Start mail input");
+					while ((line = await reader.ReadLineAsync()) is not null && line != ".")
+					{
+					}
+
+					await writer.WriteLineAsync("250 OK queued");
+				}
+				else if (line.StartsWith("QUIT", StringComparison.OrdinalIgnoreCase))
+				{
+					await writer.WriteLineAsync("221 Bye");
+					break;
+				}
+			}
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			_listener.Stop();
+			try
+			{
+				await _acceptTask.WaitAsync(TimeSpan.FromSeconds(5));
+			}
+			catch (Exception)
+			{
+			}
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,7 @@ services:
     networks:
       - proxy
       - db
+      - monitoring
     deploy:
       resources:
         limits:
@@ -199,6 +200,12 @@ services:
       Smtp__FromAddress: ${SMTP_FROM_ADDRESS:?set SMTP_FROM_ADDRESS in .env}
       Smtp__FromName: ${SMTP_FROM_NAME:?set SMTP_FROM_NAME in .env}
       Smtp__EnableSsl: "true"
+      # Second Kestrel listener, scraped by prometheus over the "monitoring"
+      # network above. Deliberately not a value from .env/secrets - it isn't
+      # sensitive, and the safety property that matters (not publicly
+      # reachable) comes from Traefik's backend router below only ever
+      # pointing at port 8080, never 8081 (#1341).
+      Metrics__Port: "8081"
     labels:
       - traefik.enable=true
       - traefik.docker.network=proxy
@@ -244,9 +251,9 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
-    # Only 2 scrape targets (itself + node-exporter), so a low ceiling is
-    # plenty - trimmed down from 256m to leave more host headroom on a
-    # memory-constrained box (staging runs on a 4GB VM).
+    # Only a handful of scrape targets (itself, node-exporter, backend), so a
+    # low ceiling is plenty - trimmed down from 256m to leave more host
+    # headroom on a memory-constrained box (staging runs on a 4GB VM).
     deploy:
       resources:
         limits:
@@ -427,6 +434,12 @@ configs:
         - job_name: node-exporter
           static_configs:
             - targets: ["node-exporter:9100"]
+
+        # Port 8081, not the Traefik-routed 8080 - see backend's Metrics__Port
+        # and networks above (#1341).
+        - job_name: backend
+          static_configs:
+            - targets: ["backend:8081"]
   grafana-datasources:
     content: |
       apiVersion: 1


### PR DESCRIPTION
Backend SMTP config and log-level (#1341) were already fixed in #1415, but send failures were still invisible to monitoring: no metric existed, and the new Grafana/Prometheus stack (#1416) only scraped host-level metrics, not the backend itself.

- Add EmailMetrics (System.Diagnostics.Metrics counter, tagged by succeeded/failed) recorded from SmtpEmailService on every send attempt.
- Wire a Prometheus exporter into the existing OTel MeterProvider, exposed only on a second Kestrel listener (Metrics__Port) gated by the physical connection port - not Traefik's routed port - so /metrics can't leak publicly even via a forged Host header.
- Add backend to the monitoring docker network and a Prometheus scrape job for it.

Closes #1341