### PR TITLE
fix: cache uploaded images with a versioned Cache-Control header

### DIFF
--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -7,6 +7,12 @@ namespace Infrastructure.Storage;
 
 internal sealed class MinioFileStorageService : IFileStorageService
 {
+	// Object keys are stable (e.g. "user-avatars/{UserId}{ext}"), so a long
+	// max-age would serve a stale image after re-upload. A moderate TTL plus
+	// the "?v=" cache-busting query param below (which changes on every
+	// upload) keeps caching effective without that staleness risk.
+	internal const string CacheControlHeaderValue = "public, max-age=3600";
+
 	private readonly IMinioClient _minio;
 	private readonly StorageSettings _settings;
 	private static readonly SemaphoreSlim _initLock = new(1, 1);
@@ -49,10 +55,14 @@ internal sealed class MinioFileStorageService : IFileStorageService
 				.WithObject(objectKey)
 				.WithStreamData(content)
 				.WithObjectSize(size)
-				.WithContentType(contentType),
+				.WithContentType(contentType)
+				.WithHeaders(new Dictionary<string, string>
+				{
+					["Cache-Control"] = CacheControlHeaderValue,
+				}),
 			cancellationToken);
 
-		return GetPublicUrl(objectKey);
+		return AppendVersionQuery(GetPublicUrl(objectKey), DateTimeOffset.UtcNow);
 	}
 
 	public async Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default)
@@ -71,6 +81,13 @@ internal sealed class MinioFileStorageService : IFileStorageService
 		var baseUrl = (_settings.PublicEndpoint ?? _settings.Endpoint).TrimEnd('/');
 		return $"{baseUrl}/{_settings.BucketName}/{objectKey}";
 	}
+
+	// Object keys don't change on re-upload, so the version query param is
+	// what invalidates a browser's cached copy once the underlying object
+	// changes - without it, CacheControlHeaderValue's max-age would let a
+	// stale image survive a re-upload until it happened to expire.
+	internal static string AppendVersionQuery(string url, DateTimeOffset uploadedOn) =>
+		$"{url}?v={uploadedOn.ToUnixTimeSeconds()}";
 
 	private async Task EnsureBucketReadyAsync(CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
+++ b/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
@@ -1,0 +1,37 @@
+using AwesomeAssertions;
+using Infrastructure.Storage;
+
+namespace IntegrationTests;
+
+public class MinioFileStorageServiceUrlTests
+{
+	[Test]
+	public void AppendVersionQuery_ShouldAppendUnixSecondsAsVersionQueryParam()
+	{
+		var uploadedOn = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+		var result = MinioFileStorageService.AppendVersionQuery(
+			"https://storage.example.com/bucket/user-avatars/abc.png", uploadedOn);
+
+		result.Should().Be($"https://storage.example.com/bucket/user-avatars/abc.png?v={uploadedOn.ToUnixTimeSeconds()}");
+	}
+
+	[Test]
+	public void AppendVersionQuery_ShouldProduceDifferentVersions_WhenReuploadedAtDifferentTimes()
+	{
+		const string url = "https://storage.example.com/bucket/user-avatars/abc.png";
+		var firstUpload = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		var secondUpload = firstUpload.AddSeconds(1);
+
+		var firstUrl = MinioFileStorageService.AppendVersionQuery(url, firstUpload);
+		var secondUrl = MinioFileStorageService.AppendVersionQuery(url, secondUpload);
+
+		firstUrl.Should().NotBe(secondUrl);
+	}
+
+	[Test]
+	public void CacheControlHeaderValue_ShouldBePublicWithModerateMaxAge()
+	{
+		MinioFileStorageService.CacheControlHeaderValue.Should().Be("public, max-age=3600");
+	}
+}


### PR DESCRIPTION
Object keys for avatars/banners/logos are stable, so a naive long max-age would serve a stale image after re-upload. Set a moderate Cache-Control (public, max-age=3600) on MinIO uploads and append a ?v=<timestamp> query param to the returned URL so re-uploads bust the cache instead of relying on revalidation for every view.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1399 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
