### PR TITLE
feat: add keyword search to volunteer opportunity list

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
@@ -90,7 +90,8 @@ internal sealed class GetVolunteerOpportunitiesEndpoint
 			request.CenterLongitude,
 			request.RadiusKm,
 			request.Categories,
-			request.Tag);
+			request.Tag,
+			request.Search);
 
 		var result = await sender.Send(query, cancellationToken);
 

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesRequest.cs
@@ -17,4 +17,5 @@ public sealed record GetVolunteerOpportunitiesRequest(
 	double? CenterLongitude,
 	double? RadiusKm,
 	string[]? Categories,
-	string? Tag);
+	string? Tag,
+	string? Search);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -929,6 +929,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQuery.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQuery.cs
@@ -20,5 +20,6 @@ public sealed record GetVolunteerOpportunitiesQuery(
 	double? CenterLongitude,
 	double? RadiusKm,
 	string[]? Categories,
-	string? Tag)
+	string? Tag,
+	string? Search)
 	: IQuery<PagedList<VolunteerOpportunitySummary>>;

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesQueryHandler.cs
@@ -33,7 +33,8 @@ internal sealed class GetVolunteerOpportunitiesQueryHandler(
 			request.CenterLongitude,
 			request.RadiusKm,
 			request.Categories,
-			request.Tag);
+			request.Tag,
+			request.Search);
 
 		return await readRepository.GetPagedSummariesAsync(filter, cancellationToken);
 	}

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunityFilter.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunityFilter.cs
@@ -17,7 +17,8 @@ public sealed record VolunteerOpportunityFilter(
 	double? CenterLongitude = null,
 	double? RadiusKm = null,
 	string[]? Categories = null,
-	string? Tag = null)
+	string? Tag = null,
+	string? Search = null)
 {
 	public bool HasBoundingBox => North.HasValue && South.HasValue && East.HasValue && West.HasValue;
 

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -73,6 +73,12 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (!string.IsNullOrWhiteSpace(filter.Tag))
 			query = query.Where(x => x.vo.Tags.Contains(filter.Tag));
 
+		if (!string.IsNullOrWhiteSpace(filter.Search))
+		{
+			var search = filter.Search.ToLower();
+			query = query.Where(x => x.vo.Title.ToLower().Contains(search) || x.vo.Description.ToLower().Contains(search));
+		}
+
 		var boundingBox = ResolveBoundingBox(filter);
 
 		if (boundingBox is GeoBoundingBox box)

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunities/GetVolunteerOpportunitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunities/GetVolunteerOpportunitiesQueryHandlerTests.cs
@@ -21,7 +21,7 @@ public class GetVolunteerOpportunitiesQueryHandlerTests
 	}
 
 	private static GetVolunteerOpportunitiesQuery Query(int pageNumber, int pageSize) =>
