### PR TITLE
fix: keep main HTTP port bound when metrics listener is configured

### DIFF
--- a/backend/src/Aspire/ServiceDefaults/Extensions.cs
+++ b/backend/src/Aspire/ServiceDefaults/Extensions.cs
@@ -93,7 +93,23 @@ public static class ServiceDefaultsExtensions
 	{
 		if (builder is WebApplicationBuilder webBuilder && TryGetMetricsPort(builder.Configuration, out var port))
 		{
-			webBuilder.WebHost.ConfigureKestrel(options => options.ListenAnyIP(port));
+			// An explicit Kestrel Listen call replaces ASP.NET Core's default URL
+			// binding (ASPNETCORE_HTTP_PORTS, set to 8080 by the base container
+			// image) instead of adding to it - without re-adding it here, the app
+			// ends up listening only on the metrics port, unreachable to both
+			// Traefik and the docker-compose healthcheck even though the process
+			// itself is healthy. Caused a staging outage the first time this
+			// second listener shipped (Metrics:Port was previously never set, so
+			// this branch never ran outside staging).
+			var mainPort = int.TryParse(builder.Configuration["ASPNETCORE_HTTP_PORTS"], out var configuredPort)
+				? configuredPort
+				: 8080;
+
+			webBuilder.WebHost.ConfigureKestrel(options =>
+			{
+				options.ListenAnyIP(mainPort);
+				options.ListenAnyIP(port);
+			});
 		}
 
 		return builder;

--- a/backend/tests/IntegrationTests/IntegrationTests.csproj
+++ b/backend/tests/IntegrationTests/IntegrationTests.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Aspire\AppHost\AppHost.csproj" />
+		<ProjectReference Include="..\..\src\Aspire\ServiceDefaults\ServiceDefaults.csproj" />
 		<ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
 	</ItemGroup>
 

--- a/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
+++ b/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Sockets;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+
+namespace IntegrationTests;
+
+// Regression coverage for a staging outage: AddMetricsPortListener
+// (Aspire/ServiceDefaults/Extensions.cs) used to call ConfigureKestrel with only
+// the metrics port's ListenAnyIP, which replaces ASP.NET Core's default HTTP
+// binding instead of adding to it, so the app stopped listening on its main port
+// entirely - unreachable to both Traefik and the docker-compose healthcheck even
+// though the process itself was healthy. Builds a real Kestrel host directly
+// (like SmtpEmailServiceTests, no Aspire/Testcontainers fixture needed) so it
+// runs fast and would have caught this before it reached staging.
+public class MetricsPortListenerTests
+{
+	[Test]
+	public async Task AddServiceDefaults_WithMetricsPortConfigured_StillListensOnMainHttpPort()
+	{
+		var mainPort = GetFreeTcpPort();
+		var metricsPort = GetFreeTcpPort();
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+		{
+			["ASPNETCORE_HTTP_PORTS"] = mainPort.ToString(),
+			["Metrics:Port"] = metricsPort.ToString(),
+		});
+
+		builder.AddServiceDefaults();
+
+		await using var app = builder.Build();
+		app.MapDefaultEndpoints();
+
+		await app.StartAsync();
+		try
+		{
+			using var client = new HttpClient();
+
+			var mainResponse = await client.GetAsync($"http://localhost:{mainPort}/alive");
+			mainResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			var metricsResponse = await client.GetAsync($"http://localhost:{metricsPort}/alive");
+			metricsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+		}
+		finally
+		{
+			await app.StopAsync();
+		}
+	}
+
+	private static int GetFreeTcpPort()
+	{
+		var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+		listener.Stop();
+		return port;
+	}
+}

--- a/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
+++ b/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace IntegrationTests;


### PR DESCRIPTION
## What

Fixes the backend Kestrel configuration so the app's main HTTP port stays bound when the staging-only metrics listener (`Metrics__Port`) is configured.

## Why

`v1.0.0-rc.331`'s staging deploy failed: `docker compose up` reported `dependency failed to start: container backend is unhealthy`. The backend container was running (`Application started`, no exceptions) but `docker inspect` showed `Health=unhealthy`, and its logs showed only `Now listening on: http://[::]:8081` - the app was never bound to port 8080, which is what both the docker-compose healthcheck (`curl http://localhost:8080/alive`) and Traefik's `backend` router target.

Root cause: `AddMetricsPortListener` (`backend/src/Aspire/ServiceDefaults/Extensions.cs`), added in #1424, calls `ConfigureKestrel(options => options.ListenAnyIP(metricsPort))`. An explicit Kestrel `Listen` call replaces ASP.NET Core's default URL binding (`ASPNETCORE_HTTP_PORTS`, set to `8080` by the base container image) instead of adding to it - so once `Metrics__Port` is set (staging only), the app silently stops listening on its main port. This is the first RC to ship with that PR, which is why every prior RC deployed successfully.

## Fix

Re-add the main HTTP port explicitly alongside the metrics port in the same `ConfigureKestrel` call, reading it from `ASPNETCORE_HTTP_PORTS` (falling back to `8080` to match the base image default) instead of hardcoding an assumption.

## Testing

- Added `backend/tests/IntegrationTests/MetricsPortListenerTests.cs`: builds a real Kestrel host directly (no Aspire/Testcontainers fixture needed, same pattern as `SmtpEmailServiceTests`) with `Metrics:Port` configured, and asserts `/alive` responds on *both* the main port and the metrics port. This reproduces the exact regression and would have caught it in CI before it ever reached staging.
- **No new `VisualTests` case added.** The regression is entirely about Kestrel's port-binding behavior when `Metrics:Port` is set, which only ever happens in the staging `docker-compose.yml` deployment - the local Aspire stack `VisualTests` runs against never sets that variable, so a VisualTests case couldn't reproduce this bug without also threading a test-only `Metrics:Port` override through `AppHost.cs`, which would just be a slower, less precise duplicate of the `IntegrationTests` case above. The generic "login + authenticated API call succeeds" path this bug ultimately breaks is already exercised by the existing VisualTests suite.
- `dotnet build` passes locally; full CI (format-check, fast-tests, integration-tests, visual-tests, editorconfig, ban-typographic-dashes, PR title) is green.

## Live verification

Cut `v1.0.0-rc.332` from this branch and deployed to staging - `deploy-staging` succeeded (`Pull and restart` and `Post-deploy health gate` both green, no rollback triggered), confirming the backend container is healthy again.

- `curl https://api.maik-hasler.de/health` -> `200`
- `curl https://api.maik-hasler.de/alive` -> `200`
- Ran a throwaway Playwright script against `https://einsatzbereit.maik-hasler.de`: logged in as `vera`, reloaded, and confirmed a non-5xx response from `api.maik-hasler.de` was observed - i.e. the frontend can actually reach the backend through Traefik post-fix, not just the health endpoint directly. Script exited 0 and was deleted per the live-verify process.

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 findings)
- [x] CI is green
- [x] Documentation updated if this change affects behavior (N/A - internal Kestrel config fix, no documented behavior change)