### PR TITLE
fix: delay the sign-in redirect after a session-expiry toast

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -25,8 +25,9 @@
 
 ### `frontend.yml`
 - **Trigger:** `frontend/**` path filter or manual
-- **Jobs (sequential):** lint → build
+- **Jobs (sequential):** lint → test → build
   - `lint`: `pnpm lint` + `pnpm check` (type check)
+  - `test`: `pnpm test` (Vitest, `src/**/*.test.ts` - currently the `lib/` pure-function suite)
   - `build`: `pnpm build`
 - **No E2E job** - E2E lives in backend `tests/VisualTests/` (run by `dotnet.yml`)
 
@@ -61,7 +62,7 @@ All images pushed to **GitHub Container Registry (GHCR)**.
 **Full release:** Tag without `-rc` suffix → image published + `latest` tag updated.
 
 ### Publish flow (backend/frontend/keycloak)
-1. Run full test suite - three parallel jobs (`backend-fast-tests`/`backend-integration-tests`/`backend-visual-tests`, same split as `dotnet.yml`) that `publish-backend`, `publish-frontend`, and `publish-keycloak` all wait on via `needs:` before building anything, so a test failure blocks every image, not just the backend's. Frontend additionally runs its own lint/type-check/build inline; keycloak has no additional test gate beyond the shared backend suite
+1. Run full test suite - three parallel jobs (`backend-fast-tests`/`backend-integration-tests`/`backend-visual-tests`, same split as `dotnet.yml`) that `publish-backend`, `publish-frontend`, and `publish-keycloak` all wait on via `needs:` before building anything, so a test failure blocks every image, not just the backend's. Frontend additionally runs its own lint/type-check/unit-tests/build inline; keycloak has no additional test gate beyond the shared backend suite
 2. Login to GHCR
 3. Extract version from tag (strips leading `v`)
 4. Build and push Docker image

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -66,9 +66,34 @@ jobs:
       - name: Type check
         run: pnpm check
 
-  build:
+  test:
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: frontend/package.json
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: frontend/package.json
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -223,6 +223,10 @@ jobs:
         working-directory: frontend
         run: pnpm check
 
+      - name: Unit tests
+        working-directory: frontend
+        run: pnpm test
+
       - name: Build
         working-directory: frontend
         run: pnpm build

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -25,6 +25,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[10.0.10]" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.10]" />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[10.0.3]" />
 		<!-- Aspire: ServiceDefaults -->
@@ -48,6 +49,7 @@
 		<!-- Tests -->
 		<PackageVersion Include="AwesomeAssertions" Version="[9.5.0]" />
 		<PackageVersion Include="Deque.AxeCore.Playwright" Version="[4.12.0]" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[10.0.10]" />
 		<PackageVersion Include="NetArchTest.Rules" Version="[1.3.2]" />
 		<PackageVersion Include="NSubstitute" Version="[6.0.0]" />
 		<PackageVersion Include="Respawn" Version="[7.0.0]" />

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -143,7 +143,6 @@ if (app.Environment.IsDevelopment())
 
 	await initializer.MigrateAsync();
 	await initializer.SeedAsync();
-	await initializer.BackfillOrganizationMembershipsAsync();
 
 	app.MapOpenApi();
 }
@@ -157,8 +156,6 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 
 	if (app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
 		await initializer.SeedAsync();
-
-	await initializer.BackfillOrganizationMembershipsAsync();
 }
 
 app.MapDefaultEndpoints();

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>

--- a/backend/src/Application/Common/Email/IEmailService.cs
+++ b/backend/src/Application/Common/Email/IEmailService.cs
@@ -1,10 +1,20 @@
 namespace Application.Common.Email;
 
+public sealed record EmailMessage(string To, string Subject, string Body);
+
 public interface IEmailService
 {
 	Task SendAsync(
 		string to,
 		string subject,
 		string body,
+		CancellationToken cancellationToken = default);
+
+	// Sends every message over a single connection instead of one connect/
+	// authenticate/disconnect round trip per message. Never throws - like
+	// SendAsync, a failure is logged and recorded via EmailMetrics - and the
+	// result list is positional: result[i] reports the outcome for messages[i].
+	Task<IReadOnlyList<bool>> SendBatchAsync(
+		IReadOnlyList<EmailMessage> messages,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
+++ b/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
@@ -1,14 +1,36 @@
 using Application.Common.Geocoding;
 using Application.Common.Messaging;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Application.Maps.SearchCities.v1;
 
 internal sealed class SearchCitiesQueryHandler(
-	IGeocodingService geocodingService)
+	IGeocodingService geocodingService,
+	IMemoryCache cache)
 	: IQueryHandler<SearchCitiesQuery, IReadOnlyList<CitySuggestion>>
 {
+	// City name-to-coordinates mappings are effectively static, so a repeated
+	// query never needs to reach Nominatim (and its shared one-request-per-
+	// second throttle, see NominatimGeocodingService) again within this window.
+	private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+
 	public async ValueTask<IReadOnlyList<CitySuggestion>> Handle(
 		SearchCitiesQuery request,
-		CancellationToken cancellationToken = default) =>
-		await geocodingService.SearchCitiesAsync(request.Query, cancellationToken);
+		CancellationToken cancellationToken = default)
+	{
+		var cacheKey = $"city-search:{request.Query.Trim().ToLowerInvariant()}";
+
+		if (cache.TryGetValue(cacheKey, out IReadOnlyList<CitySuggestion>? cached) && cached is not null)
+			return cached;
+
+		var results = await geocodingService.SearchCitiesAsync(request.Query, cancellationToken);
+
+		// Don't cache an empty result - it's indistinguishable here from a
+		// transient geocoding failure, and caching that would turn a temporary
+		// hiccup into a day-long false "no such city" for every visitor.
+		if (results.Count > 0)
+			cache.Set(cacheKey, results, CacheDuration);
+
+		return results;
+	}
 }

