### PR TITLE
fix: include slot-less opportunities under date range filters

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -47,11 +47,14 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (filter.IsRemote is bool isRemote)
 			query = query.Where(x => x.vo.IsRemote == isRemote);
 
+		// Opportunities without time slots (IndividualContact - see VolunteerOpportunity.AddTimeSlot)
+		// have no dates to compare against, so a date filter must not exclude them - matches the
+		// same "slot-less is never filtered out" convention already used for expiry above (#1059).
 		if (filter.DateFrom is DateTimeOffset dateFrom)
-			query = query.Where(x => x.vo.TimeSlots.Any(ts => ts.StartDateTime >= dateFrom));
+			query = query.Where(x => !x.vo.TimeSlots.Any() || x.vo.TimeSlots.Any(ts => ts.StartDateTime >= dateFrom));
 
 		if (filter.DateTo is DateTimeOffset dateTo)
-			query = query.Where(x => x.vo.TimeSlots.Any(ts => ts.StartDateTime <= dateTo));
+			query = query.Where(x => !x.vo.TimeSlots.Any() || x.vo.TimeSlots.Any(ts => ts.StartDateTime <= dateTo));
 
 		if (filter.Categories is { Length: > 0 })
 		{

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -372,6 +372,82 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetVolunteerOpportunities_ShouldIncludeSlotlessOpportunity_WhenDateFromFilterApplied(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var slotless = await CreateSlotlessOpportunityAsync(authenticatedClient, orgId, "Express interest opportunity", cancellationToken);
+
+		var nearSlotStart = DateTimeOffset.UtcNow.AddDays(2);
+		var tooEarly = await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Too early for the filter", nearSlotStart, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(
+			1, 10, dateFrom: DateTimeOffset.UtcNow.AddDays(5), cancellationToken: cancellationToken);
+
+		var ids = result.Items.Select(i => i.Id).ToList();
+		ids.Should().Contain(slotless.Id, "an opportunity with no time slots has no date to compare against and must not be hidden by a date filter");
+		ids.Should().NotContain(tooEarly.Id, "its only time slot starts before the requested dateFrom");
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldIncludeSlotlessOpportunity_WhenDateToFilterApplied(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var slotless = await CreateSlotlessOpportunityAsync(authenticatedClient, orgId, "Express interest opportunity", cancellationToken);
+
+		var farSlotStart = DateTimeOffset.UtcNow.AddDays(20);
+		var tooLate = await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Too late for the filter", farSlotStart, cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(
+			1, 10, dateTo: DateTimeOffset.UtcNow.AddDays(5), cancellationToken: cancellationToken);
+
+		var ids = result.Items.Select(i => i.Id).ToList();
+		ids.Should().Contain(slotless.Id, "an opportunity with no time slots has no date to compare against and must not be hidden by a date filter");
+		ids.Should().NotContain(tooLate.Id, "its only time slot starts after the requested dateTo");
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldFilterWaitlistOpportunitiesByRange_WhileStillIncludingSlotlessOnes(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var slotless = await CreateSlotlessOpportunityAsync(authenticatedClient, orgId, "Express interest opportunity", cancellationToken);
+
+		var withinRange = await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Within range", DateTimeOffset.UtcNow.AddDays(5), cancellationToken);
+
+		var outsideRange = await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Outside range", DateTimeOffset.UtcNow.AddDays(20), cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(
+			1, 10,
+			dateFrom: DateTimeOffset.UtcNow.AddDays(3),
+			dateTo: DateTimeOffset.UtcNow.AddDays(7),
+			cancellationToken: cancellationToken);
+
+		var ids = result.Items.Select(i => i.Id).ToList();
+		result.TotalItems.Should().Be(2);
+		ids.Should().Contain(slotless.Id);
+		ids.Should().Contain(withinRange.Id);
+		ids.Should().NotContain(outsideRange.Id);
+	}
+
+	[Test]
 	public async Task CreateVolunteerOpportunity_ShouldReturn403_WhenUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
@@ -590,6 +666,56 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 			{
 				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
 				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+
+		await client.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		return opportunity;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateSlotlessOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken) =>
+		await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = title,
+			Description = "No time slots - IndividualContact",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+		}, cancellationToken);
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityWithTimeSlotAsync(
+		EinsatzbereitApi client, Guid orgId, string title, DateTimeOffset slotStart, CancellationToken cancellationToken)
+	{
+		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = title,
+			Description = "Waitlist opportunity with a single time slot",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "Waitlist",
+			CheckInMethod = "None",
+			IsDraft = true,
+		}, cancellationToken);
+
+		await client.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = slotStart,
+				EndDateTime = slotStart.AddHours(2),
 				MaxParticipants = 10,
 				RecurrenceCount = 1,
 			},

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -110,7 +110,7 @@ export default function OpportunityListItem({
 					<h3 className="text-base font-semibold leading-snug text-gray-900 transition-colors group-hover:text-brand-700 sm:text-lg">
 						{item.title}
 					</h3>
-					{item.nextTimeSlotStart && (
+					{item.nextTimeSlotStart ? (
 						<p className="mt-1 flex items-center gap-1.5 text-sm font-medium text-brand-700">
 							<CalendarIcon className="h-4 w-4 shrink-0" />
 							<span>
@@ -119,6 +119,11 @@ export default function OpportunityListItem({
 									i18n.language,
 								)}
 							</span>
+						</p>
+					) : (
+						<p className="mt-1 flex items-center gap-1.5 text-sm font-medium text-gray-500">
+							<CalendarIcon className="h-4 w-4 shrink-0" />
+							<span>{t("opportunities.flexibleDate")}</span>
 						</p>
 					)}
 					{item.description && (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -160,6 +160,7 @@
       "notFound": "Nicht gefunden.",
       "back": "← Zurück",
       "filterToggle": "Filter",
+      "flexibleDate": "Flexibler Termin",
       "full": "Ausgebucht",
       "spotsLeft": "{{count}} Plätze frei",
       "spotsLeft_one": "{{count}} Platz frei",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -160,6 +160,7 @@
       "notFound": "Not found.",
       "back": "← Back",
       "filterToggle": "Filter",
+      "flexibleDate": "Flexible date",
       "full": "Full",
       "spotsLeft": "{{count}} spots left",
       "spotsLeft_one": "{{count}} spot left",


### PR DESCRIPTION
IndividualContact opportunities never have time slots, so DateFrom/DateTo filters previously hid the entire participation type whenever a volunteer picked a date range. Extend the same "slot-less is never filtered out" convention already used for expiry (line above) to the date range filter, and label such results "flexible date" in the opportunity card.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1059

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
