### PR TITLE
fix: use primary Button for anonymous sign-in CTA on opportunity detail page

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -208,6 +208,40 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task DetailPage_AnonymousVisitor_SeesPrimarySignInButton()
+	{
+		// Regression for #979: the anonymous sign-up CTA used to be an
+		// underlined text link inside a grey notice, with less visual weight
+		// than the Share button beside the title. It must now use the shared
+		// primary Button component (solid brand background), matching the
+		// prominence of the signed-in sign-up CTA below it.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
+
+		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
+		if (await firstCard.CountAsync() == 0)
+			return; // no opportunities seeded, skip
+
+		var href = await firstCard.GetAttributeAsync("href");
+		if (href is null)
+			return;
+
+		await Page.GotoAsync($"{origin}{href}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var signInBtn = Page.GetByTestId("opportunity-signin");
+		await Expect(signInBtn).ToBeVisibleAsync();
+		await Expect(signInBtn).ToHaveTextAsync("Sign in");
+
+		var className = await signInBtn.GetAttributeAsync("class");
+		className.Should().Contain("bg-brand-700",
+			"the CTA must use the shared primary Button styling, not a bare underlined text link");
+	}
+
+	[Test]
 	public async Task DetailPage_ContentIsCenteredWithinMain()
 	{
 		// Regression for #694: the content wrapper (`max-w-2xl`) had no

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -170,7 +170,7 @@
       "publish": "Veröffentlichen",
       "publishing": "Wird veröffentlicht…",
       "publishSuccess": "Bedarf veröffentlicht.",
-      "loginToApply": "Bitte <loginLink>melde dich an</loginLink>, um dich für diesen Einsatz anzumelden.",
+      "loginPrompt": "Melde dich an, um dich für diesen Einsatz anzumelden.",
       "yourApplication": "Deine Bewerbung",
       "aboutOrganization": "Über diese Organisation",
       "moreFromOrganization": "Weitere Angebote dieser Organisation",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -170,7 +170,7 @@
       "publish": "Publish",
       "publishing": "Publishing…",
       "publishSuccess": "Opportunity published.",
-      "loginToApply": "Please <loginLink>sign in</loginLink> to sign up for this opportunity.",
+      "loginPrompt": "Sign in to sign up for this opportunity.",
       "yourApplication": "Your application",
       "aboutOrganization": "About this organization",
       "moreFromOrganization": "More from this organization",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useParams, Link } from "react-router";
 import { useAuth } from "react-oidc-context";
-import { useTranslation, Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import type {
 	PublicOrganizationProfileResponse,
 	VolunteerOpportunityDetails,
@@ -521,19 +521,19 @@ export default function VolunteerOpportunityDetailPage() {
 
 			{/* Login prompt */}
 			{!isAuthenticated && !isDraft && (
-				<p className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3 text-sm text-gray-500">
-					<Trans
-						i18nKey="opportunities.loginToApply"
-						components={{
-							loginLink: (
-								<button
-									onClick={() => auth.signinRedirect(signinLocaleArgs())}
-									className="underline hover:text-gray-800"
-								/>
-							),
-						}}
-					/>
-				</p>
+				<div className="space-y-3">
+					<p className="text-sm text-gray-600">
+						{t("opportunities.loginPrompt")}
+					</p>
+					<Button
+						onClick={() => auth.signinRedirect(signinLocaleArgs())}
+						data-testid="opportunity-signin"
+						fullWidth
+						size="lg"
+					>
+						{t("nav.signIn")}
+					</Button>
+				</div>
 			)}
 
 			{/* About this organization */}


### PR DESCRIPTION
Replace the underlined text link inside a grey notice with the shared Button component, matching the visual weight already given to the signed-in sign-up CTA and outweighing the secondary Share button.

Closes #979

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
