### PR TITLE
perf: parallelize per-user Keycloak role lookups in admin user list

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -26,9 +26,9 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken = default)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/users/{userId}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -83,11 +83,12 @@ internal sealed class KeycloakUserService(
 		};
 
 		var response = await SendAuthorizedAsync(
-			() => httpClient.PutAsJsonAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}",
-				body,
-				JsonOptions,
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Put,
+				$"/admin/realms/{_options.Realm}/users/{userId}")
+			{
+				Content = JsonContent.Create(body, options: JsonOptions),
+			},
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -98,9 +99,9 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken = default)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.DeleteAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Delete,
+				$"/admin/realms/{_options.Realm}/users/{userId}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -120,9 +121,9 @@ internal sealed class KeycloakUserService(
 			: $"search={searchParam}&first={first}&max={pageSize}";
 
 		var response = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/users?{listQuery}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/users?{listQuery}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -130,22 +131,17 @@ internal sealed class KeycloakUserService(
 		var users = await response.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
 			JsonOptions, cancellationToken) ?? [];
 
-		var items = new List<AdminUserListItem>(users.Count);
+		var humanUsers = users.Where(u => u.ServiceAccountClientId is null).ToList();
 
-		// Sequential, not Task.WhenAll: SendAuthorizedAsync mutates the shared
-		// httpClient.DefaultRequestHeaders.Authorization on every call, so
-		// concurrent calls on this one instance would race on that header
-		// collection. GetDisplayNamesAsync above has the same per-user-lookup
-		// shape and is sequential for the same reason - match it.
-		foreach (var user in users)
+		// Each request now sends its own Authorization header (see
+		// SendAuthorizedAsync) instead of mutating a header shared across the
+		// HttpClient instance, so these per-user role lookups are safe to run
+		// concurrently instead of one blocking round trip at a time.
+		var roleNamesByUser = await Task.WhenAll(humanUsers.Select(async user =>
 		{
-			if (user.ServiceAccountClientId is not null)
-				continue;
-
-			IReadOnlyList<string> roles;
 			try
 			{
-				roles = await GetCompositeRealmRoleNamesAsync(user.Id, cancellationToken);
+				return await GetCompositeRealmRoleNamesAsync(user.Id, cancellationToken);
 			}
 			catch
 			{
@@ -156,18 +152,20 @@ internal sealed class KeycloakUserService(
 				// same "ignore individual lookup failures" tolerance as
 				// GetDisplayNamesAsync above, so one stale/racy id doesn't sink
 				// the whole admin Users table.
-				roles = [];
+				return (IReadOnlyList<string>)[];
 			}
+		}));
 
-			items.Add(new AdminUserListItem(
+		var items = humanUsers
+			.Zip(roleNamesByUser, (user, roles) => new AdminUserListItem(
 				Guid.Parse(user.Id),
 				user.Username,
 				NullIfEmpty(user.FirstName),
 				NullIfEmpty(user.LastName),
 				user.Email ?? string.Empty,
 				user.Enabled,
-				roles));
-		}
+				roles))
+			.ToList();
 
 		items.Sort((a, b) => string.Compare(a.Username, b.Username, StringComparison.OrdinalIgnoreCase));
 
