### PR TITLE
fix: gate frontend and keycloak image publish on backend test jobs

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -61,7 +61,7 @@ All images pushed to **GitHub Container Registry (GHCR)**.
 **Full release:** Tag without `-rc` suffix → image published + `latest` tag updated.
 
 ### Publish flow (backend/frontend/keycloak)
-1. Run full test suite - for backend, this is three parallel jobs (`backend-fast-tests`/`backend-integration-tests`/`backend-visual-tests`, same split as `dotnet.yml`) that `publish-backend` waits on via `needs:` before building anything. Frontend runs its own lint/type-check/build inline; keycloak has no test gate
+1. Run full test suite - three parallel jobs (`backend-fast-tests`/`backend-integration-tests`/`backend-visual-tests`, same split as `dotnet.yml`) that `publish-backend`, `publish-frontend`, and `publish-keycloak` all wait on via `needs:` before building anything, so a test failure blocks every image, not just the backend's. Frontend additionally runs its own lint/type-check/build inline; keycloak has no additional test gate beyond the shared backend suite
 2. Login to GHCR
 3. Extract version from tag (strips leading `v`)
 4. Build and push Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -194,6 +194,7 @@ jobs:
 
   publish-frontend:
     name: Publish Frontend
+    needs: [backend-fast-tests, backend-integration-tests, backend-visual-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -264,6 +265,7 @@ jobs:
 
   publish-keycloak:
     name: Publish Keycloak
+    needs: [backend-fast-tests, backend-integration-tests, backend-visual-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
publish-frontend and publish-keycloak had no needs on the backend test jobs, so they still pushed latest/staging when tests failed - only publish-backend was gated. Mirrors publish-backend's needs list so a failing suite blocks all three images, not just the backend's.

Fixes #1374