### PR TITLE
fix: add timeout-minutes to unbounded CI jobs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: frontend
@@ -65,6 +66,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/keycloak-realm-import.yml
+++ b/.github/workflows/keycloak-realm-import.yml
@@ -34,6 +34,7 @@ jobs:
   import-check:
     name: Import realm on production Keycloak version
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -27,6 +27,7 @@ jobs:
   promote:
     name: Promote branch to tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ jobs:
   nuget-audit:
     name: NuGet dependency audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -38,6 +39,7 @@ jobs:
   npm-audit:
     name: npm dependency audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
nuget-audit/npm-audit/frontend lint+build get 10m, keycloak-realm-import (60-iteration Docker polling loop) gets 15m, release-rc promote gets 5m - matching the discipline already in dotnet.yml/publish.yml.

Closes #1377 