### PR TITLE
test: harden VisualTests against cosmetic restyles and ambient state

### DIFF
--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -136,6 +136,16 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 				.EnsureSuccessStatusCode();
 		}
 
+		// Registered before FastSignInAsync's own navigation - Page.WaitForResponseAsync
+		// must start listening before the request fires, not after, matching the
+		// pattern already established in this suite (see
+		// OrganizationDashboardNavLinkTests.cs/CheckInPinOrganizerSetTests.cs).
+		// This is useAchievementNotifier's own on-mount GET /v1/me/achievements -
+		// awaiting it below anchors the badge-toast assertion to that check
+		// having actually run, instead of a fixed sleep (#1322).
+		var notifierCheckResponseTask = Page.WaitForResponseAsync(
+			r => r.Url.Contains("/v1/me/achievements") && r.Request.Method == "GET");
+
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
@@ -168,10 +178,13 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		// Each VisualTests test gets a fresh, isolated browser context (see
 		// VisualTestBase) - no einsatzbereit:seen-achievements localStorage entry
-		// yet, simulating a new device/browser/profile. The notifier's first
-		// check fires on mount; give it a moment, then assert no "New badge
-		// unlocked" toast appeared for an already-earned badge.
-		await Page.WaitForTimeoutAsync(3000);
+		// yet, simulating a new device/browser/profile. Wait for the notifier's
+		// own first, on-mount check to actually resolve (armed above, before
+		// FastSignInAsync's navigation) rather than a fixed sleep - a sleep-then-
+		// assert-absence passes whenever the app is merely slow enough that the
+		// check hasn't run yet, which gets *more* likely to happen, and mask the
+		// bug this test guards, the slower/more contended the runner is (#1322).
+		await notifierCheckResponseTask;
 
 		// Auto-waiting for an absent element only proves anything for the
 		// life of this context because AppHost sets VITE_TOAST_LIFETIME_MS=0

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -10,34 +12,76 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 	{
 		// Regression: org name and org link were missing from engagement cards
 		// before PR #475 added OrganizationId/OrganizationName to EngagementSummary.
+		//
+		// #1334: this used to assert against vera's *ambient* engagement cards
+		// (seed data, plus whatever throwaway engagements other concurrently
+		// running test classes happened to have created for her in this shared
+		// session), guarded by two stacked "return if empty" checks - so its
+		// assertions only ran when seed data happened to be present and no
+		// other test had already polluted the card count, and it never proved
+		// anything about a card it could actually identify. Creates and owns
+		// its own organization/opportunity/engagement instead (the pattern
+		// EngagementReactivationTests.cs already uses), and scopes every
+		// assertion to that specific card via data-engagement-id, so this is
+		// deterministic regardless of what else runs in this shared session.
 		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgName = $"MyEngagements Org {suffix}";
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain Organization
+		// aggregate, whose strongly-typed OrganizationId record struct
+		// serializes as a nested { "value": "<guid>" } object.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"MyEngagements Opportunity {suffix}",
+			description = "Created by MyEngagementsTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Signing up via MyEngagementsTests." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
-
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/my-engagements");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// Page heading must be visible regardless of whether vera has engagements.
+		// Page heading must be visible.
 		await Expect(Page.Locator("h1").First).ToBeVisibleAsync();
 
-		// Keycloak seeding can fail silently in CI - if vera has no engagement
-		// cards the empty state is valid and we skip the org-link assertions.
-		var engagementCards = Page.Locator("li.rounded-xl");
-		var cardCount = await engagementCards.CountAsync();
-		Skip.When(cardCount == 0, "Keycloak seeding can fail silently in CI - if vera has no engagement cards the empty state is valid and there is nothing to assert.");
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		// Vera has engagement cards - other, unrelated tests sharing this
-		// session can add throwaway engagements for her too, so this doesn't
-		// assert the set is *exactly* her seed engagements, only that every
-		// visible card (seed or not) exposes an org link, and that the two
-		// seed org names are present somewhere among them.
-		var orgLinks = Page.Locator("a[href^='/organizations/']");
-		await Expect(orgLinks.First).ToBeVisibleAsync();
+		var orgLink = card.Locator($"a[href='/organizations/{organizationId}']");
+		await Expect(orgLink).ToBeVisibleAsync();
+		await Expect(orgLink).ToHaveTextAsync(orgName);
 
-		// Both seed org names must appear somewhere on the page. .First avoids a
-		// Playwright strict-mode violation once Vera has more than one engagement
-		// with the same org (seed data grows release over release).
-		await Expect(Page.GetByText("Fairview Red Cross").First).ToBeVisibleAsync();
-		await Expect(Page.GetByText("Fairview Animal Welfare Association").First).ToBeVisibleAsync();
+		// Leave vera's account clean for the rest of this shared Aspire session.
+		var withdrawResponse = await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
+		withdrawResponse.EnsureSuccessStatusCode();
 	}
 }

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -56,9 +56,11 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		// volunteers yet - both KPI stats read 0.
 		await Expect(todoWidget).ToContainTextAsync("Pending Applications");
 		await Expect(todoWidget).ToContainTextAsync("Signed-up Volunteers");
