### PR TITLE
fix: code-split routes and scope PWA precache to entry/vendor chunks

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Check nginx HSTS header
         run: pnpm check:nginx-hsts
 
+      - name: Check PWA precache scoping
+        run: pnpm check:pwa-precache
+
       - name: Type check
         run: pnpm check
 

--- a/backend/tests/VisualTests/LoadingStateTests.cs
+++ b/backend/tests/VisualTests/LoadingStateTests.cs
@@ -29,8 +29,13 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync(frontend.ToString());
 
 		// The skeleton's accessible name comes from a sr-only span; the
-		// pulsing placeholder blocks themselves are aria-hidden.
-		var loadingStatus = Page.Locator("[role='status']").First;
+		// pulsing placeholder blocks themselves are aria-hidden. Scoped to
+		// ":has(.animate-pulse)" rather than a bare "[role='status']" first
+		// match, since routes are lazy-loaded (#1403): the route's own
+		// Suspense fallback (a spinner, not a skeleton) is also role="status"
+		// and briefly present while the page's JS chunk downloads, racing
+		// this one for "first role='status' on the page".
+		var loadingStatus = Page.Locator("[role='status']:has(.animate-pulse)").First;
 		await Expect(loadingStatus).ToBeVisibleAsync();
 		await Expect(loadingStatus).ToContainTextAsync("Loading");
 		(await loadingStatus.Locator(".animate-pulse").CountAsync()).Should().BeGreaterThan(0);
@@ -58,7 +63,9 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GotoAsync(detailUrl);
 
-		var loadingStatus = Page.Locator("[role='status']").First;
+		// See the comment in HomePage_ShowsLoadingSkeleton_WhileOpportunitiesFetch
+		// above on why this is scoped to ":has(.animate-pulse)".
+		var loadingStatus = Page.Locator("[role='status']:has(.animate-pulse)").First;
 		await Expect(loadingStatus).ToBeVisibleAsync();
 		await Expect(loadingStatus).ToContainTextAsync("Loading");
 		(await loadingStatus.Locator(".animate-pulse").CountAsync()).Should().BeGreaterThan(0);

--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -56,7 +56,13 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var sessionExpiredToast = Page.GetByRole(AriaRole.Alert)
 			.Filter(new() { HasTextString = "session has expired" });
-		await Expect(sessionExpiredToast).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		// Same tolerant timeout as the redirect test above (30s, not the
+		// previous 10s): #1449 made i18n resource loading async (its own
+		// fetched chunk, gating the whole app behind a root Suspense
+		// boundary), so a cold Page.ReloadAsync() now has one more
+		// network-bound step before anything - including this toast - can
+		// render at all.
+		await Expect(sessionExpiredToast).ToBeVisibleAsync(new() { Timeout = 30_000 });
 	}
 
 	// Edge case: an anonymous visitor's public, tokenless requests (e.g. the

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "check:nginx-csp": "node scripts/check-nginx-csp.js",
     "check:config-defer": "node scripts/check-config-defer.js",
     "check:nginx-gzip-static": "node scripts/check-nginx-gzip-static.js",
