### PR TITLE
perf: replace unbounded engagement query with lean volunteer-id projection

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackEndpoint.cs
@@ -22,6 +22,7 @@ internal sealed class GetOpportunityFeedbackEndpoint : IEndpoint
 			.WithName("GetOpportunityFeedback")
 			.WithTags("VolunteerOpportunities")
 			.Produces<OpportunityFeedbackSummary>()
+			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
@@ -30,16 +31,24 @@ internal sealed class GetOpportunityFeedbackEndpoint : IEndpoint
 
 	private static async Task<IResult> GetFeedbackAsync(
 		[FromRoute] Guid opportunityId,
+		[FromQuery] int pageNumber,
+		[FromQuery] int pageSize,
 		[FromServices] ISender sender,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
+		if (pageNumber < 1)
+			return Results.Problem("PageNumber must be at least 1.", statusCode: StatusCodes.Status400BadRequest);
+
+		if (pageSize < 1 || pageSize > 100)
+			return Results.Problem("PageSize must be between 1 and 100.", statusCode: StatusCodes.Status400BadRequest);
+
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
 			? UserId.Create(uid).GetValueOrThrow()
 			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 
 		var result = await sender.Send(
-			new GetOpportunityFeedbackQuery(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), userId),
+			new GetOpportunityFeedbackQuery(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), userId, pageNumber, pageSize),
 			cancellationToken);
 
 		return Results.Ok(result);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1153,6 +1153,32 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
           }
         ],
         "responses": {
@@ -1162,6 +1188,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpportunityFeedbackSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -6726,10 +6762,7 @@
             "format": "int32"
           },
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/FeedbackItemDto"
-            }
+            "$ref": "#/components/schemas/PagedListOfFeedbackItemDto"
           }
         }
       },
@@ -7198,6 +7231,45 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EngagementSummary"
+            }
+          }
+        }
+      },
+      "PagedListOfFeedbackItemDto": {
+        "required": [
+          "currentPage",
+          "items"
+        ],
+        "type": "object",
+        "properties": {
+          "totalItems": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "currentPage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pageCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeedbackItemDto"
             }
           }
         }

--- a/backend/src/Application/Engagements/IEngagementReadRepository.cs
+++ b/backend/src/Application/Engagements/IEngagementReadRepository.cs
@@ -24,8 +24,21 @@ public interface IEngagementReadRepository
 		int pageSize,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Distinct volunteer ids with an active (pending or confirmed) engagement on
