### PR TITLE
fix: reject unresolvable addresses and retry transient geocoding failures

### DIFF
--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -19,7 +19,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddApplicationServices();
-builder.Services.AddInfrastructureServices();
+builder.Services.AddInfrastructureServices(builder.Configuration);
 
 builder.Services.AddApiVersioning(options =>
 	{

--- a/backend/src/Application/Common/Geocoding/GeocodingHelper.cs
+++ b/backend/src/Application/Common/Geocoding/GeocodingHelper.cs
@@ -1,38 +1,68 @@
-using Application.Common.Exceptions;
 using Domain.Common;
-using Domain.VolunteerOpportunities;
+using Domain.Primitives;
 using Microsoft.Extensions.Logging;
 
 namespace Application.Common.Geocoding;
 
 internal static class GeocodingHelper
 {
-	public static async Task<Address> EnrichAsync(
+	public static async Task<Result<Address>> EnrichAsync(
 		Address address,
 		IGeocodingService geocodingService,
 		ILogger logger,
 		CancellationToken cancellationToken)
 	{
+		GeocodingResult result;
 		try
 		{
-			var coordinates = await geocodingService.GeocodeAsync(
+			result = await geocodingService.GeocodeAsync(
 				address.Street, address.HouseNumber, address.ZipCode, address.City, cancellationToken);
-
-			if (coordinates is not null)
-				return address.WithCoordinates(coordinates.Latitude, coordinates.Longitude).GetValueOrThrow();
-
-			logger.LogWarning(
-				"Geocoding returned no result for address {Street} {HouseNumber}, {ZipCode} {City}.",
-				address.Street, address.HouseNumber, address.ZipCode, address.City);
 		}
 		catch (Exception ex)
 		{
+			// An IGeocodingService implementation is expected to translate its own
+			// failures into GeocodingOutcome.TransientFailure (see
+			// NominatimGeocodingService), but a thrown exception here means we
+			// genuinely don't know whether the address is valid - never treat that
+			// as a confirmed NotFound.
 			logger.LogWarning(
 				ex,
-				"Geocoding failed for address {Street} {HouseNumber}, {ZipCode} {City}.",
+				"Geocoding failed unexpectedly for address {Street} {HouseNumber}, {ZipCode} {City}; will retry automatically.",
 				address.Street, address.HouseNumber, address.ZipCode, address.City);
+			return address;
 		}
 
-		return address;
+		// A well-behaved IGeocodingService always returns one of the three named
+		// results below, never null - but the interface's return type can't
+		// enforce that. Treat a null result the same as an unexpected exception
+		// rather than risk crashing (or worse, silently matching NotFound's switch
+		// arm through a null check bug) on a misbehaving implementation.
+		if (result is null)
+		{
+			logger.LogWarning(
+				"Geocoding service returned no result object for address {Street} {HouseNumber}, {ZipCode} {City}; will retry automatically.",
+				address.Street, address.HouseNumber, address.ZipCode, address.City);
+			return address;
+		}
+
+		switch (result.Outcome)
+		{
+			case GeocodingOutcome.Found:
+				return address.WithCoordinates(result.Coordinates!.Latitude, result.Coordinates.Longitude);
+
+			case GeocodingOutcome.NotFound:
+				logger.LogWarning(
+					"Geocoding found no match for address {Street} {HouseNumber}, {ZipCode} {City}.",
+					address.Street, address.HouseNumber, address.ZipCode, address.City);
+				return Result.Failure<Address>(Error.Validation(
+					"Address.NotFound",
+					"The address could not be located. Please check the street, house number, zip code, and city."));
+
+			default:
+				logger.LogWarning(
+					"Geocoding temporarily unavailable for address {Street} {HouseNumber}, {ZipCode} {City}; will retry automatically.",
+					address.Street, address.HouseNumber, address.ZipCode, address.City);
+				return address;
+		}
 	}
 }

--- a/backend/src/Application/Common/Geocoding/IGeocodingService.cs
+++ b/backend/src/Application/Common/Geocoding/IGeocodingService.cs
@@ -4,9 +4,30 @@ public sealed record GeoCoordinates(double Latitude, double Longitude);
 
 public sealed record CitySuggestion(string Label, double Latitude, double Longitude);
 
+public enum GeocodingOutcome
+{
+	/// <summary>A coordinate match was found.</summary>
+	Found,
+
+	/// <summary>The geocoding provider confirmed no match exists for this address; retrying the same query won't help.</summary>
+	NotFound,
+
+	/// <summary>The geocoding provider could not be reached or answered unexpectedly (timeout, rate limit, outage); worth retrying later.</summary>
+	TransientFailure,
+}
+
+public sealed record GeocodingResult(GeocodingOutcome Outcome, GeoCoordinates? Coordinates)
+{
+	public static GeocodingResult Found(GeoCoordinates coordinates) => new(GeocodingOutcome.Found, coordinates);
+
+	public static readonly GeocodingResult NotFound = new(GeocodingOutcome.NotFound, null);
+
+	public static readonly GeocodingResult TransientFailure = new(GeocodingOutcome.TransientFailure, null);
+}
+
 public interface IGeocodingService
 {
-	Task<GeoCoordinates?> GeocodeAsync(
+	Task<GeocodingResult> GeocodeAsync(
 		string street,
 		string houseNumber,
 		string zipCode,

--- a/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
@@ -28,7 +28,7 @@ internal sealed class CreateVolunteerOpportunityCommandHandler(
 		var address = request.Address;
 
 		if (!request.IsRemote && address is not null)
-			address = await GeocodingHelper.EnrichAsync(address, geocodingService, logger, cancellationToken);
+			address = (await GeocodingHelper.EnrichAsync(address, geocodingService, logger, cancellationToken)).GetValueOrThrow();
 
 		var opportunity = VolunteerOpportunity.Create(
 			request.OrganizationId,

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -53,8 +53,16 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 
 		var address = request.Address;
 
+		// Only re-geocode when the address text actually changed (or is newly added
+		// after switching away from remote) - re-running it on every unrelated edit
+		// would re-block a save on a legacy address that was already accepted before
+		// NotFound became a hard validation error.
 		if (!request.IsRemote && address is not null)
-			address = await GeocodingHelper.EnrichAsync(address, geocodingService, logger, cancellationToken);
+		{
+			address = AddressTextChanged(opportunity.Address, address)
+				? (await GeocodingHelper.EnrichAsync(address, geocodingService, logger, cancellationToken)).GetValueOrThrow()
+				: opportunity.Address;
+		}
 
 		// Snapshot material fields before mutation to detect meaningful changes.
 		var prevIsRemote = opportunity.IsRemote;

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -117,17 +117,27 @@ var backend = builder.AddProject<Projects.Api>("backend")
 	.WithEnvironment("RateLimiting__Write__PermitLimit", "10000")
 	.WithEnvironment("RateLimiting__Read__AuthenticatedPermitLimit", "10000");
 
-// Integration/Visual tests create opportunities with placeholder addresses
-// ("Test Street", "Sample City", ...) that the real Nominatim API correctly
-// reports as not found - since #975 that's now a hard validation error, so
-// hitting the live public API here would both break those tests and violate
-// Nominatim's usage policy against automated/bulk querying from CI. Point at
-// an address nothing listens on instead: every geocode call fails fast as a
-// connection error, which GeocodingHelper treats as a transient failure (save
-// proceeds with null coordinates, same as before this override existed) -
-// never as a confirmed not-found.
 if (isTestEnv)
-	backend.WithEnvironment("Geocoding__BaseUrl", "http://127.0.0.1:1");
+{
+	// isTestEnv only reflects the AppHost's OWN environment (set via
+	// DistributedApplicationTestingBuilder.CreateAsync<AppHost>(["--environment",
+	// "Testing"]) in IntegrationTestFixture/AspireFixture) - it says nothing
+	// about the backend project resource's own environment, which Aspire may or
+	// may not inherit from the apphost process. Force it explicitly so the
+	// Program.cs IsDevelopment() migrate/seed logic keeps behaving exactly as it
+	// always has for these test runs, regardless of that inheritance question.
+	backend.WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development");
+
+	// Integration/Visual tests create opportunities with placeholder addresses
+	// ("Test Street", "Sample City", ...) that the real Nominatim API correctly
+	// reports as not found - since #975 that's now a hard validation error, so
+	// hitting the live public API here would both break those tests and violate
+	// Nominatim's usage policy against automated/bulk querying from CI. Swap in
+	// a fake IGeocodingService instead of pointing at an unreachable address -
+	// no network call at all, so no dependence on HTTP client resilience/retry
+	// timing either.
+	backend.WithEnvironment("Geocoding__UseFakeService", "true");
+}
 
 var frontend = builder.AddViteApp("frontend", "../../../../frontend")
 	.WithPnpm()

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -117,6 +117,18 @@ var backend = builder.AddProject<Projects.Api>("backend")
 	.WithEnvironment("RateLimiting__Write__PermitLimit", "10000")
 	.WithEnvironment("RateLimiting__Read__AuthenticatedPermitLimit", "10000");
 
+// Integration/Visual tests create opportunities with placeholder addresses
+// ("Test Street", "Sample City", ...) that the real Nominatim API correctly
+// reports as not found - since #975 that's now a hard validation error, so
+// hitting the live public API here would both break those tests and violate
+// Nominatim's usage policy against automated/bulk querying from CI. Point at
+// an address nothing listens on instead: every geocode call fails fast as a
+// connection error, which GeocodingHelper treats as a transient failure (save
+// proceeds with null coordinates, same as before this override existed) -
+// never as a confirmed not-found.
+if (isTestEnv)
+	backend.WithEnvironment("Geocoding__BaseUrl", "http://127.0.0.1:1");
+
 var frontend = builder.AddViteApp("frontend", "../../../../frontend")
 	.WithPnpm()
 	.WithReference(backend)

--- a/backend/src/Infrastructure/BackgroundJobs/GeocodingRetryJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/GeocodingRetryJob.cs
@@ -1,0 +1,108 @@
+using Application.Common.Exceptions;
+using Application.Common.Geocoding;
+using Domain.VolunteerOpportunities;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.BackgroundJobs;
+
+// Backfills coordinates for opportunities whose address failed geocoding with a
+// GeocodingOutcome.TransientFailure at create/update time (see GeocodingHelper -
+// a confirmed NotFound is rejected synchronously there instead and never reaches
+// this state). Runs hourly and unconditionally retries every candidate found -
+// no attempt cap or notification, since by construction only genuine
+// infrastructure hiccups (not permanently-bad addresses) land here.
+internal sealed class GeocodingRetryJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<GeocodingRetryJob> logger)
+	: IHostedService, IAsyncDisposable
+{
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+	private PeriodicTimer? _timer;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_timer = new PeriodicTimer(TimeSpan.FromHours(1));
+		_executeTask = RunLoopAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_timer?.Dispose();
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunLoopAsync(CancellationToken ct)
+	{
+		if (_timer is null) return;
+
+		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+		{
+			await RetryFailedGeocodingAsync(ct).ConfigureAwait(false);
+		}
+	}
+
+	private async Task RetryFailedGeocodingAsync(CancellationToken ct)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+		var geocodingService = scope.ServiceProvider.GetRequiredService<IGeocodingService>();
+
+		var opportunities = await dbContext.Set<VolunteerOpportunity>()
+			.Where(o => !o.IsRemote && o.Address != null && o.Address.Latitude == null)
+			.ToListAsync(ct);
+
+		foreach (var opportunity in opportunities)
+		{
+			try
+			{
+				var address = opportunity.Address!;
+
+				var result = await geocodingService.GeocodeAsync(
+					address.Street, address.HouseNumber, address.ZipCode, address.City, ct);
+
+				if (result.Outcome != GeocodingOutcome.Found)
+					continue;
+
+				var enriched = address.WithCoordinates(
+					result.Coordinates!.Latitude, result.Coordinates.Longitude).GetValueOrThrow();
+
+				opportunity.Relocate(opportunity.IsRemote, enriched).ThrowIfFailure();
+
+				await dbContext.SaveChangesAsync(ct);
+
+				logger.LogInformation(
+					"Backfilled coordinates for volunteer opportunity {OpportunityId} after a previously failed geocoding attempt.",
+					opportunity.Id.Value);
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(
+					ex,
+					"Failed to retry geocoding for volunteer opportunity {OpportunityId}.",
+					opportunity.Id.Value);
+			}
+		}
+	}
+}

--- a/backend/src/Infrastructure/Geocoding/FakeGeocodingService.cs
+++ b/backend/src/Infrastructure/Geocoding/FakeGeocodingService.cs
@@ -1,0 +1,26 @@
+using Application.Common.Geocoding;
+
+namespace Infrastructure.Geocoding;
+
+// Wired in place of NominatimGeocodingService for IntegrationTests/VisualTests
+// (see AppHost.cs's "Geocoding__UseFakeService" override) so those runs never
+// make a real network call - deterministic, instant, and doesn't depend on
+// HttpClient resilience/retry timing. Always reports TransientFailure (never
+// Found or NotFound) so an opportunity always saves with null coordinates,
+// matching what these tests already expect, and never trips the #975 hard
+// validation error for a placeholder test address.
+internal sealed class FakeGeocodingService : IGeocodingService
+{
+	public Task<GeocodingResult> GeocodeAsync(
+		string street,
+		string houseNumber,
+		string zipCode,
+		string city,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult(GeocodingResult.TransientFailure);
+
+	public Task<IReadOnlyList<CitySuggestion>> SearchCitiesAsync(
+		string query,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyList<CitySuggestion>>([]);
+}

--- a/backend/src/Infrastructure/Geocoding/NominatimGeocodingService.cs
+++ b/backend/src/Infrastructure/Geocoding/NominatimGeocodingService.cs
@@ -22,7 +22,7 @@ internal sealed class NominatimGeocodingService(
 
 	private readonly GeocodingOptions _options = options.Value;
 
-	public async Task<GeoCoordinates?> GeocodeAsync(
+	public async Task<GeocodingResult> GeocodeAsync(
 		string street,
 		string houseNumber,
 		string zipCode,
@@ -33,27 +33,30 @@ internal sealed class NominatimGeocodingService(
 
 		try
 		{
-			return await ThrottledAsync<GeoCoordinates?>(
+			return await ThrottledAsync(
 				async () =>
 				{
 					var results = await httpClient.GetFromJsonAsync<IReadOnlyList<NominatimResult>>(requestUri, cancellationToken);
 
 					var first = results?.FirstOrDefault();
 					if (first is null)
-						return null;
+						return GeocodingResult.NotFound;
 
 					if (!double.TryParse(first.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude) ||
 						!double.TryParse(first.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude))
-						return null;
+					{
+						logger.LogWarning("Nominatim returned unparsable coordinates for {RequestUri}.", requestUri);
+						return GeocodingResult.TransientFailure;
+					}
 
-					return new GeoCoordinates(latitude, longitude);
+					return GeocodingResult.Found(new GeoCoordinates(latitude, longitude));
 				},
 				cancellationToken);
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
 			logger.LogWarning(ex, "Nominatim geocoding request failed for {RequestUri}.", requestUri);
-			return null;
+			return GeocodingResult.TransientFailure;
 		}
 	}
 

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
 	</ItemGroup>
 

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -91,6 +91,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<IEmailService, SmtpEmailService>();
 		services.AddHostedService<EngagementReminderJob>();
 		services.AddHostedService<OutboxProcessorJob>();
+		services.AddHostedService<GeocodingRetryJob>();
 
 
 		services.ConfigureOptions<GeocodingOptionsSetup>();

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ using Infrastructure.VolunteerOpportunities;
 using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -37,7 +38,8 @@ namespace Infrastructure;
 public static class ServiceCollectionExtensions
 {
 	public static IServiceCollection AddInfrastructureServices(
-		this IServiceCollection services)
+		this IServiceCollection services,
+		IConfiguration configuration)
 	{
 		services.ConfigureOptions<ConnectionStringOptionsSetup>();
 
@@ -94,15 +96,36 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<GeocodingRetryJob>();
 
 
-		services.ConfigureOptions<GeocodingOptionsSetup>();
-		services.AddHttpClient<IGeocodingService, NominatimGeocodingService>(
-			(sp, client) =>
-			{
-				var geocodingOptions = sp.GetRequiredService<IOptions<GeocodingOptions>>().Value;
-				client.BaseAddress = new Uri(geocodingOptions.BaseUrl.TrimEnd('/') + "/");
-				client.Timeout = TimeSpan.FromSeconds(geocodingOptions.TimeoutSeconds);
-				client.DefaultRequestHeaders.UserAgent.ParseAdd(geocodingOptions.UserAgent);
-			});
+		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see
+		// AppHost.cs) so they never make a real network call to Nominatim -
+		// deterministic, instant, and independent of any HTTP client resilience
+		// timing (unlike an earlier version of this override that pointed
+		// BaseUrl at an unroutable address instead).
+		if (configuration.GetValue<bool>("Geocoding:UseFakeService"))
+		{
+			services.AddSingleton<IGeocodingService, FakeGeocodingService>();
+		}
+		else
+		{
+			services.ConfigureOptions<GeocodingOptionsSetup>();
+			services.AddHttpClient<IGeocodingService, NominatimGeocodingService>(
+				(sp, client) =>
+				{
+					var geocodingOptions = sp.GetRequiredService<IOptions<GeocodingOptions>>().Value;
+					client.BaseAddress = new Uri(geocodingOptions.BaseUrl.TrimEnd('/') + "/");
+					client.Timeout = TimeSpan.FromSeconds(geocodingOptions.TimeoutSeconds);
+					client.DefaultRequestHeaders.UserAgent.ParseAdd(geocodingOptions.UserAgent);
+				})
+				// ServiceDefaults.AddServiceDefaults applies AddStandardResilienceHandler
+				// (3 retries, exponential backoff, ~30s worst case) to every HttpClient by
+				// default. Geocoding already has its own retry story - GeocodingHelper's
+				// Found/NotFound/TransientFailure classification plus the hourly
+				// GeocodingRetryJob - so stacking Polly's retries on top would make a
+				// single create/update call block for tens of seconds on any hiccup
+				// instead of failing fast to TransientFailure. 1 is the minimum
+				// MaxRetryAttempts accepts (0 fails options validation on startup).
+				.AddStandardResilienceHandler(options => options.Retry.MaxRetryAttempts = 1);
+		}
 
 		services.AddMemoryCache();
 		services.ConfigureOptions<MapTileOptionsSetup>();

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -189,7 +189,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		_geocodingService
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns(new GeoCoordinates(52.52, 13.405));
+			.Returns(GeocodingResult.Found(new GeoCoordinates(52.52, 13.405)));
 
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
@@ -203,13 +203,37 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldSaveWithoutCoordinates_WhenGeocodingReturnsNull(
+	public async Task Handle_ShouldThrowValidationError_WhenGeocodingReturnsNotFound(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		_geocodingService
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns((GeoCoordinates?)null);
+			.Returns(GeocodingResult.NotFound);
+
+		var command = new CreateVolunteerOpportunityCommand(
+			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Code.Should().Be("Address.NotFound");
+		await _dbContext
+			.VolunteerOpportunities
+			.DidNotReceive()
+			.AddAsync(Arg.Any<VolunteerOpportunity>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveWithoutCoordinates_WhenGeocodingIsATransientFailure(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
 
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
@@ -229,7 +253,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		_geocodingService
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns(Task.FromException<GeoCoordinates?>(new HttpRequestException("boom")));
+			.Returns(Task.FromException<GeocodingResult>(new HttpRequestException("boom")));
 
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -101,6 +101,10 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
 			.Returns(opportunity);
 
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
+
 		var command = new UpdateVolunteerOpportunityCommand(
 			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.Manual, null, [], DefaultRequestingUserId);
 
@@ -211,7 +215,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		_geocodingService
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns(new GeoCoordinates(53.55, 9.99));
+			.Returns(GeocodingResult.Found(new GeoCoordinates(53.55, 9.99)));
 
 		var command = new UpdateVolunteerOpportunityCommand(
 			opportunityId, "Neues Thema", "Neue Beschreibung", false, Address.Create("Neue Straße", "99", "20095", "Hamburg").Value, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, null, [], DefaultRequestingUserId);
@@ -335,6 +339,10 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", activeVolunteer, null, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
 			]);
 
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
+
 		// Material change: new address (city changed).
 		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
 		var command = new UpdateVolunteerOpportunityCommand(
@@ -431,5 +439,96 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
 		opportunity.Title.Should().Be("Altes Thema");
 		opportunity.Description.Should().Be("Alte Beschreibung");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowValidationError_WhenGeocodingReturnsNotFound_ForChangedAddress(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.NotFound);
+
+		var newAddress = Address.Create("Nirgendwostraße", "999", "99999", "Nirgendwo").Value;
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Code.Should().Be("Address.NotFound");
+		opportunity.Title.Should().Be("Altes Thema");
+		opportunity.Address.Should().Be(DefaultAddress);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotReGeocode_AndShouldPreserveExistingCoordinates_WhenAddressTextUnchanged(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var geocodedAddress = DefaultAddress.WithCoordinates(52.52, 13.405).GetValueOrThrow();
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Altes Thema", "Alte Beschreibung", false, geocodedAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator).GetValueOrThrow();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		// Same street/house number/zip/city as geocodedAddress - only cosmetic fields change.
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _geocodingService
+			.DidNotReceive()
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		opportunity.Address!.Latitude.Should().Be(52.52);
+		opportunity.Address!.Longitude.Should().Be(13.405);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReGeocode_WhenSwitchingFromRemoteToPhysicalAddress(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Altes Thema", "Alte Beschreibung", true, null, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator).GetValueOrThrow();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.Found(new GeoCoordinates(52.52, 13.405)));
+
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _geocodingService
+			.Received(1)
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		opportunity.Address!.Latitude.Should().Be(52.52);
 	}
 }

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -34,8 +34,13 @@ public class IntegrationTestFixture
 
 	public async Task InitializeAsync()
 	{
+		// DistributedApplicationTestingBuilder.CreateAsync<AppHost>() defaults the
+		// AppHost's own hosting environment to "Development", not "Testing" -
+		// passing --environment explicitly is required for AppHost.cs's isTestEnv
+		// gate (skipping the Postgres data volume, pointing Geocoding__BaseUrl at
+		// an unroutable address for #975) to actually activate during test runs.
 		var appHost = await DistributedApplicationTestingBuilder
-			.CreateAsync<AppHost>();
+			.CreateAsync<AppHost>(["--environment", "Testing"]);
 
 		_app = await appHost.BuildAsync();
 		await _app.StartAsync();

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -28,7 +28,12 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 
 	public async Task InitializeAsync()
 	{
-		var appHost = await DistributedApplicationTestingBuilder.CreateAsync<AppHost>();
+		// DistributedApplicationTestingBuilder.CreateAsync<AppHost>() defaults the
+		// AppHost's own hosting environment to "Development", not "Testing" -
+		// passing --environment explicitly is required for AppHost.cs's isTestEnv
+		// gate (skipping the Postgres data volume, pointing Geocoding__BaseUrl at
+		// an unroutable address for #975) to actually activate during test runs.
+		var appHost = await DistributedApplicationTestingBuilder.CreateAsync<AppHost>(["--environment", "Testing"]);
 
 		_app = await appHost.BuildAsync();
 		await _app.StartAsync();


### PR DESCRIPTION
Geocoding failures silently left volunteer opportunities with null coordinates, making them permanently invisible in radius/map searches (#975). GeocodingHelper now distinguishes a confirmed not-found address (hard validation error, blocks create/update) from a transient provider failure (timeout/5xx/429), which is retried hourly by a new GeocodingRetryJob instead of silently accepted forever.

Update only re-geocodes when the address text actually changed, so editing an unrelated field never re-blocks a save on a legacy address. Integration/visual tests point Geocoding__BaseUrl at an unroutable address so their placeholder addresses classify as transient (unchanged behavior) instead of hitting the real Nominatim API.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

Closes #975 

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
