### PR TITLE
fix: email volunteers on opportunity deletion and material updates

### DIFF
--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -4,8 +4,8 @@ using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Engagements.Common;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Primitives;
 
 namespace Application.Engagements.CancelEngagement.v1;
@@ -32,26 +32,13 @@ internal sealed class CancelEngagementCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		engagement.Cancel(request.Reason).ThrowIfFailure();
-
-		var notification = Notification.Create(
-			engagement.VolunteerId!.Value,
-			NotificationKind.EngagementCancelled,
-			engagement.Id.Value);
-
-		await dbContext.Notifications.AddAsync(notification, cancellationToken);
-		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId!.Value.Value, cancellationToken);
-
-		var reasonText = string.IsNullOrWhiteSpace(request.Reason)
-			? string.Empty
-			: $"\n\nReason: {request.Reason}";
-
-		await emailService.SendAsync(
-			volunteer.Email,
-			"Your engagement has been cancelled",
-			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
-			$"Unfortunately your application for \"{opportunity.Title}\" has been cancelled.{reasonText}\n\n" +
-			$"We hope to see you at another opportunity.\n\nEinsatzbereit",
+		await EngagementCancellationHelper.CancelAndNotifyAsync(
+			dbContext,
+			keycloakUserService,
+			emailService,
+			engagement,
+			opportunity.Title,
+			request.Reason,
 			cancellationToken);
 
 		return engagement;

--- a/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
@@ -1,0 +1,50 @@
+using Application.Common.Email;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+
+namespace Application.Engagements.Common;
+
+/// <summary>
+/// Cancels an engagement and sends the same in-app notification + email that
+/// <see cref="CancelEngagement.v1.CancelEngagementCommandHandler"/> sends for an
+/// organizer-triggered cancellation - shared so engagements auto-cancelled by an
+/// opportunity deletion notify the volunteer identically instead of only via the
+/// opportunity-level notification (einsatzbereit#1057).
+/// </summary>
+internal static class EngagementCancellationHelper
+{
+	public static async Task CancelAndNotifyAsync(
+		IApplicationDbContext dbContext,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
+		Engagement engagement,
+		string opportunityTitle,
+		string? reason,
+		CancellationToken cancellationToken)
+	{
+		engagement.Cancel(reason).ThrowIfFailure();
+
+		var notification = Notification.Create(
+			engagement.VolunteerId!.Value,
+			NotificationKind.EngagementCancelled,
+			engagement.Id.Value);
+
+		await dbContext.Notifications.AddAsync(notification, cancellationToken);
+		var volunteer = await keycloakUserService.GetUserAsync(engagement.VolunteerId!.Value.Value, cancellationToken);
+
+		var reasonText = string.IsNullOrWhiteSpace(reason)
+			? string.Empty
+			: $"\n\nReason: {reason}";
+
+		await emailService.SendAsync(
+			volunteer.Email,
+			"Your engagement has been cancelled",
+			$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
+			$"Unfortunately your application for \"{opportunityTitle}\" has been cancelled.{reasonText}\n\n" +
+			$"We hope to see you at another opportunity.\n\nEinsatzbereit",
+			cancellationToken);
+	}
+}

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Domain.Notifications;
@@ -14,6 +16,11 @@ internal static class OpportunityNotificationHelper
 	/// has an active (pending or confirmed) engagement on the opportunity, or -
 	/// when <paramref name="timeSlotId"/> is given - only those engaged on that
 	/// specific time slot. The opportunity id is used as the related entity id.
+	/// When <paramref name="keycloakUserService"/>, <paramref name="emailService"/>
+	/// and <paramref name="opportunityTitle"/> are all supplied, also emails every
+	/// notified volunteer in a single batch (einsatzbereit#1057) - callers that
+	/// already email affected volunteers through another path (e.g. an engagement
+	/// cancellation) should omit these so the volunteer isn't emailed twice.
 	/// </summary>
 	public static async Task NotifyActiveVolunteersAsync(
 		IApplicationDbContext dbContext,
@@ -21,7 +28,10 @@ internal static class OpportunityNotificationHelper
 		VolunteerOpportunityId opportunityId,
 		NotificationKind kind,
 		CancellationToken cancellationToken,
-		TimeSlotId? timeSlotId = null)
+		TimeSlotId? timeSlotId = null,
+		IKeycloakUserService? keycloakUserService = null,
+		IEmailService? emailService = null,
+		string? opportunityTitle = null)
 	{
 		var volunteerIds = await engagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync(
 			opportunityId, timeSlotId, cancellationToken);
@@ -35,5 +45,21 @@ internal static class OpportunityNotificationHelper
 
 			await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		}