+	/// the opportunity, filtered at the database level using the existing
+	/// (OpportunityId, Status) index - or, when <paramref name="timeSlotId"/> is
+	/// given, only those engaged on that specific time slot.
+	/// </summary>
+	ValueTask<List<Guid>> GetActiveVolunteerIdsByOpportunityAsync(
+		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
+		CancellationToken cancellationToken = default);
+
 	ValueTask<OpportunityFeedbackSummary> GetFeedbackByOpportunityAsync(
 		VolunteerOpportunityId opportunityId,
+		int pageNumber,
+		int pageSize,
 		CancellationToken cancellationToken = default);
 
 	ValueTask<EngagementCalendarInfo?> GetCalendarInfoAsync(

--- a/backend/src/Application/Engagements/OpportunityFeedbackSummary.cs
+++ b/backend/src/Application/Engagements/OpportunityFeedbackSummary.cs
@@ -1,9 +1,11 @@
+using Application.Common.Pagination;
+
 namespace Application.Engagements;
 
 public sealed record OpportunityFeedbackSummary(
 	double? AverageRating,
 	int FeedbackCount,
-	IReadOnlyList<FeedbackItemDto> Items);
+	PagedList<FeedbackItemDto> Items);
 
 public sealed record FeedbackItemDto(
 	int Rating,

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -9,8 +9,6 @@ namespace Application.Notifications;
 
 internal static class OpportunityNotificationHelper
 {
-	private static readonly string[] ActiveStatuses = ["Pending", "Confirmed"];
-
 	/// <summary>
 	/// Creates a notification of the given kind for every distinct volunteer who
 	/// has an active (pending or confirmed) engagement on the opportunity, or -
@@ -25,14 +23,8 @@ internal static class OpportunityNotificationHelper
 		CancellationToken cancellationToken,
 		TimeSlotId? timeSlotId = null)
 	{
-		var engagements = await engagementReadRepository.GetByOpportunityAsync(
-			opportunityId, cancellationToken);
-
-		var volunteerIds = engagements
-			.Where(e => ActiveStatuses.Contains(e.Status) && e.VolunteerId is not null)
-			.Where(e => timeSlotId is null || e.TimeSlotId == timeSlotId.Value.Value)
-			.Select(e => e.VolunteerId!.Value)
-			.Distinct();
+		var volunteerIds = await engagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync(
+			opportunityId, timeSlotId, cancellationToken);
 
 		foreach (var volunteerId in volunteerIds)
 		{

--- a/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQuery.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQuery.cs
@@ -7,5 +7,7 @@ namespace Application.VolunteerOpportunities.GetOpportunityFeedback.v1;
 
 public sealed record GetOpportunityFeedbackQuery(
 	VolunteerOpportunityId OpportunityId,
-	UserId RequestingUserId)
+	UserId RequestingUserId,
+	int PageNumber,
+	int PageSize)
 	: IQuery<OpportunityFeedbackSummary>;

--- a/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQueryHandler.cs
@@ -12,6 +12,8 @@ internal sealed class GetOpportunityFeedbackQueryHandler(
 	IEngagementReadRepository engagementReadRepository)
 	: IQueryHandler<GetOpportunityFeedbackQuery, OpportunityFeedbackSummary>
 {
+	private const int MaxPageSize = 100;
+
 	public async ValueTask<OpportunityFeedbackSummary> Handle(
 		GetOpportunityFeedbackQuery request,
 		CancellationToken cancellationToken = default)
@@ -27,8 +29,13 @@ internal sealed class GetOpportunityFeedbackQueryHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
+		var pageNumber = Math.Max(1, request.PageNumber);
+		var pageSize = Math.Clamp(request.PageSize, 1, MaxPageSize);
+
 		return await engagementReadRepository.GetFeedbackByOpportunityAsync(
 			request.OpportunityId,
+			pageNumber,
+			pageSize,
 			cancellationToken);
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -312,20 +312,52 @@ internal sealed class EngagementReadRepository(
 			timeSlot.EndDateTime);
 	}
 
-	public async ValueTask<OpportunityFeedbackSummary> GetFeedbackByOpportunityAsync(
+	public async ValueTask<List<Guid>> GetActiveVolunteerIdsByOpportunityAsync(
 		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
 		CancellationToken cancellationToken = default)
 	{
-		var items = await dbContext.EngagementsQuery
-			.Where(e => e.OpportunityId == opportunityId && e.FeedbackSubmittedAt != null)
+		var query = dbContext.EngagementsQuery
+			.Where(e => e.OpportunityId == opportunityId
+				&& e.VolunteerId != null
+				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed));
+
+		if (timeSlotId is not null)
+			query = query.Where(e => e.TimeSlotId == timeSlotId);
+
+		var volunteerIds = await query
+			.Select(e => e.VolunteerId)
+			.Distinct()
+			.ToListAsync(cancellationToken);
+
+		return volunteerIds.Select(id => id!.Value.Value).ToList();
+	}
+
+	public async ValueTask<OpportunityFeedbackSummary> GetFeedbackByOpportunityAsync(
+		VolunteerOpportunityId opportunityId,
+		int pageNumber,
+		int pageSize,
+		CancellationToken cancellationToken = default)
+	{
+		var scopedQuery = dbContext.EngagementsQuery
+			.Where(e => e.OpportunityId == opportunityId && e.FeedbackSubmittedAt != null);
+
+		var totalCount = await scopedQuery.CountAsync(cancellationToken);
+
+		var avg = totalCount > 0
+			? (double?)await scopedQuery.AverageAsync(e => e.FeedbackRating!.Value, cancellationToken)
+			: null;
+
+		var items = await scopedQuery
 			.OrderByDescending(e => e.FeedbackSubmittedAt)
+			.Skip((pageNumber - 1) * pageSize)
+			.Take(pageSize)
 			.Select(e => new FeedbackItemDto(
 				e.FeedbackRating!.Value,
 				e.FeedbackComment,
 				e.FeedbackSubmittedAt!.Value))
 			.ToListAsync(cancellationToken);
 
-		var avg = items.Count > 0 ? (double?)items.Average(f => f.Rating) : null;
-		return new OpportunityFeedbackSummary(avg, items.Count, items);
+		return new OpportunityFeedbackSummary(avg, totalCount, new PagedList<FeedbackItemDto>(items, totalCount, pageNumber, pageSize));
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -50,7 +50,7 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 			.GetOpenReportsForTargetAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Report>());
 		_engagementReadRepository
-			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_sut = new AdminShadowDeleteOrganizationCommandHandler(_dbContext, _engagementReadRepository);
 	}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 			.GetOpenReportsForTargetAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Report>());
 		_engagementReadRepository
