### PR TITLE
feat: add response compression and query-result caching

### DIFF
--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -6,6 +6,7 @@ using Api.Common.Health;
 using Api.Common.Middleware;
 using Api.Common.RateLimiting;
 using Application;
+using Application.Common.Caching;
 using Asp.Versioning;
 using Infrastructure;
 using Infrastructure.Persistence;
@@ -157,6 +158,15 @@ if (app.Environment.IsDevelopment())
 	await initializer.SeedAsync();
 
 	app.MapOpenApi();
+
+	// Dev-only escape hatch for IntegrationTests: Respawn resets the database with a raw
+	// SQL truncate from the test process, which never runs a command/domain event, so the
+	// query cache (CachingPipelineBehavior) has no way to learn about it on its own.
+	app.MapPost("/internal/testing/cache/clear", (ICacheInvalidator cacheInvalidator) =>
+	{
+		cacheInvalidator.InvalidateAll();
+		return Results.NoContent();
+	}).AllowAnonymous();
 }
 else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 {

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -11,6 +11,7 @@ using Infrastructure;
 using Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
@@ -66,6 +67,17 @@ builder.Services.AddCors(options =>
 		policy.WithOrigins(builder.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? ["http://localhost:4321"])
 			.AllowAnyHeader()
 			.WithMethods("GET", "POST", "PUT", "PATCH", "DELETE")));
+
+builder.Services.AddResponseCompression(options =>
+{
+	// HTTPS compression is off by default (BREACH mitigation for pages that reflect a
+	// secret alongside attacker-controlled input, e.g. a CSRF token next to a search query).
+	// This API has no such reflection - it's JWT-bearer JSON endpoints, not cookie+HTML - so
+	// the tradeoff favors enabling it.
+	options.EnableForHttps = true;
+	options.Providers.Add<BrotliCompressionProvider>();
+	options.Providers.Add<GzipCompressionProvider>();
+});
 
 builder.Services.AddHttpClient(KeycloakHealthCheck.HttpClientName, client =>
 	client.Timeout = TimeSpan.FromSeconds(5));
@@ -161,6 +173,10 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 app.MapDefaultEndpoints();
 
 app.UseHttpLogging();
+
+// Must run before anything that writes the response body so it wraps the whole
+// downstream pipeline's output, not just endpoint results.
+app.UseResponseCompression();
 
 app.Use(async (context, next) =>
 {

--- a/backend/src/Application/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogQuery.cs
+++ b/backend/src/Application/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogQuery.cs
@@ -1,7 +1,15 @@
 using Application.Achievements.BadgeCatalog;
+using Application.Common.Caching;
 using Application.Common.Messaging;
 
 namespace Application.Achievements.GetBadgeCatalog.v1;
 
 public sealed record GetBadgeCatalogQuery
-	: IQuery<List<BadgeCatalogEntry>>;
+	: ICachedQuery<List<BadgeCatalogEntry>>
+{
+	public string CacheKey => "achievements:badge-catalog";
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.BadgeCatalog];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Application/Achievements/GetUserAchievements/v1/GetUserAchievementsQuery.cs
+++ b/backend/src/Application/Achievements/GetUserAchievements/v1/GetUserAchievementsQuery.cs
@@ -1,7 +1,15 @@
+using Application.Common.Caching;
 using Application.Common.Messaging;
 using Domain.Users;
 
 namespace Application.Achievements.GetUserAchievements.v1;
 
 public sealed record GetUserAchievementsQuery(UserId UserId)
-	: IQuery<List<AchievementSummary>>;
+	: ICachedQuery<List<AchievementSummary>>
+{
+	public string CacheKey => $"achievements:user:{UserId.Value}";
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.Achievements];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Application/Common/Caching/CacheCategory.cs
+++ b/backend/src/Application/Common/Caching/CacheCategory.cs
@@ -1,0 +1,14 @@
+namespace Application.Common.Caching;
+
+public static class CacheCategory
+{
+	public const string BadgeCatalog = "BadgeCatalog";
+
+	public const string Organizations = "Organizations";
+
+	public const string VolunteerOpportunities = "VolunteerOpportunities";
+
+	public const string Users = "Users";
+
+	public const string Achievements = "Achievements";
+}

--- a/backend/src/Application/Common/Caching/CacheCategoryTokenStore.cs
+++ b/backend/src/Application/Common/Caching/CacheCategoryTokenStore.cs
@@ -26,4 +26,10 @@ internal sealed class CacheCategoryTokenStore : ICacheInvalidator, ICacheCategor
 			cts.Dispose();
 		}
 	}
+
+	public void InvalidateAll()
+	{
+		foreach (var category in _tokenSources.Keys.ToList())
+			Invalidate(category);
+	}
 }