+
+		if (keycloakUserService is null || emailService is null || volunteerIds.Count == 0)
+			return;
+
+		var messages = new List<EmailMessage>(volunteerIds.Count);
+		foreach (var volunteerId in volunteerIds)
+		{
+			var volunteer = await keycloakUserService.GetUserAsync(volunteerId, cancellationToken);
+			messages.Add(new EmailMessage(
+				volunteer.Email,
+				$"An opportunity you signed up for has changed: \"{opportunityTitle}\"",
+				$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
+				$"The details for \"{opportunityTitle}\" have changed. Please check the app for the latest information.\n\nEinsatzbereit"));
+		}
+
+		await emailService.SendBatchAsync(messages, cancellationToken);
 	}
 }

--- a/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -24,7 +26,9 @@ namespace Application.Organizations.AdminShadowDeleteOrganization.v1;
 /// </summary>
 internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<AdminShadowDeleteOrganizationCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -43,6 +47,8 @@ internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 			await VolunteerOpportunityDeletionHelper.ShadowDeleteAsync(
 				dbContext,
 				engagementReadRepository,
+				keycloakUserService,
+				emailService,
 				opportunity,
 				opportunity.Id,
 				request.AdminUserId,

--- a/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -17,7 +19,9 @@ namespace Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportuni
 /// </summary>
 internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<AdminShadowDeleteVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -33,6 +37,8 @@ internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 		await VolunteerOpportunityDeletionHelper.ShadowDeleteAsync(
 			dbContext,
 			engagementReadRepository,
+			keycloakUserService,
+			emailService,
 			opportunity,
 			opportunityId,
 			request.AdminUserId,

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -1,6 +1,9 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
+using Application.Engagements.Common;
 using Application.Notifications;
 using Domain.Notifications;
 using Domain.Reports;
@@ -20,6 +23,8 @@ internal static class VolunteerOpportunityDeletionHelper
 	public static async Task DeleteAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
 		VolunteerOpportunity opportunity,
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
@@ -27,7 +32,8 @@ internal static class VolunteerOpportunityDeletionHelper
 		CancellationToken cancellationToken)
 	{
 		await ResolveEngagementsAndReportsAsync(
-			dbContext, engagementReadRepository, opportunityId, actingUserId, now, cancellationToken);
+			dbContext, engagementReadRepository, keycloakUserService, emailService,
+			opportunity, opportunityId, actingUserId, now, cancellationToken);
 
 		dbContext.VolunteerOpportunities.Delete(opportunity);
 	}
@@ -42,6 +48,8 @@ internal static class VolunteerOpportunityDeletionHelper
 	public static async Task ShadowDeleteAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
 		VolunteerOpportunity opportunity,
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
@@ -49,7 +57,8 @@ internal static class VolunteerOpportunityDeletionHelper
 		CancellationToken cancellationToken)
 	{
 		await ResolveEngagementsAndReportsAsync(
-			dbContext, engagementReadRepository, opportunityId, actingUserId, now, cancellationToken);
+			dbContext, engagementReadRepository, keycloakUserService, emailService,
+			opportunity, opportunityId, actingUserId, now, cancellationToken);
 
 		opportunity.MarkDeleted(now).ThrowIfFailure();
 	}
