### PR TITLE
fix: eliminate duplicate outbox dispatch and reminder emails via row claiming

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -77,6 +77,14 @@
     "FromAddress": "noreply@einsatzbereit.local",
     "FromName": "Einsatzbereit"
   },
+  "Outbox": {
+    "BatchSize": 20,
+    "PollIntervalSeconds": 5
+  },
+  "EngagementReminder": {
+    "MaxBatchSize": 500,
+    "PollIntervalHours": 1
+  },
   "RateLimiting": {
     "Read": {
       "AuthenticatedPermitLimit": 200,

--- a/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
+++ b/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
@@ -1,0 +1,72 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.EngagementReminder.v1;
+
+// Consumer of EngagementReminderDueDomainEvent (#1392): EngagementReminderJob only
+// detects which engagements are due for a 24h reminder and atomically claims + queues
+// them into the outbox (Infrastructure/BackgroundJobs/EngagementReminderJob.cs); actual
+// delivery happens here, dispatched by OutboxProcessorJob like every other domain event,
+// so a transient failure is retried on the next poll cycle instead of being lost.
+internal sealed class EngagementReminderDueHandler(
+	IApplicationDbContext dbContext,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	ILogger<EngagementReminderDueHandler> logger)
+	: INotificationHandler<EngagementReminderDueDomainEvent>
+{
+	public async Task Handle(
+		EngagementReminderDueDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken);
+		var timeSlot = opportunity?.TimeSlots.FirstOrDefault(ts => ts.Id == notification.TimeSlotId);
+
+		if (opportunity is null || timeSlot is null)
+		{
+			// The opportunity/time slot this reminder was queued for no longer exists
+			// (deleted between claim and dispatch) - nothing to remind about, and
+			// retrying would never resolve, so this is treated as handled rather than
+			// re-thrown for the outbox to retry forever.
+			logger.LogWarning(
+				"Skipping reminder for engagement {EngagementId}: opportunity {OpportunityId} or time slot {TimeSlotId} no longer exists",
+				notification.EngagementId.Value,
+				notification.OpportunityId.Value,
+				notification.TimeSlotId.Value);
+			return;
+		}
+
+		var user = await keycloakUserService.GetUserAsync(notification.VolunteerId.Value, cancellationToken);
+
+		var displayName = $"{user.FirstName} {user.LastName}".Trim();
+		if (string.IsNullOrEmpty(displayName))
+			displayName = user.Username;
+
+		var startFormatted = timeSlot.StartDateTime.ToLocalTime().ToString("dddd, d. MMMM yyyy 'at' HH:mm");
+
+		var subject = $"Reminder: {opportunity.Title} starts tomorrow";
+		var body =
+			$"Hi {displayName},\n\n" +
+			$"This is a reminder that you are signed up for \"{opportunity.Title}\" " +
+			$"which starts on {startFormatted}.\n\n" +
+			$"We are looking forward to seeing you!\n\n" +
+			$"The Einsatzbereit Team";
+
+		// SendBatchAsync with a single message (rather than SendAsync) so a failed send
+		// is observable as a bool - SendAsync never throws and never reports outcome,
+		// which would make it impossible to know whether to let the outbox retry.
+		var results = await emailService.SendBatchAsync([new EmailMessage(user.Email, subject, body)], cancellationToken);
+		if (!results[0])
+			throw new InvalidOperationException(
+				$"Failed to send 24h reminder email for engagement {notification.EngagementId.Value}");
+
+		logger.LogInformation(
+			"Sent 24h reminder to {Email} for engagement {EngagementId}",
+			user.Email,
+			notification.EngagementId.Value);
+	}
+}

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -157,11 +157,6 @@ public sealed class Engagement
 		return Result.Success();
 	}
 
-	public void MarkReminderSent(DateTimeOffset sentAt)
-	{
-		ReminderSentAt = sentAt;
-	}
-
 	public Result SubmitFeedback(int rating, string? comment, DateTimeOffset now)
 	{
 		if (!IsCheckedIn)

--- a/backend/src/Domain/Engagements/EngagementReminderDueDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementReminderDueDomainEvent.cs
@@ -1,0 +1,12 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+public sealed record EngagementReminderDueDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId,
+	TimeSlotId TimeSlotId)
+	: DomainEvent;

--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
@@ -1,25 +1,29 @@
-using Application.Common.Email;
-using Application.Common.Keycloak;
 using Domain.Engagements;
 using Domain.VolunteerOpportunities;
 using Infrastructure.Persistence;
+using Infrastructure.Persistence.Outbox;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.BackgroundJobs;
 