--- a/backend/src/Application/Common/Caching/CacheCategoryTokenStore.cs
+++ b/backend/src/Application/Common/Caching/CacheCategoryTokenStore.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Primitives;
+
+namespace Application.Common.Caching;
+
+// Cache entries are tagged with a per-category IChangeToken when written (see
+// CachingPipelineBehavior). Invalidating a category cancels its token, which evicts every
+// entry tagged with it from IMemoryCache immediately, regardless of the entry's own key -
+// this is what lets a domain event invalidate "the cache for the entity" without needing to
+// enumerate or pattern-match the individual cache keys that happen to exist for it.
+internal sealed class CacheCategoryTokenStore : ICacheInvalidator, ICacheCategoryTokenProvider
+{
+	private readonly ConcurrentDictionary<string, CancellationTokenSource> _tokenSources = new();
+
+	public IChangeToken GetToken(string category)
+	{
+		var cts = _tokenSources.GetOrAdd(category, static _ => new CancellationTokenSource());
+		return new CancellationChangeToken(cts.Token);
+	}
+
+	public void Invalidate(string category)
+	{
+		if (_tokenSources.TryRemove(category, out var cts))
+		{
+			cts.Cancel();
+			cts.Dispose();
+		}
+	}
+}

--- a/backend/src/Application/Common/Caching/CachingDefaults.cs
+++ b/backend/src/Application/Common/Caching/CachingDefaults.cs
@@ -1,0 +1,6 @@
+namespace Application.Common.Caching;
+
+public static class CachingDefaults
+{
+	public static readonly TimeSpan Expiration = TimeSpan.FromSeconds(60);
+}

--- a/backend/src/Application/Common/Caching/ICacheCategoryTokenProvider.cs
+++ b/backend/src/Application/Common/Caching/ICacheCategoryTokenProvider.cs
@@ -1,0 +1,8 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Application.Common.Caching;
+
+internal interface ICacheCategoryTokenProvider
+{
+	IChangeToken GetToken(string category);
+}

--- a/backend/src/Application/Common/Caching/ICacheInvalidator.cs
+++ b/backend/src/Application/Common/Caching/ICacheInvalidator.cs
@@ -1,0 +1,6 @@
+namespace Application.Common.Caching;
+
+public interface ICacheInvalidator
+{
+	void Invalidate(string category);
+}

--- a/backend/src/Application/Common/Caching/ICacheInvalidator.cs
+++ b/backend/src/Application/Common/Caching/ICacheInvalidator.cs
@@ -3,4 +3,6 @@ namespace Application.Common.Caching;
 public interface ICacheInvalidator
 {
 	void Invalidate(string category);
+
+	void InvalidateAll();
 }

--- a/backend/src/Application/Common/Messaging/ICachedQuery.cs
+++ b/backend/src/Application/Common/Messaging/ICachedQuery.cs
@@ -1,0 +1,10 @@
+namespace Application.Common.Messaging;
+
+public interface ICachedQuery<out TResponse> : IQuery<TResponse>
+{
+	string CacheKey { get; }
+
+	IReadOnlyCollection<string> CacheCategories { get; }
+
+	TimeSpan Expiration { get; }
+}

--- a/backend/src/Application/Common/PipelineBehaviors/CachingPipelineBehavior.cs
+++ b/backend/src/Application/Common/PipelineBehaviors/CachingPipelineBehavior.cs
@@ -1,0 +1,38 @@
+using Application.Common.Caching;
+using Application.Common.Messaging;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Application.Common.PipelineBehaviors;
+
+internal sealed class CachingPipelineBehavior<TQuery, TResponse>(
+	IMemoryCache cache,
+	ICacheCategoryTokenProvider tokenProvider)
+	: IPipelineBehavior<TQuery, TResponse>
+	where TQuery : ICachedQuery<TResponse>
+{
+	public async ValueTask<TResponse> Handle(
+		TQuery request,
+		Func<ValueTask<TResponse>> next,
+		CancellationToken cancellationToken = default)
+	{
+		if (cache.TryGetValue(request.CacheKey, out TResponse? cached) && cached is not null)
+			return cached;
+
+		var response = await next().ConfigureAwait(false);
+
+		if (response is not null)
+		{
+			var options = new MemoryCacheEntryOptions
+			{
+				AbsoluteExpirationRelativeToNow = request.Expiration,
+			};
+
+			foreach (var category in request.CacheCategories)
+				options.AddExpirationToken(tokenProvider.GetToken(category));
+
+			cache.Set(request.CacheKey, response, options);
+		}
+
+		return response;
+	}
+}