@@ -57,6 +66,9 @@ internal static class VolunteerOpportunityDeletionHelper
 	private static async Task ResolveEngagementsAndReportsAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
+		VolunteerOpportunity opportunity,
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
 		DateTimeOffset now,
@@ -73,7 +85,17 @@ internal static class VolunteerOpportunityDeletionHelper
 			opportunityId, cancellationToken);
 		foreach (var engagement in activeEngagements)
 		{
-			engagement.Cancel("Opportunity was deleted.").ThrowIfFailure();
+			// Same notification + email path a single organizer-triggered cancel
+			// sends (#1057) - a deletion should not leave the volunteer with only
+			// the opportunity-level "was removed" notification above.
+			await EngagementCancellationHelper.CancelAndNotifyAsync(
+				dbContext,
+				keycloakUserService,
+				emailService,
+				engagement,
+				opportunity.Title,
+				"Opportunity was deleted.",
+				cancellationToken);
 		}
 
 		var openReports = await dbContext.GetOpenReportsForTargetAsync(

--- a/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
@@ -1,5 +1,7 @@
 using Application.Common.Authorization;
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -11,7 +13,9 @@ namespace Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 
 internal sealed class DeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<DeleteVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -35,6 +39,8 @@ internal sealed class DeleteVolunteerOpportunityCommandHandler(
 		await VolunteerOpportunityDeletionHelper.DeleteAsync(
 			dbContext,
 			engagementReadRepository,
+			keycloakUserService,
+			emailService,
 			opportunity,
 			opportunityId,
 			request.RequestingUserId,

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -1,5 +1,7 @@
 using Application.Common.Authorization;
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -12,7 +14,9 @@ namespace Application.VolunteerOpportunities.UpdateTimeSlot.v1;
 
 internal sealed class UpdateTimeSlotCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService)
 	: ICommandHandler<UpdateTimeSlotCommand, UpdateTimeSlotResult>
 {
 	public async ValueTask<UpdateTimeSlotResult> Handle(
@@ -75,7 +79,10 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			opportunityId,
 			NotificationKind.OpportunityUpdated,
 			cancellationToken,
-			timeSlotId);
+			timeSlotId,
+			keycloakUserService,
+			emailService,
+			opportunity.Title);
 
 		return new UpdateTimeSlotResult(1, []);
 	}

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -1,6 +1,8 @@
 using Application.Common.Authorization;
+using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Geocoding;
+using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -18,6 +20,8 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 	IEngagementReadRepository engagementReadRepository,
 	IGeocodingService geocodingService,
 	IPinGenerator pinGenerator,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
 	ILogger<UpdateVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<UpdateVolunteerOpportunityCommand, bool>
 {
@@ -90,7 +94,10 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 				engagementReadRepository,
 				opportunityId,
 				NotificationKind.OpportunityUpdated,
-				cancellationToken);
+				cancellationToken,
+				keycloakUserService: keycloakUserService,
+				emailService: emailService,
+				opportunityTitle: opportunity.Title);
 
 		return true;
 	}

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -157,4 +157,32 @@ public class CancelEngagementCommandHandlerTests
 		// Assert
 		result.Should().BeSameAs(engagement);
 	}
+
+	[Test]
+	public async Task Handle_ShouldNotifyAndEmailVolunteer_WhenEngagementCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = EngagementId.New();
+		var engagement = CreatePendingWaitlistEngagement();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		_keycloakUserService
+			.GetUserAsync(engagement.VolunteerId!.Value.Value, Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(engagement.VolunteerId!.Value.Value, "vera", "Vera", null, "vera@example.com"));
+
+		// Act
+		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId, "No longer needed."), cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == engagement.VolunteerId!.Value
+				&& n.Kind == NotificationKind.EngagementCancelled
+				&& n.RelatedEntityId == engagement.Id.Value),
+			cancellationToken);
+		await _emailService.Received(1).SendAsync(
+			"vera@example.com",
+			"Your engagement has been cancelled",
+			Arg.Is<string>(body => body!.Contains("Reason: No longer needed.")),
+			cancellationToken);
+	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.Organizations.AdminShadowDeleteOrganization.v1;
@@ -28,6 +30,8 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		Substitute.For<IAggregateRepository<Report, ReportId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly AdminShadowDeleteOrganizationCommandHandler _sut;
 