--- a/backend/src/Aspire/ServiceDefaults/Extensions.cs
+++ b/backend/src/Aspire/ServiceDefaults/Extensions.cs
@@ -93,7 +93,23 @@ public static class ServiceDefaultsExtensions
 	{
 		if (builder is WebApplicationBuilder webBuilder && TryGetMetricsPort(builder.Configuration, out var port))
 		{
-			webBuilder.WebHost.ConfigureKestrel(options => options.ListenAnyIP(port));
+			// An explicit Kestrel Listen call replaces ASP.NET Core's default URL
+			// binding (ASPNETCORE_HTTP_PORTS, set to 8080 by the base container
+			// image) instead of adding to it - without re-adding it here, the app
+			// ends up listening only on the metrics port, unreachable to both
+			// Traefik and the docker-compose healthcheck even though the process
+			// itself is healthy. Caused a staging outage the first time this
+			// second listener shipped (Metrics:Port was previously never set, so
+			// this branch never ran outside staging).
+			var mainPort = int.TryParse(builder.Configuration["ASPNETCORE_HTTP_PORTS"], out var configuredPort)
+				? configuredPort
+				: 8080;
+
+			webBuilder.WebHost.ConfigureKestrel(options =>
+			{
+				options.ListenAnyIP(mainPort);
+				options.ListenAnyIP(port);
+			});
 		}
 
 		return builder;

--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
@@ -15,6 +15,12 @@ internal sealed class EngagementReminderJob(
 	ILogger<EngagementReminderJob> logger)
 	: IHostedService, IAsyncDisposable
 {
+	// Caps how many engagements one hourly tick processes. Anything left over
+	// still has ReminderSentAt == null and its TimeSlot still falls in the
+	// (now+23h, now+25h) window on the next tick (the window is 2h wide, the
+	// timer fires every 1h), so it is picked up then instead of being lost.
+	private const int MaxBatchSize = 500;
+
 	private Task _executeTask = Task.CompletedTask;
 	private CancellationTokenSource? _cts;
 	private PeriodicTimer? _timer;
@@ -85,13 +91,32 @@ internal sealed class EngagementReminderJob(
 				x => x.Engagement.OpportunityId,
 				vo => vo.Id,
 				(x, vo) => new { x.Engagement, x.TimeSlot, OpportunityTitle = vo.Title })
+			.OrderBy(x => x.TimeSlot.StartDateTime)
+			.Take(MaxBatchSize)
 			.ToListAsync(ct);
+
+		if (engagements.Count == 0)
+			return;
+
+		// One email per engagement, resolved sequentially: KeycloakUserService
+		// mutates a shared HttpClient auth header per call (see its
+		// SendAuthorizedAsync comment), so these lookups cannot run concurrently.
+		// Caching by volunteer avoids repeating the lookup for a volunteer
+		// confirmed for more than one slot inside this run's window.
+		var profileCache = new Dictionary<Guid, KeycloakUserProfile>();
+		var messages = new List<EmailMessage>(engagements.Count);
+		var recipients = new List<(Engagement Engagement, string Email)>(engagements.Count);
 
 		foreach (var item in engagements)
 		{
+			var volunteerId = item.Engagement.VolunteerId!.Value.Value;
 			try
 			{
-				var user = await keycloakUserService.GetUserAsync(item.Engagement.VolunteerId!.Value.Value, ct);
+				if (!profileCache.TryGetValue(volunteerId, out var user))
+				{
+					user = await keycloakUserService.GetUserAsync(volunteerId, ct);
+					profileCache[volunteerId] = user;
+				}
 
 				var displayName = $"{user.FirstName} {user.LastName}".Trim();
 				if (string.IsNullOrEmpty(displayName))
@@ -107,23 +132,59 @@ internal sealed class EngagementReminderJob(
 					$"We are looking forward to seeing you!\n\n" +
 					$"The Einsatzbereit Team";
 
-				await emailService.SendAsync(user.Email, subject, body, ct);
-
-				item.Engagement.MarkReminderSent(now);
-				await dbContext.SaveChangesAsync(ct);
-
-				logger.LogInformation(
-					"Sent 24h reminder to {Email} for engagement {EngagementId}",
-					user.Email,
-					item.Engagement.Id.Value);
+				messages.Add(new EmailMessage(user.Email, subject, body));
+				recipients.Add((item.Engagement, user.Email));
 			}
 			catch (Exception ex)
 			{
 				logger.LogError(
 					ex,
-					"Failed to send reminder for engagement {EngagementId}",
+					"Failed to resolve volunteer profile for engagement {EngagementId}",
 					item.Engagement.Id.Value);
 			}
+		}
+
+		if (messages.Count == 0)
+			return;
+
+		// A single SMTP connection for the whole batch instead of one per engagement.
+		var sendResults = await emailService.SendBatchAsync(messages, ct);
+
+		var sentIds = new List<EngagementId>(recipients.Count);
+		for (var i = 0; i < recipients.Count; i++)
+		{
+			if (!sendResults[i])
+				continue;
+
+			var (engagement, email) = recipients[i];
+			sentIds.Add(engagement.Id);
+
+			logger.LogInformation(
+				"Sent 24h reminder to {Email} for engagement {EngagementId}",
+				email,
+				engagement.Id.Value);
+		}
+
+		if (sentIds.Count == 0)
+			return;
+
+		try
+		{
+			// A single batched UPDATE instead of one SaveChangesAsync per engagement.
+			await dbContext.Set<Engagement>()
+				.Where(e => sentIds.Contains(e.Id))
+				.ExecuteUpdateAsync(
+					s => s
+						.SetProperty(e => e.ReminderSentAt, now)
+						.SetProperty(e => e.ModifiedOn, now),
+					ct);
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(
+				ex,
+				"Failed to persist ReminderSentAt for {Count} engagements after sending reminders; they will be retried next run",
+				sentIds.Count);
 		}
 	}
 }

--- a/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
@@ -1,0 +1,131 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Domain.Organizations;
+using Domain.Users;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.BackgroundJobs;
+
+// One-shot compensator for pre-existing organizations that predate the
+// organization_membership table (migration AddOrganizationMembership, see
+// wiki/bundle/gotchas/auth-fresh-deploy-traps.md for why it's needed at all).
+// Organizations created after that migration always get their founding organizer's
+// membership row written synchronously by CreateOrganizationCommandHandler, so once
+// this has run once against every organization that existed before the table did,
+// there is nothing left for it to ever do again.
+//
+// Runs as a fire-and-forget background task from StartAsync (never awaited there) so
+// - unlike the old inline Program.cs call it replaces - it cannot block the app from
+// becoming ready. The OrganizationMembershipBackfillState marker row makes the "has this
+// run before" check itself a single indexed lookup instead of a per-organization
+// Keycloak round trip repeated on every boot forever (#1393): without a marker, an
+// organization that legitimately still has zero organizers (not just one never
+// backfilled) would look identical to "needs backfilling" and get re-queried every
+// single restart.
+internal sealed class OrganizationMembershipBackfillJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<OrganizationMembershipBackfillJob> logger)
+	: IHostedService, IAsyncDisposable
+{
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_executeTask = RunAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunAsync(CancellationToken cancellationToken)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+		var keycloakOrganizationService = scope.ServiceProvider.GetRequiredService<IKeycloakOrganizationService>();
+
+		await BackfillAsync(dbContext, keycloakOrganizationService, logger, cancellationToken);
+	}
+
+	// Exposed so IntegrationTests can exercise the marker/backfill logic directly against
+	// a real ApplicationDbContext, without rebooting the whole app to reproduce a
+	// pre-existing-organization-without-membership-rows scenario.
+	internal static async Task BackfillAsync(
+		ApplicationDbContext dbContext,
+		IKeycloakOrganizationService keycloakOrganizationService,
+		ILogger logger,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			if (await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+				return;
+
+			var organizationIds = await dbContext.Set<Organization>()
+				.Where(o => !dbContext.Set<OrganizationMembership>().Any(m => m.OrganizationId == o.Id))
+				.Select(o => o.Id)
+				.ToListAsync(cancellationToken);
+
+			foreach (var organizationId in organizationIds)
+			{
+				var members = await keycloakOrganizationService.GetMembersAsync(
+					organizationId.Value, cancellationToken);
+
+				foreach (var member in members.Where(m => m.IsOrganisator).DistinctBy(m => m.UserId))
+				{
+					dbContext.Set<OrganizationMembership>().Add(
+						OrganizationMembership.Create(
+							organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+				}
+			}
+
+			// Written unconditionally (even when organizationIds is empty, or an organization
+			// in it turned out to have zero organizers) - this pass has now covered every
+			// organization that existed at startup, and that's the only thing this marker
+			// promises. It deliberately is not scoped per-organization.
+			dbContext.Set<OrganizationMembershipBackfillState>().Add(
+				new OrganizationMembershipBackfillState { CompletedOnUtc = DateTime.UtcNow });
+
+			await dbContext.SaveChangesAsync(cancellationToken);
+
+			if (organizationIds.Count > 0)
+				logger.LogInformation(
+					"Backfilled organization_membership rows for {Count} pre-existing organization(s).",
+					organizationIds.Count);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			// No marker is written on failure, so a transient Keycloak outage during this
+			// run simply retries on the next restart instead of being marked done falsely.
+			// OperationCanceledException is let through instead of logged as an error - that's
+			// just an ordinary app shutdown racing a still-running first backfill, not a failure.
+			logger.LogError(
+				ex,
+				"An exception occurred while backfilling organization memberships");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -50,4 +50,68 @@ internal sealed class SmtpEmailService(
 			metrics.RecordFailed();
 		}
 	}
+
+	public async Task<IReadOnlyList<bool>> SendBatchAsync(
+		IReadOnlyList<EmailMessage> messages,
+		CancellationToken cancellationToken = default)
+	{
+		var results = new bool[messages.Count];
+		if (messages.Count == 0)
+			return results;
+
+		using var client = new SmtpClient();
+
+		try
+		{
+			var secureSocketOptions = _options.EnableSsl
+				? SecureSocketOptions.StartTls
+				: SecureSocketOptions.None;
+			await client.ConnectAsync(_options.Host, _options.Port, secureSocketOptions, cancellationToken);
+
+			if (!string.IsNullOrEmpty(_options.Username))
+				await client.AuthenticateAsync(_options.Username, _options.Password ?? string.Empty, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Failed to establish SMTP connection for batch of {Count} emails", messages.Count);
+			for (var i = 0; i < messages.Count; i++)
+				metrics.RecordFailed();
+
+			return results;
+		}
+
+		for (var i = 0; i < messages.Count; i++)
+		{
+			var email = messages[i];
+			try
+			{
+				using var message = new MimeMessage();
+				message.From.Add(new MailboxAddress(_options.FromName, _options.FromAddress));
+				message.To.Add(MailboxAddress.Parse(email.To));
+				message.Subject = email.Subject;
+				message.Body = new TextPart("plain") { Text = email.Body };
+
+				await client.SendAsync(message, cancellationToken);
+
+				metrics.RecordSucceeded();
+				results[i] = true;
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "Failed to send email to {To} with subject {Subject}", email.To, email.Subject);
+				metrics.RecordFailed();
+			}
+		}
+
+		try
+		{
+			await client.DisconnectAsync(true, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "Failed to cleanly disconnect SMTP client after sending a batch of {Count} emails", messages.Count);
+		}
+
+		return results;
+	}
 }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -207,46 +207,6 @@ internal sealed class ApplicationDbContextInitializer(
 		}
 	}
 
-	public async ValueTask BackfillOrganizationMembershipsAsync(
-		CancellationToken cancellationToken = default)
-	{
-		try
-		{
-			var backfilledOrganizationIds = await dbContext.Set<Organization>()
-				.Where(o => !dbContext.Set<OrganizationMembership>().Any(m => m.OrganizationId == o.Id))
-				.Select(o => o.Id)
-				.ToListAsync(cancellationToken);
-
-			if (backfilledOrganizationIds.Count == 0)
-				return;
-
-			foreach (var organizationId in backfilledOrganizationIds)
-			{
-				var members = await keycloakOrganizationService.GetMembersAsync(
-					organizationId.Value, cancellationToken);
-
-				foreach (var member in members.Where(m => m.IsOrganisator).DistinctBy(m => m.UserId))
-				{
-					dbContext.Set<OrganizationMembership>().Add(
-						OrganizationMembership.Create(
-							organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
-				}
-			}
-
-			await dbContext.SaveChangesAsync(cancellationToken);
-
-			logger.LogInformation(
-				"Backfilled organization_membership rows for {Count} pre-existing organization(s).",
-				backfilledOrganizationIds.Count);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(
-				ex,
-				"An exception occurred while backfilling organization memberships");
-		}
-	}
-
 	private async Task<OrganizationId> SeedOrg1Async(CancellationToken cancellationToken)
 	{
 		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipBackfillStateConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipBackfillStateConfiguration.cs
@@ -1,0 +1,19 @@
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+internal sealed class OrganizationMembershipBackfillStateConfiguration
+	: IEntityTypeConfiguration<OrganizationMembershipBackfillState>
+{
+	public void Configure(
+		EntityTypeBuilder<OrganizationMembershipBackfillState> builder)
+	{
+		builder.HasKey(s => s.Id);
+
+		builder.Property(s => s.Id).ValueGeneratedNever();
+
+		builder.Property(s => s.CompletedOnUtc).IsRequired();
+	}
+}

--- a/backend/src/Infrastructure/Persistence/IApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/IApplicationDbContextInitializer.cs
@@ -5,6 +5,4 @@ public interface IApplicationDbContextInitializer
 	ValueTask MigrateAsync(CancellationToken cancellationToken = default);
 
 	ValueTask SeedAsync(CancellationToken cancellationToken = default);
-
-	ValueTask BackfillOrganizationMembershipsAsync(CancellationToken cancellationToken = default);
 }

--- a/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260728050448_AddOrganizationMembershipBackfillState")]
+	partial class AddOrganizationMembershipBackfillState
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260728050448_AddOrganizationMembershipBackfillState.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOrganizationMembershipBackfillState : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateTable(
+				name: "organization_membership_backfill_state",
+				columns: table => new
+				{
+					id = table.Column<int>(type: "integer", nullable: false),
+					completed_on_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+				},
+				constraints: table =>
+				{
+					table.PrimaryKey("pk_organization_membership_backfill_state", x => x.id);
+				});
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropTable(
+				name: "organization_membership_backfill_state");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationDashboardReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationDashboardReadRepository.cs
@@ -19,14 +19,15 @@ internal sealed class OrganizationDashboardReadRepository(
 		var now = DateTimeOffset.UtcNow;
 		var sevenDaysLater = now.AddDays(7);
 
-		// Materialize the org's opportunity ids once instead of re-running the
-		// same subquery inside every count below.
-		var orgOpportunityIds = await dbContext.VolunteerOpportunitiesQuery
+		// Kept as an IQueryable (not materialized) so every use below compiles to a
+		// correlated "IN (SELECT ...)" subquery instead of shipping the id list to
+		// and from Postgres as a literal array.
+		var orgOpportunityIds = dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => vo.OrganizationId == orgId)
-			.Select(vo => vo.Id)
-			.ToListAsync(cancellationToken);
+			.Select(vo => vo.Id);
 
-		var openOpportunities = orgOpportunityIds.Count;
+		var openOpportunities = await dbContext.VolunteerOpportunitiesQuery
+			.CountAsync(vo => vo.OrganizationId == orgId, cancellationToken);
 
 		// A single grouped query covers every status breakdown (pending, cancelled, ...).
 		var countsByStatus = await dbContext.EngagementsQuery
@@ -45,7 +46,7 @@ internal sealed class OrganizationDashboardReadRepository(
 			.FirstOrDefault(c => c.Status == EngagementStatus.Confirmed)?.Count ?? 0;
 
 		// The "next 7 days" metric needs a join to time slots plus a date filter,
-		// so it stays a dedicated query (still using the materialized id list).
+		// so it stays a dedicated query (still reusing the same subquery).
 		var confirmedEngagementsNext7Days = await dbContext.EngagementsQuery
 			.Where(e => orgOpportunityIds.Contains(e.OpportunityId) && e.Status == EngagementStatus.Confirmed && e.TimeSlotId != null)
 			.Join(

--- a/backend/src/Infrastructure/Persistence/StartupTasks/OrganizationMembershipBackfillState.cs
+++ b/backend/src/Infrastructure/Persistence/StartupTasks/OrganizationMembershipBackfillState.cs
@@ -1,0 +1,13 @@
+namespace Infrastructure.Persistence.StartupTasks;
+
+// Singleton marker row: its presence means OrganizationMembershipBackfillJob has
+// completed once and must never run again, regardless of whether some organization
+// still has zero organization_membership rows for legitimate reasons (e.g. every
+// organizer left). Without this, the job's own "any org missing rows" selector would
+// re-trigger a Keycloak call for that organization on every single boot, forever (#1393).
+internal sealed class OrganizationMembershipBackfillState
+{
+	public int Id { get; init; } = 1;
+
+	public DateTime CompletedOnUtc { get; init; }
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -94,6 +94,7 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<EngagementReminderJob>();
 		services.AddHostedService<OutboxProcessorJob>();
 		services.AddHostedService<GeocodingRetryJob>();
+		services.AddHostedService<OrganizationMembershipBackfillJob>();
 
 
 		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see

--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -7,6 +7,12 @@ namespace Infrastructure.Storage;
 
 internal sealed class MinioFileStorageService : IFileStorageService
 {
+	// Object keys are stable (e.g. "user-avatars/{UserId}{ext}"), so a long
+	// max-age would serve a stale image after re-upload. A moderate TTL plus
+	// the "?v=" cache-busting query param below (which changes on every
+	// upload) keeps caching effective without that staleness risk.
+	internal const string CacheControlHeaderValue = "public, max-age=3600";
+
 	private readonly IMinioClient _minio;
 	private readonly StorageSettings _settings;
 	private static readonly SemaphoreSlim _initLock = new(1, 1);
@@ -49,10 +55,14 @@ internal sealed class MinioFileStorageService : IFileStorageService
 				.WithObject(objectKey)
 				.WithStreamData(content)
 				.WithObjectSize(size)
-				.WithContentType(contentType),
+				.WithContentType(contentType)
+				.WithHeaders(new Dictionary<string, string>
+				{
+					["Cache-Control"] = CacheControlHeaderValue,
+				}),
 			cancellationToken);
 
-		return GetPublicUrl(objectKey);
+		return AppendVersionQuery(GetPublicUrl(objectKey), DateTimeOffset.UtcNow);
 	}
 
 	public async Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default)
@@ -71,6 +81,13 @@ internal sealed class MinioFileStorageService : IFileStorageService
 		var baseUrl = (_settings.PublicEndpoint ?? _settings.Endpoint).TrimEnd('/');
 		return $"{baseUrl}/{_settings.BucketName}/{objectKey}";
 	}
+
+	// Object keys don't change on re-upload, so the version query param is
+	// what invalidates a browser's cached copy once the underlying object
+	// changes - without it, CacheControlHeaderValue's max-age would let a
+	// stale image survive a re-upload until it happened to expire.
+	internal static string AppendVersionQuery(string url, DateTimeOffset uploadedOn) =>
+		$"{url}?v={uploadedOn.ToUnixTimeSeconds()}";
 
 	private async Task EnsureBucketReadyAsync(CancellationToken cancellationToken)
 	{

--- a/backend/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/backend/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="TUnit" />

--- a/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
@@ -1,18 +1,20 @@
 using Application.Common.Geocoding;
 using Application.Maps.SearchCities.v1;
 using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 
 namespace Application.UnitTests.Maps.SearchCities;
 
-public class SearchCitiesQueryHandlerTests
+public sealed class SearchCitiesQueryHandlerTests : IDisposable
 {
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
 	private readonly SearchCitiesQueryHandler _sut;
 
 	public SearchCitiesQueryHandlerTests()
 	{
-		_sut = new SearchCitiesQueryHandler(_geocodingService);
+		_sut = new SearchCitiesQueryHandler(_geocodingService, _cache);
 	}
 
 	[Test]
@@ -68,4 +70,50 @@ public class SearchCitiesQueryHandlerTests
 
 		await _geocodingService.Received(1).SearchCitiesAsync("Hamburg", cts.Token);
 	}
+
+	[Test]
+	public async Task Handle_ShouldNotCallGeocodingServiceTwice_ForRepeatedIdenticalQuery()
+	{
+		var suggestions = new List<CitySuggestion> { new("Hamburg", 53.5511, 9.9937) };
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(suggestions);
+
+		var first = await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		var second = await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+
+		first.Should().BeEquivalentTo(suggestions);
+		second.Should().BeEquivalentTo(suggestions);
+		await _geocodingService.Received(1).SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldTreatQuery_CaseAndWhitespaceInsensitively_ForCaching()
+	{
+		var suggestions = new List<CitySuggestion> { new("Hamburg", 53.5511, 9.9937) };
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(suggestions);
+
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		var second = await _sut.Handle(new SearchCitiesQuery("  HAMBURG  "), CancellationToken.None);
+
+		second.Should().BeEquivalentTo(suggestions);
+		await _geocodingService.Received(1).SearchCitiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotCacheEmptyResult_SoARetryCanStillFindMatches()
+	{
+		_geocodingService
+			.SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>())
+			.Returns(new List<CitySuggestion>());
+
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+		await _sut.Handle(new SearchCitiesQuery("Hamburg"), CancellationToken.None);
+
+		await _geocodingService.Received(2).SearchCitiesAsync("Hamburg", Arg.Any<CancellationToken>());
+	}
+
+	public void Dispose() => _cache.Dispose();
 }

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -1,0 +1,207 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1398: OrganizationDashboardReadRepository used to
+// materialize every opportunity id for an org into memory and re-check it with
+// in-memory Contains(), instead of an IN (SELECT ...) subquery. These tests pin
+// down the KPI counts themselves so a future change to that query keeps
+// producing the same numbers, whatever shape the query takes underneath.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldReturnAllZeros_WhenOrganizationHasNoOpportunities(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		var kpis = await olafClient.GetOrganizationDashboardAsync(orgId, cancellationToken);
+
+		kpis.OpenOpportunities.Should().Be(0);
+		kpis.PendingEngagements.Should().Be(0);
+		kpis.CancelledEngagements.Should().Be(0);
+		kpis.ConfirmedEngagementsTotal.Should().Be(0);
+		kpis.ConfirmedEngagementsNext7Days.Should().Be(0);
+	}
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldReturnAccurateKpis_ForOrganizationWithMixedEngagementStatuses(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		// Two open opportunities.
+		var opportunityA = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+		var opportunityB = await CreateWaitlistOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var slotNear = (await olafClient.CreateTimeSlotAsync(
+			opportunityB.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(3),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(3).AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		var slotFar = (await olafClient.CreateTimeSlotAsync(
+			opportunityB.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(20),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(20).AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		// Pending: vera signs up for opportunityA and is left untouched.
+		await veraClient.CreateEngagementAsync(
+			opportunityA.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		// Cancelled: olaf signs up for opportunityA himself, then cancels it as organizer.
+		var toBeCancelled = await olafClient.CreateEngagementAsync(
+			opportunityA.Id,
+			new CreateEngagementRequest { Message = "Second helper" },
+			cancellationToken);
+		await olafClient.CancelEngagementAsync(
+			toBeCancelled.Id,
+			new CancelEngagementRequest { Reason = "No longer needed" },
+			cancellationToken);
+
+		// Confirmed, within next 7 days: vera on the near time slot.
+		var nearEngagement = await veraClient.CreateEngagementAsync(
+			opportunityB.Id,
+			new CreateEngagementRequest { TimeSlotId = slotNear },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(nearEngagement.Id, cancellationToken);
+
+		// Confirmed, beyond next 7 days: olaf himself on the far time slot.
+		var farEngagement = await olafClient.CreateEngagementAsync(
+			opportunityB.Id,
+			new CreateEngagementRequest { TimeSlotId = slotFar },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(farEngagement.Id, cancellationToken);
+
+		var kpis = await olafClient.GetOrganizationDashboardAsync(orgId, cancellationToken);
+
+		kpis.OpenOpportunities.Should().Be(2);
+		kpis.PendingEngagements.Should().Be(1);
+		kpis.CancelledEngagements.Should().Be(1);
+		kpis.ConfirmedEngagementsTotal.Should().Be(2);
+		kpis.ConfirmedEngagementsNext7Days.Should().Be(1);
+	}
+
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldNotCountAnotherOrganizationsEngagements(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		// org1 (olaf): one opportunity with a pending and a confirmed engagement.
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity1 = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
+		var engagement1 = await veraClient.CreateEngagementAsync(
+			opportunity1.Id,
+			new CreateEngagementRequest { Message = "Helping org1" },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement1.Id, cancellationToken);
+
+		// org2 (vera): its own opportunity with its own pending engagement, which
+		// must never leak into org1's counts. CreateVolunteerOpportunity requires
+		// the "organisator" role claim, which Keycloak only grants vera once she
+		// creates an org - her existing veraClient token predates that, so a fresh
+		// token has to be minted to pick it up.
+		var org2Id = await CreateOrganizationAsync(veraClient, cancellationToken);
+		var veraOrganizerClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var opportunity2 = await CreateOpportunityAsync(veraOrganizerClient, org2Id, cancellationToken);
+		await olafClient.CreateEngagementAsync(
+			opportunity2.Id,
+			new CreateEngagementRequest { Message = "Helping org2" },
+			cancellationToken);
+
+		var org1Kpis = await olafClient.GetOrganizationDashboardAsync(org1Id, cancellationToken);
+
+		org1Kpis.OpenOpportunities.Should().Be(1);
+		org1Kpis.PendingEngagements.Should().Be(0);
+		org1Kpis.ConfirmedEngagementsTotal.Should().Be(1);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"DashboardTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+			},
+			cancellationToken);
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateWaitlistOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		// Created as a draft: a Waitlist opportunity can't be published until it has
+		// at least one time slot, and callers add slots separately after this returns.
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Waitlist Opportunity",
+				Description = "Integration test waitlist opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "Waitlist",
+				CheckInMethod = "None",
+				IsDraft = true,
+			},
+			cancellationToken);
+	}
+}

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -175,7 +175,11 @@ public class IntegrationTestFixture
 		return false;
 	}
 
-	private ApplicationDbContext CreateApplicationDbContext()
+	// Test-only escape hatch for driving Infrastructure-internal logic (InternalsVisibleTo,
+	// see Infrastructure.csproj) directly against the real integration Postgres - e.g.
+	// OrganizationMembershipBackfillJob.BackfillAsync, which otherwise only ever runs once
+	// per app boot and can't be re-triggered through the API (#1393).
+	internal ApplicationDbContext CreateApplicationDbContext()
 	{
 		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
 			.UseNpgsql(_connectionString)

--- a/backend/tests/IntegrationTests/IntegrationTests.csproj
+++ b/backend/tests/IntegrationTests/IntegrationTests.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Aspire\AppHost\AppHost.csproj" />
+		<ProjectReference Include="..\..\src\Aspire\ServiceDefaults\ServiceDefaults.csproj" />
 		<ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
 	</ItemGroup>
 

--- a/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
+++ b/backend/tests/IntegrationTests/MetricsPortListenerTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Sockets;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace IntegrationTests;
+
+// Regression coverage for a staging outage: AddMetricsPortListener
+// (Aspire/ServiceDefaults/Extensions.cs) used to call ConfigureKestrel with only
+// the metrics port's ListenAnyIP, which replaces ASP.NET Core's default HTTP
+// binding instead of adding to it, so the app stopped listening on its main port
+// entirely - unreachable to both Traefik and the docker-compose healthcheck even
+// though the process itself was healthy. Builds a real Kestrel host directly
+// (like SmtpEmailServiceTests, no Aspire/Testcontainers fixture needed) so it
+// runs fast and would have caught this before it reached staging.
+public class MetricsPortListenerTests
+{
+	[Test]
+	public async Task AddServiceDefaults_WithMetricsPortConfigured_StillListensOnMainHttpPort()
+	{
+		var mainPort = GetFreeTcpPort();
+		var metricsPort = GetFreeTcpPort();
+
+		var builder = WebApplication.CreateBuilder();
+		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+		{
+			["ASPNETCORE_HTTP_PORTS"] = mainPort.ToString(),
+			["Metrics:Port"] = metricsPort.ToString(),
+		});
+
+		builder.AddServiceDefaults();
+
+		await using var app = builder.Build();
+		app.MapDefaultEndpoints();
+
+		await app.StartAsync();
+		try
+		{
+			using var client = new HttpClient();
+
+			var mainResponse = await client.GetAsync($"http://localhost:{mainPort}/alive");
+			mainResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			var metricsResponse = await client.GetAsync($"http://localhost:{metricsPort}/alive");
+			metricsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+		}
+		finally
+		{
+			await app.StopAsync();
+		}
+	}
+
+	private static int GetFreeTcpPort()
+	{
+		var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+		listener.Stop();
+		return port;
+	}
+}

--- a/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
+++ b/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
@@ -1,0 +1,37 @@
+using AwesomeAssertions;
+using Infrastructure.Storage;
+
+namespace IntegrationTests;
+
+public class MinioFileStorageServiceUrlTests
+{
+	[Test]
+	public void AppendVersionQuery_ShouldAppendUnixSecondsAsVersionQueryParam()
+	{
+		var uploadedOn = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+		var result = MinioFileStorageService.AppendVersionQuery(
+			"https://storage.example.com/bucket/user-avatars/abc.png", uploadedOn);
+
+		result.Should().Be($"https://storage.example.com/bucket/user-avatars/abc.png?v={uploadedOn.ToUnixTimeSeconds()}");
+	}
+
+	[Test]
+	public void AppendVersionQuery_ShouldProduceDifferentVersions_WhenReuploadedAtDifferentTimes()
+	{
+		const string url = "https://storage.example.com/bucket/user-avatars/abc.png";
+		var firstUpload = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		var secondUpload = firstUpload.AddSeconds(1);
+
+		var firstUrl = MinioFileStorageService.AppendVersionQuery(url, firstUpload);
+		var secondUrl = MinioFileStorageService.AppendVersionQuery(url, secondUpload);
+
+		firstUrl.Should().NotBe(secondUrl);
+	}
+
+	[Test]
+	public void CacheControlHeaderValue_ShouldBePublicWithModerateMaxAge()
+	{
+		MinioFileStorageService.CacheControlHeaderValue.Should().Be("public, max-age=3600");
+	}
+}

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -1,0 +1,199 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Users;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.StartupTasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
+// "Organization"/"OrganizationId" DTO types, which would otherwise shadow the domain
+// types of the same name pulled in via the "Domain.Organizations" using above.
+using DomainOrganization = Domain.Organizations.Organization;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.OrganizationMembershipBackfillJob.BackfillAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres. The job only ever runs once, automatically, at app boot - the "backend"
+// Aspire resource already completed its one real run against the seeded organizations
+// long before any test executes, and there's no API to make it run again. Driving
+// BackfillAsync directly is the only way to reproduce "a pre-existing organization that
+// predates the organization_membership table" and prove the one-shot marker actually
+// prevents the every-boot-forever Keycloak calls described in #1393.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task BackfillAsync_PreExistingOrganizationWithoutMembershipRows_InsertsRowPerDistinctOrganizer(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		var organizerId = Guid.NewGuid();
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			MembersToReturn =
+			[
+				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
+				// Same organizer reported twice (e.g. multiple Keycloak group mappings) - must
+				// not produce two rows and violate the unique (organization_id, user_id) index.
+				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
+				// Plain member, not an organizer - must not get a membership row at all.
+				new KeycloakOrganizationMember(Guid.NewGuid(), "vera", "Vera", "V.", "vera@example.com", IsOrganisator: false),
+			],
+		};
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		var memberships = await dbContext.Set<OrganizationMembership>()
+			.Where(m => m.OrganizationId == organizationId)
+			.ToListAsync(cancellationToken);
+
+		memberships.Should().ContainSingle();
+		memberships[0].UserId.Should().Be(UserId.Create(organizerId).GetValueOrThrow());
+		memberships[0].Role.Should().Be(OrganizationMemberRole.Organizer);
+
+		var marker = await dbContext.Set<OrganizationMembershipBackfillState>().SingleOrDefaultAsync(cancellationToken);
+		marker.Should().NotBeNull("a completed run must leave the one-shot marker behind");
+	}
+
+	[Test]
+	public async Task BackfillAsync_OrganizationHasNoOrganizers_StillWritesCompletionMarkerAndNeverRetries(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		// No organizers at all - a legitimate state (e.g. every organizer since left), not
+		// "not backfilled yet". Before #1393 this looked identical to "needs backfilling" and
+		// triggered a Keycloak call on every single boot forever.
+		var keycloak = new FakeKeycloakOrganizationService { MembersToReturn = [] };
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		(await dbContext.Set<OrganizationMembership>().AnyAsync(m => m.OrganizationId == organizationId, cancellationToken))
+			.Should().BeFalse();
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeTrue("the one-shot marker must be written even when no organization actually needed rows added");
+
+		keycloak.GetMembersCallCount.Should().Be(1);
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		keycloak.GetMembersCallCount.Should().Be(
+			1, "a second run must short-circuit on the marker instead of re-querying Keycloak for the still-organizer-less organization");
+	}
+
+	[Test]
+	public async Task BackfillAsync_MarkerAlreadyPresent_NeverCallsKeycloak(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		dbContext.Set<OrganizationMembershipBackfillState>().Add(
+			new OrganizationMembershipBackfillState { CompletedOnUtc = DateTime.UtcNow });
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			MembersToReturn = [new KeycloakOrganizationMember(Guid.NewGuid(), "olaf", null, null, "olaf@example.com", IsOrganisator: true)],
+		};
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		keycloak.GetMembersCallCount.Should().Be(0, "an already-completed run must skip straight past every organization check");
+	}
+
+	[Test]
+	public async Task BackfillAsync_KeycloakFails_DoesNotWriteMarkerSoALaterRunCanStillRetry(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		var keycloak = new FakeKeycloakOrganizationService { ThrowOnGetMembers = true };
+
+		var act = () => OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		await act.Should().NotThrowAsync("a transient Keycloak failure must be swallowed, not crash the caller");
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeFalse("a failed run must not be marked complete, so the next boot retries instead of skipping real work");
+
+		keycloak.ThrowOnGetMembers = false;
+		keycloak.MembersToReturn = [new KeycloakOrganizationMember(Guid.NewGuid(), "olaf", null, null, "olaf@example.com", IsOrganisator: true)];
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		(await dbContext.Set<OrganizationMembership>().AnyAsync(m => m.OrganizationId == organizationId, cancellationToken))
+			.Should().BeTrue("the retried run should now succeed and backfill the organization");
+		(await dbContext.Set<OrganizationMembershipBackfillState>().AnyAsync(cancellationToken))
+			.Should().BeTrue();
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private static async Task<DomainOrganizationId> SeedOrganizationWithoutMembershipRowsAsync(
+		ApplicationDbContext dbContext, CancellationToken cancellationToken)
+	{
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"Legacy Org {Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+		await dbContext.SaveChangesAsync(cancellationToken);
+		return organization.Id;
+	}
+
+	private sealed class FakeKeycloakOrganizationService : IKeycloakOrganizationService
+	{
+		public IReadOnlyList<KeycloakOrganizationMember> MembersToReturn { get; set; } = [];
+
+		public bool ThrowOnGetMembers { get; set; }
+
+		public int GetMembersCallCount { get; private set; }
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
+			Guid organizationId, CancellationToken cancellationToken = default)
+		{
+			GetMembersCallCount++;
+
+			if (ThrowOnGetMembers)
+				throw new HttpRequestException("Keycloak unavailable (simulated).");
+
+			return Task.FromResult(MembersToReturn);
+		}
+
+		public Task<Guid> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task AddMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task RemoveMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task DeleteOrganizationAsync(Guid organizationId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task AssignOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
+			string search, int max = 20, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+	}
+}

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using Application.Common.Email;
 using AwesomeAssertions;
 using Infrastructure.Email;
 using Microsoft.Extensions.Diagnostics.Metrics;
@@ -19,6 +20,14 @@ namespace IntegrationTests;
 // like EngagementReminderJob rely on this - see its MarkReminderSent right
 // after SendAsync) but still observable, now via a metric rather than only a
 // log line nothing was watching.
+//
+// [NotInParallel] with a key unique to this class (not the "IntegrationDb"
+// key other IntegrationTests classes share): EmailMetrics.MeterName is a
+// process-wide constant, so a MeterListener started in one test backfires
+// on every not-yet-disposed Meter of that name from a concurrently-running
+// test in this class too - it must not also serialize against the unrelated
+// Aspire/Testcontainers-backed suite this class deliberately avoids needing.
+[NotInParallel(nameof(SmtpEmailServiceTests))]
 public class SmtpEmailServiceTests
 {
 	[Test]
@@ -51,6 +60,95 @@ public class SmtpEmailServiceTests
 		await act.Should().NotThrowAsync();
 
 		recorded.Should().ContainSingle(m => m.Status == "failed" && m.Value == 1);
+	}
+
+	// Regression coverage for #1400: EngagementReminderJob used to open a fresh
+	// SMTP connection per volunteer. FakeSmtpServer only ever accepts one TCP
+	// connection (see AcceptAsync below), so if SendBatchAsync tried to reconnect
+	// for message 2 or 3 there would be nothing listening and those sends would
+	// fail - all three succeeding here is itself proof the batch shares one connection.
+	[Test]
+	public async Task SendBatchAsync_ServerAcceptsAllMessages_SendsEveryMessageOverOneConnection()
+	{
+		await using var server = await FakeSmtpServer.StartAsync();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(server.Port, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(true, true, true);
+		recorded.Count(m => m.Status == "succeeded").Should().Be(3);
+		recorded.Should().NotContain(m => m.Status == "failed");
+	}
+
+	[Test]
+	public async Task SendBatchAsync_ServerRejectsOneRecipient_ReportsThatMessageAsFailedAndKeepsSendingTheRest()
+	{
+		await using var server = await FakeSmtpServer.StartAsync(rejectRecipient: "olaf@example.com");
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(server.Port, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(true, false, true);
+		recorded.Count(m => m.Status == "succeeded").Should().Be(2);
+		recorded.Count(m => m.Status == "failed").Should().Be(1);
+	}
+
+	[Test]
+	public async Task SendBatchAsync_ServerUnreachable_AllMessagesFailWithoutThrowing()
+	{
+		var unusedPort = GetUnusedLoopbackPort();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		var sut = CreateService(unusedPort, metrics);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+		};
+
+		var results = await sut.SendBatchAsync(messages);
+
+		results.Should().Equal(false, false);
+		recorded.Count(m => m.Status == "failed").Should().Be(2);
+	}
+
+	[Test]
+	public async Task SendBatchAsync_EmptyMessageList_ReturnsEmptyResultsWithoutConnecting()
+	{
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var recorded = RecordEmailSendMeasurements(meterFactory);
+
+		// Deliberately no FakeSmtpServer started: an empty batch must not attempt
+		// a connection at all, so an unused port never being listened on is fine.
+		var sut = CreateService(GetUnusedLoopbackPort(), metrics);
+
+		var results = await sut.SendBatchAsync([]);
+
+		results.Should().BeEmpty();
+		recorded.Should().BeEmpty();
 	}
 
 	private static SmtpEmailService CreateService(int port, EmailMetrics metrics) =>
@@ -136,22 +234,24 @@ public class SmtpEmailServiceTests
 	{
 		private readonly TcpListener _listener;
 		private readonly Task _acceptTask;
+		private readonly string? _rejectRecipient;
 
-		private FakeSmtpServer(TcpListener listener, int port)
+		private FakeSmtpServer(TcpListener listener, int port, string? rejectRecipient)
 		{
 			_listener = listener;
 			Port = port;
+			_rejectRecipient = rejectRecipient;
 			_acceptTask = AcceptAsync();
 		}
 
 		public int Port { get; }
 
-		public static Task<FakeSmtpServer> StartAsync()
+		public static Task<FakeSmtpServer> StartAsync(string? rejectRecipient = null)
 		{
 			var listener = new TcpListener(IPAddress.Loopback, 0);
 			listener.Start();
 			var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-			return Task.FromResult(new FakeSmtpServer(listener, port));
+			return Task.FromResult(new FakeSmtpServer(listener, port, rejectRecipient));
 		}
 
 		private async Task AcceptAsync()
@@ -170,10 +270,21 @@ public class SmtpEmailServiceTests
 				{
 					await writer.WriteLineAsync("250 fake.local");
 				}
-				else if (line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase)
-					|| line.StartsWith("RCPT TO", StringComparison.OrdinalIgnoreCase))
+				else if (line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase))
 				{
 					await writer.WriteLineAsync("250 OK");
+				}
+				else if (line.StartsWith("RCPT TO", StringComparison.OrdinalIgnoreCase))
+				{
+					if (_rejectRecipient is not null &&
+						line.Contains(_rejectRecipient, StringComparison.OrdinalIgnoreCase))
+					{
+						await writer.WriteLineAsync("550 Requested action not taken: mailbox unavailable");
+					}
+					else
+					{
+						await writer.WriteLineAsync("250 OK");
+					}
 				}
 				else if (line.Equals("DATA", StringComparison.OrdinalIgnoreCase))
 				{
@@ -183,6 +294,13 @@ public class SmtpEmailServiceTests
 					}
 
 					await writer.WriteLineAsync("250 OK queued");
+				}
+				else if (line.StartsWith("RSET", StringComparison.OrdinalIgnoreCase))
+				{
+					// MailKit issues RSET to clear the transaction after a rejected
+					// RCPT TO before starting the next message - without a reply
+					// here the client blocks reading a response that never comes.
+					await writer.WriteLineAsync("250 OK");
 				}
 				else if (line.StartsWith("QUIT", StringComparison.OrdinalIgnoreCase))
 				{

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -380,6 +380,41 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task HomePage_LanguageSelector_SwitchingLanguage_LazilyLoadsAndAppliesTranslations()
+	{
+		// #1395: both translation bundles used to be statically imported into the
+		// entry chunk. Each language's JSON is now fetched lazily on demand via a
+		// custom i18next backend - switching language must still dynamically load
+		// and apply the target locale's strings, and switching back must reuse the
+		// already-loaded English bundle without breaking.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		var heading = Page.Locator("h1").First;
+		await Expect(heading).ToHaveTextAsync(
+			"Volunteering doesn't have to be hard.", new() { Timeout = 15_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "en");
+
+		var langBtn = Page.Locator("header button[aria-haspopup='listbox']").First;
+		await langBtn.ClickAsync();
+		var dropdown = Page.Locator("header ul[role='listbox']").First;
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await dropdown.GetByRole(AriaRole.Button, new() { Name = "Deutsch" }).ClickAsync();
+
+		await Expect(heading).ToHaveTextAsync(
+			"Ehrenamt muss nicht schwer sein.", new() { Timeout = 10_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "de");
+
+		await langBtn.ClickAsync();
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await dropdown.GetByRole(AriaRole.Button, new() { Name = "English" }).ClickAsync();
+
+		await Expect(heading).ToHaveTextAsync(
+			"Volunteering doesn't have to be hard.", new() { Timeout = 10_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "en");
+	}
+
+	[Test]
 	public async Task MobileMenu_ClosesOnEscape()
 	{
 		// #884: MobileMenu offered neither outside-click nor Escape dismissal

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -305,6 +305,119 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(calendarWidget.Locator(".rbc-time-view")).ToBeVisibleAsync();
 	}
 
+	[Test]
+	public async Task CalendarWidget_SelectEventAndSaveColor_RecoloredEventSurvivesReload()
+	{
+		// #1397: calEvents, and the Calendar's components/eventPropGetter/messages
+		// props, were rebuilt from scratch on every render (including on every
+		// pointer movement while dragging the color picker below), fixed by
+		// memoizing calEvents off calData and hoisting the static props out of
+		// the component. This exercises the full select-event -> pick color ->
+		// save round trip end to end, so a broken useMemo dependency array or a
+		// debounced picker that never flushes its final value would show up as
+		// a failing assertion here rather than only as a missed re-render.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1397 {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"Visual1397 Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by CalendarWidget color-save test",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "Waitlist",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		// Close enough to "now" that it always falls in the current month, so
+		// the widget's default month view shows it without switching tabs.
+		var start = DateTimeOffset.UtcNow.AddHours(1);
+		var end = start.AddHours(2);
+		(await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 }))
+			.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		var calendarWidget = Page.Locator("section", new()
+		{
+			Has = Page.GetByRole(AriaRole.Heading, new() { Name = "Calendar", Exact = true }),
+		});
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var calendarEvent = calendarWidget.Locator(".rbc-event").First;
+		await Expect(calendarEvent).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// No color set yet - eventPropGetter falls back to DEFAULT_EVENT_COLOR.
+		var defaultBg = await calendarEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		defaultBg.Should().Be("rgb(34, 105, 71)");
+
+		await calendarEvent.ClickAsync();
+		var colorDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(colorDialog).ToBeVisibleAsync();
+		await Expect(colorDialog).ToContainTextAsync(oppTitle);
+
+		var colorInput = Page.Locator("#event-color-picker");
+		await Expect(colorInput).ToHaveValueAsync("#226947");
+
+		const string newColor = "#3366cc";
+		await colorInput.FillAsync(newColor);
+		await Expect(Page.GetByText(newColor)).ToBeVisibleAsync();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+		await Expect(colorDialog).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var savedBg = await calendarEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		savedBg.Should().Be("rgb(51, 102, 204)");
+
+		// Reload so calData (and the memoized calEvents derived from it) come
+		// back fresh from the server, proving the color actually persisted
+		// rather than only reflecting the modal's optimistic local update.
+		await Page.ReloadAsync();
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var reloadedEvent = calendarWidget.Locator(".rbc-event").First;
+		await Expect(reloadedEvent).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var reloadedBg = await reloadedEvent.EvaluateAsync<string>(
+			"el => getComputedStyle(el).backgroundColor");
+		reloadedBg.Should().Be("rgb(51, 102, 204)");
+	}
+
 	private async Task CreateOrganizationAsync(string namePrefix)
 	{
 		// New orgs are created via the org switcher's "Create organization" entry

--- a/backend/tests/VisualTests/OrganizationsFetchDeduplicationTests.cs
+++ b/backend/tests/VisualTests/OrganizationsFetchDeduplicationTests.cs
@@ -1,0 +1,33 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrganizationsFetchDeduplicationTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task AuthenticatedHomePageLoad_FetchesOrganizationsOnce_NotOncePerHeaderAndPage()
+	{
+		// Regression for #1396: Header and HomePage each independently called
+		// GET /v1/organizations on mount, so an authenticated home page load
+		// fired the same query twice (and React StrictMode's dev-mode
+		// double-invoke - see VisualTestBase - would have doubled that again
+		// without the fix). Both now share a single in-flight request via
+		// useSharedOrgFetch.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var requestCount = 0;
+		await Page.RouteAsync("**/v1/organizations", async route =>
+		{
+			Interlocked.Increment(ref requestCount);
+			await route.ContinueAsync();
+		});
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		requestCount.Should().Be(1);
+	}
+}

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -107,15 +107,29 @@ Routes declared in `src/App.tsx`. Add new routes there.
 ## Scripts
 
 ```bash
-pnpm dev           # dev server on :4321
-pnpm build         # build to dist/ (static files)
-pnpm preview       # preview production build
-pnpm check         # tsc --noEmit
-pnpm lint          # eslint, zero warnings allowed
-pnpm format:write  # apply Prettier formatting - run before every commit
-pnpm format:check  # check Prettier formatting (used by CI)
-pnpm i18n:check    # verify en.json/de.json key parity - CI hard gate, run before committing locale changes
+pnpm dev             # dev server on :4321
+pnpm build           # build to dist/ (static files)
+pnpm preview         # preview production build
+pnpm check           # tsc --noEmit
+pnpm test            # vitest run - CI hard gate (frontend.yml's test job)
+pnpm test:watch      # vitest in watch mode, for local development
+pnpm test:coverage   # vitest run --coverage
+pnpm lint            # eslint, zero warnings allowed
+pnpm format:write    # apply Prettier formatting - run before every commit
+pnpm format:check    # check Prettier formatting (used by CI)
+pnpm i18n:check      # verify en.json/de.json key parity - CI hard gate, run before committing locale changes
 ```
+
+## Unit Tests
+
+Vitest (`vitest.config.ts`, jsdom environment) tests pure logic in `src/lib/`, colocated as `*.test.ts` next to the module under test (e.g. `src/lib/activeOrg.test.ts`). Component/page-level behavior is covered by the Playwright suite in `backend/tests/VisualTests/` instead - see root `AGENTS.md`.
+
+Conventions used across the existing suite:
+
+- Mock a module's own dependencies with `vi.mock(...)`, not the module under test itself. Values referenced inside a `vi.mock` factory must go through `vi.hoisted(...)` (mock factories are hoisted above imports, so a plain top-level `const` isn't initialized yet when the factory runs).
+- Prefer computing the expected value with the same underlying call (e.g. `new Date(iso).toLocaleString(...)`) over hardcoding a formatted string, when the result depends on the host timezone or locale data.
+- For module-level singletons/config computed at import time (e.g. `lib/runtimeConfig.ts`, `lib/keycloakRegistration.ts`), call `vi.resetModules()` in `beforeEach` and re-`import()` the module inside each test to get a fresh instance.
+- `vi.spyOn` on an already-spied method (e.g. `console.error` spied in a previous test) returns the *same* mock and keeps its call history - restore with `vi.restoreAllMocks()` in `afterEach` rather than only resetting the fake in `beforeEach`.
 
 ## Key Dependencies
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint . --max-warnings 0",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
     "format:write": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.{ts,js}\"",
@@ -47,11 +50,13 @@
     "@types/react-big-calendar": "1.16.3",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.4",
+    "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-i18next": "6.1.5",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react-hooks": "7.1.1",
+    "jsdom": "29.1.1",
     "prettier": "3.9.6",
     "tailwindcss": "4.3.3",
     "typescript": "6.0.3",
@@ -59,6 +64,7 @@
     "vite": "8.1.5",
     "vite-plugin-compression2": "2.5.3",
     "vite-plugin-pwa": "1.3.0",
-    "vite-plugin-svgr": "5.2.0"
+    "vite-plugin-svgr": "5.2.0",
+    "vitest": "4.1.10"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
-        version: 10.0.1(eslint@10.8.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
@@ -81,21 +81,27 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.4
         version: 6.0.4(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
+      '@vitest/coverage-v8':
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: 10.8.0
-        version: 10.8.0(jiti@2.7.0)
+        version: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@10.8.0(jiti@2.7.0))
+        version: 10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-i18next:
         specifier: 6.1.5
         version: 6.1.5
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@10.8.0(jiti@2.7.0))
+        version: 6.10.2(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-react-hooks:
         specifier: 7.1.1
-        version: 7.1.1(eslint@10.8.0(jiti@2.7.0))
+        version: 7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -107,7 +113,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 8.65.0
-        version: 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       vite:
         specifier: 8.1.5
         version: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
@@ -116,10 +122,13 @@ importers:
         version: 2.5.3(rollup@4.62.0)
       vite-plugin-pwa:
         specifier: 1.3.0
-        version: 1.3.0(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.3.0(supports-color@7.2.0)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1(supports-color@7.2.0))(workbox-window@7.4.1)
       vite-plugin-svgr:
         specifier: 5.2.0
-        version: 5.2.0(rollup@4.62.0)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
+        version: 5.2.0(rollup@4.62.0)(supports-color@7.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
 
 packages:
 
@@ -128,6 +137,21 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -655,6 +679,50 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
@@ -702,6 +770,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@hookform/resolvers@5.4.0':
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
@@ -1060,6 +1137,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1232,8 +1312,14 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/date-arithmetic@4.1.4':
     resolution: {integrity: sha512-p9eZ2X9B80iKiTW4ukVj8B4K6q9/+xFtQ5MGYA5HWToY9nL4EkhV9+6ftT2VHpVMEZb5Tv00Iel516bVdO+yRw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1348,6 +1434,44 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1391,8 +1515,15 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1444,6 +1575,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1484,6 +1618,10 @@ packages:
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   cldrjs@0.5.5:
     resolution: {integrity: sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA==}
@@ -1528,11 +1666,19 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1563,6 +1709,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1619,6 +1768,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -1633,6 +1786,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1721,6 +1877,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1728,6 +1887,10 @@ packages:
   eta@4.6.0:
     resolution: {integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==}
     engines: {node: '>=20'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1846,6 +2009,10 @@ packages:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -1870,6 +2037,13 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-parse-stringify@4.0.1:
     resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
@@ -1981,6 +2155,9 @@ packages:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2031,6 +2208,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
@@ -2044,12 +2233,24 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2226,9 +2427,19 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -2295,6 +2506,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   oidc-client-ts@3.5.0:
     resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
     engines: {node: '>=18'}
@@ -2326,6 +2541,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2345,12 +2563,11 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -2531,6 +2748,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2583,6 +2804,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2609,6 +2833,12 @@ packages:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2642,12 +2872,19 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -2672,12 +2909,38 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2735,6 +2998,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -2841,11 +3108,68 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -2869,6 +3193,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2924,6 +3253,13 @@ packages:
   workbox-window@7.4.1:
     resolution: {integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2948,9 +3284,29 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -2962,20 +3318,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3002,32 +3358,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -3035,26 +3391,26 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3064,27 +3420,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-wrap-function': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-wrap-function': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3099,10 +3455,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helper-wrap-function@7.29.7':
+  '@babel/helper-wrap-function@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3120,482 +3476,482 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@7.2.0))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
@@ -3610,7 +3966,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -3618,7 +3974,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3631,6 +3987,36 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -3648,17 +4034,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -3671,9 +4057,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))':
     optionalDependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -3681,6 +4067,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@hookform/resolvers@5.4.0(react-hook-form@7.82.0(react@19.2.8))':
     dependencies:
@@ -3802,10 +4190,10 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(rollup@4.62.0)':
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0(supports-color@7.2.0))(rollup@4.62.0)(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.62.0)
     optionalDependencies:
       rollup: 4.62.0
@@ -3920,56 +4308,58 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
 
-  '@svgr/core@8.1.0(typescript@6.0.3)':
+  '@svgr/core@8.1.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
@@ -3982,11 +4372,11 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@6.0.3))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -4072,7 +4462,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/date-arithmetic@4.1.4': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4112,15 +4509,15 @@ snapshots:
 
   '@types/warning@3.0.4': {}
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -4128,23 +4525,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
-      eslint: 10.8.0(jiti@2.7.0)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.65.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4158,13 +4555,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.8.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4172,13 +4569,13 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.65.0(supports-color@7.2.0)(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.17
@@ -4187,13 +4584,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4207,6 +4604,61 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
+
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4272,7 +4724,15 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -4288,27 +4748,27 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4317,6 +4777,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.27: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.14:
     dependencies:
@@ -4364,6 +4828,8 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
+  chai@6.2.2: {}
+
   cldrjs@0.5.5: {}
 
   clsx@2.1.1: {}
@@ -4399,9 +4865,21 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4427,9 +4905,13 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -4486,6 +4968,8 @@ snapshots:
       tapable: 2.3.3
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4552,6 +5036,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4577,15 +5063,15 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
 
   eslint-plugin-i18next@6.1.5:
     dependencies:
       requireindex: 1.1.0
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -4595,7 +5081,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -4604,11 +5090,11 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/parser': 7.29.3
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
@@ -4626,11 +5112,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0(jiti@2.7.0):
+  eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -4640,7 +5126,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -4681,9 +5167,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eta@4.6.0: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4693,9 +5185,9 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4807,6 +5299,8 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
+  has-flag@4.0.0: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -4830,6 +5324,14 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-parse-stringify@4.0.1: {}
 
@@ -4937,6 +5439,8 @@ snapshots:
 
   is-obj@1.0.1: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4984,6 +5488,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@4.2.3:
     dependencies:
       '@isaacs/cliui': 9.0.0
@@ -4996,11 +5513,39 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.29.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -5135,7 +5680,19 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   memoize-one@6.0.0: {}
 
@@ -5201,6 +5758,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.4: {}
+
   oidc-client-ts@3.5.0:
     dependencies:
       jwt-decode: 4.0.0
@@ -5241,6 +5800,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5254,9 +5817,9 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  picocolors@1.1.1: {}
+  pathe@2.0.3: {}
 
-  picomatch@4.0.4: {}
+  picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
 
@@ -5492,6 +6055,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -5556,6 +6123,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   smob@1.6.2: {}
@@ -5577,6 +6146,10 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5636,9 +6209,15 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.3.3: {}
 
@@ -5662,12 +6241,32 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
 
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -5716,13 +6315,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5745,6 +6344,8 @@ snapshots:
       react-lifecycles-compat: 3.0.4
 
   undici-types@7.24.6: {}
+
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -5786,22 +6387,22 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-pwa@1.3.0(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(supports-color@7.2.0)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))(workbox-build@7.4.1(supports-color@7.2.0))(workbox-window@7.4.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
-      workbox-build: 7.4.1
+      workbox-build: 7.4.1(supports-color@7.2.0)
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-svgr@5.2.0(rollup@4.62.0)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)):
+  vite-plugin-svgr@5.2.0(rollup@4.62.0)(supports-color@7.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.62.0)
-      '@svgr/core': 8.1.0(typescript@6.0.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@6.0.3))(supports-color@7.2.0)
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
     transitivePeerDependencies:
       - rollup