+// Detects which confirmed engagements need a 24h reminder and atomically claims +
+// queues one EngagementReminderDueDomainEvent per engagement into the outbox (#1392) -
+// it no longer sends anything itself. Actual delivery is handled the same way as every
+// other domain event, by OutboxProcessorJob dispatching to
+// Application.Engagements.EngagementReminder.v1.EngagementReminderDueHandler, so a
+// second replica running this job concurrently can never double-send a reminder: the
+// claim below is a single atomic UPDATE per candidate, not a racy read-then-write.
 internal sealed class EngagementReminderJob(
 	IServiceScopeFactory scopeFactory,
-	ILogger<EngagementReminderJob> logger)
+	ILogger<EngagementReminderJob> logger,
+	IOptions<EngagementReminderOptions> options)
 	: IHostedService, IAsyncDisposable
 {
-	// Caps how many engagements one hourly tick processes. Anything left over
-	// still has ReminderSentAt == null and its TimeSlot still falls in the
-	// (now+23h, now+25h) window on the next tick (the window is 2h wide, the
-	// timer fires every 1h), so it is picked up then instead of being lost.
-	private const int MaxBatchSize = 500;
+	private readonly EngagementReminderOptions _options = options.Value;
 
 	private Task _executeTask = Task.CompletedTask;
 	private CancellationTokenSource? _cts;
@@ -28,7 +32,7 @@ internal sealed class EngagementReminderJob(
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
 		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		_timer = new PeriodicTimer(TimeSpan.FromHours(1));
+		_timer = new PeriodicTimer(TimeSpan.FromHours(_options.PollIntervalHours));
 		_executeTask = RunLoopAsync(_cts.Token);
 		return Task.CompletedTask;
 	}
@@ -60,22 +64,59 @@ internal sealed class EngagementReminderJob(
 
 		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
 		{
-			await SendRemindersAsync(ct).ConfigureAwait(false);
+			try
+			{
+				await TickAsync(ct).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// Mirrors OutboxProcessorJob's tick-level catch: a failure here (e.g. a
+				// transient DB error) must not stop the PeriodicTimer from ever being
+				// awaited again. Any due engagement still has ReminderSentAt == null,
+				// so it is simply picked up again on the next tick.
+				logger.LogError(ex, "Engagement reminder tick failed; will retry on the next poll interval");
+			}
 		}
 	}
 
-	private async Task SendRemindersAsync(CancellationToken ct)
+	private async Task TickAsync(CancellationToken ct)
 	{
 		await using var scope = scopeFactory.CreateAsyncScope();
 		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-		var emailService = scope.ServiceProvider.GetRequiredService<IEmailService>();
-		var keycloakUserService = scope.ServiceProvider.GetRequiredService<IKeycloakUserService>();
 
-		var now = DateTimeOffset.UtcNow;
+		var queued = await ClaimAndQueueRemindersAsync(dbContext, DateTimeOffset.UtcNow, _options.MaxBatchSize, ct);
+
+		if (queued > 0)
+			logger.LogInformation("Queued {Count} reminder(s) for outbox dispatch", queued);
+	}
+
+	// Exposed so IntegrationTests can exercise the claim race directly against a real
+	// ApplicationDbContext - e.g. two concurrent calls racing over the same due
+	// engagement, without waiting an hour for a real tick from two replicas.
+	internal static async Task<int> ClaimAndQueueRemindersAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset now,
+		int maxBatchSize,
+		CancellationToken cancellationToken = default)
+	{
 		var windowStart = now.AddHours(23);
 		var windowEnd = now.AddHours(25);
 
-		var engagements = await dbContext.Set<Engagement>()
+		// One transaction for the whole claim-and-enqueue batch: without it, a crash or
+		// a failed SaveChangesAsync after some ExecuteUpdateAsync claims already
+		// auto-committed would leave those engagements with ReminderSentAt permanently
+		// set but no outbox row ever written for them - silently losing the reminder
+		// forever instead of retrying it next tick. Wrapping in a transaction makes the
+		// whole batch all-or-nothing while still preserving the per-row claim below:
+		// Postgres still evaluates each UPDATE's WHERE clause atomically against
+		// whatever the row's current committed state is.
+		await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+		// Caps how many engagements one tick claims. Anything left over still has
+		// ReminderSentAt == null and its TimeSlot still falls in the (now+23h, now+25h)
+		// window on the next tick (the window is 2h wide, the timer fires every
+		// PollIntervalHours), so it is picked up then instead of being lost.
+		var candidates = await dbContext.Set<Engagement>()
 			.Where(e =>
 				e.Status == EngagementStatus.Confirmed &&
 				e.TimeSlotId != null &&
@@ -84,107 +125,59 @@ internal sealed class EngagementReminderJob(
 				dbContext.Set<TimeSlot>(),
 				e => e.TimeSlotId,
 				ts => ts.Id,
-				(e, ts) => new { Engagement = e, TimeSlot = ts })
-			.Where(x => x.TimeSlot.StartDateTime >= windowStart && x.TimeSlot.StartDateTime <= windowEnd)
-			.Join(
-				dbContext.Set<VolunteerOpportunity>(),
-				x => x.Engagement.OpportunityId,
-				vo => vo.Id,
-				(x, vo) => new { x.Engagement, x.TimeSlot, OpportunityTitle = vo.Title })
-			.OrderBy(x => x.TimeSlot.StartDateTime)
-			.Take(MaxBatchSize)
-			.ToListAsync(ct);
+				(e, ts) => new { e.Id, e.VolunteerId, e.OpportunityId, e.TimeSlotId, ts.StartDateTime })
+			.Where(x => x.StartDateTime >= windowStart && x.StartDateTime <= windowEnd)
+			.OrderBy(x => x.StartDateTime)
+			.Take(maxBatchSize)
+			.ToListAsync(cancellationToken);
 
-		if (engagements.Count == 0)
-			return;
-
-		// One email per engagement, resolved sequentially: KeycloakUserService
-		// mutates a shared HttpClient auth header per call (see its
-		// SendAuthorizedAsync comment), so these lookups cannot run concurrently.
-		// Caching by volunteer avoids repeating the lookup for a volunteer
-		// confirmed for more than one slot inside this run's window.
-		var profileCache = new Dictionary<Guid, KeycloakUserProfile>();
-		var messages = new List<EmailMessage>(engagements.Count);
-		var recipients = new List<(Engagement Engagement, string Email)>(engagements.Count);
-
-		foreach (var item in engagements)
+		if (candidates.Count == 0)
 		{
-			var volunteerId = item.Engagement.VolunteerId!.Value.Value;
-			try
-			{
-				if (!profileCache.TryGetValue(volunteerId, out var user))
-				{
-					user = await keycloakUserService.GetUserAsync(volunteerId, ct);
-					profileCache[volunteerId] = user;
-				}
-
-				var displayName = $"{user.FirstName} {user.LastName}".Trim();
-				if (string.IsNullOrEmpty(displayName))
-					displayName = user.Username;
-
-				var startFormatted = item.TimeSlot.StartDateTime.ToLocalTime().ToString("dddd, d. MMMM yyyy 'at' HH:mm");
-
-				var subject = $"Reminder: {item.OpportunityTitle} starts tomorrow";
-				var body =
-					$"Hi {displayName},\n\n" +
-					$"This is a reminder that you are signed up for \"{item.OpportunityTitle}\" " +
-					$"which starts on {startFormatted}.\n\n" +
-					$"We are looking forward to seeing you!\n\n" +
-					$"The Einsatzbereit Team";
-
-				messages.Add(new EmailMessage(user.Email, subject, body));
-				recipients.Add((item.Engagement, user.Email));
-			}
-			catch (Exception ex)
-			{
-				logger.LogError(
-					ex,
-					"Failed to resolve volunteer profile for engagement {EngagementId}",
-					item.Engagement.Id.Value);
-			}
+			await transaction.CommitAsync(cancellationToken);
+			return 0;
 		}
 
-		if (messages.Count == 0)
-			return;
+		var occurredOnUtc = now.UtcDateTime;
+		var claimedMessages = new List<OutboxMessage>(candidates.Count);
 
-		// A single SMTP connection for the whole batch instead of one per engagement.
-		var sendResults = await emailService.SendBatchAsync(messages, ct);
-
-		var sentIds = new List<EngagementId>(recipients.Count);
-		for (var i = 0; i < recipients.Count; i++)
+		foreach (var candidate in candidates)
 		{
-			if (!sendResults[i])
-				continue;
-
-			var (engagement, email) = recipients[i];
-			sentIds.Add(engagement.Id);
-
-			logger.LogInformation(
-				"Sent 24h reminder to {Email} for engagement {EngagementId}",
-				email,
-				engagement.Id.Value);
-		}
-
-		if (sentIds.Count == 0)
-			return;
-
-		try
-		{
-			// A single batched UPDATE instead of one SaveChangesAsync per engagement.
-			await dbContext.Set<Engagement>()
-				.Where(e => sentIds.Contains(e.Id))
+			// Atomic per-row claim: this UPDATE's WHERE clause is re-evaluated by
+			// Postgres against the row's current committed state, so if another
+			// replica's tick already claimed this engagement, it affects 0 rows instead
+			// of racing to a duplicate reminder (#1392) - unlike the plain
+			// tracked-entity SaveChangesAsync this job used to do, which had no guard
+			// against exactly that race.
+			var rowsAffected = await dbContext.Set<Engagement>()
+				.Where(e => e.Id == candidate.Id && e.ReminderSentAt == null)
 				.ExecuteUpdateAsync(
 					s => s
 						.SetProperty(e => e.ReminderSentAt, now)
 						.SetProperty(e => e.ModifiedOn, now),
-					ct);
+					cancellationToken);
+
+			if (rowsAffected == 0)
+				continue;
+
+			var domainEvent = new EngagementReminderDueDomainEvent(
+				candidate.Id, candidate.VolunteerId!.Value, candidate.OpportunityId, candidate.TimeSlotId!.Value);
+			claimedMessages.Add(OutboxMessage.FromDomainEvent(domainEvent, occurredOnUtc));
 		}