-			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository);
 	}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -42,7 +42,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 			.GetOpenReportsForTargetAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Report>());
 		_engagementReadRepository
-			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
@@ -106,13 +106,8 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		_engagementReadRepository
-			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(
-			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", pendingVolunteer, null, null, "Pending", false, false, DateTimeOffset.UtcNow),
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", confirmedVolunteer, null, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", Guid.NewGuid(), null, null, "Cancelled", false, false, DateTimeOffset.UtcNow),
-			]);
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([pendingVolunteer, confirmedVolunteer]);
 
 		// Act
 		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
@@ -168,11 +163,8 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		_engagementReadRepository
-			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(
-			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", Guid.NewGuid(), null, null, "Cancelled", false, false, DateTimeOffset.UtcNow),
-			]);
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([]);
 
 		// Act
 		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using Application.Common.Exceptions;
+using Application.Common.Pagination;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.GetOpportunityFeedback.v1;
@@ -27,16 +28,42 @@ public class GetOpportunityFeedbackQueryHandlerTests
 	public GetOpportunityFeedbackQueryHandlerTests()
 	{
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateOpportunity());
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
+		_engagementReadRepository
+			.GetFeedbackByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new OpportunityFeedbackSummary(null, 0, new PagedList<FeedbackItemDto>([], 0, 1, 10)));
 		_sut = new GetOpportunityFeedbackQueryHandler(_dbContext, _engagementReadRepository);
 	}
 
-	private VolunteerOpportunity CreateOpportunity() =>
+	private static VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.Waitlist, CheckInMethod.None, Substitute.For<IPinGenerator>(),
 			status: OpportunityStatus.Draft).Value;