-		new(pageNumber, pageSize, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		new(pageNumber, pageSize, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
 	private async Task<VolunteerOpportunityFilter> CapturedFilterAsync(int pageNumber, int pageSize)
 	{
@@ -76,5 +76,21 @@ public class GetVolunteerOpportunitiesQueryHandlerTests
 	{
 		var filter = await CapturedFilterAsync(pageNumber: 1, pageSize: 25);
 		filter.PageSize.Should().Be(25);
+	}
+
+	[Test]
+	public async Task Handle_ShouldForwardSearch_ToFilter()
+	{
+		VolunteerOpportunityFilter? captured = null;
+		_readRepo
+			.GetPagedSummariesAsync(Arg.Do<VolunteerOpportunityFilter>(f => captured = f), Arg.Any<CancellationToken>())
+			.Returns(new PagedList<VolunteerOpportunitySummary>([], 0, 1, 10));
+
+		var query = new GetVolunteerOpportunitiesQuery(
+			1, 10, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, "Tafel");
+		await _sut.Handle(query, CancellationToken.None);
+
+		captured.Should().NotBeNull();
+		captured!.Search.Should().Be("Tafel");
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -85,7 +85,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<PagedListOfVolunteerOpportunitySummary> GetVolunteerOpportunitiesAsync(int pageNumber, int pageSize, string? city = null, string? occurrence = null, string? participationType = null, bool? isRemote = null, System.DateTimeOffset? dateFrom = null, System.DateTimeOffset? dateTo = null, double? north = null, double? south = null, double? east = null, double? west = null, double? centerLatitude = null, double? centerLongitude = null, double? radiusKm = null, System.Collections.Generic.IEnumerable<string>? categories = null, string? tag = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<PagedListOfVolunteerOpportunitySummary> GetVolunteerOpportunitiesAsync(int pageNumber, int pageSize, string? city = null, string? occurrence = null, string? participationType = null, bool? isRemote = null, System.DateTimeOffset? dateFrom = null, System.DateTimeOffset? dateTo = null, double? north = null, double? south = null, double? east = null, double? west = null, double? centerLatitude = null, double? centerLongitude = null, double? radiusKm = null, System.Collections.Generic.IEnumerable<string>? categories = null, string? tag = null, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -1644,7 +1644,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<PagedListOfVolunteerOpportunitySummary> GetVolunteerOpportunitiesAsync(int pageNumber, int pageSize, string? city = null, string? occurrence = null, string? participationType = null, bool? isRemote = null, System.DateTimeOffset? dateFrom = null, System.DateTimeOffset? dateTo = null, double? north = null, double? south = null, double? east = null, double? west = null, double? centerLatitude = null, double? centerLongitude = null, double? radiusKm = null, System.Collections.Generic.IEnumerable<string>? categories = null, string? tag = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<PagedListOfVolunteerOpportunitySummary> GetVolunteerOpportunitiesAsync(int pageNumber, int pageSize, string? city = null, string? occurrence = null, string? participationType = null, bool? isRemote = null, System.DateTimeOffset? dateFrom = null, System.DateTimeOffset? dateTo = null, double? north = null, double? south = null, double? east = null, double? west = null, double? centerLatitude = null, double? centerLongitude = null, double? radiusKm = null, System.Collections.Generic.IEnumerable<string>? categories = null, string? tag = null, string? search = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (pageNumber == null)
                 throw new System.ArgumentNullException("pageNumber");
@@ -1727,6 +1727,10 @@ namespace IntegrationTests
                     if (tag != null)
                     {
                         urlBuilder_.Append(System.Uri.EscapeDataString("Tag")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(tag, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (search != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("Search")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(search, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -621,6 +621,66 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		nonMatching.TotalItems.Should().Be(0);
 	}
 
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldFilterBySearch_MatchingTitleOrDescription(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var titleMatch = await CreateVolunteerOpportunityAsync(
+			authenticatedClient, orgId, "Downtown Food Bank Drive", "Help sort donations.", cancellationToken);
+		var descriptionMatch = await CreateVolunteerOpportunityAsync(
+			authenticatedClient, orgId, "Weekend Cleanup", "Volunteers needed at the food bank.", cancellationToken);
+		var nonMatch = await CreateVolunteerOpportunityAsync(
+			authenticatedClient, orgId, "Tutoring for Kids", "Support students after school.", cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, search: "food bank", cancellationToken: cancellationToken);
+
+		var ids = result.Items.Select(i => i.Id).ToList();
+		result.TotalItems.Should().Be(2);
+		ids.Should().Contain(titleMatch.Id);
+		ids.Should().Contain(descriptionMatch.Id);
+		ids.Should().NotContain(nonMatch.Id);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldMatchSearch_CaseInsensitively(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var match = await CreateVolunteerOpportunityAsync(
+			authenticatedClient, orgId, "Tutoring for Kids", "Support students after school.", cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, search: "TUTORING", cancellationToken: cancellationToken);
+
+		result.TotalItems.Should().Be(1);
+		result.Items.Single().Id.Should().Be(match.Id);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReturnEmpty_WhenSearchMatchesNothing(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		await CreateVolunteerOpportunityAsync(authenticatedClient, orgId, "Opportunity", "Description", cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, search: "Nonexistent Keyword Xyz", cancellationToken: cancellationToken);
+
+		result.TotalItems.Should().Be(0);
+		result.Items.Should().BeEmpty();
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
 	{
 		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -694,9 +694,10 @@ export class EinsatzbereitApi {
      * @param radiusKm (optional) 
      * @param categories (optional) 
      * @param tag (optional) 
+     * @param search (optional) 
      * @return OK
      */
-    getVolunteerOpportunities(pageNumber: number, pageSize: number, city: string | undefined, occurrence: string | undefined, participationType: string | undefined, isRemote: boolean | undefined, dateFrom: Date | undefined, dateTo: Date | undefined, north: number | undefined, south: number | undefined, east: number | undefined, west: number | undefined, centerLatitude: number | undefined, centerLongitude: number | undefined, radiusKm: number | undefined, categories: string[] | undefined, tag: string | undefined, signal?: AbortSignal): Promise<PagedListOfVolunteerOpportunitySummary> {
+    getVolunteerOpportunities(pageNumber: number, pageSize: number, city: string | undefined, occurrence: string | undefined, participationType: string | undefined, isRemote: boolean | undefined, dateFrom: Date | undefined, dateTo: Date | undefined, north: number | undefined, south: number | undefined, east: number | undefined, west: number | undefined, centerLatitude: number | undefined, centerLongitude: number | undefined, radiusKm: number | undefined, categories: string[] | undefined, tag: string | undefined, search: string | undefined, signal?: AbortSignal): Promise<PagedListOfVolunteerOpportunitySummary> {
         let url_ = this.baseUrl + "/v1/volunteer-opportunities?";
         if (pageNumber === undefined || pageNumber === null)
             throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
@@ -766,6 +767,10 @@ export class EinsatzbereitApi {
             throw new globalThis.Error("The parameter 'tag' cannot be null.");
         else if (tag !== undefined)
             url_ += "Tag=" + encodeURIComponent("" + tag) + "&";
+        if (search === null)
+            throw new globalThis.Error("The parameter 'search' cannot be null.");
+        else if (search !== undefined)
+            url_ += "Search=" + encodeURIComponent("" + search) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -18,9 +18,12 @@ import {
 	GlobeIcon,
 	HashIcon,
 	PinIcon,
+	SearchIcon,
 	TagIcon,
 	UsersIcon,
 } from "./icons";
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const CATEGORY_VALUES = [
 	"Social",
@@ -49,6 +52,7 @@ export default function VolunteerOpportunitiesList() {
 	const dateTo = searchParams.get("dateTo") ?? "";
 	const categoriesParam = searchParams.get("categories") ?? "";
 	const tag = searchParams.get("tag") ?? "";
+	const search = searchParams.get("search") ?? "";
 	const city = searchParams.get("city") ?? "";
 	const lat = searchParams.get("lat") ?? "";
 	const lng = searchParams.get("lng") ?? "";
@@ -62,6 +66,8 @@ export default function VolunteerOpportunitiesList() {
 	const [openFilter, setOpenFilter] = useState<string | null>(null);
 	const [locationCityInput, setLocationCityInput] = useState(city);
 	const [locationLoading, setLocationLoading] = useState(false);
+	const [searchInput, setSearchInput] = useState(search);
+	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const {
 		suggestions: locationSuggestions,
@@ -89,6 +95,7 @@ export default function VolunteerOpportunitiesList() {
 		dateTo,
 		categoriesParam,
 		tag,
+		search,
 		lat,
 		lng,
 		radius,
@@ -107,6 +114,39 @@ export default function VolunteerOpportunitiesList() {
 		return () => document.removeEventListener("mousedown", handleOutside);
 	}, []);
 
+	useEffect(() => {
+		return () => {
+			if (searchTimer.current) clearTimeout(searchTimer.current);
+		};
+	}, []);
+
+	function commitSearch(value: string) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (value) next.set("search", value);
+				else next.delete("search");
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleSearchInputChange(value: string) {
+		setSearchInput(value);
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		searchTimer.current = setTimeout(
+			() => commitSearch(value),
+			SEARCH_DEBOUNCE_MS,
+		);
+	}
+
+	function handleClearSearch() {
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		setSearchInput("");
+		commitSearch("");
+	}
+
 	function updateFilter(key: string, value: string) {
 		const next = new URLSearchParams(window.location.search);
 		if (value) next.set(key, value);
@@ -115,6 +155,8 @@ export default function VolunteerOpportunitiesList() {
 	}
 
 	function clearFilters() {
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		setSearchInput("");
 		setSearchParams(
 			(prev) => {
 				const next = new URLSearchParams(prev);
@@ -129,6 +171,7 @@ export default function VolunteerOpportunitiesList() {
 				next.delete("dateTo");
 				next.delete("categories");
 				next.delete("tag");
+				next.delete("search");
 				return next;
 			},
 			{ replace: true },
@@ -235,7 +278,8 @@ export default function VolunteerOpportunitiesList() {
 		dateFrom ||
 		dateTo ||
 		selectedCategories.length > 0 ||
-		tag
+		tag ||
+		search
 	);
 
 	const locationDisplayValue = hasLocation ? `${city} · ${radius} km` : "";
@@ -269,6 +313,31 @@ export default function VolunteerOpportunitiesList() {
 				<p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-gray-500 sm:text-base">
 					{t("opportunities.subtitle")}
 				</p>
+
+				<div className="relative mx-auto mt-6 max-w-lg">
+					<label htmlFor="opportunities-search" className="sr-only">
+						{t("opportunities.searchPlaceholder")}
+					</label>
+					<SearchIcon className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+					<input
+						id="opportunities-search"
+						type="search"
+						value={searchInput}
+						onChange={(e) => handleSearchInputChange(e.target.value)}
+						placeholder={t("opportunities.searchPlaceholder")}
+						className="w-full rounded-full border border-gray-200 bg-white py-2.5 pl-10 pr-9 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-500 focus:outline-none"
+					/>
+					{searchInput && (
+						<button
+							type="button"
+							onClick={handleClearSearch}
+							aria-label={t("opportunities.clearSearch")}
+							className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+						>
+							&times;
+						</button>
+					)}
+				</div>
 			</div>
 
 			{/* Filter bar */}

--- a/frontend/src/components/VolunteerOpportunitiesList/icons.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/icons.tsx
@@ -25,6 +25,29 @@ export function PinIcon({ className = "h-3.5 w-3.5" }: { className?: string }) {
 	);
 }
 
+export function SearchIcon({
+	className = "h-3.5 w-3.5",
+}: {
+	className?: string;
+}) {
+	return (
+		<svg
+			className={className}
+			fill="none"
+			viewBox="0 0 24 24"
+			strokeWidth="2"
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+			/>
+		</svg>
+	);
+}
+
 export function TagIcon({ className = "h-3.5 w-3.5" }: { className?: string }) {
 	return (
 		<svg

--- a/frontend/src/components/VolunteerOpportunitiesList/useVolunteerOpportunitiesData.ts
+++ b/frontend/src/components/VolunteerOpportunitiesList/useVolunteerOpportunitiesData.ts
@@ -15,6 +15,7 @@ export interface VolunteerOpportunitiesFilters {
 	dateTo: string;
 	categoriesParam: string;
 	tag: string;
+	search: string;
 	lat: string;
 	lng: string;
 	radius: string;
@@ -34,6 +35,7 @@ export function useVolunteerOpportunitiesData(
 		dateTo,
 		categoriesParam,
 		tag,
+		search,
 		lat,
 		lng,
 		radius,
@@ -72,6 +74,7 @@ export function useVolunteerOpportunitiesData(
 				categories:
 					selectedCategories.length > 0 ? selectedCategories : undefined,
 				tag: tag || undefined,
+				search: search || undefined,
 			});
 		},
 		{
@@ -86,6 +89,7 @@ export function useVolunteerOpportunitiesData(
 				dateTo,
 				categoriesParam,
 				tag,
+				search,
 			],
 			getErrorMessage: (err) => getApiErrorMessage(err, t("error.serverError")),
 		},

--- a/frontend/src/lib/volunteerOpportunities.test.ts
+++ b/frontend/src/lib/volunteerOpportunities.test.ts
@@ -40,6 +40,7 @@ describe("fetchVolunteerOpportunities", () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 		);
 	});
 
@@ -69,6 +70,7 @@ describe("fetchVolunteerOpportunities", () => {
 				radiusKm: 7,
 				categories: ["environment"],
 				tag: "cleanup",
+				search: "food bank",
 			},
 			signal,
 		);
@@ -91,6 +93,7 @@ describe("fetchVolunteerOpportunities", () => {
 			7,
 			["environment"],
 			"cleanup",
+			"food bank",
 			signal,
 		);
 	});

--- a/frontend/src/lib/volunteerOpportunities.ts
+++ b/frontend/src/lib/volunteerOpportunities.ts
@@ -21,6 +21,7 @@ export interface FetchVolunteerOpportunitiesOptions {
 	radiusKm?: number;
 	categories?: string[];
 	tag?: string;
+	search?: string;
 }
 
 /**
@@ -50,6 +51,7 @@ export function fetchVolunteerOpportunities(
 		options.radiusKm,
 		options.categories,
 		options.tag,
+		options.search,
 		signal,
 	);
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -86,6 +86,8 @@
       "currentNeeds": "Aktuelle Einsätze",
       "subtitle": "Finde eine Aufgabe in deiner Nähe und pack mit an - die meisten dauern nur wenige Stunden.",
       "cityPlaceholder": "Stadt…",
+      "searchPlaceholder": "Einsätze nach Stichwort suchen…",
+      "clearSearch": "Suche löschen",
       "allFrequencies": "Alle Häufigkeiten",
       "oneTime": "Einmalig",
       "recurring": "Regelmäßig",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -86,6 +86,8 @@
       "currentNeeds": "Current Opportunities",
       "subtitle": "Find a cause near you and lend a hand - most take just a few hours.",
       "cityPlaceholder": "City…",
+      "searchPlaceholder": "Search opportunities by keyword…",
+      "clearSearch": "Clear search",
       "allFrequencies": "All frequencies",
       "oneTime": "One-time",
       "recurring": "Recurring",


### PR DESCRIPTION
Adds an optional Search parameter that matches Title/Description (case-insensitive) alongside the existing 17 filters, mirroring the pattern already used by organizations/users search. Wires a debounced search box into the opportunity discovery UI.

Closes #1049

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1049

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