-		catch (Exception ex)
+
+		if (claimedMessages.Count == 0)
 		{
-			logger.LogError(
-				ex,
-				"Failed to persist ReminderSentAt for {Count} engagements after sending reminders; they will be retried next run",
-				sentIds.Count);
+			await transaction.CommitAsync(cancellationToken);
+			return 0;
 		}
+
+		// ExecuteUpdateAsync above bypasses the ChangeTracker, so
+		// ConvertDomainEventsToOutboxMessagesInterceptor never sees these events - the
+		// outbox rows are built directly here instead, then written in a single batched
+		// SaveChangesAsync for however many this tick actually won.
+		dbContext.Set<OutboxMessage>().AddRange(claimedMessages);
+		await dbContext.SaveChangesAsync(cancellationToken);
+		await transaction.CommitAsync(cancellationToken);
+
+		return claimedMessages.Count;
 	}
 }

--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderOptions.cs
@@ -1,0 +1,8 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class EngagementReminderOptions
+{
+	public int MaxBatchSize { get; init; } = 500;
+
+	public int PollIntervalHours { get; init; } = 1;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class EngagementReminderOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<EngagementReminderOptions>
+{
+	public void Configure(EngagementReminderOptions options) =>
+		configuration.GetSection("EngagementReminder").Bind(options);
+}

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxOptions.cs
@@ -1,0 +1,8 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class OutboxOptions
+{
+	public int BatchSize { get; init; } = 20;
+
+	public int PollIntervalSeconds { get; init; } = 5;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class OutboxOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<OutboxOptions>
+{
+	public void Configure(OutboxOptions options) =>
+		configuration.GetSection("Outbox").Bind(options);
+}

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.BackgroundJobs;
 
@@ -16,11 +17,11 @@ namespace Infrastructure.BackgroundJobs;
 // backend/AGENTS.md for the timing problem this replaces).
 internal sealed class OutboxProcessorJob(
 	IServiceScopeFactory scopeFactory,
-	ILogger<OutboxProcessorJob> logger)
+	ILogger<OutboxProcessorJob> logger,
+	IOptions<OutboxOptions> options)
 	: IHostedService, IAsyncDisposable
 {
-	private const int BatchSize = 20;
-	private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+	private readonly OutboxOptions _options = options.Value;
 
 	private Task _executeTask = Task.CompletedTask;
 	private CancellationTokenSource? _cts;
@@ -29,7 +30,7 @@ internal sealed class OutboxProcessorJob(
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
 		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		_timer = new PeriodicTimer(PollInterval);
+		_timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.PollIntervalSeconds));
 		_executeTask = RunLoopAsync(_cts.Token);
 		return Task.CompletedTask;
 	}
