### PR TITLE
feat: surface volunteer contact info for organizers and self-service phone

### DIFF
--- a/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
+++ b/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
@@ -44,6 +44,9 @@ internal sealed class UpdateUserProfileEndpoint
 		if (request.Bio is { Length: > 1000 })
 			return Results.Problem("Bio must not exceed 1000 characters.", statusCode: StatusCodes.Status400BadRequest);
 
+		if (request.Phone is { Length: > 30 })
+			return Results.Problem("Phone must not exceed 30 characters.", statusCode: StatusCodes.Status400BadRequest);
+
 		Domain.Users.PreferredContact? preferredContact = null;
 		if (request.PreferredContact is not null &&
 			Enum.TryParse<Domain.Users.PreferredContact>(request.PreferredContact, out var parsed))
@@ -56,6 +59,7 @@ internal sealed class UpdateUserProfileEndpoint
 			request.FirstName,
 			request.LastName,
 			request.Bio,
+			request.Phone,
 			request.Skills ?? [],
 			request.Languages ?? [],
 			preferredContact);

--- a/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileRequest.cs
+++ b/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileRequest.cs
@@ -6,6 +6,7 @@ public sealed record UpdateUserProfileRequest(
 	[MaxLength(100)] string? FirstName = null,
 	[MaxLength(100)] string? LastName = null,
 	[MaxLength(1000)] string? Bio = null,
+	[MaxLength(30)] string? Phone = null,
 	IReadOnlyList<string>? Skills = null,
 	IReadOnlyList<string>? Languages = null,
 	[MaxLength(200)] string? PreferredContact = null);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -6495,6 +6495,18 @@
               "null",
               "string"
             ]
+          },
+          "volunteerEmail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "volunteerPhone": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -6642,6 +6654,7 @@
           "email",
           "avatarUrl",
           "bio",
+          "phone",
           "skills",
           "languages",
           "preferredContact"
@@ -6677,6 +6690,12 @@
             ]
           },
           "bio": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
             "type": [
               "null",
               "string"
@@ -8093,6 +8112,12 @@
             ]
           },
           "bio": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
             "type": [
               "null",
               "string"

--- a/backend/src/Application/Common/Keycloak/IKeycloakUserService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakUserService.cs
@@ -28,6 +28,10 @@ public interface IKeycloakUserService
 		IReadOnlyList<Guid> userIds,
 		CancellationToken cancellationToken = default);
 
+	Task<IReadOnlyDictionary<Guid, KeycloakUserProfile>> GetUserProfilesAsync(
+		IReadOnlyList<Guid> userIds,
+		CancellationToken cancellationToken = default);
+
 	Task UpdateUserAsync(
 		Guid userId,
 		string? firstName,

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -16,4 +16,6 @@ public sealed record EngagementSummary(
 	string? VolunteerName = null,
 	DateTimeOffset? TimeSlotStartDateTime = null,
 	DateTimeOffset? TimeSlotEndDateTime = null,
-	string? Location = null);
+	string? Location = null,
+	string? VolunteerEmail = null,
+	string? VolunteerPhone = null);

--- a/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
@@ -39,13 +39,18 @@ internal sealed class GetEngagementsQueryHandler(
 			.Select(e => e.VolunteerId!.Value)
 			.Distinct()
 			.ToList();
-		var nameMap = await keycloakUserService.GetDisplayNamesAsync(volunteerIds, cancellationToken);
+		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
 
-		return page.Map(e => e with
+		return page.Map(e =>
 		{
-			VolunteerName = e.VolunteerId is Guid volunteerId
-				? nameMap.GetValueOrDefault(volunteerId)
-				: null,
+			if (e.VolunteerId is not Guid volunteerId || !profileMap.TryGetValue(volunteerId, out var profile))
+				return e;
+
+			var name = profile.FirstName is not null || profile.LastName is not null
+				? $"{profile.FirstName} {profile.LastName}".Trim()
+				: profile.Username;
+
+			return e with { VolunteerName = name, VolunteerEmail = profile.Email };
 		});
 	}
 }

