### PR TITLE
fix: dedupe redundant getOrganizations fetch on home page load

### DIFF
--- a/backend/tests/VisualTests/OrganizationsFetchDeduplicationTests.cs
+++ b/backend/tests/VisualTests/OrganizationsFetchDeduplicationTests.cs
@@ -1,0 +1,33 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrganizationsFetchDeduplicationTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task AuthenticatedHomePageLoad_FetchesOrganizationsOnce_NotOncePerHeaderAndPage()
+	{
+		// Regression for #1396: Header and HomePage each independently called
+		// GET /v1/organizations on mount, so an authenticated home page load
+		// fired the same query twice (and React StrictMode's dev-mode
+		// double-invoke - see VisualTestBase - would have doubled that again
+		// without the fix). Both now share a single in-flight request via
+		// useSharedOrgFetch.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var requestCount = 0;
+		await Page.RouteAsync("**/v1/organizations", async route =>
+		{
+			Interlocked.Increment(ref requestCount);
+			await route.ContinueAsync();
+		});
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		requestCount.Should().Be(1);
+	}
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link, useLocation } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
 import { useApiClient } from "../../hooks/useApiClient";
+import { useSharedOrgFetch } from "../../hooks/useSharedOrgFetch";
 import { signinRedirectForRegistration } from "../../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../../lib/authLocale";
 import { getActiveOrgId, resolveActiveOrg } from "../../lib/activeOrg";
@@ -54,8 +55,14 @@ export default function Header({
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
 	const isAdmin = roles.includes("admin");
-	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
-	const [orgsLoading, setOrgsLoading] = useState(true);
+	// Shared with HomePage, which independently needs the same top-level
+	// organization list on the same mount (#1396) - see useSharedOrgFetch.
+	const [orgsData, , orgsError] = useSharedOrgFetch<OrganizationSummaryDto[]>(
+		`organizations:${isLoggedIn}`,
+		() => (isLoggedIn ? api.getOrganizations() : Promise.resolve([])),
+	);
+	const orgs = isLoggedIn ? (orgsData ?? []) : [];
+	const orgsLoading = isLoggedIn && orgsData === null && !orgsError;
 	const activeOrg = resolveActiveOrg(orgs, getActiveOrgId());
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [orgMenuOpen, setOrgMenuOpen] = useState(false);
@@ -74,29 +81,6 @@ export default function Header({
 	useEffect(() => {
 		if (!mobileOpen) setOrgMenuOpen(false);
 	}, [mobileOpen]);
-
-	useEffect(() => {
-		if (!isLoggedIn) {
-			setOrgs([]);
-			setOrgsLoading(false);
-			return;
-		}
-		const controller = new AbortController();
-		setOrgsLoading(true);
-		api
-			.getOrganizations(controller.signal)
-			.then((data) => {
-				if (!controller.signal.aborted) setOrgs(data);
-			})
-			.catch(() => {
-				if (!controller.signal.aborted) setOrgs([]);
-			})
-			.finally(() => {
-				if (!controller.signal.aborted) setOrgsLoading(false);
-			});
-		return () => controller.abort();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isLoggedIn]);
 
 	const isTransparent = location.pathname === "/" && !scrolled;
 

--- a/frontend/src/hooks/useSharedOrgFetch.ts
+++ b/frontend/src/hooks/useSharedOrgFetch.ts
@@ -1,16 +1,17 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 
 // Module-level registry of in-flight requests, keyed by a caller-supplied
-// string (typically `${resource}:${organizationId}:${refreshKey}`). Several
-// dashboard widgets independently need the same organization-wide data on the
-// same mount - Calendar and Upcoming Opportunities both call
-// getOrganizationCalendarEvents, Upcoming Opportunities and Quick Check-in
-// both call getOrganizationOpportunities - and without this, each widget
-// fires its own copy of the same request. Only the in-flight *request* is
-// shared, not the resolved data: each caller still gets its own local
-// useState copy (see the returned setter) so one widget can optimistically
-// mutate its view (e.g. CalendarWidget after saving an event color) without
-// affecting another widget that happened to share the fetch.
+// string (typically `${resource}:${organizationId}:${refreshKey}`, or just
+// `${resource}` for a resource with no such scoping). Several call sites
+// independently need the same data on the same mount - Calendar and Upcoming
+// Opportunities widgets both call getOrganizationCalendarEvents, Upcoming
+// Opportunities and Quick Check-in both call getOrganizationOpportunities,
+// Header and HomePage both call getOrganizations - and without this, each
+// caller fires its own copy of the same request. Only the in-flight
+// *request* is shared, not the resolved data: each caller still gets its own
+// local useState copy (see the returned setter) so one widget can
+// optimistically mutate its view (e.g. CalendarWidget after saving an event
+// color) without affecting another that happened to share the fetch.
 const inFlight = new Map<string, Promise<unknown>>();
 
 export function useSharedOrgFetch<T>(

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import CreateOrganizationModal from "../components/CreateOrganizationModal";
 import Button from "../components/Button";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { useSharedOrgFetch } from "../hooks/useSharedOrgFetch";
 import { signinLocaleArgs } from "../lib/authLocale";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 import { getActiveOrgId, resolveOrgAppPath } from "../lib/activeOrg";
@@ -86,28 +87,15 @@ export default function HomePage() {
 	const orgsTeaserTitleId = useId();
 
 	const [showCreateOrgModal, setShowCreateOrgModal] = useState(false);
-	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
 	const [searchParams, setSearchParams] = useSearchParams();
 
-	useEffect(() => {
-		if (!auth.isAuthenticated) {
-			setOrgs([]);
-			return;
-		}
-		let cancelled = false;
-		api
-			.getOrganizations()
-			.then((data) => {
-				if (!cancelled) setOrgs(data);
-			})
-			.catch(() => {
-				if (!cancelled) setOrgs([]);
-			});
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [auth.isAuthenticated]);
+	// Shared with Header, which independently needs the same top-level
+	// organization list on the same mount (#1396) - see useSharedOrgFetch.
+	const [orgsData] = useSharedOrgFetch<OrganizationSummaryDto[]>(
+		`organizations:${auth.isAuthenticated}`,
+		() => (auth.isAuthenticated ? api.getOrganizations() : Promise.resolve([])),
+	);
+	const orgs = auth.isAuthenticated ? (orgsData ?? []) : [];
 
 	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
 

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -13,7 +13,7 @@ import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 // The *default* view a fresh mount opens on - a narrow tile can't usefully

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -12,7 +12,7 @@ import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 interface Props {

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -9,7 +9,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 const MAX_ITEMS = 5;


### PR DESCRIPTION
Header and HomePage each independently fetched the organization list on mount, firing the same GET /v1/organizations query twice per authenticated page load. Relocate useSharedOrgFetch from OrgDashboardPage to hooks/ and have both call sites share one in-flight request via the same cache key.

Fixes #1396

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
