### PR TITLE
perf: bound org calendar-events query to a date range, drop per-slot COUNT subquery

### DIFF
--- a/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
@@ -19,6 +19,7 @@ internal sealed class GetOrganizationCalendarEventsEndpoint
 		app.MapGet("/organizations/{organizationId:guid}/calendar-events", GetOrganizationCalendarEventsAsync)
 			.WithName("GetOrganizationCalendarEvents")
 			.Produces<IReadOnlyList<OrganizationCalendarEventDto>>()
+			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
@@ -29,15 +30,20 @@ internal sealed class GetOrganizationCalendarEventsEndpoint
 
 	private static async Task<IResult> GetOrganizationCalendarEventsAsync(
 		[FromRoute] Guid organizationId,
+		[FromQuery] DateTimeOffset from,
+		[FromQuery] DateTimeOffset to,
 		[FromServices] ISender sender,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
+		if (to < from)
+			return Results.Problem("'to' must not be before 'from'.", statusCode: StatusCodes.Status400BadRequest);
+
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
-		var query = new GetOrganizationCalendarEventsQuery(organizationId, userId);
+		var query = new GetOrganizationCalendarEventsQuery(organizationId, userId, from, to);
 		var result = await sender.Send(query, cancellationToken);
 		return Results.Ok(result);
 	}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -3786,6 +3786,24 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           }
         ],
         "responses": {
@@ -3798,6 +3816,16 @@
                   "items": {
                     "$ref": "#/components/schemas/OrganizationCalendarEventDto"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQuery.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQuery.cs
@@ -5,5 +5,7 @@ namespace Application.Organizations.GetOrganizationCalendarEvents.v1;
 
 public sealed record GetOrganizationCalendarEventsQuery(
 	Guid OrganizationId,
-	UserId RequestingUserId)
+	UserId RequestingUserId,
+	DateTimeOffset From,
+	DateTimeOffset To)
 	: IQuery<IReadOnlyList<OrganizationCalendarEventDto>>;

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
@@ -22,6 +22,8 @@ internal sealed class GetOrganizationCalendarEventsQueryHandler(
 
 		return await readRepository.GetCalendarEventsAsync(
 			request.OrganizationId,
+			request.From,
+			request.To,
 			cancellationToken);
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
+++ b/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
@@ -31,5 +31,7 @@ public interface IVolunteerOpportunityReadRepository
 
 	ValueTask<IReadOnlyList<OrganizationCalendarEventDto>> GetCalendarEventsAsync(
 		Guid organizationId,
+		DateTimeOffset from,
+		DateTimeOffset to,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -542,40 +542,49 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 	public async ValueTask<IReadOnlyList<OrganizationCalendarEventDto>> GetCalendarEventsAsync(
 		Guid organizationId,
+		DateTimeOffset from,
+		DateTimeOffset to,
 		CancellationToken cancellationToken = default)
 	{
 		var orgId = OrganizationId.Create(organizationId).GetValueOrThrow();
 
 		var rows = await dbContext.VolunteerOpportunitiesQuery
 			.Where(vo => vo.OrganizationId == orgId)
-			.Where(vo => vo.TimeSlots.Any())
-			.OrderBy(vo => vo.TimeSlots.Min(ts => ts.StartDateTime))
+			.Where(vo => vo.TimeSlots.Any(ts => ts.StartDateTime >= from && ts.StartDateTime <= to))
+			.OrderBy(vo => vo.TimeSlots
+				.Where(ts => ts.StartDateTime >= from && ts.StartDateTime <= to)
+				.Min(ts => ts.StartDateTime))
 			.Select(vo => new
 			{
 				Id = vo.Id.Value,
 				vo.Title,
 				vo.Color,
 				TimeSlots = vo.TimeSlots
+					.Where(ts => ts.StartDateTime >= from && ts.StartDateTime <= to)
 					.OrderBy(ts => ts.StartDateTime)
 					.Select(ts => new { SlotId = ts.Id.Value, ts.StartDateTime, ts.EndDateTime, ts.MaxParticipants })
 					.ToList(),
 			})
 			.ToListAsync(cancellationToken);
 
-		var opportunityIds = rows.Select(r => VolunteerOpportunityId.Create(r.Id).GetValueOrThrow()).ToList();
-		var slotCounts = opportunityIds.Count == 0
-			? new Dictionary<Guid, int>()
-			: await dbContext.VolunteerOpportunitiesQuery
-				.Where(vo => opportunityIds.Contains(vo.Id))
-				.SelectMany(vo => vo.TimeSlots)
-				.Select(ts => new
-				{
-					SlotId = ts.Id.Value,
-					BookedCount = dbContext.EngagementsQuery.Count(e =>
-						e.TimeSlotId == ts.Id &&
-						(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed)),
-				})
-				.ToDictionaryAsync(x => x.SlotId, x => x.BookedCount, cancellationToken);
+		if (rows.Count == 0)
+			return [];
+
+		var slotIds = rows
+			.SelectMany(r => r.TimeSlots)
+			.Select(ts => TimeSlotId.Create(ts.SlotId).GetValueOrThrow())
+			.ToList();
+
+		// Grouped instead of a correlated Count(...) subquery per slot (#1389) -
+		// mirrors LoadParticipantStatsAsync's participantCounts query below.
+		var bookedCounts = await dbContext.EngagementsQuery
+			.Where(e => e.TimeSlotId.HasValue && slotIds.Contains(e.TimeSlotId.Value) &&
+				(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
+			.GroupBy(e => e.TimeSlotId!.Value)
+			.Select(g => new { SlotId = g.Key.Value, Count = g.Count() })
+			.ToListAsync(cancellationToken);
+
+		var slotCounts = bookedCounts.ToDictionary(x => x.SlotId, x => x.Count);
 
 		return rows
 			.Select(r => new OrganizationCalendarEventDto(

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -572,19 +572,26 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 		var slotIds = rows
 			.SelectMany(r => r.TimeSlots)
-			.Select(ts => TimeSlotId.Create(ts.SlotId).GetValueOrThrow())
+			.Select(ts => (TimeSlotId?)TimeSlotId.Create(ts.SlotId).GetValueOrThrow())
 			.ToList();
 
-		// Grouped instead of a correlated Count(...) subquery per slot (#1389) -
-		// mirrors LoadParticipantStatsAsync's participantCounts query below.
-		var bookedCounts = await dbContext.EngagementsQuery
-			.Where(e => e.TimeSlotId.HasValue && slotIds.Contains(e.TimeSlotId.Value) &&
+		// Single query instead of a correlated Count(...) subquery per slot
+		// (#1389) - but grouped client-side rather than via GroupBy(...).Value in
+		// the query itself: EF Core can't reliably translate .Value/GroupBy on a
+		// Nullable<TimeSlotId> sitting behind TimeSlotId's HasConversion (unlike
+		// LoadParticipantStatsAsync's participantCounts query below, which groups
+		// by the non-nullable OpportunityId and works fine). Fetching the raw
+		// nullable values and counting them here keeps it to one round trip
+		// without hitting that translation gap.
+		var activeSlotIds = await dbContext.EngagementsQuery
+			.Where(e => slotIds.Contains(e.TimeSlotId) &&
 				(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
-			.GroupBy(e => e.TimeSlotId!.Value)
-			.Select(g => new { SlotId = g.Key.Value, Count = g.Count() })
+			.Select(e => e.TimeSlotId)
 			.ToListAsync(cancellationToken);
 
-		var slotCounts = bookedCounts.ToDictionary(x => x.SlotId, x => x.Count);
+		var slotCounts = activeSlotIds
+			.GroupBy(id => id!.Value.Value)
+			.ToDictionary(g => g.Key, g => g.Count());
 
 		return rows
 			.Select(r => new OrganizationCalendarEventDto(

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
@@ -18,6 +18,8 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 
 	private static readonly Guid DefaultOrgId = Guid.NewGuid();
 	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static readonly DateTimeOffset DefaultFrom = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+	private static readonly DateTimeOffset DefaultTo = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
 
 	public GetOrganizationCalendarEventsQueryHandlerTests()
 	{
@@ -36,15 +38,40 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 		{
 			new(Guid.NewGuid(), "Title", "#ff0000", []),
 		};
-		_readRepository.GetCalendarEventsAsync(DefaultOrgId, cancellationToken).Returns(events);
+		_readRepository.GetCalendarEventsAsync(DefaultOrgId, DefaultFrom, DefaultTo, cancellationToken).Returns(events);
 
-		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId);
+		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId, DefaultFrom, DefaultTo);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
 		result.Should().BeEquivalentTo(events);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPassThroughFromAndTo_Unchanged(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var capturedFrom = DateTimeOffset.MinValue;
+		var capturedTo = DateTimeOffset.MinValue;
+		_readRepository
+			.GetCalendarEventsAsync(
+				Arg.Any<Guid>(),
+				Arg.Do<DateTimeOffset>(f => capturedFrom = f),
+				Arg.Do<DateTimeOffset>(t => capturedTo = t),
+				Arg.Any<CancellationToken>())
+			.Returns([]);
+
+		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId, DefaultFrom, DefaultTo);
+
+		// Act
+		await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		capturedFrom.Should().Be(DefaultFrom);
+		capturedTo.Should().Be(DefaultTo);
 	}
 
 	[Test]
@@ -56,7 +83,7 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
-		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId);
+		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId, DefaultFrom, DefaultTo);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
@@ -64,6 +91,7 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 		// Assert
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
-		await _readRepository.DidNotReceive().GetCalendarEventsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+		await _readRepository.DidNotReceive().GetCalendarEventsAsync(
+			Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -295,7 +295,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.DateTimeOffset from, System.DateTimeOffset to, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
@@ -6396,10 +6396,16 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<OrganizationCalendarEventDto>> GetOrganizationCalendarEventsAsync(System.Guid organizationId, System.DateTimeOffset from, System.DateTimeOffset to, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (organizationId == null)
                 throw new System.ArgumentNullException("organizationId");
+
+            if (from == null)
+                throw new System.ArgumentNullException("from");
+
+            if (to == null)
+                throw new System.ArgumentNullException("to");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -6416,6 +6422,10 @@ namespace IntegrationTests
                     urlBuilder_.Append("v1/organizations/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/calendar-events");
+                    urlBuilder_.Append('?');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("from")).Append('=').Append(System.Uri.EscapeDataString(from.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("to")).Append('=').Append(System.Uri.EscapeDataString(to.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Length--;
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -6448,6 +6458,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 401)

--- a/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
@@ -1,0 +1,227 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1389: GetCalendarEventsAsync used to return every
+// time slot an organization ever created, with no date bound and a
+// per-slot correlated COUNT subquery. These tests pin down that only slots
+// within the requested [from, to] window come back, and that booked counts
+// stay correct once the count query is grouped instead of correlated.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OrganizationCalendarEventsTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturnOnlySlotsWithinRange_ExcludingSlotsOutsideRange(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateWaitlistDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var inRangeStart = DateTimeOffset.UtcNow.AddDays(10);
+		var inRangeSlot = (await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = inRangeStart,
+				EndDateTime = inRangeStart.AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		var outOfRangeStart = DateTimeOffset.UtcNow.AddDays(90);
+		await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = outOfRangeStart,
+				EndDateTime = outOfRangeStart.AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		var events = await olafClient.GetOrganizationCalendarEventsAsync(
+			orgId,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		var evt = events.Single();
+		evt.OpportunityId.Should().Be(opportunity.Id);
+		evt.TimeSlots.Select(ts => ts.TimeSlotId).Should().BeEquivalentTo([inRangeSlot]);
+	}
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturnBookedCount_ForPendingAndConfirmedEngagementsOnly(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateWaitlistDraftOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var slotStart = DateTimeOffset.UtcNow.AddDays(5);
+		var slotId = (await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = slotStart,
+				EndDateTime = slotStart.AddHours(2),
+				MaxParticipants = 5,
+				RecurrenceCount = 1,
+			},
+			cancellationToken)).Single().Id;
+
+		// Pending engagement counts toward bookedCount.
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { TimeSlotId = slotId },
+			cancellationToken);
+
+		// Cancelled engagement must not count.
+		var toBeCancelled = await olafClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { TimeSlotId = slotId },
+			cancellationToken);
+		await olafClient.CancelEngagementAsync(
+			toBeCancelled.Id,
+			new CancelEngagementRequest { Reason = "No longer needed" },
+			cancellationToken);
+
+		var events = await olafClient.GetOrganizationCalendarEventsAsync(
+			orgId,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		events.Single().TimeSlots.Single().BookedCount.Should().Be(1);
+	}
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturnEmptyList_WhenNoSlotsFallWithinRange(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		var events = await olafClient.GetOrganizationCalendarEventsAsync(
+			orgId,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		events.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturn400_WhenToIsBeforeFrom(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		var act = () => olafClient.GetOrganizationCalendarEventsAsync(
+			orgId,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(-1),
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturn401_WhenNotAuthenticated(
+		CancellationToken cancellationToken)
+	{
+		var anonClient = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var act = () => anonClient.GetOrganizationCalendarEventsAsync(
+			Guid.NewGuid(),
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(401);
+	}
+
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldReturn403_WhenOrganisatorAccessesOtherOrgsEvents(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		var veraToken = await fixture.GetAccessTokenAsync("vera", "vera123");
+		var veraHttpClient = fixture.CreateHttpClient();
+		veraHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", veraToken);
+		var veraClient = new EinsatzbereitApi(veraHttpClient);
+
+		// vera creates her own org - this grants her the organisator role
+		await CreateOrganizationAsync(veraClient, cancellationToken);
+
+		// vera (organisator, but NOT in org1) tries to access org1's calendar events
+		var act = () => veraClient.GetOrganizationCalendarEventsAsync(
+			org1Id,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"CalendarEventsTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateWaitlistDraftOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		// Time slots can only be added to Waitlist opportunities (see
+		// VolunteerOpportunity.AddTimeSlot). Created as a draft since a Waitlist
+		// opportunity can't be published until it has at least one time slot.
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Calendar Events Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "Recurring",
+				ParticipationType = "Waitlist",
+				CheckInMethod = "None",
+				IsDraft = true,
+			},
+			cancellationToken);
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3364,11 +3364,19 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
-    getOrganizationCalendarEvents(organizationId: string, signal?: AbortSignal): Promise<OrganizationCalendarEventDto[]> {
-        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/calendar-events";
+    getOrganizationCalendarEvents(organizationId: string, from: Date, to: Date, signal?: AbortSignal): Promise<OrganizationCalendarEventDto[]> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/calendar-events?";
         if (organizationId === undefined || organizationId === null)
             throw new globalThis.Error("The parameter 'organizationId' must be defined.");
         url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        if (from === undefined || from === null)
+            throw new globalThis.Error("The parameter 'from' must be defined and cannot be null.");
+        else
+            url_ += "from=" + encodeURIComponent(from ? "" + from.toISOString() : "") + "&";
+        if (to === undefined || to === null)
+            throw new globalThis.Error("The parameter 'to' must be defined and cannot be null.");
+        else
+            url_ += "to=" + encodeURIComponent(to ? "" + to.toISOString() : "") + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -3392,6 +3400,12 @@ export class EinsatzbereitApi {
             let result200: any = null;
             result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as OrganizationCalendarEventDto[];
             return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
             });
         } else if (status === 401) {
             return response.text().then((_responseText) => {

--- a/frontend/src/lib/calendarRange.test.ts
+++ b/frontend/src/lib/calendarRange.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { format } from "date-fns";
+import { visibleCalendarRange } from "./calendarRange";
+
+// date-fns's own functions (and react-big-calendar's) all operate in local
+// time, so assertions format with `format(..., "yyyy-MM-dd")` (local) rather
+// than `toISOString()` (UTC) - the latter would shift by a day whenever the
+// test runner's local timezone isn't UTC.
+const day = (date: Date) => format(date, "yyyy-MM-dd");
+
+describe("visibleCalendarRange", () => {
+	it("pads month view to full weeks around the month's start and end", () => {
+		// 2026-02-01 is a Sunday, 2026-02-28 is a Saturday - date-fns's default
+		// (Sunday-start) week already aligns with the month here, so the
+		// padding is a useful sanity check: it should stay exactly on those
+		// boundaries rather than pulling in an extra week on either side.
+		const { from, to } = visibleCalendarRange(new Date(2026, 1, 15), "month");
+
+		expect(day(from)).toBe("2026-02-01");
+		expect(day(to)).toBe("2026-02-28");
+	});
+
+	it("pads month view to the surrounding weeks when the month doesn't align to week boundaries", () => {
+		// 2026-03-01 is a Sunday too, but 2026-03-31 is a Tuesday, so the
+		// visible grid must extend into early April to complete that week.
+		const { from, to } = visibleCalendarRange(new Date(2026, 2, 10), "month");
+
+		expect(day(from)).toBe("2026-03-01");
+		expect(day(to)).toBe("2026-04-04");
+	});
+
+	it("returns the Sunday-to-Saturday week for week view", () => {
+		const { from, to } = visibleCalendarRange(new Date(2026, 2, 11), "week");
+
+		expect(day(from)).toBe("2026-03-08");
+		expect(day(to)).toBe("2026-03-14");
+	});
+
+	it("returns the same range for work_week as for week", () => {
+		const week = visibleCalendarRange(new Date(2026, 2, 11), "week");
+		const workWeek = visibleCalendarRange(new Date(2026, 2, 11), "work_week");
+
+		expect(workWeek).toEqual(week);
+	});
+
+	it("returns just the single day for day view", () => {
+		const { from, to } = visibleCalendarRange(new Date(2026, 2, 11), "day");
+
+		expect(day(from)).toBe("2026-03-11");
+		expect(day(to)).toBe("2026-03-11");
+		expect(from.getHours()).toBe(0);
+		expect(to.getHours()).toBe(23);
+	});
+
+	it("returns a 30-day forward window for agenda view, matching react-big-calendar's default length", () => {
+		const { from, to } = visibleCalendarRange(new Date(2026, 2, 11), "agenda");
+
+		expect(day(from)).toBe("2026-03-11");
+		expect(day(to)).toBe("2026-04-10");
+	});
+
+	it("always returns from before or equal to to", () => {
+		const views: Array<Parameters<typeof visibleCalendarRange>[1]> = [
+			"month",
+			"week",
+			"work_week",
+			"day",
+			"agenda",
+		];
+		for (const view of views) {
+			const { from, to } = visibleCalendarRange(new Date(2026, 5, 20), view);
+			expect(from.getTime()).toBeLessThanOrEqual(to.getTime());
+		}
+	});
+});

--- a/frontend/src/lib/calendarRange.ts
+++ b/frontend/src/lib/calendarRange.ts
@@ -1,0 +1,46 @@
+import {
+	startOfWeek,
+	endOfWeek,
+	startOfMonth,
+	endOfMonth,
+	startOfDay,
+	endOfDay,
+	addDays,
+} from "date-fns";
+import type { View } from "react-big-calendar";
+
+// Matches react-big-calendar's own default Agenda view length (see
+// DEFAULT_LENGTH in its Agenda view) - the widget never overrides `length`,
+// so requesting the same window keeps calendar-events data aligned with
+// what the agenda view actually renders.
+const AGENDA_LENGTH_DAYS = 30;
+
+// Mirrors the date math react-big-calendar's own view components use
+// internally to decide what's on screen (Month.range/Week.range/etc. via
+// its default date-fns localizer) - CalendarWidget needs the exact same
+// bounds *before* the calendar ever fires onRangeChange (which only runs on
+// navigation, never on initial mount), so it's computed here directly from
+// (date, view) instead of relying on that callback.
+export function visibleCalendarRange(
+	date: Date,
+	view: View,
+): { from: Date; to: Date } {
+	switch (view) {
+		case "month":
+			return {
+				from: startOfWeek(startOfMonth(date)),
+				to: endOfWeek(endOfMonth(date)),
+			};
+		case "week":
+		case "work_week":
+			return { from: startOfWeek(date), to: endOfWeek(date) };
+		case "agenda":
+			return {
+				from: startOfDay(date),
+				to: endOfDay(addDays(date, AGENDA_LENGTH_DAYS)),
+			};
+		case "day":
+		default:
+			return { from: startOfDay(date), to: endOfDay(date) };
+	}
+}

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -20,6 +20,7 @@ import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
+import { visibleCalendarRange } from "../../../lib/calendarRange";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 // The *default* view a fresh mount opens on - a narrow tile can't usefully
@@ -116,19 +117,29 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 
-	// Shared with UpcomingOpportunitiesWidget, which fetches the same
-	// organization-wide calendar events - see useSharedOrgFetch.
-	const [calData, setCalData, calError] = useSharedOrgFetch<
-		OrganizationCalendarEventDto[]
-	>(`calendarEvents:${organizationId}:${refreshKey}`, () =>
-		api.getOrganizationCalendarEvents(organizationId),
-	);
-	const calLoading = calData === null && !calError;
 	// Lazy initializer - only the INITIAL view depends on size; once mounted,
 	// the organizer's own view-button clicks take over and this doesn't
 	// re-run just because a drag elsewhere changed this widget's span.
 	const [calView, setCalView] = useState<View>(() => defaultViewForSize(size));
 	const [calDate, setCalDate] = useState(new Date());
+
+	// Bound to whatever's actually on screen (#1389) rather than fetching
+	// every calendar event the org has ever created - an org with years of
+	// weekly recurring shifts would otherwise pull thousands of slots on
+	// every dashboard load. Recomputed whenever the visible window changes
+	// (view switch or navigation), which naturally triggers a refetch since
+	// it's part of useSharedOrgFetch's key.
+	const { from: rangeFrom, to: rangeTo } = useMemo(
+		() => visibleCalendarRange(calDate, calView),
+		[calDate, calView],
+	);
+	const [calData, setCalData, calError] = useSharedOrgFetch<
+		OrganizationCalendarEventDto[]
+	>(
+		`calendarEvents:${organizationId}:${refreshKey}:${rangeFrom.toISOString()}:${rangeTo.toISOString()}`,
+		() => api.getOrganizationCalendarEvents(organizationId, rangeFrom, rangeTo),
+	);
+	const calLoading = calData === null && !calError;
 	const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
 	const [pickerColor, setPickerColor] = useState(DEFAULT_EVENT_COLOR);
 	const [savingColor, setSavingColor] = useState(false);

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -1,10 +1,7 @@
 import { memo, useMemo } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
-import type {
-	OrganizationCalendarEventDto,
-	VolunteerOpportunitySummary,
-} from "../../../client/api-client";
+import type { VolunteerOpportunitySummary } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
 import ErrorBanner from "../../../components/ErrorBanner";
@@ -38,12 +35,16 @@ function UpcomingOpportunitiesWidget({
 	const api = useApiClient();
 	const locale = i18n.language === "de" ? "de-DE" : "en-GB";
 
-	// Both fetches are shared with sibling widgets that need the same
-	// organization-wide data on the same mount - opportunities with
-	// QuickCheckInWidget, calendar events with CalendarWidget - see
-	// useSharedOrgFetch. Only one of the two "opportunities" fetcher closures
-	// actually runs per useSharedOrgFetch's dedup, so its args (status,
-	// pageNumber, pageSize) must stay identical to QuickCheckInWidget's.
+	// Shared with QuickCheckInWidget, which fetches the same organization-wide
+	// opportunities on the same mount - see useSharedOrgFetch. Only one of the
+	// two fetcher closures actually runs per useSharedOrgFetch's dedup, so its
+	// args (status, pageNumber, pageSize) must stay identical to
+	// QuickCheckInWidget's. `nextTimeSlotStart` (already computed server-side
+	// per opportunity) covers this widget's whole need for "when's the next
+	// shift" - no separate getOrganizationCalendarEvents fetch required (#1389:
+	// that endpoint now requires a bounded date range, and this widget has no
+	// natural one to bind to since it wants the single soonest upcoming slot
+	// across every opportunity, however far out that is).
 	const [opportunities, , opportunitiesError] = useSharedOrgFetch<
 		VolunteerOpportunitySummary[]
 	>(`opportunities:${organizationId}:${refreshKey}`, () =>
@@ -56,33 +57,18 @@ function UpcomingOpportunitiesWidget({
 			)
 			.then((page) => page.items),
 	);
-	const [calendarEvents, , calendarEventsError] = useSharedOrgFetch<
-		OrganizationCalendarEventDto[]
-	>(`calendarEvents:${organizationId}:${refreshKey}`, () =>
-		api.getOrganizationCalendarEvents(organizationId),
-	);
-	const error = opportunitiesError ?? calendarEventsError;
+	const error = opportunitiesError;
 
 	const items = useMemo<UpcomingItem[] | null>(() => {
-		if (!opportunities || !calendarEvents) return null;
-		const now = new Date();
-		const eventsByOpportunity = new Map<string, OrganizationCalendarEventDto>(
-			calendarEvents.map((e) => [e.opportunityId, e]),
-		);
+		if (!opportunities) return null;
 		return opportunities
-			.map((o): UpcomingItem => {
-				const futureSlots = (eventsByOpportunity.get(o.id)?.timeSlots ?? [])
-					.map((s) => new Date(s.startDateTime))
-					.filter((d) => d >= now)
-					.sort((a, b) => a.getTime() - b.getTime());
-				return {
-					id: o.id,
-					title: o.title || t("orgDashboard.unnamedDraft"),
-					nextStart: futureSlots[0] ?? null,
-					bookedCount: o.currentParticipantCount,
-					maxParticipants: o.totalMaxParticipants,
-				};
-			})
+			.map((o): UpcomingItem => ({
+				id: o.id,
+				title: o.title || t("orgDashboard.unnamedDraft"),
+				nextStart: o.nextTimeSlotStart ? new Date(o.nextTimeSlotStart) : null,
+				bookedCount: o.currentParticipantCount,
+				maxParticipants: o.totalMaxParticipants,
+			}))
 			.sort((a, b) => {
 				if (a.nextStart && b.nextStart)
 					return a.nextStart.getTime() - b.nextStart.getTime();
@@ -91,7 +77,7 @@ function UpcomingOpportunitiesWidget({
 				return 0;
 			})
 			.slice(0, MAX_ITEMS);
-	}, [opportunities, calendarEvents, t]);
+	}, [opportunities, t]);
 
 	return (
 		<WidgetCard


### PR DESCRIPTION
GetCalendarEventsAsync returned every time slot an org had ever created, unpaginated and with a correlated Count(...) subquery per slot - an org with years of weekly recurring shifts made the dashboard's first paint wait on thousands of rows. from/to now bound the query to what's actually visible; CalendarWidget derives that range from its own view+date instead of fetching everything up front. UpcomingOpportunitiesWidget dropped its call to this endpoint entirely - it only ever needed nextTimeSlotStart, already present on the opportunities it fetches separately.

Fixes #1389

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
