### PR TITLE
feat: show next time slot date on volunteer opportunity cards

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -8140,6 +8140,8 @@
           "category",
           "tags",
           "createdOn",
+          "nextTimeSlotStart",
+          "nextTimeSlotEnd",
           "totalMaxParticipants",
           "currentParticipantCount",
           "status",
@@ -8235,6 +8237,20 @@
           },
           "createdOn": {
             "type": "string",
+            "format": "date-time"
+          },
+          "nextTimeSlotStart": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "nextTimeSlotEnd": {
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "totalMaxParticipants": {

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
@@ -19,6 +19,8 @@ public sealed record VolunteerOpportunitySummary(
 	string? Category,
 	IReadOnlyList<string> Tags,
 	DateTimeOffset CreatedOn,
+	DateTimeOffset? NextTimeSlotStart,
+	DateTimeOffset? NextTimeSlotEnd,
 	int TotalMaxParticipants,
 	int CurrentParticipantCount,
 	string Status,

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -103,6 +103,16 @@ internal sealed class VolunteerOpportunityReadRepository(
 				x.vo.Category,
 				x.vo.Tags,
 				x.vo.CreatedOn,
+				NextTimeSlotStart = x.vo.TimeSlots
+					.Where(ts => ts.EndDateTime >= now)
+					.OrderBy(ts => ts.StartDateTime)
+					.Select(ts => (DateTimeOffset?)ts.StartDateTime)
+					.FirstOrDefault(),
+				NextTimeSlotEnd = x.vo.TimeSlots
+					.Where(ts => ts.EndDateTime >= now)
+					.OrderBy(ts => ts.StartDateTime)
+					.Select(ts => (DateTimeOffset?)ts.EndDateTime)
+					.FirstOrDefault(),
 				x.vo.Status,
 				x.vo.BannerImageUrl,
 			});
@@ -132,7 +142,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 			var summaries = page
 				.Select(x => ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, x.OrgName, x.OrgIsVerified, x.OrgLogoUrl,
 					x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
-					x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.Status, x.BannerImageUrl,
+					x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.NextTimeSlotStart, x.NextTimeSlotEnd,
+					x.Status, x.BannerImageUrl,
 					maxPMap.GetValueOrDefault(x.Id, 0), partCountMap.GetValueOrDefault(x.Id, 0)))
 				.ToList();
 
@@ -154,7 +165,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 		var result = rows
 			.Select(x => ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, x.OrgName, x.OrgIsVerified, x.OrgLogoUrl,
 				x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
-				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.Status, x.BannerImageUrl,
+				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.NextTimeSlotStart, x.NextTimeSlotEnd,
+				x.Status, x.BannerImageUrl,
 				maxParticipantsMap.GetValueOrDefault(x.Id, 0), participantCountMap.GetValueOrDefault(x.Id, 0)))
 			.ToList();
 
@@ -228,6 +240,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 		Category? category,
 		IReadOnlyList<string> tags,
 		DateTimeOffset createdOn,
+		DateTimeOffset? nextTimeSlotStart,
+		DateTimeOffset? nextTimeSlotEnd,
 		OpportunityStatus status,
 		string? bannerImageUrl,
 		int totalMaxParticipants,
@@ -251,6 +265,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 			category?.ToString(),
 			tags,
 			createdOn,
+			nextTimeSlotStart,
+			nextTimeSlotEnd,
 			totalMaxParticipants,
 			currentParticipantCount,
 			status.ToString(),
@@ -379,6 +395,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 		CancellationToken cancellationToken = default)
 	{
 		var organizationId_ = OrganizationId.Create(organizationId).GetValueOrThrow();
+		var now = DateTimeOffset.UtcNow;
 
 		var orgQuery = dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => vo.OrganizationId == organizationId_);
@@ -415,6 +432,16 @@ internal sealed class VolunteerOpportunityReadRepository(
 				x.vo.Category,
 				x.vo.Tags,
 				x.vo.CreatedOn,
+				NextTimeSlotStart = x.vo.TimeSlots
+					.Where(ts => ts.EndDateTime >= now)
+					.OrderBy(ts => ts.StartDateTime)
+					.Select(ts => (DateTimeOffset?)ts.StartDateTime)
+					.FirstOrDefault(),
+				NextTimeSlotEnd = x.vo.TimeSlots
+					.Where(ts => ts.EndDateTime >= now)
+					.OrderBy(ts => ts.StartDateTime)
+					.Select(ts => (DateTimeOffset?)ts.EndDateTime)
+					.FirstOrDefault(),
 				x.vo.Status,
 				x.vo.BannerImageUrl,
 			})
