### PR TITLE
fix: batch EngagementReminderJob email/DB I/O and cap its batch size

### DIFF
--- a/backend/src/Application/Common/Email/IEmailService.cs
+++ b/backend/src/Application/Common/Email/IEmailService.cs
@@ -1,10 +1,20 @@
 namespace Application.Common.Email;
 
+public sealed record EmailMessage(string To, string Subject, string Body);
+
 public interface IEmailService
 {
 	Task SendAsync(
 		string to,
 		string subject,
 		string body,
+		CancellationToken cancellationToken = default);
+
+	// Sends every message over a single connection instead of one connect/
+	// authenticate/disconnect round trip per message. Never throws - like
+	// SendAsync, a failure is logged and recorded via EmailMetrics - and the
+	// result list is positional: result[i] reports the outcome for messages[i].
+	Task<IReadOnlyList<bool>> SendBatchAsync(
+		IReadOnlyList<EmailMessage> messages,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
@@ -15,6 +15,12 @@ internal sealed class EngagementReminderJob(
 	ILogger<EngagementReminderJob> logger)
 	: IHostedService, IAsyncDisposable
 {
+	// Caps how many engagements one hourly tick processes. Anything left over
+	// still has ReminderSentAt == null and its TimeSlot still falls in the
+	// (now+23h, now+25h) window on the next tick (the window is 2h wide, the
+	// timer fires every 1h), so it is picked up then instead of being lost.
+	private const int MaxBatchSize = 500;
+
 	private Task _executeTask = Task.CompletedTask;
 	private CancellationTokenSource? _cts;
 	private PeriodicTimer? _timer;
@@ -85,13 +91,32 @@ internal sealed class EngagementReminderJob(
 				x => x.Engagement.OpportunityId,
 				vo => vo.Id,
 				(x, vo) => new { x.Engagement, x.TimeSlot, OpportunityTitle = vo.Title })
+			.OrderBy(x => x.TimeSlot.StartDateTime)
+			.Take(MaxBatchSize)
 			.ToListAsync(ct);
+
+		if (engagements.Count == 0)
+			return;
+
+		// One email per engagement, resolved sequentially: KeycloakUserService
+		// mutates a shared HttpClient auth header per call (see its
+		// SendAuthorizedAsync comment), so these lookups cannot run concurrently.
+		// Caching by volunteer avoids repeating the lookup for a volunteer
+		// confirmed for more than one slot inside this run's window.
+		var profileCache = new Dictionary<Guid, KeycloakUserProfile>();
+		var messages = new List<EmailMessage>(engagements.Count);
+		var recipients = new List<(Engagement Engagement, string Email)>(engagements.Count);
 
 		foreach (var item in engagements)
 		{
+			var volunteerId = item.Engagement.VolunteerId!.Value.Value;
 			try
 			{
-				var user = await keycloakUserService.GetUserAsync(item.Engagement.VolunteerId!.Value.Value, ct);
+				if (!profileCache.TryGetValue(volunteerId, out var user))
+				{
+					user = await keycloakUserService.GetUserAsync(volunteerId, ct);
+					profileCache[volunteerId] = user;
+				}
 
 				var displayName = $"{user.FirstName} {user.LastName}".Trim();
 				if (string.IsNullOrEmpty(displayName))
@@ -107,23 +132,59 @@ internal sealed class EngagementReminderJob(
 					$"We are looking forward to seeing you!\n\n" +
 					$"The Einsatzbereit Team";
 
-				await emailService.SendAsync(user.Email, subject, body, ct);
-
-				item.Engagement.MarkReminderSent(now);
-				await dbContext.SaveChangesAsync(ct);
-
-				logger.LogInformation(
-					"Sent 24h reminder to {Email} for engagement {EngagementId}",
-					user.Email,
-					item.Engagement.Id.Value);
+				messages.Add(new EmailMessage(user.Email, subject, body));
+				recipients.Add((item.Engagement, user.Email));
 			}
 			catch (Exception ex)
 			{
 				logger.LogError(
 					ex,
-					"Failed to send reminder for engagement {EngagementId}",
+					"Failed to resolve volunteer profile for engagement {EngagementId}",
 					item.Engagement.Id.Value);
 			}
+		}
+
+		if (messages.Count == 0)
+			return;
+
+		// A single SMTP connection for the whole batch instead of one per engagement.
+		var sendResults = await emailService.SendBatchAsync(messages, ct);
+
+		var sentIds = new List<EngagementId>(recipients.Count);
+		for (var i = 0; i < recipients.Count; i++)
+		{
+			if (!sendResults[i])
+				continue;
+
+			var (engagement, email) = recipients[i];
+			sentIds.Add(engagement.Id);
+
+			logger.LogInformation(
+				"Sent 24h reminder to {Email} for engagement {EngagementId}",
+				email,
+				engagement.Id.Value);
+		}
+
+		if (sentIds.Count == 0)
+			return;
+
+		try
+		{
+			// A single batched UPDATE instead of one SaveChangesAsync per engagement.
+			await dbContext.Set<Engagement>()
+				.Where(e => sentIds.Contains(e.Id))
+				.ExecuteUpdateAsync(
+					s => s
+						.SetProperty(e => e.ReminderSentAt, now)
+						.SetProperty(e => e.ModifiedOn, now),
+					ct);
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(
+				ex,
+				"Failed to persist ReminderSentAt for {Count} engagements after sending reminders; they will be retried next run",
+				sentIds.Count);
 		}
 	}
 }

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -50,4 +50,68 @@ internal sealed class SmtpEmailService(
 			metrics.RecordFailed();
 		}
 	}
+
+	public async Task<IReadOnlyList<bool>> SendBatchAsync(
+		IReadOnlyList<EmailMessage> messages,
+		CancellationToken cancellationToken = default)
+	{
+		var results = new bool[messages.Count];
+		if (messages.Count == 0)
+			return results;
+
+		using var client = new SmtpClient();
+
+		try
+		{
+			var secureSocketOptions = _options.EnableSsl
+				? SecureSocketOptions.StartTls
+				: SecureSocketOptions.None;
+			await client.ConnectAsync(_options.Host, _options.Port, secureSocketOptions, cancellationToken);
+
+			if (!string.IsNullOrEmpty(_options.Username))
+				await client.AuthenticateAsync(_options.Username, _options.Password ?? string.Empty, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Failed to establish SMTP connection for batch of {Count} emails", messages.Count);
+			for (var i = 0; i < messages.Count; i++)
+				metrics.RecordFailed();
+
+			return results;
+		}
+
+		for (var i = 0; i < messages.Count; i++)
+		{
+			var email = messages[i];
+			try
+			{
+				using var message = new MimeMessage();
+				message.From.Add(new MailboxAddress(_options.FromName, _options.FromAddress));
+				message.To.Add(MailboxAddress.Parse(email.To));
+				message.Subject = email.Subject;
+				message.Body = new TextPart("plain") { Text = email.Body };
+
+				await client.SendAsync(message, cancellationToken);
+
+				metrics.RecordSucceeded();
+				results[i] = true;
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "Failed to send email to {To} with subject {Subject}", email.To, email.Subject);
+				metrics.RecordFailed();
+			}
+		}
+
+		try
+		{
+			await client.DisconnectAsync(true, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "Failed to cleanly disconnect SMTP client after sending a batch of {Count} emails", messages.Count);
+		}
+
+		return results;
+	}
 }

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using Application.Common.Email;
 using AwesomeAssertions;
 using Infrastructure.Email;
 using Microsoft.Extensions.Diagnostics.Metrics;
