### PR TITLE
fix: enable HTTP request logging and export traces to Grafana Tempo

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.HttpLogging": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/backend/tests/IntegrationTests/HttpLoggingLogLevelTests.cs
+++ b/backend/tests/IntegrationTests/HttpLoggingLogLevelTests.cs
@@ -1,0 +1,58 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1352: "Microsoft.AspNetCore": "Warning" in appsettings.json's
+// LogLevel map was the longest matching prefix for the
+// "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware" category, so Program.cs's
+// AddHttpLogging/UseHttpLogging calls produced no output in any deployed environment -
+// the middleware ran, but every entry it emitted (at Information) was filtered out before
+// reaching any provider. Builds a real host directly (like MetricsPortListenerTests, no
+// Aspire/Testcontainers fixture needed) with the exact LogLevel keys from Api/appsettings.json,
+// so it would have caught the suppression without needing a live deploy.
+public class HttpLoggingLogLevelTests
+{
+	private static readonly Dictionary<string, string?> ProductionLogLevelConfig = new()
+	{
+		["Logging:LogLevel:Default"] = "Information",
+		["Logging:LogLevel:Microsoft.AspNetCore"] = "Warning",
+		["Logging:LogLevel:Microsoft.AspNetCore.HttpLogging"] = "Information",
+	};
+
+	[Test]
+	public async Task HttpLoggingCategory_IsEnabledAtInformation_WithProductionLogLevelConfig()
+	{
+		var builder = WebApplication.CreateBuilder();
+		builder.Configuration.AddInMemoryCollection(ProductionLogLevelConfig);
+
+		await using var app = builder.Build();
+
+		var logger = app.Services.GetRequiredService<ILoggerFactory>()
+			.CreateLogger("Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware");
+
+		logger.IsEnabled(LogLevel.Information).Should().BeTrue();
+	}
+
+	// Guards against overcorrecting: the fix adds a more specific override for the
+	// HttpLogging subcategory, it must not blanket re-enable Information logs for the rest
+	// of "Microsoft.AspNetCore" - that category was set to Warning deliberately, to keep
+	// framework-internal noise (routing, hosting, etc.) out of production logs.
+	[Test]
+	public async Task OtherAspNetCoreCategories_StayFilteredAtWarning_WithProductionLogLevelConfig()
+	{
+		var builder = WebApplication.CreateBuilder();
+		builder.Configuration.AddInMemoryCollection(ProductionLogLevelConfig);
+
+		await using var app = builder.Build();
+
+		var logger = app.Services.GetRequiredService<ILoggerFactory>()
+			.CreateLogger("Microsoft.AspNetCore.Routing.EndpointMiddleware");
+
+		logger.IsEnabled(LogLevel.Information).Should().BeFalse();
+		logger.IsEnabled(LogLevel.Warning).Should().BeTrue();
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,13 @@ services:
       # reachable) comes from Traefik's backend router below only ever
       # pointing at port 8080, never 8081 (#1341).
       Metrics__Port: "8081"
+      # Read by ServiceDefaults/Extensions.cs's AddOpenTelemetryExporters -
+      # enables the OTLP trace exporter, which is otherwise a no-op. Plain
+      # http (no TLS) is fine: this traffic never leaves the internal
+      # "monitoring" network above. gRPC is the exporter's default protocol,
+      # so no separate OTEL_EXPORTER_OTLP_PROTOCOL is needed for tempo's
+      # matching gRPC receiver on 4317 (#1352).
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
     labels:
       - traefik.enable=true
       - traefik.docker.network=proxy
@@ -408,6 +415,36 @@ services:
       - --storage.path=/var/lib/alloy/data
       - /etc/alloy/config.alloy
 
+  # Trace store. Receives OTLP push directly from the backend (see backend's
+  # OTEL_EXPORTER_OTLP_ENDPOINT above) rather than being discovered/scraped -
+  # unlike Loki, there is no separate shipper here since the backend already
+  # speaks OTLP natively via ServiceDefaults. Single-binary mode (no separate
+  # ingester/querier/compactor processes), mirrors Loki's monolithic setup
+  # above - proportionate to this stack's own trace volume.
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo
+    restart: unless-stopped
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 160m
+          cpus: "0.25"
+    volumes:
+      - tempo_data:/var/tempo
+    configs:
+      - source: tempo-config
+        target: /etc/tempo/tempo.yaml
+    command:
+      - -config.file=/etc/tempo/tempo.yaml
+    # No Docker healthcheck: unlike Loki (confirmed lacking wget/shell on
+    # staging, see loki's comment above), this hasn't been verified either
+    # way for the Tempo image - left out rather than guessed at. Nothing
+    # depends on this container via `condition: service_healthy`, so a
+    # missing healthcheck doesn't block or gate anything else.
+
 networks:
   proxy:
     name: proxy
@@ -425,6 +462,7 @@ volumes:
   grafana_data:
   loki_data:
   alloy_data:
+  tempo_data:
 
 configs:
   postgres-init:
@@ -466,6 +504,11 @@ configs:
           type: loki
           access: proxy
           url: http://loki:3100
+          editable: false
+        - name: Tempo
+          type: tempo
+          access: proxy
+          url: http://tempo:3200
           editable: false
   alloy-config:
     content: |
@@ -511,3 +554,29 @@ configs:
           url = "http://loki:3100/loki/api/v1/push"
         }
       }