-		var statValues = todoWidget.Locator("p.text-3xl");
-		await Expect(statValues.Nth(0)).ToHaveTextAsync("0");
-		await Expect(statValues.Nth(1)).ToHaveTextAsync("0");
+		// Selects on data-testid rather than the text-3xl Tailwind utility
+		// class - see #1328, a purely cosmetic restyle of that class would
+		// otherwise silently make these locators match nothing.
+		await Expect(todoWidget.GetByTestId("todo-widget-stat-pending")).ToHaveTextAsync("0");
+		await Expect(todoWidget.GetByTestId("todo-widget-stat-confirmed")).ToHaveTextAsync("0");
 
 		// No opportunities yet, so the Upcoming Opportunities widget shows its
 		// empty state instead of a stale/placeholder list.

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -147,15 +147,18 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 	}
 
 	/// <summary>
-	/// Asserts the page's `.max-w-2xl` content wrapper inside `&lt;main&gt;` has equal
-	/// left/right whitespace, i.e. it is horizontally centered via `mx-auto`
-	/// rather than left-aligned. See #694.
+	/// Asserts the page's content wrapper inside `&lt;main&gt;` (marked with the
+	/// `data-content-wrapper` attribute - see #1328, this used to select on the
+	/// `.max-w-2xl` Tailwind utility class directly, which a purely cosmetic
+	/// class rename would silently break) has equal left/right whitespace,
+	/// i.e. it is horizontally centered via `mx-auto` rather than left-aligned.
+	/// See #694.
 	/// </summary>
 	protected async Task AssertMaxWidthContentCenteredAsync(string label)
 	{
 		var main = Page.Locator("main");
 		await Expect(main).ToBeVisibleAsync();
-		var container = main.Locator(".max-w-2xl").First;
+		var container = main.Locator("[data-content-wrapper]").First;
 		await Expect(container).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		// Both boxes read in a single EvaluateAsync call rather than two
@@ -175,20 +178,21 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				}
 				""");
 			return gapDelta < 2;
-		}, () => $"{label}: .max-w-2xl content should be horizontally centered within <main> "
+		}, () => $"{label}: content wrapper should be horizontally centered within <main> "
 			+ $"(last observed |leftGap - rightGap| = {gapDelta}px, must be <2px)");
 	}
 
 	/// <summary>
-	/// Asserts the page's `.max-w-2xl` content wrapper inside `&lt;main&gt;` sits
-	/// flush against the left edge, i.e. it is left-aligned rather than centered
-	/// via `mx-auto`. See #766.
+	/// Asserts the page's content wrapper inside `&lt;main&gt;` (marked with the
+	/// `data-content-wrapper` attribute - see #1328) sits flush against the
+	/// left edge, i.e. it is left-aligned rather than centered via `mx-auto`.
+	/// See #766.
 	/// </summary>
 	protected async Task AssertMaxWidthContentLeftAlignedAsync(string label)
 	{
 		var main = Page.Locator("main");
 		await Expect(main).ToBeVisibleAsync();
-		var container = main.Locator(".max-w-2xl").First;
+		var container = main.Locator("[data-content-wrapper]").First;
 		await Expect(container).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		// Single EvaluateAsync call - see AssertMaxWidthContentCenteredAsync.
@@ -208,7 +212,7 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				}
 				""");
 			return Math.Abs(leftGap) < 2;
-		}, () => $"{label}: .max-w-2xl content should sit flush against <main>'s left padding edge, "
+		}, () => $"{label}: content wrapper should sit flush against <main>'s left padding edge, "
 			+ $"not be centered (last observed gap = {leftGap}px, must be <2px)");
 	}
 }

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -152,9 +152,10 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		// Banner upload affordance present on step 1.
 		await Expect(Page.Locator("#opportunity-banner")).ToBeAttachedAsync();
 
-		// Step 2 hint card present.
+		// Step 2 hint card present. Selects on data-testid rather than the
+		// bg-brand-50 Tailwind utility class - see #1328.
 		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
-		var hint = Page.GetByTestId("wizard-step-2").Locator("[class*='bg-brand-50']").First;
+		var hint = Page.GetByTestId("wizard-step-2").GetByTestId("location-hint");
 		await Expect(hint).ToBeVisibleAsync();
 
 		// The form is dirty (title/description filled in) - Escape must ask