--- a/backend/src/Application/Organizations/Common/InvalidateOrganizationsCacheHandler.cs
+++ b/backend/src/Application/Organizations/Common/InvalidateOrganizationsCacheHandler.cs
@@ -1,0 +1,29 @@
+using Application.Common.Caching;
+using Application.Common.Messaging;
+using Domain.Organizations;
+
+namespace Application.Organizations.Common;
+
+internal sealed class InvalidateOrganizationsCacheHandler(ICacheInvalidator cacheInvalidator)
+	: INotificationHandler<OrganizationCreatedDomainEvent>,
+		INotificationHandler<OrganizationDeletedDomainEvent>,
+		INotificationHandler<OrganizationRestoredDomainEvent>,
+		INotificationHandler<OrganizationVerifiedDomainEvent>,
+		INotificationHandler<OrganizationVerificationRevokedDomainEvent>
+{
+	public Task Handle(OrganizationCreatedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(OrganizationDeletedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(OrganizationRestoredDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(OrganizationVerifiedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(OrganizationVerificationRevokedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	private Task Invalidate()
+	{
+		cacheInvalidator.Invalidate(CacheCategory.Organizations);
+		return Task.CompletedTask;
+	}
+}

--- a/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQuery.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQuery.cs
@@ -1,6 +1,14 @@
+using Application.Common.Caching;
 using Application.Common.Messaging;
 
 namespace Application.Organizations.GetPublicOrganizationProfile.v1;
 
 public sealed record GetPublicOrganizationProfileQuery(Guid OrganizationId)
-	: IQuery<PublicOrganizationProfileResponse?>;
+	: ICachedQuery<PublicOrganizationProfileResponse?>
+{
+	public string CacheKey => $"organizations:profile:{OrganizationId}";
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.Organizations, CacheCategory.VolunteerOpportunities];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQuery.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsQuery.cs
@@ -1,3 +1,4 @@
+using Application.Common.Caching;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 
@@ -7,4 +8,12 @@ public sealed record GetPublicOrganizationsQuery(
 	int PageNumber,
 	int PageSize,
 	string? Search)
-	: IQuery<PagedList<PublicOrganizationSummary>>;
+	: ICachedQuery<PagedList<PublicOrganizationSummary>>
+{
+	public string CacheKey =>
+		string.Join('|', "organizations:directory", PageNumber, PageSize, Search?.Trim().ToLowerInvariant() ?? string.Empty);
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.Organizations, CacheCategory.VolunteerOpportunities];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Application/ServiceCollectionExtensions.cs
+++ b/backend/src/Application/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Application.Common.Caching;
 using Application.Common.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +12,10 @@ public static class ServiceCollectionExtensions
 	{
 		services.AddTransient<ISender, Sender>();
 		services.AddTransient<IPublisher, Publisher>();
+
+		services.AddSingleton<CacheCategoryTokenStore>();
+		services.AddSingleton<ICacheInvalidator>(sp => sp.GetRequiredService<CacheCategoryTokenStore>());
+		services.AddSingleton<ICacheCategoryTokenProvider>(sp => sp.GetRequiredService<CacheCategoryTokenStore>());
 
 		services.AddHandlersFromAssembly(Assembly.GetExecutingAssembly());
 		services.AddBehaviorsFromAssembly(Assembly.GetExecutingAssembly());

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQuery.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQuery.cs
@@ -1,7 +1,15 @@
+using Application.Common.Caching;
 using Application.Common.Messaging;
 using Domain.Users;
 
 namespace Application.Users.GetPublicUserProfile.v1;
 
 public sealed record GetPublicUserProfileQuery(UserId UserId)
-	: IQuery<PublicUserProfileResponse?>;
+	: ICachedQuery<PublicUserProfileResponse?>
+{
+	public string CacheKey => $"users:profile:{UserId.Value}";
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.Users];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Application/VolunteerOpportunities/Common/InvalidateVolunteerOpportunitiesCacheHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/InvalidateVolunteerOpportunitiesCacheHandler.cs
@@ -1,0 +1,26 @@
+using Application.Common.Caching;
+using Application.Common.Messaging;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.Common;
+
+internal sealed class InvalidateVolunteerOpportunitiesCacheHandler(ICacheInvalidator cacheInvalidator)
+	: INotificationHandler<VolunteerOpportunityCreatedDomainEvent>,
+		INotificationHandler<VolunteerOpportunityPublishedDomainEvent>,
+		INotificationHandler<VolunteerOpportunityDeletedDomainEvent>,
+		INotificationHandler<VolunteerOpportunityRestoredDomainEvent>
+{
+	public Task Handle(VolunteerOpportunityCreatedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(VolunteerOpportunityPublishedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(VolunteerOpportunityDeletedDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	public Task Handle(VolunteerOpportunityRestoredDomainEvent notification, CancellationToken cancellationToken) => Invalidate();
+
+	private Task Invalidate()
+	{
+		cacheInvalidator.Invalidate(CacheCategory.VolunteerOpportunities);
+		return Task.CompletedTask;
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQuery.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQuery.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using Application.Common.Caching;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 
@@ -21,4 +23,31 @@ public sealed record GetVolunteerOpportunitiesQuery(
 	double? RadiusKm,
 	string[]? Categories,
 	string? Tag)
-	: IQuery<PagedList<VolunteerOpportunitySummary>>;
+	: ICachedQuery<PagedList<VolunteerOpportunitySummary>>
+{
+	public string CacheKey =>
+		string.Join(
+			'|',
+			"volunteer-opportunities:list",
+			PageNumber,
+			PageSize,
+			City?.Trim().ToLowerInvariant() ?? string.Empty,
+			Occurrence ?? string.Empty,
+			ParticipationType ?? string.Empty,
+			IsRemote?.ToString() ?? string.Empty,
+			DateFrom?.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+			DateTo?.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+			North?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			South?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			East?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			West?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			CenterLatitude?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			CenterLongitude?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			RadiusKm?.ToString("R", CultureInfo.InvariantCulture) ?? string.Empty,
+			Categories is { Length: > 0 } ? string.Join(',', Categories.OrderBy(c => c, StringComparer.OrdinalIgnoreCase)) : string.Empty,
+			Tag?.Trim().ToLowerInvariant() ?? string.Empty);
+
+	public IReadOnlyCollection<string> CacheCategories { get; } = [CacheCategory.VolunteerOpportunities];
+
+	public TimeSpan Expiration => CachingDefaults.Expiration;
+}

--- a/backend/src/Domain/Organizations/Organization.cs
+++ b/backend/src/Domain/Organizations/Organization.cs
@@ -51,7 +51,9 @@ public sealed class Organization
 		if (string.IsNullOrWhiteSpace(name))
 			return Result.Failure<Organization>(Error.Validation("Organization.NameRequired", "Name must not be empty."));
 
-		return new Organization(id, name);
+		var organization = new Organization(id, name);
+		organization.AddEvent(new OrganizationCreatedDomainEvent(id));
+		return organization;
 	}
 
 	public void SetLogoUrl(string? url)
@@ -112,6 +114,7 @@ public sealed class Organization
 
 		IsDeleted = true;
 		DeletedOn = deletedOn;
+		AddEvent(new OrganizationDeletedDomainEvent(Id));
 		return Result.Success();
 	}
 
@@ -122,6 +125,7 @@ public sealed class Organization
 
 		IsDeleted = false;
 		DeletedOn = null;
+		AddEvent(new OrganizationRestoredDomainEvent(Id));
 		return Result.Success();
 	}
 }

--- a/backend/src/Domain/Organizations/OrganizationCreatedDomainEvent.cs
+++ b/backend/src/Domain/Organizations/OrganizationCreatedDomainEvent.cs
@@ -1,0 +1,7 @@
+using Domain.Primitives;
+
+namespace Domain.Organizations;
+
+public sealed record OrganizationCreatedDomainEvent(
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Domain/Organizations/OrganizationDeletedDomainEvent.cs
+++ b/backend/src/Domain/Organizations/OrganizationDeletedDomainEvent.cs
@@ -1,0 +1,7 @@
+using Domain.Primitives;
+
+namespace Domain.Organizations;
+
+public sealed record OrganizationDeletedDomainEvent(
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Domain/Organizations/OrganizationRestoredDomainEvent.cs
+++ b/backend/src/Domain/Organizations/OrganizationRestoredDomainEvent.cs
@@ -1,0 +1,7 @@
+using Domain.Primitives;
+
+namespace Domain.Organizations;
+
+public sealed record OrganizationRestoredDomainEvent(
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -161,7 +161,7 @@ public sealed class VolunteerOpportunity
 					"A Waitlist opportunity must be created as a draft and published after adding at least one time slot."));
 		}
 
-		return new VolunteerOpportunity(
+		var opportunity = new VolunteerOpportunity(
 			VolunteerOpportunityId.New(),
 			organizationId,
 			title,
@@ -176,6 +176,9 @@ public sealed class VolunteerOpportunity
 			status,
 			pinGenerator,
 			checkInPin);
+
+		opportunity.AddEvent(new VolunteerOpportunityCreatedDomainEvent(opportunity.Id, organizationId));
+		return opportunity;
 	}
 
 	private static Result EnsurePublishable(
@@ -371,6 +374,7 @@ public sealed class VolunteerOpportunity
 
 		IsDeleted = true;
 		DeletedOn = deletedOn;
+		AddEvent(new VolunteerOpportunityDeletedDomainEvent(Id, OrganizationId));
 		return Result.Success();
 	}
 
@@ -381,6 +385,7 @@ public sealed class VolunteerOpportunity
 
 		IsDeleted = false;
 		DeletedOn = null;
+		AddEvent(new VolunteerOpportunityRestoredDomainEvent(Id, OrganizationId));
 		return Result.Success();
 	}
 }

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityCreatedDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityCreatedDomainEvent.cs
@@ -1,0 +1,9 @@
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityCreatedDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityDeletedDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityDeletedDomainEvent.cs
@@ -1,0 +1,9 @@
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityDeletedDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityRestoredDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityRestoredDomainEvent.cs
@@ -1,0 +1,9 @@
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityRestoredDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/tests/Application.UnitTests/Common/Caching/CacheCategoryTokenStoreTests.cs
+++ b/backend/tests/Application.UnitTests/Common/Caching/CacheCategoryTokenStoreTests.cs
@@ -1,0 +1,76 @@
+using Application.Common.Caching;
+using AwesomeAssertions;
+
+namespace Application.UnitTests.Common.Caching;
+
+public class CacheCategoryTokenStoreTests
+{
+	[Test]
+	public void GetToken_ShouldReturnTokenThatHasNotFired_WhenCategoryIsUntouched()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+
+		// Act
+		var token = store.GetToken("Category");
+
+		// Assert
+		token.HasChanged.Should().BeFalse();
+	}
+
+	[Test]
+	public void Invalidate_ShouldFireTheToken_ThatWasIssuedForTheSameCategory()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+		var token = store.GetToken("Category");
+
+		// Act
+		store.Invalidate("Category");
+
+		// Assert
+		token.HasChanged.Should().BeTrue();
+	}
+
+	[Test]
+	public void Invalidate_ShouldNotFireTokens_IssuedForADifferentCategory()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+		var token = store.GetToken("Category");
+
+		// Act
+		store.Invalidate("OtherCategory");
+
+		// Assert
+		token.HasChanged.Should().BeFalse();
+	}
+
+	[Test]
+	public void Invalidate_ShouldNotThrow_WhenCategoryHasNoTokensYet()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+
+		// Act
+		var act = () => store.Invalidate("NeverRequested");
+
+		// Assert
+		act.Should().NotThrow();
+	}
+
+	[Test]
+	public void GetToken_ShouldReturnFreshUnfiredToken_AfterThePriorTokenWasInvalidated()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+		store.GetToken("Category");
+		store.Invalidate("Category");
+
+		// Act
+		var token = store.GetToken("Category");
+
+		// Assert
+		token.HasChanged.Should().BeFalse();
+	}
+}

