### PR TITLE
fix: point Keycloak version manager at AGENTS.md, not CLAUDE.md

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^(keycloak/)?CLAUDE\\.md$/",
+        "/^(keycloak/)?AGENTS\\.md$/",
         "/^docs/Architecture/src/.*\\.adoc$/",
         "/^docs/Architecture/images/.*\\.puml$/"
       ],


### PR DESCRIPTION
The version string moved to AGENTS.md when CLAUDE.md became a thin @AGENTS.md include, but the Renovate custom manager still watched CLAUDE.md and silently stopped bumping the documented version.

Fixes #1363

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