@@ -431,9 +432,12 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(draftsSection).ToBeVisibleAsync();
 		await Expect(draftsSection.GetByText(uniqueTitle)).ToBeVisibleAsync();
 
-		// Amber badge present (bg-amber-100 class applied to the draft status pill).
-		var amberBadge = draftsSection.Locator("[class*='bg-amber-100']").First;
-		await Expect(amberBadge).ToBeVisibleAsync();
+		// Draft status pill present - selects on data-testid and asserts the
+		// draft-specific label rather than matching the bg-amber-100 Tailwind
+		// utility class directly, which a cosmetic restyle would otherwise
+		// silently break (see #1328).
+		var statusBadge = draftsSection.GetByTestId("opportunity-status-badge").First;
+		await Expect(statusBadge).ToHaveTextAsync("Draft");
 
 		// The public home page must NOT show the draft.
 		await Page.GotoAsync(frontend.ToString());

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -153,8 +153,17 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(Page.Locator("#opportunity-banner")).ToBeAttachedAsync();
 
 		// Step 2 hint card present. Selects on data-testid rather than the
-		// bg-brand-50 Tailwind utility class - see #1328.
+		// bg-brand-50 Tailwind utility class - see #1328. That class match
+		// was never actually anchored to the hint card: the remote-checkbox
+		// label a few lines above it in LocationStep.tsx also carries
+		// "bg-brand-50" (as part of hover:bg-brand-50/has-[:checked]:bg-brand-50)
+		// and always renders, so `[class*='bg-brand-50']` silently matched
+		// that label instead - passing regardless of remote state. The hint
+		// card itself only renders when not remote, so "remote" (checked
+		// above to skip step 2's address validation) must be unchecked
+		// again first for this to assert against the real element.
 		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
+		await Page.Locator("#opportunity-remote").UncheckAsync();
 		var hint = Page.GetByTestId("wizard-step-2").GetByTestId("location-hint");
 		await Expect(hint).ToBeVisibleAsync();
 

