### PR TITLE
feat: add comment bloat lens to /lens skill

### DIFF
--- a/.claude/skills/lens/SKILL.md
+++ b/.claude/skills/lens/SKILL.md
@@ -8,12 +8,13 @@ description: >
   bugs, dead code, dead features, repo hygiene, docs drift, test gaps, CI
   health, security, contributor accessibility, live personas (Volunteer
   Vera/Organizer Olaf/Platform Admin - functional friction and visual/
-  content quality together), accessibility, or code/comment complexity -
-  and files evidenced, ranked GitHub issues. Never writes code, never opens
-  a branch or PR. Use whenever asked to review the repo or the live app,
-  run the recurring routine, audit einsatzbereit, hunt for dead code/bugs/
-  UX gaps/accessibility issues/overly complex code, simulate a user, or
-  names any of the lenses - even without the word "review".
+  content quality together), accessibility, code/comment complexity, or
+  comment bloat - and files evidenced, ranked GitHub issues. Never writes
+  code, never opens a branch or PR. Use whenever asked to review the repo
+  or the live app, run the recurring routine, audit einsatzbereit, hunt
+  for dead code/bugs/UX gaps/accessibility issues/overly complex code,
+  huge or meaningless comments, simulate a user, or names any of the
+  lenses - even without the word "review".
 ---
 
 # Lens