+  tempo-config:
+    content: |
+      server:
+        http_listen_port: 3200
+
+      distributor:
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+              http:
+
+      storage:
+        trace:
+          backend: local
+          local:
+            path: /var/tempo/traces
+          wal:
+            path: /var/tempo/wal
+
+      # Bounds disk usage on a memory/disk-constrained staging VM - traces
+      # older than this are dropped, unlike Prometheus/Loki which currently
+      # have no equivalent explicit retention cap.
+      compactor:
+        compaction:
+          block_retention: 48h

--- a/docs/ADRs/6_distributed_tracing_via_tempo.adoc
+++ b/docs/ADRs/6_distributed_tracing_via_tempo.adoc
@@ -1,0 +1,60 @@
+== 6. Distributed Tracing via Grafana Tempo
+
+=== Status
+Accepted
+
+=== Date
+2026-07-29
+
+=== Context
+Issue #1352 (filed from the 2026-07-25 1.0 readiness audit) found that `Microsoft.AspNetCore: Warning` in `appsettings.json`'s `LogLevel` map was the longest matching prefix for the `Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware` category, so `Program.cs`'s `AddHttpLogging`/`UseHttpLogging` calls produced no output in any deployed environment - the middleware ran, but every Information-level entry it emitted was filtered out before reaching a provider. The same audit noted that `ServiceDefaults/Extensions.cs`'s `AddOpenTelemetryExporters` only calls `UseOtlpExporter()` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, which `docker-compose.yml` never did, so distributed traces were never exported anywhere in staging/production - `08_concepts.adoc` had documented this as "any OTLP-compatible backend in production when `OTEL_EXPORTER_OTLP_ENDPOINT` is set", but no such backend was ever deployed to receive it.
+
+Metrics were not actually broken - `AddPrometheusExporter` plus the existing `prometheus`/`grafana` services already give a working metrics pipeline - and container stdout was already shipped to Loki via Alloy (ADR-adjacent addition, #1341-era). The gap was specifically: (1) HTTP request logs suppressed by log level, and (2) no destination at all for OTLP traces.
+
+=== Decision
+Add `"Microsoft.AspNetCore.HttpLogging": "Information"` to `Api/appsettings.json`'s `LogLevel` map, restoring HTTP request logs (they now reach stdout and, from there, Loki via the existing Alloy pipeline) without re-enabling the framework-noise categories `Microsoft.AspNetCore: Warning` was set to suppress.
+
+Add a `tempo` service (`grafana/tempo`, single-binary mode, local-disk storage, 48h block retention) to `docker-compose.yml`, on the same internal-only `monitoring` network as Prometheus/Loki, and point the backend's `OTEL_EXPORTER_OTLP_ENDPOINT` at it (`http://tempo:4317`, gRPC - the OTLP exporter's default protocol, so no separate `OTEL_EXPORTER_OTLP_PROTOCOL` override is needed). Add Tempo as a third Grafana datasource alongside Prometheus and Loki, so traces are queryable (TraceQL) from the same dashboard as metrics and logs.
+
+=== Rationale
+* The log-level fix is a one-line, zero-risk config change: it only widens what already-written, already-wired-up middleware is allowed to emit, and only for its own category.
+* Grafana, Prometheus, and Loki are already deployed and already the operational home for this app's metrics and logs; adding Tempo alongside them keeps all three observability signals in one place instead of introducing a second dashboard/vendor for traces only.
+* Tempo's single-binary mode (no separate ingester/querier/compactor processes) matches how Loki is already run in this stack - proportionate to this project's own trace volume, and consistent with the "self-hosting over SaaS" trade-off already made for the rest of the monitoring stack.
+* The backend already emits OTLP traces unconditionally (`ConfigureOpenTelemetry`'s `WithTracing(...)`); `AddOpenTelemetryExporters` already gates the exporter itself behind `OTEL_EXPORTER_OTLP_ENDPOINT` being set, so wiring this up is purely a `docker-compose.yml`/deployment change - no application code changes.
+* Pushing traces directly from the backend to Tempo over OTLP (rather than via a shipper, the way Alloy fronts Loki) needs no extra component: the backend already speaks OTLP natively, unlike its logs, which only reach Loki because Alloy tails container stdout.
+
+=== Considered Alternatives
+
+==== Log-level fix only, defer tracing
+Ship `"Microsoft.AspNetCore.HttpLogging": "Information"` and leave `OTEL_EXPORTER_OTLP_ENDPOINT` unset, as originally scoped for this "Minor" severity issue.
+
+* Pros
+** Smallest possible change; no new container, volume, or resource budget on a memory-constrained (4GB) staging VM
+** Matches the issue's own severity label and `08_concepts.adoc`'s previously-documented "not wired in by default" trade-off
+* Cons
+** Leaves distributed tracing permanently unusable in every deployed environment - the OTLP exporter code path exists and is unconditionally configured, but has nowhere to send data
+** A production incident spanning multiple services (backend -> Keycloak, backend -> Postgres) still has to be diagnosed from logs and metrics alone, with no request-scoped trace to tie them together
+
+==== Jaeger instead of Tempo
+Use Jaeger as the OTLP trace collector/store instead of Tempo.
+
+* Pros
+** Also a well-established, purpose-built distributed tracing backend with native OTLP support
+* Cons
+** Would be the only non-Grafana-family component in a monitoring stack otherwise entirely built on Prometheus/Loki/Grafana/Alloy, needing its own UI, its own datasource plugin for Grafana (extra config, worse integration than Tempo's first-party Grafana datasource), and its own storage/retention story to reason about
+** No material capability advantage for this project's scale that would justify the inconsistency
+
+==== Third-party observability SaaS (Grafana Cloud, Honeycomb, Datadog, etc.)
+Point `OTEL_EXPORTER_OTLP_ENDPOINT` at a hosted vendor instead of self-hosting a collector.
+
+* Pros
+** No new container to operate; vendor handles storage, retention, and scaling
+* Cons
+** Recurring cost and a new data-processing relationship with a third party, for a project whose staging environment is explicitly disposable demo/QA infrastructure (see root `AGENTS.md`)
+** Contradicts the "no third-party observability SaaS" trade-off `08_concepts.adoc` had already documented for metrics and logs; a self-hosted option (Tempo) achieves the same goal without reversing it
+
+=== Consequences
+* Tempo adds one more container to the staging host's resource budget (160m memory / 0.25 CPU limit, matching Loki's sizing) and one more named Docker volume (`tempo_data`) with a fixed 48h trace retention - old traces are not kept indefinitely, unlike metrics (Prometheus) or logs (Loki), which currently have no equivalent explicit retention cap.
+* Unlike Loki (fed by Alloy, which discovers and ships *any* container's stdout), Tempo only ever receives what the backend itself pushes over OTLP - if another service in this stack needs distributed tracing later, it must be wired up individually, there is no shared shipper for traces the way Alloy is for logs.
+* No Docker healthcheck is defined for the `tempo` service, since (unlike Loki, confirmed lacking wget/shell on staging) whether the `grafana/tempo` image ships either has not been verified; nothing currently depends on it via `condition: service_healthy`, so this does not block or gate any other service's startup.
+* `08_concepts.adoc`'s Logging and Observability section and `07_deployment_view.adoc`'s service table/diagram were updated to describe Tempo as the actual OTLP destination, replacing the previous "any OTLP-compatible backend... when set" phrasing that described a code path with nothing behind it.

--- a/docs/Architecture/images/deployment-staging.puml
+++ b/docs/Architecture/images/deployment-staging.puml
@@ -53,6 +53,10 @@ Deployment_Node(host, "Staging Host (VM)", "Docker Compose") {
 	Deployment_Node(al_node, "alloy", "grafana/alloy") {
 		Container(al, "Log shipper", "Grafana Alloy", "internal only")
 	}
+
+	Deployment_Node(tm_node, "tempo", "grafana/tempo") {
+		Container(tm, "Trace store", "Tempo", "internal only")
+	}
 }
 
 Rel(traefik, fe, "HTTPS")
@@ -67,7 +71,9 @@ Rel(kc, pg, "Realm data")
 Rel(bk, pg, "pg_dump")
 Rel(gf, pr, "PromQL queries")
 Rel(gf, lo, "LogQL queries")
+Rel(gf, tm, "TraceQL queries")
 Rel(pr, ne, "scrape /metrics")
 Rel(al, lo, "push logs")
+Rel(be, tm, "OTLP traces (gRPC)")
 
 @enduml

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -158,7 +158,7 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Grafana
 |`grafana/grafana`
 |`grafana.maik-hasler.de`
-|Dashboards; datasources are Prometheus (metrics) and Loki (logs)
+|Dashboards; datasources are Prometheus (metrics), Loki (logs), and Tempo (traces)
 
 |Prometheus
 |`prom/prometheus`
@@ -180,6 +180,11 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |internal only
 |Ships container logs to Loki; discovers containers via a read-only Docker socket mount
 
+|Tempo
+|`grafana/tempo`
+|internal only
+|Trace store; receives OTLP pushes directly from the backend, not exposed via Traefik
+
 |Traefik
 |host-level (shared)
 |`*.maik-hasler.de`
@@ -188,4 +193,4 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 
 Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`). The deploy is health-gated (backend `/alive` and `/health`) and rolls back to the previous images on failure.
 
-Prometheus, node-exporter, and Loki sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics or log content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads both Prometheus (metrics) and Loki (logs) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient.
+Prometheus, node-exporter, Loki, and Tempo sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics, log, or trace content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads Prometheus (metrics), Loki (logs), and Tempo (traces) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient. Tempo has no equivalent shipper: the backend pushes traces to it directly over OTLP (see ADR 6), since the app already speaks OTLP natively via the Aspire service defaults.

--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -111,12 +111,12 @@ Opportunity addresses are geocoded at write time, and spatial search uses a boun
 
 The backend uses the .NET built-in `ILogger<T>` abstraction. Every request runs inside a logging scope that enriches its entries with the OpenTelemetry trace ID and the authenticated user ID.
 
-Observability is built on OpenTelemetry (via the Aspire service defaults): logs, metrics (ASP.NET Core, HTTP client, runtime), and distributed traces are exported over OTLP - collected by the Aspire dashboard in development, and by any OTLP-compatible backend in production when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+Observability is built on OpenTelemetry (via the Aspire service defaults): logs, metrics (ASP.NET Core, HTTP client, runtime), and distributed traces are exported over OTLP - collected by the Aspire dashboard in development, and by Grafana Tempo in staging/production, where `docker-compose.yml` points `OTEL_EXPORTER_OTLP_ENDPOINT` at it (ADR 6).
 
 Key logged events:
 
-* HTTP request logs (method, path, status, duration)
+* HTTP request logs (method, path, status, duration) - the `Microsoft.AspNetCore.HttpLogging` category has its own `LogLevel` override so these survive the broader `Microsoft.AspNetCore: Warning` filter (#1352)
 * Unhandled exceptions (with trace ID)
 * Slow requests (flagged by the performance pipeline behavior)
 
-No third-party observability SaaS (Datadog, Grafana Cloud, etc.) is wired in by default - a deliberate trade-off to keep operational complexity minimal; any OTLP backend can be pointed at the exporter.
+No third-party observability SaaS (Datadog, Grafana Cloud, etc.) is wired in by default - a deliberate trade-off to keep operational complexity minimal; any OTLP backend can be pointed at the exporter, and the self-hosted Grafana stack (Prometheus, Loki, Tempo) already deployed alongside the app is what it points at in staging/production.

--- a/docs/Architecture/src/09_architecture_decisions.adoc
+++ b/docs/Architecture/src/09_architecture_decisions.adoc
@@ -45,6 +45,13 @@ The following table lists the relevant architecture decisions. Each decision lin
 |2026-07-27
 |link:ADRs/5_map_and_geocoding_request_proxying.html[Proxying]
 
+|6
+|Distributed tracing
+|Add Grafana Tempo to the staging/production monitoring stack and point the backend's OTLP exporter at it; fix the log-level override that was silently suppressing HTTP request logs.
+|Accepted
+|2026-07-29
+|link:ADRs/6_distributed_tracing_via_tempo.html[Tempo]
+
 |===
 
 See <<section-solution-strategy>> for how the key decisions map to the quality goals.


### PR DESCRIPTION
"Microsoft.AspNetCore": "Warning" was the longest matching LogLevel prefix for the HttpLoggingMiddleware category, silently suppressing the request logs Program.cs already wires up. Add a more specific override so they survive.

Also add a Tempo service to the staging monitoring stack and point the backend's OTLP exporter at it, closing the other half of #1352: distributed traces had a code path but no destination.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1352

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
