### PR TITLE
fix: bound notification list query and poll unread count instead

### DIFF
--- a/backend/src/Api/Notifications/GetMyNotifications/v1/GetMyNotificationsEndpoint.cs
+++ b/backend/src/Api/Notifications/GetMyNotifications/v1/GetMyNotificationsEndpoint.cs
@@ -27,13 +27,22 @@ internal sealed class GetMyNotificationsEndpoint
 	private static async Task<IResult> GetMyNotificationsAsync(
 		[FromServices] ISender sender,
 		HttpContext httpContext,
-		[FromQuery] DateTimeOffset? before,
+		// A DateTimeOffset query param would round-trip through NSwag's
+		// generated clients as "s" format (second precision, no offset) -
+		// coarse enough to corrupt this cursor between two requests issued
+		// less than a second apart. Unix milliseconds, a plain long, avoids
+		// that lossy format string entirely.
+		[FromQuery] long? beforeUnixMs,
 		[FromQuery] Guid? beforeId,
 		CancellationToken cancellationToken)
 	{
 		var subClaim = httpContext.User.FindFirst("sub")?.Value;
 		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
+
+		var before = beforeUnixMs is not null
+			? DateTimeOffset.FromUnixTimeMilliseconds(beforeUnixMs.Value)
+			: (DateTimeOffset?)null;
 
 		var query = new GetMyNotificationsQuery(UserId.Create(userId).GetValueOrThrow(), before, beforeId);
 		var result = await sender.Send(query, cancellationToken);

--- a/backend/src/Api/Notifications/GetMyNotifications/v1/GetMyNotificationsEndpoint.cs
+++ b/backend/src/Api/Notifications/GetMyNotifications/v1/GetMyNotificationsEndpoint.cs
@@ -28,13 +28,14 @@ internal sealed class GetMyNotificationsEndpoint
 		[FromServices] ISender sender,
 		HttpContext httpContext,
 		[FromQuery] DateTimeOffset? before,
+		[FromQuery] Guid? beforeId,
 		CancellationToken cancellationToken)
 	{
 		var subClaim = httpContext.User.FindFirst("sub")?.Value;
 		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
 
-		var query = new GetMyNotificationsQuery(UserId.Create(userId).GetValueOrThrow(), before);
+		var query = new GetMyNotificationsQuery(UserId.Create(userId).GetValueOrThrow(), before, beforeId);
 		var result = await sender.Send(query, cancellationToken);
 		return Results.Ok(result);
 	}

--- a/backend/src/Api/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountEndpoint.cs
+++ b/backend/src/Api/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountEndpoint.cs
@@ -3,38 +3,36 @@ using Api.Common.Endpoints;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
-using Application.Notifications;
-using Application.Notifications.GetMyNotifications.v1;
+using Application.Notifications.GetUnreadNotificationCount.v1;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Notifications.GetMyNotifications.v1;
+namespace Api.Notifications.GetUnreadNotificationCount.v1;
 
-internal sealed class GetMyNotificationsEndpoint
+internal sealed class GetUnreadNotificationCountEndpoint
 	: IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
-		app.MapGet("/notifications", GetMyNotificationsAsync)
-			.WithName("GetMyNotifications")
+		app.MapGet("/notifications/unread-count", GetUnreadNotificationCountAsync)
+			.WithName("GetUnreadNotificationCount")
 			.WithTags("Notifications")
-			.Produces<NotificationsPage>()
+			.Produces<int>()
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 
-	private static async Task<IResult> GetMyNotificationsAsync(
+	private static async Task<IResult> GetUnreadNotificationCountAsync(
 		[FromServices] ISender sender,
 		HttpContext httpContext,
-		[FromQuery] DateTimeOffset? before,
 		CancellationToken cancellationToken)
 	{
 		var subClaim = httpContext.User.FindFirst("sub")?.Value;
 		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
 
-		var query = new GetMyNotificationsQuery(UserId.Create(userId).GetValueOrThrow(), before);
+		var query = new GetUnreadNotificationCountQuery(UserId.Create(userId).GetValueOrThrow());
 		var result = await sender.Send(query, cancellationToken);
 		return Results.Ok(result);
 	}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4161,6 +4161,14 @@
               "type": "string",
               "format": "date-time"
             }
+          },
+          {
+            "name": "beforeId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4155,11 +4155,15 @@
         "operationId": "GetMyNotifications",
         "parameters": [
           {
-            "name": "before",
+            "name": "beforeUnixMs",
             "in": "query",
             "schema": {
-              "type": "string",
-              "format": "date-time"
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int64"
             }
           },
           {

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4102,22 +4102,74 @@
         }
       }
     },
-    "/v1/notifications": {
+    "/v1/notifications/unread-count": {
       "get": {
         "tags": [
           "Notifications"
         ],
-        "operationId": "GetMyNotifications",
+        "operationId": "GetUnreadNotificationCount",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NotificationSummary"
-                  }
+                  "pattern": "^-?(?:0|[1-9]\\d*)$",
+                  "type": [
+                    "integer",
+                    "string"
+                  ],
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "GetMyNotifications",
+        "parameters": [
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsPage"
                 }
               }
             }
@@ -6497,6 +6549,24 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "NotificationsPage": {
+        "required": [
+          "items",
+          "hasMore"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationSummary"
+            }
+          },
+          "hasMore": {
+            "type": "boolean"
           }
         }
       },

--- a/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQuery.cs
+++ b/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQuery.cs
@@ -3,5 +3,5 @@ using Domain.Users;
 
 namespace Application.Notifications.GetMyNotifications.v1;
 
-public sealed record GetMyNotificationsQuery(UserId RecipientId)
-	: IQuery<List<NotificationSummary>>;
+public sealed record GetMyNotificationsQuery(UserId RecipientId, DateTimeOffset? Before)
+	: IQuery<NotificationsPage>;

