### PR TITLE
fix: surface dashboard layout fetch failures instead of silently using defaults

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -272,6 +272,31 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrgDashboardPage_LayoutLoadFailed_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1234: a failed dashboard-layout fetch now renders its own inline
+		// error banner + retry button and disables the "Edit" quick action -
+		// a DOM state the plain page-load scan above never reaches, since its
+		// GET .../dashboard/layout always succeeds.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.RouteAsync("**/dashboard/layout", async route =>
+		{
+			if (route.Request.Method == "GET")
+				await route.AbortAsync();
+			else
+				await route.ContinueAsync();
+		});
+
+		await NavigateToOrgAppDashboardAsOlafAsync(frontend);
+
+		await Expect(Page.GetByTestId("dashboard-layout-retry")).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task OrgDashboardPage_CalendarWidgetColorDialog_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// #762 rebuilt the dashboard as a widget grid; the Calendar widget's

--- a/backend/tests/VisualTests/OrgDashboardLayoutLoadFailureTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardLayoutLoadFailureTests.cs
@@ -1,0 +1,90 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1234: a failed GET .../dashboard/layout used to be
+/// swallowed silently, falling back to DEFAULT_LAYOUT with no indication
+/// anything went wrong - indistinguishable from the same optimistic default
+/// render a brand-new organizer sees. An organizer with a real saved layout
+/// who hit this during a transient backend outage could edit the (wrong,
+/// default) dashboard shown to them and Save, permanently overwriting their
+/// actual server-side layout. index.tsx now tracks a `layoutLoadFailed` state:
+/// an inline error banner with a retry button renders, and the "Edit" quick
+/// action is disabled until a load actually succeeds.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgDashboardLayoutLoadFailureTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task LayoutFetchFails_ShowsInlineErrorAndDisablesEdit()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.RouteAsync("**/dashboard/layout", async route =>
+		{
+			if (route.Request.Method == "GET")
+				await route.AbortAsync();
+			else
+				await route.ContinueAsync();
+		});
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		await Expect(Page.GetByRole(AriaRole.Alert))
+			.ToContainTextAsync("Couldn't confirm your saved dashboard layout");
+		await Expect(Page.GetByTestId("dashboard-layout-retry")).ToBeVisibleAsync();
+
+		// The organizer must not be able to enter edit mode (and from there,
+		// Save) while the real saved layout is still unconfirmed - doing so
+		// would persist whatever DEFAULT_LAYOUT happens to be showing right
+		// now over their actual saved one.
+		var editButton = Page.GetByTestId("quick-action-edit");
+		await Expect(editButton).ToBeDisabledAsync();
+
+		// A disabled native button drops out of the tab order with no other
+		// indication why - review feedback on the first version of this fix
+		// flagged the missing explanation, so a `title` carries the same
+		// reason the inline banner shows.
+		await Expect(editButton).ToHaveAttributeAsync(
+			"title", new Regex("^Couldn't confirm your saved dashboard layout"));
+
+		// The retry button's own accessible name ("Retry") says nothing about
+		// what it's retrying - aria-describedby ties it to the banner text.
+		var retryButton = Page.GetByTestId("dashboard-layout-retry");
+		await Expect(retryButton).ToHaveAttributeAsync("aria-describedby", "dashboard-layout-load-error");
+	}
+
+	[Test]
+	public async Task LayoutFetchFails_RetryButton_RecoversOnceTheFetchSucceeds()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		// Aborts only the very first GET - the retry's own request (and any
+		// PUT save, though none happens in this test) goes through normally,
+		// so this exercises an organizer recovering from a single transient
+		// failure rather than a permanently broken backend.
+		var getAttempts = 0;
+		await Page.RouteAsync("**/dashboard/layout", async route =>
+		{
+			if (route.Request.Method == "GET" && Interlocked.Increment(ref getAttempts) == 1)
+				await route.AbortAsync();
+			else
+				await route.ContinueAsync();
+		});
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		await Expect(Page.GetByRole(AriaRole.Alert))
+			.ToContainTextAsync("Couldn't confirm your saved dashboard layout");
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeDisabledAsync();
+
+		await Page.GetByTestId("dashboard-layout-retry").ClickAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Alert)).ToHaveCountAsync(0, new() { Timeout = 10_000 });
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeEnabledAsync();
+	}
+}

