### PR TITLE
fix: reschedule QR scan loop after failed check-in

### DIFF
--- a/backend/tests/VisualTests/QRScannerModalTests.cs
+++ b/backend/tests/VisualTests/QRScannerModalTests.cs
@@ -142,6 +142,54 @@ public class QRScannerModalTests(AspireFixture fixture) : VisualTestBase(fixture
 	}
 
 	[Test]
+	public async Task QRScannerModal_ResumesScanning_AfterFailedCheckIn()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (opportunityId, organizationId, engagementId) =
+			await CreateQrCheckInEngagementAsync(keycloak, backend, "Retry");
+
+		await MockQrCameraSupportAsync(Page, grantCamera: true);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Scan QR code" }).ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+		await Expect(dialog.Locator("video")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Regression for #1228: a failed check-in (404 here) used to leave the
+		// scan loop permanently dead - the camera stayed live but the timer
+		// that reschedules the next detect() call never fired again. Presenting
+		// a valid QR code afterwards must still succeed, proving the loop kept
+		// polling instead of silently doing nothing.
+		var unknownId = Guid.NewGuid().ToString();
+		await Page.EvaluateAsync(
+			"(id) => { window.__qrTestBarcodes = [{ rawValue: id, format: 'qr_code' }]; }",
+			unknownId);
+
+		await Expect(dialog.GetByText("Engagement not found."))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.EvaluateAsync(
+			"(id) => { window.__qrTestBarcodes = [{ rawValue: id, format: 'qr_code' }]; }",
+			engagementId);
+
+		await Expect(dialog.GetByText("Volunteer checked in successfully!"))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Done" }).ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
+
+		await Expect(Page.GetByText("Checked in")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
 	public async Task QRScannerModal_ShowsCameraError_WhenCameraPermissionDenied()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -84,6 +84,7 @@ export default function QRScannerModal({
 				try {
 					const detector = new BarcodeDetector({ formats: ["qr_code"] });
 					const barcodes = await detector.detect(video);
+					let matched = false;
 					for (const barcode of barcodes) {
 						const raw = barcode.rawValue.trim();
 						if (!UUID_RE.test(raw)) continue;
@@ -92,6 +93,7 @@ export default function QRScannerModal({
 						// a real, checkable-in engagement - there is no complete
 						// client-side list to match against once the organizer's
 						// engagement view is paginated (#1401).
+						matched = true;
 						alive = false;
 						try {
 							await api.checkInEngagement(raw);
@@ -101,11 +103,14 @@ export default function QRScannerModal({
 							setScanError(
 								getApiErrorMessage(err, t("checkIn.qrCheckInError")),
 							);
+							// A failed check-in is retryable - keep the loop alive so
+							// the timer below reschedules the next scan instead of
+							// leaving the camera live with a dead loop (#1228).
 							alive = true;
 						}
-						return;
+						break;
 					}
-					setScanError(null);
+					if (!matched) setScanError(null);
 				} catch {
 					// detection failure - retry on next tick
 				}


### PR DESCRIPTION
A failed checkInEngagement call reset alive=true but then hit an unconditional return before the timer that reschedules the next detect() call, leaving the camera live with a dead scan loop (#1228).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1228

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
