### PR TITLE
fix: stop GetMembersAsync fetching every realm organisator per call

### DIFF
--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -36,6 +36,14 @@ public interface IKeycloakOrganizationService
 		Guid organizationId,
 		CancellationToken cancellationToken = default);
 
+	// Realm-wide, not scoped to an organization - Keycloak has no per-organization
+	// organisator role to query. Reserved for one-shot reconciliation
+	// (OrganizationMembershipBackfillJob) against the local organization_membership
+	// table; GetMembersAsync answers IsOrganisator from that table instead, since
+	// calling this on every request is exactly the perf/correctness bug fixed by #1386.
+	Task<IReadOnlySet<Guid>> GetRealmOrganisatorUserIdsAsync(
+		CancellationToken cancellationToken = default);
+
 	Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 		string search,
 		int max = 20,

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -40,6 +40,10 @@ public interface IApplicationDbContext
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
 
+	Task<HashSet<Guid>> GetOrganizerUserIdsAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default);
+
 	Task<OrganizationDashboardLayout?> GetDashboardLayoutAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
@@ -90,16 +90,28 @@ internal sealed class OrganizationMembershipBackfillJob(
 				.Select(o => o.Id)
 				.ToListAsync(cancellationToken);
 
-			foreach (var organizationId in organizationIds)
+			if (organizationIds.Count > 0)
 			{
-				var members = await keycloakOrganizationService.GetMembersAsync(
-					organizationId.Value, cancellationToken);
+				// Realm-wide organizer set fetched once for the whole run, not per
+				// organization - GetMembersAsync's own IsOrganisator flag can't be used
+				// here since it now reads the very organization_membership rows this job
+				// exists to create (see #1386), which are empty for every organization in
+				// organizationIds by definition.
+				var realmOrganizerIds = await keycloakOrganizationService.GetRealmOrganisatorUserIdsAsync(cancellationToken);
 
-				foreach (var member in members.Where(m => m.IsOrganisator).DistinctBy(m => m.UserId))
+				foreach (var organizationId in organizationIds)
 				{
-					dbContext.Set<OrganizationMembership>().Add(
-						OrganizationMembership.Create(
-							organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+					var members = await keycloakOrganizationService.GetMembersAsync(
+						organizationId.Value, cancellationToken);
+
+					foreach (var member in members
+						.Where(m => realmOrganizerIds.Contains(m.UserId))
+						.DistinctBy(m => m.UserId))
+					{
+						dbContext.Set<OrganizationMembership>().Add(
+							OrganizationMembership.Create(
+								organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+					}
 				}
 			}
 

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -4,7 +4,10 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Domain.Organizations;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Keycloak;
@@ -12,7 +15,8 @@ namespace Infrastructure.Keycloak;
 internal sealed class KeycloakOrganizationService(
 	HttpClient httpClient,
 	KeycloakAdminTokenProvider tokenProvider,
-	IOptions<KeycloakOptions> options)
+	IOptions<KeycloakOptions> options,
+	IApplicationDbContext dbContext)
 	: IKeycloakOrganizationService
 {
 	private static readonly JsonSerializerOptions JsonOptions = new()
@@ -102,16 +106,13 @@ internal sealed class KeycloakOrganizationService(
 		var members = await membersResponse.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
 			JsonOptions, cancellationToken) ?? [];
 
-		var organisatorsResponse = await httpClient.GetAsync(
-			$"/admin/realms/{_options.Realm}/roles/organisator/users",
-			cancellationToken);
-
-		await EnsureSuccessAsync(organisatorsResponse, cancellationToken);
-
-		var organisators = await organisatorsResponse.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
-			JsonOptions, cancellationToken) ?? [];
-
-		var organisatorIds = organisators.Select(u => u.Id).ToHashSet();
+		// Organizer status is answered from the local organization_membership table
+		// (scoped to this organization) instead of Keycloak's realm-wide organisator
+		// role - see #1386. That also makes it correctly per-organization, where the
+		// old Keycloak-role-based check was global across every organization a user
+		// ever organized.
+		var organizerIds = await dbContext.GetOrganizerUserIdsAsync(
+			OrganizationId.Create(organizationId).GetValueOrThrow(), cancellationToken);
 
 		return members
 			.Select(u => new KeycloakOrganizationMember(
@@ -120,8 +121,25 @@ internal sealed class KeycloakOrganizationService(
 				u.FirstName,
 				u.LastName,
 				u.Email ?? string.Empty,
-				organisatorIds.Contains(u.Id)))
+				organizerIds.Contains(Guid.Parse(u.Id))))
 			.ToList();
+	}
+
+	public async Task<IReadOnlySet<Guid>> GetRealmOrganisatorUserIdsAsync(
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var response = await httpClient.GetAsync(
+			$"/admin/realms/{_options.Realm}/roles/organisator/users",
+			cancellationToken);
+
+		await EnsureSuccessAsync(response, cancellationToken);
+
+		var users = await response.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
+			JsonOptions, cancellationToken) ?? [];
+
+		return users.Select(u => Guid.Parse(u.Id)).ToHashSet();
 	}
 
 	public async Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -110,6 +110,19 @@ internal sealed class ApplicationDbContext(
 			.CountAsync(m => m.OrganizationId == organizationId
 				&& m.Role == OrganizationMemberRole.Organizer, cancellationToken);
 
+	public async Task<HashSet<Guid>> GetOrganizerUserIdsAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default)
+	{
+		var userIds = await Set<OrganizationMembership>()
+			.AsNoTracking()
+			.Where(m => m.OrganizationId == organizationId && m.Role == OrganizationMemberRole.Organizer)
+			.Select(m => m.UserId)
+			.ToListAsync(cancellationToken);
+
+		return userIds.Select(id => id.Value).ToHashSet();
+	}
+
 	public async Task<OrganizationDashboardLayout?> GetDashboardLayoutAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -69,6 +69,36 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 	}
 
 	[Test]
