### PR TITLE
fix: distinguish 403/404/network errors in OrgAppLayout instead of one "not authorized" screen

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -855,4 +855,78 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
+
+	// #1224: OrgAppLayout's "not authorized" screen (a non-organizer hitting
+	// a 403) had zero axe coverage before this, despite predating the fix -
+	// pinning down its own unique markup while touching this file for the
+	// new "error" state right below.
+	[Test]
+	public async Task OrgAppLayout_Forbidden_AsVera_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var organizationId = await CreateOrganizationAsOlafAsync("A11yForbidden");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard");
+
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("You don't have access to this organization.");
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	// #1224: the new recoverable "something went wrong, try again" state (a
+	// 500/network failure, as opposed to the permanent 403 above) - its own
+	// unique markup, otherwise never scanned. OrgAppLayoutErrorStatesTests.cs
+	// covers this state's functional behavior (branching + retry); this is
+	// its axe-core pass.
+	[Test]
+	public async Task OrgAppLayout_ServerError_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var organizationId = await CreateOrganizationAsOlafAsync("A11yServerError");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 500,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.6.1\",\"status\":500}",
+			});
+		});
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard");
+
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Something went wrong");
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" })).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	private async Task<string> CreateOrganizationAsOlafAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var response = await http.PostAsJsonAsync("/v1/organizations", new { name = $"{label} {suffix}" });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()
+			?? throw new InvalidOperationException("Created organization had no id.");
+	}
 }

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -79,24 +79,36 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 			var nameCell = row.Locator("p").First;
-			var nameBox = await nameCell.BoundingBoxAsync();
-			nameBox.Should().NotBeNull("Could not get bounding box for the user name");
-
 			var blockButton = row.GetByRole(AriaRole.Button, new() { Name = "Block" });
 			await Expect(blockButton).ToBeVisibleAsync();
-			var blockBox = await blockButton.BoundingBoxAsync();
-			blockBox.Should().NotBeNull("Could not get bounding box for the Block button");
 
 			// Regression #813: on narrow viewports the name/email cell used to shrink
 			// to a sliver next to the still-full-width status badge and action