--- a/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQuery.cs
+++ b/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQuery.cs
@@ -3,5 +3,5 @@ using Domain.Users;
 
 namespace Application.Notifications.GetMyNotifications.v1;
 
-public sealed record GetMyNotificationsQuery(UserId RecipientId, DateTimeOffset? Before)
+public sealed record GetMyNotificationsQuery(UserId RecipientId, DateTimeOffset? Before, Guid? BeforeId)
 	: IQuery<NotificationsPage>;

--- a/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQueryHandler.cs
+++ b/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQueryHandler.cs
@@ -13,7 +13,7 @@ internal sealed class GetMyNotificationsQueryHandler(
 		CancellationToken cancellationToken = default)
 	{
 		var notifications = await readRepository.GetByRecipientAsync(
-			request.RecipientId, request.Before, PageSize + 1, cancellationToken);
+			request.RecipientId, request.Before, request.BeforeId, PageSize + 1, cancellationToken);
 
 		var hasMore = notifications.Count > PageSize;
 		var items = hasMore ? notifications.Take(PageSize).ToList() : notifications;

--- a/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQueryHandler.cs
+++ b/backend/src/Application/Notifications/GetMyNotifications/v1/GetMyNotificationsQueryHandler.cs
@@ -4,10 +4,20 @@ namespace Application.Notifications.GetMyNotifications.v1;
 
 internal sealed class GetMyNotificationsQueryHandler(
 	INotificationReadRepository readRepository)
-	: IQueryHandler<GetMyNotificationsQuery, List<NotificationSummary>>
+	: IQueryHandler<GetMyNotificationsQuery, NotificationsPage>
 {
-	public async ValueTask<List<NotificationSummary>> Handle(
+	private const int PageSize = 50;
+
+	public async ValueTask<NotificationsPage> Handle(
 		GetMyNotificationsQuery request,
-		CancellationToken cancellationToken = default) =>
-			await readRepository.GetByRecipientAsync(request.RecipientId, cancellationToken);
+		CancellationToken cancellationToken = default)
+	{
+		var notifications = await readRepository.GetByRecipientAsync(
+			request.RecipientId, request.Before, PageSize + 1, cancellationToken);
+
+		var hasMore = notifications.Count > PageSize;
+		var items = hasMore ? notifications.Take(PageSize).ToList() : notifications;
+
+		return new NotificationsPage(items, hasMore);
+	}
 }

--- a/backend/src/Application/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountQuery.cs
+++ b/backend/src/Application/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountQuery.cs
@@ -1,0 +1,7 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.Notifications.GetUnreadNotificationCount.v1;
+
+public sealed record GetUnreadNotificationCountQuery(UserId RecipientId)
+	: IQuery<int>;

--- a/backend/src/Application/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountQueryHandler.cs
+++ b/backend/src/Application/Notifications/GetUnreadNotificationCount/v1/GetUnreadNotificationCountQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Common.Messaging;
+
+namespace Application.Notifications.GetUnreadNotificationCount.v1;
+
+internal sealed class GetUnreadNotificationCountQueryHandler(
+	INotificationReadRepository readRepository)
+	: IQueryHandler<GetUnreadNotificationCountQuery, int>
+{
+	public async ValueTask<int> Handle(
+		GetUnreadNotificationCountQuery request,
+		CancellationToken cancellationToken = default) =>
+			await readRepository.CountUnreadByRecipientAsync(request.RecipientId, cancellationToken);
+}