+
+	private async Task<(int PageNumber, int PageSize)> CapturedArgsAsync(int pageNumber, int pageSize)
+	{
+		var capturedPageNumber = 0;
+		var capturedPageSize = 0;
+		_engagementReadRepository
+			.GetFeedbackByOpportunityAsync(
+				Arg.Any<VolunteerOpportunityId>(),
+				Arg.Do<int>(p => capturedPageNumber = p),
+				Arg.Do<int>(s => capturedPageSize = s),
+				Arg.Any<CancellationToken>())
+			.Returns(new OpportunityFeedbackSummary(null, 0, new PagedList<FeedbackItemDto>([], 0, 1, 10)));
+
+		var opportunity = CreateOpportunity();
+		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
+
+		await _sut.Handle(new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId, pageNumber, pageSize), CancellationToken.None);
+
+		return (capturedPageNumber, capturedPageSize);
+	}
 
 	[Test]
 	public async Task Handle_ShouldReturnFeedbackSummary_WhenOrganizer(
@@ -46,20 +73,49 @@ public class GetOpportunityFeedbackQueryHandlerTests
 		var opportunity = CreateOpportunity();
 		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
 
-		var summary = new OpportunityFeedbackSummary(4.5, 2,
-		[
-			new FeedbackItemDto(5, "Great!", DateTimeOffset.UtcNow),
-			new FeedbackItemDto(4, null, DateTimeOffset.UtcNow),
-		]);
-		_engagementReadRepository.GetFeedbackByOpportunityAsync(opportunity.Id, cancellationToken).Returns(summary);
+		var summary = new OpportunityFeedbackSummary(4.5, 2, new PagedList<FeedbackItemDto>(
+			[
+				new FeedbackItemDto(5, "Great!", DateTimeOffset.UtcNow),
+				new FeedbackItemDto(4, null, DateTimeOffset.UtcNow),
+			],
+			2, 1, 10));
+		_engagementReadRepository.GetFeedbackByOpportunityAsync(opportunity.Id, 1, 10, cancellationToken).Returns(summary);
 
-		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId);
+		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId, 1, 10);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
 		result.Should().BeEquivalentTo(summary);
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampZeroPageNumber_ToOne()
+	{
+		var (pageNumber, _) = await CapturedArgsAsync(pageNumber: 0, pageSize: 10);
+		pageNumber.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampNegativePageNumber_ToOne()
+	{
+		var (pageNumber, _) = await CapturedArgsAsync(pageNumber: -5, pageSize: 10);
+		pageNumber.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldClampZeroPageSize_ToOne()
+	{
+		var (_, pageSize) = await CapturedArgsAsync(pageNumber: 1, pageSize: 0);
+		pageSize.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCapExcessivePageSize_ToHundred()
+	{
+		var (_, pageSize) = await CapturedArgsAsync(pageNumber: 1, pageSize: 5000);
+		pageSize.Should().Be(100);
 	}
 
 	[Test]
@@ -73,7 +129,7 @@ public class GetOpportunityFeedbackQueryHandlerTests
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
-		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId);
+		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId, 1, 10);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
@@ -82,6 +138,25 @@ public class GetOpportunityFeedbackQueryHandlerTests
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
 		await _engagementReadRepository.DidNotReceive().GetFeedbackByOpportunityAsync(
-			Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>());
+			Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns((VolunteerOpportunity?)null);
+
+		var query = new GetOpportunityFeedbackQuery(VolunteerOpportunityId.New(), DefaultRequestingUserId, 1, 10);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -41,7 +41,7 @@ public class UpdateTimeSlotCommandHandlerTests
 			.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
 			.Returns(0);
 		_engagementReadRepository
-			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository);
 	}
@@ -167,12 +167,8 @@ public class UpdateTimeSlotCommandHandlerTests
 			.Returns(opportunity);
 
 		_engagementReadRepository
-			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(
-			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", editedSlotVolunteer, editedSlot.Id.Value, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", otherSlotVolunteer, otherSlot.Id.Value, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
-			]);
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), editedSlot.Id, cancellationToken)
+			.Returns([editedSlotVolunteer]);
 
 		var command = new UpdateTimeSlotCommand(
 			opportunityId, editedSlot.Id.Value, BaseStart.AddHours(1), BaseEnd.AddHours(1), 10, DefaultRequestingUserId);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -38,6 +38,9 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		_engagementReadRepository
 			.GetByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns([]);
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
+			.Returns([]);
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
@@ -333,11 +336,8 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		_engagementReadRepository
-			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(
-			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", activeVolunteer, null, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
-			]);
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteer]);
 
 		_geocodingService
 			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -371,11 +371,8 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		_engagementReadRepository
