### PR TITLE
refactor: colocate Leaflet CSS with SingleMarkerMap instead of global css

### DIFF
--- a/frontend/src/components/SingleMarkerMap.css
+++ b/frontend/src/components/SingleMarkerMap.css
@@ -1,0 +1,55 @@
+/* Leaflet's own base stylesheet and our brand overrides below it are kept
+in one file, colocated with SingleMarkerMap (this component's sole consumer)
+instead of living in styles/global.css - see #1383. Note this does NOT
+currently split Leaflet's CSS out of the app's single stylesheet into a
+separate on-demand chunk: vite.config.ts sets build.cssCodeSplit: false
+(see the comment there) precisely so CSS always bundles into one file
+regardless of which module - lazy-loaded or not - imports it, after a
+per-chunk-split react-big-calendar stylesheet once raced global.css's
+overrides for the same classes and lost. This file is colocation only
+(so Leaflet's markup and its styling live next to each other, and the two
+rule sets below stay in a fixed, safe relative order - base then override -
+wherever the bundler places this module's output within that single file);
+it ships to every visitor either way. Actually splitting it out would need
+either flipping cssCodeSplit back on (reopening the calendar-CSS ordering
+bug for a fix) or a manual runtime <style> injection, both judged not worth
+it for ~5 kB gzip. */
+@import "leaflet/dist/leaflet.css";
+
+/* ── Leaflet tile filter: desaturate OSM tiles for a clean modern look ───── */
+.leaflet-tile-pane {
+	filter: grayscale(1) brightness(1.05) contrast(0.9);
+}
+
+/* ── Leaflet popup overrides ─────────────────────────────────────────────── */
+.leaflet-popup-content-wrapper {
+	border-radius: 0.75rem;
+	box-shadow:
+		0 4px 16px -2px rgb(0 0 0 / 0.1),
+		0 2px 4px -1px rgb(0 0 0 / 0.06);
+	border: 1px solid rgb(229 231 235);
+	padding: 0;
+	overflow: hidden;
+}
+
+.leaflet-popup-content {
+	margin: 0;
+	min-width: 180px;
+}
+
+.leaflet-popup-tip {
+	background: white;
+	box-shadow: none;
+}
+
+.leaflet-popup-close-button {
+	color: rgb(156 163 175);
+	padding: 6px 8px 0 0;
+	font-size: 18px;
+	line-height: 1;
+}
+
+.leaflet-popup-close-button:hover {
+	color: rgb(55 65 81);
+	background: none;
+}

--- a/frontend/src/components/SingleMarkerMap.tsx
+++ b/frontend/src/components/SingleMarkerMap.tsx
@@ -1,6 +1,10 @@
 import L from "leaflet";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import { runtimeConfig } from "../lib/runtimeConfig";
+// Colocated with this component (not styles/global.css) - see #1383 and the
+// comment atop SingleMarkerMap.css for why the overrides moved here too, and
+// why this doesn't split into its own CSS chunk (cssCodeSplit is off).
+import "./SingleMarkerMap.css";
 
 // Proxied through the backend rather than tile.openstreetmap.org directly so
 // visitor IP addresses aren't disclosed to the OpenStreetMap Foundation - see

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -337,7 +337,7 @@ export default function EngagementManagementPage() {
 											<button
 												onClick={() => handleConfirm(e.id)}
 												disabled={confirming === e.id}
-												className="rounded-xl bg-green-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+												className="rounded-xl bg-green-700 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-green-800 disabled:opacity-50"
 											>
 												{confirming === e.id
 													? t("engagementManagement.processing")

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "leaflet/dist/leaflet.css";
 
 html {
 	scroll-behavior: smooth;
@@ -33,44 +32,6 @@ html {
 	.animate-fade-up-d4 {
 		animation: fade-up 0.55s ease-out 0.48s both;
 	}
-}
-
-/* ── Leaflet tile filter: desaturate OSM tiles for a clean modern look ───── */
-.leaflet-tile-pane {
-	filter: grayscale(1) brightness(1.05) contrast(0.9);
-}
-
-/* ── Leaflet popup overrides ─────────────────────────────────────────────── */
-.leaflet-popup-content-wrapper {
-	border-radius: 0.75rem;
-	box-shadow:
-		0 4px 16px -2px rgb(0 0 0 / 0.1),
-		0 2px 4px -1px rgb(0 0 0 / 0.06);
-	border: 1px solid rgb(229 231 235);
-	padding: 0;
-	overflow: hidden;
-}
-
-.leaflet-popup-content {
-	margin: 0;
-	min-width: 180px;
-}
-
-.leaflet-popup-tip {
-	background: white;
-	box-shadow: none;
-}
-
-.leaflet-popup-close-button {
-	color: rgb(156 163 175);
-	padding: 6px 8px 0 0;
-	font-size: 18px;
-	line-height: 1;
-}
-
-.leaflet-popup-close-button:hover {
-	color: rgb(55 65 81);
-	background: none;
 }
 
 /* ── datetime-local / date / time input normalization ────────────────────── */


### PR DESCRIPTION
Follows up on #1383: the anonymous-visitor bundle size problem it reported was already fixed by prior route-splitting/lazy-loading PRs (#1452, #1462). This addresses the one remaining suggestion - Leaflet's stylesheet still lived in the always-loaded global.css - by moving it and its brand overrides next to their sole consumer. Doesn't reduce shipped bytes since vite.config.ts intentionally disables cssCodeSplit (documented there, to avoid a cascade-order regression with react-big-calendar's CSS), but keeps Leaflet's markup and styling together and documents the constraint for the next person who tries the same split.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1383

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