@@ -96,7 +97,8 @@ it and raise the confidence bar.
 
 If the user names a lens (or something that clearly maps to one, e.g.
 "simulate a user" -> personas, "check contrast" -> accessibility, "find
-overly clever code" -> complexity), skip triage and go to Step 2. If they
+overly clever code" -> complexity, "comments are too long/AI writes huge
+comments" -> comment-bloat), skip triage and go to Step 2. If they
 reference the previous run ("last time was CI"), exclude that lens from
 triage.
 
@@ -128,6 +130,7 @@ lens; it is not the review. Do not start investigating findings here.
 | Test-to-src churn | ratio of changed test files to changed src files (from churn probe) | test-gaps |
 | a11y coverage gap | grep `AccessibilityTests.cs` for `HasNoSeriousA11yViolations`, diff against `App.tsx` routes | accessibility |
 | Comment hedge scan | grep `careful\|hack\|workaround\|don't\|must\|NOTE\|WARNING` density across `backend/src`, `frontend/src` | complexity |
+| Comment density outliers | rough comment-line-to-code-line ratio per file (`grep -c '^\s*//\|^\s*\*\|^\s*///'` vs `wc -l`) on the churn-hotspot files from the churn probe; eyeball the 5 highest-ratio files | comment-bloat |
 | Days since last live pass | check recent closed/open issues labeled `lens` for a personas-lens finding's timestamp | personas |
 
 Score every lens 1-5 for **signal** (evidence something is off) and
@@ -157,6 +160,7 @@ Then read exactly one lens file:
 | Personas | `references/lens-personas.md` | live - drives staging as Vera/Olaf/Admin; functional friction and visual/content quality together |
 | Accessibility | `references/lens-accessibility.md` | static + live |
 | Code & comment complexity | `references/lens-complexity.md` | static |
+| Comment bloat & noise | `references/lens-comment-bloat.md` | static |
 
 ### Step 3 - Execute the lens
 

--- a/.claude/skills/lens/references/lens-comment-bloat.md
+++ b/.claude/skills/lens/references/lens-comment-bloat.md
@@ -1,0 +1,85 @@
+# Lens: Comment bloat & noise
+
+Goal: comments that cost more to read than the code they annotate returns
+in value - length, redundancy, and staleness, independent of whether the
+underlying code is structurally complex. LLM-authored contributions have a
+well-documented tendency toward over-explaining: restating what a line
+already says, multi-paragraph docstrings on simple functions, narrating a
+change's history instead of stating a durable invariant. That pattern is
+easy to miss as a single bullet inside a broader lens - it earns its own
+dedicated sweep.
+
+## Method
+
+1. **Find comment-to-code density outliers.** Rough ratio per file
+   (comment lines - `//`, `///`, `/* */`, `#` - versus total lines) across
+   `backend/src` and `frontend/src`; sample enough files first to learn
+   this codebase's own norm, then flag files/functions markedly above it -
+   don't apply a universal threshold. Backend XML doc comments (`///`)
+   repeated near-verbatim across many similar handlers/endpoints are a
+   distinct boilerplate pattern worth its own line even when no single file
+   is a density outlier.
+2. **Read each candidate and classify the bloat:**
+   - **Restates the code (WHAT, not WHY)** - `// increment counter` above
+     `counter++`, a docstring that just re-lists the parameter names in
+     prose.
+   - **Over-explains the obvious** - a paragraph where the code needs a
+     clause; explains something any contributor at this repo's stated
+     skill level would already know.
+   - **Narrates process, not invariant** - "we changed this because the
+     old approach broke X", "added for the Y flow", "fix for issue #NNN".
+     That belongs in the commit message or PR description; it rots the
+     moment the code moves on and the comment doesn't.
+   - **Stale** - describes behavior the code below no longer has; cross-
+     check `git blame`/history when the mismatch is surprising.
+   - **Genuinely load-bearing (the good case)** - explains a non-obvious
+     WHY: a hidden constraint, a workaround, a subtle invariant. Read it,
+     don't flag it - note a couple of these in the report as a positive
+     baseline, not just a list of complaints.
+3. **Judge length against necessity, not a word count.** A comment's
+   length should track the complexity of the WHY, not the length of the
+   code below it - a five-line comment above a five-line function is
+   suspect regardless of content. Test: would deleting this comment
+   confuse the next reader? If not, it is a deletion candidate, not a
+   trim candidate.
+4. **Check neighbors once you find one.** Bloat clusters - if `git blame`
+   or a commit message on a candidate points at one PR/session, check the
+   other files that same commit touched before generalizing from a single
+   file to "this is everywhere".
+
+## Verification bar
+
+A finding quotes the comment verbatim (or the representative lines, if
+long) plus the code it sits on, states the bloat category (restates /
+over-explains / narrates process / stale), and gives a concrete fix -
+delete entirely, trim to N lines, or move the one durable WHY into a
+single line - not "shorten this". A density finding states the actual
+ratio measured and the baseline it was compared against, learned from
+sampling this codebase, not an arbitrary universal number.
+
+## Traps
+
+Comment volume is not a defect by default: domain-inherent complexity
+(geocoding, timezone handling, the dashboard drag/resize/overlap logic)
+can legitimately need a longer explanation - the target state is a
+comment whose length matches the WHY's actual complexity, not a ceiling.
+Generated code (`api-client.ts`'s NSwag header, EF migration files) and
+vendored comment blocks (license headers, `.claude/skills/frontend-design`
+per its own Apache-2.0 provenance note) are out of scope. Public API
+surface doc comments required by convention (check whether one actually
+exists here before assuming) are not bloat merely for existing - judge
+their content, not their presence.
+
+## Boundary to the code/comment complexity lens
+
+`lens-complexity.md` also reads comments, but only as evidence of
+underlying *structural* complexity - a hedge comment (`careful`, `hack`,
+`must`) marking real fragility, or a density outlier read as a symptom of
+tangled code. If a finding is really "this code is hard to change safely
+and the comment proves it", file it there. This lens's findings stand on
+their own even next to trivially simple code: a bloated, redundant, or
+stale comment is a defect whether or not the function underneath it is
+fragile. When a single comment fits both descriptions, one finding is
+enough - file it wherever the *primary* problem lives (the code's
+structure, or the comment's own writing) and don't double-count it in
+both reports.

--- a/.claude/skills/lens/references/lens-complexity.md
+++ b/.claude/skills/lens/references/lens-complexity.md
@@ -34,15 +34,16 @@ its own; unexplained or unnecessary complexity is.
    whether the comment is compensating for complexity that could instead
    be removed (extract a function, name the invariant in a type, add a
    guard clause) rather than just narrated.
-3. **Find comment noise in the other direction.** Comments that restate
-   what the next line already says (`// increment counter` above
-   `counter++`), comments describing behavior the code below no longer
-   has (stale - cross-check against git blame/history if the mismatch is
-   surprising), and outlier comment-to-code density (a file or function
-   with far more comment lines than its neighbors) - the last one cuts
-   both ways: it can mean good documentation of real complexity, or it can
-   mean the code needed that many words *because* it's more tangled than
-   it should be. Read enough to tell which.
+3. **Read comment density as a structural symptom, not a style nit.** An
+   outlier comment-to-code ratio (a file or function with far more comment
+   lines than its neighbors) cuts both ways: it can mean good documentation
+   of real complexity, or it can mean the code needed that many words
+   *because* it's more tangled than it should be - read enough to tell
+   which, and only flag it here if the conclusion is "this needs
+   restructuring", not "this comment is bloated". Redundant, stale, or
+   over-explained comments in their own right (regardless of what the
+   surrounding code's structure looks like) are `lens-comment-bloat.md`'s
+   job, not this one - see that file's boundary section.
 4. **Cross-reference against this repo's own stated preference.** Root
    `AGENTS.md`'s "Simple code: the source code should be simple enough
    that anyone can contribute" is a named goal, not an aspiration to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@ edit on your own initiative):
   review tool: one lens per run - static repo audits (bugs, dead code, dead
   features, repo hygiene, docs drift, test gaps, CI, security, contributor
   accessibility) or live passes against staging as Vera/Olaf/Admin
-  (personas, accessibility), or code/comment complexity - chosen by triage
-  or named by the user. Report-only: files GitHub issues
+  (personas, accessibility), code/comment complexity, or comment bloat -
+  chosen by triage or named by the user. Report-only: files GitHub issues
   (label `lens`, capped at 5/run), never code or a PR.
   `.claude/skills/{ingest,query,lint}/` (`/ingest`, `/query`, `/lint`) run
   the `wiki/` bundle's ingest/query/lint workflow - see `wiki/AGENTS.md`.


### PR DESCRIPTION
AI-authored comments trend toward over-explaining: restating the code, narrating process instead of invariant, or padding a simple function with a multi-paragraph docstring. lens-complexity.md already reads comments, but only as evidence of structural fragility - this bloat pattern needed its own dedicated sweep, independent of whether the underlying code is complex at all.

Adds lens-comment-bloat.md, wires it into SKILL.md's triage/lens tables and frontmatter, narrows lens-complexity.md's comment-density step to avoid double-counting, and updates the lens enumeration in root AGENTS.md.