--- a/backend/src/Application/Users/GetUserProfile/v1/GetUserProfileQuery.cs
+++ b/backend/src/Application/Users/GetUserProfile/v1/GetUserProfileQuery.cs
@@ -14,6 +14,7 @@ public sealed record MyProfileResponse(
 	string Email,
 	string? AvatarUrl,
 	string? Bio,
+	string? Phone,
 	IReadOnlyList<string> Skills,
 	IReadOnlyList<string> Languages,
 	string? PreferredContact);

--- a/backend/src/Application/Users/GetUserProfile/v1/GetUserProfileQueryHandler.cs
+++ b/backend/src/Application/Users/GetUserProfile/v1/GetUserProfileQueryHandler.cs
@@ -36,6 +36,7 @@ internal sealed class GetUserProfileQueryHandler(
 			keycloakUser.Email,
 			user.AvatarUrl,
 			user.Bio,
+			user.Phone,
 			user.Skills,
 			user.Languages,
 			user.PreferredContact?.ToString());

--- a/backend/src/Application/Users/UpdateUserProfile/v1/UpdateUserProfileCommand.cs
+++ b/backend/src/Application/Users/UpdateUserProfile/v1/UpdateUserProfileCommand.cs
@@ -8,6 +8,7 @@ public sealed record UpdateUserProfileCommand(
 	string? FirstName,
 	string? LastName,
 	string? Bio,
+	string? Phone,
 	IReadOnlyList<string> Skills,
 	IReadOnlyList<string> Languages,
 	PreferredContact? PreferredContactValue)

--- a/backend/src/Application/Users/UpdateUserProfile/v1/UpdateUserProfileCommandHandler.cs
+++ b/backend/src/Application/Users/UpdateUserProfile/v1/UpdateUserProfileCommandHandler.cs
@@ -30,6 +30,7 @@ internal sealed class UpdateUserProfileCommandHandler(
 		}
 
 		user.ChangeBio(request.Bio);
+		user.SetPhone(request.Phone);
 		user.UpdateSkills(request.Skills);
 		user.UpdateLanguages(request.Languages);
 		user.SetPreferredContact(request.PreferredContactValue);

--- a/backend/src/Domain/Users/User.cs
+++ b/backend/src/Domain/Users/User.cs
@@ -14,6 +14,8 @@ public sealed class User
 
 	public string? Bio { get; private set; }
 
+	public string? Phone { get; private set; }
+
 	public IReadOnlyList<string> Skills => _skills.AsReadOnly();
 
 	public IReadOnlyList<string> Languages => _languages.AsReadOnly();
@@ -40,6 +42,11 @@ public sealed class User
 	public void ChangeBio(string? bio)
 	{
 		Bio = bio;
+	}
+
+	public void SetPhone(string? phone)
+	{
+		Phone = phone;
 	}
 
 	public void UpdateSkills(IReadOnlyCollection<string> skills)

--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -68,6 +68,25 @@ internal sealed class KeycloakUserService(
 		return result;
 	}
 
