### PR TITLE
fix: replace materialized opportunity-id list with IN subquery in dashboard KPIs

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationDashboardReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationDashboardReadRepository.cs
@@ -19,14 +19,15 @@ internal sealed class OrganizationDashboardReadRepository(
 		var now = DateTimeOffset.UtcNow;
 		var sevenDaysLater = now.AddDays(7);
 
-		// Materialize the org's opportunity ids once instead of re-running the
-		// same subquery inside every count below.
-		var orgOpportunityIds = await dbContext.VolunteerOpportunitiesQuery
+		// Kept as an IQueryable (not materialized) so every use below compiles to a
+		// correlated "IN (SELECT ...)" subquery instead of shipping the id list to
+		// and from Postgres as a literal array.
+		var orgOpportunityIds = dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => vo.OrganizationId == orgId)
-			.Select(vo => vo.Id)
-			.ToListAsync(cancellationToken);
+			.Select(vo => vo.Id);
 
-		var openOpportunities = orgOpportunityIds.Count;
+		var openOpportunities = await dbContext.VolunteerOpportunitiesQuery
+			.CountAsync(vo => vo.OrganizationId == orgId, cancellationToken);
 
 		// A single grouped query covers every status breakdown (pending, cancelled, ...).
 		var countsByStatus = await dbContext.EngagementsQuery
