### PR TITLE
perf: memoize CalendarWidget events and debounce color picker

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -305,6 +305,119 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(calendarWidget.Locator(".rbc-time-view")).ToBeVisibleAsync();
 	}
 
+	[Test]
+	public async Task CalendarWidget_SelectEventAndSaveColor_RecoloredEventSurvivesReload()
+	{
+		// #1397: calEvents, and the Calendar's components/eventPropGetter/messages
+		// props, were rebuilt from scratch on every render (including on every
+		// pointer movement while dragging the color picker below), fixed by
+		// memoizing calEvents off calData and hoisting the static props out of
+		// the component. This exercises the full select-event -> pick color ->
+		// save round trip end to end, so a broken useMemo dependency array or a
+		// debounced picker that never flushes its final value would show up as
+		// a failing assertion here rather than only as a missed re-render.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1397 {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"Visual1397 Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by CalendarWidget color-save test",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "Waitlist",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		// Close enough to "now" that it always falls in the current month, so
+		// the widget's default month view shows it without switching tabs.
+		var start = DateTimeOffset.UtcNow.AddHours(1);
+		var end = start.AddHours(2);
+		(await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 }))
+			.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		var calendarWidget = Page.Locator("section", new()
+		{
+			Has = Page.GetByRole(AriaRole.Heading, new() { Name = "Calendar", Exact = true }),
+		});
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var calendarEvent = calendarWidget.Locator(".rbc-event").First;
+		await Expect(calendarEvent).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// No color set yet - eventPropGetter falls back to DEFAULT_EVENT_COLOR.
+		var defaultBg = await calendarEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		defaultBg.Should().Be("rgb(34, 105, 71)");
+
+		await calendarEvent.ClickAsync();
+		var colorDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(colorDialog).ToBeVisibleAsync();
+		await Expect(colorDialog).ToContainTextAsync(oppTitle);
+
+		var colorInput = Page.Locator("#event-color-picker");
+		await Expect(colorInput).ToHaveValueAsync("#226947");
+
+		const string newColor = "#3366cc";
+		await colorInput.FillAsync(newColor);
+		await Expect(Page.GetByText(newColor)).ToBeVisibleAsync();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+		await Expect(colorDialog).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var savedBg = await calendarEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		savedBg.Should().Be("rgb(51, 102, 204)");
+
+		// Reload so calData (and the memoized calEvents derived from it) come
+		// back fresh from the server, proving the color actually persisted
+		// rather than only reflecting the modal's optimistic local update.
+		await Page.ReloadAsync();
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var reloadedEvent = calendarWidget.Locator(".rbc-event").First;
+		await Expect(reloadedEvent).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var reloadedBg = await reloadedEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		reloadedBg.Should().Be("rgb(51, 102, 204)");
+	}
+
 	private async Task CreateOrganizationAsync(string namePrefix)
 	{
 		// New orgs are created via the org switcher's "Create organization" entry

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
@@ -65,6 +65,29 @@ function CalEventChip({ event }: { event: object }) {
 	);
 }
 
