### PR TITLE
docs: add CODEOWNERS and PR template

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -132,6 +132,11 @@ Both templates are in **German**. Fields:
 
 **Feature request:** Priorität, User Story (Als X, möchte ich Y, damit Z), Akzeptanzkriterien (checkboxes), Beschreibung, Umsetzungsideen, Zusätzliche Infos
 
+## Review & PR Template
+
+- `.github/CODEOWNERS` - `* @maik-hasler`, so review is auto-requested on every PR instead of relying on contributors to remember (see `CONTRIBUTING.md` "Pull Request Process")
+- `.github/PULL_REQUEST_TEMPLATE.md` - prompts for What/Why, the issue link, a Testing section, and the "Live verification" section required by root `AGENTS.md`'s deploy-and-verify flow
+
 ## Notes
 
 - Path filters prevent unnecessary builds (backend change → only `dotnet.yml` runs)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Falls back to the review expectation already documented in CONTRIBUTING.md.
+* @maik-hasler

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What
+
+<!-- Summarize the change in one or two sentences. -->
+
+## Why
+
+<!-- Explain the motivation. Link the issue this addresses. -->
+
+Closes #
+
+## Testing
+
+<!-- Which tests were added/updated, and how were they run? -->
+
+## Live verification
+
+<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
+Document what was observed on the release-candidate / live-staging check, or state why this
+change doesn't need one (e.g. docs-only, CI config). -->
+
+## Checklist
+
+- [ ] `/self-review` run and findings addressed
+- [ ] CI is green
+- [ ] Documentation updated if this change affects behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,8 @@ PR titles are validated against Conventional Commits in CI by the [`PR Title`](.
 1. Keep PRs focused - one logical change per PR
 2. Update documentation if your change affects behavior
 3. Ensure CI passes before requesting review
-4. The PR description should explain *why* the change is needed
-5. Request review from `@maik-hasler`
+4. Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) - it explains *why* the change is needed and links the issue
+5. Review is auto-requested via [`.github/CODEOWNERS`](.github/CODEOWNERS) (`@maik-hasler`)
 
 ## Testing
 


### PR DESCRIPTION
Auto-request review and prompt contributors for what/why, issue link, and live verification instead of relying on memory (#1369).

Closes #1369