--- a/frontend/src/components/CreateVolunteerOpportunityModal/LocationStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/LocationStep.tsx
@@ -58,7 +58,10 @@ export default function LocationStep({
 
 			{!isRemote && (
 				<>
-					<div className="rounded-card border border-brand-100 bg-brand-50 px-4 py-3">
+					<div
+						data-testid="location-hint"
+						className="rounded-card border border-brand-100 bg-brand-50 px-4 py-3"
+					>
 						<div className="flex items-start justify-between gap-3">
 							<p className="text-sm leading-relaxed text-brand-800">
 								{t("createOpportunity.locationHint")}

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -75,7 +75,7 @@ export default function OrganizationProfileView({
 				{actions}
 			</div>
 
-			<div className="max-w-2xl">
+			<div data-content-wrapper className="max-w-2xl">
 				{beforeContent}
 
 				{description && (

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -311,6 +311,8 @@ export default function ActivitySection() {
 					{engagements.map((e) => (
 						<li
 							key={e.id}
+							data-testid="engagement-card"
+							data-engagement-id={e.id}
 							className="flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting transition-shadow hover:shadow-raised"
 						>
 							<div className="flex items-start justify-between gap-3">

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -99,7 +99,7 @@ export default function UserProfilePage() {
 				profile.skills.length > 0 ||
 				profile.languages.length > 0 ||
 				profile.preferredContact) && (
-				<div className="mb-8 max-w-2xl space-y-5">
+				<div data-content-wrapper className="mb-8 max-w-2xl space-y-5">
 					<ProfileFieldsView
 						bio={profile.bio}
 						skills={profile.skills}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -212,7 +212,7 @@ export default function VolunteerOpportunityDetailPage() {
 			.slice(0, 3) ?? [];
 
 	return (
-		<div className="mx-auto max-w-2xl">
+		<div data-content-wrapper className="mx-auto max-w-2xl">
 			{/* Banner image */}
 			{opportunity.bannerImageUrl && (
 				<img

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -58,7 +58,10 @@ function ToDoWidget({ organizationId, size }: Props) {
 					}
 				>
 					<div>
-						<p className="text-3xl font-bold text-gray-900">
+						<p
+							data-testid="todo-widget-stat-pending"
+							className="text-3xl font-bold text-gray-900"
+						>
 							{kpis.pendingEngagements}
 						</p>
 						<p className="text-sm text-gray-500">
@@ -66,7 +69,10 @@ function ToDoWidget({ organizationId, size }: Props) {
 						</p>
 					</div>
 					<div>
-						<p className="text-3xl font-bold text-gray-900">
+						<p
+							data-testid="todo-widget-stat-confirmed"
+							className="text-3xl font-bold text-gray-900"
+						>
 							{kpis.confirmedEngagementsTotal}
 						</p>
 						<p className="text-sm text-gray-500">

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -135,7 +135,7 @@ export default function OrgMembersPage() {
 
 	return (
 		<div>
-			<div className="max-w-2xl">
+			<div data-content-wrapper className="max-w-2xl">
 				{successMessage && (
 					<div className="mb-4 rounded-card bg-green-50 px-4 py-3 text-sm text-green-700">
 						{successMessage}

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -214,6 +214,7 @@ export default function OrgOpportunitiesPage() {
 							{item.title || t("orgDashboard.unnamedDraft")}
 						</Link>
 						<span
+							data-testid="opportunity-status-badge"
 							className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${
 								isDraft
 									? "bg-amber-100 text-amber-800"

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -193,7 +193,7 @@ export default function OrgSettingsPage() {
 
 	return (
 		<div>
-			<div className="max-w-2xl">
+			<div data-content-wrapper className="max-w-2xl">
 				{!editing && (
 					<OrganizationProfileView
 						name={org.name}


### PR DESCRIPTION
## What

Implements the three concrete fixes from a VisualTests state-of-the-union report delivered earlier in this session (analysis of why the suite has been flaky in PRs/RC pipelines despite yesterday's `#1476`/`#1483` fixes):

1. Replaces six locators keyed to literal Tailwind utility classes with stable `data-testid`/`data-content-wrapper` hooks.
2. Rewrites `MyEngagementsTests` to own its data instead of asserting against ambient seed state.
3. Replaces a fixed 3s sleep in `AchievementsTests` with a positive network-response sync point.

## Why

- **#1328** - `li.rounded-xl`, `p.text-3xl`, `[class*='bg-brand-50']`, `[class*='bg-amber-100']`, and `VisualTestBase`'s two `.max-w-2xl` centering/alignment helpers all selected on literal Tailwind utility classes. A purely cosmetic restyle silently disables (or breaks) these assertions. This isn't theoretical: earlier today, `#1468` ("tokenize typography, radius and elevation design system") renamed `rounded-2xl` -> `rounded-card` and `shadow-sm`/`shadow-lg` -> `shadow-resting`/`shadow-raised` on a sibling engagement-card component - the same class of change that would break these locators outright. Added `data-testid`/`data-content-wrapper` attributes to the actual components (purely additive, no className/structure/behavior change - verified via the `a11y-check` subagent) and pointed the C# locators at those instead.
- **#1334** - `MyEngagementsTests`' only test asserted against vera's *ambient* engagement cards (seed data, plus whatever throwaway engagements other concurrently-running test classes happened to create for her in this shared session), guarded by two stacked "return if empty" checks. Its outcome depended on which other tests ran first, and it never proved anything about a card it could actually identify. Rewritten to create and own its own organization/opportunity/engagement via the API (the pattern `EngagementReactivationTests.cs` already uses), scope every assertion to that specific card via a new `data-engagement-id` attribute, and clean up afterward. Both guards are gone.
- **#1322** - `AchievementsTests.cs:168` slept a fixed 3s then asserted a toast never appeared - a pattern that gets *more* likely to (falsely) pass the slower/more contended the runner is, exactly backwards for a regression test. Replaced with `Page.WaitForResponseAsync` for the achievement notifier's own on-mount `GET /v1/me/achievements`, armed *before* `FastSignInAsync`'s navigation (matching the precedent already established in `OrganizationDashboardNavLinkTests`/`CheckInPinOrganizerSetTests` for this exact ordering requirement).

Closes #1328, #1334, #1322

## Testing

- `dotnet build` - 0 warnings, 0 errors
- `Application.UnitTests` - 514/514 passed
- `ArchitectureTests` - 332/332 passed
- `dotnet format --verify-no-changes` - clean
- `pnpm lint` / `pnpm check` / `pnpm test` (Vitest) - clean / clean / 89/89 passed
- `VisualTests` itself (the suite these changes fix) can't run locally in this sandbox (needs real Docker/Aspire networking - see root `AGENTS.md`'s Sandbox Limitations) - CI's `dotnet.yml` `visual-tests` job is the actual verification for these changes and must be green before merge.

## Live verification

Not applicable - this is a test-infrastructure reliability fix with zero user-visible behavior change (only `data-testid`/`data-content-wrapper` attributes added to existing markup, plus VisualTests-internal locator/synchronization changes). There is nothing to observe on live staging that a Playwright script could distinguish from before this change. The correctness signal for this PR is CI's `visual-tests` job actually passing against the rewritten tests, not a staging RC.

## Checklist

- [x] `/self-review` run and findings addressed (clean - no P1-P4 findings; `a11y-check` subagent confirmed the `.tsx` attribute additions are non-visual/non-behavioral)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRBpN7RFAgK44TPuyVE4w9)_