### PR TITLE
fix: stop profile edit form reset on silent token renewal

### DIFF
--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -244,4 +244,90 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 
 		await Expect(Page.GetByText("Profile saved.")).ToBeVisibleAsync();
 	}
+
+	[Test]
+	public async Task ProfileEditForm_PreservesUnsavedDraft_ThroughSilentTokenRenewal()
+	{
+		// #1221: react-oidc-context's automaticSilentRenew mints a fresh access
+		// token roughly every ~4 minutes in production (Keycloak's ~5 min default
+		// access token lifespan minus oidc-client-ts's 60s renewal buffer). The
+		// profile-load effect used to depend on that token's identity, so every
+		// renewal re-triggered form.reset(profile) and wiped whatever the user
+		// was mid-typing.
+		//
+		// FastSignInAsync can't reproduce this - its ROPC-minted refresh token
+		// belongs to the "frontend-test" client, not "frontend" (see its own
+		// comment on why it drops the refresh token entirely rather than seed an
+		// unusable one), so a silent renewal attempt would fail outright. A real
+		// LoginAsync session's refresh token is valid for "frontend", so
+		// oidc-client-ts's automaticSilentRenew can genuinely succeed via a
+		// background refresh-token grant (UserManager.signinSilent prefers the
+		// refresh token over the interactive iframe whenever one is present - no
+		// Keycloak SSO session needed for that path). Falsifying the just-minted
+		// session's stored expires_at makes that renewal fire on a short,
+		// predictable schedule instead of waiting out the realm's local
+		// accessTokenLifespan (3600s, bumped in AppHost.cs for other tests'
+		// benefit) or production's real ~4 minutes.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		// 80s remaining life at the next mount (below) means oidc-client-ts's
+		// AccessTokenEvents arms the "expiring" timer for 20s after that mount
+		// (80s - its 60s notification buffer) - comfortably after the
+		// navigate/edit/type steps below, but short enough not to bloat this
+		// test's runtime.
+		var originalAccessToken = await Page.EvaluateAsync<string>(
+			"""
+			() => {
+				for (let i = 0; i < localStorage.length; i++) {
+					const key = localStorage.key(i);
+					if (key && key.startsWith('oidc.user:')) {
+						const entry = JSON.parse(localStorage.getItem(key));
+						entry.expires_at = Math.floor(Date.now() / 1000) + 80;
+						localStorage.setItem(key, JSON.stringify(entry));
+						return entry.access_token;
+					}
+				}
+				throw new Error('no oidc.user storage entry found after LoginAsync');
+			}
+			""");
+
+		await Page.GotoAsync($"{origin}/profile");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var editButton = Page.GetByRole(AriaRole.Button, new() { Name = "Edit" }).First;
+		await Expect(editButton).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await editButton.ClickAsync();
+
+		var draftBio = $"Unsaved silent-renewal draft {Guid.NewGuid()}";
+		await Page.Locator("#bio").FillAsync(draftBio, new() { Timeout = 10_000 });
+
+		// Confirms the renewal actually happened - without this, the assertion
+		// below would trivially pass on the old, buggy dependency array too,
+		// simply because nothing occurred within the wait.
+		string? renewedAccessToken = null;
+		await PollUntilAsync(async () =>
+		{
+			renewedAccessToken = await Page.EvaluateAsync<string?>(
+				"""
+				() => {
+					for (let i = 0; i < localStorage.length; i++) {
+						const key = localStorage.key(i);
+						if (key && key.startsWith('oidc.user:')) {
+							return JSON.parse(localStorage.getItem(key)).access_token;
+						}
+					}
+					return null;
+				}
+				""");
+			return renewedAccessToken != null && renewedAccessToken != originalAccessToken;
+		}, () => "silent token renewal should have replaced the stored access token "
+			+ $"within the timeout (last observed: {renewedAccessToken ?? "null"})",
+			timeoutMs: 40_000);
+
+		await Expect(Page.Locator("#bio")).ToHaveValueAsync(draftBio);
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Save" })).ToBeVisibleAsync();
+	}
 }

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -125,8 +125,6 @@ export default function ProfileOverviewPage() {
 	usePageTitle(t("profile.title"));
 	usePageToolbar([{ label: t("breadcrumb.profile") }]);
 
-	const accessToken = auth.user?.access_token;
-
 	const [profile, setProfile] = useState<MyProfileResponse | null>(null);
 	const [profileLoading, setProfileLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
@@ -140,7 +138,13 @@ export default function ProfileOverviewPage() {
 	const form = useProfileForm(profile);
 	const avatarUpload = useAvatarUpload(setAvatarUrl);
 
-	// Load profile data (always load on mount with retry)
+	// Load profile data (always load on mount with retry). Depends on
+	// auth.isAuthenticated, not on the access token itself - react-oidc-context's
+	// automaticSilentRenew mints a fresh access token every ~4 minutes, and this
+	// effect previously kept re-running on that token's identity (#1221),
+	// re-triggering form.reset() and discarding whatever the user was mid-typing.
+	// ProtectedRoute only ever mounts this page while isAuthenticated is already
+	// true, so in practice this now runs once per mount.
 	useEffect(() => {
 		let cancelled = false;
 		const retryDelaysMs = [500, 1000, 2000];
@@ -177,7 +181,7 @@ export default function ProfileOverviewPage() {
 			cancelled = true;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [accessToken]);
+	}, [auth.isAuthenticated]);
 
 	// Streak chips in the identity hero - a lightweight, non-critical stat
 	// display, so a failed fetch is silently ignored rather than surfaced.


### PR DESCRIPTION
ProfileOverviewPage's profile-load effect depended on the access token's identity, so react-oidc-context's automaticSilentRenew (firing every ~4 min) re-triggered form.reset() and wiped whatever the user was mid-typing. Depend on auth.isAuthenticated instead.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1221

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