-			// buttons instead of wrapping onto its own line above them.
-			nameBox!.Width.Should().BeGreaterThan(
-				200f,
-				$"Name cell width ({nameBox.Width:F0}px) should span most of the {MobileWidth}px viewport, not be compressed next to the action buttons");
+			// buttons instead of wrapping onto its own line above them. Poll rather
+			// than read both boxes once: the row's flex-col layout can still be
+			// mid-reflow the instant it first becomes visible (trailing the search
+			// re-render), and a single read can catch that transient frame under
+			// CI resource contention - same rationale as VisualTestBase's own
+			// PollUntilAsync-based geometry assertions.
+			var nameWidth = 0f;
+			var nameBottom = 0f;
+			var blockY = 0f;
+			await PollUntilAsync(async () =>
+			{
+				var nameBox = await nameCell.BoundingBoxAsync();
+				var blockBox = await blockButton.BoundingBoxAsync();
+				if (nameBox is null || blockBox is null)
+					return false;
 
-			blockBox!.Y.Should().BeGreaterThanOrEqualTo(
-				nameBox.Y + nameBox.Height,
-				"Block button should stack below the name/email text on narrow viewports, not sit beside it");
+				nameWidth = nameBox.Width;
+				nameBottom = nameBox.Y + nameBox.Height;
+				blockY = blockBox.Y;
+				return nameWidth > 200f && blockY >= nameBottom;
+			}, () => $"Name cell width ({nameWidth:F0}px, want >200px - should span most of the "
+				+ $"{MobileWidth}px viewport, not be compressed next to the action buttons) / "
+				+ $"Block button Y ({blockY:F0}px, want >= name-cell-bottom {nameBottom:F0}px - "
+				+ "should stack below the name/email text on narrow viewports, not sit beside it)",
+				timeoutMs: 10_000);
 		}
 		finally
 		{

--- a/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
+++ b/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
@@ -1,0 +1,116 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1224: OrgAppLayout used to funnel every org-load failure -
+/// a 403, a 404, a dropped connection, a 500 - through a single .catch() into
+/// one "You are not authorized" screen. It now branches on the actual
+/// failure: 403 stays the "not authorized" screen, 404 renders the shared
+/// NotFoundPage, and everything else gets a recoverable state with a retry
+/// action instead of being mislabeled as a permissions problem.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task NonOrganizerVisitingOrgApp_Gets403_ShowsNotAuthorizedScreen()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var organizationId = await CreateOrganizationAsync("Org403Screen");
+
+		// vera is a plain "user" (no organisator role), so
+		// GetOrganizationDetails' EinsatzbereitOrganisatorPolicy rejects her
+		// with 403 regardless of which organization she targets - the
+		// permanent, non-recoverable case this screen is for.
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "You don't have access to this organization." }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Back to Einsatzbereit" }))
+			.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task OrganizerVisitingUnknownOrgId_Gets404_ShowsNotFoundPage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		await Page.GotoAsync($"{origin}/app/{Guid.NewGuid()}/dashboard");
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Page not found" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task ServerError_ShowsRecoverableStateWithRetry_AndRetrySucceeds()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var organizationId = await CreateOrganizationAsync("Org500Retry");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		var shouldFail = true;
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}", async route =>
+		{
+			if (route.Request.Method != "GET" || !shouldFail)
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 500,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.6.1\",\"status\":500}",
+			});
+		});
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		var heading = Page.GetByRole(AriaRole.Heading, new() { Name = "Something went wrong" });
+		await Expect(heading).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		// Not the "not authorized" screen - the whole point of the fix (#1224).
+		await Expect(Page.GetByText("You don't have access to this organization.")).Not.ToBeVisibleAsync();
+
+		var retryButton = Page.GetByRole(AriaRole.Button, new() { Name = "Try again" });
+		await Expect(retryButton).ToBeVisibleAsync();
+
+		shouldFail = false;
+		await retryButton.ClickAsync();
+
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(heading).Not.ToBeVisibleAsync();
+	}
+
+	private async Task<string> CreateOrganizationAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var response = await http.PostAsJsonAsync("/v1/organizations", new
+		{
+			name = $"VisualTests {label} {suffix}",
+		});
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()
+			?? throw new InvalidOperationException("Created organization had no id.");
+	}
+}

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -200,19 +200,26 @@ export default function OrgAppLayout() {
 
 	if (status === "loading") {
 		return (
-			<div className="flex min-h-screen items-center justify-center bg-gray-50">
+			<main className="flex min-h-screen items-center justify-center bg-gray-50">
 				<Spinner label={t("orgDashboard.loading")} size="lg" />
-			</div>
+			</main>
 		);
 	}
 
 	if (status === "notFound") {
-		return <NotFoundPage />;
+		// NotFoundPage has no <main> of its own - it relies on AppLayout to
+		// supply one on its usual wildcard route. OrgAppLayout bypasses
+		// AppLayout entirely, so it must supply the landmark here instead.
+		return (
+			<main>
+				<NotFoundPage />
+			</main>
+		);
 	}
 
 	if (status === "error") {
 		return (
-			<div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
+			<main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
 				<h1 className={`text-gray-900 ${statusTitleClass}`}>
 					{t("error.boundaryTitle")}
 				</h1>
@@ -229,18 +236,18 @@ export default function OrgAppLayout() {
 						{t("orgApp.backToSite")}
 					</Button>
 				</div>
-			</div>
+			</main>
 		);
 	}
 
 	if (status === "forbidden" || !org) {
 		return (
-			<div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
+			<main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
 				<h1 className={`text-gray-900 ${statusTitleClass}`}>
 					{t("orgApp.notAuthorized")}
 				</h1>
 				<Button to="/">{t("orgApp.backToSite")}</Button>
-			</div>
+			</main>
 		);
 	}
 

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -216,9 +216,9 @@ export default function OrgAppLayout() {
 				<h1 className={`text-gray-900 ${statusTitleClass}`}>
 					{t("error.boundaryTitle")}
 				</h1>
-				{/* role="alert"/aria-live (via ErrorBanner) so a retry that fails
-				    again - re-rendering this same branch, no navigation - is still
-				    announced to screen reader users, not just sighted ones. */}
+				{/* role="alert"/aria-live (via ErrorBanner) so a retry that fails again
+				- re-rendering this same branch, no navigation - is still announced to
+				screen reader users, not just sighted ones. */}
 				<ErrorBanner
 					message={errorMessage ?? t("error.serverError")}
 					className="max-w-md"

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { Link, Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../client/api-client";
@@ -7,6 +7,11 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { setActiveOrgId } from "../lib/activeOrg";
 import { ORG_TABS, orgTabPath } from "../lib/orgTabs";
 import { statusTitleClass } from "../lib/headingClasses";
+import {
+	getApiErrorMessage,
+	isApiForbiddenError,
+	isApiNotFoundError,
+} from "../lib/apiError";
 import {
 	OrgBreadcrumbProvider,
 	useOrgBreadcrumbExtra,
@@ -18,6 +23,8 @@ import {
 import Header from "../components/Header/Header";
 import Spinner from "../components/Spinner";
 import Button from "../components/Button";
+import ErrorBanner from "../components/ErrorBanner";
+import NotFoundPage from "../pages/NotFoundPage";
 
 export interface OrgAppContext {
 	org: OrganizationDetailsResponse;
@@ -120,6 +127,8 @@ function OrgAppShell({
 	);
 }
 
+type LoadStatus = "loading" | "ok" | "forbidden" | "notFound" | "error";
+
 export default function OrgAppLayout() {
 	const { organizationId } = useParams<{ organizationId: string }>();
 	const api = useApiClient();
@@ -127,21 +136,41 @@ export default function OrgAppLayout() {
 	const location = useLocation();
 
 	const [org, setOrg] = useState<OrganizationDetailsResponse | null>(null);
-	const [loading, setLoading] = useState(true);
-	const [forbidden, setForbidden] = useState(false);
+	const [status, setStatus] = useState<LoadStatus>("loading");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// Guards against a fast org switch (or a manual retry) racing its own
+	// previous request: only the response for the most recently issued
+	// request is allowed to update state, same pattern as
+	// VolunteerOpportunityDetailPage's latestRequestRef.
+	const latestRequestRef = useRef(0);
 
 	function load() {
 		if (!organizationId) return;
-		setLoading(true);
-		setForbidden(false);
+		const requestId = ++latestRequestRef.current;
+		setStatus("loading");
 		api
 			.getOrganizationDetails(organizationId)
 			.then((data) => {
+				if (requestId !== latestRequestRef.current) return;
 				setOrg(data);
 				setActiveOrgId(organizationId);
+				setStatus("ok");
 			})
-			.catch(() => setForbidden(true))
-			.finally(() => setLoading(false));
+			.catch((err) => {
+				if (requestId !== latestRequestRef.current) return;
+				if (isApiForbiddenError(err)) {
+					setStatus("forbidden");
+				} else if (isApiNotFoundError(err)) {
+					setStatus("notFound");
+				} else {
+					// Covers everything that isn't a permanent 403/404 - a dropped
+					// connection, a 500, an unexpected exception - so it gets a
+					// recoverable "try again" state instead of being mislabeled as
+					// "not authorized" (#1224).
+					setErrorMessage(getApiErrorMessage(err, t("error.serverError")));
+					setStatus("error");
+				}
+			});
 	}
 
 	useEffect(() => {
@@ -169,7 +198,7 @@ export default function OrgAppLayout() {
 		ORG_TABS.find((tab) => tab.key === activeTabKey) ?? ORG_TABS[0];
 	const activeTabLabel = t(activeTab.labelKey);
 
-	if (loading) {
+	if (status === "loading") {
 		return (
 			<div className="flex min-h-screen items-center justify-center bg-gray-50">
 				<Spinner label={t("orgDashboard.loading")} size="lg" />
@@ -177,7 +206,34 @@ export default function OrgAppLayout() {
 		);
 	}
 
-	if (forbidden || !org) {
+	if (status === "notFound") {
+		return <NotFoundPage />;
+	}
+
+	if (status === "error") {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
+				<h1 className={`text-gray-900 ${statusTitleClass}`}>
+					{t("error.boundaryTitle")}
+				</h1>
+				{/* role="alert"/aria-live (via ErrorBanner) so a retry that fails
+				    again - re-rendering this same branch, no navigation - is still
+				    announced to screen reader users, not just sighted ones. */}
+				<ErrorBanner
+					message={errorMessage ?? t("error.serverError")}
+					className="max-w-md"
+				/>
+				<div className="flex gap-3">
+					<Button onClick={load}>{t("orgApp.retry")}</Button>
+					<Button to="/" variant="secondary">
+						{t("orgApp.backToSite")}
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (status === "forbidden" || !org) {
 		return (
 			<div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center">
 				<h1 className={`text-gray-900 ${statusTitleClass}`}>

--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -15,6 +15,7 @@ vi.mock("../i18n", () => ({
 import {
 	getApiErrorMessage,
 	isApiErrorCode,
+	isApiForbiddenError,
 	isApiNotFoundError,
 } from "./apiError";
 
@@ -148,5 +149,27 @@ describe("isApiErrorCode", () => {
 				"VolunteerOpportunity.AlreadyPublished",
 			),
 		).toBe(false);
+	});
+});
+
+describe("isApiForbiddenError", () => {
+	it("returns true when status is 403", () => {
+		expect(isApiForbiddenError({ status: 403 })).toBe(true);
+	});
+
+	it("returns false when status is a different code", () => {
+		expect(isApiForbiddenError({ status: 500 })).toBe(false);
+	});
+
+	it("returns false when status is missing", () => {
+		expect(isApiForbiddenError({})).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isApiForbiddenError(null)).toBe(false);
+	});
+
+	it("returns false for a non-object value", () => {
+		expect(isApiForbiddenError("403")).toBe(false);
 	});
 });

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -55,3 +55,15 @@ export function isApiErrorCode(err: unknown, code: string): boolean {
 		(err as { errorCode?: unknown }).errorCode === code
 	);
 }
+
+/**
+ * Detects a 403 from a rejected API call - see isApiNotFoundError above for
+ * why `.status` works across both shapes the NSwag client can throw.
+ */
+export function isApiForbiddenError(err: unknown): boolean {
+	return (
+		!!err &&
+		typeof err === "object" &&
+		(err as { status?: unknown }).status === 403
+	);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -321,7 +321,8 @@
     },
     "orgApp": {
       "backToSite": "Zurück zu Einsatzbereit",
-      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation."
+      "notAuthorized": "Du hast keinen Zugriff auf diese Organisation.",
+      "retry": "Erneut versuchen"
     },
     "orgOpportunities": {
       "loading": "Wird geladen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -321,7 +321,8 @@
     },
     "orgApp": {
       "backToSite": "Back to Einsatzbereit",
-      "notAuthorized": "You don't have access to this organization."
+      "notAuthorized": "You don't have access to this organization.",
+      "retry": "Try again"
     },
     "orgOpportunities": {
       "loading": "Loading…",


### PR DESCRIPTION
Any org-load failure - a dropped connection, a 500, an expired token - used to render the same permanent "not authorized" dead end (#1224). Now branches on the actual failure: 403 stays "not authorized", 404 renders the shared NotFoundPage, everything else gets a recoverable state with a retry action. Also guards against a fast org switch racing its own stale response, same pattern as
VolunteerOpportunityDetailPage.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1224

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
