### PR TITLE
fix: confirm before removing an org member

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -152,6 +152,60 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task RemoveMember_ShowsConfirmationDialog_AndOnlyRemovesAfterConfirm()
+	{
+		// Regression for #1231: the Members page's "Remove" button used to call
+		// RemoveMember directly on click - no confirmation, no way to back out,
+		// unlike every other destructive action on this page (Leave, Delete
+		// Organization) which already goes through ConfirmDialog. Verifies
+		// "Remove" now opens a dialog naming the member, "Keep" cancels without
+		// removing them, and only "Yes, remove" actually calls the API.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1231 RemoveConfirm", pinnedOrgId!.Value);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = Guid.Parse(match.Groups[1].Value);
+
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		await Fixture.AddPlainMemberDirectlyAsync(organizationId, vera.UserId);
+
+		// OrgAppLayout only refetches org details on organizationId change, so
+		// the dashboard we're still on would otherwise keep showing its
+		// pre-membership snapshot (olaf as sole member) - force a refetch, same
+		// as the SoleOrganizer test above.
+		await Page.ReloadAsync();
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+
+		var removeButton = Page.GetByRole(AriaRole.Button, new() { Name = "Remove" });
+		await Expect(removeButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await removeButton.ClickAsync();
+
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await Expect(dialog.GetByText("Vera Volunteer")).ToBeVisibleAsync();
+
+		// "Keep" must close the dialog without removing the member.
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Keep" }).ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
+		await Expect(removeButton).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Vera Volunteer")).ToBeVisibleAsync();
+
+		// "Yes, remove" on a second attempt actually removes them.
+		await removeButton.ClickAsync();
+		await Expect(dialog).ToBeVisibleAsync();
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, remove" }).ClickAsync();
+
+		await Expect(dialog).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByText("Vera Volunteer")).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task SoleMember_CanDeleteOrganization_FromSettingsPage()
 	{
 		// #580: the new "Delete Organization" action, enabled only for the

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -182,19 +182,27 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
 
-		var removeButton = Page.GetByRole(AriaRole.Button, new() { Name = "Remove" });
-		await Expect(removeButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		// Scope to vera's row by her stable seed email rather than her display
+		// name: other tests in this shared session (e.g. ProfileOverviewTests)
+		// rename her last name to "Sample", and that mutation isn't reset
+		// between tests, so asserting a specific full name here is order-
+		// dependent flakiness waiting to happen.
+		var veraRow = Page.Locator("li", new() { HasText = "vera@example.com" });
+		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		var veraName = await veraRow.Locator("p").First.TextContentAsync();
+		veraName.Should().NotBeNullOrEmpty();
+
+		var removeButton = veraRow.GetByRole(AriaRole.Button, new() { Name = "Remove" });
 		await removeButton.ClickAsync();
 
 		var dialog = Page.GetByRole(AriaRole.Dialog);
 		await Expect(dialog).ToBeVisibleAsync();
-		await Expect(dialog.GetByText("Vera Volunteer")).ToBeVisibleAsync();
+		await Expect(dialog.GetByText(veraName!)).ToBeVisibleAsync();
 
 		// "Keep" must close the dialog without removing the member.
 		await dialog.GetByRole(AriaRole.Button, new() { Name = "Keep" }).ClickAsync();
 		await Expect(dialog).Not.ToBeVisibleAsync();
-		await Expect(removeButton).ToBeVisibleAsync();
-		await Expect(Page.GetByText("Vera Volunteer")).ToBeVisibleAsync();
+		await Expect(veraRow).ToBeVisibleAsync();
 
 		// "Yes, remove" on a second attempt actually removes them.
 		await removeButton.ClickAsync();
@@ -202,7 +210,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, remove" }).ClickAsync();
 
 		await Expect(dialog).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await Expect(Page.GetByText("Vera Volunteer")).Not.ToBeVisibleAsync();
+		await Expect(veraRow).Not.ToBeVisibleAsync();
 	}
 
 	[Test]

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -689,6 +689,11 @@
         "message": "Möchtest du \"{{name}}\" wirklich verlassen? Du verlierst den Organisator-Zugriff darauf.",
         "confirm": "Ja, verlassen"
       },
+      "removeMember": {
+        "title": "Mitglied entfernen?",
+        "message": "Möchtest du {{name}} wirklich aus dieser Organisation entfernen?",
+        "confirm": "Ja, entfernen"
+      },
       "deleteOrganization": {
         "title": "Organisation löschen?",
         "message": "Möchtest du \"{{name}}\" wirklich dauerhaft löschen? Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -689,6 +689,11 @@
         "message": "Are you sure you want to leave \"{{name}}\"? You will lose organizer access to it.",
         "confirm": "Yes, leave"
       },
+      "removeMember": {
+        "title": "Remove member?",
+        "message": "Are you sure you want to remove {{name}} from this organization?",
+        "confirm": "Yes, remove"
+      },
       "deleteOrganization": {
         "title": "Delete organization?",
         "message": "Are you sure you want to permanently delete \"{{name}}\"? This cannot be undone.",

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -36,11 +36,21 @@ export default function OrgMembersPage() {
 	const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 	const [leaving, setLeaving] = useState(false);
 
+	const [removeTarget, setRemoveTarget] = useState<{
+		userId: string;
+		name: string;
+	} | null>(null);
+	const [removingMember, setRemovingMember] = useState(false);
+	const [removeMemberError, setRemoveMemberError] = useState<string | null>(
+		null,
+	);
+
 	const [memberSearch, setMemberSearch] = useState("");
 	const [memberCandidates, setMemberCandidates] = useState<
 		MemberCandidateDto[]
 	>([]);
 	const [memberSearchLoading, setMemberSearchLoading] = useState(false);
+	const [invitingUserId, setInvitingUserId] = useState<string | null>(null);
 	const memberSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	function handleMemberSearchChange(value: string) {
@@ -61,6 +71,9 @@ export default function OrgMembersPage() {
 	}
 
 	const [invitations, setInvitations] = useState<OrgInvitationDto[]>([]);
+	const [dismissingInvitationId, setDismissingInvitationId] = useState<
+		string | null
+	>(null);
 
 	useEffect(() => {
 		api
@@ -71,6 +84,7 @@ export default function OrgMembersPage() {
 	}, [org.id]);
 
 	async function handleInviteMember(userId: string) {
+		setInvitingUserId(userId);
 		try {
 			const response = await api.createInvitation(org.id, {
 				inviteeId: userId,
@@ -96,24 +110,38 @@ export default function OrgMembersPage() {
 		} catch {
 			setSuccessMessage(null);
 			setSettingsError(t("orgSettings.inviteError"));
+		} finally {
+			setInvitingUserId(null);
 		}
 	}
 
 	async function handleDismissInvitation(invitationId: string) {
+		setDismissingInvitationId(invitationId);
 		try {
 			await api.dismissInvitation(org.id, invitationId);
 			setInvitations((prev) => prev.filter((i) => i.id !== invitationId));
 		} catch {
 			setSettingsError(t("orgSettings.dismissError"));
+		} finally {
+			setDismissingInvitationId(null);
 		}
 	}
 
-	async function handleRemoveMember(userId: string) {
+	async function handleConfirmRemoveMember() {
+		if (!removeTarget) return;
+		const { userId } = removeTarget;
+		setRemovingMember(true);
+		setRemoveMemberError(null);
 		try {
 			await api.removeMember(org.id, userId);
 			setMembers((prev) => prev.filter((m) => m.userId !== userId));
-		} catch {
-			setSettingsError(t("orgSettings.removeMemberError"));
+			setRemoveTarget(null);
+		} catch (err) {
+			setRemoveMemberError(
+				getApiErrorMessage(err, t("orgSettings.removeMemberError")),
+			);
+		} finally {
+			setRemovingMember(false);
 		}
 	}
 
@@ -185,6 +213,7 @@ export default function OrgMembersPage() {
 									<Button
 										type="button"
 										onClick={() => handleInviteMember(candidate.userId)}
+										disabled={invitingUserId === candidate.userId}
 										size="sm"
 										className="ml-3 shrink-0"
 									>
@@ -259,7 +288,8 @@ export default function OrgMembersPage() {
 										<button
 											type="button"
 											onClick={() => handleDismissInvitation(invitation.id)}
-											className="ml-3 shrink-0 text-xs text-red-700 hover:text-red-800"
+											disabled={dismissingInvitationId === invitation.id}
+											className="ml-3 shrink-0 text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
 										>
 											{t("orgSettings.dismissInvitation")}
 										</button>
@@ -311,7 +341,15 @@ export default function OrgMembersPage() {
 								) : (
 									<button
 										type="button"
-										onClick={() => handleRemoveMember(member.userId)}
+										onClick={() =>
+											setRemoveTarget({
+												userId: member.userId,
+												name:
+													member.firstName && member.lastName
+														? `${member.firstName} ${member.lastName}`
+														: member.username,
+											})
+										}
 										className="text-xs text-red-700 hover:text-red-800"
 									>
 										{t("orgSettings.removeMember")}
@@ -338,6 +376,24 @@ export default function OrgMembersPage() {
 					onConfirm={handleLeaveOrganization}
 					onClose={() => setShowLeaveConfirm(false)}
 					loading={leaving}
+				/>
+			)}
+
+			{removeTarget && (
+				<ConfirmDialog
+					title={t("confirmDialog.removeMember.title")}
+					message={t("confirmDialog.removeMember.message", {
+						name: removeTarget.name,
+					})}
+					confirmLabel={t("confirmDialog.removeMember.confirm")}
+					onConfirm={() => void handleConfirmRemoveMember()}
+					onClose={() => {
+						if (removingMember) return;
+						setRemoveTarget(null);
+						setRemoveMemberError(null);
+					}}
+					loading={removingMember}
+					error={removeMemberError}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
Removing a member was a single unguarded click with no confirmation and no in-flight protection, unlike every other destructive action on the page (Leave, Delete Organization). Route it through ConfirmDialog and disable invite/dismiss-invitation/remove buttons while their requests are in flight.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1231

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