+	public async Task<IReadOnlyDictionary<Guid, KeycloakUserProfile>> GetUserProfilesAsync(
+		IReadOnlyList<Guid> userIds,
+		CancellationToken cancellationToken = default)
+	{
+		var result = new Dictionary<Guid, KeycloakUserProfile>(userIds.Count);
+		foreach (var userId in userIds.Distinct())
+		{
+			try
+			{
+				result[userId] = await GetUserAsync(userId, cancellationToken);
+			}
+			catch
+			{
+				// ignore individual lookup failures - same tolerance as GetDisplayNamesAsync above
+			}
+		}
+		return result;
+	}
+
 	public async Task UpdateUserAsync(
 		Guid userId,
 		string? firstName,

--- a/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -25,6 +25,8 @@ internal sealed class UserConfiguration
 
 		builder.Property(u => u.Bio);
 
+		builder.Property(u => u.Phone);
+
 		var listComparer = new ValueComparer<IReadOnlyList<string>>(
 			(a, b) => a != null && b != null && a.SequenceEqual(b),
 			v => v.Aggregate(0, (h, s) => HashCode.Combine(h, s.GetHashCode())),

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730074229_AddUserPhone.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730074229_AddUserPhone.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260730074229_AddUserPhone")]
+	partial class AddUserPhone
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730074229_AddUserPhone.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730074229_AddUserPhone.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddUserPhone : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "phone",
+				table: "user",
+				type: "text",
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "phone",
+				table: "user");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -127,6 +127,20 @@ internal sealed class EngagementReadRepository(
 			.Take(pageSize)
 			.ToListAsync(cancellationToken);
 
+		var pageVolunteerIds = raw
+			.Where(x => x.VolunteerId is not null)
+			.Select(x => x.VolunteerId!.Value)
+			.Distinct()
+			.ToList();
+
+		Dictionary<Guid, string?> phonesByVolunteerId = [];
+		if (pageVolunteerIds.Count > 0)
+		{
+			phonesByVolunteerId = await dbContext.UsersQuery
+				.Where(u => pageVolunteerIds.Contains(u.Id))
+				.ToDictionaryAsync(u => u.Id.Value, u => u.Phone, cancellationToken);
+		}
+
 		var items = raw.Select(x => new EngagementSummary(
 			x.Id.Value,
 			x.OpportunityId.Value,
@@ -139,7 +153,10 @@ internal sealed class EngagementReadRepository(
 			x.Status.ToString(),
 			x.IsCheckedIn,
 			x.FeedbackSubmittedAt.HasValue,
-			x.CreatedOn)).ToList();
+			x.CreatedOn,
+			VolunteerPhone: x.VolunteerId is not null
+				? phonesByVolunteerId.GetValueOrDefault(x.VolunteerId.Value.Value)
+				: null)).ToList();
 
 		return new PagedList<EngagementSummary>(items, totalCount, pageNumber, pageSize);
 	}

--- a/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
@@ -41,8 +41,8 @@ public class GetEngagementsQueryHandlerTests
 			.GetPagedByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
 			.Returns(new PagedList<EngagementSummary>([], 0, 1, 10));
 		_keycloakUserService
-			.GetDisplayNamesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-			.Returns(new Dictionary<Guid, string>());
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
 		_sut = new GetEngagementsQueryHandler(_readRepository, _dbContext, _keycloakUserService);
 	}
 
@@ -124,7 +124,47 @@ public class GetEngagementsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldEnrichVolunteerName_FromDisplayNameMap(
+	public async Task Handle_ShouldEnrichVolunteerNameAndEmail_FromKeycloakProfile(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			"Ready to help",
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow,
+			VolunteerPhone: "+49 30 1234567");
+
+		_readRepository
+			.GetPagedByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new PagedList<EngagementSummary>([engagement], 1, 1, 10));
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera", "Volunteer", "vera@example.com"),
+			});
+
+		var query = new GetEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId, 1, 10);
+
+		var result = await _sut.Handle(query, cancellationToken);
+
+		result.Items.Should().ContainSingle(e =>
+			e.VolunteerName == "Vera Volunteer"
+			&& e.VolunteerEmail == "vera@example.com"
+			&& e.VolunteerPhone == "+49 30 1234567");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToUsername_WhenKeycloakProfileHasNoName(
 		CancellationToken cancellationToken)
 	{
 		var volunteerId = Guid.NewGuid();
@@ -146,14 +186,58 @@ public class GetEngagementsQueryHandlerTests
 			.GetPagedByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
 			.Returns(new PagedList<EngagementSummary>([engagement], 1, 1, 10));
 		_keycloakUserService
-			.GetDisplayNamesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-			.Returns(new Dictionary<Guid, string> { [volunteerId] = "Vera Volunteer" });
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", null, null, "vera@example.com"),
+			});
 
 		var query = new GetEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId, 1, 10);
 
 		var result = await _sut.Handle(query, cancellationToken);
 
