### PR TITLE
fix: scope engagement uniqueness to time slot, not opportunity

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -103,6 +103,7 @@ public interface IApplicationDbContext
 	Task<bool> HasEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
 		CancellationToken cancellationToken = default);
 
 	IAggregateRepository<UserStreak, UserStreakId> UserStreaks { get; }
@@ -178,6 +179,7 @@ public interface IApplicationDbContext
 	Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
 		CancellationToken cancellationToken = default);
 
 	Task<bool> CanConnectAsync(

--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -29,7 +29,7 @@ internal sealed class CreateEngagementCommandHandler(
 			throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity with id '{request.OpportunityId.Value}' was not found."));
 
 		var alreadySignedUp = await dbContext.HasEngagementAsync(
-			request.VolunteerId, request.OpportunityId, cancellationToken);
+			request.VolunteerId, request.OpportunityId, request.TimeSlotId, cancellationToken);
 
 		if (alreadySignedUp)
 			throw new ResultFailureException(Error.Conflict("Engagement.AlreadySignedUp", "Conflict: you are already signed up for this opportunity."));
@@ -47,7 +47,7 @@ internal sealed class CreateEngagementCommandHandler(
 		}
 
 		var existingTerminal = await dbContext.GetTerminalEngagementAsync(
-			request.VolunteerId, request.OpportunityId, cancellationToken);
+			request.VolunteerId, request.OpportunityId, request.TimeSlotId, cancellationToken);
 
 		Engagement engagement;
 		if (existingTerminal is not null)

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -204,10 +204,12 @@ internal sealed class ApplicationDbContext(
 	public async Task<bool> HasEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
 		CancellationToken cancellationToken = default) =>
 		await Set<Engagement>()
 			.AnyAsync(e => e.VolunteerId == volunteerId
 				&& e.OpportunityId == opportunityId
+				&& e.TimeSlotId == timeSlotId
 				&& e.Status != EngagementStatus.Withdrawn
 				&& e.Status != EngagementStatus.Cancelled, cancellationToken);
 
@@ -366,10 +368,12 @@ internal sealed class ApplicationDbContext(
 	public async Task<Engagement?> GetTerminalEngagementAsync(
 		UserId volunteerId,
 		VolunteerOpportunityId opportunityId,
+		TimeSlotId? timeSlotId,
 		CancellationToken cancellationToken = default) =>
 		await Set<Engagement>()
 			.FirstOrDefaultAsync(e => e.VolunteerId == volunteerId
 				&& e.OpportunityId == opportunityId
+				&& e.TimeSlotId == timeSlotId
 				&& (e.Status == EngagementStatus.Withdrawn || e.Status == EngagementStatus.Cancelled),
 				cancellationToken);
 

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -70,8 +70,17 @@ internal sealed class EngagementConfiguration
 
 		builder.HasIndex(e => new { e.VolunteerId, e.Status });
 
-		builder.HasIndex(e => new { e.VolunteerId, e.OpportunityId })
+		// One engagement per volunteer per time slot - lets a volunteer sign up for
+		// several slots of the same recurring waitlist opportunity (#1067).
+		builder.HasIndex(e => new { e.VolunteerId, e.TimeSlotId })
 			.IsUnique();
+
+		// Individual-contact engagements have no time slot, so the index above
+		// doesn't constrain them (Postgres treats every NULL as distinct) - keep the
+		// original one-engagement-per-opportunity rule for that case explicitly.
+		builder.HasIndex(e => new { e.VolunteerId, e.OpportunityId })
+			.IsUnique()
+			.HasFilter("time_slot_id IS NULL");
 
 		builder.HasOne<TimeSlot>()
 			.WithMany()

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730060440_ReplaceEngagementUniqueConstraintWithTimeSlotScope.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730060440_ReplaceEngagementUniqueConstraintWithTimeSlotScope.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260730060440_ReplaceEngagementUniqueConstraintWithTimeSlotScope")]
+	partial class ReplaceEngagementUniqueConstraintWithTimeSlotScope
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730060440_ReplaceEngagementUniqueConstraintWithTimeSlotScope.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730060440_ReplaceEngagementUniqueConstraintWithTimeSlotScope.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class ReplaceEngagementUniqueConstraintWithTimeSlotScope : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement",
+				columns: new[] { "volunteer_id", "opportunity_id" },
+				unique: true,
+				filter: "time_slot_id IS NULL");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_volunteer_id_time_slot_id",
+				table: "engagement",
+				columns: new[] { "volunteer_id", "time_slot_id" },
+				unique: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement");
+
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_volunteer_id_time_slot_id",
+				table: "engagement");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement",
+				columns: new[] { "volunteer_id", "opportunity_id" },
+				unique: true);
+		}
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -59,7 +59,7 @@ public class CreateEngagementCommandHandlerTests
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
 		_dbContext.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
 			.Returns(0);
