### PR TITLE
fix: replace obsolete SmtpClient with MailKit for outbound email

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -13,6 +13,8 @@
 		<PackageVersion Include="NSwag.MSBuild" Version="[14.7.1]" PrivateAssets="All" />
 		<!-- Infrastructure -->
 		<PackageVersion Include="Minio" Version="[7.0.0]" />
+		<PackageVersion Include="MailKit" Version="[4.17.0]" />
+		<PackageVersion Include="MimeKit" Version="[4.17.0]" />
 		<PackageVersion Include="EFCore.NamingConventions" Version="[10.0.1]" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[10.0.10]" PrivateAssets="All" />

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -1,8 +1,9 @@
-using System.Net;
-using System.Net.Mail;
 using Application.Common.Email;
+using MailKit.Net.Smtp;
+using MailKit.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MimeKit;
 
 namespace Infrastructure.Email;
 
@@ -22,28 +23,24 @@ internal sealed class SmtpEmailService(
 	{
 		try
 		{
-#pragma warning disable SYSLIB0006
-			using var client = new SmtpClient(_options.Host, _options.Port)
-			{
-				DeliveryMethod = SmtpDeliveryMethod.Network,
-				EnableSsl = _options.EnableSsl,
-				UseDefaultCredentials = false
-			};
-#pragma warning restore SYSLIB0006
+			using var client = new SmtpClient();
+
+			var secureSocketOptions = _options.EnableSsl
+				? SecureSocketOptions.StartTls
+				: SecureSocketOptions.None;
+			await client.ConnectAsync(_options.Host, _options.Port, secureSocketOptions, cancellationToken);
 
 			if (!string.IsNullOrEmpty(_options.Username))
-				client.Credentials = new NetworkCredential(_options.Username, _options.Password);
+				await client.AuthenticateAsync(_options.Username, _options.Password ?? string.Empty, cancellationToken);
 
-			using var message = new MailMessage
-			{
-				From = new MailAddress(_options.FromAddress, _options.FromName),
-				Subject = subject,
-				Body = body,
-				IsBodyHtml = false
-			};
-			message.To.Add(to);
+			using var message = new MimeMessage();
+			message.From.Add(new MailboxAddress(_options.FromName, _options.FromAddress));
+			message.To.Add(MailboxAddress.Parse(to));
+			message.Subject = subject;
+			message.Body = new TextPart("plain") { Text = body };
 
-			await client.SendMailAsync(message, cancellationToken);
+			await client.SendAsync(message, cancellationToken);
+			await client.DisconnectAsync(true, cancellationToken);
 
 			metrics.RecordSucceeded();
 		}

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -2,6 +2,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Minio" />
+		<PackageReference Include="MailKit" />
+		<PackageReference Include="MimeKit" />
 		<PackageReference Include="EFCore.NamingConventions" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -130,7 +130,7 @@ public class SmtpEmailServiceTests
 
 	// Minimal but protocol-correct SMTP responder: greets, accepts EHLO/MAIL
 	// FROM/RCPT TO/DATA/QUIT with no auth or TLS (matching EnableSsl=false,
-	// Username=null in these tests), just enough for SmtpClient.SendMailAsync
+	// Username=null in these tests), just enough for MailKit's SmtpClient.SendAsync
 	// to consider the send successful.
 	private sealed class FakeSmtpServer : IAsyncDisposable
 	{


### PR DESCRIPTION
System.Net.Mail.SmtpClient is obsolete (SYSLIB0006) and lacks modern TLS/auth support. SmtpEmailService now uses MailKit's async SmtpClient and MimeKit's MimeMessage instead, closing the last open item from #1071 (SmtpOptions auth fields, docker-compose env vars, and warning->error logging were already fixed by #1341/#1342).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

Closes #1071

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
