### PR TITLE
fix: retry a failed publish without creating a duplicate draft

### DIFF
--- a/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
@@ -1,0 +1,154 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class CreateOpportunityRetryTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task PublishWaitlist_TimeSlotFailureMidPublish_RetryUpdatesSameDraftInsteadOfDuplicating()
+	{
+		// Regression for #1227: the create-then-publish flow is create draft ->
+		// upload banner -> create N time slots -> publish. If a time slot
+		// creation fails partway through, the draft opportunity is already
+		// persisted, incomplete. Retrying used to call createVolunteerOpportunity
+		// again, producing a second, duplicate draft opportunity. The retry must
+		// now reuse the first attempt's opportunity id (updating it instead of
+		// re-creating it) and only create the time slots still missing.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var uniqueTitle = $"Retry Dedup Test {Guid.NewGuid().ToString("N")[..8]}";
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		var organizationId = pinnedOrgId!.Value;
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, organizationId);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+
+		// Step 1: title/description.
+		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
+		await Page.Locator("#opportunity-description").FillAsync(
+			"Regression test for the #1227 retry-duplicate-draft bug.");
+
+		// Step 2: remote, to skip address fields.
+		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
+		await Page.Locator("#opportunity-remote").CheckAsync();
+
+		// Step 3: Waitlist, so publishing requires time slots and goes through
+		// the create-draft-then-publish path this bug lives in.
+		await Page.GetByTestId("wizard-stepper-3").ClickAsync();
+		await Page.Locator("label:has(input[name='participationType'][value='Waitlist'])").ClickAsync();
+
+		// Step 4: add two time slots up front - the first CreateTimeSlot call
+		// is made to fail below, and the second must still end up created
+		// after the retry succeeds.
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+		var step4 = Page.GetByTestId("wizard-step-4");
+
+		async Task AddSlotAsync(int daysFromNow)
+		{
+			var start = DateTimeOffset.UtcNow.AddDays(daysFromNow);
+			var end = start.AddHours(2);
+			await step4.Locator("#slot-start").FillAsync(start.ToString("yyyy-MM-ddTHH:mm"));
+			await step4.Locator("#slot-end").FillAsync(end.ToString("yyyy-MM-ddTHH:mm"));
+			await step4.GetByRole(AriaRole.Button, new() { Name = "Add", Exact = true }).ClickAsync();
+		}
+
+		await AddSlotAsync(7);
+		await AddSlotAsync(14);
+		await Expect(step4.Locator("ul li")).ToHaveCountAsync(2);
+
+		// Fail exactly the first CreateTimeSlot call (whichever slot the
+		// frontend happens to send first) with a plain 500 - everything else,
+		// including the earlier CreateVolunteerOpportunity call and every
+		// later request, passes through untouched.
+		var timeSlotCallCount = 0;
+		await Page.RouteAsync("**/volunteer-opportunities/*/time-slots", async route =>
+		{
+			if (route.Request.Method != "POST")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			timeSlotCallCount++;
+			if (timeSlotCallCount != 1)
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			// Cross-origin in this test environment (see ToastDeduplicationTests)
+			// - a fulfilled response still needs CORS headers or the browser
+			// rejects it before the app's own error handling runs.
+			await route.FulfillAsync(new()
+			{
+				Status = 500,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"about:blank\",\"status\":500,\"title\":\"Internal Server Error\"}",
+			});
+		});
+
+		await Page.GetByTestId("modal-submit").ClickAsync();
+
+		// The mocked failure surfaces as the generic fallback error (no
+		// errorCode on the mocked body) and the dialog stays open for retry.
+		var errorBanner = Page.GetByRole(AriaRole.Alert)
+			.Filter(new() { HasTextString = "Unknown error" });
+		await Expect(errorBanner).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator("[role='dialog']")).ToBeVisibleAsync();
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		async Task<List<JsonElement>> GetOpportunitiesByTitleAsync(string status)
+		{
+			var response = await http.GetAsync(
+				$"/v1/organizations/{organizationId}/opportunities?status={status}&pageNumber=1&pageSize=100");
+			response.EnsureSuccessStatusCode();
+			var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+			return body.GetProperty("items").EnumerateArray()
+				.Where(o => o.GetProperty("title").GetString() == uniqueTitle)
+				.ToList();
+		}
+
+		// Exactly one draft exists after the failed attempt - the create call
+		// itself succeeded before the mocked time-slot failure, but no second
+		// draft was created by that failure.
+		var draftsAfterFailure = await GetOpportunitiesByTitleAsync("Draft");
+		draftsAfterFailure.Should().HaveCount(1,
+			"the failed time-slot creation must leave exactly the one draft created before it failed");
+		var opportunityId = draftsAfterFailure[0].GetProperty("id").GetString();
+
+		// Retry: same button, same form state. All requests now succeed,
+		// including the previously-failing time slot.
+		await Page.GetByTestId("modal-submit").ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		var draftsAfterRetry = await GetOpportunitiesByTitleAsync("Draft");
+		draftsAfterRetry.Should().BeEmpty(
+			"the retried publish must move the original draft to Published, not leave a second draft behind");
+
+		var publishedAfterRetry = await GetOpportunitiesByTitleAsync("Published");
+		publishedAfterRetry.Should().HaveCount(1,
+			"retrying publish must reuse the original draft's id instead of creating a duplicate opportunity");
+		publishedAfterRetry[0].GetProperty("id").GetString().Should().Be(opportunityId,
+			"the published opportunity must be the same one created on the first attempt");
+
+		var detailsResponse = await http.GetAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		detailsResponse.EnsureSuccessStatusCode();
+		var details = await detailsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		details.GetProperty("timeSlots").GetArrayLength().Should().Be(2,
+			"both time slots must exist exactly once - the one that failed on the first attempt, "
+			+ "created on retry, plus the one that never failed");
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -11,7 +11,7 @@ import type {
 } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import { dispatchToast } from "../../lib/toastBus";