@@ -52,7 +56,10 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new AdminShadowDeleteOrganizationCommandHandler(_dbContext, _engagementReadRepository);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_sut = new AdminShadowDeleteOrganizationCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService);
 	}
 
 	private static Organization CreateOrganization(Guid id) =>
@@ -139,6 +146,46 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		// Assert
 		orgReport.Status.Should().Be(ReportStatus.Actioned);
 		opportunityReport.Status.Should().Be(ReportStatus.Actioned);
+	}
+
+	[Test]
+	public async Task Handle_ShouldEmailEngagedVolunteers_AcrossAllCascadedOpportunities(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the cascade must email affected volunteers on every one of the
+		// org's opportunities (#1057), not just the first.
+		var orgId = Guid.NewGuid();
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(organizationId, cancellationToken).Returns(organization);
+
+		var timeSlotId = TimeSlotId.New();
+		var opportunityA = CreateOpportunity(organizationId);
+		var engagementA = Engagement.CreateWaitlistSignUp(opportunityA.Id, UserId.New(), timeSlotId);
+		engagementA.Confirm();
+		var opportunityB = CreateOpportunity(organizationId);
+		var engagementB = Engagement.CreateWaitlistSignUp(opportunityB.Id, UserId.New(), timeSlotId);
+		engagementB.Confirm();
+
+		_dbContext
+			.GetOpportunitiesForOrganizationAsync(organizationId, cancellationToken)
+			.Returns([opportunityA, opportunityB]);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunityA.Id, cancellationToken)
+			.Returns([engagementA]);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunityB.Id, cancellationToken)
+			.Returns([engagementB]);
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _emailService.Received(2).SendAsync(
+			"user@example.com",
+			"Your engagement has been cancelled",
+			Arg.Is<string>(body => body!.Contains("Reason: Opportunity was deleted.")),
+			cancellationToken);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity.v1;
@@ -26,6 +28,8 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		Substitute.For<IAggregateRepository<Report, ReportId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly AdminShadowDeleteVolunteerOpportunityCommandHandler _sut;
 
@@ -47,7 +51,10 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
@@ -95,6 +102,42 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		// Assert
 		report.Status.Should().Be(ReportStatus.Actioned);
 		report.ResolvedByUserId.Should().Be(DefaultAdminUserId);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotifyAndEmailEachVolunteer_WhenActiveEngagementsAutoCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - same guarantee as the organizer-triggered delete (#1057): a
+		// shadow-delete's auto-cancelled engagements must notify+email too.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		var timeSlotId = TimeSlotId.New();
+		var engagement = Engagement.CreateWaitlistSignUp(
+			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
+		engagement.Confirm();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns([engagement]);
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == engagement.VolunteerId!.Value
+				&& n.Kind == NotificationKind.EngagementCancelled
+				&& n.RelatedEntityId == engagement.Id.Value),
+			cancellationToken);
+		await _emailService.Received(1).SendAsync(
+			"user@example.com",
+			"Your engagement has been cancelled",
+			Arg.Is<string>(body => body!.Contains("Reason: Opportunity was deleted.")),
+			cancellationToken);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
@@ -24,6 +26,8 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly DeleteVolunteerOpportunityCommandHandler _sut;
 
@@ -47,7 +51,10 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_sut = new DeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_sut = new DeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
@@ -148,6 +155,50 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		pendingEngagement.CancellationReason.Should().Be("Opportunity was deleted.");
 		confirmedEngagement.Status.Should().Be(EngagementStatus.Cancelled);
 		confirmedEngagement.CancellationReason.Should().Be("Opportunity was deleted.");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotifyAndEmailEachVolunteer_WhenActiveEngagementsAutoCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a deletion must notify+email the volunteer the same way an
