### PR TITLE
fix: reject invalid enum filter values in GetVolunteerOpportunities

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
@@ -3,6 +3,7 @@ using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
+using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.VolunteerOpportunities.GetVolunteerOpportunities.v1;
@@ -47,6 +48,30 @@ internal sealed class GetVolunteerOpportunitiesEndpoint
 
 		if (request.RadiusKm is <= 0)
 			return Results.Problem("RadiusKm must be greater than zero.", statusCode: StatusCodes.Status400BadRequest);
+
+		if (!string.IsNullOrWhiteSpace(request.Occurrence)
+			&& (!Enum.TryParse<Occurrence>(request.Occurrence, ignoreCase: true, out var occurrence) || !Enum.IsDefined(occurrence)))
+		{
+			return Results.Problem(
+				"Invalid occurrence. Allowed values: OneTime, Recurring.",
+				statusCode: StatusCodes.Status400BadRequest);
+		}
+
+		if (!string.IsNullOrWhiteSpace(request.ParticipationType)
+			&& (!Enum.TryParse<ParticipationType>(request.ParticipationType, ignoreCase: true, out var participationType) || !Enum.IsDefined(participationType)))
+		{
+			return Results.Problem(
+				"Invalid participation type. Allowed values: Waitlist, IndividualContact.",
+				statusCode: StatusCodes.Status400BadRequest);
+		}
+
+		if (request.Categories is { Length: > 0 }
+			&& request.Categories.Any(c => !Enum.TryParse<Category>(c, ignoreCase: true, out var category) || !Enum.IsDefined(category)))
+		{
+			return Results.Problem(
+				"Invalid category. Allowed values: Social, Environment, Sport, Education, DisasterRelief, Health, Animals, Culture, Technology, Other.",
+				statusCode: StatusCodes.Status400BadRequest);
+		}
 
 		var query = new GetVolunteerOpportunitiesQuery(
 			request.PageNumber,

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -352,6 +352,92 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(400);
 	}
 
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnBadRequest_WhenOccurrenceIsInvalid(
+		CancellationToken cancellationToken)
+	{
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => sut.GetVolunteerOpportunitiesAsync(
+			1, 10, occurrence: "Bogus", cancellationToken: cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnBadRequest_WhenParticipationTypeIsInvalid(
+		CancellationToken cancellationToken)
+	{
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => sut.GetVolunteerOpportunitiesAsync(
+			1, 10, participationType: "Nonsense", cancellationToken: cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnBadRequest_WhenCategoryIsInvalid(
+		CancellationToken cancellationToken)
+	{
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => sut.GetVolunteerOpportunitiesAsync(
+			1, 10, categories: ["NotACategory"], cancellationToken: cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldFilterByOccurrenceAndParticipationTypeAndCategory_WhenValid(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Matching opportunity",
+			Description = "Description",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "Waitlist",
+			CheckInMethod = "None",
+			Category = "Environment",
+			IsDraft = true,
+		}, cancellationToken);
+
+		await authenticatedClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		await authenticatedClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var matching = await sut.GetVolunteerOpportunitiesAsync(
+			1, 10, occurrence: "onetime", participationType: "waitlist", categories: ["environment"], cancellationToken: cancellationToken);
+		var nonMatching = await sut.GetVolunteerOpportunitiesAsync(
+			1, 10, occurrence: "Recurring", cancellationToken: cancellationToken);
+
+		matching.TotalItems.Should().Be(1);
+		nonMatching.TotalItems.Should().Be(0);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
 	{
 		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");


### PR DESCRIPTION
Occurrence, participationType, and categories query params were silently ignored when given an invalid value, returning unfiltered results instead of a 400. Validate each with Enum.TryParse + Enum.IsDefined before building the query, matching SaveDashboardLayoutCommandHandler's pattern.

Fixes #976

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