-		_dbContext.GetTerminalEngagementAsync(Arg.Any<UserId>(), Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+		_dbContext.GetTerminalEngagementAsync(Arg.Any<UserId>(), Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns((Engagement?)null);
 		_sut = new CreateEngagementCommandHandler(_dbContext, _keycloakService, _keycloakUserService, _emailService);
 	}
@@ -219,5 +219,90 @@ public class CreateEngagementCommandHandlerTests
 
 		// Assert
 		result.VolunteerId.Should().Be(volunteerId);
+	}
+
+	// --- Time-slot-scoped uniqueness (#1067) ---
+
+	[Test]
+	public async Task Handle_ShouldCheckForDuplicateSignUp_ScopedToTheRequestedTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var volunteerId = UserId.New();
+		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert - the duplicate check is scoped to this time slot, not the whole
+		// opportunity, so a second sign-up for a different slot isn't blocked.
+		await _dbContext.Received(1).HasEngagementAsync(volunteerId, opportunityId, timeSlotId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldLookUpTerminalEngagement_ScopedToTheRequestedTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var volunteerId = UserId.New();
+		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert - a terminated engagement for a *different* slot must never
+		// surface here, or reactivating it would wipe that other slot's
+		// attendance/feedback data (the #1067 compounding bug).
+		await _dbContext.Received(1).GetTerminalEngagementAsync(volunteerId, opportunityId, timeSlotId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReuseTerminalEngagement_WhenOneExistsForTheRequestedTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var volunteerId = UserId.New();
+		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
+		var terminalEngagement = Engagement.CreateWaitlistSignUp(opportunityId, volunteerId, timeSlotId);
+		terminalEngagement.Withdraw();
+		_dbContext.GetTerminalEngagementAsync(volunteerId, opportunityId, timeSlotId, Arg.Any<CancellationToken>())
+			.Returns(terminalEngagement);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeSameAs(terminalEngagement);
+		result.Status.Should().Be(EngagementStatus.Pending);
+		await _engagementRepo.DidNotReceive().AddAsync(Arg.Any<Engagement>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreateNewEngagement_WhenATerminalEngagementOnlyExistsForAnotherTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - simulates the volunteer having a cancelled/attended
+		// engagement on a different slot of the same opportunity: since
+		// GetTerminalEngagementAsync is stubbed per-timeSlotId, it returns null
+		// for *this* slot, exactly like the real time-slot-scoped query would.
+		var opportunityId = VolunteerOpportunityId.New();
+		var volunteerId = UserId.New();
+		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert - a fresh engagement is created for this slot; nothing about the
+		// other slot's terminal engagement is touched.
+		result.TimeSlotId.Should().Be(timeSlotId);
+		result.Status.Should().Be(EngagementStatus.Pending);
+		await _engagementRepo.Received(1).AddAsync(Arg.Any<Engagement>(), cancellationToken);
 	}
 }

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1055,6 +1055,138 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(400);
 	}
 
