### PR TITLE
fix: cache city search results to cut redundant Nominatim proxy calls

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -25,6 +25,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[10.0.10]" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[10.0.3]" />
 		<!-- Aspire: ServiceDefaults -->
@@ -48,6 +49,7 @@
 		<!-- Tests -->
 		<PackageVersion Include="AwesomeAssertions" Version="[9.5.0]" />
 		<PackageVersion Include="Deque.AxeCore.Playwright" Version="[4.12.0]" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[10.0.10]" />
 		<PackageVersion Include="NetArchTest.Rules" Version="[1.3.2]" />
 		<PackageVersion Include="NSubstitute" Version="[6.0.0]" />
 		<PackageVersion Include="Respawn" Version="[7.0.0]" />

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>

--- a/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
+++ b/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
@@ -1,14 +1,36 @@
 using Application.Common.Geocoding;
 using Application.Common.Messaging;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Application.Maps.SearchCities.v1;
 
 internal sealed class SearchCitiesQueryHandler(
-	IGeocodingService geocodingService)
+	IGeocodingService geocodingService,
+	IMemoryCache cache)
 	: IQueryHandler<SearchCitiesQuery, IReadOnlyList<CitySuggestion>>
 {
+	// City name-to-coordinates mappings are effectively static, so a repeated
+	// query never needs to reach Nominatim (and its shared one-request-per-
+	// second throttle, see NominatimGeocodingService) again within this window.
+	private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+
 	public async ValueTask<IReadOnlyList<CitySuggestion>> Handle(
 		SearchCitiesQuery request,
-		CancellationToken cancellationToken = default) =>
-		await geocodingService.SearchCitiesAsync(request.Query, cancellationToken);
+		CancellationToken cancellationToken = default)
+	{
+		var cacheKey = $"city-search:{request.Query.Trim().ToLowerInvariant()}";
+
+		if (cache.TryGetValue(cacheKey, out IReadOnlyList<CitySuggestion>? cached) && cached is not null)
+			return cached;
+
+		var results = await geocodingService.SearchCitiesAsync(request.Query, cancellationToken);
+
+		// Don't cache an empty result - it's indistinguishable here from a
+		// transient geocoding failure, and caching that would turn a temporary
+		// hiccup into a day-long false "no such city" for every visitor.
+		if (results.Count > 0)
+			cache.Set(cacheKey, results, CacheDuration);
+
+		return results;
+	}
 }

--- a/backend/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/backend/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="TUnit" />

--- a/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
@@ -1,18 +1,20 @@
 using Application.Common.Geocoding;
 using Application.Maps.SearchCities.v1;
 using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 
 namespace Application.UnitTests.Maps.SearchCities;
 
-public class SearchCitiesQueryHandlerTests
+public sealed class SearchCitiesQueryHandlerTests : IDisposable
 {
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
 	private readonly SearchCitiesQueryHandler _sut;
 
 	public SearchCitiesQueryHandlerTests()
 	{
-		_sut = new SearchCitiesQueryHandler(_geocodingService);
+		_sut = new SearchCitiesQueryHandler(_geocodingService, _cache);
 	}
 
 	[Test]
@@ -68,4 +70,50 @@ public class SearchCitiesQueryHandlerTests
 
 		await _geocodingService.Received(1).SearchCitiesAsync("Hamburg", cts.Token);
 	}
+
+	[Test]
+	public async Task Handle_ShouldNotCallGeocodingServiceTwice_ForRepeatedIdenticalQuery()
+	{
+		var suggestions = new List<CitySuggestion> { new("Hamburg", 53.5511, 9.9937) };
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(suggestions);
+
+		var first = await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		var second = await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+
+		first.Should().BeEquivalentTo(suggestions);
+		second.Should().BeEquivalentTo(suggestions);
+		await _geocodingService.Received(1).SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldTreatQuery_CaseAndWhitespaceInsensitively_ForCaching()
+	{
+		var suggestions = new List<CitySuggestion> { new("Hamburg", 53.5511, 9.9937) };
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(suggestions);
+
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		var second = await _sut.Handle(new SearchCitiesQuery("  HAMBURG  "), CancellationToken.None);
+
+		second.Should().BeEquivalentTo(suggestions);
+		await _geocodingService.Received(1).SearchCitiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotCacheEmptyResult_SoARetryCanStillFindMatches()
+	{
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(new List<CitySuggestion>());
+
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+
+		await _geocodingService.Received(2).SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>());
+	}
+
+	public void Dispose() => _cache.Dispose();
 }

--- a/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
+++ b/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
@@ -7,6 +7,19 @@ export interface CitySuggestion {
 	lng: number;
 }
 
+// Module-level so it survives across hook re-mounts for the lifetime of the
+// page (cleared on reload) - repeated searches for the same city (e.g. the
+// user re-focuses the field, or backspaces and retypes) never need to hit the
+// backend again since city name-to-coordinates mappings are effectively
+// static. Never stores an empty result: an empty response is indistinguishable
+// here from a transient backend/upstream hiccup, and caching it would turn
+// that into a permanent false "no such city" for the rest of the page's life.
+const cityCache = new Map<string, CitySuggestion[]>();
+
+function cacheKeyFor(query: string) {
+	return query.trim().toLowerCase();
+}
+
 // Debounced city-name autocomplete for the location filter's "search by city"
 // input. Proxied through the backend's /v1/maps/cities endpoint (which in turn
 // queries the public Nominatim/OpenStreetMap geocoder) so the visitor's IP
@@ -24,6 +37,14 @@ export function useCitySuggestions(query: string) {
 			setShow(false);
 			return;
 		}
+
+		const cached = cityCache.get(cacheKeyFor(query));
+		if (cached) {
+			setSuggestions(cached);
+			setShow(cached.length > 0);
+			return;
+		}
+
 		abortRef.current?.abort();
 		const controller = new AbortController();
 		abortRef.current = controller;
@@ -35,6 +56,9 @@ export function useCitySuggestions(query: string) {
 					lat: place.latitude,
 					lng: place.longitude,
 				}));
+				if (results.length > 0) {
+					cityCache.set(cacheKeyFor(query), results);
+				}
 				setSuggestions(results);
 				setShow(results.length > 0);
 			} catch {


### PR DESCRIPTION
Repeated identical city-autocomplete queries re-hit the backend's Nominatim proxy every time even though city name-to-coordinate mappings are effectively static. Cache non-empty results in SearchCitiesQueryHandler (IMemoryCache, 24h) and client-side (Map keyed by normalized query) so only the first lookup for a given city touches the shared Nominatim throttle; empty/failed lookups stay uncached so a transient hiccup can't masquerade as "no such city" for a day.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1394 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