@@ -177,9 +175,9 @@ internal sealed class KeycloakUserService(
 		// to correct for a cosmetic pageCount imprecision on an admin-only page.
 		var countQuery = searchParam is null ? "" : $"?search={searchParam}";
 		var countResponse = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/users/count{countQuery}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/users/count{countQuery}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(countResponse, cancellationToken);
@@ -195,11 +193,12 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken = default)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.PutAsJsonAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}",
-				new { enabled },
-				JsonOptions,
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Put,
+				$"/admin/realms/{_options.Realm}/users/{userId}")
+			{
+				Content = JsonContent.Create(new { enabled }, options: JsonOptions),
+			},
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -212,11 +211,12 @@ internal sealed class KeycloakUserService(
 		var role = await GetRealmRoleAsync("admin", cancellationToken);
 
 		var response = await SendAuthorizedAsync(
-			() => httpClient.PostAsJsonAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm",
-				new[] { role },
-				JsonOptions,
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Post,
+				$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm")
+			{
+				Content = JsonContent.Create(new[] { role }, options: JsonOptions),
+			},
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -228,17 +228,13 @@ internal sealed class KeycloakUserService(
 	{
 		var role = await GetRealmRoleAsync("admin", cancellationToken);
 
-		// A new HttpRequestMessage per attempt: SendAuthorizedAsync may invoke
-		// the delegate twice (retry-after-401), and a message can only be sent once.
 		var response = await SendAuthorizedAsync(
-			() => httpClient.SendAsync(
-				new HttpRequestMessage(
-					HttpMethod.Delete,
-					$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm")
-				{
-					Content = JsonContent.Create(new[] { role }, options: JsonOptions),
-				},
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Delete,
+				$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm")
+			{
+				Content = JsonContent.Create(new[] { role }, options: JsonOptions),
+			},
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -249,9 +245,9 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken = default)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/users/{userId}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -267,9 +263,9 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm/composite",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm/composite"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -285,9 +281,9 @@ internal sealed class KeycloakUserService(
 		CancellationToken cancellationToken)
 	{
 		var response = await SendAuthorizedAsync(
-			() => httpClient.GetAsync(
-				$"/admin/realms/{_options.Realm}/roles/{roleName}",
-				cancellationToken),
+			() => new HttpRequestMessage(
+				HttpMethod.Get,
+				$"/admin/realms/{_options.Realm}/roles/{roleName}"),
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
@@ -297,13 +293,19 @@ internal sealed class KeycloakUserService(
 			?? throw new InvalidOperationException($"Keycloak role '{roleName}' not found.");
 	}
 
+	// Builds a fresh HttpRequestMessage per attempt (rather than accepting an
+	// already-built one, or a delegate that calls a shared-httpClient
+	// extension method) and sets the bearer token directly on that message's
+	// own Headers instead of httpClient.DefaultRequestHeaders. That keeps
+	// concurrent calls on this one HttpClient instance from racing on shared
+	// header state, so callers (e.g. ListUsersAsync's per-user role lookups)
+	// can safely run them via Task.WhenAll instead of one at a time.
 	private async Task<HttpResponseMessage> SendAuthorizedAsync(
-		Func<Task<HttpResponseMessage>> send,
+		Func<HttpRequestMessage> createRequest,
 		CancellationToken cancellationToken)
 	{
-		await SetBearerAsync(forceRefresh: false, cancellationToken);
-
-		var response = await send();
+		var token = await tokenProvider.GetTokenAsync(forceRefresh: false, cancellationToken);
+		var response = await SendWithBearerAsync(createRequest(), token, cancellationToken);
 		if (response.StatusCode != HttpStatusCode.Unauthorized)
 		{
 			return response;
@@ -311,18 +313,21 @@ internal sealed class KeycloakUserService(
 
 		// The cached admin token was rejected (e.g. Keycloak cold start or key
 		// rotation). Refresh once and retry so a transient 401 self-heals
-		// instead of bubbling up as a 500.
+		// instead of bubbling up as a 500. A message can only be sent once, so
+		// the retry sends a freshly built request from createRequest().
 		response.Dispose();
-		await SetBearerAsync(forceRefresh: true, cancellationToken);
-		return await send();
+		token = await tokenProvider.GetTokenAsync(forceRefresh: true, cancellationToken);
+		return await SendWithBearerAsync(createRequest(), token, cancellationToken);
 	}
 
-	private async Task SetBearerAsync(
-		bool forceRefresh,
-		CancellationToken cancellationToken) =>
-		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-			"Bearer",
-			await tokenProvider.GetTokenAsync(forceRefresh, cancellationToken));
+	private Task<HttpResponseMessage> SendWithBearerAsync(
+		HttpRequestMessage request,
+		string token,
+		CancellationToken cancellationToken)
+	{
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return httpClient.SendAsync(request, cancellationToken);
+	}
 
 	private static string? NullIfEmpty(string? value) =>
 		string.IsNullOrEmpty(value) ? null : value;

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -118,7 +118,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		var keycloak = Fixture.GetEndpoint("keycloak");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
-		var sharedPrefix = $"admintest1387-{Guid.NewGuid():N}";
+		const string sharedPrefix = "admintest1387";
 		var (plainUsername, plainUserId) = await CreateDisposableUserAsync(
 			keycloak, $"{sharedPrefix}-plain");
 		var (adminUsername, adminUserId) = await CreateDisposableUserAsync(

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -118,11 +118,13 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		var keycloak = Fixture.GetEndpoint("keycloak");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
-		const string sharedPrefix = "admintest1387";
+		// Neither branch of sharedPrefix may contain "admin" as a substring -
+		// see CreateDisposableUserAsync's own note on why.
+		const string sharedPrefix = "tempuser1387";
 		var (plainUsername, plainUserId) = await CreateDisposableUserAsync(
 			keycloak, $"{sharedPrefix}-plain");
-		var (adminUsername, adminUserId) = await CreateDisposableUserAsync(
-			keycloak, $"{sharedPrefix}-admin", ["user", "admin"]);
+		var (elevatedUsername, elevatedUserId) = await CreateDisposableUserAsync(
+			keycloak, $"{sharedPrefix}-elevated", ["user", "admin"]);
 		try
 		{
 			await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
@@ -133,17 +135,17 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
 
 			var plainRow = Page.Locator("tr").Filter(new() { HasTextString = plainUsername });
-			var adminRow = Page.Locator("tr").Filter(new() { HasTextString = adminUsername });
+			var elevatedRow = Page.Locator("tr").Filter(new() { HasTextString = elevatedUsername });
 			await Expect(plainRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
-			await Expect(adminRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+			await Expect(elevatedRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-			await Expect(adminRow.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
+			await Expect(elevatedRow.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
 			await Expect(plainRow.GetByText("Admin", new() { Exact = true })).Not.ToBeVisibleAsync();
 		}
 		finally
 		{
 			await DeleteKeycloakUserAsync(keycloak, plainUserId);
-			await DeleteKeycloakUserAsync(keycloak, adminUserId);
+			await DeleteKeycloakUserAsync(keycloak, elevatedUserId);
 		}
 	}
 

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -104,6 +104,49 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		}
 	}
 
+	/// <summary>
+	/// Regression for #1387: the admin user list used to fetch each row's
+	/// composite realm roles with one blocking, sequential Keycloak call per
+	/// user. The fetches now run concurrently - this pins down that
+	/// parallelizing them still attributes the right roles to the right row
+	/// (no cross-user mixup) when two users come back in the same search.
+	/// </summary>
+	[Test]
+	public async Task AdministrationPage_MultipleUsersInOneSearch_ShowsDistinctRolesPerRow()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var sharedPrefix = $"admintest1387-{Guid.NewGuid():N}";
+		var (plainUsername, plainUserId) = await CreateDisposableUserAsync(
+			keycloak, $"{sharedPrefix}-plain");
+		var (adminUsername, adminUserId) = await CreateDisposableUserAsync(
+			keycloak, $"{sharedPrefix}-admin", ["user", "admin"]);
+		try
+		{
+			await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+			await Page.GotoAsync($"{origin}/administration");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			await Page.Locator("#admin-user-search").FillAsync(sharedPrefix);
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
+
+			var plainRow = Page.Locator("tr").Filter(new() { HasTextString = plainUsername });
+			var adminRow = Page.Locator("tr").Filter(new() { HasTextString = adminUsername });
+			await Expect(plainRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+			await Expect(adminRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+			await Expect(adminRow.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
+			await Expect(plainRow.GetByText("Admin", new() { Exact = true })).Not.ToBeVisibleAsync();
+		}
+		finally
+		{
+			await DeleteKeycloakUserAsync(keycloak, plainUserId);
+			await DeleteKeycloakUserAsync(keycloak, adminUserId);
+		}
+	}
+
 	[Test]
 	public async Task AdministrationPage_OwnRow_HasNoBlockOrDemoteButtons()
 	{
@@ -123,17 +166,21 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(ownRow.GetByRole(AriaRole.Button)).Not.ToBeVisibleAsync();
 	}
 
-	private static async Task<(string Username, string UserId)> CreateDisposableUserAsync(Uri keycloak)
+	private static async Task<(string Username, string UserId)> CreateDisposableUserAsync(
+		Uri keycloak,
+		string usernamePrefix = "tempuser760",
+		IReadOnlyList<string>? roleNames = null)
 	{
 		var adminToken = await GetAdminTokenAsync(keycloak);
-		// Not "admintest760-..." (deliberately doesn't contain "admin" as a
-		// substring): Keycloak's search= does infix matching, so a name
-		// containing "admin" would also match AdministrationPage_OwnRow_
-		// HasNoBlockOrDemoteButtons's search for "admin", surfacing this
-		// disposable user's row in that unrelated test's results - and if
-		// this test's own cleanup below deletes it mid-request, the other
-		// test's per-user Keycloak role lookup 404s on the now-gone id.
-		var username = $"tempuser760-{Guid.NewGuid():N}";
+
+		// Callers must not pass a prefix containing "admin" as a substring:
+		// Keycloak's search= does infix matching, so a name containing "admin"
+		// would also match AdministrationPage_OwnRow_HasNoBlockOrDemoteButtons's
+		// search for "admin", surfacing this disposable user's row in that
+		// unrelated test's results - and if this test's own cleanup below
+		// deletes it mid-request, the other test's per-user Keycloak role
+		// lookup 404s on the now-gone id.
+		var username = $"{usernamePrefix}-{Guid.NewGuid():N}";
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
@@ -149,14 +196,17 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		createResponse.EnsureSuccessStatusCode();
 		var userId = createResponse.Headers.Location!.Segments[^1];
 
-		var roleResponse = await adminHttp.GetAsync($"/admin/realms/{Realm}/roles/user");
-		roleResponse.EnsureSuccessStatusCode();
-		var role = await roleResponse.Content.ReadFromJsonAsync<JsonElement>();
+		foreach (var roleName in roleNames ?? ["user"])
+		{
+			var roleResponse = await adminHttp.GetAsync($"/admin/realms/{Realm}/roles/{roleName}");
+			roleResponse.EnsureSuccessStatusCode();
+			var role = await roleResponse.Content.ReadFromJsonAsync<JsonElement>();
 
-		var assignRoleResponse = await adminHttp.PostAsJsonAsync(
-			$"/admin/realms/{Realm}/users/{userId}/role-mappings/realm",
-			new[] { new { id = role.GetProperty("id").GetString(), name = role.GetProperty("name").GetString() } });
-		assignRoleResponse.EnsureSuccessStatusCode();
+			var assignRoleResponse = await adminHttp.PostAsJsonAsync(
+				$"/admin/realms/{Realm}/users/{userId}/role-mappings/realm",
+				new[] { new { id = role.GetProperty("id").GetString(), name = role.GetProperty("name").GetString() } });
+			assignRoleResponse.EnsureSuccessStatusCode();
+		}
 
 		return (username, userId);
 	}


### PR DESCRIPTION
ListUsersAsync fetched each page's composite realm roles with one blocking sequential Keycloak call per user (10 users -> 12 serialized HTTP round trips per page load). The root cause was SendAuthorizedAsync mutating the shared httpClient.DefaultRequestHeaders.Authorization on every call, which would race under concurrency.

Build a fresh HttpRequestMessage per attempt instead, with the bearer token set directly on that message, so concurrent calls on the same HttpClient no longer share mutable state. The per-user role lookups in ListUsersAsync now run via Task.WhenAll instead of one at a time.

Adds a VisualTests regression covering two users returned in one search to pin down that concurrent lookups still attribute the right roles to the right row.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1387 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
