### PR TITLE
fix: define global focus-visible ring and drop low-contrast outline-none override

### DIFF
--- a/backend/tests/VisualTests/FocusVisibleRingTests.cs
+++ b/backend/tests/VisualTests/FocusVisibleRingTests.cs
@@ -1,0 +1,92 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #992: the app defined no custom :focus-visible ring, so
+/// keyboard-focus appearance depended entirely on the browser default -
+/// invisible in engines that render outline-color 'auto' as white on a
+/// white/light surface. The homepage's "Browse organizations" CTA
+/// additionally suppressed the outline entirely via a low-contrast,
+/// ring-only focus style (outline: none with no visible fallback), a direct
+/// WCAG 2.4.7 failure. Both cases now resolve to the single shared
+/// :focus-visible token in global.css.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class FocusVisibleRingTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// brand-700 (#226947), the shared --focus-ring-color token in global.css.
+	private const string ExpectedRingColor = "rgb(34, 105, 71)";
+
+	[Test]
+	public async Task HomePage_OrgDirectoryCta_ShowsVisibleFocusRingOnKeyboardFocus()
+	{
+		// This CTA (Button.tsx) used to pair focus-visible:outline-none with a
+		// 30%-opacity ring - reported by the live audit as outlineStyle 'none'
+		// with no adequate replacement.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var cta = Page.Locator("[data-testid='organizations-teaser-cta']");
+		await Expect(cta).ToBeVisibleAsync();
+		await TabToAsync(cta);
+
+		var outlineStyle = await cta.EvaluateAsync<string>("el => getComputedStyle(el).outlineStyle");
+		var outlineColor = await cta.EvaluateAsync<string>("el => getComputedStyle(el).outlineColor");
+
+		outlineStyle.Should().Be("solid", "the CTA must no longer suppress its focus outline entirely");
+		outlineColor.Should().Be(ExpectedRingColor);
+	}
+
+	[Test]
+	public async Task Footer_BrowseOrganizationsLink_ShowsVisibleFocusRingOnDarkSurface()
+	{
+		// The footer (bg-brand-800, the same dark surface as the homepage hero)
+		// styles none of its links for focus - before this fix they relied
+		// entirely on the browser default outline, which is not guaranteed to
+		// contrast against a dark background.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var link = Page.Locator("footer").GetByRole(AriaRole.Link, new() { Name = "Browse organizations" });
+		await Expect(link).ToBeVisibleAsync();
+		await TabToAsync(link);
+
+		var outlineStyle = await link.EvaluateAsync<string>("el => getComputedStyle(el).outlineStyle");
+		var outlineColor = await link.EvaluateAsync<string>("el => getComputedStyle(el).outlineColor");
+		var boxShadow = await link.EvaluateAsync<string>("el => getComputedStyle(el).boxShadow");
+
+		outlineStyle.Should().Be("solid");
+		outlineColor.Should().Be(ExpectedRingColor);
+		// The white halo is what keeps the ring visible against this dark
+		// footer background (a flat brand-700 outline alone is too close in
+		// luminance to bg-brand-800 to clear 3:1 contrast).
+		boxShadow.Should().Contain("255, 255, 255");
+	}
+
+	/// <summary>
+	/// Locator.FocusAsync() calls the DOM focus() method directly, which does
+	/// not set the browser's internal "focus came from the keyboard" flag -
+	/// :focus-visible then never matches and every assertion here would
+	/// observe the un-focused, un-ringed element instead. Real Tab keypresses
+	/// (as a keyboard-only visitor would use) do set that flag, so drive
+	/// focus that way instead - bounded so a missing/unreachable target fails
+	/// fast rather than hanging.
+	/// </summary>
+	private async Task TabToAsync(ILocator target, int maxPresses = 40)
+	{
+		for (var i = 0; i < maxPresses; i++)
+		{
+			await Page.Keyboard.PressAsync("Tab");
+			if (await target.EvaluateAsync<bool>("el => el === document.activeElement"))
+				return;
+		}
+
+		throw new Exception($"Could not reach the target element via Tab within {maxPresses} presses.");
+	}
+}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -12,8 +12,11 @@ type Size = keyof typeof SIZE_CLASSES;
 // Shared shape/behavior every button/link in the app should share (see
 // issue #846: four different border-radius values across primary buttons
 // before this existed).
+// Focus-visible styling comes from the global :focus-visible ring in
+// global.css (issue #992) - not from a per-component outline-none/ring
+// pair, which had too little contrast on this shared component.
 const BASE_CLASSES =
-	"inline-flex items-center justify-center gap-1.5 rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+	"inline-flex items-center justify-center gap-1.5 rounded-xl transition-colors disabled:cursor-not-allowed disabled:opacity-50";
 
 // primary: solid brand-color CTA. secondary: borderless cancel/close action -
 // the single style every modal's cancel/close button should share (see

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -379,6 +379,27 @@ overflow-y-auto already handles vertical scrolling. */
 	}
 }
 
+/* ── Global focus-visible ring (issue #992) ──────────────────────────────
+A single shared token instead of the browser's inconsistent default outline
+or ad-hoc per-component ring utilities. Dual-tone (brand outline + white
+halo) so it stays visible whether the focused element sits on a light
+surface or the dark hero section - no single flat color has enough
+contrast against both. Written outside any @layer so it takes priority
+over Tailwind's layered focus-visible:outline-none/ring-* utilities
+regardless of specificity (see .rbc-btn-group/.rbc-event above for the
+same unlayered-override pattern already used in this file). */
+:root {
+	--focus-ring-color: #226947;
+}
+
+:focus-visible {
+	outline-width: 2px;
+	outline-style: solid;
+	outline-color: var(--focus-ring-color);
+	outline-offset: 2px;
+	box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.9);
+}
+
 @theme {
 	--color-brand-50: #f0faf5;
 	--color-brand-100: #d6f0e3;


### PR DESCRIPTION
The app relied entirely on the browser's default outline for keyboard focus, invisible on some surfaces (e.g. white outline on a white header), and the homepage's "Browse organizations" CTA suppressed its outline entirely via a 30%-opacity ring with no visible fallback - a WCAG 2.4.7 violation. Add a single dual-tone (brand outline + white halo) token in global.css so focus stays visible on both light surfaces and the dark hero, and drop the CTA's per-component outline-none/ring pair in favor of it.

Closes #992

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