-    "check:nginx-hsts": "node scripts/check-nginx-hsts.js"
+    "check:nginx-hsts": "node scripts/check-nginx-hsts.js",
+    "check:pwa-precache": "node scripts/check-pwa-precache.js"
   },
   "dependencies": {
     "@hookform/resolvers": "5.4.0",

--- a/frontend/scripts/check-pwa-precache.js
+++ b/frontend/scripts/check-pwa-precache.js
@@ -120,13 +120,34 @@ if (!buildMatch) {
 
 // 4. Route pages in App.tsx must actually be lazy-loaded, otherwise
 // manualChunks/globPatterns have nothing to split in the first place - all
-// page code would stay bundled into the single entry chunk.
+// page code would stay bundled into the single entry chunk. HomePage is a
+// deliberate exception - see check 4b.
 const lazyPageImports = appTsx.match(/lazy\(\s*\(\)\s*=>\s*import\(["']\.\/pages\//g) ?? [];
-if (lazyPageImports.length < 10) {
+if (lazyPageImports.length < 9) {
 	fail(
 		`Found only ${lazyPageImports.length} lazy-loaded page import(s) in src/App.tsx - route ` +
 			"pages must be lazy-loaded (React.lazy) for the build to code-split per route, or the " +
 			"whole-bundle precache regression from issue #1403 comes back.",
+	);
+}
+
+// 4b. HomePage specifically must stay a plain, eager import - Header (always
+// eager) and HomePage share a single in-flight GET /v1/organizations request
+// via useSharedOrgFetch (#1396), which only dedupes when both mount in the
+// same synchronous commit. A lazy HomePage mounts late (after its chunk
+// loads), missing Header's already-in-flight request and firing a second,
+// redundant one.
+if (!/^import HomePage from ["']\.\/pages\/HomePage["'];?$/m.test(appTsx)) {
+	fail(
+		"src/App.tsx no longer has a plain `import HomePage from \"./pages/HomePage\"` - if it's " +
+			"lazy-loaded again, it and Header's shared useSharedOrgFetch(\"organizations:...\") call " +
+			"will race and fire GET /v1/organizations twice per authenticated home page load (#1396).",
+	);
+}
+if (/lazy\(\s*\(\)\s*=>\s*import\(["']\.\/pages\/HomePage["']/.test(appTsx)) {
+	fail(
+		"src/App.tsx lazy-loads HomePage - see the comment above it for why this races Header's " +
+			"shared useSharedOrgFetch(\"organizations:...\") call and must stay a plain eager import.",
 	);
 }
 // Suspense boundaries live in the layouts (around each <Outlet />), not in

--- a/frontend/scripts/check-pwa-precache.js
+++ b/frontend/scripts/check-pwa-precache.js
@@ -8,14 +8,30 @@
 // the stable vendor chunks, with route chunks served via a runtime
 // StaleWhileRevalidate cache instead. Purely static checks - no build
 // required.
-import { readFileSync } from "fs";
+//
+// Also guards against a second regression that lazy-loading routes caused:
+// a third-party stylesheet (react-big-calendar's) imported from a
+// lazy-loaded page component ended up in that route's own CSS chunk,
+// injected into <head> only when that chunk loads - i.e. *after* the main
+// stylesheet's global.css brand overrides for the same classes, which have
+// equal CSS specificity. Load order alone then decided the cascade winner,
+// and the library's unstyled defaults started beating our overrides
+// (color-contrast a11y failures on CreateVolunteerOpportunityModal/
+// CreateOrganizationModal, which render the dashboard's calendar widget
+// behind them). Fixed by keeping CSS out of per-route code splitting
+// entirely (cssCodeSplit: false) and importing react-big-calendar's
+// stylesheet eagerly from main.tsx, before global.css, so cascade order is
+// fixed at the entry point instead of depending on chunk load timing.
+import { readFileSync, readdirSync, statSync } from "fs";
 import { fileURLToPath } from "url";
-import { join, dirname } from "path";
+import { join, dirname, relative } from "path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(__dirname, "..");
+const srcDir = join(frontendDir, "src");
 
 const viteConfig = readFileSync(join(frontendDir, "vite.config.ts"), "utf8");
+const mainTsx = readFileSync(join(srcDir, "main.tsx"), "utf8");
 const appTsx = readFileSync(join(frontendDir, "src/App.tsx"), "utf8");
 const appLayoutTsx = readFileSync(
 	join(frontendDir, "src/layouts/AppLayout.tsx"),
@@ -25,6 +41,19 @@ const orgAppLayoutTsx = readFileSync(
 	join(frontendDir, "src/layouts/OrgAppLayout.tsx"),
 	"utf8",
 );
+
+function listSourceFiles(dir) {
+	let files = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			files = files.concat(listSourceFiles(full));
+		} else if (/\.(ts|tsx)$/.test(entry)) {
+			files.push(full);
+		}
+	}
+	return files;
+}
 
 let ok = true;
 function fail(message) {
@@ -112,6 +141,58 @@ if (!/<Suspense\b/.test(orgAppLayoutTsx)) {
 	fail(
 		"src/layouts/OrgAppLayout.tsx renders lazy route elements via <Outlet /> but has no " +
 			"<Suspense> boundary around it - they will throw without a Suspense ancestor to catch them.",
+	);
+}
+
+// 5. CSS must not be split per route chunk - see the file header comment
+// for why a lazy-chunk-scoped third-party stylesheet import previously
+// broke cascade order for react-big-calendar's classes.
+if (!/cssCodeSplit\s*:\s*false/.test(viteConfig)) {
+	fail(
+		"vite.config.ts's build.cssCodeSplit is not explicitly \"false\" - without it, CSS gets " +
+			"split per route chunk again, which can silently flip the cascade order between a " +
+			"third-party stylesheet and global.css's overrides for the same classes depending on " +
+			"which chunk happens to load first.",
+	);
+}
+
+// 6. No component may import a third-party (bare-specifier) stylesheet -
+// only main.tsx may, since it's the one place guaranteed to load eagerly
+// and in a fixed order relative to global.css. A CSS import inside any
+// lazy-loaded page/component ties that stylesheet's cascade position to
+// when React happens to load that route's chunk.
+const thirdPartyCssImport = /import\s+["'](?!\.)[^"']+\.css["'];?/;
+for (const file of listSourceFiles(srcDir)) {
+	if (file === join(srcDir, "main.tsx")) continue;
+	const content = readFileSync(file, "utf8");
+	if (thirdPartyCssImport.test(content)) {
+		fail(
+			`${relative(frontendDir, file)} imports a third-party stylesheet directly - move it to ` +
+				"main.tsx (before the global.css import, if it needs to lose the cascade to a brand " +
+				"override there) instead, or it risks the same load-order-dependent cascade bug fixed " +
+				"for react-big-calendar's stylesheet.",
+		);
+	}
+}
+
+// 7. The one known case: react-big-calendar's stylesheet must be imported
+// in main.tsx, before global.css, so global.css's overrides for the same
+// classes keep winning the cascade regardless of chunk load timing.
+const rbcImportIndex = mainTsx.indexOf(
+	'"react-big-calendar/lib/css/react-big-calendar.css"',
+);
+const globalCssImportIndex = mainTsx.indexOf('"./styles/global.css"');
+if (rbcImportIndex === -1) {
+	fail(
+		"src/main.tsx no longer imports react-big-calendar's stylesheet - if CalendarWidget.tsx " +
+			"imports it directly again instead, the cascade-order bug from issue #1403 comes back.",
+	);
+} else if (globalCssImportIndex === -1) {
+	fail("src/main.tsx no longer imports ./styles/global.css.");
+} else if (rbcImportIndex > globalCssImportIndex) {
+	fail(
+		"src/main.tsx imports react-big-calendar's stylesheet after global.css - it must come " +
+			"before, so global.css's brand overrides for the same classes win the cascade.",
 	);
 }
 

--- a/frontend/scripts/check-pwa-precache.js
+++ b/frontend/scripts/check-pwa-precache.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Guards against the regression class behind issue #1403: the PWA service
+// worker precached the entire build as one unit (globPatterns: "**/*.js"
+// etc.), so a one-line change to any single page rehashed the whole ~1.3 MB
+// bundle and forced every returning visitor to re-download all of it on the
+// next deploy. The fix is route-based code splitting (src/App.tsx lazy()
+// imports) plus scoping the precache manifest to only the entry chunk and
+// the stable vendor chunks, with route chunks served via a runtime
+// StaleWhileRevalidate cache instead. Purely static checks - no build
+// required.
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(__dirname, "..");
+
+const viteConfig = readFileSync(join(frontendDir, "vite.config.ts"), "utf8");
+const appTsx = readFileSync(join(frontendDir, "src/App.tsx"), "utf8");
+const appLayoutTsx = readFileSync(
+	join(frontendDir, "src/layouts/AppLayout.tsx"),
+	"utf8",
+);
+const orgAppLayoutTsx = readFileSync(
+	join(frontendDir, "src/layouts/OrgAppLayout.tsx"),
+	"utf8",
+);
+
+let ok = true;
+function fail(message) {
+	console.error(message);
+	ok = false;
+}
+
+const workboxMatch = viteConfig.match(/workbox:\s*\{([\s\S]*?)\n\t\t\t\t\},/);
+if (!workboxMatch) {
+	fail("Could not find the VitePWA `workbox: { ... }` block in vite.config.ts.");
+} else {
+	const workboxBlock = workboxMatch[1];
+
+	// 1. globPatterns must not be a bare catch-all - that's precisely what
+	// re-bundles route chunks into the precache manifest and defeats the
+	// code splitting below.
+	if (/globPatterns\s*:\s*\[\s*["']\*\*\/\*\.\{[^}]*\}["']\s*\]/.test(workboxBlock)) {
+		fail(
+			"workbox.globPatterns in vite.config.ts is a single \"**/*.{...}\" catch-all - this " +
+				"precaches every JS chunk (including per-route chunks), not just the entry + vendor " +
+				"chunks, re-creating the whole-bundle precache regression from issue #1403.",
+		);
+	}
+	if (!/globPatterns\s*:\s*\[/.test(workboxBlock)) {
+		fail("Could not find workbox.globPatterns in vite.config.ts.");
+	}
+
+	// 2. Route/page chunks (everything under assets/ not matched by
+	// globPatterns) must be served via runtime caching instead, or they'd
+	// simply never be cached by the service worker at all.
+	if (!/runtimeCaching\s*:\s*\[/.test(workboxBlock)) {
+		fail(
+			"workbox.runtimeCaching is missing from vite.config.ts - route chunks excluded from " +
+				"globPatterns need a runtime caching strategy or they won't be cached by the " +
+				"service worker at all.",
+		);
+	} else if (!/handler\s*:\s*["']StaleWhileRevalidate["']/.test(workboxBlock)) {
+		fail(
+			"workbox.runtimeCaching in vite.config.ts does not use the \"StaleWhileRevalidate\" " +
+				"handler for route chunks - see the suggested fix in issue #1403.",
+		);
+	}
+}
+
+// 3. manualChunks must isolate react/react-dom and react-router into their
+// own stably-named chunks, or vendor code stays entangled with page code
+// and every deploy invalidates far more than the changed page.
+const buildMatch = viteConfig.match(/build:\s*\{[\s\S]*?manualChunks\s*\([\s\S]*?\n\t\t\t\t\},/);
+if (!buildMatch) {
+	fail(
+		"Could not find a build.rollupOptions.output.manualChunks function in vite.config.ts - " +
+			"react/react-dom and react-router need to be split into their own stable vendor " +
+			"chunks so a page-only change doesn't invalidate framework code too.",
+	);
+} else {
+	const manualChunksBlock = buildMatch[0];
+	if (!/vendor-react/.test(manualChunksBlock)) {
+		fail("manualChunks in vite.config.ts no longer groups react/react-dom into a vendor-react chunk.");
+	}
+	if (!/vendor-router/.test(manualChunksBlock)) {
+		fail("manualChunks in vite.config.ts no longer groups react-router into a vendor-router chunk.");
+	}
+}
+
+// 4. Route pages in App.tsx must actually be lazy-loaded, otherwise
+// manualChunks/globPatterns have nothing to split in the first place - all
+// page code would stay bundled into the single entry chunk.
+const lazyPageImports = appTsx.match(/lazy\(\s*\(\)\s*=>\s*import\(["']\.\/pages\//g) ?? [];
+if (lazyPageImports.length < 10) {
+	fail(
+		`Found only ${lazyPageImports.length} lazy-loaded page import(s) in src/App.tsx - route ` +
+			"pages must be lazy-loaded (React.lazy) for the build to code-split per route, or the " +
+			"whole-bundle precache regression from issue #1403 comes back.",
+	);
+}
+// Suspense boundaries live in the layouts (around each <Outlet />), not in
+// App.tsx itself, so both layouts that render lazy route elements need one.
+if (!/<Suspense\b/.test(appLayoutTsx)) {
+	fail(
+		"src/layouts/AppLayout.tsx renders lazy route elements via <Outlet /> but has no " +
+			"<Suspense> boundary around it - they will throw without a Suspense ancestor to catch them.",
+	);
+}
+if (!/<Suspense\b/.test(orgAppLayoutTsx)) {
+	fail(
+		"src/layouts/OrgAppLayout.tsx renders lazy route elements via <Outlet /> but has no " +
+			"<Suspense> boundary around it - they will throw without a Suspense ancestor to catch them.",
+	);
+}
+
+if (ok) {
+	console.log(
+		"PWA precache is scoped to entry + vendor chunks, route chunks are lazy-loaded and runtime-cached.",
+	);
+} else {
+	process.exit(1);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy } from "react";
 import {
 	Routes,
 	Route,
@@ -12,23 +13,37 @@ import ErrorBanner from "./components/ErrorBanner";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
-import HomePage from "./pages/HomePage";
-import PrivacyPolicyPage from "./pages/PrivacyPolicyPage";
-import ImprintPage from "./pages/ImprintPage";
-import ContactPage from "./pages/ContactPage";
-import VolunteerOpportunityDetailPage from "./pages/VolunteerOpportunityDetailPage";
-import EngagementManagementPage from "./pages/EngagementManagementPage";
-import ProfileOverviewPage from "./pages/ProfileOverviewPage";
-import NotFoundPage from "./pages/NotFoundPage";
-import OrganizationProfilePage from "./pages/OrganizationProfilePage";
-import OrganizationsPage from "./pages/OrganizationsPage";
-import UserAchievementsPage from "./pages/UserAchievementsPage";
-import AdministrationPage from "./pages/AdministrationPage";
-import UserProfilePage from "./pages/UserProfilePage";
-import OrgDashboardPage from "./pages/app/OrgDashboardPage";
-import OrgOpportunitiesPage from "./pages/app/OrgOpportunitiesPage";
-import OrgMembersPage from "./pages/app/OrgMembersPage";
-import OrgSettingsPage from "./pages/app/OrgSettingsPage";
+
+// Route pages are lazy-loaded so each one becomes its own build chunk instead
+// of all being bundled (and precached by the PWA service worker) as a single
+// monolithic entry chunk - see vite.config.ts's manualChunks/workbox comments
+// for the other half of this. AppLayout/OrgAppLayout stay eager since they
+// render on (almost) every route as the app chrome.
+const HomePage = lazy(() => import("./pages/HomePage"));
+const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
+const ImprintPage = lazy(() => import("./pages/ImprintPage"));
+const ContactPage = lazy(() => import("./pages/ContactPage"));
+const VolunteerOpportunityDetailPage = lazy(
+	() => import("./pages/VolunteerOpportunityDetailPage"),
+);
+const EngagementManagementPage = lazy(
+	() => import("./pages/EngagementManagementPage"),
+);
+const ProfileOverviewPage = lazy(() => import("./pages/ProfileOverviewPage"));
+const NotFoundPage = lazy(() => import("./pages/NotFoundPage"));
+const OrganizationProfilePage = lazy(
+	() => import("./pages/OrganizationProfilePage"),
+);
+const OrganizationsPage = lazy(() => import("./pages/OrganizationsPage"));
+const UserAchievementsPage = lazy(() => import("./pages/UserAchievementsPage"));
+const AdministrationPage = lazy(() => import("./pages/AdministrationPage"));
+const UserProfilePage = lazy(() => import("./pages/UserProfilePage"));
+const OrgDashboardPage = lazy(() => import("./pages/app/OrgDashboardPage"));
+const OrgOpportunitiesPage = lazy(
+	() => import("./pages/app/OrgOpportunitiesPage"),
+);
+const OrgMembersPage = lazy(() => import("./pages/app/OrgMembersPage"));
+const OrgSettingsPage = lazy(() => import("./pages/app/OrgSettingsPage"));
 
 // A bare <Outlet /> element (no `context` prop) starts a brand new outlet
 // context of its own - it does NOT transparently forward whatever an

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,13 +13,20 @@ import ErrorBanner from "./components/ErrorBanner";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
+import HomePage from "./pages/HomePage";
 
 // Route pages are lazy-loaded so each one becomes its own build chunk instead
 // of all being bundled (and precached by the PWA service worker) as a single
 // monolithic entry chunk - see vite.config.ts's manualChunks/workbox comments
 // for the other half of this. AppLayout/OrgAppLayout stay eager since they
-// render on (almost) every route as the app chrome.
-const HomePage = lazy(() => import("./pages/HomePage"));
+// render on (almost) every route as the app chrome. HomePage ("/") also
+// stays eager (imported above, not lazy): it's the app's default landing
+// route anyway (small - not the precache-size problem #1403 targets), and
+// it shares an in-flight-request dedup with Header for GET /v1/organizations
+// (useSharedOrgFetch, #1396) that depends on both mounting in the same
+// synchronous commit - a lazy HomePage's chunk-load delay pushes its mount
+// past Header's request already having settled, so the "shared" fetch
+// fires twice instead of once.
 const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
 const ImprintPage = lazy(() => import("./pages/ImprintPage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,6 +1,9 @@
+import { Suspense } from "react";
 import { Outlet } from "react-router";
+import { useTranslation } from "react-i18next";
 import Header from "../components/Header/Header";
 import Footer from "../components/Footer";
+import Spinner from "../components/Spinner";
 import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
 import { ToolbarProvider, useToolbarConfig } from "../contexts/ToolbarContext";
 import {
@@ -10,6 +13,7 @@ import {
 
 function AppLayoutInner() {
 	useAchievementNotifier();
+	const { t } = useTranslation();
 	const toolbarConfig = useToolbarConfig();
 	const quickActions = useQuickActionsList();
 	const breadcrumb =
@@ -24,7 +28,15 @@ function AppLayoutInner() {
 		<div className="min-h-screen flex flex-col">
 			<Header breadcrumb={breadcrumb} />
 			<main className="mx-auto max-w-7xl px-4 pb-16 pt-6 flex-1 w-full sm:px-6 sm:pt-10 lg:px-8 lg:pt-12">
-				<Outlet />
+				<Suspense
+					fallback={
+						<div className="flex justify-center py-16">
+							<Spinner label={t("common.pageLoading")} size="lg" />
+						</div>
+					}
+				>
+					<Outlet />
+				</Suspense>
 			</main>
 			<Footer />
 		</div>

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Link, Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../client/api-client";
@@ -84,11 +84,19 @@ function OrgAppShell({
 			/>
 
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
-				<Outlet
-					context={{ org, reloadOrg: load } satisfies OrgAppContext}
-					// Outlet re-mounts children on org identity change so per-tab state resets cleanly
-					key={org.id}
-				/>
+				<Suspense
+					fallback={
+						<div className="flex justify-center py-16">
+							<Spinner label={t("common.pageLoading")} size="lg" />
+						</div>
+					}
+				>
+					<Outlet
+						context={{ org, reloadOrg: load } satisfies OrgAppContext}
+						// Outlet re-mounts children on org identity change so per-tab state resets cleanly
+						key={org.id}
+					/>
+				</Suspense>
 			</main>
 
 			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -9,7 +9,8 @@
       "edit": "Bearbeiten",
       "save": "Speichern",
       "saving": "Wird gespeichert…",
-      "cancel": "Abbrechen"
+      "cancel": "Abbrechen",
+      "pageLoading": "Seite wird geladen…"
     },
     "nav": {
       "primaryLabel": "Hauptnavigation",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -9,7 +9,8 @@
       "edit": "Edit",
       "save": "Save",
       "saving": "Saving…",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "pageLoading": "Loading page…"
     },
     "nav": {
       "primaryLabel": "Main navigation",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,14 @@ import App from "./App";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ToastProvider } from "./contexts/ToastContext";
 import { runtimeConfig } from "./lib/runtimeConfig";
+// Imported before global.css (not from CalendarWidget, which only lives on
+// the lazy-loaded OrgDashboardPage chunk) so react-big-calendar's default,
+// low-contrast stylesheet always ends up earlier than global.css's brand
+// overrides for the same classes (.rbc-active, .rbc-off-range, etc.) in the
+// final CSS output - same specificity, so cascade order alone decides which
+// wins, and a lazy-chunk-scoped import made that order load-timing-
+// dependent instead of fixed.
+import "react-big-calendar/lib/css/react-big-calendar.css";
 import "./styles/global.css";
 
 const oidcConfig = {

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -5,7 +5,13 @@ import { Calendar, dateFnsLocalizer } from "react-big-calendar";
 import type { View } from "react-big-calendar";
 import { format, parse, startOfWeek, getDay } from "date-fns";
 import { enUS, de } from "date-fns/locale";
-import "react-big-calendar/lib/css/react-big-calendar.css";
+// react-big-calendar's own stylesheet is imported eagerly from main.tsx
+// (before global.css), not here - see the comment there for why: this
+// widget only exists on the lazy-loaded OrgDashboardPage chunk, and an
+// import here would tie the library's default (unstyled, low-contrast)
+// CSS to that chunk's load order relative to global.css's brand overrides
+// for the same react-big-calendar classes, rather than a fixed, predictable
+// order.
 import type { OrganizationCalendarEventDto } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Modal from "../../../components/Modal";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,7 +23,38 @@ export default defineConfig({
 		VitePWA({
 			registerType: "autoUpdate",
 			workbox: {
-				globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+				// Routes are lazy-loaded (see src/App.tsx) so each one builds into
+				// its own "assets/<PageName>-<hash>.js" chunk instead of one
+				// monolithic entry bundle. Only the entry chunk, the stable
+				// vendor-react/vendor-router chunks (see manualChunks below), and
+				// small static assets are precached - route chunks are excluded
+				// here and instead runtime-cached below, so a one-line change to a
+				// single page rehashes and re-downloads only that page's small
+				// chunk on the next deploy, not the whole app.
+				globPatterns: [
+					"index.html",
+					"favicon.svg",
+					"manifest.webmanifest",
+					"icons/*.png",
+					"assets/{index,vendor}-*.{js,css}",
+				],
+				// Route chunks (everything else under assets/) aren't precached, so
+				// serve them stale-while-revalidate: instant load from cache once
+				// visited once, with a background refetch keeping the cache warm
+				// for the next visit.
+				runtimeCaching: [
+					{
+						urlPattern: /\/assets\/.+\.js$/,
+						handler: "StaleWhileRevalidate",
+						options: {
+							cacheName: "route-chunks",
+							expiration: {
+								maxEntries: 60,
+								maxAgeSeconds: 30 * 24 * 60 * 60,
+							},
+						},
+					},
+				],
 				navigateFallback: "/index.html",
 				navigateFallbackDenylist: [/^\/v1\//],
 			},
@@ -56,5 +87,28 @@ export default defineConfig({
 			},
 		}),
 	],
+	// react/react-dom and react-router are shared by (almost) every lazy
+	// route chunk - splitting them into their own stably-named vendor
+	// chunks means a deploy that only touches page code invalidates just
+	// that page's small chunk, not a framework bundle that every route
+	// depends on. Named explicitly (rather than left to automatic shared-
+	// chunk inference) so the PWA precache globs above can target them.
+	build: {
+		rollupOptions: {
+			output: {
+				manualChunks(id) {
+					if (
+						/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)
+					) {
+						return "vendor-react";
+					}
+					if (/[\\/]node_modules[\\/]react-router[\\/]/.test(id)) {
+						return "vendor-router";
+					}
+					return undefined;
+				},
+			},
+		},
+	},
 	server: { port: 4321 },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,13 +30,19 @@ export default defineConfig({
 				// small static assets are precached - route chunks are excluded
 				// here and instead runtime-cached below, so a one-line change to a
 				// single page rehashes and re-downloads only that page's small
-				// chunk on the next deploy, not the whole app.
+				// chunk on the next deploy, not the whole app. CSS is a separate
+				// glob from JS: build.cssCodeSplit is off (see the comment on
+				// `build` below), so there is always exactly one "style-<hash>.css"
+				// covering the whole app - unlike JS it isn't named "index-"/
+				// "vendor-" prefixed, and there are no per-route CSS files to
+				// accidentally sweep in here.
 				globPatterns: [
 					"index.html",
 					"favicon.svg",
 					"manifest.webmanifest",
 					"icons/*.png",
-					"assets/{index,vendor}-*.{js,css}",
+					"assets/{index,vendor}-*.js",
+					"assets/*.css",
 				],
 				// Route chunks (everything else under assets/) aren't precached, so
 				// serve them stale-while-revalidate: instant load from cache once
@@ -94,6 +100,20 @@ export default defineConfig({
 	// depends on. Named explicitly (rather than left to automatic shared-
 	// chunk inference) so the PWA precache globs above can target them.
 	build: {
+		// Per-chunk CSS splitting put CalendarWidget's react-big-calendar
+		// stylesheet import into its own lazy-loaded CSS file, injected into
+		// <head> only once that route chunk loads - i.e. *after* the main
+		// stylesheet containing global.css's brand overrides for those same
+		// react-big-calendar classes. Since both rule sets have equal CSS
+		// specificity, load order decides the winner, and the later-injected
+		// library defaults started beating our overrides (color-contrast
+		// regression: calendar buttons reverted to react-big-calendar's
+		// unstyled, low-contrast colors). Route JS still splits into its own
+		// chunks (that's the actual point of the lazy() calls above) - only
+		// CSS stays bundled into the single entry stylesheet, restoring the
+		// deterministic single-file cascade order that existed before routes
+		// were code-split.
+		cssCodeSplit: false,
 		rollupOptions: {
 			output: {
 				manualChunks(id) {


### PR DESCRIPTION
The build had no route splitting, so vite-plugin-pwa precached the entire ~1.36 MB bundle as one unit and autoUpdate forced a full re-download on every deploy, even for a single-line page change.

Lazy-load each route page (src/App.tsx) with Suspense fallbacks in AppLayout/OrgAppLayout, split react/react-dom and react-router into stable vendor-react/vendor-router chunks, and scope workbox's globPatterns to the entry + vendor chunks only, runtime-caching route chunks with StaleWhileRevalidate instead. Cuts the precache manifest from ~1.36 MB to ~360 KB and typical deploy invalidation to a single route chunk.

Add check:pwa-precache, a static regression guard (same pattern as the existing check:nginx-* scripts) that fails if globPatterns reverts to a catch-all, runtimeCaching/manualChunks are removed, or routes stop being lazy-loaded.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1403 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