+	// ── Multiple time slots per opportunity (#1067) ───────────────────────────
+
+	[Test]
+	public async Task CreateEngagement_ShouldSucceed_WhenVolunteerSignsUpForASecondTimeSlot_OnSameWaitlistOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateWaitlistOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = "Weekly",
+				RecurrenceCount = 2,
+			},
+			cancellationToken);
+		var firstSlotId = timeSlots.ElementAt(0).Id;
+		var secondSlotId = timeSlots.ElementAt(1).Id;
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var firstEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { TimeSlotId = firstSlotId },
+			cancellationToken);
+
+		var secondEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { TimeSlotId = secondSlotId },
+			cancellationToken);
+
+		firstEngagement.Status.Should().Be("Pending");
+		secondEngagement.Status.Should().Be("Pending");
+		secondEngagement.Id.Should().NotBe(firstEngagement.Id);
+	}
+
+	[Test]
+	public async Task CreateEngagement_ShouldReturn409_WhenVolunteerSignsUpTwiceForTheSameTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateWaitlistOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+		var slotId = timeSlots.First().Id;
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = slotId }, cancellationToken);
+
+		var act = () => veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = slotId }, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
+	[Test]
+	public async Task CreateEngagement_ShouldPreserveAttendanceAndFeedback_WhenOrganizerCancelsToFreeUpADifferentTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1067: an organizer cancelling an attended engagement to
+		// "unblock" a volunteer for a different slot of the same recurring
+		// opportunity must not resurrect that attended record into the new slot -
+		// its attendance/feedback history has to survive untouched, and the new
+		// slot needs a brand new engagement row.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateWaitlistOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = "Weekly",
+				RecurrenceCount = 2,
+			},
+			cancellationToken);
+		var firstSlotId = timeSlots.ElementAt(0).Id;
+		var secondSlotId = timeSlots.ElementAt(1).Id;
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var firstEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = firstSlotId }, cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(firstEngagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(firstEngagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			firstEngagement.Id,
+			new SubmitFeedbackRequest { Rating = 5, Comment = "Great first session" },
+			cancellationToken);
+
+		// Organizer cancels the attended engagement to free up a spot for vera.
+		await olafClient.CancelEngagementAsync(
+			firstEngagement.Id,
+			new CancelEngagementRequest { Reason = "Freeing up a spot" },
+			cancellationToken);
+
+		var secondEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = secondSlotId }, cancellationToken);
+
+		var engagements = await olafClient.GetEngagementsAsync(opportunity.Id, 1, 10, cancellationToken);
+		var firstAfter = engagements.Items.Single(e => e.Id == firstEngagement.Id);
+		var secondAfter = engagements.Items.Single(e => e.Id == secondEngagement.Id);
+
+		firstAfter.Status.Should().Be("Cancelled");
+		firstAfter.IsCheckedIn.Should().BeTrue();
+		firstAfter.HasFeedback.Should().BeTrue();
+		firstAfter.TimeSlotId.Should().Be(firstSlotId);
+
+		secondAfter.Status.Should().Be("Pending");
+		secondAfter.TimeSlotId.Should().Be(secondSlotId);
+		secondAfter.Id.Should().NotBe(firstEngagement.Id);
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(


### PR DESCRIPTION
A volunteer could only ever hold one Engagement per VolunteerOpportunity, so a 52-slot recurring waitlist series was effectively single-attendance. Replace the (VolunteerId, OpportunityId) unique index with (VolunteerId, TimeSlotId), keeping the opportunity-scoped rule only for direct-contact engagements (TimeSlotId IS NULL) via a partial index.

The duplicate/terminal-engagement lookups in CreateEngagementCommandHandler are now scoped the same way, which also fixes the compounding bug where cancelling an attended engagement to free up a different slot reactivated and wiped that attended record instead of leaving it untouched.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1067

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
