### PR TITLE
fix: run organization membership backfill once in the background, not on every boot

### DIFF
--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -143,7 +143,6 @@ if (app.Environment.IsDevelopment())
 
 	await initializer.MigrateAsync();
 	await initializer.SeedAsync();
-	await initializer.BackfillOrganizationMembershipsAsync();
 
 	app.MapOpenApi();
 }
@@ -157,8 +156,6 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 
 	if (app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
 		await initializer.SeedAsync();
-
-	await initializer.BackfillOrganizationMembershipsAsync();
 }
 
 app.MapDefaultEndpoints();

--- a/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
@@ -1,0 +1,131 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Domain.Organizations;
+using Domain.Users;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.BackgroundJobs;
+
+// One-shot compensator for pre-existing organizations that predate the
+// organization_membership table (migration AddOrganizationMembership, see
+// wiki/bundle/gotchas/auth-fresh-deploy-traps.md for why it's needed at all).
+// Organizations created after that migration always get their founding organizer's
+// membership row written synchronously by CreateOrganizationCommandHandler, so once
+// this has run once against every organization that existed before the table did,
+// there is nothing left for it to ever do again.
+//
+// Runs as a fire-and-forget background task from StartAsync (never awaited there) so
+// - unlike the old inline Program.cs call it replaces - it cannot block the app from
+// becoming ready. The OrganizationMembershipBackfillState marker row makes the "has this
+// run before" check itself a single indexed lookup instead of a per-organization
+// Keycloak round trip repeated on every boot forever (#1393): without a marker, an
+// organization that legitimately still has zero organizers (not just one never
+// backfilled) would look identical to "needs backfilling" and get re-queried every
+// single restart.
+internal sealed class OrganizationMembershipBackfillJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<OrganizationMembershipBackfillJob> logger)
+	: IHostedService, IAsyncDisposable
+{
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_executeTask = RunAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunAsync(CancellationToken cancellationToken)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+		var keycloakOrganizationService = scope.ServiceProvider.GetRequiredService<IKeycloakOrganizationService>();
+
+		await BackfillAsync(dbContext, keycloakOrganizationService, logger, cancellationToken);
+	}
+
+	// Exposed so IntegrationTests can exercise the marker/backfill logic directly against
+	// a real ApplicationDbContext, without rebooting the whole app to reproduce a
+	// pre-existing-organization-without-membership-rows scenario.
+	internal static async Task BackfillAsync(
+		ApplicationDbContext dbContext,
+		IKeycloakOrganizationService keycloakOrganizationService,
+		ILogger logger,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			if (await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+				return;
+
+			var organizationIds = await dbContext.Set<Organization>()
+				.Where(o => !dbContext.Set<OrganizationMembership>().Any(m => m.OrganizationId == o.Id))
+				.Select(o => o.Id)
+				.ToListAsync(cancellationToken);
+
+			foreach (var organizationId in organizationIds)
+			{
+				var members = await keycloakOrganizationService.GetMembersAsync(
+					organizationId.Value, cancellationToken);
+
+				foreach (var member in members.Where(m => m.IsOrganisator).DistinctBy(m => m.UserId))
+				{
+					dbContext.Set<OrganizationMembership>().Add(
+						OrganizationMembership.Create(
+							organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+				}
+			}
+
+			// Written unconditionally (even when organizationIds is empty, or an organization
+			// in it turned out to have zero organizers) - this pass has now covered every
+			// organization that existed at startup, and that's the only thing this marker
+			// promises. It deliberately is not scoped per-organization.
+			dbContext.Set<OrganizationMembershipBackfillState>().Add(
+				new OrganizationMembershipBackfillState { CompletedOnUtc = DateTime.UtcNow });
+
+			await dbContext.SaveChangesAsync(cancellationToken);
+
+			if (organizationIds.Count > 0)
+				logger.LogInformation(
+					"Backfilled organization_membership rows for {Count} pre-existing organization(s).",
+					organizationIds.Count);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			// No marker is written on failure, so a transient Keycloak outage during this
+			// run simply retries on the next restart instead of being marked done falsely.
+			// OperationCanceledException is let through instead of logged as an error - that's
+			// just an ordinary app shutdown racing a still-running first backfill, not a failure.
+			logger.LogError(
+				ex,
+				"An exception occurred while backfilling organization memberships");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -207,46 +207,6 @@ internal sealed class ApplicationDbContextInitializer(
 		}
 	}
 
-	public async ValueTask BackfillOrganizationMembershipsAsync(
-		CancellationToken cancellationToken = default)
-	{
-		try
-		{
-			var backfilledOrganizationIds = await dbContext.Set<Organization>()
-				.Where(o => !dbContext.Set<OrganizationMembership>().Any(m => m.OrganizationId == o.Id))
-				.Select(o => o.Id)
-				.ToListAsync(cancellationToken);
-
-			if (backfilledOrganizationIds.Count == 0)
-				return;
-
-			foreach (var organizationId in backfilledOrganizationIds)
-			{
-				var members = await keycloakOrganizationService.GetMembersAsync(
-					organizationId.Value, cancellationToken);
-
-				foreach (var member in members.Where(m => m.IsOrganisator).DistinctBy(m => m.UserId))
-				{
-					dbContext.Set<OrganizationMembership>().Add(
-						OrganizationMembership.Create(
-							organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
-				}
-			}
-
-			await dbContext.SaveChangesAsync(cancellationToken);
-
-			logger.LogInformation(
-				"Backfilled organization_membership rows for {Count} pre-existing organization(s).",
-				backfilledOrganizationIds.Count);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(
-				ex,
-				"An exception occurred while backfilling organization memberships");
-		}
-	}
-
 	private async Task<OrganizationId> SeedOrg1Async(CancellationToken cancellationToken)
 	{
 		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipBackfillStateConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipBackfillStateConfiguration.cs
@@ -1,0 +1,19 @@
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+internal sealed class OrganizationMembershipBackfillStateConfiguration
+	: IEntityTypeConfiguration<OrganizationMembershipBackfillState>
+{
+	public void Configure(
+		EntityTypeBuilder<OrganizationMembershipBackfillState> builder)
+	{
+		builder.HasKey(s => s.Id);
+
+		builder.Property(s => s.Id).ValueGeneratedNever();
+
+		builder.Property(s => s.CompletedOnUtc).IsRequired();
+	}
+}

--- a/backend/src/Infrastructure/Persistence/IApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/IApplicationDbContextInitializer.cs
@@ -5,6 +5,4 @@ public interface IApplicationDbContextInitializer
 	ValueTask MigrateAsync(CancellationToken cancellationToken = default);
 
 	ValueTask SeedAsync(CancellationToken cancellationToken = default);
-
-	ValueTask BackfillOrganizationMembershipsAsync(CancellationToken cancellationToken = default);
 }

--- a/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260728050448_AddOrganizationMembershipBackfillState")]
+	partial class AddOrganizationMembershipBackfillState
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOrganizationMembershipBackfillState : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateTable(
+				name: "organization_membership_backfill_state",
+				columns: table => new
+				{
+					id = table.Column<int>(type: "integer", nullable: false),
+					completed_on_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+				},
+				constraints: table =>
+				{
+					table.PrimaryKey("pk_organization_membership_backfill_state", x => x.id);
+				});
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropTable(
+				name: "organization_membership_backfill_state");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/StartupTasks/OrganizationMembershipBackfillState.cs
+++ b/backend/src/Infrastructure/Persistence/StartupTasks/OrganizationMembershipBackfillState.cs
@@ -1,0 +1,13 @@
+namespace Infrastructure.Persistence.StartupTasks;
+
+// Singleton marker row: its presence means OrganizationMembershipBackfillJob has
+// completed once and must never run again, regardless of whether some organization
+// still has zero organization_membership rows for legitimate reasons (e.g. every
+// organizer left). Without this, the job's own "any org missing rows" selector would
+// re-trigger a Keycloak call for that organization on every single boot, forever (#1393).
+internal sealed class OrganizationMembershipBackfillState
+{
+	public int Id { get; init; } = 1;
+
+	public DateTime CompletedOnUtc { get; init; }
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -94,6 +94,7 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<EngagementReminderJob>();
 		services.AddHostedService<OutboxProcessorJob>();
 		services.AddHostedService<GeocodingRetryJob>();
+		services.AddHostedService<OrganizationMembershipBackfillJob>();
 
 
 		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -175,7 +175,11 @@ public class IntegrationTestFixture
 		return false;
 	}
 
-	private ApplicationDbContext CreateApplicationDbContext()
+	// Test-only escape hatch for driving Infrastructure-internal logic (InternalsVisibleTo,
+	// see Infrastructure.csproj) directly against the real integration Postgres - e.g.
+	// OrganizationMembershipBackfillJob.BackfillAsync, which otherwise only ever runs once
+	// per app boot and can't be re-triggered through the API (#1393).
+	internal ApplicationDbContext CreateApplicationDbContext()
 	{
 		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
 			.UseNpgsql(_connectionString)

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -1,0 +1,199 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Users;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
+// "Organization"/"OrganizationId" DTO types, which would otherwise shadow the domain
+// types of the same name pulled in via the "Domain.Organizations" using above.
+using DomainOrganization = Domain.Organizations.Organization;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.OrganizationMembershipBackfillJob.BackfillAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres. The job only ever runs once, automatically, at app boot - the "backend"
+// Aspire resource already completed its one real run against the seeded organizations
+// long before any test executes, and there's no API to make it run again. Driving
+// BackfillAsync directly is the only way to reproduce "a pre-existing organization that
+// predates the organization_membership table" and prove the one-shot marker actually
+// prevents the every-boot-forever Keycloak calls described in #1393.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task BackfillAsync_PreExistingOrganizationWithoutMembershipRows_InsertsRowPerDistinctOrganizer(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		var organizerId = Guid.NewGuid();
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			MembersToReturn =
+			[
+				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
+				// Same organizer reported twice (e.g. multiple Keycloak group mappings) - must
+				// not produce two rows and violate the unique (organization_id, user_id) index.
+				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
+				// Plain member, not an organizer - must not get a membership row at all.
+				new KeycloakOrganizationMember(Guid.NewGuid(), "vera", "Vera", "V.", "vera@example.com", IsOrganisator: false),
+			],
+		};
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		var memberships = await dbContext.Set<OrganizationMembership>()
+			.Where(m => m.OrganizationId == organizationId)
+			.ToListAsync(cancellationToken);
+
+		memberships.Should().ContainSingle();
+		memberships[0].UserId.Should().Be(UserId.Create(organizerId).GetValueOrThrow());
+		memberships[0].Role.Should().Be(OrganizationMemberRole.Organizer);
+
+		var marker = await dbContext.Set<OrganizationMembershipBackfillState>().SingleOrDefaultAsync(cancellationToken);
+		marker.Should().NotBeNull("a completed run must leave the one-shot marker behind");
+	}
+
+	[Test]
+	public async Task BackfillAsync_OrganizationHasNoOrganizers_StillWritesCompletionMarkerAndNeverRetries(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		// No organizers at all - a legitimate state (e.g. every organizer since left), not
+		// "not backfilled yet". Before #1393 this looked identical to "needs backfilling" and
+		// triggered a Keycloak call on every single boot forever.
+		var keycloak = new FakeKeycloakOrganizationService { MembersToReturn = [] };
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		(await dbContext.Set<OrganizationMembership>().AnyAsync(m => m.OrganizationId == organizationId, cancellationToken))
+			.Should().BeFalse();
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeTrue("the one-shot marker must be written even when no organization actually needed rows added");
+
+		keycloak.GetMembersCallCount.Should().Be(1);
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		keycloak.GetMembersCallCount.Should().Be(
+			1, "a second run must short-circuit on the marker instead of re-querying Keycloak for the still-organizer-less organization");
+	}
+
+	[Test]
+	public async Task BackfillAsync_MarkerAlreadyPresent_NeverCallsKeycloak(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		dbContext.Set<OrganizationMembershipBackfillState>().Add(
+			new OrganizationMembershipBackfillState { CompletedOnUtc = DateTime.UtcNow });
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			MembersToReturn = [new KeycloakOrganizationMember(Guid.NewGuid(), "olaf", null, null, "olaf@example.com", IsOrganisator: true)],
+		};
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		keycloak.GetMembersCallCount.Should().Be(0, "an already-completed run must skip straight past every organization check");
+	}
+
+	[Test]
+	public async Task BackfillAsync_KeycloakFails_DoesNotWriteMarkerSoALaterRunCanStillRetry(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		var keycloak = new FakeKeycloakOrganizationService { ThrowOnGetMembers = true };
+
+		var act = () => OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		await act.Should().NotThrowAsync("a transient Keycloak failure must be swallowed, not crash the caller");
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeFalse("a failed run must not be marked complete, so the next boot retries instead of skipping real work");
+
+		keycloak.ThrowOnGetMembers = false;
+		keycloak.MembersToReturn = [new KeycloakOrganizationMember(Guid.NewGuid(), "olaf", null, null, "olaf@example.com", IsOrganisator: true)];
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		(await dbContext.Set<OrganizationMembership>().AnyAsync(m => m.OrganizationId == organizationId, cancellationToken))
+			.Should().BeTrue("the retried run should now succeed and backfill the organization");
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeTrue();
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private static async Task<DomainOrganizationId> SeedOrganizationWithoutMembershipRowsAsync(
+		ApplicationDbContext dbContext, CancellationToken cancellationToken)
+	{
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"Legacy Org {Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+		await dbContext.SaveChangesAsync(cancellationToken);
+		return organization.Id;
+	}
+
+	private sealed class FakeKeycloakOrganizationService : IKeycloakOrganizationService
+	{
+		public IReadOnlyList<KeycloakOrganizationMember> MembersToReturn { get; set; } = [];
+
+		public bool ThrowOnGetMembers { get; set; }
+
+		public int GetMembersCallCount { get; private set; }
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
+			Guid organizationId, CancellationToken cancellationToken = default)
+		{
+			GetMembersCallCount++;
+
+			if (ThrowOnGetMembers)
+				throw new HttpRequestException("Keycloak unavailable (simulated).");
+
+			return Task.FromResult(MembersToReturn);
+		}
+
+		public Task<Guid> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task AddMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task RemoveMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task DeleteOrganizationAsync(Guid organizationId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task AssignOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
+			string search, int max = 20, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+	}
+}


### PR DESCRIPTION
BackfillOrganizationMembershipsAsync used to run inline in Program.cs on every startup, blocking the app from becoming ready while it made a sequential Keycloak call per organization missing membership rows. Worse, an organization with zero organizers looked identical to "never backfilled", so it kept getting queried again on every single restart.

Move the logic into OrganizationMembershipBackfillJob, a hosted service that fires in the background instead of blocking startup, and gate it on a one-shot OrganizationMembershipBackfillState marker row so the whole pass - regardless of per-organization outcome - runs at most once ever. A failed run leaves no marker, so a later boot still retries.

Closes #1393

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
