### PR TITLE
docs: fix keycloak/AGENTS.md workflow reference

### DIFF
--- a/keycloak/AGENTS.md
+++ b/keycloak/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Custom Keycloak 26.7.0 image with the `einsatzbereit` realm pre-baked. Built and published to GHCR via `.github/workflows/keycloak.yml`.
+Custom Keycloak 26.7.0 image with the `einsatzbereit` realm pre-baked. Built and published to GHCR via the `publish-keycloak` job in `.github/workflows/publish.yml`; `.github/workflows/keycloak-realm-import.yml` guards that the committed realm still imports cleanly on that Keycloak version before it reaches staging.
 
 ```
 keycloak/


### PR DESCRIPTION
Points at the nonexistent .github/workflows/keycloak.yml. The image is actually built by the publish-keycloak job in publish.yml; the realm is validated separately by keycloak-realm-import.yml.

Fixes #1376