@@ -85,18 +86,50 @@ internal sealed class OutboxProcessorJob(
 		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 		var dispatcher = scope.ServiceProvider.GetRequiredService<IDomainEventDispatcher>();
 
+		await ProcessBatchAsync(dbContext, dispatcher, logger, _options.BatchSize, ct);
+	}
+
+	// Exposed so IntegrationTests can exercise the row-claiming behavior directly
+	// against a real Postgres - e.g. two concurrent calls racing over the same pending
+	// batch - without waiting on the real 5s PollInterval from two replicas.
+	internal static async Task<int> ProcessBatchAsync(
+		ApplicationDbContext dbContext,
+		IDomainEventDispatcher dispatcher,
+		ILogger logger,
+		int batchSize,
+		CancellationToken cancellationToken = default)
+	{
+		// FOR UPDATE SKIP LOCKED (#1392): without this, two replicas' timers ticking
+		// concurrently would both SELECT the same unprocessed rows and both dispatch
+		// them, since nothing previously marked a row "claimed" before dispatch - it was
+		// only marked ProcessedOnUtc after dispatch succeeded. Holding the row locks for
+		// this whole transaction (not just the SELECT) is what makes a second replica's
+		// concurrent SKIP LOCKED query skip these rows entirely instead of blocking on
+		// them, so it picks a disjoint batch instead of waiting to double-process this one.
+		await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
 		var messages = await dbContext.Set<OutboxMessage>()
-			.Where(m => m.ProcessedOnUtc == null)
-			.OrderBy(m => m.OccurredOnUtc)
-			.Take(BatchSize)
-			.ToListAsync(ct);
+			.FromSqlInterpolated($@"
+				SELECT id, type, content, occurred_on_utc, processed_on_utc, error
+				FROM outbox_message
+				WHERE processed_on_utc IS NULL
+				ORDER BY occurred_on_utc
+				LIMIT {batchSize}
+				FOR UPDATE SKIP LOCKED")
+			.ToListAsync(cancellationToken);
+
+		if (messages.Count == 0)
+		{
+			await transaction.CommitAsync(cancellationToken);
+			return 0;
+		}
 
 		foreach (var message in messages)
 		{
 			try
 			{
 				var domainEvent = message.ToDomainEvent();
-				await dispatcher.DispatchAsync([domainEvent], ct);
+				await dispatcher.DispatchAsync([domainEvent], cancellationToken);
 
 				message.ProcessedOnUtc = DateTime.UtcNow;
 				message.Error = null;
@@ -111,8 +144,14 @@ internal sealed class OutboxProcessorJob(
 					message.Id,
 					message.Type);
 			}
-
-			await dbContext.SaveChangesAsync(ct);
 		}
+
+		// A single SaveChangesAsync for the whole batch instead of one per message - the
+		// row locks from FOR UPDATE above are held for this transaction regardless, so
+		// batching the writes costs nothing extra.
+		await dbContext.SaveChangesAsync(cancellationToken);
+		await transaction.CommitAsync(cancellationToken);
+
+		return messages.Count;
 	}
 }

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -91,7 +91,9 @@ public static class ServiceCollectionExtensions
 		services.ConfigureOptions<SmtpOptionsSetup>();
 		services.AddSingleton<EmailMetrics>();
 		services.AddScoped<IEmailService, SmtpEmailService>();