-		result.Items.Should().ContainSingle(e => e.VolunteerName == "Vera Volunteer");
+		result.Items.Should().ContainSingle(e => e.VolunteerName == "vera");
+	}
+
+	[Test]
+	public async Task Handle_ShouldLeaveVolunteerNameAndEmailNull_WhenKeycloakLookupFailsForVolunteer(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			"Ready to help",
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow,
+			VolunteerPhone: "+49 30 1234567");
+
+		_readRepository
+			.GetPagedByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new PagedList<EngagementSummary>([engagement], 1, 1, 10));
+		// GetUserProfilesAsync swallows individual Keycloak lookup failures (deleted user,
+		// transient error) and simply omits that id from the map - this volunteer's entry
+		// must fall back to whatever the repository already returned (VolunteerPhone stays
+		// intact; VolunteerName/VolunteerEmail stay null) rather than throwing.
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
+
+		var query = new GetEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId, 1, 10);
+
+		var result = await _sut.Handle(query, cancellationToken);
+
+		result.Items.Should().ContainSingle(e =>
+			e.VolunteerName == null
+			&& e.VolunteerEmail == null
+			&& e.VolunteerPhone == "+49 30 1234567");
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Users/GetUserProfile/GetUserProfileQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/GetUserProfile/GetUserProfileQueryHandlerTests.cs
@@ -1,0 +1,57 @@
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Users.GetUserProfile.v1;
+using AwesomeAssertions;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Users.GetUserProfile;
+
+public class GetUserProfileQueryHandlerTests
+{
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<User, UserId> _userRepo = Substitute.For<IAggregateRepository<User, UserId>>();
+	private readonly GetUserProfileQueryHandler _sut;
+
+	public GetUserProfileQueryHandlerTests()
+	{
+		_dbContext.Users.Returns(_userRepo);
+		_sut = new GetUserProfileQueryHandler(_keycloakUserService, _dbContext, _unitOfWork);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnPhone_WhenUserRowHasOne(
+		CancellationToken cancellationToken)
+	{
+		var userId = UserId.New();
+		_keycloakUserService
+			.GetUserAsync(userId.Value, cancellationToken)
+			.Returns(new KeycloakUserProfile(userId.Value, "vera", "Vera", "Volunteer", "vera@test.de"));
+
+		var user = User.Create(userId);
+		user.SetPhone("+49 30 1234567");
+		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+
+		var result = await _sut.Handle(new GetUserProfileQuery(userId), cancellationToken);
+
+		result.Phone.Should().Be("+49 30 1234567");
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnNullPhone_WhenNoUserRowExistsYet(
+		CancellationToken cancellationToken)
+	{
+		var userId = UserId.New();
+		_keycloakUserService
+			.GetUserAsync(userId.Value, cancellationToken)
+			.Returns(new KeycloakUserProfile(userId.Value, "vera", "Vera", "Volunteer", "vera@test.de"));
+
+		_userRepo.FindAsync(userId, cancellationToken).Returns((User?)null);
+
+		var result = await _sut.Handle(new GetUserProfileQuery(userId), cancellationToken);
+
+		result.Phone.Should().BeNull();
+	}
+}

--- a/backend/tests/Application.UnitTests/Users/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
@@ -1,0 +1,75 @@
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Users.UpdateUserProfile.v1;
+using AwesomeAssertions;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Users.UpdateUserProfile;
+
+public class UpdateUserProfileCommandHandlerTests
+{
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<User, UserId> _userRepo = Substitute.For<IAggregateRepository<User, UserId>>();
+	private readonly UpdateUserProfileCommandHandler _sut;
+
+	public UpdateUserProfileCommandHandlerTests()
+	{
+		_dbContext.Users.Returns(_userRepo);
+		_sut = new UpdateUserProfileCommandHandler(_keycloakUserService, _dbContext, _unitOfWork);
+	}
+
+	[Test]
+	public async Task Handle_ShouldSetPhone_OnExistingUserRow(
+		CancellationToken cancellationToken)
+	{
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+
+		var command = new UpdateUserProfileCommand(
+			userId, "Vera", "Volunteer", "Bio", "+49 30 1234567", [], [], null);
+
+		await _sut.Handle(command, cancellationToken);
+
+		user.Phone.Should().Be("+49 30 1234567");
+	}
+
+	[Test]
+	public async Task Handle_ShouldClearPhone_WhenNullGiven(
+		CancellationToken cancellationToken)
+	{
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		user.SetPhone("+49 30 1234567");
+		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+
+		var command = new UpdateUserProfileCommand(
+			userId, "Vera", "Volunteer", "Bio", null, [], [], null);
+
+		await _sut.Handle(command, cancellationToken);
+
+		user.Phone.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldSetPhone_OnNewlyCreatedUserRow(
+		CancellationToken cancellationToken)
+	{
+		var userId = UserId.New();
+		_userRepo.FindAsync(userId, cancellationToken).Returns((User?)null);
+
+		User? added = null;
+		await _userRepo.AddAsync(Arg.Do<User>(u => added = u), cancellationToken);
+
+		var command = new UpdateUserProfileCommand(
+			userId, "Vera", "Volunteer", "Bio", "+49 30 1234567", [], [], null);
+
+		await _sut.Handle(command, cancellationToken);
+
+		added.Should().NotBeNull();
+		added!.Phone.Should().Be("+49 30 1234567");
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -10241,6 +10241,12 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("location")]
         public string? Location { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("volunteerEmail")]
+        public string? VolunteerEmail { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("volunteerPhone")]
+        public string? VolunteerPhone { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -10414,6 +10420,9 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("bio")]
         public string? Bio { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("phone")]
+        public string? Phone { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("skills")]
         [System.ComponentModel.DataAnnotations.Required]
@@ -11669,6 +11678,9 @@ namespace IntegrationTests
 
         [System.Text.Json.Serialization.JsonPropertyName("bio")]
         public string? Bio { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("phone")]
+        public string? Phone { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("skills")]
         public System.Collections.Generic.ICollection<string>? Skills { get; set; } = default!;

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -11,6 +11,7 @@ using TUnit.Core.Interfaces;
 // types of the same name pulled in via the "Domain.Common"/"Domain.Organizations"
 // usings below (see the same workaround in OrganizationMembershipBackfillJobTests.cs).
 using DomainAddress = Domain.Common.Address;
+using DomainOrganization = Domain.Organizations.Organization;
 using DomainOrganizationId = Domain.Organizations.OrganizationId;
 
 namespace IntegrationTests;
@@ -98,5 +99,49 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 			opportunity.Id, slotA.Id, cancellationToken);
 
 		volunteerIds.Should().BeEquivalentTo([onSlotA.VolunteerId!.Value.Value]);
+	}
+
+	[Test]
+	public async Task GetPagedByOpportunityAsync_ShouldEnrichVolunteerPhone_FromLocalUserRow(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"PhoneTestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		dbContext.Set<VolunteerOpportunity>().Add(opportunity);
+
+		var volunteerWithPhone = UserId.New();
+		var volunteerWithoutProfile = UserId.New();
+
+		var user = User.Create(volunteerWithPhone);
+		user.SetPhone("+49 30 1234567");
+		await dbContext.Users.AddAsync(user, cancellationToken);
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagementWithPhone = Engagement.CreateIndividualContact(opportunity.Id, volunteerWithPhone, "Call me").GetValueOrThrow();
+		var engagementWithoutProfile = Engagement.CreateIndividualContact(opportunity.Id, volunteerWithoutProfile, "No profile row").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagementWithPhone, cancellationToken);
+		await dbContext.Engagements.AddAsync(engagementWithoutProfile, cancellationToken);
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetPagedByOpportunityAsync(opportunity.Id, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle(e => e.VolunteerId == volunteerWithPhone.Value && e.VolunteerPhone == "+49 30 1234567");
+		page.Items.Should().ContainSingle(e => e.VolunteerId == volunteerWithoutProfile.Value && e.VolunteerPhone == null);
+	}
+
+	private sealed class NoOpPinGenerator : IPinGenerator
+	{
+		public string GeneratePin() => "0000";
 	}
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5191,6 +5191,8 @@ export interface EngagementSummary {
     timeSlotStartDateTime?: Date | undefined;
     timeSlotEndDateTime?: Date | undefined;
     location?: string | undefined;
+    volunteerEmail?: string | undefined;
+    volunteerPhone?: string | undefined;
 
     [key: string]: any;
 }
@@ -5242,6 +5244,7 @@ export interface MyProfileResponse {
     email: string;
     avatarUrl: string | undefined;
     bio: string | undefined;
+    phone: string | undefined;
     skills: string[];
     languages: string[];
     preferredContact: string | undefined;
@@ -5618,6 +5621,7 @@ export interface UpdateUserProfileRequest {
     firstName?: string | undefined;
     lastName?: string | undefined;
     bio?: string | undefined;
+    phone?: string | undefined;
     skills?: string[] | undefined;
     languages?: string[] | undefined;
     preferredContact?: string | undefined;

--- a/frontend/src/components/ProfileFieldsView.tsx
+++ b/frontend/src/components/ProfileFieldsView.tsx
@@ -5,6 +5,7 @@ interface ProfileFieldsViewProps {
 	skills: string[];
 	languages: string[];
 	preferredContact?: string | null;
+	phone?: string | null;
 }
 
 export default function ProfileFieldsView({
@@ -12,6 +13,7 @@ export default function ProfileFieldsView({
 	skills,
 	languages,
 	preferredContact,
+	phone,
 }: ProfileFieldsViewProps) {
 	const { t } = useTranslation();
 
@@ -72,6 +74,15 @@ export default function ProfileFieldsView({
 							? t("profile.preferredContactEmail")
 							: t("profile.preferredContactPhone")}
 					</p>
+				</div>
+			)}
+
+			{phone && (
+				<div>
+					<p className="mb-1 text-sm font-medium text-gray-700">
+						{t("profile.fieldPhone")}
+					</p>
+					<p className="text-sm text-gray-600">{phone}</p>
 				</div>
 			)}
 		</>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -755,6 +755,8 @@
       "skillsPlaceholder": "Fähigkeit eingeben und Enter drücken",
       "fieldLanguages": "Sprachen",
       "languagesPlaceholder": "Sprache eingeben und Enter drücken",
+      "fieldPhone": "Telefon",
+      "phonePlaceholder": "Telefonnummer hinzufügen, unter der dich Organisatoren erreichen können",
       "fieldPreferredContact": "Bevorzugter Kontaktweg",
       "preferredContactEmail": "E-Mail",
       "preferredContactPhone": "Telefon",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -755,6 +755,8 @@
       "skillsPlaceholder": "Add a skill and press Enter",
       "fieldLanguages": "Languages",
       "languagesPlaceholder": "Add a language and press Enter",
+      "fieldPhone": "Phone",
+      "phonePlaceholder": "Add a phone number organizers can reach you on",
       "fieldPreferredContact": "Preferred contact channel",
       "preferredContactEmail": "Email",
       "preferredContactPhone": "Phone",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -309,6 +309,26 @@ export default function EngagementManagementPage() {
 											</span>
 										)}
 									</p>
+									{(e.volunteerEmail || e.volunteerPhone) && (
+										<p className="mt-1 flex flex-wrap gap-x-3 text-xs text-gray-500">
+											{e.volunteerEmail && (
+												<a
+													href={`mailto:${e.volunteerEmail}`}
+													className="hover:underline"
+												>
+													{e.volunteerEmail}
+												</a>
+											)}
+											{e.volunteerPhone && (
+												<a
+													href={`tel:${e.volunteerPhone}`}
+													className="hover:underline"
+												>
+													{e.volunteerPhone}
+												</a>
+											)}
+										</p>
+									)}
 									{e.message && (
 										<p className="mt-1 text-sm italic text-gray-700">
 											&ldquo;{e.message}&rdquo;

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -222,6 +222,7 @@ export default function ProfileOverviewPage() {
 				firstName: form.state.firstName || undefined,
 				lastName: form.state.lastName || undefined,
 				bio: form.state.bio || undefined,
+				phone: form.state.phone || undefined,
 				skills: form.state.skills,
 				languages: form.state.languages,
 				preferredContact: form.state.preferredContact || undefined,
@@ -358,6 +359,7 @@ export default function ProfileOverviewPage() {
 								skills={form.state.skills}
 								languages={form.state.languages}
 								preferredContact={form.state.preferredContact || null}
+								phone={form.state.phone || null}
 							/>
 						)}
 
@@ -500,6 +502,17 @@ export default function ProfileOverviewPage() {
 											onAdd={form.addLanguage}
 											onRemove={form.removeLanguage}
 											removeLabel={t("profile.removeChip")}
+										/>
+									</Field>
+
+									<Field label={t("profile.fieldPhone")} id="phone">
+										<input
+											id="phone"
+											type="tel"
+											value={form.state.phone}
+											placeholder={t("profile.phonePlaceholder")}
+											onChange={(e) => form.setPhone(e.target.value)}
+											className={inputClass}
 										/>
 									</Field>
 

--- a/frontend/src/pages/ProfileOverviewPage/useProfileForm.ts
+++ b/frontend/src/pages/ProfileOverviewPage/useProfileForm.ts
@@ -7,6 +7,7 @@ interface FormState {
 	firstName: string;
 	lastName: string;
 	bio: string;
+	phone: string;
 	skills: string[];
 	languages: string[];
 	preferredContact: ContactPref;
@@ -19,6 +20,7 @@ type FormAction =
 	| { type: "setFirstName"; value: string }
 	| { type: "setLastName"; value: string }
 	| { type: "setBio"; value: string }
+	| { type: "setPhone"; value: string }
 	| { type: "setPreferredContact"; value: ContactPref }
 	| { type: "setSkillInput"; value: string }
 	| { type: "setLangInput"; value: string }
@@ -32,6 +34,7 @@ function emptyState(): FormState {
 		firstName: "",
 		lastName: "",
 		bio: "",
+		phone: "",
 		skills: [],
 		languages: [],
 		preferredContact: "",
@@ -47,6 +50,7 @@ function fromProfile(profile: MyProfileResponse | null): FormState {
 		firstName: profile.firstName ?? "",
 		lastName: profile.lastName ?? "",
 		bio: profile.bio ?? "",
+		phone: profile.phone ?? "",
 		skills: profile.skills ?? [],
 		languages: profile.languages ?? [],
 		preferredContact: pref === "Email" || pref === "Phone" ? pref : "",
@@ -71,6 +75,8 @@ function reducer(state: FormState, action: FormAction): FormState {
 			return { ...state, lastName: action.value };
 		case "setBio":
 			return { ...state, bio: action.value };
+		case "setPhone":
+			return { ...state, phone: action.value };
 		case "setPreferredContact":
 			return { ...state, preferredContact: action.value };
 		case "setSkillInput":
@@ -121,6 +127,7 @@ export function useProfileForm(profile: MyProfileResponse | null) {
 		setFirstName: (value: string) => dispatch({ type: "setFirstName", value }),
 		setLastName: (value: string) => dispatch({ type: "setLastName", value }),
 		setBio: (value: string) => dispatch({ type: "setBio", value }),
+		setPhone: (value: string) => dispatch({ type: "setPhone", value }),
 		setPreferredContact: (value: ContactPref) =>
 			dispatch({ type: "setPreferredContact", value }),
 		setSkillInput: (value: string) =>


### PR DESCRIPTION
Add a Phone field to the User aggregate, exposed on GetUserProfile and settable via UpdateUserProfile, so PreferredContact=Phone points at real data. Surface VolunteerEmail (Keycloak) and VolunteerPhone (local) on EngagementSummary so organizers can actually reach signed-up volunteers from the engagement management list.

Closes #1043

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
