### PR TITLE
fix: keep release branch when tag validation or push fails

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -59,5 +59,5 @@ jobs:
           git push origin "$TAG"
 
       - name: Delete release branch
-        if: always()
+        if: success()
         run: git push origin --delete "${GITHUB_REF#refs/heads/}" || true


### PR DESCRIPTION
release-rc.yml deleted the release/* branch unconditionally (if: always()), even when tag extraction or the tag push step failed. That orphans any commits on the branch and forces the operator to recreate it from scratch to retry. Only delete on success() now.

Fixes #1368