@@ -45,7 +46,7 @@ internal sealed class OrganizationDashboardReadRepository(
 			.FirstOrDefault(c => c.Status == EngagementStatus.Confirmed)?.Count ?? 0;
 
 		// The "next 7 days" metric needs a join to time slots plus a date filter,
-		// so it stays a dedicated query (still using the materialized id list).
+		// so it stays a dedicated query (still reusing the same subquery).
 		var confirmedEngagementsNext7Days = await dbContext.EngagementsQuery
 			.Where(e => orgOpportunityIds.Contains(e.OpportunityId) && e.Status == EngagementStatus.Confirmed && e.TimeSlotId != null)
 			.Join(

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -1,0 +1,203 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1398: OrganizationDashboardReadRepository used to
+// materialize every opportunity id for an org into memory and re-check it with
+// in-memory Contains(), instead of an IN (SELECT ...) subquery. These tests pin
+// down the KPI counts themselves so a future change to that query keeps
+// producing the same numbers, whatever shape the query takes underneath.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldReturnAllZeros_WhenOrganizationHasNoOpportunities(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		var kpis = await olafClient.GetOrganizationDashboardAsync(orgId, cancellationToken);
+
+		kpis.OpenOpportunities.Should().Be(0);
+		kpis.PendingEngagements.Should().Be(0);
+		kpis.CancelledEngagements.Should().Be(0);
+		kpis.ConfirmedEngagementsTotal.Should().Be(0);
+		kpis.ConfirmedEngagementsNext7Days.Should().Be(0);
+	}
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldReturnAccurateKpis_ForOrganizationWithMixedEngagementStatuses(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		// Two open opportunities.
+		var opportunityA = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+		var opportunityB = await CreateWaitlistOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var slotNear = (await olafClient.CreateTimeSlotAsync(
+			opportunityB.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(3),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(3).AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		var slotFar = (await olafClient.CreateTimeSlotAsync(
+			opportunityB.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(20),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(20).AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		// Pending: vera signs up for opportunityA and is left untouched.
+		await veraClient.CreateEngagementAsync(
+			opportunityA.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		// Cancelled: olaf signs up for opportunityA himself, then cancels it as organizer.
+		var toBeCancelled = await olafClient.CreateEngagementAsync(
+			opportunityA.Id,
+			new CreateEngagementRequest { Message = "Second helper" },
+			cancellationToken);
+		await olafClient.CancelEngagementAsync(
+			toBeCancelled.Id,
+			new CancelEngagementRequest { Reason = "No longer needed" },
+			cancellationToken);
+
+		// Confirmed, within next 7 days: vera on the near time slot.
+		var nearEngagement = await veraClient.CreateEngagementAsync(
+			opportunityB.Id,
+			new CreateEngagementRequest { TimeSlotId = slotNear },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(nearEngagement.Id, cancellationToken);
+
+		// Confirmed, beyond next 7 days: olaf himself on the far time slot.
+		var farEngagement = await olafClient.CreateEngagementAsync(
+			opportunityB.Id,
+			new CreateEngagementRequest { TimeSlotId = slotFar },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(farEngagement.Id, cancellationToken);
+
+		var kpis = await olafClient.GetOrganizationDashboardAsync(orgId, cancellationToken);
+
+		kpis.OpenOpportunities.Should().Be(2);
+		kpis.PendingEngagements.Should().Be(1);
+		kpis.CancelledEngagements.Should().Be(1);
+		kpis.ConfirmedEngagementsTotal.Should().Be(2);
+		kpis.ConfirmedEngagementsNext7Days.Should().Be(1);
+	}
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldNotCountAnotherOrganizationsEngagements(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		// org1 (olaf): one opportunity with a pending and a confirmed engagement.
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity1 = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
+		var engagement1 = await veraClient.CreateEngagementAsync(
+			opportunity1.Id,
+			new CreateEngagementRequest { Message = "Helping org1" },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement1.Id, cancellationToken);
+
+		// org2 (vera): its own opportunity with its own pending engagement, which
+		// must never leak into org1's counts.
+		var org2Id = await CreateOrganizationAsync(veraClient, cancellationToken);
+		var opportunity2 = await CreateOpportunityAsync(veraClient, org2Id, cancellationToken);
+		await olafClient.CreateEngagementAsync(
+			opportunity2.Id,
+			new CreateEngagementRequest { Message = "Helping org2" },
+			cancellationToken);
+
+		var org1Kpis = await olafClient.GetOrganizationDashboardAsync(org1Id, cancellationToken);
+
+		org1Kpis.OpenOpportunities.Should().Be(1);
+		org1Kpis.PendingEngagements.Should().Be(0);
+		org1Kpis.ConfirmedEngagementsTotal.Should().Be(1);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"DashboardTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+			},
+			cancellationToken);
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateWaitlistOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		// Created as a draft: a Waitlist opportunity can't be published until it has
+		// at least one time slot, and callers add slots separately after this returns.
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Waitlist Opportunity",
+				Description = "Integration test waitlist opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "Waitlist",
+				CheckInMethod = "None",
+				IsDraft = true,
+			},
+			cancellationToken);
+	}
+}

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -122,9 +122,13 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 		await olafClient.ConfirmEngagementAsync(engagement1.Id, cancellationToken);
 
 		// org2 (vera): its own opportunity with its own pending engagement, which
-		// must never leak into org1's counts.
+		// must never leak into org1's counts. CreateVolunteerOpportunity requires
+		// the "organisator" role claim, which Keycloak only grants vera once she
+		// creates an org - her existing veraClient token predates that, so a fresh
+		// token has to be minted to pick it up.
 		var org2Id = await CreateOrganizationAsync(veraClient, cancellationToken);
-		var opportunity2 = await CreateOpportunityAsync(veraClient, org2Id, cancellationToken);
+		var veraOrganizerClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var opportunity2 = await CreateOpportunityAsync(veraOrganizerClient, org2Id, cancellationToken);
 		await olafClient.CreateEngagementAsync(
 			opportunity2.Id,
 			new CreateEngagementRequest { Message = "Helping org2" },


### PR DESCRIPTION
OrganizationDashboardReadRepository pulled every opportunity id for an org into memory and re-checked it in-memory via Contains(), shipping the id list to and from Postgres twice per dashboard load. Query the ids as an IQueryable so EF Core compiles it to a correlated IN (SELECT ...) subquery instead, and count open opportunities directly.

Closes #1398

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