@@ -5821,11 +6422,56 @@ snapshots:
       jiti: 2.7.0
       terser: 5.48.0
 
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.5
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
 
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@7.1.0:
     dependencies:
@@ -5878,6 +6524,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   workbox-background-sync@7.4.1:
@@ -5889,13 +6540,13 @@ snapshots:
     dependencies:
       workbox-core: 7.4.1
 
-  workbox-build@7.4.1:
+  workbox-build@7.4.1(supports-color@7.2.0):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.7(ajv@8.20.0)
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/runtime': 7.29.7
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(rollup@4.62.0)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0(supports-color@7.2.0))(rollup@4.62.0)(supports-color@7.2.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
       '@rollup/plugin-terser': 1.0.0(rollup@4.62.0)
@@ -5992,6 +6643,10 @@ snapshots:
     dependencies:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link, useLocation } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
 import { useApiClient } from "../../hooks/useApiClient";
+import { useSharedOrgFetch } from "../../hooks/useSharedOrgFetch";
 import { signinRedirectForRegistration } from "../../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../../lib/authLocale";
 import { getActiveOrgId, resolveActiveOrg } from "../../lib/activeOrg";
@@ -54,8 +55,14 @@ export default function Header({
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
 	const isAdmin = roles.includes("admin");
-	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
-	const [orgsLoading, setOrgsLoading] = useState(true);
+	// Shared with HomePage, which independently needs the same top-level
+	// organization list on the same mount (#1396) - see useSharedOrgFetch.
+	const [orgsData, , orgsError] = useSharedOrgFetch<OrganizationSummaryDto[]>(
+		`organizations:${isLoggedIn}`,
+		() => (isLoggedIn ? api.getOrganizations() : Promise.resolve([])),
+	);
+	const orgs = isLoggedIn ? (orgsData ?? []) : [];
+	const orgsLoading = isLoggedIn && orgsData === null && !orgsError;
 	const activeOrg = resolveActiveOrg(orgs, getActiveOrgId());
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [orgMenuOpen, setOrgMenuOpen] = useState(false);
@@ -74,29 +81,6 @@ export default function Header({
 	useEffect(() => {
 		if (!mobileOpen) setOrgMenuOpen(false);
 	}, [mobileOpen]);
-
-	useEffect(() => {
-		if (!isLoggedIn) {
-			setOrgs([]);
-			setOrgsLoading(false);
-			return;
-		}
-		const controller = new AbortController();
-		setOrgsLoading(true);
-		api
-			.getOrganizations(controller.signal)
-			.then((data) => {
-				if (!controller.signal.aborted) setOrgs(data);
-			})
-			.catch(() => {
-				if (!controller.signal.aborted) setOrgs([]);
-			})
-			.finally(() => {
-				if (!controller.signal.aborted) setOrgsLoading(false);
-			});
-		return () => controller.abort();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isLoggedIn]);
 
 	const isTransparent = location.pathname === "/" && !scrolled;
 

--- a/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
+++ b/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
@@ -7,6 +7,19 @@ export interface CitySuggestion {
 	lng: number;
 }
 
+// Module-level so it survives across hook re-mounts for the lifetime of the
+// page (cleared on reload) - repeated searches for the same city (e.g. the
+// user re-focuses the field, or backspaces and retypes) never need to hit the
+// backend again since city name-to-coordinates mappings are effectively
+// static. Never stores an empty result: an empty response is indistinguishable
+// here from a transient backend/upstream hiccup, and caching it would turn
+// that into a permanent false "no such city" for the rest of the page's life.
+const cityCache = new Map<string, CitySuggestion[]>();
+
+function cacheKeyFor(query: string) {
+	return query.trim().toLowerCase();
+}
+
 // Debounced city-name autocomplete for the location filter's "search by city"
 // input. Proxied through the backend's /v1/maps/cities endpoint (which in turn
 // queries the public Nominatim/OpenStreetMap geocoder) so the visitor's IP
@@ -24,6 +37,14 @@ export function useCitySuggestions(query: string) {
 			setShow(false);
 			return;
 		}
+
+		const cached = cityCache.get(cacheKeyFor(query));
+		if (cached) {
+			setSuggestions(cached);
+			setShow(cached.length > 0);
+			return;
+		}
+
 		abortRef.current?.abort();
 		const controller = new AbortController();
 		abortRef.current = controller;
@@ -35,6 +56,9 @@ export function useCitySuggestions(query: string) {
 					lat: place.latitude,
 					lng: place.longitude,
 				}));
+				if (results.length > 0) {
+					cityCache.set(cacheKeyFor(query), results);
+				}
 				setSuggestions(results);
 				setShow(results.length > 0);
 			} catch {

--- a/frontend/src/hooks/useSessionExpiryHandler.ts
+++ b/frontend/src/hooks/useSessionExpiryHandler.ts
@@ -27,6 +27,8 @@ export function useSessionExpiryHandler() {
 	}, [auth.isAuthenticated]);
 
 	useEffect(() => {
+		let redirectTimer: ReturnType<typeof setTimeout> | null = null;
+
 		function handleExpiry() {
 			// Several concurrent API calls (or a bus event racing a silent-renew
 			// failure) can all report expiry around the same time - only act once.
@@ -34,12 +36,19 @@ export function useSessionExpiryHandler() {
 			handledRef.current = true;
 
 			dispatchToast("error", t("error.sessionExpired"));
-			void auth.signinRedirect({
-				...signinLocaleArgs(),
-				state: {
-					returnTo: locationRef.current.pathname + locationRef.current.search,
-				},
-			});
+			// Give the toast a moment to actually render before the redirect tears
+			// the page down - firing signinRedirect immediately raced the toast's
+			// paint against Keycloak's top-level navigation, which occasionally
+			// won (the toast never becoming visible) even though the navigation
+			// itself was expected to land on a real page rather than commit.
+			redirectTimer = setTimeout(() => {
+				void auth.signinRedirect({
+					...signinLocaleArgs(),
+					state: {
+						returnTo: locationRef.current.pathname + locationRef.current.search,
+					},
+				});
+			}, 2000);
 		}
 
 		const unsubscribeBus = subscribeSessionExpired(handleExpiry);
@@ -49,6 +58,7 @@ export function useSessionExpiryHandler() {
 		return () => {
 			unsubscribeBus();
 			unsubscribeSilentRenewError();
+			if (redirectTimer !== null) clearTimeout(redirectTimer);
 		};
 	}, [auth, t]);
 }

--- a/frontend/src/hooks/useSharedOrgFetch.ts
+++ b/frontend/src/hooks/useSharedOrgFetch.ts
@@ -1,16 +1,17 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 
 // Module-level registry of in-flight requests, keyed by a caller-supplied
-// string (typically `${resource}:${organizationId}:${refreshKey}`). Several
-// dashboard widgets independently need the same organization-wide data on the
-// same mount - Calendar and Upcoming Opportunities both call
-// getOrganizationCalendarEvents, Upcoming Opportunities and Quick Check-in
-// both call getOrganizationOpportunities - and without this, each widget
-// fires its own copy of the same request. Only the in-flight *request* is
-// shared, not the resolved data: each caller still gets its own local
-// useState copy (see the returned setter) so one widget can optimistically
-// mutate its view (e.g. CalendarWidget after saving an event color) without
-// affecting another widget that happened to share the fetch.
+// string (typically `${resource}:${organizationId}:${refreshKey}`, or just
+// `${resource}` for a resource with no such scoping). Several call sites
+// independently need the same data on the same mount - Calendar and Upcoming
+// Opportunities widgets both call getOrganizationCalendarEvents, Upcoming
+// Opportunities and Quick Check-in both call getOrganizationOpportunities,
+// Header and HomePage both call getOrganizations - and without this, each
+// caller fires its own copy of the same request. Only the in-flight
+// *request* is shared, not the resolved data: each caller still gets its own
+// local useState copy (see the returned setter) so one widget can
+// optimistically mutate its view (e.g. CalendarWidget after saving an event
+// color) without affecting another that happened to share the fetch.
 const inFlight = new Map<string, Promise<unknown>>();
 
 export function useSharedOrgFetch<T>(

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,18 +1,36 @@
-import i18next from "i18next";
+import i18next, { type BackendModule, type ReadCallback } from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
-import de from "./locales/de.json";
-import en from "./locales/en.json";
+type LocaleModule = typeof import("./locales/en.json");
+
+// Dynamic imports so each language's translation JSON is its own chunk,
+// fetched only for the language actually in use instead of both upfront.
+const localeLoaders: Record<string, () => Promise<LocaleModule>> = {
+	de: () => import("./locales/de.json"),
+	en: () => import("./locales/en.json"),
+};
+
+const lazyBackend: BackendModule = {
+	type: "backend",
+	init: () => {},
+	read: (language, _namespace, callback: ReadCallback) => {
+		const loadLocale = localeLoaders[language];
+		if (!loadLocale) {
+			callback(new Error(`Unsupported language: ${language}`), null);
+			return;
+		}
+		loadLocale()
+			.then((module) => callback(null, module.translation))
+			.catch((error: unknown) => callback(error as Error, null));
+	},
+};
 
 void i18next
+	.use(lazyBackend)
 	.use(LanguageDetector)
 	.use(initReactI18next)
 	.init({
-		resources: {
-			de: { translation: de.translation },
-			en: { translation: en.translation },
-		},
 		fallbackLng: "en",
 		supportedLngs: ["de", "en"],
 		detection: {

--- a/frontend/src/lib/activeOrg.test.ts
+++ b/frontend/src/lib/activeOrg.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { OrganizationSummaryDto } from "../client/api-client";
+import {
+	getActiveOrgId,
+	setActiveOrgId,
+	resolveActiveOrg,
+	resolveOrgAppPath,
+} from "./activeOrg";
+
+function clearCookies(): void {
+	document.cookie.split(";").forEach((cookie) => {
+		const name = cookie.split("=")[0].trim();
+		if (name) {
+			document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+		}
+	});
+}
+
+function org(id: string, name: string): OrganizationSummaryDto {
+	return { id, name, logoUrl: undefined };
+}
+
+describe("getActiveOrgId / setActiveOrgId", () => {
+	beforeEach(() => {
+		clearCookies();
+	});
+
+	it("returns null when no cookie is set", () => {
+		expect(getActiveOrgId()).toBeNull();
+	});
+
+	it("round-trips an id through set then get", () => {
+		setActiveOrgId("org-123");
+		expect(getActiveOrgId()).toBe("org-123");
+	});
+
+	it("URL-decodes the stored value", () => {
+		setActiveOrgId("org with spaces");
+		expect(getActiveOrgId()).toBe("org with spaces");
+	});
+
+	it("finds the cookie among unrelated cookies", () => {
+		document.cookie = "foo=bar";
+		setActiveOrgId("org-456");
+		document.cookie = "baz=qux";
+		expect(getActiveOrgId()).toBe("org-456");
+	});
+});
+
+describe("resolveActiveOrg", () => {
+	it("returns null when there are no organizations", () => {
+		expect(resolveActiveOrg([], "any-id")).toBeNull();
+	});
+
+	it("returns the only organization when there is exactly one", () => {
+		const only = org("1", "Only Org");
+		expect(resolveActiveOrg([only], "does-not-match")).toBe(only);
+	});
+
+	it("returns the org matching activeOrgId when present", () => {
+		const a = org("a", "Alpha");
+		const b = org("b", "Beta");
+		expect(resolveActiveOrg([a, b], "b")).toBe(b);
+	});
+
+	it("falls back to alphabetically-first by name when activeOrgId is null", () => {
+		const zeta = org("z", "Zeta");
+		const alpha = org("a", "Alpha");
+		expect(resolveActiveOrg([zeta, alpha], null)).toBe(alpha);
+	});
+
+	it("falls back to alphabetically-first by name when activeOrgId matches nothing", () => {
+		const zeta = org("z", "Zeta");
+		const alpha = org("a", "Alpha");
+		expect(resolveActiveOrg([zeta, alpha], "missing-id")).toBe(alpha);
+	});
+
+	it("does not mutate the input array while sorting the fallback", () => {
+		const zeta = org("z", "Zeta");
+		const alpha = org("a", "Alpha");
+		const orgs = [zeta, alpha];
+		resolveActiveOrg(orgs, null);
+		expect(orgs).toEqual([zeta, alpha]);
+	});
+});
+
+describe("resolveOrgAppPath", () => {
+	it("returns null when there are no organizations", () => {
+		expect(resolveOrgAppPath([], null)).toBeNull();
+	});
+
+	it("builds the dashboard path for the resolved organization", () => {
+		const only = org("org-1", "Only Org");
+		expect(resolveOrgAppPath([only], null)).toBe("/app/org-1/dashboard");
+	});
+
+	it("uses the activeOrgId match over alphabetical fallback", () => {
+		const a = org("a", "Alpha");
+		const b = org("b", "Beta");
+		expect(resolveOrgAppPath([a, b], "b")).toBe("/app/b/dashboard");
+	});
+});

--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { existsMock, tMock } = vi.hoisted(() => ({
+	existsMock: vi.fn(),
+	tMock: vi.fn(),
+}));
+
+vi.mock("../i18n", () => ({
+	default: {
+		exists: existsMock,
+		t: tMock,
+	},
+}));
+
+import { getApiErrorMessage, isApiNotFoundError } from "./apiError";
+
+describe("getApiErrorMessage", () => {
+	beforeEach(() => {
+		existsMock.mockReset();
+		tMock.mockReset();
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns the fallback for a non-object error", () => {
+		expect(getApiErrorMessage("boom", "fallback text")).toBe("fallback text");
+	});
+
+	it("returns the fallback for null", () => {
+		expect(getApiErrorMessage(null, "fallback text")).toBe("fallback text");
+	});
+
+	it("returns the fallback when errorCode has no matching translation", () => {
+		existsMock.mockReturnValue(false);
+		const message = getApiErrorMessage(
+			{ errorCode: "Unmapped.Code" },
+			"fallback text",
+		);
+		expect(message).toBe("fallback text");
+		expect(existsMock).toHaveBeenCalledWith("apiError.Unmapped.Code");
+	});
+
+	it("returns the translated message when errorCode has a matching key", () => {
+		existsMock.mockReturnValue(true);
+		tMock.mockReturnValue("Localized message");
+		const message = getApiErrorMessage(
+			{ errorCode: "Org.NotFound" },
+			"fallback text",
+		);
+		expect(message).toBe("Localized message");
+		expect(tMock).toHaveBeenCalledWith("apiError.Org.NotFound");
+	});
+
+	it("returns the fallback when errorCode is an empty string", () => {
+		const message = getApiErrorMessage({ errorCode: "   " }, "fallback text");
+		expect(message).toBe("fallback text");
+		expect(existsMock).not.toHaveBeenCalled();
+	});
+
+	it("returns the fallback when there is no errorCode at all (e.g. network failure)", () => {
+		const message = getApiErrorMessage({}, "fallback text");
+		expect(message).toBe("fallback text");
+	});
+
+	it("logs a non-empty detail without exposing it in the returned message", () => {
+		existsMock.mockReturnValue(false);
+		const message = getApiErrorMessage(
+			{ detail: "Internal SQL error at line 42" },
+			"fallback text",
+		);
+		expect(message).toBe("fallback text");
+		expect(console.error).toHaveBeenCalledWith(
+			"[API] error detail (not shown to user):",
+			"Internal SQL error at line 42",
+		);
+	});
+
+	it("does not log when detail is only whitespace", () => {
+		getApiErrorMessage({ detail: "   " }, "fallback text");
+		expect(console.error).not.toHaveBeenCalled();
+	});
+});
+
+describe("isApiNotFoundError", () => {
+	it("returns true when status is 404", () => {
+		expect(isApiNotFoundError({ status: 404 })).toBe(true);
+	});
+
+	it("returns false when status is a different code", () => {
+		expect(isApiNotFoundError({ status: 500 })).toBe(false);
+	});
+
+	it("returns false when status is missing", () => {
+		expect(isApiNotFoundError({})).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isApiNotFoundError(null)).toBe(false);
+	});
+
+	it("returns false for a non-object value", () => {
+		expect(isApiNotFoundError("404")).toBe(false);
+	});
+});

--- a/frontend/src/lib/authLocale.test.ts
+++ b/frontend/src/lib/authLocale.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+
+const i18nMock = vi.hoisted(() => ({ language: "en" }));
+
+vi.mock("../i18n", () => ({
+	default: i18nMock,
+}));
+
+import { signinLocaleArgs } from "./authLocale";
+
+describe("signinLocaleArgs", () => {
+	it("reflects the current i18next language", () => {
+		i18nMock.language = "en";
+		expect(signinLocaleArgs()).toEqual({ ui_locales: "en" });
+	});
+
+	it("picks up a language change", () => {
+		i18nMock.language = "de";
+		expect(signinLocaleArgs()).toEqual({ ui_locales: "de" });
+	});
+});

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { TFunction } from "i18next";
+import {
+	formatOccurrence,
+	formatParticipationType,
+	formatDateTime,
+	formatPostedAgo,
+} from "./format";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function fakeT(): TFunction {
+	return vi.fn((key: string, options?: Record<string, unknown>) =>
+		options ? `${key}:${JSON.stringify(options)}` : key,
+	) as unknown as TFunction;
+}
+
+describe("formatOccurrence", () => {
+	it("translates Recurring", () => {
+		const t = fakeT();
+		expect(formatOccurrence("Recurring", t)).toBe("opportunities.recurring");
+	});
+
+	it("translates anything else as one-time", () => {
+		const t = fakeT();
+		expect(formatOccurrence("OneTime", t)).toBe("opportunities.oneTime");
+	});
+});
+
+describe("formatParticipationType", () => {
+	it("translates Waitlist", () => {
+		const t = fakeT();
+		expect(formatParticipationType("Waitlist", t)).toBe(
+			"opportunities.waitlist",
+		);
+	});
+
+	it("translates anything else as individual contact", () => {
+		const t = fakeT();
+		expect(formatParticipationType("DirectContact", t)).toBe(
+			"opportunities.individualContact",
+		);
+	});
+});
+
+describe("formatDateTime", () => {
+	// Compares against the identical Intl call rather than a hardcoded string
+	// so the assertion doesn't depend on the host's local timezone offset.
+	it("formats using en-GB style by default", () => {
+		const iso = "2024-03-15T14:30:00Z";
+		const expected = new Date(iso).toLocaleString("en-GB", {
+			dateStyle: "medium",
+			timeStyle: "short",
+		});
+		expect(formatDateTime(iso)).toBe(expected);
+	});
+
+	it("formats using de-DE style when locale is de", () => {
+		const iso = "2024-03-15T14:30:00Z";
+		const expected = new Date(iso).toLocaleString("de-DE", {
+			dateStyle: "medium",
+			timeStyle: "short",
+		});
+		expect(formatDateTime(iso, "de")).toBe(expected);
+	});
+
+	it("produces a different format for de than for en", () => {
+		const iso = "2024-03-15T14:30:00Z";
+		expect(formatDateTime(iso, "de")).not.toBe(formatDateTime(iso, "en"));
+	});
+});
+
+describe("formatPostedAgo", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports posted today when the date is exactly now", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		const t = fakeT();
+		expect(formatPostedAgo(now.toISOString(), t)).toBe(
+			"opportunities.postedToday",
+		);
+	});
+
+	it("reports the number of days for a date exactly 3 days in the past", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		const threeDaysAgo = new Date(now.getTime() - 3 * DAY_MS);
+		const t = fakeT();
+		expect(formatPostedAgo(threeDaysAgo.toISOString(), t)).toBe(
+			'opportunities.postedDaysAgo:{"count":3}',
+		);
+	});
+
+	it("treats a future date as posted today rather than a negative count", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		const future = new Date(now.getTime() + 5 * DAY_MS);
+		const t = fakeT();
+		expect(formatPostedAgo(future.toISOString(), t)).toBe(
+			"opportunities.postedToday",
+		);
+	});
+});