--- a/frontend/src/components/Header/BreadcrumbBar.tsx
+++ b/frontend/src/components/Header/BreadcrumbBar.tsx
@@ -91,6 +91,7 @@ export default function BreadcrumbBar({
 								type="button"
 								onClick={action.onClick}
 								disabled={action.disabled}
+								title={action.title}
 								aria-label={action.label}
 								data-testid={`quick-action-${action.key}`}
 								className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -14,6 +14,10 @@ export type QuickAction = {
 	onClick: () => void;
 	variant?: "primary" | "default";
 	disabled?: boolean;
+	// Surfaced as the button's `title` - mainly for a disabled action, where
+	// the native `disabled` attribute alone gives no indication why (see
+	// useEditModeQuickActions's editDisabledTitle).
+	title?: string;
 };
 
 type QuickActionsContextValue = {

--- a/frontend/src/hooks/useEditModeQuickActions.tsx
+++ b/frontend/src/hooks/useEditModeQuickActions.tsx
@@ -9,6 +9,16 @@ import { CancelIcon, EditIcon, SaveIcon } from "../components/QuickActionIcons";
 interface Options {
 	editing: boolean;
 	saving?: boolean;
+	// Disables just the "Edit" action (e.g. OrgDashboardPage while its saved
+	// layout fetch has failed - entering edit mode on an unconfirmed layout
+	// risks a Save that overwrites the organizer's real one, see #1234).
+	editDisabled?: boolean;
+	// Native `disabled` alone drops the button from the tab order with no way
+	// for a keyboard/screen-reader user to discover why it's gone - surfaced
+	// as a `title` on the button instead (see OrgMembersPage's
+	// leaveOrganizationLastOrganizerHint for the same disabled+title pairing).
+	// Only meaningful while editDisabled is true.
+	editDisabledTitle?: string;
 	onEdit: () => void;
 	onSave: () => void;
 	onCancel: () => void;
@@ -24,6 +34,8 @@ interface Options {
 export function useEditModeQuickActions({
 	editing,
 	saving,
+	editDisabled,
+	editDisabledTitle,
 	onEdit,
 	onSave,
 	onCancel,
@@ -103,9 +115,11 @@ export function useEditModeQuickActions({
 							label: t("common.edit"),
 							icon: <EditIcon />,
 							onClick: () => onEditRef.current(),
+							disabled: editDisabled,
+							title: editDisabled ? editDisabledTitle : undefined,
 						},
 					],
-		[editing, saving, t, extraEditingActions],
+		[editing, saving, editDisabled, editDisabledTitle, t, extraEditingActions],
 	);
 
 	useQuickActions(actions);

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -10,6 +10,8 @@
       "save": "Speichern",
       "saving": "Wird gespeichert…",
       "cancel": "Abbrechen",
+      "retry": "Erneut versuchen",
+      "retrying": "Wird erneut versucht…",
       "loading": "Wird geladen…",
       "pageLoading": "Seite wird geladen…"
     },
@@ -339,6 +341,7 @@
       "title": "Organisations-Dashboard",
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",
+      "layoutLoadError": "Dein gespeichertes Dashboard-Layout konnte nicht bestätigt werden. Die Ansicht unten stimmt damit möglicherweise nicht überein - Bearbeiten ist deaktiviert, bis dies erfolgreich geladen wurde.",
       "notFound": "Organisation nicht gefunden.",
       "openOpportunities": "Offene Einsätze",
       "openOpportunitiesDesc": "Veröffentlichte Einsatzmöglichkeiten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -10,6 +10,8 @@
       "save": "Save",
       "saving": "Saving…",
       "cancel": "Cancel",
+      "retry": "Retry",
+      "retrying": "Retrying…",
       "loading": "Loading…",
       "pageLoading": "Loading page…"
     },
@@ -339,6 +341,7 @@
       "title": "Organization Dashboard",
       "loading": "Loading…",
       "error": "Error: {{message}}",
+      "layoutLoadError": "Couldn't confirm your saved dashboard layout. What's shown below may not match it, and editing is disabled until this loads successfully.",
       "notFound": "Organization not found.",
       "openOpportunities": "Open Opportunities",
       "openOpportunitiesDesc": "Published volunteer opportunities",

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -15,6 +15,7 @@ import { dispatchToast } from "../../../lib/toastBus";
 import { getApiErrorMessage } from "../../../lib/apiError";
 import { PlusIcon } from "../../../components/QuickActionIcons";
 import EmptyState from "../../../components/EmptyState";
+import ErrorBanner from "../../../components/ErrorBanner";
 import AddWidgetModal from "./AddWidgetModal";
 import CalendarWidget from "./CalendarWidget";
 import UpcomingOpportunitiesWidget from "./UpcomingOpportunitiesWidget";
@@ -81,11 +82,21 @@ export default function OrgDashboardPage() {
 	const [draftLayout, setDraftLayout] = useState<PlacedWidget[] | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [showAddWidgetModal, setShowAddWidgetModal] = useState(false);
+	// Distinguishes "no custom layout exists" (the optimistic DEFAULT_LAYOUT
+	// render above is genuinely accurate) from "the fetch to confirm that
+	// failed" (#1234: it used to collapse both into the same silent
+	// DEFAULT_LAYOUT fallback - indistinguishable from a real empty
+	// customization, so a returning organizer hitting a transient backend
+	// outage could edit and save over their actual saved layout without ever
+	// being told theirs failed to load). Blocks entering edit mode (see
+	// startEditing below) until a load actually succeeds.
+	const [layoutLoadFailed, setLayoutLoadFailed] = useState(false);
+	const [retryingLayoutLoad, setRetryingLayoutLoad] = useState(false);
 
 	const placement = useWidgetPlacement({ draftLayout, setDraftLayout });
 
-	useEffect(() => {
-		api
+	const loadLayout = useCallback(() => {
+		return api
 			.getDashboardLayout(organizationId)
 			.then((response) => {
 				const sanitized = response.widgets
@@ -110,10 +121,20 @@ export default function OrgDashboardPage() {
 				// default, is the #771 follow-up fix for "remove all widgets,
 				// it resets back to the default set on refresh".
 				setSavedLayout(response.hasCustomLayout ? sanitized : DEFAULT_LAYOUT);
+				setLayoutLoadFailed(false);
 			})
-			.catch(() => setSavedLayout(DEFAULT_LAYOUT));
+			.catch(() => setLayoutLoadFailed(true));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [organizationId]);
+
+	useEffect(() => {
+		void loadLayout();
+	}, [loadLayout]);
+
+	function retryLoadLayout() {
+		setRetryingLayoutLoad(true);
+		void loadLayout().finally(() => setRetryingLayoutLoad(false));
+	}
 
 	const layout = editing ? (draftLayout ?? []) : savedLayout;
 	const availableToAdd = WIDGET_KEYS.filter(
@@ -172,6 +193,11 @@ export default function OrgDashboardPage() {
 	}
 
 	function startEditing() {
+		// Blocked while the true saved layout is unconfirmed (see
+		// layoutLoadFailed above) - the "Edit" quick action is already
+		// disabled for this, but the empty-state CTA below calls this
+		// directly too.
+		if (layoutLoadFailed) return;
 		setDraftLayout(savedLayout);
 		setEditing(true);
 	}
@@ -206,6 +232,8 @@ export default function OrgDashboardPage() {
 	useEditModeQuickActions({
 		editing,
 		saving,
+		editDisabled: layoutLoadFailed,
+		editDisabledTitle: t("orgDashboard.layoutLoadError"),
 		onEdit: startEditing,
 		onSave: () => void handleSave(),
 		onCancel: handleCancel,
@@ -540,6 +568,31 @@ export default function OrgDashboardPage() {
 						className="shrink-0 rounded-lg px-2 py-1 text-xs font-semibold text-brand-800 hover:bg-brand-100"
 					>
 						{t("common.cancel")}
+					</button>
+				</div>
+			)}
+
+			{layoutLoadFailed && (
+				<div className="mb-3 flex items-center gap-3">
+					<ErrorBanner
+						id="dashboard-layout-load-error"
+						className="flex-1"
+						message={t("orgDashboard.layoutLoadError")}
+					/>
+					{/* aria-describedby ties this to the error text above - its own
+					accessible name ("Retry") says nothing about what it's retrying,
+					and a screen-reader user tabbing to it after the banner's one-time
+					aria-live announcement has already passed would otherwise hear
+					just "Retry, button" with no context. */}
+					<button
+						type="button"
+						onClick={retryLoadLayout}
+						disabled={retryingLayoutLoad}
+						aria-describedby="dashboard-layout-load-error"
+						data-testid="dashboard-layout-retry"
+						className="shrink-0 rounded-card bg-red-50 px-3 py-3 text-sm font-semibold text-red-700 hover:bg-red-100 disabled:opacity-50"
+					>
+						{retryingLayoutLoad ? t("common.retrying") : t("common.retry")}
 					</button>
 				</div>
 			)}


### PR DESCRIPTION
A failed GET dashboard/layout previously fell back to DEFAULT_LAYOUT with no indication anything went wrong - indistinguishable from a brand-new organizer's optimistic default render. An organizer with a real saved layout who hit a transient fetch failure could edit the (wrong) default shown to them and Save, permanently overwriting their actual layout.

Adds a layoutLoadFailed state: an inline error banner with a retry action renders on failure, and the "Edit" quick action is disabled (with a title explaining why) until a load succeeds.

Closes #1234

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