+		services.ConfigureOptions<EngagementReminderOptionsSetup>();
 		services.AddHostedService<EngagementReminderJob>();
+		services.ConfigureOptions<OutboxOptionsSetup>();
 		services.AddHostedService<OutboxProcessorJob>();
 		services.AddHostedService<GeocodingRetryJob>();
 		services.AddHostedService<OrganizationMembershipBackfillJob>();

--- a/backend/tests/Application.UnitTests/Engagements/EngagementReminder/EngagementReminderDueHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementReminder/EngagementReminderDueHandlerTests.cs
@@ -1,0 +1,137 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.EngagementReminder.v1;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Organizations;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.EngagementReminder;
+
+public class EngagementReminderDueHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly EngagementReminderDueHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+
+	public EngagementReminderDueHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_sut = new EngagementReminderDueHandler(
+			_dbContext, _keycloakUserService, _emailService, NullLogger<EngagementReminderDueHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateOpportunityWithTimeSlot(out TimeSlotId timeSlotId)
+	{
+		// Waitlist opportunities can't be created directly as Published (they must have
+		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
+		// here since the handler doesn't look at Status at all.
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Beach Cleanup", "Help clean the beach", true, null,
+			Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+		var now = DateTimeOffset.UtcNow;
+		var timeSlot = opportunity.AddTimeSlot(now.AddHours(24), now.AddHours(26), 10, now).Value;
+		timeSlotId = timeSlot.Id;
+		return opportunity;
+	}
+
+	[Test]
+	public async Task Handle_ShouldSendReminderEmail_WhenOpportunityAndTimeSlotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityWithTimeSlot(out var timeSlotId);
+		var volunteerId = UserId.New();
+		var domainEvent = new EngagementReminderDueDomainEvent(
+			EngagementId.New(), volunteerId, opportunity.Id, timeSlotId);
+
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_keycloakUserService.GetUserAsync(volunteerId.Value, cancellationToken)
+			.Returns(new KeycloakUserProfile(volunteerId.Value, "vera", "Vera", "Volunteer", "vera@example.com"));
+		_emailService.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), cancellationToken)
+			.Returns([true]);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(m => m!.Count == 1 && m[0].To == "vera@example.com"),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_AndShouldNotSendEmail_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var domainEvent = new EngagementReminderDueDomainEvent(
+			EngagementId.New(), UserId.New(), opportunityId, TimeSlotId.New());
+
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _emailService.DidNotReceive().SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_AndShouldNotSendEmail_WhenTimeSlotNoLongerExistsOnOpportunity(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the time slot the event was queued for was removed from the
+		// opportunity between claim and dispatch.
+		var opportunity = CreateOpportunityWithTimeSlot(out _);
+		var domainEvent = new EngagementReminderDueDomainEvent(
+			EngagementId.New(), UserId.New(), opportunity.Id, TimeSlotId.New());
+
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _emailService.DidNotReceive().SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEmailSendFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: a failed send must propagate so OutboxProcessorJob records the
+		// error and retries on its next poll cycle instead of losing the reminder.
+		var opportunity = CreateOpportunityWithTimeSlot(out var timeSlotId);
+		var volunteerId = UserId.New();
+		var domainEvent = new EngagementReminderDueDomainEvent(
+			EngagementId.New(), volunteerId, opportunity.Id, timeSlotId);
+
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_keycloakUserService.GetUserAsync(volunteerId.Value, cancellationToken)
+			.Returns(new KeycloakUserProfile(volunteerId.Value, "vera", "Vera", "Volunteer", "vera@example.com"));
+		_emailService.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), cancellationToken)
+			.Returns([false]);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}

