### PR TITLE
fix: translate flagged-target ID filters instead of unwrapping to raw Guid

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
@@ -1,9 +1,13 @@
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Pagination;
 using Application.Reports;
 using Application.Reports.GetReportHistoryForTarget.v1;
 using Application.Reports.ListFlaggedTargets.v1;
+using Domain.Organizations;
 using Domain.Reports;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
@@ -44,21 +48,26 @@ internal sealed class AdminReportReadRepository(
 		var organizationIds = page.Where(g => g.TargetType == ReportTargetType.Organization).Select(g => g.TargetId).ToList();
 		var userIds = page.Where(g => g.TargetType == ReportTargetType.User).Select(g => g.TargetId).ToList();
 
+		var opportunityIdVOs = opportunityIds.Select(id => VolunteerOpportunityId.Create(id).GetValueOrThrow()).ToList();
+		var organizationIdVOs = organizationIds.Select(id => OrganizationId.Create(id).GetValueOrThrow()).ToList();
+		var userIdVOs = userIds.Select(id => UserId.Create(id).GetValueOrThrow()).ToList();
+
 		var opportunities = await dbContext.VolunteerOpportunitiesQuery
 			.IgnoreQueryFilters()
-			.Where(vo => opportunityIds.Contains(vo.Id.Value))
+			.Where(vo => opportunityIdVOs.Contains(vo.Id))
 			.ToDictionaryAsync(vo => vo.Id.Value, vo => new { vo.Title, vo.IsDeleted }, cancellationToken);
 
 		var organizations = await dbContext.OrganizationsQuery
 			.IgnoreQueryFilters()
-			.Where(o => organizationIds.Contains(o.Id.Value))
+			.Where(o => organizationIdVOs.Contains(o.Id))
 			.ToDictionaryAsync(o => o.Id.Value, o => new { o.Name, o.IsDeleted }, cancellationToken);
 
 		var deletedUserIds = await dbContext.UsersQuery
 			.IgnoreQueryFilters()
-			.Where(u => userIds.Contains(u.Id.Value) && u.IsDeleted)
-			.Select(u => u.Id.Value)
+			.Where(u => userIdVOs.Contains(u.Id) && u.IsDeleted)
+			.Select(u => u.Id)
 			.ToListAsync(cancellationToken);
+		var deletedUserIdSet = deletedUserIds.Select(id => id.Value).ToHashSet();
 		var userDisplayNames = userIds.Count > 0
 			? await keycloakUserService.GetDisplayNamesAsync(userIds, cancellationToken)
 			: new Dictionary<Guid, string>();
@@ -81,7 +90,7 @@ internal sealed class AdminReportReadRepository(
 				{
 					ReportTargetType.VolunteerOpportunity => opportunities.GetValueOrDefault(g.TargetId)?.IsDeleted ?? false,
 					ReportTargetType.Organization => organizations.GetValueOrDefault(g.TargetId)?.IsDeleted ?? false,
-					ReportTargetType.User => deletedUserIds.Contains(g.TargetId),
+					ReportTargetType.User => deletedUserIdSet.Contains(g.TargetId),
 					_ => false,
 				}))
 			.ToList();