@@ -19,6 +20,14 @@ namespace IntegrationTests;
 // like EngagementReminderJob rely on this - see its MarkReminderSent right
 // after SendAsync) but still observable, now via a metric rather than only a
 // log line nothing was watching.
+//
+// [NotInParallel] with a key unique to this class (not the "IntegrationDb"
+// key other IntegrationTests classes share): EmailMetrics.MeterName is a
+// process-wide constant, so a MeterListener started in one test backfires
+// on every not-yet-disposed Meter of that name from a concurrently-running
+// test in this class too - it must not also serialize against the unrelated
+// Aspire/Testcontainers-backed suite this class deliberately avoids needing.
+[NotInParallel(nameof(SmtpEmailServiceTests))]
 public class SmtpEmailServiceTests
 {
 	[Test]
@@ -51,6 +60,95 @@ public class SmtpEmailServiceTests
 		await act.Should().NotThrowAsync();
 
 		recorded.Should().ContainSingle(m => m.Status == "failed" && m.Value == 1);
+	}
+
+	// Regression coverage for #1400: EngagementReminderJob used to open a fresh
+	// SMTP connection per volunteer. FakeSmtpServer only ever accepts one TCP
+	// connection (see AcceptAsync below), so if SendBatchAsync tried to reconnect
+	// for message 2 or 3 there would be nothing listening and those sends would
+	// fail - all three succeeding here is itself proof the batch shares one connection.
+	[Test]
+	public async Task SendBatchAsync_ServerAcceptsAllMessages_SendsEveryMessageOverOneConnection()
+	{
+		await using var server = await FakeSmtpServer.StartAsync();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(server.Port, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(true, true, true);
+		recorded.Count(m => m.Status == "succeeded").Should().Be(3);
+		recorded.Should().NotContain(m => m.Status == "failed");
+	}
+
+	[Test]
+	public async Task SendBatchAsync_ServerRejectsOneRecipient_ReportsThatMessageAsFailedAndKeepsSendingTheRest()
+	{
+		await using var server = await FakeSmtpServer.StartAsync(rejectRecipient: "olaf@example.com");
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(server.Port, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(true, false, true);
+		recorded.Count(m => m.Status == "succeeded").Should().Be(2);
+		recorded.Count(m => m.Status == "failed").Should().Be(1);
+	}
+
+	[Test]
+	public async Task SendBatchAsync_ServerUnreachable_AllMessagesFailWithoutThrowing()
+	{
+		var unusedPort = GetUnusedLoopbackPort();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(unusedPort, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(false, false);
+		recorded.Count(m => m.Status == "failed").Should().Be(2);
+	}
+
+	[Test]
+	public async Task SendBatchAsync_EmptyMessageList_ReturnsEmptyResultsWithoutConnecting()
+	{
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		// Deliberately no FakeSmtpServer started: an empty batch must not attempt
+		// a connection at all, so an unused port never being listened on is fine.
+		var sut = CreateService(GetUnusedLoopbackPort(), metrics);
+
+		var results = await sut.SendBatchAsync([]);
+
+		results.Should().BeEmpty();
+		recorded.Should().BeEmpty();
 	}
 
 	private static SmtpEmailService CreateService(int port, EmailMetrics metrics) =>
@@ -136,22 +234,24 @@ public class SmtpEmailServiceTests
 	{
 		private readonly TcpListener _listener;
 		private readonly Task _acceptTask;
+		private readonly string? _rejectRecipient;
 
-		private FakeSmtpServer(TcpListener listener, int port)
+		private FakeSmtpServer(TcpListener listener, int port, string? rejectRecipient)
 		{
 			_listener = listener;
 			Port = port;
+			_rejectRecipient = rejectRecipient;
 			_acceptTask = AcceptAsync();
 		}
 
 		public int Port { get; }
 
-		public static Task<FakeSmtpServer> StartAsync()
+		public static Task<FakeSmtpServer> StartAsync(string? rejectRecipient = null)
 		{
 			var listener = new TcpListener(IPAddress.Loopback, 0);
 			listener.Start();
 			var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-			return Task.FromResult(new FakeSmtpServer(listener, port));
+			return Task.FromResult(new FakeSmtpServer(listener, port, rejectRecipient));
 		}
 
 		private async Task AcceptAsync()
@@ -170,10 +270,21 @@ public class SmtpEmailServiceTests
 				{
 					await writer.WriteLineAsync("250 fake.local");
 				}
-				else if (line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase)
-					|| line.StartsWith("RCPT TO", StringComparison.OrdinalIgnoreCase))
+				else if (line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase))
 				{
 					await writer.WriteLineAsync("250 OK");
+				}
+				else if (line.StartsWith("RCPT TO", StringComparison.OrdinalIgnoreCase))
+				{
+					if (_rejectRecipient is not null &&
+						line.Contains(_rejectRecipient, StringComparison.OrdinalIgnoreCase))
+					{
+						await writer.WriteLineAsync("550 Requested action not taken: mailbox unavailable");
+					}
+					else
+					{
+						await writer.WriteLineAsync("250 OK");
+					}
 				}
 				else if (line.Equals("DATA", StringComparison.OrdinalIgnoreCase))
 				{
@@ -183,6 +294,13 @@ public class SmtpEmailServiceTests
 					}
 
 					await writer.WriteLineAsync("250 OK queued");
+				}
+				else if (line.StartsWith("RSET", StringComparison.OrdinalIgnoreCase))
+				{
+					// MailKit issues RSET to clear the transaction after a rejected
+					// RCPT TO before starting the next message - without a reply
+					// here the client blocks reading a response that never comes.
+					await writer.WriteLineAsync("250 OK");
 				}
 				else if (line.StartsWith("QUIT", StringComparison.OrdinalIgnoreCase))
 				{


### PR DESCRIPTION
Reuse a single SMTP connection for a whole reminder run instead of one connect/authenticate/disconnect per volunteer, cache Keycloak profile lookups by volunteer within a run, mark all sent reminders with one ExecuteUpdate instead of one SaveChanges per row, and cap the query with Take so one run cannot process an unbounded number of engagements.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1400

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