--- a/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
@@ -1,0 +1,171 @@
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
+// "Organization"/"OrganizationId" DTO types, which would otherwise shadow the domain
+// types of the same name pulled in via the "Domain.Organizations" using above.
+using DomainOrganization = Domain.Organizations.Organization;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.EngagementReminderJob.ClaimAndQueueRemindersAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres - the job's own PeriodicTimer only fires hourly, and the interesting behavior
+// here (#1392) is the atomic per-row claim that prevents two replicas' ticks from both
+// queuing a reminder for the same engagement, which is only provable by calling it twice
+// concurrently against two independent ApplicationDbContexts/connections.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class EngagementReminderJobTests(IntegrationTestFixture fixture)
+{
+	private const string ReminderDueDomainEventType = "Domain.Engagements.EngagementReminderDueDomainEvent";
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task ClaimAndQueueRemindersAsync_EngagementDueForReminder_ClaimsItAndQueuesOutboxMessage(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotStart: now.AddHours(24), reminderSentAt: null, cancellationToken);
+
+		var queued = await EngagementReminderJob.ClaimAndQueueRemindersAsync(dbContext, now, 500, cancellationToken);
+
+		queued.Should().Be(1);
+
+		var reminderSentAt = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.ReminderSentAt)
+			.SingleAsync(cancellationToken);
+		reminderSentAt.Should().NotBeNull("claiming must stamp ReminderSentAt so the same engagement isn't picked up again");
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(ReminderDueDomainEventType)).Should().Be(1);
+	}
+
+	[Test]
+	public async Task ClaimAndQueueRemindersAsync_TimeSlotOutsideReminderWindow_DoesNotClaim(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotStart: now.AddDays(5), reminderSentAt: null, cancellationToken);
+
+		var queued = await EngagementReminderJob.ClaimAndQueueRemindersAsync(dbContext, now, 500, cancellationToken);
+
+		queued.Should().Be(0);
+
+		var reminderSentAt = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.ReminderSentAt)
+			.SingleAsync(cancellationToken);
+		reminderSentAt.Should().BeNull();
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(ReminderDueDomainEventType)).Should().Be(0);
+	}
+
+	[Test]
+	public async Task ClaimAndQueueRemindersAsync_AlreadyReminded_DoesNotClaimAgain(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotStart: now.AddHours(24), reminderSentAt: now.AddMinutes(-5), cancellationToken);
+
+		var queued = await EngagementReminderJob.ClaimAndQueueRemindersAsync(dbContext, now, 500, cancellationToken);
+
+		queued.Should().Be(0);
+		(await fixture.CountOutboxMessagesOfTypeAsync(ReminderDueDomainEventType)).Should().Be(0);
+	}
+
+	[Test]
+	public async Task ClaimAndQueueRemindersAsync_TwoConcurrentCallsAgainstTheSameEngagement_OnlyOneClaimsIt(
+		CancellationToken cancellationToken)
+	{
+		// Simulates two replicas' EngagementReminderJob ticks racing over the same due
+		// engagement - the bug #1392 describes for the real job (duplicate 24h reminder
+		// emails). Two independent ApplicationDbContexts (separate connections) so the
+		// atomic per-row claim is genuinely exercised at the database level, not just
+		// serialized by sharing one DbContext/connection.
+		await using var seedContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			seedContext, timeSlotStart: now.AddHours(24), reminderSentAt: null, cancellationToken);
+
+		await using var contextA = fixture.CreateApplicationDbContext();
+		await using var contextB = fixture.CreateApplicationDbContext();
+
+		var results = await Task.WhenAll(
+			EngagementReminderJob.ClaimAndQueueRemindersAsync(contextA, now, 500, cancellationToken),
+			EngagementReminderJob.ClaimAndQueueRemindersAsync(contextB, now, 500, cancellationToken));
+
+		results.Sum().Should().Be(1, "exactly one of the two concurrent ticks should have won the claim");
+
+		var reminderSentAt = await seedContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.ReminderSentAt)
+			.SingleAsync(cancellationToken);
+		reminderSentAt.Should().NotBeNull();
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(ReminderDueDomainEventType)).Should().Be(
+			1, "the losing replica must not have queued a second reminder for the same engagement");
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private static async Task<(EngagementId EngagementId, VolunteerOpportunityId OpportunityId, TimeSlotId TimeSlotId)> SeedConfirmedEngagementAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset timeSlotStart,
+		DateTimeOffset? reminderSentAt,
+		CancellationToken cancellationToken)
+	{
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"ReminderTestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		// Waitlist opportunities can't be created directly as Published (they must have
+		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
+		// here since nothing in this test path depends on the opportunity being published.
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Beach Cleanup", "Help clean the beach", true, null,
+			Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).Value;
+
+		var timeSlot = opportunity.AddTimeSlot(
+			timeSlotStart, timeSlotStart.AddHours(2), 10, DateTimeOffset.UtcNow).Value;
+		dbContext.Set<VolunteerOpportunity>().Add(opportunity);
+
+		var engagement = Engagement.CreateWaitlistSignUp(opportunity.Id, UserId.New(), timeSlot.Id);
+		engagement.Confirm();
+		dbContext.Set<Engagement>().Add(engagement);
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		if (reminderSentAt.HasValue)
+		{
+			await dbContext.Set<Engagement>()
+				.Where(e => e.Id == engagement.Id)
+				.ExecuteUpdateAsync(s => s.SetProperty(e => e.ReminderSentAt, reminderSentAt), cancellationToken);
+		}
+
+		return (engagement.Id, opportunity.Id, timeSlot.Id);
+	}
+
+	private sealed class NoOpPinGenerator : IPinGenerator
+	{
+		public string GeneratePin() => "0000";
+	}
+}