--- a/backend/tests/VisualTests/AdminReportsTests.cs
+++ b/backend/tests/VisualTests/AdminReportsTests.cs
@@ -1,0 +1,78 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for the admin Reports panel returning a 500: AdminReportReadRepository
+/// filtered VolunteerOpportunitiesQuery/OrganizationsQuery/UsersQuery with
+/// <c>x.Id.Value</c> inside a still-queryable Where/Select. EF Core cannot invert
+/// the strongly-typed ID's non-trivial "from provider" conversion
+/// (<c>guid => VolunteerOpportunityId.Create(guid).GetValueOrThrow()</c>) to
+/// translate <c>.Id.Value</c> back to the raw column, so every load of the admin
+/// Reports section threw at query-translation time - even with zero reports in
+/// the database, since translation depends on the expression shape, not the
+/// captured list's runtime contents. Fixed by converting the captured Guid lists
+/// to strongly-typed IDs first and comparing with <c>idVOs.Contains(x.Id)</c>,
+/// matching the established pattern elsewhere (e.g. NotificationReadRepository).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class AdminReportsTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task AdministrationPage_ReportsSection_ListsFlaggedOpportunityWithoutError()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"Admin Reports Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var title = $"Flagged Opportunity {suffix}";
+		var opportunityResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title,
+			description = "Regression coverage for the admin reports 500.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		opportunityResponse.EnsureSuccessStatusCode();
+		var opportunity = await opportunityResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var reportResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/reports",
+			new { reason = "Spam", details = $"Regression coverage {suffix}." });
+		reportResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "admin", "admin123");
+		await Page.GotoAsync($"{origin}/administration");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByText("Failed to load reports.")).Not.ToBeVisibleAsync();
+
+		var row = Page.Locator("tr").Filter(new() { HasTextString = title });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(row.GetByText("Opportunity", new() { Exact = true })).ToBeVisibleAsync();
+		await Expect(row.GetByText("Active", new() { Exact = true })).ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -595,7 +595,7 @@ function ReportsSection() {
 											{row.targetTitle ||
 												t("administration.reports.unknownTarget")}
 										</Link>
-										<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+										<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
 											{t(`administration.reports.targetType.${row.targetType}`)}
 										</span>
 										<span
@@ -778,7 +778,7 @@ function ReportHistoryModal({
 								<span className="text-sm font-medium text-gray-900">
 									{t(`administration.reports.reason.${entry.reason}`)}
 								</span>
-								<span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+								<span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
 									{t(`administration.reports.status.${entry.status}`)}
 								</span>
 							</div>


### PR DESCRIPTION
## What

Fixes a 500 error when loading the admin panel's Reports section.

## Why

`AdminReportReadRepository.GetFlaggedTargetsPagedAsync` filtered `VolunteerOpportunitiesQuery`/`OrganizationsQuery`/`UsersQuery` with `.Where(x => guidList.Contains(x.Id.Value))`. EF Core cannot translate `x.Id.Value` back to the raw column, because the strongly-typed ID's "from provider" conversion (`guid => FooId.Create(guid).GetValueOrThrow()`) isn't invertible by the query translator. Every load of the admin Reports panel threw a translation exception at query time, which surfaced to the client as a 500 - **regardless of whether any reports existed**, since translation depends on the expression shape, not the captured list's contents at runtime.

Fixed by converting the captured `Guid` lists to strongly-typed IDs first and comparing with `idVOs.Contains(x.Id)`, matching the pattern already used (and working) in `NotificationReadRepository`.

Also fixes a real, pre-existing WCAG AA color-contrast bug in the reports badges (`bg-gray-100 text-gray-500`) that the 500 had been masking - the reports table never actually rendered a row before this fix, so axe-core never got to scan it. Darkened to `text-gray-600`, matching the same badge pattern already used elsewhere (`VolunteerOpportunityDetailPage`, `OrganizationProfilePage`).

No linked issue - reported directly by the repo owner.

## Testing

- `dotnet build` (Api.csproj, VisualTests.csproj) - 0 warnings/errors
- `dotnet test tests/Application.UnitTests` - 484/484 passed
- `dotnet test tests/ArchitectureTests` - 328/328 passed
- Added `backend/tests/VisualTests/AdminReportsTests.cs`: creates an organization + volunteer opportunity via API (as olaf), reports it (as vera), then logs in as admin and asserts the Reports section renders the flagged opportunity with no error banner - this is the durable regression coverage for the bug (root-caused as an EF Core query-translation failure, which only an integration-style test hitting a real Postgres can catch; the existing unit test mocks the repository and couldn't have caught this). This same test's first CI run also caught the color-contrast bug above via `AccessibilityTests.cs`.
- `/self-review` run: no findings on the fix itself. `ef-migration-check` confirmed no EF model/migration changes needed (pure query-predicate rewrite).
- CI: all checks green on PR HEAD (`11ee54a`). One `visual-tests` job hit a pre-existing, unrelated flake (`AuthenticatedRequest_Returns401_ShowsSessionExpiredToast`) on two attempts - confirmed via job logs that the identical failure also occurs on `main` independent of this branch; a retrigger passed clean.

## Live verification

Cut release candidate `v1.0.0-rc.333` from this branch; `publish.yml` (test gate -> build -> `deploy-staging`) succeeded end to end, health gate green.

Ran a throwaway Playwright script against `https://einsatzbereit.maik-hasler.de` (logged in as `admin`, navigated to `/administration`):

- `GET /admin/reports/targets` returned **200** (previously 500 on every load)
- No "Failed to load reports." error banner
- Reports section heading renders
- Reports section shows either the empty state or a populated table, not stuck loading/erroring

All 4 assertions passed, script exited 0.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal bug fix, no behavior/contract change)
