### PR TITLE
fix: reserve two cores from VisualTests concurrency, not one, for CPU-heavy axe scans

### DIFF
--- a/backend/tests/VisualTests/AssemblyParallelLimit.cs
+++ b/backend/tests/VisualTests/AssemblyParallelLimit.cs
@@ -26,9 +26,32 @@ using TUnit.Core.Interfaces;
 // as running out of headroom. Environment.ProcessorCount rather than a
 // hardcoded number so this scales with whatever runner size CI happens to
 // use, and with a larger local dev machine.
+//
+// Reserving just one core still wasn't enough: on 2026-07-29, three
+// AccessibilityTests methods (OrgDashboardPage_PlacingAWidget_AsOlaf,
+// EngagementManagementPage_AsOlaf, OrganizationSettingsPage_
+// EditModeValidationError_AsOlaf - the single heaviest class in the suite,
+// every method paying for a Page.RunAxe() DOM scan on top of the Chromium
+// work every other test already does) hit this limit's cap of 3 concurrently
+// and all three sat in the runner's "[slow] still running after 1m 00s" log
+// at once; one blew past a 30s Playwright action timeout on a plain input
+// fill (no network call involved), meaning it was CPU-starved, not
+// backend-starved. The obvious-looking fix - give AccessibilityTests its own,
+// tighter [ParallelLimiter<T>] at the class level on top of this assembly-wide
+// one - does NOT work: verified empirically (throwaway TUnit project, two
+// classes, one assembly-level limiter plus one class-level limiter on the
+// second class, tests recording their own peak concurrency) that when both an
+// assembly-level and a class-level ParallelLimiter apply to the same test,
+// TUnit 1.34.5 honors only the assembly-level one - the class-level cap is
+// silently ignored, in both directions (a looser assembly limit lets the
+// class exceed its own tighter one; a tighter assembly limit overrides a
+// looser class one). A class-level-only fix would have shipped as a
+// no-op that still passes the build. Reduce the shared limit itself instead -
+// this does cost the whole suite a slightly lower ceiling, not just the
+// heaviest class, but it's the one lever that's actually proven to work.
 [assembly: ParallelLimiter<VisualTestsParallelLimit>]
 
 public sealed class VisualTestsParallelLimit : IParallelLimit
 {
-	public int Limit => Math.Max(1, Environment.ProcessorCount - 1);
+	public int Limit => Math.Max(1, Environment.ProcessorCount - 2);
 }


### PR DESCRIPTION
Reserving one core (6ac12f6) wasn't enough: three AccessibilityTests methods hit the ProcessorCount-1 cap and ran concurrently in CI on 2026-07-29, all three CPU-heavy axe-core scans, and one blew past a 30s Playwright action timeout on a plain input fill (no network call involved) - CPU starvation, not backend starvation.

A class-level ParallelLimiter scoped just to AccessibilityTests looked like the more surgical fix, but verified empirically (throwaway TUnit project) that it doesn't stack with the existing assembly-level one in TUnit 1.34.5 - the class-level cap is silently ignored, so that would have shipped as a no-op. Lowering the shared assembly-wide limit is the one lever proven to actually work.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