@@ -429,7 +456,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 		return rows
 			.Select(x => ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, x.OrgName, x.OrgIsVerified, x.OrgLogoUrl,
 				x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
-				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.Status, x.BannerImageUrl,
+				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.NextTimeSlotStart, x.NextTimeSlotEnd,
+				x.Status, x.BannerImageUrl,
 				maxParticipantsMap.GetValueOrDefault(x.Id, 0), participantCountMap.GetValueOrDefault(x.Id, 0)))
 			.ToList();
 	}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -11689,6 +11689,12 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.DateTimeOffset CreatedOn { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("nextTimeSlotStart")]
+        public System.DateTimeOffset? NextTimeSlotStart { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("nextTimeSlotEnd")]
+        public System.DateTimeOffset? NextTimeSlotEnd { get; set; } = default!;
+
         [System.Text.Json.Serialization.JsonPropertyName("totalMaxParticipants")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -147,6 +147,124 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnNextTimeSlotStartAndEnd_WhenTimeSlotExists(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Opportunity with a slot",
+			Description = "Description",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "Waitlist",
+			CheckInMethod = "None",
+			IsDraft = true,
+		}, cancellationToken);
+
+		var start = DateTimeOffset.UtcNow.AddDays(7);
+		var end = start.AddHours(2);
+		await authenticatedClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = start,
+				EndDateTime = end,
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		await authenticatedClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, cancellationToken: cancellationToken);
+
+		var item = result.Items.Single();
+		item.NextTimeSlotStart.Should().BeCloseTo(start, TimeSpan.FromSeconds(1));
+		item.NextTimeSlotEnd.Should().BeCloseTo(end, TimeSpan.FromSeconds(1));
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnEarliestUpcomingTimeSlot_WhenMultipleSlotsExist(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Opportunity with recurring slots",
+			Description = "Description",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "Recurring",
+			ParticipationType = "Waitlist",
+			CheckInMethod = "None",
+			IsDraft = true,
+		}, cancellationToken);
+
+		var earliestStart = DateTimeOffset.UtcNow.AddDays(3);
+		await authenticatedClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = earliestStart,
+				EndDateTime = earliestStart.AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = "WEEKLY",
+				RecurrenceCount = 3,
+			},
+			cancellationToken);
+
+		await authenticatedClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, cancellationToken: cancellationToken);
+
+		var item = result.Items.Single();
+		item.NextTimeSlotStart.Should().BeCloseTo(earliestStart, TimeSpan.FromSeconds(1));
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnNullNextTimeSlot_WhenNoTimeSlotsExist(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Opportunity without slots",
+			Description = "Description",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+		}, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, cancellationToken: cancellationToken);
+
+		var item = result.Items.Single();
+		item.NextTimeSlotStart.Should().BeNull();
+		item.NextTimeSlotEnd.Should().BeNull();
+	}
+
+	[Test]
 	public async Task CreateVolunteerOpportunity_ShouldReturn403_WhenUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5561,6 +5561,8 @@ export interface VolunteerOpportunitySummary {
     category: string | undefined;
     tags: string[];
     createdOn: Date;
+    nextTimeSlotStart: Date | undefined;
+    nextTimeSlotEnd: Date | undefined;
     totalMaxParticipants: number;
     currentParticipantCount: number;
     status: string;

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -2,10 +2,10 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "react-oidc-context";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
-import { formatOccurrence } from "../../lib/format";
+import { formatDateTime, formatOccurrence } from "../../lib/format";
 import { useApiClient } from "../../hooks/useApiClient";
 import ReportFlagButton from "../ReportFlagButton";
-import { CategoryGlyph, GlobeIcon, PinIcon } from "./icons";
+import { CalendarIcon, CategoryGlyph, GlobeIcon, PinIcon } from "./icons";
 
 function orgInitials(name: string): string {
 	const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -19,7 +19,7 @@ export default function OpportunityListItem({
 }: {
 	item: VolunteerOpportunitySummary;
 }) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const auth = useAuth();
 	const spotsLeft =
@@ -107,6 +107,17 @@ export default function OpportunityListItem({
 					<h3 className="text-base font-semibold leading-snug text-gray-900 transition-colors group-hover:text-brand-700 sm:text-lg">
 						{item.title}
 					</h3>
+					{item.nextTimeSlotStart && (
+						<p className="mt-1 flex items-center gap-1.5 text-sm font-medium text-brand-700">
+							<CalendarIcon className="h-4 w-4 shrink-0" />
+							<span>
+								{formatDateTime(
+									item.nextTimeSlotStart as unknown as string,
+									i18n.language,
+								)}
+							</span>
+						</p>
+					)}
 					{item.description && (
 						<p className="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-500">
 							{item.description}


### PR DESCRIPTION
The browse-list DTO only carried CreatedOn, so search results never showed when an opportunity happens even though the date filter works. Adds NextTimeSlotStart/NextTimeSlotEnd (earliest upcoming slot) to VolunteerOpportunitySummary and renders the start as the card's primary metadata line.

Fixes #974

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