--- a/backend/tests/Application.UnitTests/Common/Caching/CacheCategoryTokenStoreTests.cs
+++ b/backend/tests/Application.UnitTests/Common/Caching/CacheCategoryTokenStoreTests.cs
@@ -73,4 +73,48 @@ public class CacheCategoryTokenStoreTests
 		// Assert
 		token.HasChanged.Should().BeFalse();
 	}
+
+	[Test]
+	public void InvalidateAll_ShouldFireTokens_ForEveryCategoryEverRequested()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+		var tokenA = store.GetToken("CategoryA");
+		var tokenB = store.GetToken("CategoryB");
+
+		// Act
+		store.InvalidateAll();
+
+		// Assert
+		tokenA.HasChanged.Should().BeTrue();
+		tokenB.HasChanged.Should().BeTrue();
+	}
+
+	[Test]
+	public void InvalidateAll_ShouldNotThrow_WhenNoCategoryHasBeenRequestedYet()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+
+		// Act
+		var act = () => store.InvalidateAll();
+
+		// Assert
+		act.Should().NotThrow();
+	}
+
+	[Test]
+	public void GetToken_ShouldReturnFreshUnfiredToken_AfterInvalidateAll()
+	{
+		// Arrange
+		var store = new CacheCategoryTokenStore();
+		store.GetToken("Category");
+		store.InvalidateAll();
+
+		// Act
+		var token = store.GetToken("Category");
+
+		// Assert
+		token.HasChanged.Should().BeFalse();
+	}
 }