--- a/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
+++ b/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
@@ -1,0 +1,151 @@
+using Application.Common;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.Outbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares a
+// "DomainEvent" DTO type, which would otherwise shadow Domain.Primitives.DomainEvent.
+using CoreDomainEvent = Domain.Primitives.DomainEvent;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.OutboxProcessorJob.ProcessBatchAsync directly
+// (InternalsVisibleTo, see Infrastructure.csproj) against the real integration Postgres.
+// The interesting behavior here (#1392) is the FOR UPDATE SKIP LOCKED row-claiming that
+// stops two replicas' timers from both dispatching the same pending message - only
+// provable by holding one call's transaction open (via a gated fake dispatcher) while a
+// second concurrent call proves it skips the locked row instead of double-dispatching.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OutboxProcessorJobTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task ProcessBatchAsync_PendingMessage_DispatchesItAndMarksProcessed(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(dbContext, domainEvent, cancellationToken);
+
+		var dispatcher = new RecordingDispatcher();
+		var processed = await OutboxProcessorJob.ProcessBatchAsync(
+			dbContext, dispatcher, NullLogger.Instance, batchSize: 20, cancellationToken);
+
+		processed.Should().Be(1);
+		dispatcher.DispatchedEvents.Should().ContainSingle();
+
+		var message = await dbContext.Set<OutboxMessage>()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		message.ProcessedOnUtc.Should().NotBeNull();
+		message.Error.Should().BeNull();
+	}
+
+	[Test]
+	public async Task ProcessBatchAsync_DispatchThrows_RecordsErrorAndLeavesMessageUnprocessedForRetry(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(dbContext, domainEvent, cancellationToken);
+
+		var dispatcher = new RecordingDispatcher { ThrowOnDispatch = true };
+		var attempted = await OutboxProcessorJob.ProcessBatchAsync(
+			dbContext, dispatcher, NullLogger.Instance, batchSize: 20, cancellationToken);
+
+		attempted.Should().Be(1, "the message was selected and attempted even though dispatch failed");
+
+		var message = await dbContext.Set<OutboxMessage>()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		message.ProcessedOnUtc.Should().BeNull("a failed dispatch must leave the message unprocessed so the next poll cycle retries it");
+		message.Error.Should().NotBeNullOrEmpty();
+	}
+
+	[Test]
+	public async Task ProcessBatchAsync_TwoConcurrentCalls_OnlyOneDispatchesTheLockedMessage(
+		CancellationToken cancellationToken)
+	{
+		await using var seedContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(seedContext, domainEvent, cancellationToken);
+
+		var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var gatedDispatcher = new GatedDispatcher(started, release.Task);
+
+		await using var contextA = fixture.CreateApplicationDbContext();
+		await using var contextB = fixture.CreateApplicationDbContext();
+
+		var taskA = OutboxProcessorJob.ProcessBatchAsync(
+			contextA, gatedDispatcher, NullLogger.Instance, batchSize: 20, cancellationToken);
+
+		// Wait until A's transaction has actually reached the dispatcher - meaning its
+		// SELECT ... FOR UPDATE SKIP LOCKED already committed the row lock - before
+		// starting B, so B's own SKIP LOCKED query has something real to skip instead of
+		// racing to see an as-yet-unlocked row.
+		await started.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+		var recordingDispatcher = new RecordingDispatcher();
+		var selectedByB = await OutboxProcessorJob.ProcessBatchAsync(
+			contextB, recordingDispatcher, NullLogger.Instance, batchSize: 20, cancellationToken);
+
+		selectedByB.Should().Be(0, "the only pending message is locked by A's still-open transaction, so B's SKIP LOCKED query must skip it rather than dispatch it a second time");
+		recordingDispatcher.DispatchedEvents.Should().BeEmpty();
+
+		release.SetResult();
+		var processedByA = await taskA;
+
+		processedByA.Should().Be(1);
+
+		var message = await seedContext.Set<OutboxMessage>()
+			.AsNoTracking()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		message.ProcessedOnUtc.Should().NotBeNull();
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private static async Task SeedOutboxMessageAsync(
+		ApplicationDbContext dbContext, CoreDomainEvent domainEvent, CancellationToken cancellationToken)
+	{
+		dbContext.Set<OutboxMessage>().Add(OutboxMessage.FromDomainEvent(domainEvent, DateTime.UtcNow));
+		await dbContext.SaveChangesAsync(cancellationToken);
+	}
+
+	private sealed class RecordingDispatcher : IDomainEventDispatcher
+	{
+		public List<CoreDomainEvent> DispatchedEvents { get; } = [];
+
+		public bool ThrowOnDispatch { get; set; }
+
+		public ValueTask DispatchAsync(IEnumerable<CoreDomainEvent> events, CancellationToken cancellationToken = default)
+		{
+			if (ThrowOnDispatch)
+				throw new InvalidOperationException("Simulated dispatch failure.");
+
+			DispatchedEvents.AddRange(events);
+			return ValueTask.CompletedTask;
+		}
+	}
+
+	// Signals `started` the instant DispatchAsync is entered (i.e. after ProcessBatchAsync's
+	// SELECT ... FOR UPDATE SKIP LOCKED has already run and committed its row lock), then
+	// blocks until the test releases it - simulating a slow dispatch so a concurrent
+	// second call's SKIP LOCKED query has a genuinely still-locked row to skip.
+	private sealed class GatedDispatcher(TaskCompletionSource started, Task releaseGate) : IDomainEventDispatcher
+	{
+		public async ValueTask DispatchAsync(IEnumerable<CoreDomainEvent> events, CancellationToken cancellationToken = default)
+		{
+			started.TrySetResult();
+			await releaseGate;
+		}
+	}
+}

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -16,10 +16,10 @@ namespace IntegrationTests;
 // so - unlike the rest of this project - it needs no Aspire/Testcontainers
 // fixture and runs as a plain fast unit test.
 //
