### PR TITLE
fix: allow camera on same-origin so QR check-in scanner works in production

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Check nginx HSTS header
         run: pnpm check:nginx-hsts
 
+      - name: Check nginx Permissions-Policy header
+        run: pnpm check:nginx-permissions-policy
+
       - name: Check PWA precache scoping
         run: pnpm check:pwa-precache
 

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -25,7 +25,7 @@ server {
 	add_header X-Frame-Options "DENY" always;
 	add_header X-XSS-Protection "1; mode=block" always;
 	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
+	add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	add_header Content-Security-Policy $csp_header always;
 
@@ -39,7 +39,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
+		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
@@ -51,7 +51,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
+		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
@@ -62,7 +62,7 @@ server {
 		add_header X-Frame-Options "DENY" always;
 		add_header X-XSS-Protection "1; mode=block" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-		add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=()" always;
+		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "check:config-defer": "node scripts/check-config-defer.js",
     "check:nginx-gzip-static": "node scripts/check-nginx-gzip-static.js",
     "check:nginx-hsts": "node scripts/check-nginx-hsts.js",
+    "check:nginx-permissions-policy": "node scripts/check-nginx-permissions-policy.js",
     "check:pwa-precache": "node scripts/check-pwa-precache.js"
   },
   "dependencies": {

--- a/frontend/scripts/check-nginx-permissions-policy.js
+++ b/frontend/scripts/check-nginx-permissions-policy.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Guards against the regression class behind issue #1220: the
+// Permissions-Policy header shipped `camera=()` (an empty allowlist), so the
+// browser rejected camera access before ever prompting the user - silently
+// breaking the QR check-in scanner in production while leaving it visually
+// functional. The value is duplicated across four nginx location blocks (no
+// $host-keyed map like $csp_header, since it never varies by host), so a
+// future edit could silently regress one block and miss the other three.
+// Purely static checks - no Docker/nginx required.
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(__dirname, "..");
+
+const template = readFileSync(
+	join(frontendDir, "nginx.conf.template"),
+	"utf8",
+);
+
+let ok = true;
+function fail(message) {
+	console.error(message);
+	ok = false;
+}
+
+const permissionsPolicyLines = template
+	.split("\n")
+	.map((line) => line.trim())
+	.filter((line) => /^add_header\s+Permissions-Policy\s+/.test(line));
+
+if (permissionsPolicyLines.length === 0) {
+	fail("No `add_header Permissions-Policy` lines found in nginx.conf.template.");
+}
+
+const expected =
+	'add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;';
+for (const line of permissionsPolicyLines) {
+	if (line !== expected) {
+		fail(
+			`Found a Permissions-Policy header not matching the expected value: "${line}". ` +
+				`Every location must emit exactly: ${expected}`,
+		);
+	}
+}
+
+if (ok) {
+	console.log(
+		`nginx Permissions-Policy header allows camera=(self) consistently across all ${permissionsPolicyLines.length} location blocks.`,
+	);
+} else {
+	process.exit(1);
+}


### PR DESCRIPTION
Permissions-Policy shipped camera=(), an empty allowlist that made the browser reject getUserMedia before ever prompting the user - the QR scanner in engagement management and the quick check-in widget looked functional but silently could never request camera access. Change all four nginx.conf.template location blocks to camera=(self), and add check-nginx-permissions-policy.js (wired into frontend.yml CI) to guard against future drift, matching the existing CSP/HSTS header checks.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1220 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