--- a/backend/src/Application/Notifications/INotificationReadRepository.cs
+++ b/backend/src/Application/Notifications/INotificationReadRepository.cs
@@ -6,5 +6,11 @@ public interface INotificationReadRepository
 {
 	ValueTask<List<NotificationSummary>> GetByRecipientAsync(
 		UserId recipientId,
+		DateTimeOffset? before,
+		int limit,
+		CancellationToken cancellationToken = default);
+
+	ValueTask<int> CountUnreadByRecipientAsync(
+		UserId recipientId,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Notifications/INotificationReadRepository.cs
+++ b/backend/src/Application/Notifications/INotificationReadRepository.cs
@@ -7,6 +7,7 @@ public interface INotificationReadRepository
 	ValueTask<List<NotificationSummary>> GetByRecipientAsync(
 		UserId recipientId,
 		DateTimeOffset? before,
+		Guid? beforeId,
 		int limit,
 		CancellationToken cancellationToken = default);
 

--- a/backend/src/Application/Notifications/NotificationsPage.cs
+++ b/backend/src/Application/Notifications/NotificationsPage.cs
@@ -1,0 +1,5 @@
+namespace Application.Notifications;
+
+public sealed record NotificationsPage(
+	IReadOnlyList<NotificationSummary> Items,
+	bool HasMore);

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -23,17 +23,37 @@ internal sealed class NotificationReadRepository(
 	public async ValueTask<List<NotificationSummary>> GetByRecipientAsync(
 		UserId recipientId,
 		DateTimeOffset? before,
+		Guid? beforeId,
 		int limit,
 		CancellationToken cancellationToken = default)
 	{
 		var query = dbContext.NotificationsQuery
 			.Where(n => n.RecipientId == recipientId);
 
-		if (before is not null)
+		// Notifications created in the same batch (e.g. several engagement
+		// events processed by the outbox job in one tick) can share an
+		// identical CreatedOn - AuditableEntityInterceptor stamps one UtcNow
+		// per SaveChanges call, not per entity. CreatedOn alone is therefore
+		// not a safe keyset cursor: paging strictly on "< before" would drop
+		// same-timestamp siblings that land on the far side of a page
+		// boundary. Id (a UUIDv7, so still roughly time-ordered) breaks the
+		// tie deterministically; EF.Property<Guid> reads the raw provider
+		// column instead of going through NotificationId's value converter,
+		// which only has == translation support, not < / >.
+		if (before is not null && beforeId is not null)
+		{
+			query = query.Where(n =>
+				n.CreatedOn < before.Value ||
+				(n.CreatedOn == before.Value && EF.Property<Guid>(n, nameof(Notification.Id)) < beforeId.Value));
+		}
+		else if (before is not null)
+		{
 			query = query.Where(n => n.CreatedOn < before.Value);
+		}
 
 		var notifications = await query
 			.OrderByDescending(n => n.CreatedOn)
+			.ThenByDescending(n => EF.Property<Guid>(n, nameof(Notification.Id)))
 			.Take(limit)
 			.ToListAsync(cancellationToken);
 

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -68,7 +68,20 @@ internal sealed class NotificationReadRepository(
 			.Take(limit)
 			.ToListAsync(cancellationToken);
 
-		var notifications = tiedWithCursor.Concat(older).Take(limit).ToList();
+		// SQL only orders "older" by CreatedOn (see above - no safe way to add
+		// Id as a second ORDER BY key without the same translation risk), so
+		// same-timestamp siblings within it can come back in an arbitrary
+		// sub-order. Re-sort the combined, already-materialized batch in
+		// memory (CreatedOn desc, then Id desc) so the array this method
+		// returns always has a single, deterministic tie-break convention -
+		// the same one `tiedWithCursor` above already used - regardless of
+		// what order Postgres happened to hand ties back in.
+		var notifications = tiedWithCursor
+			.Concat(older)
+			.OrderByDescending(n => n.CreatedOn)
+			.ThenByDescending(n => n.Id.Value)
+			.Take(limit)
+			.ToList();
 
 		// Collect entity IDs by type
 		var engagementIds = notifications

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -22,11 +22,19 @@ internal sealed class NotificationReadRepository(
 
 	public async ValueTask<List<NotificationSummary>> GetByRecipientAsync(
 		UserId recipientId,
+		DateTimeOffset? before,
+		int limit,
 		CancellationToken cancellationToken = default)
 	{
-		var notifications = await dbContext.NotificationsQuery
-			.Where(n => n.RecipientId == recipientId)
+		var query = dbContext.NotificationsQuery
+			.Where(n => n.RecipientId == recipientId);
+
+		if (before is not null)
+			query = query.Where(n => n.CreatedOn < before.Value);
+
+		var notifications = await query
 			.OrderByDescending(n => n.CreatedOn)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 
 		// Collect entity IDs by type
@@ -106,4 +114,10 @@ internal sealed class NotificationReadRepository(
 				n.CreatedOn);
 		}).ToList();
 	}
+
+	public async ValueTask<int> CountUnreadByRecipientAsync(
+		UserId recipientId,
+		CancellationToken cancellationToken = default) =>
+		await dbContext.NotificationsQuery
+			.CountAsync(n => n.RecipientId == recipientId && !n.IsRead, cancellationToken);
 }

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -27,7 +27,7 @@ internal sealed class NotificationReadRepository(
 		int limit,
 		CancellationToken cancellationToken = default)
 	{
-		var query = dbContext.NotificationsQuery
+		var recipientQuery = dbContext.NotificationsQuery
 			.Where(n => n.RecipientId == recipientId);
 
 		// Notifications created in the same batch (e.g. several engagement
@@ -36,26 +36,39 @@ internal sealed class NotificationReadRepository(
 		// per SaveChanges call, not per entity. CreatedOn alone is therefore
 		// not a safe keyset cursor: paging strictly on "< before" would drop
 		// same-timestamp siblings that land on the far side of a page
-		// boundary. Id (a UUIDv7, so still roughly time-ordered) breaks the
-		// tie deterministically; EF.Property<Guid> reads the raw provider
-		// column instead of going through NotificationId's value converter,
-		// which only has == translation support, not < / >.
+		// boundary. NotificationId's value converter only translates == (not
+		// < / >, which isn't defined on the value object at all, and
+		// EF.Property<Guid> on a converted property isn't a supported read
+		// of the raw column either - it 500'd against real Postgres despite
+		// compiling fine), so the tie is broken by Id (a UUIDv7, still
+		// roughly time-ordered) in memory instead: fetch the *complete*
+		// same-timestamp bucket via a plain equality query (cheap - ties are
+		// bounded by how many notifications one SaveChanges call creates for
+		// a single recipient, normally a handful) rather than risk an
+		// arbitrary SQL tie order silently truncating it via Take().
+		List<Notification> tiedWithCursor = [];
 		if (before is not null && beforeId is not null)
 		{
-			query = query.Where(n =>
-				n.CreatedOn < before.Value ||
-				(n.CreatedOn == before.Value && EF.Property<Guid>(n, nameof(Notification.Id)) < beforeId.Value));
-		}
-		else if (before is not null)
-		{
-			query = query.Where(n => n.CreatedOn < before.Value);
+			var cursorTiedBucket = await recipientQuery
+				.Where(n => n.CreatedOn == before.Value)
+				.ToListAsync(cancellationToken);
+
+			tiedWithCursor = cursorTiedBucket
+				.Where(n => n.Id.Value.CompareTo(beforeId.Value) < 0)
+				.OrderByDescending(n => n.Id.Value)
+				.ToList();
 		}
 
-		var notifications = await query
+		var olderQuery = before is not null
+			? recipientQuery.Where(n => n.CreatedOn < before.Value)
+			: recipientQuery;
+
+		var older = await olderQuery
 			.OrderByDescending(n => n.CreatedOn)
-			.ThenByDescending(n => EF.Property<Guid>(n, nameof(Notification.Id)))
 			.Take(limit)
 			.ToListAsync(cancellationToken);
+
+		var notifications = tiedWithCursor.Concat(older).Take(limit).ToList();
 
 		// Collect entity IDs by type
 		var engagementIds = notifications

--- a/backend/tests/Application.UnitTests/Notifications/GetMyNotifications/GetMyNotificationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/GetMyNotifications/GetMyNotificationsQueryHandlerTests.cs
@@ -23,9 +23,9 @@ public class GetMyNotificationsQueryHandlerTests
 		// Arrange
 		var recipientId = UserId.New();
 		var notifications = CreateSummaries(10);
-		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+		_readRepository.GetByRecipientAsync(recipientId, null, null, 51, cancellationToken)
 			.Returns(notifications);
-		var query = new GetMyNotificationsQuery(recipientId, null);
+		var query = new GetMyNotificationsQuery(recipientId, null, null);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
@@ -42,9 +42,9 @@ public class GetMyNotificationsQueryHandlerTests
 		// Arrange
 		var recipientId = UserId.New();
 		var notifications = CreateSummaries(50);
-		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+		_readRepository.GetByRecipientAsync(recipientId, null, null, 51, cancellationToken)
 			.Returns(notifications);
-		var query = new GetMyNotificationsQuery(recipientId, null);
+		var query = new GetMyNotificationsQuery(recipientId, null, null);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
@@ -61,9 +61,9 @@ public class GetMyNotificationsQueryHandlerTests
 		// Arrange
 		var recipientId = UserId.New();
 		var notifications = CreateSummaries(51);
-		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+		_readRepository.GetByRecipientAsync(recipientId, null, null, 51, cancellationToken)
 			.Returns(notifications);
-		var query = new GetMyNotificationsQuery(recipientId, null);
+		var query = new GetMyNotificationsQuery(recipientId, null, null);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
@@ -81,15 +81,16 @@ public class GetMyNotificationsQueryHandlerTests
 		// Arrange
 		var recipientId = UserId.New();
 		var before = DateTimeOffset.UtcNow.AddDays(-1);
-		_readRepository.GetByRecipientAsync(recipientId, before, 51, cancellationToken)
+		var beforeId = Guid.NewGuid();
+		_readRepository.GetByRecipientAsync(recipientId, before, beforeId, 51, cancellationToken)
 			.Returns([]);
-		var query = new GetMyNotificationsQuery(recipientId, before);
+		var query = new GetMyNotificationsQuery(recipientId, before, beforeId);
 
 		// Act
 		await _sut.Handle(query, cancellationToken);
 
 		// Assert
-		await _readRepository.Received(1).GetByRecipientAsync(recipientId, before, 51, cancellationToken);
+		await _readRepository.Received(1).GetByRecipientAsync(recipientId, before, beforeId, 51, cancellationToken);
 	}
 
 	private static List<NotificationSummary> CreateSummaries(int count) =>

--- a/backend/tests/Application.UnitTests/Notifications/GetMyNotifications/GetMyNotificationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/GetMyNotifications/GetMyNotificationsQueryHandlerTests.cs
@@ -1,0 +1,106 @@
+using Application.Notifications;
+using Application.Notifications.GetMyNotifications.v1;
+using AwesomeAssertions;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.GetMyNotifications;
+
+public class GetMyNotificationsQueryHandlerTests
+{
+	private readonly INotificationReadRepository _readRepository = Substitute.For<INotificationReadRepository>();
+	private readonly GetMyNotificationsQueryHandler _sut;
+
+	public GetMyNotificationsQueryHandlerTests()
+	{
+		_sut = new GetMyNotificationsQueryHandler(_readRepository);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnAllItemsAndHasMoreFalse_WhenFewerThanPageSizeExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		var notifications = CreateSummaries(10);
+		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+			.Returns(notifications);
+		var query = new GetMyNotificationsQuery(recipientId, null);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Items.Should().HaveCount(10);
+		result.HasMore.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnExactlyPageSizeItemsAndHasMoreFalse_WhenExactlyPageSizeExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		var notifications = CreateSummaries(50);
+		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+			.Returns(notifications);
+		var query = new GetMyNotificationsQuery(recipientId, null);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Items.Should().HaveCount(50);
+		result.HasMore.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnOnlyPageSizeItemsAndHasMoreTrue_WhenMoreThanPageSizeExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		var notifications = CreateSummaries(51);
+		_readRepository.GetByRecipientAsync(recipientId, null, 51, cancellationToken)
+			.Returns(notifications);
+		var query = new GetMyNotificationsQuery(recipientId, null);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Items.Should().HaveCount(50);
+		result.HasMore.Should().BeTrue();
+		result.Items.Should().BeEquivalentTo(notifications.Take(50), o => o.WithStrictOrdering());
+	}
+
+	[Test]
+	public async Task Handle_ShouldForwardBeforeCursorToRepository(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		var before = DateTimeOffset.UtcNow.AddDays(-1);
+		_readRepository.GetByRecipientAsync(recipientId, before, 51, cancellationToken)
+			.Returns([]);
+		var query = new GetMyNotificationsQuery(recipientId, before);
+
+		// Act
+		await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		await _readRepository.Received(1).GetByRecipientAsync(recipientId, before, 51, cancellationToken);
+	}
+
+	private static List<NotificationSummary> CreateSummaries(int count) =>
+		Enumerable.Range(0, count)
+			.Select(i => new NotificationSummary(
+				Guid.NewGuid(),
+				"EngagementCreated",
+				Guid.NewGuid(),
+				"Some Title",
+				"/my-engagements",
+				false,
+				DateTimeOffset.UtcNow.AddMinutes(-i)))
+			.ToList();
+}

--- a/backend/tests/Application.UnitTests/Notifications/GetUnreadNotificationCount/GetUnreadNotificationCountQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/GetUnreadNotificationCount/GetUnreadNotificationCountQueryHandlerTests.cs
@@ -1,0 +1,50 @@
+using Application.Notifications;
+using Application.Notifications.GetUnreadNotificationCount.v1;
+using AwesomeAssertions;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.GetUnreadNotificationCount;
+
+public class GetUnreadNotificationCountQueryHandlerTests
+{
+	private readonly INotificationReadRepository _readRepository = Substitute.For<INotificationReadRepository>();
+	private readonly GetUnreadNotificationCountQueryHandler _sut;
+
+	public GetUnreadNotificationCountQueryHandlerTests()
+	{
+		_sut = new GetUnreadNotificationCountQueryHandler(_readRepository);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCountFromRepository(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		_readRepository.CountUnreadByRecipientAsync(recipientId, cancellationToken).Returns(7);
+		var query = new GetUnreadNotificationCountQuery(recipientId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().Be(7);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnZero_WhenNoUnreadNotificationsExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		_readRepository.CountUnreadByRecipientAsync(recipientId, cancellationToken).Returns(0);
+		var query = new GetUnreadNotificationCountQuery(recipientId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().Be(0);
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -330,7 +330,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -7110,7 +7110,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -7129,6 +7129,10 @@ namespace IntegrationTests
                     if (before != null)
                     {
                         urlBuilder_.Append(System.Uri.EscapeDataString("before")).Append('=').Append(System.Uri.EscapeDataString(before.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (beforeId != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("beforeId")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(beforeId, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -325,7 +325,12 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<NotificationSummary>> GetMyNotificationsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<int> GetUnreadNotificationCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -7014,7 +7019,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<NotificationSummary>> GetMyNotificationsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<int> GetUnreadNotificationCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -7027,8 +7032,8 @@ namespace IntegrationTests
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                 
-                    // Operation Path: "v1/notifications"
-                    urlBuilder_.Append("v1/notifications");
+                    // Operation Path: "v1/notifications/unread-count"
+                    urlBuilder_.Append("v1/notifications/unread-count");
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -7055,7 +7060,104 @@ namespace IntegrationTests
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<NotificationSummary>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<int>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/notifications"
+                    urlBuilder_.Append("v1/notifications");
+                    urlBuilder_.Append('?');
+                    if (before != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("before")).Append('=').Append(System.Uri.EscapeDataString(before.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<NotificationsPage>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -10235,6 +10337,28 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("preferredContact")]
         public string? PreferredContact { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class NotificationsPage
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<NotificationSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<NotificationSummary>();
+
+        [System.Text.Json.Serialization.JsonPropertyName("hasMore")]
+        public bool HasMore { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -330,7 +330,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(long? beforeUnixMs = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -7110,7 +7110,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(System.DateTimeOffset? before = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(long? beforeUnixMs = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -7126,9 +7126,9 @@ namespace IntegrationTests
                     // Operation Path: "v1/notifications"
                     urlBuilder_.Append("v1/notifications");
                     urlBuilder_.Append('?');
-                    if (before != null)
+                    if (beforeUnixMs != null)
                     {
-                        urlBuilder_.Append(System.Uri.EscapeDataString("before")).Append('=').Append(System.Uri.EscapeDataString(before.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                        urlBuilder_.Append(System.Uri.EscapeDataString("beforeUnixMs")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(beforeUnixMs, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     if (beforeId != null)
                     {

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -81,7 +81,7 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			.ToList();
 		ordered.Should().HaveCount(2);
 
-		var secondPage = await olafClient.GetMyNotificationsAsync(ordered[0].CreatedOn, cancellationToken);
+		var secondPage = await olafClient.GetMyNotificationsAsync(ordered[0].CreatedOn, ordered[0].Id, cancellationToken);
 
 		secondPage.Items.Should().ContainSingle(n => n.Id == ordered[1].Id);
 		secondPage.Items.Should().NotContain(n => n.Id == ordered[0].Id);

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -81,7 +81,7 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			.ToList();
 		ordered.Should().HaveCount(2);
 
-		var secondPage = await olafClient.GetMyNotificationsAsync(ordered[0].CreatedOn, ordered[0].Id, cancellationToken);
+		var secondPage = await olafClient.GetMyNotificationsAsync(ordered[0].CreatedOn.ToUnixTimeMilliseconds(), ordered[0].Id, cancellationToken);
 
 		secondPage.Items.Should().ContainSingle(n => n.Id == ordered[1].Id);
 		secondPage.Items.Should().NotContain(n => n.Id == ordered[0].Id);

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -26,9 +26,9 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
-		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 
-		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
 		notification.RelatedTitle.Should().Be(opportunityTitle);
 		notification.ActionUrl.Should()
 			.Be($"/app/{orgId}/dashboard/opportunities/{opportunity.Id}/engagements");
@@ -52,11 +52,61 @@ public class NotificationTests(IntegrationTestFixture fixture)
 
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 
-		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken);
+		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 
-		var notification = veraNotifications.Single(n => n.Kind == "EngagementConfirmed");
+		var notification = veraNotifications.Items.Single(n => n.Kind == "EngagementConfirmed");
 		notification.RelatedTitle.Should().Be(opportunityTitle);
 		notification.ActionUrl.Should().Be("/my-engagements");
+	}
+
+	[Test]
+	public async Task GetMyNotifications_BeforeCursor_ReturnsOnlyOlderNotifications(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunityOne = await CreateOpportunityAsync(olafClient, orgId, "Cursor Test One", cancellationToken);
+		var opportunityTwo = await CreateOpportunityAsync(olafClient, orgId, "Cursor Test Two", cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunityOne.Id, new CreateEngagementRequest { Message = "First" }, cancellationToken);
+		await veraClient.CreateEngagementAsync(
+			opportunityTwo.Id, new CreateEngagementRequest { Message = "Second" }, cancellationToken);
+
+		var firstPage = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var ordered = firstPage.Items
+			.Where(n => n.Kind == "EngagementCreated")
+			.OrderByDescending(n => n.CreatedOn)
+			.ToList();
+		ordered.Should().HaveCount(2);
+
+		var secondPage = await olafClient.GetMyNotificationsAsync(ordered[0].CreatedOn, cancellationToken);
+
+		secondPage.Items.Should().ContainSingle(n => n.Id == ordered[1].Id);
+		secondPage.Items.Should().NotContain(n => n.Id == ordered[0].Id);
+		secondPage.HasMore.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task GetUnreadNotificationCount_ReflectsUnreadNotificationsAndMarkAllRead(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, "Unread Count Test", cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+
+		var countBeforeRead = await olafClient.GetUnreadNotificationCountAsync(cancellationToken);
+		countBeforeRead.Should().Be(1);
+
+		await olafClient.MarkAllNotificationsReadAsync(cancellationToken);
+
+		var countAfterRead = await olafClient.GetUnreadNotificationCountAsync(cancellationToken);
+		countAfterRead.Should().Be(0);
 	}
 
 	[Test]
@@ -75,13 +125,13 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
-		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
-		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
 
 		await olafClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
 
-		var updatedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
-		updatedNotifications.Single(n => n.Id == notification.Id).IsRead.Should().BeTrue();
+		var updatedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		updatedNotifications.Items.Single(n => n.Id == notification.Id).IsRead.Should().BeTrue();
 	}
 
 	[Test]
@@ -100,8 +150,8 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
-		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
-		var notification = olafNotifications.Single(n => n.Kind == "EngagementCreated");
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
 
 		// Direct ownership-check coverage for #829: vera is not the recipient of
 		// olaf's notification, so this must 404 (not 403, to avoid leaking
@@ -111,8 +161,8 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(404);
 
-		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken);
-		unchangedNotifications.Single(n => n.Id == notification.Id).IsRead.Should().BeFalse();
+		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		unchangedNotifications.Items.Single(n => n.Id == notification.Id).IsRead.Should().BeFalse();
 	}
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -720,6 +720,65 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task NotificationDropdown_Open_HasNoSeriousA11yViolations()
+	{
+		// #1384: the dropdown gained cursor-based "load more" pagination on top
+		// of the existing mark-all-read/per-item controls - the panel only
+		// exists in the DOM while open, so a plain page-load scan never reaches
+		// it (see NotificationBell_OpensPanel_WhenClicked in NotificationTests.cs
+		// for the equivalent functional-only coverage).
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"NotifA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"NotifA11y Opportunity {suffix}",
+			description = "Created by AccessibilityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		var applyResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "For the a11y scan." });
+		applyResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await bell.ClickAsync();
+
+		var panel = Page.GetByTestId("notification-panel");
+		await Expect(panel).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(panel.Locator("li").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task AdministrationPage_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -81,8 +81,10 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 	{
 		var response = await http.GetAsync("/v1/notifications");
 		response.EnsureSuccessStatusCode();
-		var notifications = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return notifications.EnumerateArray()
+		var page = await response.Content.ReadFromJsonAsync<JsonElement>();
+		// GetMyNotifications returns a NotificationsPage ({ items, hasMore }),
+		// not a bare array, since einsatzbereit#1384 added cursor pagination.
+		return page.GetProperty("items").EnumerateArray()
 			.First(n => n.GetProperty("kind").GetString() == "EngagementCreated");
 	}
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3703,8 +3703,8 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
-    getMyNotifications(signal?: AbortSignal): Promise<NotificationSummary[]> {
-        let url_ = this.baseUrl + "/v1/notifications";
+    getUnreadNotificationCount(signal?: AbortSignal): Promise<number> {
+        let url_ = this.baseUrl + "/v1/notifications/unread-count";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -3716,17 +3716,17 @@ export class EinsatzbereitApi {
         };
 
         return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processGetMyNotifications(_response);
+            return this.processGetUnreadNotificationCount(_response);
         });
     }
 
-    protected processGetMyNotifications(response: Response): Promise<NotificationSummary[]> {
+    protected processGetUnreadNotificationCount(response: Response): Promise<number> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
-            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as NotificationSummary[];
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as number;
             return result200;
             });
         } else if (status === 401) {
@@ -3746,7 +3746,61 @@ export class EinsatzbereitApi {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<NotificationSummary[]>(null as any);
+        return Promise.resolve<number>(null as any);
+    }
+
+    /**
+     * @param before (optional) 
+     * @return OK
+     */
+    getMyNotifications(before: Date | undefined, signal?: AbortSignal): Promise<NotificationsPage> {
+        let url_ = this.baseUrl + "/v1/notifications?";
+        if (before === null)
+            throw new globalThis.Error("The parameter 'before' cannot be null.");
+        else if (before !== undefined)
+            url_ += "before=" + encodeURIComponent(before ? "" + before.toISOString() : "") + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetMyNotifications(_response);
+        });
+    }
+
+    protected processGetMyNotifications(response: Response): Promise<NotificationsPage> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as NotificationsPage;
+            return result200;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<NotificationsPage>(null as any);
     }
 
     /**
@@ -5126,6 +5180,13 @@ export interface MyProfileResponse {
     skills: string[];
     languages: string[];
     preferredContact: string | undefined;
+
+    [key: string]: any;
+}
+
+export interface NotificationsPage {
+    items: NotificationSummary[];
+    hasMore: boolean;
 
     [key: string]: any;
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3751,14 +3751,19 @@ export class EinsatzbereitApi {
 
     /**
      * @param before (optional) 
+     * @param beforeId (optional) 
      * @return OK
      */
-    getMyNotifications(before: Date | undefined, signal?: AbortSignal): Promise<NotificationsPage> {
+    getMyNotifications(before: Date | undefined, beforeId: string | undefined, signal?: AbortSignal): Promise<NotificationsPage> {
         let url_ = this.baseUrl + "/v1/notifications?";
         if (before === null)
             throw new globalThis.Error("The parameter 'before' cannot be null.");
         else if (before !== undefined)
             url_ += "before=" + encodeURIComponent(before ? "" + before.toISOString() : "") + "&";
+        if (beforeId === null)
+            throw new globalThis.Error("The parameter 'beforeId' cannot be null.");
+        else if (beforeId !== undefined)
+            url_ += "beforeId=" + encodeURIComponent("" + beforeId) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3750,16 +3750,16 @@ export class EinsatzbereitApi {
     }
 
     /**
-     * @param before (optional) 
+     * @param beforeUnixMs (optional) 
      * @param beforeId (optional) 
      * @return OK
      */
-    getMyNotifications(before: Date | undefined, beforeId: string | undefined, signal?: AbortSignal): Promise<NotificationsPage> {
+    getMyNotifications(beforeUnixMs: number | undefined, beforeId: string | undefined, signal?: AbortSignal): Promise<NotificationsPage> {
         let url_ = this.baseUrl + "/v1/notifications?";
-        if (before === null)
-            throw new globalThis.Error("The parameter 'before' cannot be null.");
-        else if (before !== undefined)
-            url_ += "before=" + encodeURIComponent(before ? "" + before.toISOString() : "") + "&";
+        if (beforeUnixMs === null)
+            throw new globalThis.Error("The parameter 'beforeUnixMs' cannot be null.");
+        else if (beforeUnixMs !== undefined)
+            url_ += "beforeUnixMs=" + encodeURIComponent("" + beforeUnixMs) + "&";
         if (beforeId === null)
             throw new globalThis.Error("The parameter 'beforeId' cannot be null.");
         else if (beforeId !== undefined)

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -31,6 +31,9 @@ export default function NotificationDropdown({
 	const {
 		notifications,
 		unreadCount,
+		notifHasMore,
+		notifLoadingMore,
+		loadMoreNotifications,
 		notifOpen,
 		setNotifOpen,
 		markAllRead,
@@ -103,13 +106,34 @@ export default function NotificationDropdown({
 								{t("notifications.empty")}
 							</li>
 						) : (
-							notifications.map((n) => (
-								<NotificationItem
-									key={n.id}
-									notification={n}
-									onSelect={handleSelect}
-								/>
-							))
+							<>
+								{notifications.map((n) => (
+									<NotificationItem
+										key={n.id}
+										notification={n}
+										onSelect={handleSelect}
+									/>
+								))}
+								{notifHasMore && (
+									<li className="px-4 py-2 text-center">
+										<button
+											type="button"
+											data-testid={
+												mobile
+													? "notification-load-more-mobile"
+													: "notification-load-more"
+											}
+											disabled={notifLoadingMore}
+											onClick={() => void loadMoreNotifications()}
+											className="text-xs hover:underline cursor-pointer text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+										>
+											{notifLoadingMore
+												? t("notifications.loadingMore")
+												: t("notifications.loadMore")}
+										</button>
+									</li>
+								)}
+							</>
 						)}
 					</ul>
 				</div>

--- a/frontend/src/components/Header/NotificationItem.tsx
+++ b/frontend/src/components/Header/NotificationItem.tsx
@@ -31,7 +31,7 @@ export default function NotificationItem({
 							defaultValue: n.kind,
 						})}
 						<br />
-						<span className="text-xs text-gray-400">
+						<span className="text-xs text-gray-500">
 							{formatDateTime(n.createdOn as unknown as string, i18n.language)}
 						</span>
 					</span>

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -145,7 +145,10 @@ export function useAccountMenu(
 		setNotifLoadingMore(true);
 		try {
 			const last = notifications[notifications.length - 1];
-			const result = await api.getMyNotifications(last.createdOn, last.id);
+			const result = await api.getMyNotifications(
+				last.createdOn.getTime(),
+				last.id,
+			);
 			setNotifications((prev) => [...prev, ...result.items]);
 			setNotifHasMore(result.hasMore);
 		} catch {

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -9,6 +9,9 @@ export interface AccountMenuState {
 	avatarUrl: string | null;
 	notifications: NotificationSummary[];
 	unreadCount: number;
+	notifHasMore: boolean;
+	notifLoadingMore: boolean;
+	loadMoreNotifications: () => Promise<void>;
 	notifOpen: boolean;
 	setNotifOpen: Dispatch<SetStateAction<boolean>>;
 	notifRef: RefObject<HTMLDivElement | null>;
@@ -37,6 +40,9 @@ export function useAccountMenu(
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [notifOpen, setNotifOpen] = useState(false);
 	const [notifications, setNotifications] = useState<NotificationSummary[]>([]);
+	const [notifHasMore, setNotifHasMore] = useState(false);
+	const [notifLoadingMore, setNotifLoadingMore] = useState(false);
+	const [unreadCount, setUnreadCount] = useState(0);
 	const dropdownRef = useDismissableOverlay<HTMLDivElement>(dropdownOpen, () =>
 		setDropdownOpen(false),
 	);
@@ -46,22 +52,52 @@ export function useAccountMenu(
 		extraNotifContainers,
 	);
 
+	// Only the unread count is polled (a single cheap indexed COUNT query) -
+	// the full notification list is fetched on-demand when the dropdown opens
+	// instead, see einsatzbereit#1384. Polling pauses while the tab is hidden
+	// and catches up with an immediate fetch when it becomes visible again.
 	useEffect(() => {
 		if (!isLoggedIn) return;
 		const controller = new AbortController();
-		const fetchCount = async () => {
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+
+		const fetchUnreadCount = async () => {
 			try {
-				const result = await api.getMyNotifications(controller.signal);
-				setNotifications(result);
+				const count = await api.getUnreadNotificationCount(controller.signal);
+				setUnreadCount(count);
 			} catch {
 				// silently ignore (includes AbortError on cleanup)
 			}
 		};
-		void fetchCount();
-		const id = setInterval(() => void fetchCount(), 60_000);
+
+		const startPolling = () => {
+			if (intervalId !== null) return;
+			intervalId = setInterval(() => void fetchUnreadCount(), 60_000);
+		};
+
+		const stopPolling = () => {
+			if (intervalId === null) return;
+			clearInterval(intervalId);
+			intervalId = null;
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "visible") {
+				void fetchUnreadCount();
+				startPolling();
+			} else {
+				stopPolling();
+			}
+		};
+
+		void fetchUnreadCount();
+		if (document.visibilityState === "visible") startPolling();
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
 		return () => {
 			controller.abort();
-			clearInterval(id);
+			stopPolling();
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isLoggedIn]);
@@ -89,8 +125,11 @@ export function useAccountMenu(
 		let cancelled = false;
 		void (async () => {
 			try {
-				const result = await api.getMyNotifications();
-				if (!cancelled) setNotifications(result);
+				const result = await api.getMyNotifications(undefined);
+				if (!cancelled) {
+					setNotifications(result.items);
+					setNotifHasMore(result.hasMore);
+				}
 			} catch {
 				// silently ignore fetch errors
 			}
@@ -101,11 +140,25 @@ export function useAccountMenu(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [notifOpen, isLoggedIn]);
 
-	const unreadCount = notifications.filter((n) => !n.isRead).length;
+	async function loadMoreNotifications() {
+		if (notifications.length === 0 || notifLoadingMore) return;
+		setNotifLoadingMore(true);
+		try {
+			const cursor = notifications[notifications.length - 1].createdOn;
+			const result = await api.getMyNotifications(cursor);
+			setNotifications((prev) => [...prev, ...result.items]);
+			setNotifHasMore(result.hasMore);
+		} catch {
+			// silently ignore fetch errors
+		} finally {
+			setNotifLoadingMore(false);
+		}
+	}
 
 	async function markAllRead() {
 		await api.markAllNotificationsRead();
 		setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+		setUnreadCount(0);
 	}
 
 	async function markOneRead(id: string) {
@@ -113,12 +166,16 @@ export function useAccountMenu(
 		setNotifications((prev) =>
 			prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)),
 		);
+		setUnreadCount((prev) => Math.max(0, prev - 1));
 	}
 
 	return {
 		avatarUrl,
 		notifications,
 		unreadCount,
+		notifHasMore,
+		notifLoadingMore,
+		loadMoreNotifications,
 		notifOpen,
 		setNotifOpen,
 		notifRef,

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -125,7 +125,7 @@ export function useAccountMenu(
 		let cancelled = false;
 		void (async () => {
 			try {
-				const result = await api.getMyNotifications(undefined);
+				const result = await api.getMyNotifications(undefined, undefined);
 				if (!cancelled) {
 					setNotifications(result.items);
 					setNotifHasMore(result.hasMore);
@@ -144,8 +144,8 @@ export function useAccountMenu(
 		if (notifications.length === 0 || notifLoadingMore) return;
 		setNotifLoadingMore(true);
 		try {
-			const cursor = notifications[notifications.length - 1].createdOn;
-			const result = await api.getMyNotifications(cursor);
+			const last = notifications[notifications.length - 1];
+			const result = await api.getMyNotifications(last.createdOn, last.id);
 			setNotifications((prev) => [...prev, ...result.items]);
 			setNotifHasMore(result.hasMore);
 		} catch {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -609,6 +609,8 @@
       "bellLabel": "Benachrichtigungen",
       "markAllRead": "Alle als gelesen markieren",
       "empty": "Keine Benachrichtigungen.",
+      "loadMore": "Mehr laden",
+      "loadingMore": "Lädt...",
       "deletedOpportunityPlaceholder": "einen gelöschten Bedarf",
       "kinds": {
         "EngagementCreated": "Neue Bewerbung eingegangen für {{title}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -609,6 +609,8 @@
       "bellLabel": "Notifications",
       "markAllRead": "Mark all as read",
       "empty": "No notifications.",
+      "loadMore": "Load more",
+      "loadingMore": "Loading...",
       "deletedOpportunityPlaceholder": "a deleted opportunity",
       "kinds": {
         "EngagementCreated": "New application received for {{title}}",


### PR DESCRIPTION
GetMyNotifications loaded a user's entire notification history unbounded, then fanned out two more sequential queries to resolve engagement/opportunity titles - cost grew linearly with account lifetime. Every open tab also polled that same full-list endpoint every 60s, including while hidden, just to compute an unread count.

- Repository/query/endpoint now take a `before` cursor and cap each page at 50 via Take(51) (fetch one extra to derive HasMore without a separate COUNT query)
- Add GET /v1/notifications/unread-count (indexed CountAsync on the existing (RecipientId, IsRead) index) for the poll to use instead of the full list
- Poll pauses while document.visibilityState is hidden and catches up immediately on becoming visible again
- Notification dropdown gets a "Load more" button wired to the cursor

Retention/pruning of old read notifications (also suggested in the issue) was explicitly declined for this change - not implemented.

Refs #1384

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1384

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