-import { getApiErrorMessage } from "../../lib/apiError";
+import { getApiErrorMessage, isApiErrorCode } from "../../lib/apiError";
 import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
 import Button from "../Button";
@@ -215,6 +215,16 @@ export default function CreateVolunteerOpportunityModal({
 	>(null);
 	const [recurrenceFrequency, setRecurrenceFrequency] = useState("Weekly");
 	const [recurrenceCount, setRecurrenceCount] = useState(1);
+
+	// Create mode only: once the draft opportunity is persisted, its id is
+	// kept here (not in state) for the lifetime of this modal instance. If a
+	// later step (banner, a time slot, publish) throws and the user retries
+	// via the same button, `submit` reuses this id instead of calling
+	// `createVolunteerOpportunity` again - which would otherwise create a
+	// second, duplicate draft (#1227). `createdSlotIdsRef` mirrors this for
+	// time slots so a retry only creates the ones still missing.
+	const createdOpportunityIdRef = useRef<string | null>(null);
+	const createdSlotIdsRef = useRef<Set<string>>(new Set());
 
 	const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -553,42 +563,86 @@ export default function CreateVolunteerOpportunityModal({
 				// publish - this also keeps it invisible in listings if any step
 				// in between fails, instead of leaving a published dead-end.
 				const publishWaitlistAfterCreate = !asDraft && isWaitlist;
-				const opportunity = await api.createVolunteerOpportunity({
-					title: values.title,
-					description: values.description,
-					organizationId,
-					isRemote: values.isRemote,
-					street: values.isRemote ? undefined : values.street,
-					houseNumber: values.isRemote ? undefined : values.houseNumber,
-					zipCode: values.isRemote ? undefined : values.zipCode,
-					city: values.isRemote ? undefined : values.city,
-					occurrence: values.occurrence,
-					participationType: values.participationType,
-					checkInMethod: values.checkInMethod,
-					checkInPin: resolveCheckInPin(values),
-					category: values.category,
-					tags: values.tags,
-					isDraft: asDraft || publishWaitlistAfterCreate,
-				});
+
+				// If a previous attempt already created the draft but failed on a
+				// later step, reuse that id and update it instead of creating a
+				// second opportunity - createVolunteerOpportunity/createTimeSlot
+				// have no dedup on the backend, so calling either twice for the
+				// same logical attempt produces duplicates (#1227).
+				let opportunityId = createdOpportunityIdRef.current;
+				if (opportunityId) {
+					await api.updateVolunteerOpportunity(opportunityId, {
+						title: values.title,
+						description: values.description,
+						isRemote: values.isRemote,
+						street: values.isRemote ? undefined : values.street,
+						houseNumber: values.isRemote ? undefined : values.houseNumber,
+						zipCode: values.isRemote ? undefined : values.zipCode,
+						city: values.isRemote ? undefined : values.city,
+						occurrence: values.occurrence,
+						participationType: values.participationType,
+						checkInMethod: values.checkInMethod,
+						checkInPin: resolveCheckInPin(values),
+						category: values.category || undefined,
+						tags: values.tags,
+					});
+				} else {
+					const opportunity = await api.createVolunteerOpportunity({
+						title: values.title,
+						description: values.description,
+						organizationId,
+						isRemote: values.isRemote,
+						street: values.isRemote ? undefined : values.street,
+						houseNumber: values.isRemote ? undefined : values.houseNumber,
+						zipCode: values.isRemote ? undefined : values.zipCode,
+						city: values.isRemote ? undefined : values.city,
+						occurrence: values.occurrence,
+						participationType: values.participationType,
+						checkInMethod: values.checkInMethod,
+						checkInPin: resolveCheckInPin(values),
+						category: values.category,
+						tags: values.tags,
+						isDraft: asDraft || publishWaitlistAfterCreate,
+					});
+					opportunityId = opportunity.id;
+					createdOpportunityIdRef.current = opportunityId;
+				}
 				if (bannerFile) {
-					await uploadBanner(api, opportunity.id, bannerFile, () =>
+					await uploadBanner(api, opportunityId, bannerFile, () =>
 						dispatchToast("error", t("createOpportunity.bannerUploadFailed")),
 					);
 				}
 				for (const slot of pendingSlots) {
-					await api.createTimeSlot(opportunity.id, {
+					if (createdSlotIdsRef.current.has(slot.id)) continue;
+					await api.createTimeSlot(opportunityId, {
 						startDateTime: new Date(slot.startDateTime),
 						endDateTime: new Date(slot.endDateTime),
 						maxParticipants: slot.maxParticipants,
 						recurrenceFrequency: undefined,
 						recurrenceCount: 1,
 					});
+					createdSlotIdsRef.current.add(slot.id);
 				}
 				if (publishWaitlistAfterCreate) {
-					await api.publishVolunteerOpportunity(opportunity.id);
+					try {
+						await api.publishVolunteerOpportunity(opportunityId);
+					} catch (publishErr) {
+						// Publish isn't idempotent on the backend (a second call 409s
+						// with AlreadyPublished) - if a retry lands here after a prior
+						// attempt's publish call actually succeeded, treat that as the
+						// success it already is instead of surfacing a confusing error.
+						if (
+							!isApiErrorCode(
+								publishErr,
+								"VolunteerOpportunity.AlreadyPublished",
+							)
+						) {
+							throw publishErr;
+						}
+					}
 				}
 				if (asDraft) {
-					createdDraftId = opportunity.id;
+					createdDraftId = opportunityId;
 					dispatchToast("success", t("createOpportunity.draftSavedToast"));
 				}
 			}

--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -12,7 +12,11 @@ vi.mock("../i18n", () => ({
 	},
 }));
 
-import { getApiErrorMessage, isApiNotFoundError } from "./apiError";
+import {
+	getApiErrorMessage,
+	isApiErrorCode,
+	isApiNotFoundError,
+} from "./apiError";
 
 describe("getApiErrorMessage", () => {
 	beforeEach(() => {
@@ -103,5 +107,46 @@ describe("isApiNotFoundError", () => {
 
 	it("returns false for a non-object value", () => {
 		expect(isApiNotFoundError("404")).toBe(false);
+	});
+});
+
+describe("isApiErrorCode", () => {
+	it("returns true when errorCode matches", () => {
+		expect(
+			isApiErrorCode(
+				{ errorCode: "VolunteerOpportunity.AlreadyPublished" },
+				"VolunteerOpportunity.AlreadyPublished",
+			),
+		).toBe(true);
+	});
+
+	it("returns false when errorCode is a different code", () => {
+		expect(
+			isApiErrorCode(
+				{ errorCode: "VolunteerOpportunity.NotFound" },
+				"VolunteerOpportunity.AlreadyPublished",
+			),
+		).toBe(false);
+	});
+
+	it("returns false when errorCode is missing", () => {
+		expect(isApiErrorCode({}, "VolunteerOpportunity.AlreadyPublished")).toBe(
+			false,
+		);
+	});
+
+	it("returns false for null", () => {
+		expect(isApiErrorCode(null, "VolunteerOpportunity.AlreadyPublished")).toBe(
+			false,
+		);
+	});
+
+	it("returns false for a non-object value", () => {
+		expect(
+			isApiErrorCode(
+				"VolunteerOpportunity.AlreadyPublished",
+				"VolunteerOpportunity.AlreadyPublished",
+			),
+		).toBe(false);
 	});
 });

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -41,3 +41,17 @@ export function isApiNotFoundError(err: unknown): boolean {
 		(err as { status?: unknown }).status === 404
 	);
 }
+
+/**
+ * Detects a specific Result-pattern `errorCode` on a rejected API call (see
+ * `getApiErrorMessage` for the shape). Used to treat one particular failure
+ * as a benign no-op rather than surfacing it - e.g. a retried publish call
+ * landing on an opportunity a previous attempt already published.
+ */
+export function isApiErrorCode(err: unknown, code: string): boolean {
+	return (
+		!!err &&
+		typeof err === "object" &&
+		(err as { errorCode?: unknown }).errorCode === code
+	);
+}


### PR DESCRIPTION
A time-slot creation failure partway through the create-draft -> upload-banner -> create-slots -> publish flow left the draft opportunity persisted but incomplete. Retrying called createVolunteerOpportunity again, producing a second, duplicate draft.

Track the created opportunity id and already-created slot ids across retries within the same modal session: a resubmit now updates the existing draft and only creates the time slots still missing, instead of starting over. A retried publish call's AlreadyPublished conflict (the backend's Publish() is not idempotent) is now treated as success rather than surfaced as an error.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1227

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