--- a/backend/tests/Application.UnitTests/Common/PipelineBehaviors/CachingPipelineBehaviorTests.cs
+++ b/backend/tests/Application.UnitTests/Common/PipelineBehaviors/CachingPipelineBehaviorTests.cs
@@ -1,0 +1,135 @@
+using Application.Common.Caching;
+using Application.Common.Messaging;
+using Application.Common.PipelineBehaviors;
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Application.UnitTests.Common.PipelineBehaviors;
+
+public class CachingPipelineBehaviorTests
+{
+	[Test]
+	public async Task Handle_ShouldCallNext_WhenCacheIsEmpty(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, new CacheCategoryTokenStore());
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>("value"); }
+
+		// Act
+		var result = await behavior.Handle(new TestQuery("key-1", "TestCategory"), Next, cancellationToken);
+
+		// Assert
+		result.Should().Be("value");
+		nextCallCount.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCachedValue_WithoutCallingNextAgain_WhenCacheHit(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, new CacheCategoryTokenStore());
+		var query = new TestQuery("key-1", "TestCategory");
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>("value"); }
+
+		// Act
+		await behavior.Handle(query, Next, cancellationToken);
+		var second = await behavior.Handle(query, Next, cancellationToken);
+
+		// Assert
+		second.Should().Be("value");
+		nextCallCount.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCallNextAgain_WhenCacheKeyDiffers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, new CacheCategoryTokenStore());
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>("value"); }
+
+		// Act
+		await behavior.Handle(new TestQuery("key-1", "TestCategory"), Next, cancellationToken);
+		await behavior.Handle(new TestQuery("key-2", "TestCategory"), Next, cancellationToken);
+
+		// Assert
+		nextCallCount.Should().Be(2);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCallNextAgain_WhenCategoryIsInvalidated(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var tokenStore = new CacheCategoryTokenStore();
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, tokenStore);
+		var query = new TestQuery("key-1", "TestCategory");
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>("value"); }
+
+		// Act
+		await behavior.Handle(query, Next, cancellationToken);
+		tokenStore.Invalidate("TestCategory");
+		await behavior.Handle(query, Next, cancellationToken);
+
+		// Assert
+		nextCallCount.Should().Be(2);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAffectOtherCategories_WhenOneCategoryIsInvalidated(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var tokenStore = new CacheCategoryTokenStore();
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, tokenStore);
+		var query = new TestQuery("key-1", "TestCategory");
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>("value"); }
+
+		// Act
+		await behavior.Handle(query, Next, cancellationToken);
+		tokenStore.Invalidate("SomeOtherCategory");
+		await behavior.Handle(query, Next, cancellationToken);
+
+		// Assert
+		nextCallCount.Should().Be(1);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCallNextEveryTime_WhenResultIsNull(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a null result (e.g. "not found") is never cached, so a repeated
+		// lookup for a still-missing entity isn't stuck returning null forever.
+		using var cache = new MemoryCache(new MemoryCacheOptions());
+		var behavior = new CachingPipelineBehavior<TestQuery, string?>(cache, new CacheCategoryTokenStore());
+		var query = new TestQuery("key-1", "TestCategory");
+		var nextCallCount = 0;
+		ValueTask<string?> Next() { nextCallCount++; return ValueTask.FromResult<string?>(null); }
+
+		// Act
+		await behavior.Handle(query, Next, cancellationToken);
+		await behavior.Handle(query, Next, cancellationToken);
+
+		// Assert
+		nextCallCount.Should().Be(2);
+	}
+
+	private sealed record TestQuery(string CacheKey, string Category) : ICachedQuery<string?>
+	{
+		public IReadOnlyCollection<string> CacheCategories { get; } = [Category];
+
+		public TimeSpan Expiration => TimeSpan.FromMinutes(5);
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/Common/InvalidateOrganizationsCacheHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/Common/InvalidateOrganizationsCacheHandlerTests.cs
@@ -1,0 +1,63 @@
+using Application.Common.Caching;
+using Application.Organizations.Common;
+using AwesomeAssertions;
+using Domain.Organizations;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.Common;
+
+public class InvalidateOrganizationsCacheHandlerTests
+{
+	private readonly ICacheInvalidator _cacheInvalidator = Substitute.For<ICacheInvalidator>();
+	private readonly InvalidateOrganizationsCacheHandler _sut;
+
+	public InvalidateOrganizationsCacheHandlerTests()
+	{
+		_sut = new InvalidateOrganizationsCacheHandler(_cacheInvalidator);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateOrganizationsCategory_WhenOrganizationCreated(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new OrganizationCreatedDomainEvent(OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.Organizations);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateOrganizationsCategory_WhenOrganizationDeleted(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new OrganizationDeletedDomainEvent(OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.Organizations);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateOrganizationsCategory_WhenOrganizationRestored(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new OrganizationRestoredDomainEvent(OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.Organizations);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateOrganizationsCategory_WhenOrganizationVerified(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new OrganizationVerifiedDomainEvent(OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.Organizations);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateOrganizationsCategory_WhenOrganizationVerificationRevoked(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new OrganizationVerificationRevokedDomainEvent(OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.Organizations);
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/GetPublicOrganizations/GetPublicOrganizationsQueryCacheKeyTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetPublicOrganizations/GetPublicOrganizationsQueryCacheKeyTests.cs
@@ -1,0 +1,35 @@
+using Application.Organizations.GetPublicOrganizations.v1;
+using AwesomeAssertions;
+
+namespace Application.UnitTests.Organizations.GetPublicOrganizations;
+
+public class GetPublicOrganizationsQueryCacheKeyTests
+{
+	[Test]
+	public void CacheKey_ShouldBeEqual_WhenSearchCasingDiffers()
+	{
+		new GetPublicOrganizationsQuery(1, 20, "berlin").CacheKey.Should()
+			.Be(new GetPublicOrganizationsQuery(1, 20, "BERLIN").CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldTreatNullAndEmptySearch_AsEqual()
+	{
+		new GetPublicOrganizationsQuery(1, 20, null).CacheKey.Should()
+			.Be(new GetPublicOrganizationsQuery(1, 20, "").CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldDiffer_WhenPageNumberDiffers()
+	{
+		new GetPublicOrganizationsQuery(1, 20, "berlin").CacheKey.Should()
+			.NotBe(new GetPublicOrganizationsQuery(2, 20, "berlin").CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldDiffer_WhenSearchDiffers()
+	{
+		new GetPublicOrganizationsQuery(1, 20, "berlin").CacheKey.Should()
+			.NotBe(new GetPublicOrganizationsQuery(1, 20, "hamburg").CacheKey);
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
@@ -68,6 +68,113 @@ public class OrganizationTests
 	}
 
 	[Test]
+	public void Create_ShouldRaiseCreatedDomainEvent()
+	{
+		// Arrange
+		var id = OrganizationId.New();
+
+		// Act
+		var org = Organization.Create(id, "Org").Value;
+
+		// Assert
+		var domainEvent = org.Events.Should().ContainSingle().Which;
+		domainEvent.Should().BeOfType<OrganizationCreatedDomainEvent>();
+		((OrganizationCreatedDomainEvent)domainEvent).OrganizationId.Should().Be(id);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldSetIsDeletedTrue()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		var deletedOn = DateTimeOffset.UtcNow;
+
+		// Act
+		var result = org.MarkDeleted(deletedOn);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		org.IsDeleted.Should().BeTrue();
+		org.DeletedOn.Should().Be(deletedOn);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldRaiseDeletedDomainEvent()
+	{
+		// Arrange
+		var id = OrganizationId.New();
+		var org = Organization.Create(id, "Org").Value;
+
+		// Act
+		org.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Assert
+		var domainEvent = org.Events.Should().ContainSingle(e => e is OrganizationDeletedDomainEvent).Which;
+		((OrganizationDeletedDomainEvent)domainEvent).OrganizationId.Should().Be(id);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldFail_WhenAlreadyDeleted()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		org.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		var result = org.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Organization is already shadow-deleted.");
+	}
+
+	[Test]
+	public void Restore_ShouldClearDeletedState()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		org.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		var result = org.Restore();
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		org.IsDeleted.Should().BeFalse();
+		org.DeletedOn.Should().BeNull();
+	}
+
+	[Test]
+	public void Restore_ShouldRaiseRestoredDomainEvent()
+	{
+		// Arrange
+		var id = OrganizationId.New();
+		var org = Organization.Create(id, "Org").Value;
+		org.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		org.Restore();
+
+		// Assert
+		var domainEvent = org.Events.Should().ContainSingle(e => e is OrganizationRestoredDomainEvent).Which;
+		((OrganizationRestoredDomainEvent)domainEvent).OrganizationId.Should().Be(id);
+	}
+
+	[Test]
+	public void Restore_ShouldFail_WhenNotDeleted()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+
+		// Act
+		var result = org.Restore();
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Organization is not shadow-deleted.");
+	}
+
+	[Test]
 	public void Verify_ShouldSetIsVerifiedTrue()
 	{
 		// Arrange

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/Common/InvalidateVolunteerOpportunitiesCacheHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/Common/InvalidateVolunteerOpportunitiesCacheHandlerTests.cs
@@ -1,0 +1,55 @@
+using Application.Common.Caching;
+using Application.VolunteerOpportunities.Common;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.Common;
+
+public class InvalidateVolunteerOpportunitiesCacheHandlerTests
+{
+	private readonly ICacheInvalidator _cacheInvalidator = Substitute.For<ICacheInvalidator>();
+	private readonly InvalidateVolunteerOpportunitiesCacheHandler _sut;
+
+	public InvalidateVolunteerOpportunitiesCacheHandlerTests()
+	{
+		_sut = new InvalidateVolunteerOpportunitiesCacheHandler(_cacheInvalidator);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateVolunteerOpportunitiesCategory_WhenOpportunityCreated(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new VolunteerOpportunityCreatedDomainEvent(VolunteerOpportunityId.New(), OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.VolunteerOpportunities);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateVolunteerOpportunitiesCategory_WhenOpportunityPublished(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new VolunteerOpportunityPublishedDomainEvent(VolunteerOpportunityId.New(), OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.VolunteerOpportunities);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateVolunteerOpportunitiesCategory_WhenOpportunityDeleted(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new VolunteerOpportunityDeletedDomainEvent(VolunteerOpportunityId.New(), OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.VolunteerOpportunities);
+	}
+
+	[Test]
+	public async Task Handle_ShouldInvalidateVolunteerOpportunitiesCategory_WhenOpportunityRestored(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(new VolunteerOpportunityRestoredDomainEvent(VolunteerOpportunityId.New(), OrganizationId.New()), cancellationToken);
+
+		_cacheInvalidator.Received(1).Invalidate(CacheCategory.VolunteerOpportunities);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunities/GetVolunteerOpportunitiesQueryCacheKeyTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunities/GetVolunteerOpportunitiesQueryCacheKeyTests.cs
@@ -1,0 +1,58 @@
+using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
+using AwesomeAssertions;
+
+namespace Application.UnitTests.VolunteerOpportunities.GetVolunteerOpportunities;
+
+public class GetVolunteerOpportunitiesQueryCacheKeyTests
+{
+	private static GetVolunteerOpportunitiesQuery CreateQuery(
+		int pageNumber = 1,
+		int pageSize = 20,
+		string? city = "Berlin",
+		string[]? categories = null,
+		string? tag = null) =>
+		new(pageNumber, pageSize, city, null, null, null, null, null, null, null, null, null, null, null, null, categories, tag);
+
+	[Test]
+	public void CacheKey_ShouldBeEqual_ForEquivalentQueries()
+	{
+		CreateQuery().CacheKey.Should().Be(CreateQuery().CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldDiffer_WhenPageNumberDiffers()
+	{
+		CreateQuery(pageNumber: 1).CacheKey.Should().NotBe(CreateQuery(pageNumber: 2).CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldDiffer_WhenTagDiffers()
+	{
+		CreateQuery(tag: "cleanup").CacheKey.Should().NotBe(CreateQuery(tag: "other").CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldBeCaseInsensitive_ForCity()
+	{
+		CreateQuery(city: "berlin").CacheKey.Should().Be(CreateQuery(city: "BERLIN").CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldBeOrderIndependent_ForCategories()
+	{
+		CreateQuery(categories: ["Environment", "Social"]).CacheKey.Should()
+			.Be(CreateQuery(categories: ["Social", "Environment"]).CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldDiffer_WhenCategoriesDiffer()
+	{
+		CreateQuery(categories: ["Environment"]).CacheKey.Should().NotBe(CreateQuery(categories: ["Social"]).CacheKey);
+	}
+
+	[Test]
+	public void CacheKey_ShouldTreatNullAndEmptyCategories_AsEqual()
+	{
+		CreateQuery(categories: null).CacheKey.Should().Be(CreateQuery(categories: []).CacheKey);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/PublishVolunteerOpportunity/PublishVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/PublishVolunteerOpportunity/PublishVolunteerOpportunityCommandHandlerTests.cs
@@ -90,9 +90,9 @@ public class PublishVolunteerOpportunityCommandHandlerTests
 		await _sut.Handle(new PublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
 
 		// Assert
-		var domainEvent = opportunity.Events.Should().ContainSingle().Which;
-		domainEvent.Should().BeOfType<VolunteerOpportunityPublishedDomainEvent>();
-		var published = (VolunteerOpportunityPublishedDomainEvent)domainEvent;
+		// Create() itself now also raises a VolunteerOpportunityCreatedDomainEvent (#1391),
+		// so this asserts on the Published event specifically rather than Events as a whole.
+		var published = opportunity.Events.OfType<VolunteerOpportunityPublishedDomainEvent>().Should().ContainSingle().Which;
 		published.OpportunityId.Should().Be(opportunity.Id);
 		published.OrganizationId.Should().Be(DefaultOrgId);
 	}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -663,4 +663,126 @@ public class VolunteerOpportunityTests
 		opportunity.TimeSlots.Should().HaveCount(1);
 		opportunity.TimeSlots.Should().NotContain(ts => ts.Id == idToRemove);
 	}
+
+	[Test]
+	public void Create_ShouldRaiseCreatedDomainEvent()
+	{
+		// Act
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+
+		// Assert
+		var domainEvent = opportunity.Events.Should().ContainSingle().Which;
+		domainEvent.Should().BeOfType<VolunteerOpportunityCreatedDomainEvent>();
+		var created = (VolunteerOpportunityCreatedDomainEvent)domainEvent;
+		created.OpportunityId.Should().Be(opportunity.Id);
+		created.OrganizationId.Should().Be(TestOrganizationId);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldSetIsDeletedTrue()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+		var deletedOn = DateTimeOffset.UtcNow;
+
+		// Act
+		var result = opportunity.MarkDeleted(deletedOn);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		opportunity.IsDeleted.Should().BeTrue();
+		opportunity.DeletedOn.Should().Be(deletedOn);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldRaiseDeletedDomainEvent()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+
+		// Act
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Assert
+		var domainEvent = opportunity.Events.Should().ContainSingle(e => e is VolunteerOpportunityDeletedDomainEvent).Which;
+		var deleted = (VolunteerOpportunityDeletedDomainEvent)domainEvent;
+		deleted.OpportunityId.Should().Be(opportunity.Id);
+		deleted.OrganizationId.Should().Be(TestOrganizationId);
+	}
+
+	[Test]
+	public void MarkDeleted_ShouldFail_WhenAlreadyDeleted()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		var result = opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Opportunity is already shadow-deleted.");
+	}
+
+	[Test]
+	public void Restore_ShouldClearDeletedState()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		var result = opportunity.Restore();
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		opportunity.IsDeleted.Should().BeFalse();
+		opportunity.DeletedOn.Should().BeNull();
+	}
+
+	[Test]
+	public void Restore_ShouldRaiseRestoredDomainEvent()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+
+		// Act
+		opportunity.Restore();
+
+		// Assert
+		var domainEvent = opportunity.Events.Should().ContainSingle(e => e is VolunteerOpportunityRestoredDomainEvent).Which;
+		var restored = (VolunteerOpportunityRestoredDomainEvent)domainEvent;
+		restored.OpportunityId.Should().Be(opportunity.Id);
+		restored.OrganizationId.Should().Be(TestOrganizationId);
+	}
+
+	[Test]
+	public void Restore_ShouldFail_WhenNotDeleted()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, PinGenerator).Value;
+
+		// Act
+		var result = opportunity.Restore();
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Opportunity is not shadow-deleted.");
+	}
 }

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -120,6 +120,13 @@ public class IntegrationTestFixture
 		await using var conn = new NpgsqlConnection(_connectionString);
 		await conn.OpenAsync();
 		await _respawner.ResetAsync(conn);
+
+		// Respawn truncates tables with a raw SQL connection from this test process, which
+		// the backend's query cache (CachingPipelineBehavior) has no way to observe on its
+		// own - no command runs, so no domain event fires to invalidate it.
+		using var httpClient = CreateHttpClient();
+		using var response = await httpClient.PostAsync("/internal/testing/cache/clear", content: null);
+		await EnsureSuccessAsync(response);
 	}
 
 	// Test-only escape hatch to simulate an opportunity row removed without

--- a/backend/tests/IntegrationTests/ResponseCompressionTests.cs
+++ b/backend/tests/IntegrationTests/ResponseCompressionTests.cs
@@ -1,0 +1,42 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+public class ResponseCompressionTests(IntegrationTestFixture fixture)
+{
+	[Test]
+	public async Task GetBadgeCatalog_ShouldCompressWithBrotli_WhenClientAcceptsBrotli(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/v1/badges");
+		request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().Contain("br");
+	}
+
+	[Test]
+	public async Task GetBadgeCatalog_ShouldCompressWithGzip_WhenClientOnlyAcceptsGzip(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/v1/badges");
+		request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().Contain("gzip");
+	}
+
+	[Test]
+	public async Task GetBadgeCatalog_ShouldNotCompress_WhenClientSendsNoAcceptEncoding(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync("/v1/badges", cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
Add Brotli/Gzip response compression in Program.cs, plus an ICachedQuery/CachingPipelineBehavior mechanism so anonymous read queries (badge catalog, public org directory/profile, public user profile, user achievements, opportunity search) cache their results for 60s. Cache entries are tagged per entity-category and invalidated via new domain events (Created/Deleted/Restored) on Organization and VolunteerOpportunity, reusing existing Publish/Verify events.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1391

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
