### PR TITLE
fix: render org app page title as h1, escalate axe heading/landmark gate

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -10,10 +10,33 @@ namespace VisualTests;
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
+	// #973: axe reports the "page has no h1" defect (page-has-heading-one) and
+	// most landmark-structure defects at "moderate" impact, not "serious" or
+	// "critical" - the plain serious/critical filter below let all four org app
+	// pages ship with no h1 for months without CI ever seeing it. Escalate just
+	// these rule IDs to CI-blocking rather than every moderate violation, which
+	// would also flag things like color-contrast-enhanced noise unrelated to
+	// this gate's purpose.
+	private static readonly string[] EscalatedModerateRuleIds =
+	[
+		"page-has-heading-one",
+		"heading-order",
+		"landmark-one-main",
+		"landmark-banner-is-top-level",
+		"landmark-complementary-is-top-level",
+		"landmark-contentinfo-is-top-level",
+		"landmark-main-is-top-level",
+		"landmark-no-duplicate-banner",
+		"landmark-no-duplicate-contentinfo",
+		"landmark-no-duplicate-main",
+		"landmark-unique",
+	];
+
 	private static void AssertNoViolations(AxeResult result)
 	{
 		var violations = result.Violations
-			.Where(v => v.Impact is "serious" or "critical")
+			.Where(v => v.Impact is "serious" or "critical"
+				|| (v.Impact is "moderate" && EscalatedModerateRuleIds.Contains(v.Id)))
 			.ToList();
 
 		if (violations.Count == 0)
@@ -23,7 +46,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 			$"[{v.Impact}] {v.Id}: {v.Description}\n" +
 			string.Join("\n", v.Nodes.Select(n => $"  - {n.Html}"))));
 
-		throw new Exception($"Axe found {violations.Count} serious/critical a11y violation(s):\n{summary}");
+		throw new Exception($"Axe found {violations.Count} a11y violation(s):\n{summary}");
 	}
 
 	[Test]
@@ -247,6 +270,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
+		// #973: OrgAppShell previously rendered no h1 on any org app page.
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Dashboard");
+
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
@@ -292,6 +318,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
+		// #973: OrgAppShell previously rendered no h1 on any org app page.
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Opportunities");
+
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
@@ -310,6 +339,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
+		// #973: OrgAppShell previously rendered no h1 on any org app page.
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Members");
+
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
@@ -325,6 +357,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// "Edit settings" link instead.
 		await Page.GetByRole(AriaRole.Link, new() { Name = "Edit settings" }).ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// #973: OrgAppShell previously rendered no h1 on any org app page.
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Settings");
 
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
@@ -552,6 +587,14 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await manageLink.First.ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// #973: on a nested route, the h1 must track the breadcrumb's trailing
+		// "extra" segment (the opportunity title, set via
+		// useSetOrgBreadcrumbExtra) rather than staying on the parent tab's
+		// own label ("Opportunities") - the one place this pageTitle logic
+		// could regress silently.
+		await Expect(Page.Locator("h1")).Not.ToHaveTextAsync("Opportunities");
+		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -101,10 +101,14 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		// entirely - the org switcher in the header already shows the org
 		// name. #775/#777 brought the tab bar back (mobile burger submenu
 		// needed it too), so that part of #771's removal no longer holds -
-		// see OrgAppMobileResponsiveTests for tab-bar coverage. This test
-		// keeps proving the h1 removal and that the dashboard's own widgets
-		// are a second, independent way to reach every subsite (not just the
-		// tab bar).
+		// see OrgAppMobileResponsiveTests for tab-bar coverage. #973 then
+		// gave OrgAppShell a real h1 again (axe's page-has-heading-one gate
+		// had a blind spot that let every org app page ship with no h1 at
+		// all) - but it renders the tab/page title ("Dashboard"), not the
+		// org name, so #771's actual intent (no org-name duplication) still
+		// holds. This test now asserts exactly that single, correctly-titled
+		// h1, plus that the dashboard's own widgets are a second, independent
+		// way to reach every subsite (not just the tab bar).
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -114,7 +118,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await CreateOrganizationAsync("Visual771 Reachability");
 
 		(await Page.Locator("h1").CountAsync())
-			.Should().Be(0, "the dashboard no longer duplicates the org name as a heading");
+			.Should().Be(1, "OrgAppShell renders one page-title h1 (#973), but it must still not duplicate the org name the header's org switcher already shows");
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Dashboard");
 
 		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
 		match.Success.Should().BeTrue();

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -19,9 +19,9 @@ export default function Footer() {
 
 					{/* Links */}
 					<div>
-						<h3 className="text-white font-semibold mb-4 uppercase text-xs tracking-wider">
+						<h2 className="text-white font-semibold mb-4 uppercase text-xs tracking-wider">
 							{t("footer.platform")}
-						</h3>
+						</h2>
 						<ul className="space-y-2 text-sm">
 							<li>
 								<Link to="/" className="hover:text-white transition-colors">
@@ -46,9 +46,9 @@ export default function Footer() {
 							</li>
 						</ul>
 
-						<h3 className="text-white font-semibold mb-4 mt-6 uppercase text-xs tracking-wider">
+						<h2 className="text-white font-semibold mb-4 mt-6 uppercase text-xs tracking-wider">
 							{t("footer.legal")}
-						</h3>
+						</h2>
 						<ul className="space-y-2 text-sm">
 							<li>
 								<Link
@@ -79,9 +79,9 @@ export default function Footer() {
 
 					{/* Social */}
 					<div>
-						<h3 className="text-white font-semibold mb-4 uppercase text-xs tracking-wider">
+						<h2 className="text-white font-semibold mb-4 uppercase text-xs tracking-wider">
 							{t("footer.followUs")}
-						</h3>
+						</h2>
 						<div className="flex space-x-4">
 							<a
 								href="https://github.com/maik-hasler/einsatzbereit"

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -72,6 +72,12 @@ function OrgAppShell({
 		...(extra ? [{ label: extra }] : []),
 	];
 
+	// #973: OrgAppShell is the only place that knows the current tab/nested-page
+	// title (activeTabLabel/extra, same source as the breadcrumb's last item) -
+	// render it as a real h1 here rather than in each of the four tab pages, so
+	// axe's page-has-heading-one/heading-order rules pass on every org app page.
+	const pageTitle = extra ?? activeTabLabel;
+
 	return (
 		<div className="flex min-h-screen flex-col bg-gray-50">
 			<Header
@@ -84,6 +90,7 @@ function OrgAppShell({
 			/>
 
 			<main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+				<h1 className="mb-6 text-2xl font-bold text-gray-900">{pageTitle}</h1>
 				<Outlet
 					context={{ org, reloadOrg: load } satisfies OrgAppContext}
 					// Outlet re-mounts children on org identity change so per-tab state resets cleanly


### PR DESCRIPTION
OrgAppShell rendered Header + Outlet + footer with no h1 anywhere in the normal flow - the only h1 in OrgAppLayout.tsx lived in the not-authorized error branch. Add an h1 (tab label, or the nested-page breadcrumb extra when set) above the Outlet so Dashboard/Opportunities/ Members/Settings each get one.

AccessibilityTests' axe gate only failed on serious/critical impact, but page-has-heading-one/heading-order/landmark-* violations report at moderate - which is exactly why this shipped unnoticed. Escalate just those rule ids to CI-blocking, and assert the new h1's text on each affected page test.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #973 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
