### PR TITLE
feat: collect and surface engagement cancellation reason

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -6706,6 +6706,12 @@
               "null",
               "string"
             ]
+          },
+          "cancellationReason": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -18,4 +18,5 @@ public sealed record EngagementSummary(
 	DateTimeOffset? TimeSlotEndDateTime = null,
 	string? Location = null,
 	string? VolunteerEmail = null,
-	string? VolunteerPhone = null);
+	string? VolunteerPhone = null,
+	string? CancellationReason = null);

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -37,6 +37,7 @@ internal sealed class EngagementReadRepository(
 					e.IsCheckedIn,
 					e.FeedbackSubmittedAt,
 					e.CreatedOn,
+					e.CancellationReason,
 				})
 			.Join(
 				dbContext.OrganizationsQuery.Select(org => new { org.Id, org.Name }),
@@ -56,6 +57,7 @@ internal sealed class EngagementReadRepository(
 					x.IsCheckedIn,
 					x.FeedbackSubmittedAt,
 					x.CreatedOn,
+					x.CancellationReason,
 				})
 			.OrderByDescending(x => x.CreatedOn)
 			.ToListAsync(cancellationToken);
@@ -72,7 +74,8 @@ internal sealed class EngagementReadRepository(
 			x.Status.ToString(),
 			x.IsCheckedIn,
 			x.FeedbackSubmittedAt.HasValue,
-			x.CreatedOn)).ToList();
+			x.CreatedOn,
+			CancellationReason: x.CancellationReason)).ToList();
 	}
 
 	public async ValueTask<PagedList<EngagementSummary>> GetPagedByOpportunityAsync(
@@ -127,6 +130,7 @@ internal sealed class EngagementReadRepository(
 					e.IsCheckedIn,
 					e.FeedbackSubmittedAt,
 					e.CreatedOn,
+					e.CancellationReason,
 				})
 			.Join(
 				dbContext.OrganizationsQuery.Select(org => new { org.Id, org.Name }),
@@ -146,6 +150,7 @@ internal sealed class EngagementReadRepository(
 					x.IsCheckedIn,
 					x.FeedbackSubmittedAt,
 					x.CreatedOn,
+					x.CancellationReason,
 				})
 			.OrderByDescending(x => x.CreatedOn)
 			.Skip((pageNumber - 1) * pageSize)
@@ -181,7 +186,8 @@ internal sealed class EngagementReadRepository(
 			x.CreatedOn,
 			VolunteerPhone: x.VolunteerId is not null
 				? phonesByVolunteerId.GetValueOrDefault(x.VolunteerId.Value.Value)
-				: null)).ToList();
+				: null,
+			CancellationReason: x.CancellationReason)).ToList();
 
 		return new PagedList<EngagementSummary>(items, totalCount, pageNumber, pageSize);
 	}
@@ -293,7 +299,8 @@ internal sealed class EngagementReadRepository(
 				e.CreatedOn,
 				TimeSlotStartDateTime: timeSlot?.StartDateTime,
 				TimeSlotEndDateTime: timeSlot?.EndDateTime,
-				Location: location);
+				Location: location,
+				CancellationReason: e.CancellationReason);
 		}).ToList();
 
 		return new PagedList<EngagementSummary>(items, totalCount, pageNumber, pageSize);

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -10464,6 +10464,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("volunteerPhone")]
         public string? VolunteerPhone { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("cancellationReason")]