+		// organizer-triggered single-engagement cancel does (einsatzbereit#1057),
+		// not just via the opportunity-level "was removed" notification.
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		var timeSlotId = TimeSlotId.New();
+		var pendingEngagement = Engagement.CreateWaitlistSignUp(
+			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
+		var confirmedEngagement = Engagement.CreateWaitlistSignUp(
+			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
+		confirmedEngagement.Confirm();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns([pendingEngagement, confirmedEngagement]);
+
+		// Act
+		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == pendingEngagement.VolunteerId!.Value
+				&& n.Kind == NotificationKind.EngagementCancelled
+				&& n.RelatedEntityId == pendingEngagement.Id.Value),
+			cancellationToken);
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == confirmedEngagement.VolunteerId!.Value
+				&& n.Kind == NotificationKind.EngagementCancelled
+				&& n.RelatedEntityId == confirmedEngagement.Id.Value),
+			cancellationToken);
+		await _emailService.Received(2).SendAsync(
+			"user@example.com",
+			"Your engagement has been cancelled",
+			Arg.Is<string>(body => body!.Contains("Reason: Opportunity was deleted.")),
+			cancellationToken);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -1,4 +1,6 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.UpdateTimeSlot.v1;
@@ -22,6 +24,8 @@ public class UpdateTimeSlotCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly UpdateTimeSlotCommandHandler _sut;
 
 	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
@@ -43,7 +47,13 @@ public class UpdateTimeSlotCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailService
+			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
+		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService);
 	}
 
 	private VolunteerOpportunity CreateWaitlistOpportunity() =>
@@ -184,6 +194,34 @@ public class UpdateTimeSlotCommandHandlerTests
 		await _notifRepo.DidNotReceive().AddAsync(
 			Arg.Is<Notification>(n => n!.RecipientId.Value == otherSlotVolunteer),
 			cancellationToken);
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages => messages!.Count == 1 && messages[0].To == "user@example.com"),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEmail_WhenNoActiveVolunteersOnEditedSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateWaitlistOpportunity();
+		var editedSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
+		var opportunityId = opportunity.Id.Value;
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		var command = new UpdateTimeSlotCommand(
+			opportunityId, editedSlot.Id.Value, BaseStart.AddHours(1), BaseEnd.AddHours(1), 10, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(),
+			Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -1,5 +1,7 @@
+using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Geocoding;
+using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
@@ -25,6 +27,8 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly UpdateVolunteerOpportunityCommandHandler _sut;
 
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
@@ -44,11 +48,19 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailService
+			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
 		_sut = new UpdateVolunteerOpportunityCommandHandler(
 			_dbContext,
 			_engagementReadRepository,
 			_geocodingService,
 			_pinGenerator,
+			_keycloakUserService,
+			_emailService,
 			NullLogger<UpdateVolunteerOpportunityCommandHandler>.Instance);
 	}
 
@@ -355,6 +367,10 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
 			cancellationToken);
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages =>
+				messages!.Count == 1 && messages[0].To == "user@example.com" && messages[0].Body.Contains("Neues Thema")),
+			cancellationToken);
 	}
 
 	[Test]
@@ -381,10 +397,13 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Act
 		await _sut.Handle(command, cancellationToken);
 
-		// Assert - no notification should be added
+		// Assert - no notification and no email should be sent
 		await _notifRepo.DidNotReceive().AddAsync(
 			Arg.Any<Notification>(),
 			cancellationToken);
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(),
+			Arg.Any<CancellationToken>());
 	}
 
 	[Test]


### PR DESCRIPTION
Auto-cancelled engagements from a deletion now go through the same notification+email path as an organizer-triggered single cancel, extracted into EngagementCancellationHelper. Material opportunity updates and time slot changes now also batch-email affected volunteers alongside the existing in-app notification.

Closes #1057

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
