### PR TITLE
perf: lazy-load i18n translation bundles instead of bundling both upfront

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -380,6 +380,41 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task HomePage_LanguageSelector_SwitchingLanguage_LazilyLoadsAndAppliesTranslations()
+	{
+		// #1395: both translation bundles used to be statically imported into the
+		// entry chunk. Each language's JSON is now fetched lazily on demand via a
+		// custom i18next backend - switching language must still dynamically load
+		// and apply the target locale's strings, and switching back must reuse the
+		// already-loaded English bundle without breaking.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		var heading = Page.Locator("h1").First;
+		await Expect(heading).ToHaveTextAsync(
+			"Volunteering doesn't have to be hard.", new() { Timeout = 15_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "en");
+
+		var langBtn = Page.Locator("header button[aria-haspopup='listbox']").First;
+		await langBtn.ClickAsync();
+		var dropdown = Page.Locator("header ul[role='listbox']").First;
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await dropdown.GetByRole(AriaRole.Button, new() { Name = "Deutsch" }).ClickAsync();
+
+		await Expect(heading).ToHaveTextAsync(
+			"Ehrenamt muss nicht schwer sein.", new() { Timeout = 10_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "de");
+
+		await langBtn.ClickAsync();
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await dropdown.GetByRole(AriaRole.Button, new() { Name = "English" }).ClickAsync();
+
+		await Expect(heading).ToHaveTextAsync(
+			"Volunteering doesn't have to be hard.", new() { Timeout = 10_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "en");
+	}
+
+	[Test]
 	public async Task MobileMenu_ClosesOnEscape()
 	{
 		// #884: MobileMenu offered neither outside-click nor Escape dismissal

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,18 +1,36 @@
-import i18next from "i18next";
+import i18next, { type BackendModule, type ReadCallback } from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
-import de from "./locales/de.json";
-import en from "./locales/en.json";
+type LocaleModule = typeof import("./locales/en.json");
+
+// Dynamic imports so each language's translation JSON is its own chunk,
+// fetched only for the language actually in use instead of both upfront.
+const localeLoaders: Record<string, () => Promise<LocaleModule>> = {
+	de: () => import("./locales/de.json"),
+	en: () => import("./locales/en.json"),
+};
+
+const lazyBackend: BackendModule = {
+	type: "backend",
+	init: () => {},
+	read: (language, _namespace, callback: ReadCallback) => {
+		const loadLocale = localeLoaders[language];
+		if (!loadLocale) {
+			callback(new Error(`Unsupported language: ${language}`), null);
+			return;
+		}
+		loadLocale()
+			.then((module) => callback(null, module.translation))
+			.catch((error: unknown) => callback(error as Error, null));
+	},
+};
 
 void i18next
+	.use(lazyBackend)
 	.use(LanguageDetector)
 	.use(initReactI18next)
 	.init({
-		resources: {
-			de: { translation: de.translation },
-			en: { translation: en.translation },
-		},
 		fallbackLng: "en",
 		supportedLngs: ["de", "en"],
 		detection: {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,5 @@
 import i18n from "./i18n";
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
 import { WebStorageStateStore, type User } from "oidc-client-ts";
@@ -32,13 +32,15 @@ const oidcConfig = {
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>
 		<ErrorBoundary>
-			<ToastProvider>
-				<AuthProvider {...oidcConfig}>
-					<BrowserRouter>
-						<App />
-					</BrowserRouter>
-				</AuthProvider>
-			</ToastProvider>
+			<Suspense fallback={null}>
+				<ToastProvider>
+					<AuthProvider {...oidcConfig}>
+						<BrowserRouter>
+							<App />
+						</BrowserRouter>
+					</AuthProvider>
+				</ToastProvider>
+			</Suspense>
 		</ErrorBoundary>
 	</React.StrictMode>,
 );


### PR DESCRIPTION
Both de.json and en.json (~81 KB) were statically imported into the entry chunk regardless of which language the user actually has. Replace the static imports with a small custom i18next backend that dynamically imports only the active language's JSON, so it becomes its own build chunk fetched on demand (verified via pnpm build: en/de split into ~42/~47 KB chunks, no longer referenced from index.html).

react-i18next's Suspense integration needs a boundary now that resource loading is async, so wrap the app root in <Suspense fallback={null}>.

Refs #1395.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1395

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