+        public string? CancellationReason { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -144,4 +144,77 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 	{
 		public string GeneratePin() => "0000";
 	}
+
+	// Regression for #1051: EngagementSummary never carried CancellationReason,
+	// so a reason set via Engagement.Cancel(reason) never reached the
+	// volunteer's own "My Profile -> Engagements" list (GetByVolunteerAsync)
+	// nor the organizer's "Manage applications" list (GetPagedByOpportunityAsync),
+	// even though the domain model, command, and email already supported it.
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldIncludeCancellationReason_WhenEngagementCancelledWithReason(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+		var opportunityId = VolunteerOpportunityId.New();
+
+		var engagement = Engagement.CreateIndividualContact(opportunityId, volunteerId, "Please let me help.").GetValueOrThrow();
+		engagement.Cancel("No longer needed").ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CancellationReason.Should().Be("No longer needed");
+	}
+
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldReturnNullReason_WhenEngagementCancelledWithoutReason(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+		var opportunityId = VolunteerOpportunityId.New();
+
+		var engagement = Engagement.CreateIndividualContact(opportunityId, volunteerId, "Please let me help.").GetValueOrThrow();
+		engagement.Cancel().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CancellationReason.Should().BeNull();
+	}
+
+	[Test]
+	public async Task GetPagedByOpportunityAsync_ShouldIncludeCancellationReason_WhenEngagementCancelledWithReason(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var opportunity = VolunteerOpportunity.Create(
+			DomainOrganizationId.New(), "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, new RandomPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, UserId.New(), "Please let me help.").GetValueOrThrow();
+		engagement.Cancel("Position filled").ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetPagedByOpportunityAsync(opportunity.Id, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CancellationReason.Should().Be("Position filled");
+	}
 }

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -218,7 +218,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 
 		var repository = new EngagementReadRepository(dbContext);
 
-		var page = await repository.GetPagedByOpportunityAsync(opportunity.Id, pageNumber: 1, pageSize: 10, cancellationToken);
+		var page = await repository.GetPagedByOpportunityAsync(opportunity.Id, pageNumber: 1, pageSize: 10, cancellationToken: cancellationToken);
 
 		page.Items.Should().ContainSingle()
 			.Which.CancellationReason.Should().Be("Position filled");

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -198,8 +198,14 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 	{
 		await using var dbContext = fixture.CreateApplicationDbContext();
 
+		// GetPagedByOpportunityAsync inner-joins through to OrganizationsQuery, so
+		// a random unsaved OrganizationId would silently drop the row - a real
+		// Organization must exist for the opportunity to be returned at all.
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"CancellationReasonOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
 		var opportunity = VolunteerOpportunity.Create(
-			DomainOrganizationId.New(), "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -929,4 +929,64 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		return org.GetProperty("id").GetProperty("value").GetString()
 			?? throw new InvalidOperationException("Created organization had no id.");
 	}
+
+	[Test]
+	public async Task EngagementManagementPage_CancelDialog_HasNoSeriousA11yViolations()
+	{
+		// #1051: the cancel/revoke ConfirmDialog gained an optional reason
+		// <label>/<textarea> + character-counter <p> (previously a plain
+		// yes/no dialog with no form control) - EngagementManagementPage_AsOlaf_...
+		// above never opens this dialog, so its new markup had zero axe
+		// coverage. Seeds its own opportunity/engagement rather than relying
+		// on olaf's shared seed data, so this doesn't skip like that test can.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"CancelDialogA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"CancelDialogA11y Opportunity {suffix}",
+			description = "Created by AccessibilityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		var applyResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "For the a11y scan." });
+		applyResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync(
+			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Cancel" }).ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await Expect(dialog.Locator("#cancel-reason")).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
 }

--- a/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
+++ b/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
@@ -1,0 +1,161 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1051: the backend fully supported an engagement cancellation
+/// reason (domain model, command, email, endpoint) but EngagementManagementPage
+/// always called cancelEngagement with a null body, and EngagementSummary had no
+/// CancellationReason field for the volunteer's own activity list to render. Now
+/// the organizer's cancel dialog collects an optional reason and the volunteer's
+/// "My Profile -> Engagements" list shows it on the Cancelled row.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task EngagementManagementPage_CancelDialog_SendsEnteredReason_ToBackend()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CancelReasonOrganizer");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		IResponse? cancelResponse = null;
+		Page.Response += (_, response) =>
+		{
+			if (response.Url.Contains("/cancel", StringComparison.Ordinal))
+				cancelResponse = response;
+		};
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Cancel" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+
+		await Page.Locator("#cancel-reason").FillAsync("Position no longer available");
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Yes, cancel" }).ClickAsync();
+
+		await PollUntilAsync(
+			() => Task.FromResult(cancelResponse is not null),
+			() => "Expected the cancel request to reach the backend.");
+
+		var body = await cancelResponse!.JsonAsync();
+		body!.Value.GetProperty("cancellationReason").GetString().Should().Be("Position no longer available");
+	}
+
+	[Test]
+	public async Task ProfileActivitySection_ShowsCancellationReason_ForCancelledEngagement()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CancelReasonVolunteer");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var engagementsResponse = await olafHttp.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/engagements?pageNumber=1&pageSize=10");
+		engagementsResponse.EnsureSuccessStatusCode();
+		var engagements = await engagementsResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagements.GetProperty("items").EnumerateArray().First().GetProperty("id").GetString();
+
+		var cancelResponse = await olafHttp.PostAsJsonAsync(
+			$"/v1/engagements/{engagementId}/cancel",
+			new { reason = "Volunteer no longer needed" });
+		cancelResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.Locator("[data-testid='engagements-scope-past']").ClickAsync();
+
+		await Expect(Page.GetByText("Reason: Volunteer no longer needed"))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	private static async Task<string> ApplyAsync(HttpClient http, string opportunityId, string message)
+	{
+		var response = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
+		Uri keycloak, Uri backend, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Create a fresh organization rather than reusing olaf's shared seed
+		// org - other VisualTests running concurrently in this shared Aspire
+		// session can mutate/delete shared orgs, which made GET
+		// /v1/organizations intermittently race to an empty list here.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"{label} Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain Organization
+		// aggregate (unlike GetOrganizations, which projects to a DTO), so
+		// its strongly-typed OrganizationId record struct serializes as a
+		// nested { "value": "<guid>" } object rather than a plain string.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"{label} {suffix}",
+			description = "Created by EngagementCancellationReasonTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return (opportunity.GetProperty("id").GetString()!, organizationId);
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5316,6 +5316,7 @@ export interface EngagementSummary {
     location?: string | undefined;
     volunteerEmail?: string | undefined;
     volunteerPhone?: string | undefined;
+    cancellationReason?: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import Modal from "./Modal";
 import Button from "./Button";
@@ -11,6 +12,8 @@ interface Props {
 	onClose: () => void;
 	loading?: boolean;
 	error?: string | null;
+	/** Extra content rendered between the message and the action buttons, e.g. an optional-detail input. */
+	children?: ReactNode;
 }
 
 export default function ConfirmDialog({
@@ -21,14 +24,21 @@ export default function ConfirmDialog({
 	onClose,
 	loading = false,
 	error = null,
+	children,
 }: Props) {
 	const { t } = useTranslation();
+	// Scopes initial focus to the action row rather than the whole dialog, so
+	// an optional-detail child (e.g. EngagementManagementPage's cancel-reason
+	// textarea) rendered above it doesn't steal default focus from "Keep" -
+	// the safe, non-destructive action a confirm dialog should default to.
+	const actionsRef = useRef<HTMLDivElement>(null);
 
 	return (
 		<Modal
 			onClose={onClose}
 			labelledBy="confirm-dialog-title"
 			maxWidth="max-w-sm"
+			initialFocusRef={actionsRef}
 		>
 			<h2
 				id="confirm-dialog-title"
@@ -38,9 +48,11 @@ export default function ConfirmDialog({
 			</h2>
 			<p className="mt-2 text-sm text-gray-600">{message}</p>
 
+			{children && <div className="mt-3">{children}</div>}
+
 			{error && <ErrorBanner message={error} className="mt-3" />}
 
-			<div className="mt-5 flex justify-end gap-3">
+			<div ref={actionsRef} className="mt-5 flex justify-end gap-3">
 				<Button
 					type="button"
 					variant="secondary"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -560,6 +560,7 @@
       "scheduledFor": "Termin: {{range}}",
       "registeredOn": "Angemeldet: {{date}}",
       "deletedOpportunityTitle": "Dieser Bedarf wurde entfernt",
+      "cancellationReason": "Grund: {{reason}}",
       "checkIn": "Einchecken",
       "withdraw": "Zurückziehen",
       "withdrawing": "…",
@@ -716,7 +717,9 @@
       "cancel": {
         "title": "Engagement absagen?",
         "message": "Möchtest du dieses Engagement wirklich absagen? Der Freiwillige wird informiert.",
-        "confirm": "Ja, absagen"
+        "confirm": "Ja, absagen",
+        "reasonLabel": "Grund (optional)",
+        "reasonPlaceholder": "Teile dem Freiwilligen den Grund mit…"
       },
       "editTimeSlot": {
         "title": "Zeitslot bearbeiten?",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -560,6 +560,7 @@
       "scheduledFor": "Scheduled: {{range}}",
       "registeredOn": "Signed up: {{date}}",
       "deletedOpportunityTitle": "This opportunity has been removed",
+      "cancellationReason": "Reason: {{reason}}",
       "checkIn": "Check in",
       "withdraw": "Withdraw",
       "withdrawing": "…",
@@ -716,7 +717,9 @@
       "cancel": {
         "title": "Cancel engagement?",
         "message": "Are you sure you want to cancel this engagement? The volunteer will be informed.",
-        "confirm": "Yes, cancel"
+        "confirm": "Yes, cancel",
+        "reasonLabel": "Reason (optional)",
+        "reasonPlaceholder": "Let the volunteer know why…"
       },
       "editTimeSlot": {
         "title": "Edit time slot?",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -593,7 +593,7 @@ export default function EngagementManagementPage() {
 						disabled={cancelling}
 						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
 					/>
-					<p className="mt-1 text-right text-xs text-gray-400">
+					<p className="mt-1 text-right text-xs text-gray-500">
 						{cancelReason.length}/500
 					</p>
 				</ConfirmDialog>

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -70,6 +70,7 @@ export default function EngagementManagementPage() {
 	const [notFound, setNotFound] = useState(false);
 	const [confirming, setConfirming] = useState<string | null>(null);
 	const [confirmCancelId, setConfirmCancelId] = useState<string | null>(null);
+	const [cancelReason, setCancelReason] = useState("");
 	const [cancelling, setCancelling] = useState(false);
 	const [cancelError, setCancelError] = useState<string | null>(null);
 	const [checkingIn, setCheckingIn] = useState<string | null>(null);
@@ -204,13 +205,17 @@ export default function EngagementManagementPage() {
 		setCancelling(true);
 		setCancelError(null);
 		try {
-			const updated = await api.cancelEngagement(confirmCancelId, null);
+			const trimmedReason = cancelReason.trim();
+			const updated = await api.cancelEngagement(confirmCancelId, {
+				reason: trimmedReason.length > 0 ? trimmedReason : undefined,
+			});
 			setEngagements((prev) =>
 				prev.map((e) =>
 					e.id === confirmCancelId ? { ...e, status: updated.status } : e,
 				),
 			);
 			setConfirmCancelId(null);
+			setCancelReason("");
 		} catch (err) {
 			setCancelError(
 				err instanceof Error
@@ -225,6 +230,7 @@ export default function EngagementManagementPage() {
 	function handleCancelClose() {
 		if (cancelling) return;
 		setConfirmCancelId(null);
+		setCancelReason("");
 		setCancelError(null);
 	}
 
@@ -570,7 +576,27 @@ export default function EngagementManagementPage() {
 					onClose={handleCancelClose}
 					loading={cancelling}
 					error={cancelError}
-				/>
+				>
+					<label
+						htmlFor="cancel-reason"
+						className="block text-xs font-medium text-gray-700"
+					>
+						{t("confirmDialog.cancel.reasonLabel")}
+					</label>
+					<textarea
+						id="cancel-reason"
+						rows={3}
+						maxLength={500}
+						value={cancelReason}
+						onChange={(e) => setCancelReason(e.target.value)}
+						placeholder={t("confirmDialog.cancel.reasonPlaceholder")}
+						disabled={cancelling}
+						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+					/>
+					<p className="mt-1 text-right text-xs text-gray-400">
+						{cancelReason.length}/500
+					</p>
+				</ConfirmDialog>
 			)}
 
 			{feedbackStats !== null && (

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -347,6 +347,13 @@ export default function ActivitySection() {
 											&ldquo;{e.message}&rdquo;
 										</p>
 									)}
+									{e.status === "Cancelled" && e.cancellationReason && (
+										<p className="mt-1 text-xs text-gray-500">
+											{t("myEngagements.cancellationReason", {
+												reason: e.cancellationReason,
+											})}
+										</p>
+									)}
 									{e.timeSlotStartDateTime && e.timeSlotEndDateTime && (
 										<p className="mt-1 text-xs font-medium text-gray-700">
 											{t("myEngagements.scheduledFor", {


### PR DESCRIPTION
The backend already stored/emailed the cancellation reason end-to-end, but the organizer's cancel dialog never collected one and the volunteer's engagement list had no field to show it.

- Add an optional reason textarea to EngagementManagementPage's cancel ConfirmDialog and send it via cancelEngagement
- Add CancellationReason to EngagementSummary and populate it in all three EngagementReadRepository query paths
- Render the reason on a volunteer's Cancelled engagement card in ActivitySection
- Scope ConfirmDialog's initial focus to its action-button row so an injected child (the new textarea) doesn't steal default focus from the safe "Keep" action

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1051

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
