### PR TITLE
fix: vary opportunity card fallback banner by category

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "react-oidc-context";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
 import { formatDateTime, formatOccurrence } from "../../lib/format";
+import { getOpportunityCategoryBannerClassName } from "../../lib/opportunityCategoryTheme";
 import { useApiClient } from "../../hooks/useApiClient";
 import ReportFlagButton from "../ReportFlagButton";
 import { CalendarIcon, CategoryGlyph, GlobeIcon, PinIcon } from "./icons";
@@ -36,7 +37,9 @@ export default function OpportunityListItem({
 			/>
 			<div className="flex flex-col sm:flex-row">
 				{/* Banner image or category banner */}
-				<div className="relative flex h-24 shrink-0 items-center justify-center overflow-hidden bg-gradient-to-br from-brand-500 to-brand-800 sm:h-auto sm:w-36 lg:w-44">
+				<div
+					className={`relative flex h-24 shrink-0 items-center justify-center overflow-hidden sm:h-auto sm:w-36 lg:w-44 ${getOpportunityCategoryBannerClassName(item.category)}`}
+				>
 					{item.bannerImageUrl ? (
 						<img
 							src={item.bannerImageUrl}

--- a/frontend/src/lib/opportunityCategoryTheme.test.ts
+++ b/frontend/src/lib/opportunityCategoryTheme.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	OPPORTUNITY_CATEGORY_BANNER_CLASSES,
+	OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+	getOpportunityCategoryBannerClassName,
+} from "./opportunityCategoryTheme";
+
+describe("getOpportunityCategoryBannerClassName", () => {
+	it("returns the mapped gradient for a known category", () => {
+		expect(getOpportunityCategoryBannerClassName("Environment")).toBe(
+			OPPORTUNITY_CATEGORY_BANNER_CLASSES.Environment,
+		);
+	});
+
+	it("returns a distinct gradient per known category", () => {
+		const classNames = Object.keys(OPPORTUNITY_CATEGORY_BANNER_CLASSES).map(
+			(category) => getOpportunityCategoryBannerClassName(category),
+		);
+		expect(new Set(classNames).size).toBe(classNames.length);
+	});
+
+	it("falls back to the brand gradient for an unrecognized category", () => {
+		expect(getOpportunityCategoryBannerClassName("SomeFutureCategory")).toBe(
+			OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+		);
+	});
+
+	it("falls back to the brand gradient for Other", () => {
+		expect(getOpportunityCategoryBannerClassName("Other")).toBe(
+			OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+		);
+	});
+
+	it("falls back to the brand gradient when category is undefined", () => {
+		expect(getOpportunityCategoryBannerClassName(undefined)).toBe(
+			OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+		);
+	});
+
+	it("falls back to the brand gradient for an empty string", () => {
+		expect(getOpportunityCategoryBannerClassName("")).toBe(
+			OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+		);
+	});
+});

--- a/frontend/src/lib/opportunityCategoryTheme.ts
+++ b/frontend/src/lib/opportunityCategoryTheme.ts
@@ -1,0 +1,28 @@
+// Fallback banner gradient shown on an opportunity card when it has no
+// uploaded banner image, varied by category so a list of fallback cards
+// doesn't read as one undifferentiated block of color (paired with the
+// per-category icon in VolunteerOpportunitiesList/icons.tsx).
+export const OPPORTUNITY_CATEGORY_BANNER_CLASSES: Record<string, string> = {
+	Social: "bg-gradient-to-br from-rose-500 to-rose-800",
+	Environment: "bg-gradient-to-br from-emerald-500 to-emerald-800",
+	Sport: "bg-gradient-to-br from-orange-500 to-orange-800",
+	Education: "bg-gradient-to-br from-sky-500 to-sky-800",
+	DisasterRelief: "bg-gradient-to-br from-red-500 to-red-800",
+	Health: "bg-gradient-to-br from-pink-500 to-pink-800",
+	Animals: "bg-gradient-to-br from-amber-500 to-amber-800",
+	Culture: "bg-gradient-to-br from-violet-500 to-violet-800",
+	Technology: "bg-gradient-to-br from-indigo-500 to-indigo-800",
+};
+
+export const OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS =
+	"bg-gradient-to-br from-brand-500 to-brand-800";
+
+export function getOpportunityCategoryBannerClassName(
+	category: string | undefined,
+): string {
+	if (!category) return OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS;
+	return (
+		OPPORTUNITY_CATEGORY_BANNER_CLASSES[category] ??
+		OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS
+	);
+}


### PR DESCRIPTION
Cards without a banner image all rendered the same brand-green gradient, so a list read as one undifferentiated block of color. Give each category its own gradient hue, falling back to the brand gradient for Other/unmapped categories.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #978 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