-// Regression coverage for #1341: a send failure must be swallowed (callers
-// like EngagementReminderJob rely on this - see its MarkReminderSent right
-// after SendAsync) but still observable, now via a metric rather than only a
-// log line nothing was watching.
+// Regression coverage for #1341: a send failure must be swallowed - SendAsync
+// never throws, by design (see the comment on IEmailService.SendBatchAsync) -
+// but still observable, now via a metric rather than only a log line nothing
+// was watching.
 //
 // [NotInParallel] with a key unique to this class (not the "IntegrationDb"
 // key other IntegrationTests classes share): EmailMetrics.MeterName is a
@@ -62,11 +62,12 @@ public class SmtpEmailServiceTests
 		recorded.Should().ContainSingle(m => m.Status == "failed" && m.Value == 1);
 	}
 
-	// Regression coverage for #1400: EngagementReminderJob used to open a fresh
-	// SMTP connection per volunteer. FakeSmtpServer only ever accepts one TCP
-	// connection (see AcceptAsync below), so if SendBatchAsync tried to reconnect
-	// for message 2 or 3 there would be nothing listening and those sends would
-	// fail - all three succeeding here is itself proof the batch shares one connection.
+	// Regression coverage for #1400: SendBatchAsync must share one SMTP connection
+	// across every message in the batch, not reconnect per message. FakeSmtpServer
+	// only ever accepts one TCP connection (see AcceptAsync below), so if
+	// SendBatchAsync tried to reconnect for message 2 or 3 there would be nothing
+	// listening and those sends would fail - all three succeeding here is itself
+	// proof the batch shares one connection.
 	[Test]
 	public async Task SendBatchAsync_ServerAcceptsAllMessages_SendsEveryMessageOverOneConnection()
 	{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,22 @@ services:
 
   backend:
     image: ghcr.io/maik-hasler/einsatzbereit-backend:staging
-    container_name: backend
+    # No container_name (#1392): a fixed name forbids `docker compose up --scale
+    # backend=N`, since Compose can't give a second replica the same name. Traefik's
+    # Docker provider merges multiple containers sharing the same
+    # traefik.http.routers.backend.* labels into one load-balanced service
+    # automatically, and the prometheus-config target below resolves every replica via
+    # DNS instead of a single fixed hostname, so no other change is needed here to make
+    # scaling itself work.
+    #
+    # Not yet done: OutboxProcessorJob/EngagementReminderJob are now safe to run
+    # multiplied (#1392 fixed their claim races), but the Database__MigrateOnStartup
+    # env var below is not - two replicas booting together would both attempt to apply
+    # pending EF Core migrations concurrently with no lock between them. Actually
+    # running `--scale backend=2` on staging needs that solved first (e.g. a
+    # migration-only leader step, or a Postgres advisory lock around
+    # Database.MigrateAsync()); this change only removes the blocker that made scaling
+    # impossible to even attempt.
     restart: unless-stopped
     networks:
       - proxy
@@ -447,10 +462,18 @@ configs:
             - targets: ["node-exporter:9100"]
 
         # Port 8081, not the Traefik-routed 8080 - see backend's Metrics__Port
-        # and networks above (#1341).
+        # and networks above (#1341). dns_sd_configs (not static_configs) so a
+        # scaled `docker compose up --scale backend=N` gets every replica scraped:
+        # Docker's embedded DNS returns one A record per replica for the plain
+        # service name "backend" on a shared network, and Prometheus's DNS-SD
+        # re-resolves that on every refresh_interval instead of caching a single
+        # IP the way static_configs would (#1392).
         - job_name: backend
-          static_configs:
-            - targets: ["backend:8081"]
+          dns_sd_configs:
+            - names: ["backend"]
+              type: A
+              port: 8081
+              refresh_interval: 30s
   grafana-datasources:
     content: |
       apiVersion: 1


### PR DESCRIPTION
Two replicas polling the same 5s timer could both dispatch the same outbox message, and two replicas' hourly EngagementReminderJob ticks could both send the same 24h reminder - neither job claimed a row before acting on it.

- OutboxProcessorJob now claims its batch with SELECT ... FOR UPDATE SKIP LOCKED inside an explicit transaction, and writes the whole batch in one SaveChangesAsync instead of one per message.
- EngagementReminderJob no longer sends email itself. It atomically claims each due engagement (ExecuteUpdateAsync guarded by ReminderSentAt IS NULL) and queues one EngagementReminderDueDomainEvent per winner into the outbox, the same way every other domain event flows through this system. A new EngagementReminderDueHandler sends the actual email once the outbox dispatches it, so a transient failure retries on the outbox's own 5s cycle instead of being silently lost or double-sent. The whole claim-and-enqueue batch runs in one transaction so a crash between claiming and writing the outbox row can't strand a reminder forever.
- Batch size and poll interval for both jobs are now configurable (EngagementReminderOptions/OutboxOptions) instead of hardcoded consts.
- docker-compose.yml drops the fixed backend container_name (the actual blocker preventing `--scale backend=N`) and switches the Prometheus scrape target to DNS-based discovery so every replica gets scraped. Actually running multiple replicas on staging still needs concurrent Database__MigrateOnStartup handled separately - noted inline as a follow-up, not fixed here.
- Removed the now-fully-unused Engagement.MarkReminderSent domain method.

Fixes #1392

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