-			.GetByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(
-			[
-				new EngagementSummary(Guid.NewGuid(), opportunityId, "T", Guid.NewGuid(), "Org", activeVolunteer, null, null, "Confirmed", false, false, DateTimeOffset.UtcNow),
-			]);
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteer]);
 
 		// Cosmetic change only: title and description change, address/remote/occurrence unchanged.
 		var command = new UpdateVolunteerOpportunityCommand(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -100,7 +100,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<OpportunityFeedbackSummary> GetOpportunityFeedbackAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<OpportunityFeedbackSummary> GetOpportunityFeedbackAsync(System.Guid opportunityId, int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -2053,10 +2053,16 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<OpportunityFeedbackSummary> GetOpportunityFeedbackAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<OpportunityFeedbackSummary> GetOpportunityFeedbackAsync(System.Guid opportunityId, int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (opportunityId == null)
                 throw new System.ArgumentNullException("opportunityId");
+
+            if (pageNumber == null)
+                throw new System.ArgumentNullException("pageNumber");
+
+            if (pageSize == null)
+                throw new System.ArgumentNullException("pageSize");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -2073,6 +2079,10 @@ namespace IntegrationTests
                     urlBuilder_.Append("v1/volunteer-opportunities/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/feedback");
+                    urlBuilder_.Append('?');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    urlBuilder_.Length--;
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -2105,6 +2115,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 401)
@@ -10474,7 +10494,7 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("items")]
         [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<FeedbackItemDto> Items { get; set; } = new System.Collections.ObjectModel.Collection<FeedbackItemDto>();
+        public PagedListOfFeedbackItemDto Items { get; set; } = new PagedListOfFeedbackItemDto();
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
@@ -10868,6 +10888,38 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("items")]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<EngagementSummary> Items { get; set; } = new System.Collections.ObjectModel.Collection<EngagementSummary>();
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PagedListOfFeedbackItemDto
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("totalItems")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int TotalItems { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("currentPage")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int CurrentPage { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageCount")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int PageCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<FeedbackItemDto> Items { get; set; } = new System.Collections.ObjectModel.Collection<FeedbackItemDto>();
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -1,0 +1,102 @@
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Infrastructure.Persistence.Repositories;
+using Infrastructure.VolunteerOpportunities;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
+// "Address"/"OrganizationId" DTO types, which would otherwise shadow the domain
+// types of the same name pulled in via the "Domain.Common"/"Domain.Organizations"
+// usings below (see the same workaround in OrganizationMembershipBackfillJobTests.cs).
+using DomainAddress = Domain.Common.Address;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.Persistence.Repositories.EngagementReadRepository directly
+// (InternalsVisibleTo, see Infrastructure.csproj) against the real integration Postgres.
+// GetActiveVolunteerIdsByOpportunityAsync's DB-level status/time-slot filtering and its
+// nullable-UserId Distinct() projection (einsatzbereit#1390) aren't exercised by the
+// NSubstitute-mocked Application.UnitTests handler tests (which only assert on the
+// interface's behavior, not that the EF query actually translates) - this is the only
+// place that would catch an EF query-translation failure against real Postgres.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
+{
+	private static readonly DomainAddress DefaultAddress = DomainAddress.Create("Teststrasse", "1", "12345", "Berlin").Value;
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetActiveVolunteerIdsByOpportunityAsync_ShouldReturnOnlyPendingAndConfirmed_ExcludingTerminalAndAnonymized(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var opportunityId = VolunteerOpportunityId.New();
+
+		// No time slots involved here, so plain individual-contact engagements
+		// (TimeSlotId always null) avoid the TimeSlot foreign key entirely.
+		var pending = Engagement.CreateIndividualContact(opportunityId, UserId.New(), "Pending").GetValueOrThrow();
+		var confirmed = Engagement.CreateIndividualContact(opportunityId, UserId.New(), "Confirmed").GetValueOrThrow();
+		confirmed.Confirm().ThrowIfFailure();
+		var cancelled = Engagement.CreateIndividualContact(opportunityId, UserId.New(), "Cancelled").GetValueOrThrow();
+		cancelled.Cancel().ThrowIfFailure();
+		var withdrawn = Engagement.CreateIndividualContact(opportunityId, UserId.New(), "Withdrawn").GetValueOrThrow();
+		withdrawn.Withdraw().ThrowIfFailure();
+		// A pending engagement whose volunteer account was later deleted (#829) -
+		// VolunteerId is null even though Status is still Pending, so there is no
+		// one left to notify and it must not show up in the result.
+		var anonymizedPending = Engagement.CreateIndividualContact(opportunityId, UserId.New(), "Anonymized").GetValueOrThrow();
+		anonymizedPending.Anonymize();
+
+		foreach (var engagement in new[] { pending, confirmed, cancelled, withdrawn, anonymizedPending })
+			await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var volunteerIds = await repository.GetActiveVolunteerIdsByOpportunityAsync(
+			opportunityId, timeSlotId: null, cancellationToken);
+
+		volunteerIds.Should().BeEquivalentTo(
+		[
+			pending.VolunteerId!.Value.Value,
+			confirmed.VolunteerId!.Value.Value,
+		]);
+	}
+
+	[Test]
+	public async Task GetActiveVolunteerIdsByOpportunityAsync_ShouldScopeToTimeSlot_WhenGiven(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var opportunity = VolunteerOpportunity.Create(
+			DomainOrganizationId.New(), "Titel", "Beschreibung", false, DefaultAddress, Occurrence.Recurring,
+			ParticipationType.Waitlist, CheckInMethod.None, new RandomPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var slotA = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		var slotB = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(2), DateTimeOffset.UtcNow.AddDays(2).AddHours(2), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var onSlotA = Engagement.CreateWaitlistSignUp(opportunity.Id, UserId.New(), slotA.Id);
+		var onSlotB = Engagement.CreateWaitlistSignUp(opportunity.Id, UserId.New(), slotB.Id);
+		await dbContext.Engagements.AddAsync(onSlotA, cancellationToken);
+		await dbContext.Engagements.AddAsync(onSlotB, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var volunteerIds = await repository.GetActiveVolunteerIdsByOpportunityAsync(
+			opportunity.Id, slotA.Id, cancellationToken);
+
+		volunteerIds.Should().BeEquivalentTo([onSlotA.VolunteerId!.Value.Value]);
+	}
+}

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -942,11 +942,11 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
 
-		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, cancellationToken);
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
 
 		summary.AverageRating.Should().BeNull();
 		summary.FeedbackCount.Should().Be(0);
-		summary.Items.Should().BeEmpty();
+		summary.Items.Items.Should().BeEmpty();
 	}
 
 	[Test]
@@ -970,11 +970,55 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			new SubmitFeedbackRequest { Rating = 4, Comment = "Great experience" },
 			cancellationToken);
 
-		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, cancellationToken);
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
 
 		summary.AverageRating.Should().Be(4);
 		summary.FeedbackCount.Should().Be(1);
-		summary.Items.Should().ContainSingle(i => i.Rating == 4 && i.Comment == "Great experience");
+		summary.Items.Items.Should().ContainSingle(i => i.Rating == 4 && i.Comment == "Great experience");
+	}
+
+	[Test]
+	public async Task GetOpportunityFeedback_ShouldPaginate_AcrossMultiplePages(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		// Two distinct volunteers each submit feedback so the total spans more than
+		// one page at pageSize=1 - olaf both organizes the opportunity and, here,
+		// engages on it as a second volunteer (no domain rule forbids that).
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var veraEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "Vera helps" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(veraEngagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(veraEngagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			veraEngagement.Id, new SubmitFeedbackRequest { Rating = 5, Comment = "Vera's feedback" }, cancellationToken);
+
+		var olafEngagement = await olafClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "Olaf helps too" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(olafEngagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(olafEngagement.Id, cancellationToken);
+		await olafClient.SubmitFeedbackAsync(
+			olafEngagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Olaf's feedback" }, cancellationToken);
+
+		var firstPage = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 1, cancellationToken);
+		var secondPage = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 2, 1, cancellationToken);
+
+		firstPage.FeedbackCount.Should().Be(2);
+		firstPage.AverageRating.Should().Be(4);
+		firstPage.Items.Items.Should().ContainSingle();
+		firstPage.Items.TotalItems.Should().Be(2);
+		firstPage.Items.PageCount.Should().Be(2);
+
+		secondPage.FeedbackCount.Should().Be(2);
+		secondPage.AverageRating.Should().Be(4);
+		secondPage.Items.Items.Should().ContainSingle();
+
+		var firstPageComments = firstPage.Items.Items.Select(i => i.Comment).ToList();
+		var secondPageComments = secondPage.Items.Items.Select(i => i.Comment).ToList();
+		firstPageComments.Should().NotBeEquivalentTo(secondPageComments);
 	}
 
 	// ── Cross-opportunity time slot validation (#524) ─────────────────────────

--- a/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
+++ b/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
@@ -66,11 +66,11 @@ public class OrganizationEngagementsTabTests(AspireFixture fixture) : VisualTest
 		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var opportunityId = opportunity.GetProperty("id").GetString();
 
-		var feedbackResponse = await http.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/feedback");
+		var feedbackResponse = await http.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/feedback?pageNumber=1&pageSize=10");
 		feedbackResponse.EnsureSuccessStatusCode();
 		var feedback = await feedbackResponse.Content.ReadFromJsonAsync<JsonElement>();
 		feedback.GetProperty("feedbackCount").GetInt32().Should().Be(0);
-		feedback.GetProperty("items").GetArrayLength().Should().Be(0);
+		feedback.GetProperty("items").GetProperty("items").GetArrayLength().Should().Be(0);
 
 		// The org "Engagements" tab became the unified "Opportunities" hub. A
 		// published opportunity is listed under the Published section with a

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -954,11 +954,19 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
-    getOpportunityFeedback(opportunityId: string, signal?: AbortSignal): Promise<OpportunityFeedbackSummary> {
-        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/feedback";
+    getOpportunityFeedback(opportunityId: string, pageNumber: number, pageSize: number, signal?: AbortSignal): Promise<OpportunityFeedbackSummary> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/feedback?";
         if (opportunityId === undefined || opportunityId === null)
             throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
         url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
+        else
+            url_ += "pageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -982,6 +990,12 @@ export class EinsatzbereitApi {
             let result200: any = null;
             result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as OpportunityFeedbackSummary;
             return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
             });
         } else if (status === 401) {
             return response.text().then((_responseText) => {
@@ -5243,7 +5257,7 @@ export interface NotificationSummary {
 export interface OpportunityFeedbackSummary {
     averageRating: number | undefined;
     feedbackCount: number;
-    items: FeedbackItemDto[];
+    items: PagedListOfFeedbackItemDto;
 
     [key: string]: any;
 }
@@ -5361,6 +5375,15 @@ export interface PagedListOfEngagementSummary {
     currentPage: number;
     pageCount?: number;
     items: EngagementSummary[];
+
+    [key: string]: any;
+}
+
+export interface PagedListOfFeedbackItemDto {
+    totalItems?: number;
+    currentPage: number;
+    pageCount?: number;
+    items: FeedbackItemDto[];
 
     [key: string]: any;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -480,7 +480,8 @@
       "organizerTab": "Feedback",
       "noFeedback": "Noch kein Feedback.",
       "feedbackCount_one": "{{count}} Bewertung",
-      "feedbackCount_other": "{{count}} Bewertungen"
+      "feedbackCount_other": "{{count}} Bewertungen",
+      "loadMore": "Mehr laden"
     },
     "checkIn": {
       "buttonLabel": "Einchecken",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -480,7 +480,8 @@
       "organizerTab": "Feedback",
       "noFeedback": "No feedback yet.",
       "feedbackCount_one": "{{count}} rating",
-      "feedbackCount_other": "{{count}} ratings"
+      "feedbackCount_other": "{{count}} ratings",
+      "loadMore": "Load more"
     },
     "checkIn": {
       "buttonLabel": "Check in",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type {
 	EngagementSummary,
-	OpportunityFeedbackSummary,
+	FeedbackItemDto,
 	TimeSlotDetail,
 	VolunteerOpportunityDetails,
 } from "../client/api-client";
@@ -25,6 +25,7 @@ import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
 const ENGAGEMENTS_PAGE_SIZE = 10;
+const FEEDBACK_PAGE_SIZE = 10;
 
 // Lazy-loaded: only needed once an organizer actually opens the scanner - #971.
 const QRScannerModal = lazy(() => import("../components/QRScannerModal"));
@@ -59,9 +60,10 @@ export default function EngagementManagementPage() {
 		return map;
 	}, [opportunity]);
 
-	const [feedback, setFeedback] = useState<OpportunityFeedbackSummary | null>(
-		null,
-	);
+	const [feedbackStats, setFeedbackStats] = useState<{
+		averageRating: number | null;
+		feedbackCount: number;
+	} | null>(null);
 	const [checkInPin, setCheckInPin] = useState<string | null>(null);
 	const [notFound, setNotFound] = useState(false);
 	const [confirming, setConfirming] = useState<string | null>(null);
@@ -98,15 +100,32 @@ export default function EngagementManagementPage() {
 		},
 	);
 
+	const {
+		items: feedbackItems,
+		loading: feedbackLoading,
+		loadingMore: feedbackLoadingMore,
+		error: feedbackError,
+		hasMore: hasMoreFeedback,
+		loadMore: loadMoreFeedback,
+	} = useLoadMore<FeedbackItemDto>(async (page) => {
+		if (!opportunityId) return { items: [], pageCount: 0 };
+		const result = await api.getOpportunityFeedback(
+			opportunityId,
+			page,
+			FEEDBACK_PAGE_SIZE,
+		);
+		setFeedbackStats({
+			averageRating: result.averageRating ?? null,
+			feedbackCount: result.feedbackCount,
+		});
+		return { items: result.items.items, pageCount: result.items.pageCount };
+	});
+
 	useEffect(() => {
 		if (!opportunityId) return;
 		api
 			.getVolunteerOpportunityDetails(opportunityId)
 			.then(setOpportunity)
-			.catch(() => undefined);
-		api
-			.getOpportunityFeedback(opportunityId)
-			.then(setFeedback)
 			.catch(() => undefined);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [opportunityId]);
@@ -424,23 +443,23 @@ export default function EngagementManagementPage() {
 				/>
 			)}
 
-			{feedback !== null && (
+			{feedbackStats !== null && (
 				<section className="mt-8">
 					<h2 className="mb-4 text-lg font-semibold text-gray-900">
 						{t("feedback.organizerTab")}
 					</h2>
-					{feedback.feedbackCount === 0 ? (
+					{feedbackStats.feedbackCount === 0 ? (
 						<p className="text-sm text-gray-500">{t("feedback.noFeedback")}</p>
 					) : (
 						<>
 							<p className="mb-4 text-sm text-gray-700">
 								{t("feedback.averageRating", {
-									rating: feedback.averageRating?.toFixed(1) ?? "-",
-									count: feedback.feedbackCount,
+									rating: feedbackStats.averageRating?.toFixed(1) ?? "-",
+									count: feedbackStats.feedbackCount,
 								})}
 							</p>
 							<ul className="space-y-3">
-								{feedback.items.map((item, idx) => (
+								{feedbackItems.map((item, idx) => (
 									<li
 										key={idx}
 										className="rounded-xl border border-gray-100 bg-white px-4 py-3 shadow-sm"
@@ -469,6 +488,22 @@ export default function EngagementManagementPage() {
 									</li>
 								))}
 							</ul>
+							{!feedbackLoading &&
+								!feedbackError &&
+								feedbackItems.length > 0 &&
+								hasMoreFeedback && (
+									<div className="mt-6 flex justify-center">
+										<button
+											onClick={loadMoreFeedback}
+											disabled={feedbackLoadingMore}
+											className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
+										>
+											{feedbackLoadingMore
+												? t("engagementManagement.loading")
+												: t("feedback.loadMore")}
+										</button>
+									</div>
+								)}
 						</>
 					)}
 				</section>


### PR DESCRIPTION
OpportunityNotificationHelper re-ran a full two-join GetByOpportunityAsync just to collect volunteer ids on every opportunity/time-slot edit; now uses a dedicated GetActiveVolunteerIdsByOpportunityAsync that filters by status and time slot at the database level via the existing (OpportunityId, Status) index. GetOpportunityFeedbackAsync now paginates its items query and computes the average/count with CountAsync/AverageAsync instead of loading everything into memory - the feedback endpoint and frontend tab now page through results like the engagements list does.

Closes #1390.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
