### PR TITLE
fix: pre-compress frontend build output for nginx gzip_static

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check nginx CSP header
         run: pnpm check:nginx-csp
 
+      - name: Check nginx gzip_static wiring
+        run: pnpm check:nginx-gzip-static
+
       - name: Type check
         run: pnpm check
 

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,4 +1,5 @@
 gzip on;
+gzip_static on;
 gzip_types text/plain text/css text/javascript application/javascript application/json image/svg+xml;
 gzip_min_length 1024;
 gzip_vary on;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
     "format:write": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
     "i18n:check": "node scripts/check-i18n-keys.js",
-    "check:nginx-csp": "node scripts/check-nginx-csp.js"
+    "check:nginx-csp": "node scripts/check-nginx-csp.js",
+    "check:nginx-gzip-static": "node scripts/check-nginx-gzip-static.js"
   },
   "dependencies": {
     "@hookform/resolvers": "5.4.0",
@@ -54,6 +55,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",
     "vite": "8.1.5",
+    "vite-plugin-compression2": "2.5.3",
     "vite-plugin-pwa": "1.3.0",
     "vite-plugin-svgr": "5.2.0"
   }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: 8.1.5
         version: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
+      vite-plugin-compression2:
+        specifier: 2.5.3
+        version: 2.5.3(rollup@4.62.0)
       vite-plugin-pwa:
         specifier: 1.3.0
         version: 1.3.0(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
@@ -2653,6 +2656,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-mini@0.2.0:
+    resolution: {integrity: sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -2771,6 +2777,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite-plugin-compression2@2.5.3:
+    resolution: {integrity: sha512-ItPgqQWkcnBbVw7is9OKwiZ8v6+ju9rYROl5Lp6QfQDEx/d55AwJQb/KLpsQqsU9HoigYBsZ8tK6I02UwJNvEw==}
 
   vite-plugin-pwa@1.3.0:
     resolution: {integrity: sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==}
@@ -3832,7 +3841,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.0
 
@@ -5635,6 +5644,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-mini@0.2.0: {}
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -5767,6 +5778,13 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  vite-plugin-compression2@2.5.3(rollup@4.62.0):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.0)
+      tar-mini: 0.2.0
+    transitivePeerDependencies:
+      - rollup
 
   vite-plugin-pwa@1.3.0(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:

--- a/frontend/scripts/check-nginx-gzip-static.js
+++ b/frontend/scripts/check-nginx-gzip-static.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Guards against the regression class behind issue #1406: nginx re-gzipped
+// every JS/CSS asset from scratch on each cold-cache request because no
+// pre-compressed .gz siblings were emitted at build time and gzip_static
+// was never enabled. Purely static checks - no Docker/nginx/build required.
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(__dirname, "..");
+
+const nginxTemplate = readFileSync(
+	join(frontendDir, "nginx.conf.template"),
+	"utf8",
+);
+const viteConfig = readFileSync(join(frontendDir, "vite.config.ts"), "utf8");
+
+let ok = true;
+function fail(message) {
+	console.error(message);
+	ok = false;
+}
+
+// 1. nginx must be told to serve pre-compressed .gz siblings directly
+// instead of compressing matching responses on the fly every time.
+if (!/^\s*gzip_static\s+on;\s*$/m.test(nginxTemplate)) {
+	fail(
+		"nginx.conf.template is missing `gzip_static on;` - without it nginx re-gzips " +
+			"every matching response from scratch on each cold-cache request instead of " +
+			"serving a pre-built .gz file.",
+	);
+}
+
+// 2. Something must actually produce those .gz siblings at build time, or
+// gzip_static has nothing to serve and silently falls back to on-the-fly
+// compression (or none, if gzip is off).
+if (!/from\s+["']vite-plugin-compression2["']/.test(viteConfig)) {
+	fail(
+		"vite.config.ts no longer imports vite-plugin-compression2 - gzip_static in " +
+			"nginx.conf.template has no pre-compressed .gz assets to serve without it.",
+	);
+}
+
+const compressionCallMatch = viteConfig.match(
+	/compression\(\s*\{([\s\S]*?)\}\s*\)/,
+);
+if (!compressionCallMatch) {
+	fail("Could not find a `compression({ ... })` plugin call in vite.config.ts.");
+} else if (!/algorithms\s*:\s*\[[^\]]*["']gzip["']/.test(compressionCallMatch[1])) {
+	fail(
+		"The compression() plugin call in vite.config.ts does not request the \"gzip\" " +
+			"algorithm, so no .gz assets will be emitted for nginx's gzip_static to serve.",
+	);
+}
+
+if (ok) {
+	console.log(
+		"nginx gzip_static is enabled and vite.config.ts emits matching pre-compressed .gz assets.",
+	);
+} else {
+	process.exit(1);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,12 +3,23 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import svgr from "vite-plugin-svgr";
 import { VitePWA } from "vite-plugin-pwa";
+import { compression } from "vite-plugin-compression2";
 
 export default defineConfig({
 	plugins: [
 		react(),
 		tailwindcss(),
 		svgr(),
+		// Pre-compress build output so nginx can serve a .gz sibling directly
+		// (gzip_static in nginx.conf.template) instead of re-gzipping every
+		// asset from scratch on each cold-cache request. Matches nginx's
+		// gzip_types/gzip_min_length so only the same file types/sizes it
+		// would otherwise compress on the fly get a pre-built .gz.
+		compression({
+			algorithms: ["gzip"],
+			include: /\.(js|mjs|css|json|svg)$/,
+			threshold: 1024,
+		}),
 		VitePWA({
 			registerType: "autoUpdate",
 			workbox: {


### PR DESCRIPTION
Every cold-cache request made nginx gzip JS/CSS from scratch since no .gz siblings existed and gzip_static was off. vite-plugin-compression2 now emits .gz assets matching nginx's gzip_types/gzip_min_length, and gzip_static on serves them directly instead of compressing on demand.

Brotli is out of scope: stock nginx:alpine has no ngx_brotli module, so brotli_static would fail to start nginx.

Closes #1406 