--- a/frontend/src/lib/keycloakRegistration.test.ts
+++ b/frontend/src/lib/keycloakRegistration.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { UserManagerMock, WebStorageStateStoreMock, signinRedirectMock } =
+	vi.hoisted(() => {
+		const signinRedirectMock = vi.fn().mockResolvedValue(undefined);
+		const UserManagerMock = vi.fn().mockImplementation(function (
+			options: unknown,
+		) {
+			return { signinRedirect: signinRedirectMock, options };
+		});
+		const WebStorageStateStoreMock = vi.fn().mockImplementation(function (
+			options: unknown,
+		) {
+			return { options };
+		});
+		return { UserManagerMock, WebStorageStateStoreMock, signinRedirectMock };
+	});
+
+vi.mock("oidc-client-ts", () => ({
+	UserManager: UserManagerMock,
+	WebStorageStateStore: WebStorageStateStoreMock,
+}));
+
+vi.mock("./runtimeConfig", () => ({
+	runtimeConfig: {
+		keycloakAuthorityUrl: "https://keycloak.example/realms/einsatzbereit",
+		keycloakClientId: "frontend",
+		apiUrl: "https://api.example",
+	},
+}));
+
+describe("signinRedirectForRegistration", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		UserManagerMock.mockClear();
+		WebStorageStateStoreMock.mockClear();
+		signinRedirectMock.mockClear();
+	});
+
+	it("points the UserManager's authorization_endpoint at the registrations endpoint", async () => {
+		const { signinRedirectForRegistration } =
+			await import("./keycloakRegistration");
+		await signinRedirectForRegistration();
+
+		expect(UserManagerMock).toHaveBeenCalledTimes(1);
+		const options = UserManagerMock.mock.calls[0][0] as {
+			authority: string;
+			client_id: string;
+			scope: string;
+			redirect_uri: string;
+			metadataSeed: { authorization_endpoint: string };
+		};
+		expect(options.authority).toBe(
+			"https://keycloak.example/realms/einsatzbereit",
+		);
+		expect(options.client_id).toBe("frontend");
+		expect(options.scope).toBe("openid profile email");
+		expect(options.redirect_uri).toBe(`${window.location.origin}/callback`);
+		expect(options.metadataSeed.authorization_endpoint).toBe(
+			"https://keycloak.example/realms/einsatzbereit/protocol/openid-connect/registrations",
+		);
+	});
+
+	it("reuses the same UserManager instance across repeated calls", async () => {
+		const { signinRedirectForRegistration } =
+			await import("./keycloakRegistration");
+		await signinRedirectForRegistration();
+		await signinRedirectForRegistration();
+
+		expect(UserManagerMock).toHaveBeenCalledTimes(1);
+		expect(signinRedirectMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("forwards the extra signin args to signinRedirect", async () => {
+		const { signinRedirectForRegistration } =
+			await import("./keycloakRegistration");
+		await signinRedirectForRegistration({ ui_locales: "de" });
+
+		expect(signinRedirectMock).toHaveBeenCalledWith({ ui_locales: "de" });
+	});
+});

--- a/frontend/src/lib/orgTabs.test.ts
+++ b/frontend/src/lib/orgTabs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { ORG_TABS, orgTabPath } from "./orgTabs";
+
+describe("ORG_TABS", () => {
+	it("declares the dashboard, opportunities, settings and members tabs in order", () => {
+		expect(ORG_TABS.map((tab) => tab.key)).toEqual([
+			"dashboard",
+			"opportunities",
+			"settings",
+			"members",
+		]);
+	});
+
+	it("gives every tab a non-empty labelKey", () => {
+		for (const tab of ORG_TABS) {
+			expect(tab.labelKey.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("orgTabPath", () => {
+	it("returns the bare dashboard path for the dashboard tab", () => {
+		expect(orgTabPath("org-1", "dashboard")).toBe("/app/org-1/dashboard");
+	});
+
+	it("nests every other tab under /dashboard/", () => {
+		expect(orgTabPath("org-1", "members")).toBe("/app/org-1/dashboard/members");
+		expect(orgTabPath("org-1", "opportunities")).toBe(
+			"/app/org-1/dashboard/opportunities",
+		);
+		expect(orgTabPath("org-1", "settings")).toBe(
+			"/app/org-1/dashboard/settings",
+		);
+	});
+});

--- a/frontend/src/lib/organizationFormSchema.test.ts
+++ b/frontend/src/lib/organizationFormSchema.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import type { TFunction } from "i18next";
+import {
+	buildOrganizationFormSchema,
+	ORGANIZATION_FORM_DEFAULT_VALUES,
+	type OrganizationFormValues,
+} from "./organizationFormSchema";
+
+const fakeT = ((key: string) => key) as TFunction;
+
+function issuePaths(result: {
+	success: boolean;
+	error?: { issues: { path: PropertyKey[] }[] };
+}): string[] {
+	return (result.error?.issues ?? []).map((issue) => String(issue.path[0]));
+}
+
+function values(
+	overrides: Partial<OrganizationFormValues>,
+): OrganizationFormValues {
+	return { ...ORGANIZATION_FORM_DEFAULT_VALUES, ...overrides };
+}
+
+describe("buildOrganizationFormSchema", () => {
+	const schema = buildOrganizationFormSchema(fakeT);
+
+	it("rejects the untouched default values because name is required", () => {
+		const result = schema.safeParse(ORGANIZATION_FORM_DEFAULT_VALUES);
+		expect(result.success).toBe(false);
+		expect(issuePaths(result)).toEqual(["name"]);
+	});
+
+	it("accepts a name with no address at all", () => {
+		const result = schema.safeParse(values({ name: "Rotes Kreuz" }));
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a name that is only whitespace", () => {
+		const result = schema.safeParse(values({ name: "   " }));
+		expect(result.success).toBe(false);
+		expect(issuePaths(result)).toContain("name");
+	});
+
+	it("requires every address field once any one of them is filled in", () => {
+		const result = schema.safeParse(
+			values({ name: "Org", street: "Hauptstrasse" }),
+		);
+		expect(result.success).toBe(false);
+		expect(issuePaths(result).sort()).toEqual(
+			["city", "houseNumber", "zipCode"].sort(),
+		);
+	});
+
+	it("accepts a fully specified address", () => {
+		const result = schema.safeParse(
+			values({
+				name: "Org",
+				street: "Hauptstrasse",
+				houseNumber: "12",
+				zipCode: "12345",
+				city: "Berlin",
+			}),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a zip code that is not exactly 5 digits long", () => {
+		const result = schema.safeParse(
+			values({
+				name: "Org",
+				street: "Hauptstrasse",
+				houseNumber: "12",
+				zipCode: "123",
+				city: "Berlin",
+			}),
+		);
+		expect(result.success).toBe(false);
+		const zipIssue = result.error?.issues.find(
+			(issue) => issue.path[0] === "zipCode",
+		);
+		expect(zipIssue?.message).toBe("orgSettings.zipInvalid");
+	});
+
+	it("reports zip code as missing (not invalid) when left blank alongside the rest of the address", () => {
+		const result = schema.safeParse(
+			values({
+				name: "Org",
+				street: "Hauptstrasse",
+				houseNumber: "12",
+				zipCode: "",
+				city: "Berlin",
+			}),
+		);
+		expect(result.success).toBe(false);
+		const zipIssue = result.error?.issues.find(
+			(issue) => issue.path[0] === "zipCode",
+		);
+		expect(zipIssue?.message).toBe("orgSettings.fieldRequired");
+	});
+
+	it("rejects a name longer than 100 characters", () => {
+		const result = schema.safeParse(values({ name: "a".repeat(101) }));
+		expect(result.success).toBe(false);
+		expect(issuePaths(result)).toContain("name");
+	});
+
+	it("trims whitespace-only address fields the same as empty ones", () => {
+		const result = schema.safeParse(
+			values({
+				name: "Org",
+				street: "   ",
+				houseNumber: "",
+				zipCode: "",
+				city: "",
+			}),
+		);
+		expect(result.success).toBe(true);
+	});
+});
+
+describe("ORGANIZATION_FORM_DEFAULT_VALUES", () => {
+	it("defaults every field to an empty string", () => {
+		expect(
+			Object.values(ORGANIZATION_FORM_DEFAULT_VALUES).every((v) => v === ""),
+		).toBe(true);
+	});
+});

--- a/frontend/src/lib/runtimeConfig.test.ts
+++ b/frontend/src/lib/runtimeConfig.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("runtimeConfig", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		delete window.__APP_CONFIG__;
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		delete window.__APP_CONFIG__;
+	});
+
+	it("uses the build-time env var when no runtime config is injected", async () => {
+		vi.stubEnv("VITE_API_URL", "https://build-time.example");
+		const { runtimeConfig } = await import("./runtimeConfig");
+		expect(runtimeConfig.apiUrl).toBe("https://build-time.example");
+	});
+
+	it("prefers window.__APP_CONFIG__ once it has been substituted by the container", async () => {
+		vi.stubEnv("VITE_API_URL", "https://build-time.example");
+		window.__APP_CONFIG__ = { API_URL: "https://runtime.example" };
+		const { runtimeConfig } = await import("./runtimeConfig");
+		expect(runtimeConfig.apiUrl).toBe("https://runtime.example");
+	});
+
+	it("falls back to the build-time value when the runtime placeholder was never substituted", async () => {
+		vi.stubEnv("VITE_API_URL", "https://build-time.example");
+		window.__APP_CONFIG__ = { API_URL: "${VITE_API_URL}" };
+		const { runtimeConfig } = await import("./runtimeConfig");
+		expect(runtimeConfig.apiUrl).toBe("https://build-time.example");
+	});
+
+	it("resolves the keycloak authority url, client id and api url independently", async () => {
+		vi.stubEnv("VITE_KEYCLOAK_AUTHORITY_URL", "https://keycloak.example");
+		vi.stubEnv("VITE_KEYCLOAK_CLIENT_ID", "frontend");
+		vi.stubEnv("VITE_API_URL", "https://api.example");
+		window.__APP_CONFIG__ = { API_URL: "https://runtime.example" };
+
+		const { runtimeConfig } = await import("./runtimeConfig");
+
+		expect(runtimeConfig.keycloakAuthorityUrl).toBe("https://keycloak.example");
+		expect(runtimeConfig.keycloakClientId).toBe("frontend");
+		expect(runtimeConfig.apiUrl).toBe("https://runtime.example");
+	});
+});

--- a/frontend/src/lib/sessionExpiryBus.test.ts
+++ b/frontend/src/lib/sessionExpiryBus.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+	subscribeSessionExpired,
+	notifySessionExpired,
+} from "./sessionExpiryBus";
+
+describe("sessionExpiryBus", () => {
+	it("does not throw when notifying with no listeners", () => {
+		expect(() => notifySessionExpired()).not.toThrow();
+	});
+
+	it("calls a subscribed listener when notified", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeSessionExpired(listener);
+		notifySessionExpired();
+		expect(listener).toHaveBeenCalledTimes(1);
+		unsubscribe();
+	});
+
+	it("calls every subscribed listener", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const unsubscribeFirst = subscribeSessionExpired(first);
+		const unsubscribeSecond = subscribeSessionExpired(second);
+		notifySessionExpired();
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+		unsubscribeFirst();
+		unsubscribeSecond();
+	});
+
+	it("stops calling a listener after it unsubscribes", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeSessionExpired(listener);
+		unsubscribe();
+		notifySessionExpired();
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("leaves other listeners intact when one unsubscribes", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const unsubscribeFirst = subscribeSessionExpired(first);
+		const unsubscribeSecond = subscribeSessionExpired(second);
+		unsubscribeFirst();
+		notifySessionExpired();
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledTimes(1);
+		unsubscribeSecond();
+	});
+
+	it("is safe to call unsubscribe more than once", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeSessionExpired(listener);
+		unsubscribe();
+		expect(() => unsubscribe()).not.toThrow();
+		notifySessionExpired();
+		expect(listener).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/toastBus.test.ts
+++ b/frontend/src/lib/toastBus.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { subscribeToasts, dispatchToast, type ToastEvent } from "./toastBus";
+
+describe("toastBus", () => {
+	it("does not throw when dispatching with no listeners", () => {
+		expect(() => dispatchToast("info", "hello")).not.toThrow();
+	});
+
+	it("delivers the level and message to a subscribed listener", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeToasts(listener);
+		dispatchToast("error", "Something failed");
+		expect(listener).toHaveBeenCalledTimes(1);
+		const event = listener.mock.calls[0][0] as ToastEvent;
+		expect(event.level).toBe("error");
+		expect(event.message).toBe("Something failed");
+		expect(typeof event.id).toBe("string");
+		expect(event.id.length).toBeGreaterThan(0);
+		unsubscribe();
+	});
+
+	it("assigns a distinct id per dispatched toast", () => {
+		const seen: string[] = [];
+		const unsubscribe = subscribeToasts((event) => seen.push(event.id));
+		dispatchToast("success", "first");
+		dispatchToast("success", "second");
+		expect(seen[0]).not.toBe(seen[1]);
+		unsubscribe();
+	});
+
+	it("notifies every subscribed listener", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const unsubscribeFirst = subscribeToasts(first);
+		const unsubscribeSecond = subscribeToasts(second);
+		dispatchToast("warning", "careful");
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+		unsubscribeFirst();
+		unsubscribeSecond();
+	});
+
+	it("stops notifying a listener after it unsubscribes", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeToasts(listener);
+		unsubscribe();
+		dispatchToast("info", "ignored");
+		expect(listener).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/volunteerOpportunities.test.ts
+++ b/frontend/src/lib/volunteerOpportunities.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+	EinsatzbereitApi,
+	PagedListOfVolunteerOpportunitySummary,
+} from "../client/api-client";
+import { fetchVolunteerOpportunities } from "./volunteerOpportunities";
+
+function fakeApi(): { getVolunteerOpportunities: ReturnType<typeof vi.fn> } {
+	return {
+		getVolunteerOpportunities: vi
+			.fn()
+			.mockResolvedValue({} as PagedListOfVolunteerOpportunitySummary),
+	};
+}
+
+describe("fetchVolunteerOpportunities", () => {
+	it("forwards required options and leaves the rest undefined", async () => {
+		const api = fakeApi();
+		await fetchVolunteerOpportunities(api as unknown as EinsatzbereitApi, {
+			pageNumber: 1,
+			pageSize: 10,
+		});
+
+		expect(api.getVolunteerOpportunities).toHaveBeenCalledWith(
+			1,
+			10,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+		);
+	});
+
+	it("forwards every option in the positional order the generated client expects", async () => {
+		const api = fakeApi();
+		const dateFrom = new Date("2024-01-01");
+		const dateTo = new Date("2024-02-01");
+		const signal = new AbortController().signal;
+
+		await fetchVolunteerOpportunities(
+			api as unknown as EinsatzbereitApi,
+			{
+				pageNumber: 2,
+				pageSize: 20,
+				city: "Berlin",
+				occurrence: "Recurring",
+				participationType: "Waitlist",
+				isRemote: true,
+				dateFrom,
+				dateTo,
+				north: 1,
+				south: 2,
+				east: 3,
+				west: 4,
+				centerLatitude: 5,
+				centerLongitude: 6,
+				radiusKm: 7,
+				categories: ["environment"],
+				tag: "cleanup",
+			},
+			signal,
+		);
+
+		expect(api.getVolunteerOpportunities).toHaveBeenCalledWith(
+			2,
+			20,
+			"Berlin",
+			"Recurring",
+			"Waitlist",
+			true,
+			dateFrom,
+			dateTo,
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			["environment"],
+			"cleanup",
+			signal,
+		);
+	});
+
+	it("returns whatever the underlying API call resolves with", async () => {
+		const api = fakeApi();
+		const page = {
+			items: [],
+			totalCount: 0,
+		} as unknown as PagedListOfVolunteerOpportunitySummary;
+		api.getVolunteerOpportunities.mockResolvedValue(page);
+
+		const result = await fetchVolunteerOpportunities(
+			api as unknown as EinsatzbereitApi,
+			{ pageNumber: 1, pageSize: 10 },
+		);
+
+		expect(result).toBe(page);
+	});
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,5 @@
 import i18n from "./i18n";
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
 import { WebStorageStateStore, type User } from "oidc-client-ts";
@@ -32,13 +32,15 @@ const oidcConfig = {
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>
 		<ErrorBoundary>
-			<ToastProvider>
-				<AuthProvider {...oidcConfig}>
-					<BrowserRouter>
-						<App />
-					</BrowserRouter>
-				</AuthProvider>
-			</ToastProvider>
+			<Suspense fallback={null}>
+				<ToastProvider>
+					<AuthProvider {...oidcConfig}>
+						<BrowserRouter>
+							<App />
+						</BrowserRouter>
+					</AuthProvider>
+				</ToastProvider>
+			</Suspense>
 		</ErrorBoundary>
 	</React.StrictMode>,
 );

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import CreateOrganizationModal from "../components/CreateOrganizationModal";
 import Button from "../components/Button";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { useSharedOrgFetch } from "../hooks/useSharedOrgFetch";
 import { signinLocaleArgs } from "../lib/authLocale";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
 import { getActiveOrgId, resolveOrgAppPath } from "../lib/activeOrg";
@@ -86,28 +87,15 @@ export default function HomePage() {
 	const orgsTeaserTitleId = useId();
 
 	const [showCreateOrgModal, setShowCreateOrgModal] = useState(false);
-	const [orgs, setOrgs] = useState<OrganizationSummaryDto[]>([]);
 	const [searchParams, setSearchParams] = useSearchParams();
 
-	useEffect(() => {
-		if (!auth.isAuthenticated) {
-			setOrgs([]);
-			return;
-		}
-		let cancelled = false;
-		api
-			.getOrganizations()
-			.then((data) => {
-				if (!cancelled) setOrgs(data);
-			})
-			.catch(() => {
-				if (!cancelled) setOrgs([]);
-			});
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [auth.isAuthenticated]);
+	// Shared with Header, which independently needs the same top-level
+	// organization list on the same mount (#1396) - see useSharedOrgFetch.
+	const [orgsData] = useSharedOrgFetch<OrganizationSummaryDto[]>(
+		`organizations:${auth.isAuthenticated}`,
+		() => (auth.isAuthenticated ? api.getOrganizations() : Promise.resolve([])),
+	);
+	const orgs = auth.isAuthenticated ? (orgsData ?? []) : [];
 
 	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
 

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
@@ -65,6 +65,29 @@ function CalEventChip({ event }: { event: object }) {
 	);
 }
 
+// Neither depends on component state/props, so both are declared once at
+// module scope - passing fresh object/function literals as Calendar props
+// on every render defeats react-big-calendar's own internal memoization
+// (see #1397).
+const calendarComponents = { event: CalEventChip };
+
+function calendarEventPropGetter(event: object) {
+	const e = event as CalEvent;
+	const bg = e.color ?? DEFAULT_EVENT_COLOR;
+	return {
+		style: {
+			backgroundColor: bg,
+			borderColor: bg,
+			color: "#ffffff",
+		},
+	};
+}
+
+// The color picker's onChange fires continuously while the user drags across
+// the native picker UI; debouncing avoids re-rendering the whole widget (and
+// its Calendar subtree) on every pointer movement (#1397).
+const COLOR_INPUT_DEBOUNCE_MS = 100;
+
 interface Props {
 	organizationId: string;
 	refreshKey: number;
@@ -104,24 +127,59 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 	const [pickerColor, setPickerColor] = useState(DEFAULT_EVENT_COLOR);
 	const [savingColor, setSavingColor] = useState(false);
 	const [colorSaveError, setColorSaveError] = useState<string | null>(null);
+	const colorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	const calEvents: CalEvent[] = (calData ?? []).flatMap((opp) =>
-		opp.timeSlots.map((slot) => ({
-			id: slot.timeSlotId,
-			title: opp.title,
-			start: new Date(slot.startDateTime),
-			end: new Date(slot.endDateTime),
-			opportunityId: opp.opportunityId,
-			color: opp.color,
-			bookedCount: slot.bookedCount,
-			maxParticipants: slot.maxParticipants,
-		})),
+	useEffect(() => {
+		return () => {
+			if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		};
+	}, []);
+
+	const calEvents: CalEvent[] = useMemo(
+		() =>
+			(calData ?? []).flatMap((opp) =>
+				opp.timeSlots.map((slot) => ({
+					id: slot.timeSlotId,
+					title: opp.title,
+					start: new Date(slot.startDateTime),
+					end: new Date(slot.endDateTime),
+					opportunityId: opp.opportunityId,
+					color: opp.color,
+					bookedCount: slot.bookedCount,
+					maxParticipants: slot.maxParticipants,
+				})),
+			),
+		[calData],
 	);
 
-	function handleSelectEvent(event: CalEvent) {
-		setSelectedEvent(event);
-		setPickerColor(event.color ?? DEFAULT_EVENT_COLOR);
+	const calendarMessages = useMemo(
+		() => ({
+			today: t("orgOverview.calendarToday"),
+			previous: t("orgOverview.calendarBack"),
+			next: t("orgOverview.calendarNext"),
+			month: t("orgOverview.calendarMonth"),
+			week: t("orgOverview.calendarWeek"),
+			work_week: t("orgOverview.calendarWorkWeek"),
+			day: t("orgOverview.calendarDay"),
+			agenda: t("orgOverview.calendarAgenda"),
+			noEventsInRange: t("orgOverview.calendarNoEvents"),
+		}),
+		[t],
+	);
+
+	const handleSelectEvent = useCallback((event: object) => {
+		const e = event as CalEvent;
+		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		setSelectedEvent(e);
+		setPickerColor(e.color ?? DEFAULT_EVENT_COLOR);
 		setColorSaveError(null);
+	}, []);
+
+	function handleColorPickerChange(value: string) {
+		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
+		colorDebounceRef.current = setTimeout(() => {
+			setPickerColor(value);
+		}, COLOR_INPUT_DEBOUNCE_MS);
 	}
 
 	async function handleColorSave() {
@@ -174,32 +232,10 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 						onNavigate={(d: Date) => setCalDate(d)}
 						views={["month", "week", "work_week", "day", "agenda"]}
 						style={{ height: "100%", minHeight: CALENDAR_MIN_HEIGHT_PX }}
-						components={{ event: CalEventChip }}
-						eventPropGetter={(event: object) => {
-							const e = event as CalEvent;
-							const bg = e.color ?? DEFAULT_EVENT_COLOR;
-							return {
-								style: {
-									backgroundColor: bg,
-									borderColor: bg,
-									color: "#ffffff",
-								},
-							};
-						}}
-						onSelectEvent={(event: object) =>
-							handleSelectEvent(event as CalEvent)
-						}
-						messages={{
-							today: t("orgOverview.calendarToday"),
-							previous: t("orgOverview.calendarBack"),
-							next: t("orgOverview.calendarNext"),
-							month: t("orgOverview.calendarMonth"),
-							week: t("orgOverview.calendarWeek"),
-							work_week: t("orgOverview.calendarWorkWeek"),
-							day: t("orgOverview.calendarDay"),
-							agenda: t("orgOverview.calendarAgenda"),
-							noEventsInRange: t("orgOverview.calendarNoEvents"),
-						}}
+						components={calendarComponents}
+						eventPropGetter={calendarEventPropGetter}
+						onSelectEvent={handleSelectEvent}
+						messages={calendarMessages}
 					/>
 				</div>
 			)}
@@ -238,7 +274,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 									id="event-color-picker"
 									type="color"
 									value={pickerColor}
-									onChange={(e) => setPickerColor(e.target.value)}
+									onChange={(e) => handleColorPickerChange(e.target.value)}
 									className="h-9 w-16 cursor-pointer rounded border border-gray-300"
 								/>
 								<span className="text-sm text-gray-500">{pickerColor}</span>

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -13,7 +13,7 @@ import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 // The *default* view a fresh mount opens on - a narrow tile can't usefully

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -12,7 +12,7 @@ import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 interface Props {

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -9,7 +9,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
-import { useSharedOrgFetch } from "./useSharedOrgFetch";
+import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 const MAX_ITEMS = 5;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "jsdom",
+		coverage: {
+			provider: "v8",
+			include: ["src/lib/**/*.ts"],
+		},
+	},
+});


### PR DESCRIPTION
handleExpiry dispatched the "session has expired" toast and then fired signinRedirect (a real top-level navigation) essentially in the same tick, racing the toast's render against the navigation attempt - in production this meant the toast could vanish before a user ever saw it, and in CI it made SessionExpiryTests.ShowsSessionExpiredToast flaky (the toast occasionally never became visible within the timeout).

Delay the redirect by 2s so the toast reliably renders first.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