+	public async Task BackfillAsync_MultiplePreExistingOrganizations_FetchesRealmOrganizerSetOnlyOnce(
+		CancellationToken cancellationToken)
+	{
+		// #1386: the realm-wide organizer set must be fetched once per run, not
+		// once per organization - GetMembersAsync itself no longer makes that
+		// realm-wide call at all (it now reads local organization_membership rows),
+		// so this job is the only remaining caller and must not reintroduce an
+		// O(organizations) Keycloak round trip.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+		await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
+
+		var organizerId = Guid.NewGuid();
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			MembersToReturn =
+			[
+				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
+			],
+		};
+
+		await OrganizationMembershipBackfillJob.BackfillAsync(
+			dbContext, keycloak, NullLogger.Instance, cancellationToken);
+
+		keycloak.GetMembersCallCount.Should().Be(2, "each of the two pre-existing organizations still needs its own member list");
+		keycloak.GetRealmOrganisatorCallCount.Should().Be(
+			1, "the realm-wide organizer set is shared across every organization in the same run, not re-fetched per organization");
+	}
+
+	[Test]
 	public async Task BackfillAsync_OrganizationHasNoOrganizers_StillWritesCompletionMarkerAndNeverRetries(
 		CancellationToken cancellationToken)
 	{
@@ -166,6 +196,8 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 
 		public int GetMembersCallCount { get; private set; }
 
+		public int GetRealmOrganisatorCallCount { get; private set; }
+
 		public Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
 			Guid organizationId, CancellationToken cancellationToken = default)
 		{
@@ -175,6 +207,18 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 				throw new HttpRequestException("Keycloak unavailable (simulated).");
 
 			return Task.FromResult(MembersToReturn);
+		}
+
+		// Derived from MembersToReturn's IsOrganisator flags rather than tracked
+		// separately - BackfillAsync now sources the organizer set from here instead
+		// of from each member's IsOrganisator (see #1386), and every existing test in
+		// this class already expresses "who is an organizer" that way.
+		public Task<IReadOnlySet<Guid>> GetRealmOrganisatorUserIdsAsync(CancellationToken cancellationToken = default)
+		{
+			GetRealmOrganisatorCallCount++;
+
+			return Task.FromResult<IReadOnlySet<Guid>>(
+				MembersToReturn.Where(m => m.IsOrganisator).Select(m => m.UserId).ToHashSet());
 		}
 
 		public Task<Guid> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default) =>

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -228,6 +228,37 @@ public class OrganizationSettingsTests(
 		stillThere.Name.Should().Be("Escalation Test Org");
 	}
 
+	[Test]
+	public async Task GetOrganizationDetails_ShouldNotFlagMemberAsOrganisator_WhenTheyOnlyOrganizeAnUnrelatedOrg(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1386: GetMembersAsync used to derive each member's
+		// IsOrganisator from Keycloak's platform-wide "organisator" role, so a
+		// plain member here who happens to organize a different org would
+		// incorrectly show as an organizer of this one too. It now answers
+		// per-organization from the local organization_membership table instead.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		// vera organizes her own, unrelated org - she holds the platform-wide
+		// Keycloak "organisator" role.
+		await veraClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Vera's Own Org 5" }, cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Cross-Org Organizer Display Test Org" }, cancellationToken);
+
+		// olaf's org gains vera as a plain member only, never promoted here.
+		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
+
+		var details = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+
+		details.Members.Should().Contain(m => m.UserId == olaf.Id && m.IsOrganisator);
+		details.Members.Should().Contain(m => m.UserId == vera.Id && !m.IsOrganisator);
+	}
+
 	// ── Invitations ─────────────────────────────────────────────────────────
 
 	[Test]


### PR DESCRIPTION
GetMembersAsync fetched Keycloak's whole realm-wide organisator role list on every call (nearly every org-app page load), unbounded and scaling with total platform organisators rather than the viewed org. Answer per-organization organizer status from the already-synced local organization_membership table instead - also fixes it being global across every org a user organizes rather than per-organization.

OrganizationMembershipBackfillJob still needs the real, realm-wide Keycloak role list to seed that same table for pre-existing orgs, so it gets its own GetRealmOrganisatorUserIdsAsync call (now once per run instead of once per organization).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1386 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