+// Neither depends on component state/props, so both are declared once at
+// module scope - passing fresh object/function literals as Calendar props
+// on every render defeats react-big-calendar's own internal memoization
+// (see #1397).
+const calendarComponents = { event: CalEventChip };
+
+function calendarEventPropGetter(event: object) {
+	const e = event as CalEvent;
+	const bg = e.color ?? DEFAULT_EVENT_COLOR;
+	return {
+		style: {
+			backgroundColor: bg,
+			borderColor: bg,
+			color: "#ffffff",
+		},
+	};
+}
+
+// The color picker's onChange fires continuously while the user drags across
+// the native picker UI; debouncing avoids re-rendering the whole widget (and
+// its Calendar subtree) on every pointer movement (#1397).
+const COLOR_INPUT_DEBOUNCE_MS = 100;
+
 interface Props {
 	organizationId: string;
 	refreshKey: number;
@@ -104,24 +127,59 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 	const [pickerColor, setPickerColor] = useState(DEFAULT_EVENT_COLOR);
 	const [savingColor, setSavingColor] = useState(false);
 	const [colorSaveError, setColorSaveError] = useState<string | null>(null);
+	const colorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	const calEvents: CalEvent[] = (calData ?? []).flatMap((opp) =>
-		opp.timeSlots.map((slot) => ({
-			id: slot.timeSlotId,
-			title: opp.title,
-			start: new Date(slot.startDateTime),
-			end: new Date(slot.endDateTime),
-			opportunityId: opp.opportunityId,
-			color: opp.color,
-			bookedCount: slot.bookedCount,
-			maxParticipants: slot.maxParticipants,
-		})),
+	useEffect(() => {
+		return () => {
+			if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		};
+	}, []);
+
+	const calEvents: CalEvent[] = useMemo(
+		() =>
+			(calData ?? []).flatMap((opp) =>
+				opp.timeSlots.map((slot) => ({
+					id: slot.timeSlotId,
+					title: opp.title,
+					start: new Date(slot.startDateTime),
+					end: new Date(slot.endDateTime),
+					opportunityId: opp.opportunityId,
+					color: opp.color,
+					bookedCount: slot.bookedCount,
+					maxParticipants: slot.maxParticipants,
+				})),
+			),
+		[calData],
 	);
 
-	function handleSelectEvent(event: CalEvent) {
-		setSelectedEvent(event);
-		setPickerColor(event.color ?? DEFAULT_EVENT_COLOR);
+	const calendarMessages = useMemo(
+		() => ({
+			today: t("orgOverview.calendarToday"),
+			previous: t("orgOverview.calendarBack"),
+			next: t("orgOverview.calendarNext"),
+			month: t("orgOverview.calendarMonth"),
+			week: t("orgOverview.calendarWeek"),
+			work_week: t("orgOverview.calendarWorkWeek"),
+			day: t("orgOverview.calendarDay"),
+			agenda: t("orgOverview.calendarAgenda"),
+			noEventsInRange: t("orgOverview.calendarNoEvents"),
+		}),
+		[t],
+	);
+
+	const handleSelectEvent = useCallback((event: object) => {
+		const e = event as CalEvent;
+		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		setSelectedEvent(e);
+		setPickerColor(e.color ?? DEFAULT_EVENT_COLOR);
 		setColorSaveError(null);
+	}, []);
+
+	function handleColorPickerChange(value: string) {
+		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		colorDebounceRef.current = setTimeout(() => {
+			setPickerColor(value);
+		}, COLOR_INPUT_DEBOUNCE_MS);
 	}
 
 	async function handleColorSave() {
@@ -174,32 +232,10 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 						onNavigate={(d: Date) => setCalDate(d)}
 						views={["month", "week", "work_week", "day", "agenda"]}
 						style={{ height: "100%", minHeight: CALENDAR_MIN_HEIGHT_PX }}
-						components={{ event: CalEventChip }}
-						eventPropGetter={(event: object) => {
-							const e = event as CalEvent;
-							const bg = e.color ?? DEFAULT_EVENT_COLOR;
-							return {
-								style: {
-									backgroundColor: bg,
-									borderColor: bg,
-									color: "#ffffff",
-								},
-							};
-						}}
-						onSelectEvent={(event: object) =>
-							handleSelectEvent(event as CalEvent)
-						}
-						messages={{
-							today: t("orgOverview.calendarToday"),
-							previous: t("orgOverview.calendarBack"),
-							next: t("orgOverview.calendarNext"),
-							month: t("orgOverview.calendarMonth"),
-							week: t("orgOverview.calendarWeek"),
-							work_week: t("orgOverview.calendarWorkWeek"),
-							day: t("orgOverview.calendarDay"),
-							agenda: t("orgOverview.calendarAgenda"),
-							noEventsInRange: t("orgOverview.calendarNoEvents"),
-						}}
+						components={calendarComponents}
+						eventPropGetter={calendarEventPropGetter}
+						onSelectEvent={handleSelectEvent}
+						messages={calendarMessages}
 					/>
 				</div>
 			)}
@@ -238,7 +274,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 									id="event-color-picker"
 									type="color"
 									value={pickerColor}
-									onChange={(e) => setPickerColor(e.target.value)}
+									onChange={(e) => handleColorPickerChange(e.target.value)}
 									className="h-9 w-16 cursor-pointer rounded border border-gray-300"
 								/>
 								<span className="text-sm text-gray-500">{pickerColor}</span>


### PR DESCRIPTION
Rebuilding calEvents and passing fresh components/eventPropGetter/ messages object literals on every render defeated react-big-calendar's own render optimization; the color picker's onChange fired on every pointer movement, re-rendering the whole widget each time. Memoize calEvents off calData, hoist the static Calendar props to module scope, and debounce the color input's state update.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1397

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
