### PR TITLE
fix: throttle dashboard drag re-renders and delegate grid-cell events

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -279,6 +279,111 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	}
 
 	[Test]
+	public async Task CornerPlacement_HoveringAGuideCell_UpdatesThePlacementBanner()
+	{
+		// #1402: the grid-guide backdrop cells' click/hover handling moved from
+		// one onClick/onPointerEnter pair per cell (up to 832 of them) to a
+		// single delegated pair on the grid container, which reads the hovered
+		// cell's col/row off data-col/data-row attributes via closest() rather
+		// than a per-cell closure. This is the regression guard for the hover
+		// half of that refactor: hovering a cell that was never clicked must
+		// still move the live placement cursor, purely via a real bubbled
+		// pointerover - the click-driven half is already exercised end to end
+		// by every other placement test in this file (each click bubbles
+		// through the same delegated container handler).
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual DashHoverBanner");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await RemoveAllWidgetsAsync();
+
+		// Add exactly one widget so its placement lands at a known (x=1, y=1,
+		// width=4, height=2) - see placeNewWidget in widgetCatalog.ts.
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await dialog.GetByTestId("add-widget-option-ToDo").ClickAsync();
+		await dialog.GetByTestId("add-widget-done").ClickAsync();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Move or resize Needs Your Attention" }).ClickAsync();
+		await Expect(Page.GetByTestId("dashboard-placement-status")).ToContainTextAsync("Column 1, row 1");
+
+		// Hover a distant cell without clicking it - a real mouse move, so the
+		// resulting pointerover must bubble to the container's delegated
+		// handler exactly like a real drag/hover would.
+		await HoverGridCellAsync(col: 8, row: 3);
+
+		await Expect(Page.GetByTestId("dashboard-placement-status")).ToContainTextAsync("Column 8, row 3");
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(Page.GetByTestId("dashboard-placement-status")).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task PointerDrag_WithManyRapidIntermediateMoves_StillCommitsTheFinalPosition()
+	{
+		// #1402: dragging now batches its live preview updates to at most one
+		// per animation frame (see useWidgetPlacement's rAF throttle) instead
+		// of one per raw pointermove - a high-polling-rate mouse/trackpad can
+		// fire pointermove well past the screen's refresh rate. The widget's
+		// actual committed rect on release must still reflect the very last
+		// pointer position even though most of the intermediate ones were
+		// coalesced away, so this drags through many more intermediate steps
+		// than PointerDrag_MovingAWidget_... above to make sure nothing about
+		// that batching drops or staggers the final commit.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual DashRapidDrag");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await RemoveAllWidgetsAsync();
+
+		// Add exactly one widget so its placement lands at a known (x=1, y=1,
+		// width=4, height=2) - see placeNewWidget in widgetCatalog.ts.
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await dialog.GetByTestId("add-widget-option-ToDo").ClickAsync();
+		await dialog.GetByTestId("add-widget-done").ClickAsync();
+
+		var tile = Page.GetByTestId("widget-tile-ToDo");
+		var tileBox = await tile.BoundingBoxAsync();
+		tileBox.Should().NotBeNull();
+		var colPx = tileBox!.Width / 4;
+
+		var grip = Page.GetByRole(AriaRole.Button, new() { Name = "Move or resize Needs Your Attention" });
+		var gripBox = await grip.BoundingBoxAsync();
+		gripBox.Should().NotBeNull();
+		var startX = gripBox!.X + gripBox.Width / 2;
+		var startY = gripBox.Y + gripBox.Height / 2;
+
+		// Drag four grid columns to the right (x=1 -> x=5) over many small
+		// steps, well beyond what a single animation frame could each get its
+		// own render for.
+		await Page.Mouse.MoveAsync(startX, startY);
+		await Page.Mouse.DownAsync();
+		await Page.Mouse.MoveAsync(startX + colPx * 4, startY, new() { Steps = 40 });
+		await Page.Mouse.UpAsync();
+
+		await Expect(Page.GetByTestId("dashboard-placement-status")).Not.ToBeVisibleAsync();
+		await AssertWidgetOccupiesCellsAsync("ToDo", x: 5, y: 1, width: 4, height: 2);
+
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+
+		await AssertWidgetOccupiesCellsAsync("ToDo", x: 5, y: 1, width: 4, height: 2);
+	}
+
+	[Test]
 	public async Task PointerDrag_MovingAWidget_UpdatesItsGridPosition_AndPersistsAcrossReload()
 	{
 		// #16: a real press-and-drag on the grip button, distinct from the
@@ -773,6 +878,16 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	private async Task ClickGridCellAsync(int col, int row)
 	{
 		await Page.GetByTestId("dashboard-grid-guide-cell").Nth(GridCellIndex(col, row)).ClickAsync();
+	}
+
+	/// <summary>
+	/// Hovers the grid guide cell at 1-based (col, row) without clicking it -
+	/// a real mouse move, so it exercises the same delegated pointerover
+	/// handler on the grid container a real drag would (see #1402).
+	/// </summary>
+	private async Task HoverGridCellAsync(int col, int row)
+	{
+		await Page.GetByTestId("dashboard-grid-guide-cell").Nth(GridCellIndex(col, row)).HoverAsync();
 	}
 
 	/// <summary>

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	type MouseEvent as ReactMouseEvent,
+	type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrgAppContext } from "../../../layouts/OrgAppLayout";
@@ -315,6 +322,76 @@ export default function OrgDashboardPage() {
 		? Math.min(GRID_MAX_ROWS + 4, rawGuideRows)
 		: GRID_MAX_ROWS + 4;
 
+	// #1402: previously rebuilt with a fresh onClick/onPointerEnter closure
+	// per cell on every render - up to 832 cells at GRID_MAX_ROWS, so up to
+	// 1664 throwaway closures per pointermove while dragging (see
+	// useWidgetPlacement's rAF throttle for the other half of that fix).
+	// Handlers now live once on the grid container (see handleGuideCellClick/
+	// handleGuideCellPointerOver below) and read data-col/data-row off the
+	// event target instead, and the array itself is memoized so an unrelated
+	// re-render (e.g. `saving` toggling) doesn't recompute all 832 cells for
+	// no reason.
+	const guideCells = useMemo(() => {
+		if (!editing || !isLargeViewport) return null;
+		return Array.from({ length: guideRows * GRID_COLUMNS }, (_, i) => {
+			const col = (i % GRID_COLUMNS) + 1;
+			const row = Math.floor(i / GRID_COLUMNS) + 1;
+			const inPreview = previewRect && cellInRect(col, row, previewRect);
+			const tint = inPreview
+				? previewValid
+					? "bg-brand-300/50"
+					: "bg-red-400/50"
+				: "bg-green-300/40";
+			return (
+				<div
+					key={`grid-guide-${col}-${row}`}
+					data-testid="dashboard-grid-guide-cell"
+					data-col={col}
+					data-row={row}
+					aria-hidden="true"
+					className={`-m-1 rounded-md ${tint} ${placingKey ? "cursor-pointer" : "pointer-events-none"}`}
+					style={{ gridColumn: col, gridRow: row }}
+				/>
+			);
+		});
+	}, [
+		editing,
+		isLargeViewport,
+		guideRows,
+		previewRect,
+		previewValid,
+		placingKey,
+	]);
+
+	// Delegated handlers for the grid-guide backdrop cells (see guideCells
+	// above) - a single pair of listeners on the container instead of one
+	// onClick/onPointerEnter per cell. Cells carry no handlers of their own;
+	// pointer-events-none (see the className above) already keeps events from
+	// reaching them at all while nothing is being placed, so both of these
+	// are effectively no-ops outside an active placement even though they're
+	// always wired up.
+	function guideCellFromEvent(
+		target: EventTarget | null,
+	): { col: number; row: number } | null {
+		const cellEl = (target as HTMLElement | null)?.closest<HTMLElement>(
+			'[data-testid="dashboard-grid-guide-cell"]',
+		);
+		if (!cellEl) return null;
+		return { col: Number(cellEl.dataset.col), row: Number(cellEl.dataset.row) };
+	}
+
+	function handleGuideCellClick(event: ReactMouseEvent<HTMLDivElement>) {
+		const cell = guideCellFromEvent(event.target);
+		if (cell) placement.handleCellClick(cell);
+	}
+
+	function handleGuideCellPointerOver(
+		event: ReactPointerEvent<HTMLDivElement>,
+	) {
+		const cell = guideCellFromEvent(event.target);
+		if (cell) placement.handleCellHover(cell);
+	}
+
 	const grid = isEmpty ? (
 		<div data-testid="dashboard-empty-state">
 			<EmptyState
@@ -348,46 +425,35 @@ export default function OrgDashboardPage() {
 			// every cell roughly square, and a widget's proportions consistent,
 			// on any screen the organizer views it on.
 			className="dashboard-widget-grid grid grid-cols-1 gap-4 lg:grid-cols-8"
+			// role="presentation": this delegated onClick/onPointerOver only ever
+			// acts on a bubbled event that actually originated on one of the
+			// aria-hidden guide cells above (see guideCellFromEvent) - the
+			// container's own "clickability" isn't a perceivable action in its
+			// own right, and doesn't affect its real interactive descendants
+			// (the widget tiles' own buttons keep their normal roles/focus).
+			// Satisfies jsx-a11y/click-events-have-key-events and
+			// jsx-a11y/no-static-element-interactions, which both exempt
+			// presentation/hidden elements - the keyboard-accessible equivalent
+			// of this same placement flow is the per-widget "Move or resize"
+			// button + arrow keys (see useWidgetPlacement's handleArrowKeyDown).
+			// Must be a literal string, not a conditional - both rules read it
+			// via getLiteralPropValue and don't resolve a ternary.
+			role="presentation"
+			onClick={editing && isLargeViewport ? handleGuideCellClick : undefined}
+			onPointerOver={
+				editing && isLargeViewport ? handleGuideCellPointerOver : undefined
+			}
 		>
 			{/* Light green cell backdrop behind the whole grid while editing, so
 			an organizer can see the underlying 8-column structure. These cells
 			double as the corner-to-corner placement surface: while a widget is
-			being placed, they become clickable (see handleCellClick) and are
-			tinted blue/red to preview whether the current selection is a valid
-			placement. Gated on isLargeViewport since the grid itself collapses
-			to a single stacked column below `lg`, where this wouldn't mean
-			anything. */}
-			{editing &&
-				isLargeViewport &&
-				Array.from({ length: guideRows * GRID_COLUMNS }, (_, i) => {
-					const col = (i % GRID_COLUMNS) + 1;
-					const row = Math.floor(i / GRID_COLUMNS) + 1;
-					const inPreview = previewRect && cellInRect(col, row, previewRect);
-					const tint = inPreview
-						? previewValid
-							? "bg-brand-300/50"
-							: "bg-red-400/50"
-						: "bg-green-300/40";
-					return (
-						<div
-							key={`grid-guide-${col}-${row}`}
-							data-testid="dashboard-grid-guide-cell"
-							aria-hidden="true"
-							onClick={
-								placingKey
-									? () => placement.handleCellClick({ col, row })
-									: undefined
-							}
-							onPointerEnter={
-								placingKey
-									? () => placement.handleCellHover({ col, row })
-									: undefined
-							}
-							className={`-m-1 rounded-md ${tint} ${placingKey ? "cursor-pointer" : "pointer-events-none"}`}
-							style={{ gridColumn: col, gridRow: row }}
-						/>
-					);
-				})}
+			being placed, they become clickable (see handleGuideCellClick above -
+			delegated once at the container instead of a listener per cell, #1402)
+			and are tinted blue/red to preview whether the current selection is a
+			valid placement. Gated on isLargeViewport since the grid itself
+			collapses to a single stacked column below `lg`, where this wouldn't
+			mean anything. */}
+			{guideCells}
 			{layout.map((widget) => {
 				const isPlacingThis = activeKey === widget.widgetKey;
 				const rect = isPlacingThis && previewRect ? previewRect : widget;

--- a/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
@@ -283,6 +283,23 @@ export function useWidgetPlacement({
 	useEffect(() => {
 		if (!dragActive) return;
 
+		// #1402: a real pointer/mouse can fire pointermove far more often than
+		// the browser actually paints (well past 60-120Hz on a high-polling-
+		// rate mouse or trackpad), and each call used to setDragPreview
+		// synchronously - re-rendering OrgDashboardPage, and with it every one
+		// of the up to 832 grid-guide backdrop cells, once per raw event
+		// instead of once per displayed frame. rafId batches every pointermove
+		// that arrives between two frames into a single state update, so the
+		// preview still tracks the pointer smoothly but the backdrop only
+		// re-renders as often as the screen can actually show it.
+		let rafId: number | null = null;
+		let pendingRect: PlacedWidget | null = null;
+
+		function flushPendingRect() {
+			rafId = null;
+			if (pendingRect) setDragPreview(pendingRect);
+		}
+
 		function handlePointerMove(event: globalThis.PointerEvent) {
 			const session = dragSessionRef.current;
 			if (!session) return;
@@ -309,10 +326,15 @@ export function useWidgetPlacement({
 							height: Math.max(1, session.origRect.height + deltaRow),
 						};
 			session.currentRect = nextRect;
-			setDragPreview(nextRect);
+			pendingRect = nextRect;
+			rafId ??= requestAnimationFrame(flushPendingRect);
 		}
 
 		function endDrag() {
+			if (rafId !== null) {
+				cancelAnimationFrame(rafId);
+				rafId = null;
+			}
 			const session = dragSessionRef.current;
 			dragSessionRef.current = null;
 			setDragActive(false);
@@ -327,6 +349,7 @@ export function useWidgetPlacement({
 		document.addEventListener("pointerup", endDrag);
 		document.addEventListener("pointercancel", endDrag);
 		return () => {
+			if (rafId !== null) cancelAnimationFrame(rafId);
 			document.removeEventListener("pointermove", handlePointerMove);
 			document.removeEventListener("pointerup", endDrag);
 			document.removeEventListener("pointercancel", endDrag);


### PR DESCRIPTION
Widget drags in the dashboard's edit mode fired setDragPreview on every raw pointermove, re-rendering all up to 832 grid-guide backdrop cells (each with fresh onClick/onPointerEnter closures) far more often than the screen can paint. Batch preview updates to one per animation frame, memoize the guide-cell array, and delegate click/hover handling to the grid container instead of one listener per cell.

Closes #1402