### PR TITLE
fix: add HSTS header to API and cover subdomains on frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check nginx gzip_static wiring
         run: pnpm check:nginx-gzip-static
 
+      - name: Check nginx HSTS header
+        run: pnpm check:nginx-hsts
+
       - name: Type check
         run: pnpm check
 

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -170,6 +170,12 @@ app.Use(async (context, next) =>
 	context.Response.Headers["X-Content-Type-Options"] = "nosniff";
 	context.Response.Headers["X-Frame-Options"] = "DENY";
 	context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+	// Bearer tokens must never travel over a downgraded HTTP connection - skipped in
+	// Development since local dev runs over plain HTTP (#1370).
+	if (!app.Environment.IsDevelopment())
+		context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+
 	context.Response.Headers["X-Trace-Id"] =
 		Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
 	await next();

--- a/backend/tests/IntegrationTests/SecurityHeadersTests.cs
+++ b/backend/tests/IntegrationTests/SecurityHeadersTests.cs
@@ -1,0 +1,39 @@
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+public class SecurityHeadersTests(IntegrationTestFixture fixture)
+{
+	[Test]
+	public async Task GetAlive_ShouldIncludeBaselineSecurityHeaders(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync("/alive", cancellationToken);
+
+		response.Headers.TryGetValues("X-Content-Type-Options", out var contentTypeOptions).Should().BeTrue();
+		contentTypeOptions.Should().ContainSingle().Which.Should().Be("nosniff");
+
+		response.Headers.TryGetValues("X-Frame-Options", out var frameOptions).Should().BeTrue();
+		frameOptions.Should().ContainSingle().Which.Should().Be("DENY");
+
+		response.Headers.TryGetValues("Referrer-Policy", out var referrerPolicy).Should().BeTrue();
+		referrerPolicy.Should().ContainSingle().Which.Should().Be("strict-origin-when-cross-origin");
+	}
+
+	// The Aspire-hosted backend under test runs with ASPNETCORE_ENVIRONMENT=Development
+	// (Api's own launchSettings.json profile - AppHost.cs never overrides it for the
+	// "backend" resource), which is exactly the environment HSTS is intentionally
+	// skipped for (#1370): local dev serves plain HTTP, and HSTS would force a
+	// browser-cached HTTPS upgrade that breaks it.
+	[Test]
+	public async Task GetAlive_ShouldNotIncludeHsts_WhenRunningInDevelopment(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync("/alive", cancellationToken);
+
+		response.Headers.TryGetValues("Strict-Transport-Security", out _).Should().BeFalse();
+	}
+}

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -26,7 +26,7 @@ server {
 	add_header X-XSS-Protection "1; mode=block" always;
 	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
-	add_header Strict-Transport-Security "max-age=31536000" always;
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	add_header Content-Security-Policy $csp_header always;
 
 	location / {
@@ -40,7 +40,7 @@ server {
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
-		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
 
@@ -52,7 +52,7 @@ server {
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
-		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
 
@@ -63,7 +63,7 @@ server {
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
-		add_header Strict-Transport-Security "max-age=31536000" always;
+		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "i18n:check": "node scripts/check-i18n-keys.js",
     "check:nginx-csp": "node scripts/check-nginx-csp.js",
     "check:config-defer": "node scripts/check-config-defer.js",
-    "check:nginx-gzip-static": "node scripts/check-nginx-gzip-static.js"
+    "check:nginx-gzip-static": "node scripts/check-nginx-gzip-static.js",
+    "check:nginx-hsts": "node scripts/check-nginx-hsts.js"
   },
   "dependencies": {
     "@hookform/resolvers": "5.4.0",

--- a/frontend/scripts/check-nginx-hsts.js
+++ b/frontend/scripts/check-nginx-hsts.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Guards against the regression class behind issue #1370: the
+// Strict-Transport-Security header was missing includeSubDomains, so only the
+// exact host was protected against protocol downgrade and every subdomain
+// stayed open to it. The value is duplicated across four nginx location
+// blocks (no $host-keyed map like $csp_header, since it never varies by
+// host), so a future edit could silently fix it in one block and miss the
+// other three. Purely static checks - no Docker/nginx required.
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(__dirname, "..");
+
+const template = readFileSync(
+	join(frontendDir, "nginx.conf.template"),
+	"utf8",
+);
+
+let ok = true;
+function fail(message) {
+	console.error(message);
+	ok = false;
+}
+
+const hstsLines = template
+	.split("\n")
+	.map((line) => line.trim())
+	.filter((line) => /^add_header\s+Strict-Transport-Security\s+/.test(line));
+
+if (hstsLines.length === 0) {
+	fail("No `add_header Strict-Transport-Security` lines found in nginx.conf.template.");
+}
+
+const expected = 'add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;';
+for (const line of hstsLines) {
+	if (line !== expected) {
+		fail(
+			`Found a Strict-Transport-Security header not matching the expected value: "${line}". ` +
+				`Every location must emit exactly: ${expected}`,
+		);
+	}
+}
+
+if (ok) {
+	console.log(
+		`nginx Strict-Transport-Security header includes includeSubDomains consistently across all ${hstsLines.length} location blocks.`,
+	);
+} else {
+	process.exit(1);
+}


### PR DESCRIPTION
The API set three security headers but no Strict-Transport-Security, leaving bearer-token traffic without a browser-enforced HTTPS upgrade rule; nginx already set HSTS but omitted includeSubDomains. Adds the API header outside Development and extends the nginx value on all four location blocks, guarded by a new static consistency check (#1370).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

Closes #1370

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
