### PR TITLE
feat: add promote/demote for organization members

### DIFF
--- a/backend/src/Api/Organizations/ChangeMemberRole/v1/ChangeMemberRoleEndpoint.cs
+++ b/backend/src/Api/Organizations/ChangeMemberRole/v1/ChangeMemberRoleEndpoint.cs
@@ -1,0 +1,58 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Organizations.ChangeMemberRole.v1;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Organizations.ChangeMemberRole.v1;
+
+internal sealed class ChangeMemberRoleEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapPut("/organizations/{organizationId:guid}/members/{userId:guid}/role", ChangeMemberRoleAsync)
+			.WithName("ChangeMemberRole")
+			.WithTags("Organizations")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+	}
+
+	private static async Task<IResult> ChangeMemberRoleAsync(
+		[FromRoute] Guid organizationId,
+		[FromRoute] Guid userId,
+		[FromBody] ChangeMemberRoleRequest request,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var requestingUserId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? UserId.Create(uid).GetValueOrThrow() : throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		if (!Enum.TryParse<OrganizationMemberRole>(request.Role, ignoreCase: true, out var role) || !Enum.IsDefined(role))
+			throw new ResultFailureException(Error.Validation("OrganizationMembership.InvalidRole", "Invalid role."));
+
+		var command = new ChangeMemberRoleCommand(
+			OrganizationId.Create(organizationId).GetValueOrThrow(),
+			UserId.Create(userId).GetValueOrThrow(),
+			role,
+			requestingUserId);
+
+		await sender.Send(command, cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/Organizations/ChangeMemberRole/v1/ChangeMemberRoleRequest.cs
+++ b/backend/src/Api/Organizations/ChangeMemberRole/v1/ChangeMemberRoleRequest.cs
@@ -1,0 +1,3 @@
+namespace Api.Organizations.ChangeMemberRole.v1;
+
+public sealed record ChangeMemberRoleRequest(string Role);

--- a/backend/src/Api/Organizations/CreateInvitation/v1/CreateInvitationEndpoint.cs
+++ b/backend/src/Api/Organizations/CreateInvitation/v1/CreateInvitationEndpoint.cs
@@ -5,6 +5,7 @@ using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Organizations.CreateInvitation.v1;
 using Domain.Organizations;
+using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
 
@@ -39,9 +40,13 @@ internal sealed class CreateInvitationEndpoint : IEndpoint
 		if (subClaim is null || !Guid.TryParse(subClaim, out var invitedById))
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
 
+		if (!Enum.TryParse<OrganizationMemberRole>(request.Role, ignoreCase: true, out var role) || !Enum.IsDefined(role))
+			throw new ResultFailureException(Error.Validation("OrganizationInvitation.InvalidRole", "Invalid role."));
+
 		var command = new CreateInvitationCommand(
 			OrganizationId.Create(organizationId).GetValueOrThrow(),
 			UserId.Create(request.InviteeId).GetValueOrThrow(),
+			role,
 			UserId.Create(invitedById).GetValueOrThrow());
 
 		var invitationId = await sender.Send(command, cancellationToken);

--- a/backend/src/Api/Organizations/CreateInvitation/v1/CreateInvitationRequest.cs
+++ b/backend/src/Api/Organizations/CreateInvitation/v1/CreateInvitationRequest.cs
@@ -1,3 +1,3 @@
 namespace Api.Organizations.CreateInvitation.v1;
 
-public sealed record CreateInvitationRequest(Guid InviteeId);
+public sealed record CreateInvitationRequest(Guid InviteeId, string Role);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4116,6 +4116,109 @@
         }
       }
     },
+    "/v1/organizations/{organizationId}/members/{userId}/role": {
+      "put": {
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "ChangeMemberRole",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangeMemberRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/organizations/{organizationId}": {
       "delete": {
         "tags": [
@@ -5906,6 +6009,17 @@
           }
         }
       },
+      "ChangeMemberRoleRequest": {
+        "required": [
+          "role"
+        ],
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          }
+        }
+      },
       "CheckInWithPinRequest": {
         "required": [
           "pin"
@@ -6023,13 +6137,17 @@
       },
       "CreateInvitationRequest": {
         "required": [
-          "inviteeId"
+          "inviteeId",
+          "role"
         ],
         "type": "object",
         "properties": {
           "inviteeId": {
             "type": "string",
             "format": "uuid"
+          },
+          "role": {
+            "type": "string"
           }
         }
       },
@@ -7280,7 +7398,8 @@
           "firstName",
           "lastName",
           "email",
-          "isOrganisator"
+          "isOrganisator",
+          "role"
         ],
         "type": "object",
         "properties": {
@@ -7308,6 +7427,9 @@
           },
           "isOrganisator": {
             "type": "boolean"
+          },
+          "role": {
+            "type": "string"
           }
         }
       },
@@ -7339,6 +7461,7 @@
           "id",
           "inviteeId",
           "inviteeName",
+          "intendedRole",
           "status",
           "createdOn"
         ],
@@ -7353,6 +7476,9 @@
             "format": "uuid"
           },
           "inviteeName": {
+            "type": "string"
+          },
+          "intendedRole": {
             "type": "string"
           },
           "status": {

--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -32,6 +32,15 @@ public interface IKeycloakOrganizationService
 		Guid userId,
 		CancellationToken cancellationToken = default);
 
+	// Symmetric counterpart to AssignOrganizerRoleAsync, for demoting a member
+	// away from the Organizer tier. Callers must only invoke this once the
+	// user holds no remaining Organizer membership in any organization - the
+	// role is realm-wide, not per-organization, so revoking it while the user
+	// still organizes a different org would lock them out of that org too.
+	Task RevokeOrganizerRoleAsync(
+		Guid userId,
+		CancellationToken cancellationToken = default);
+
 	Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
 		Guid organizationId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -44,6 +44,11 @@ public interface IApplicationDbContext
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
 
+	Task<OrganizationMembership?> GetMembershipAsync(
+		OrganizationId organizationId,
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
 	Task<OrganizationDashboardLayout?> GetDashboardLayoutAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
+++ b/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
@@ -25,27 +25,26 @@ internal sealed class AcceptInvitationCommandHandler(
 
 		invitation.Accept().ThrowIfFailure();
 
-		// Accepting grants full Organizer capability, the only membership tier
-		// this app currently gives any real access - matching how
-		// CreateOrganizationCommandHandler seats the org's creator. Without this,
-		// an accepted invitee is a Keycloak org member with no local
-		// OrganizationMembership row and no "organisator" realm role, so every
-		// org-scoped endpoint (all gated by that role and/or a per-org Organizer
-		// check) stays unreachable for them and they never appear in their own
-		// org switcher - accepting would grant no functional capability at all.
 		await keycloakOrganizationService.AddMemberAsync(
 			invitation.OrganizationId.Value,
 			invitation.InviteeId.Value,
 			cancellationToken);
 
-		await keycloakOrganizationService.AssignOrganizerRoleAsync(
-			invitation.InviteeId.Value,
-			cancellationToken);
+		// The realm "organisator" role is only needed for the Organizer tier -
+		// it gates org-management endpoints as a coarse precondition on top of
+		// the real per-org OrganizationMembership.Role check. A plain Member
+		// never needs it.
+		if (invitation.IntendedRole == OrganizationMemberRole.Organizer)
+		{
+			await keycloakOrganizationService.AssignOrganizerRoleAsync(
+				invitation.InviteeId.Value,
+				cancellationToken);
+		}
 
 		var membership = OrganizationMembership.Create(
 			invitation.OrganizationId,
 			invitation.InviteeId,
-			OrganizationMemberRole.Organizer);
+			invitation.IntendedRole);
 
 		await dbContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
 

--- a/backend/src/Application/Organizations/ChangeMemberRole/v1/ChangeMemberRoleCommand.cs
+++ b/backend/src/Application/Organizations/ChangeMemberRole/v1/ChangeMemberRoleCommand.cs
@@ -1,0 +1,11 @@
+using Application.Common.Messaging;
+using Domain.Organizations;
+using Domain.Users;
+
+namespace Application.Organizations.ChangeMemberRole.v1;
+
+public sealed record ChangeMemberRoleCommand(
+	OrganizationId OrganizationId,
+	UserId TargetUserId,
+	OrganizationMemberRole Role,
+	UserId RequestingUserId) : ICommand<bool>;

--- a/backend/src/Application/Organizations/ChangeMemberRole/v1/ChangeMemberRoleCommandHandler.cs
+++ b/backend/src/Application/Organizations/ChangeMemberRole/v1/ChangeMemberRoleCommandHandler.cs
@@ -1,0 +1,67 @@
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Application.Organizations.ChangeMemberRole.v1;
+
+internal sealed class ChangeMemberRoleCommandHandler(
+	IApplicationDbContext dbContext,
+	IKeycloakOrganizationService keycloakOrganizationService)
+	: ICommandHandler<ChangeMemberRoleCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		ChangeMemberRoleCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			request.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		var membership = await dbContext.GetMembershipAsync(
+			request.OrganizationId, request.TargetUserId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound(
+				"OrganizationMembership.NotFound", "Membership not found."));
+
+		var wasOrganizer = membership.Role == OrganizationMemberRole.Organizer;
+		var demoting = wasOrganizer && request.Role != OrganizationMemberRole.Organizer;
+
+		if (demoting)
+		{
+			var organizerCount = await dbContext.CountOrganizersAsync(request.OrganizationId, cancellationToken);
+
+			if (organizerCount <= 1)
+				throw new ResultFailureException(Error.Conflict(
+					"Organization.SoleOrganizerDemote",
+					"Conflict: you cannot demote the only organizer of this organization. Promote another member first, or delete the organization."));
+		}
+
+		membership.ChangeRole(request.Role).ThrowIfFailure();
+
+		if (request.Role == OrganizationMemberRole.Organizer && !wasOrganizer)
+		{
+			await keycloakOrganizationService.AssignOrganizerRoleAsync(
+				request.TargetUserId.Value, cancellationToken);
+		}
+		else if (demoting)
+		{
+			// The role is realm-wide, not per-organization (see #1386), so it can
+			// only be revoked once the user organizes no other organization -
+			// otherwise this demotion would also lock them out of that other org.
+			var remainingOrganizerOrgs = await dbContext.GetOrganizerOrganizationsAsync(
+				request.TargetUserId, cancellationToken);
+			var stillOrganizerElsewhere = remainingOrganizerOrgs.Any(o => o.Id != request.OrganizationId);
+
+			if (!stillOrganizerElsewhere)
+				await keycloakOrganizationService.RevokeOrganizerRoleAsync(
+					request.TargetUserId.Value, cancellationToken);
+		}
+
+		return true;
+	}
+}

--- a/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommand.cs
+++ b/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommand.cs
@@ -7,4 +7,5 @@ namespace Application.Organizations.CreateInvitation.v1;
 public sealed record CreateInvitationCommand(
 	OrganizationId OrganizationId,
 	UserId InviteeId,
+	OrganizationMemberRole Role,
 	UserId InvitedById) : ICommand<OrganizationInvitationId>;

--- a/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
@@ -54,6 +54,7 @@ internal sealed class CreateInvitationCommandHandler(
 			request.InviteeId,
 			inviteeName,
 			request.InvitedById,
+			request.Role,
 			now);
 
 		await dbContext.OrganizationInvitations.AddAsync(invitation, cancellationToken);

--- a/backend/src/Application/Organizations/GetOrgInvitations/v1/GetOrgInvitationsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrgInvitations/v1/GetOrgInvitationsQueryHandler.cs
@@ -26,6 +26,7 @@ internal sealed class GetOrgInvitationsQueryHandler(
 				i.Id.Value,
 				i.InviteeId.Value,
 				i.InviteeName,
+				i.IntendedRole.ToString(),
 				i.Status.ToString(),
 				i.CreatedOn))
 			.ToList();

--- a/backend/src/Application/Organizations/GetOrgInvitations/v1/OrgInvitationDto.cs
+++ b/backend/src/Application/Organizations/GetOrgInvitations/v1/OrgInvitationDto.cs
@@ -4,5 +4,6 @@ public sealed record OrgInvitationDto(
 	Guid Id,
 	Guid InviteeId,
 	string InviteeName,
+	string IntendedRole,
 	string Status,
 	DateTimeOffset CreatedOn);

--- a/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
@@ -58,7 +58,8 @@ internal sealed class GetOrganizationDetailsQueryHandler(
 					m.FirstName,
 					m.LastName,
 					m.Email,
-					m.IsOrganisator))
+					m.IsOrganisator,
+					(m.IsOrganisator ? OrganizationMemberRole.Organizer : OrganizationMemberRole.Member).ToString()))
 				.ToList());
 	}
 }

--- a/backend/src/Application/Organizations/GetOrganizationDetails/v1/OrganizationDetailsResponse.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDetails/v1/OrganizationDetailsResponse.cs
@@ -26,4 +26,5 @@ public sealed record OrganizationMemberDto(
 	string? FirstName,
 	string? LastName,
 	string Email,
-	bool IsOrganisator);
+	bool IsOrganisator,
+	string Role);

--- a/backend/src/Domain/Organizations/OrganizationInvitation.cs
+++ b/backend/src/Domain/Organizations/OrganizationInvitation.cs
@@ -17,6 +17,8 @@ public sealed class OrganizationInvitation
 
 	public UserId InvitedById { get; private set; }
 
+	public OrganizationMemberRole IntendedRole { get; private set; }
+
 	public InvitationStatus Status { get; private set; }
 
 	public DateTimeOffset ExpiresOn { get; private set; }
@@ -41,6 +43,7 @@ public sealed class OrganizationInvitation
 		UserId inviteeId,
 		string inviteeName,
 		UserId invitedById,
+		OrganizationMemberRole intendedRole,
 		DateTimeOffset now)
 		: base(id)
 	{
@@ -49,6 +52,7 @@ public sealed class OrganizationInvitation
 		InviteeId = inviteeId;
 		InviteeName = inviteeName;
 		InvitedById = invitedById;
+		IntendedRole = intendedRole;
 		Status = InvitationStatus.Pending;
 		ExpiresOn = now.AddDays(ExpiryWindowDays);
 	}
@@ -59,6 +63,7 @@ public sealed class OrganizationInvitation
 		UserId inviteeId,
 		string inviteeName,
 		UserId invitedById,
+		OrganizationMemberRole intendedRole,
 		DateTimeOffset now) =>
 		new(
 			OrganizationInvitationId.New(),
@@ -67,6 +72,7 @@ public sealed class OrganizationInvitation
 			inviteeId,
 			inviteeName,
 			invitedById,
+			intendedRole,
 			now);
 
 	private Result EnsurePending() =>

--- a/backend/src/Domain/Organizations/OrganizationMembership.cs
+++ b/backend/src/Domain/Organizations/OrganizationMembership.cs
@@ -42,4 +42,13 @@ public sealed class OrganizationMembership
 			organizationId,
 			userId,
 			role);
+
+	public Result ChangeRole(OrganizationMemberRole role)
+	{
+		if (Role == role)
+			return Result.Failure(Error.Conflict("OrganizationMembership.RoleUnchanged", "Member already has this role."));
+
+		Role = role;
+		return Result.Success();
+	}
 }

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -91,6 +91,33 @@ internal sealed class KeycloakOrganizationService(
 		await EnsureSuccessAsync(response, cancellationToken);
 	}
 
+	public async Task RevokeOrganizerRoleAsync(
+		Guid userId,
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var rolesResponse = await httpClient.GetAsync(
+			$"/admin/realms/{_options.Realm}/roles/organisator",
+			cancellationToken);
+
+		await EnsureSuccessAsync(rolesResponse, cancellationToken);
+
+		var role = await rolesResponse.Content.ReadFromJsonAsync<KeycloakRole>(
+			JsonOptions, cancellationToken);
+
+		using var request = new HttpRequestMessage(
+			HttpMethod.Delete,
+			$"/admin/realms/{_options.Realm}/users/{userId}/role-mappings/realm")
+		{
+			Content = JsonContent.Create(new[] { role }, options: JsonOptions)
+		};
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		await EnsureSuccessAsync(response, cancellationToken);
+	}
+
 	public async Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
 		Guid organizationId,
 		CancellationToken cancellationToken = default)

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -125,6 +125,13 @@ internal sealed class ApplicationDbContext(
 		return userIds.Select(id => id.Value).ToHashSet();
 	}
 
+	public async Task<OrganizationMembership?> GetMembershipAsync(
+		OrganizationId organizationId,
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationMembership>()
+			.FirstOrDefaultAsync(m => m.OrganizationId == organizationId && m.UserId == userId, cancellationToken);
+
 	public async Task<OrganizationDashboardLayout?> GetDashboardLayoutAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationInvitationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationInvitationConfiguration.cs
@@ -40,6 +40,10 @@ internal sealed class OrganizationInvitationConfiguration : IEntityTypeConfigura
 				guid => UserId.Create(guid).GetValueOrThrow())
 			.IsRequired();
 
+		builder.Property(i => i.IntendedRole)
+			.HasConversion<string>()
+			.IsRequired();
+
 		builder.Property(i => i.Status)
 			.HasConversion<string>()
 			.IsRequired();

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730074428_AddOrganizationInvitationIntendedRole.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730074428_AddOrganizationInvitationIntendedRole.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260730074428_AddOrganizationInvitationIntendedRole")]
+	partial class AddOrganizationInvitationIntendedRole
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
@@ -325,10 +328,6 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnType("timestamp with time zone")
 						.HasColumnName("created_on");
 
-					b.Property<DateTimeOffset>("ExpiresOn")
-						.HasColumnType("timestamp with time zone")
-						.HasColumnName("expires_on");
-
 					b.Property<string>("IntendedRole")
 						.IsRequired()
 						.HasColumnType("text")
@@ -505,10 +504,6 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnType("text")
 						.HasColumnName("languages");
 
-					b.Property<string>("Phone")
-						.HasColumnType("text")
-						.HasColumnName("phone");
-
 					b.Property<string>("PreferredContact")
 						.HasColumnType("text")
 						.HasColumnName("preferred_contact");
@@ -592,22 +587,9 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnType("timestamp with time zone")
 						.HasColumnName("end_date_time");
 
-					b.Property<int?>("MaxParticipants")
+					b.Property<int>("MaxParticipants")
 						.HasColumnType("integer")
 						.HasColumnName("max_participants");
-
-					b.Property<int?>("RecurrenceCount")
-						.HasColumnType("integer")
-						.HasColumnName("recurrence_count");
-
-					b.Property<string>("RecurrenceFrequency")
-						.HasMaxLength(20)
-						.HasColumnType("character varying(20)")
-						.HasColumnName("recurrence_frequency");
-
-					b.Property<Guid?>("SeriesId")
-						.HasColumnType("uuid")
-						.HasColumnName("series_id");
 
 					b.Property<DateTimeOffset>("StartDateTime")
 						.HasColumnType("timestamp with time zone")
@@ -619,9 +601,6 @@ namespace Infrastructure.Persistence.Migrations
 
 					b.HasKey("Id")
 						.HasName("pk_time_slot");
-
-					b.HasIndex("SeriesId")
-						.HasDatabaseName("ix_time_slot_series_id");
 
 					b.HasIndex("volunteer_opportunity_id")
 						.HasDatabaseName("ix_time_slot_volunteer_opportunity_id");

--- a/backend/src/Infrastructure/Persistence/Migrations/20260730074428_AddOrganizationInvitationIntendedRole.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260730074428_AddOrganizationInvitationIntendedRole.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOrganizationInvitationIntendedRole : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "intended_role",
+				table: "organization_invitation",
+				type: "text",
+				nullable: false,
+				defaultValue: "Organizer");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "intended_role",
+				table: "organization_invitation");
+		}
+	}
+}

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
@@ -32,8 +32,9 @@ public class AcceptInvitationCommandHandlerTests
 		_sut = new AcceptInvitationCommandHandler(_dbContext, _unitOfWork, _keycloakService);
 	}
 
-	private static OrganizationInvitation CreatePendingInvitation() =>
-		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId, DateTimeOffset.UtcNow);
+	private static OrganizationInvitation CreatePendingInvitation(
+		OrganizationMemberRole intendedRole = OrganizationMemberRole.Organizer) =>
+		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId, intendedRole, DateTimeOffset.UtcNow);
 
 	[Test]
 	public async Task Handle_ShouldGrantOrganizerCapability_OnAccept(
@@ -47,16 +48,39 @@ public class AcceptInvitationCommandHandlerTests
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
 
-		// Assert - accepting must grant real, functional capability, not just
-		// Keycloak org membership with nothing behind it (#826): the invitee
-		// becomes a full Organizer, the only membership tier this app
-		// currently gives any real access.
+		// Assert - accepting an Organizer-intended invitation must grant real,
+		// functional capability, not just Keycloak org membership with nothing
+		// behind it (#826): the invitee becomes a full Organizer.
 		result.Should().BeTrue();
 		await _keycloakService.Received(1).AddMemberAsync(OrgId.Value, InviteeId.Value, cancellationToken);
 		await _keycloakService.Received(1).AssignOrganizerRoleAsync(InviteeId.Value, cancellationToken);
 		await _membershipRepo.Received(1).AddAsync(
 			Arg.Is<OrganizationMembership>(m =>
 				m != null && m.OrganizationId == OrgId && m.UserId == InviteeId && m.Role == OrganizationMemberRole.Organizer),
+			cancellationToken);
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldGrantMemberCapabilityOnly_WhenInvitationIntendedRoleIsMember(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreatePendingInvitation(OrganizationMemberRole.Member);
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new AcceptInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert - a Member-intended invitation must not grant the realm-wide
+		// organizer role, only local org membership.
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).AddMemberAsync(OrgId.Value, InviteeId.Value, cancellationToken);
+		await _keycloakService.DidNotReceive().AssignOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+		await _membershipRepo.Received(1).AddAsync(
+			Arg.Is<OrganizationMembership>(m =>
+				m != null && m.OrganizationId == OrgId && m.UserId == InviteeId && m.Role == OrganizationMemberRole.Member),
 			cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}

--- a/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class DeclineInvitationCommandHandlerTests
 	}
 
 	private static OrganizationInvitation CreatePendingInvitation() =>
-		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId, DateTimeOffset.UtcNow);
+		OrganizationInvitation.Create(OrgId, "Test Org", InviteeId, "Invitee Name", InviterId, OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
 
 	[Test]
 	public async Task Handle_ShouldDeclineInvitationAndSaveChanges_WhenPending(

--- a/backend/tests/Application.UnitTests/Organizations/ChangeMemberRole/ChangeMemberRoleCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ChangeMemberRole/ChangeMemberRoleCommandHandlerTests.cs
@@ -1,0 +1,160 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Organizations.ChangeMemberRole.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Organizations.ChangeMemberRole;
+
+public class ChangeMemberRoleCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly ChangeMemberRoleCommandHandler _sut;
+
+	private static readonly OrganizationId OrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static readonly UserId TargetUserId = UserId.New();
+
+	public ChangeMemberRoleCommandHandlerTests()
+	{
+		_dbContext
+			.IsOrganizerAsync(OrgId, DefaultRequestingUserId, Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new ChangeMemberRoleCommandHandler(_dbContext, _keycloakService);
+	}
+
+	private void SetMembership(OrganizationMemberRole role)
+	{
+		var membership = OrganizationMembership.Create(OrgId, TargetUserId, role);
+		_dbContext.GetMembershipAsync(OrgId, TargetUserId, Arg.Any<CancellationToken>()).Returns(membership);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPromoteAndAssignKeycloakRole_WhenChangingMemberToOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		SetMembership(OrganizationMemberRole.Member);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Organizer, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).AssignOrganizerRoleAsync(TargetUserId.Value, cancellationToken);
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDemoteAndRevokeKeycloakRole_WhenTargetOrganizesNoOtherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		SetMembership(OrganizationMemberRole.Organizer);
+		_dbContext.CountOrganizersAsync(OrgId, Arg.Any<CancellationToken>()).Returns(2);
+		_dbContext.GetOrganizerOrganizationsAsync(TargetUserId, Arg.Any<CancellationToken>()).Returns([]);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Member, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).RevokeOrganizerRoleAsync(TargetUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDemoteButNotRevokeKeycloakRole_WhenTargetStillOrganizesAnotherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the realm role is shared across every org the user organizes (#1386),
+		// so it must stay assigned while they still organize a different one.
+		SetMembership(OrganizationMemberRole.Organizer);
+		_dbContext.CountOrganizersAsync(OrgId, Arg.Any<CancellationToken>()).Returns(2);
+		var otherOrg = Organization.Create(OrganizationId.New(), "Other Org").GetValueOrThrow();
+		_dbContext.GetOrganizerOrganizationsAsync(TargetUserId, Arg.Any<CancellationToken>()).Returns([otherOrg]);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Member, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenDemotingTheOnlyOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		SetMembership(OrganizationMemberRole.Organizer);
+		_dbContext.CountOrganizersAsync(OrgId, Arg.Any<CancellationToken>()).Returns(1);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Member, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenRoleIsUnchanged(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		SetMembership(OrganizationMemberRole.Organizer);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Organizer, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowNotFound_WhenMembershipDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_dbContext.GetMembershipAsync(OrgId, TargetUserId, Arg.Any<CancellationToken>()).Returns((OrganizationMembership?)null);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Organizer, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowForbidden_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_dbContext
+			.IsOrganizerAsync(OrgId, DefaultRequestingUserId, Arg.Any<CancellationToken>())
+			.Returns(false);
+		var command = new ChangeMemberRoleCommand(OrgId, TargetUserId, OrganizationMemberRole.Organizer, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		await _dbContext.DidNotReceive().GetMembershipAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -56,7 +56,7 @@ public class CreateInvitationCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(DefaultOrgId, DefaultInvitedById, cancellationToken)
 			.Returns(false);
-		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, DefaultInvitedById);
+		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, OrganizationMemberRole.Organizer, DefaultInvitedById);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -73,14 +73,16 @@ public class CreateInvitationCommandHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, DefaultInvitedById);
+		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, OrganizationMemberRole.Member, DefaultInvitedById);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
 		result.Should().NotBeNull();
-		await _invitationRepo.Received(1).AddAsync(Arg.Any<OrganizationInvitation>(), cancellationToken);
+		await _invitationRepo.Received(1).AddAsync(
+			Arg.Is<OrganizationInvitation>(i => i != null && i.IntendedRole == OrganizationMemberRole.Member),
+			cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 		await _emailService.Received(1).SendAsync(
 			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), cancellationToken);

--- a/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
@@ -33,7 +33,7 @@ public class DismissInvitationCommandHandlerTests
 	private static OrganizationInvitation CreateDeclinedInvitation(OrganizationId orgId)
 	{
 		var invitation = OrganizationInvitation.Create(
-			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), DateTimeOffset.UtcNow);
+			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
 		invitation.Decline();
 		return invitation;
 	}
@@ -42,14 +42,14 @@ public class DismissInvitationCommandHandlerTests
 	{
 		var now = DateTimeOffset.UtcNow;
 		var invitation = OrganizationInvitation.Create(
-			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), now);
+			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), OrganizationMemberRole.Organizer, now);
 		invitation.Expire(now.AddDays(OrganizationInvitation.ExpiryWindowDays));
 		return invitation;
 	}
 
 	private static OrganizationInvitation CreatePendingInvitation(OrganizationId orgId) =>
 		OrganizationInvitation.Create(
-			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), DateTimeOffset.UtcNow);
+			orgId, "Test Org", UserId.New(), "Vera", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
 
 	[Test]
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotMemberOfTheOrganization(

--- a/backend/tests/Application.UnitTests/Organizations/GetOrgInvitations/GetOrgInvitationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrgInvitations/GetOrgInvitationsQueryHandlerTests.cs
@@ -51,7 +51,7 @@ public class GetOrgInvitationsQueryHandlerTests
 	{
 		// Arrange
 		var invitation = OrganizationInvitation.Create(
-			DefaultOrgId, "Test Org", UserId.New(), "Vera", UserId.New(), DateTimeOffset.UtcNow);
+			DefaultOrgId, "Test Org", UserId.New(), "Vera", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
 		_dbContext.GetInvitationsForOrganizationAsync(DefaultOrgId, cancellationToken)
 			.Returns([invitation]);
 		var query = new GetOrgInvitationsQuery(DefaultOrgId, DefaultRequestingUserId);
@@ -63,6 +63,7 @@ public class GetOrgInvitationsQueryHandlerTests
 		result.Should().HaveCount(1);
 		result[0].Id.Should().Be(invitation.Id.Value);
 		result[0].InviteeName.Should().Be("Vera");
+		result[0].IntendedRole.Should().Be("Organizer");
 		result[0].Status.Should().Be("Pending");
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
@@ -43,14 +43,14 @@ public class ResendInvitationCommandHandlerTests
 	{
 		var now = DateTimeOffset.UtcNow;
 		var invitation = OrganizationInvitation.Create(
-			orgId, "Test Org", DefaultInviteeId, "Vera", UserId.New(), now);
+			orgId, "Test Org", DefaultInviteeId, "Vera", UserId.New(), OrganizationMemberRole.Organizer, now);
 		invitation.Expire(now.AddDays(OrganizationInvitation.ExpiryWindowDays)).ThrowIfFailure();
 		return invitation;
 	}
 
 	private static OrganizationInvitation CreatePendingInvitation(OrganizationId orgId) =>
 		OrganizationInvitation.Create(
-			orgId, "Test Org", DefaultInviteeId, "Vera", UserId.New(), DateTimeOffset.UtcNow);
+			orgId, "Test Org", DefaultInviteeId, "Vera", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
 
 	[Test]
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotMemberOfTheOrganization(

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -67,7 +67,7 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 			new CreateOrganizationRequest { Name = "Shared Membership Test Org" }, cancellationToken);
 		var invitation = await olafClient.CreateInvitationAsync(
 			sharedOrg.Id.Value,
-			new CreateInvitationRequest { InviteeId = ephemeralUserId },
+			new CreateInvitationRequest { InviteeId = ephemeralUserId, Role = "Organizer" },
 			cancellationToken);
 		await ephemeralClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
 
@@ -95,7 +95,7 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 		// user - an organization_invitation row on the inviter (invited_by_id) side.
 		await ephemeralClient.CreateInvitationAsync(
 			sharedOrg.Id.Value,
-			new CreateInvitationRequest { InviteeId = thirdPartyUserId },
+			new CreateInvitationRequest { InviteeId = thirdPartyUserId, Role = "Member" },
 			cancellationToken);
 
 		await ephemeralClient.DeleteMyAccountAsync(cancellationToken);

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -310,6 +310,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ChangeMemberRoleAsync(System.Guid organizationId, System.Guid userId, ChangeMemberRoleRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task AdminShadowDeleteOrganizationAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -6845,6 +6850,148 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ChangeMemberRoleAsync(System.Guid organizationId, System.Guid userId, ChangeMemberRoleRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            if (userId == null)
+                throw new System.ArgumentNullException("userId");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/organizations/{organizationId}/members/{userId}/role"
+                    urlBuilder_.Append("v1/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/members/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(userId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/role");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task AdminShadowDeleteOrganizationAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (organizationId == null)
@@ -9786,6 +9933,25 @@ namespace IntegrationTests
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ChangeMemberRoleRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("role")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Role { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CheckInWithPinRequest
     {
 
@@ -9927,6 +10093,10 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("inviteeId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid InviteeId { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("role")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Role { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
@@ -10978,6 +11148,10 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("isOrganisator")]
         public bool IsOrganisator { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("role")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Role { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -11030,6 +11204,10 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("inviteeName")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string InviteeName { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("intendedRole")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string IntendedRole { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("status")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Application.Common.Exceptions;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
@@ -279,6 +280,10 @@ public class IntegrationTestFixture
 	// plain member, without granting the Organizer role. Accepting an
 	// invitation grants Organizer too (#826), so it's the only way left to
 	// reconstruct a plain-member-only state for regression tests (#691, #825).
+	// Also seeds the matching local organization_membership row (Role: Member)
+	// - ChangeMemberRoleCommandHandler (#1050) resolves membership from that
+	// local table, not Keycloak, so callers exercising promote/demote need it
+	// to exist alongside the Keycloak-side membership.
 	public async Task AddPlainMemberDirectlyAsync(
 		Guid organizationId, Guid userId, CancellationToken cancellationToken = default)
 	{
@@ -293,6 +298,14 @@ public class IntegrationTestFixture
 
 		var response = await _keycloakClient.SendAsync(request, cancellationToken);
 		await EnsureSuccessAsync(response);
+
+		await using var dbContext = CreateApplicationDbContext();
+		var membership = Domain.Organizations.OrganizationMembership.Create(
+			Domain.Organizations.OrganizationId.Create(organizationId).GetValueOrThrow(),
+			Domain.Users.UserId.Create(userId).GetValueOrThrow(),
+			Domain.Organizations.OrganizationMemberRole.Member);
+		dbContext.Set<Domain.Organizations.OrganizationMembership>().Add(membership);
+		await dbContext.SaveChangesAsync(cancellationToken);
 	}
 
 	// Creates a brand-new, disposable Keycloak user with the realm's baseline

--- a/backend/tests/IntegrationTests/InvitationExpiryJobTests.cs
+++ b/backend/tests/IntegrationTests/InvitationExpiryJobTests.cs
@@ -98,7 +98,7 @@ public class InvitationExpiryJobTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var invitation = OrganizationInvitation.Create(
-			organization.Id, organization.Name, UserId.New(), "Invitee", UserId.New(), createdAt);
+			organization.Id, organization.Name, UserId.New(), "Invitee", UserId.New(), OrganizationMemberRole.Organizer, createdAt);
 		if (accept)
 			invitation.Accept().ThrowIfFailure();
 		dbContext.Set<OrganizationInvitation>().Add(invitation);

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -77,7 +77,7 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
 		await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -236,6 +236,9 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 		public Task AssignOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();
 
+		public Task RevokeOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
 		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 			string search, int max = 20, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -280,7 +280,7 @@ public class OrganizationSettingsTests(
 		// The ownership check runs before any invitee lookup, so a fabricated
 		// invitee id is enough to prove the 403 fires first.
 		var act = () => veraClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = Guid.NewGuid() }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = Guid.NewGuid(), Role = "Organizer" }, cancellationToken);
 
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(403);
@@ -298,12 +298,45 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Invite Success Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		invitation.InvitationId.Should().NotBeEmpty();
 
 		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
 		invitations.Should().ContainSingle(i => i.Id == invitation.InvitationId && i.Status == "Pending");
+	}
+
+	[Test]
+	public async Task CreateInvitation_ThenAccept_ShouldPersistMemberRole_NotSilentlyCoerceToOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// #1050: OrganizationInvitationConfiguration.IntendedRole originally had
+		// HasDefaultValue(Organizer) alongside HasConversion<string>() - since
+		// OrganizationMemberRole.Member is the enum's CLR default (0), EF Core
+		// treats any explicitly-set Member value as "unset" and silently
+		// substitutes the database default instead. That bug is invisible to
+		// mocked handler tests (no real SaveChanges/round trip) - only a real
+		// Postgres save-and-reread, as this integration test does, would have
+		// caught it: an invitation created with Role=Member would come back
+		// as Organizer, and the invitee would wrongly become an organizer on
+		// accept. Fixed by dropping the HasDefaultValue from the model.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Member Role Round-Trip Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
+		invitations.Should().ContainSingle(i => i.Id == invitation.InvitationId && i.IntendedRole == "Member");
+
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var details = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		details.Members.Should().Contain(m => m.UserId == vera.Id && !m.IsOrganisator && m.Role == "Member");
 	}
 
 	[Test]
@@ -324,7 +357,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Accept Grants Capability Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Organizer" }, cancellationToken);
 		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
 
 		var veraOrganizations = await veraClient.GetOrganizationsAsync(cancellationToken);
@@ -354,7 +387,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Decline Success Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
 
@@ -374,7 +407,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Decline 403 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		// admin is neither the inviter nor the invitee - guaranteed not to be vera.
 		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
@@ -412,7 +445,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Decline 409 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Organizer" }, cancellationToken);
 		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
 
 		var act = () => veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
@@ -433,7 +466,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Accept 403 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		// admin is neither the inviter nor the invitee - guaranteed not to be vera.
 		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
@@ -490,7 +523,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Dismiss 403 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
 
 		await veraClient.CreateOrganizationAsync(
@@ -516,7 +549,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Dismiss Success Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
 
 		await olafClient.DismissInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);
@@ -644,6 +677,83 @@ public class OrganizationSettingsTests(
 		await InvitationExpiryJob.ExpireDueInvitationsAsync(dbContext, future, cancellationToken);
 	}
 
+	// ── ChangeMemberRole (promote/demote, #1050) ──────────────────────────────
+
+	[Test]
+	public async Task ChangeMemberRole_ShouldReturn204AndPromoteThenDemote_WhenRequestingUserIsOrganizer(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "ChangeMemberRole Success Test Org" }, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
+
+		await olafClient.ChangeMemberRoleAsync(
+			org.Id.Value, vera.Id, new ChangeMemberRoleRequest { Role = "Organizer" }, cancellationToken);
+
+		var afterPromote = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		afterPromote.Members.Should().Contain(m => m.UserId == vera.Id && m.IsOrganisator && m.Role == "Organizer");
+
+		// olaf remains an organizer, so demoting vera back is allowed.
+		await olafClient.ChangeMemberRoleAsync(
+			org.Id.Value, vera.Id, new ChangeMemberRoleRequest { Role = "Member" }, cancellationToken);
+
+		var afterDemote = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		afterDemote.Members.Should().Contain(m => m.UserId == vera.Id && !m.IsOrganisator && m.Role == "Member");
+	}
+
+	[Test]
+	public async Task ChangeMemberRole_ShouldReturn409_WhenDemotingTheOnlyOrganizer(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "ChangeMemberRole SoleOrganizer Test Org" }, cancellationToken);
+		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
+
+		var act = () => olafClient.ChangeMemberRoleAsync(
+			org.Id.Value, olaf.Id, new ChangeMemberRoleRequest { Role = "Member" }, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().Contain(m => m.UserId == olaf.Id && m.IsOrganisator);
+	}
+
+	[Test]
+	public async Task ChangeMemberRole_ShouldReturn403_WhenRequestingUserIsNotMemberOfTheOrganization(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "ChangeMemberRole 403 Test Org" }, cancellationToken);
+
+		// vera creates her own, unrelated organization, which grants her the
+		// platform-wide organisator role without making her a member of org.
+		await veraClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Vera's Own Org 6" }, cancellationToken);
+		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
+
+		var act = () => veraClient.ChangeMemberRoleAsync(
+			org.Id.Value, olaf.Id, new ChangeMemberRoleRequest { Role = "Member" }, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().Contain(m => m.UserId == olaf.Id && m.IsOrganisator);
+	}
+
 	// ── RemoveMember (last-member protection, #580) ──────────────────────────
 
 	[Test]
@@ -738,7 +848,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Delete 409 Members Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Organizer" }, cancellationToken);
 		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
 
 		var act = () => olafClient.DeleteOrganizationAsync(org.Id.Value, cancellationToken);

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -572,7 +572,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Resend 409 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 
 		var act = () => olafClient.ResendInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);
 
@@ -592,7 +592,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Resend Success Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 		await ExpireAllDueInvitationsAsync(cancellationToken);
 
 		var invitationsBeforeResend = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
@@ -621,7 +621,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Resend 403 Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 		await ExpireAllDueInvitationsAsync(cancellationToken);
 
 		await veraClient.CreateOrganizationAsync(
@@ -659,7 +659,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Dismiss Expired Test Org" }, cancellationToken);
 
 		var invitation = await olafClient.CreateInvitationAsync(
-			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id }, cancellationToken);
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
 		await ExpireAllDueInvitationsAsync(cancellationToken);
 
 		await olafClient.DismissInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Playwright;
@@ -357,6 +358,49 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		// #973: OrgAppShell previously rendered no h1 on any org app page.
 		await Expect(Page.Locator("h1")).ToHaveTextAsync("Members");
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
+	public async Task OrgMembersPage_MemberRowWithPromoteDemoteButtons_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1050: the new "Promote to Organizer"/"Demote to Member" button pair
+		// only renders for a non-self member row - NavigateToOrgAppDashboardAsOlafAsync
+		// pins an org where Olaf is the only member, so the scan above never
+		// reaches it. Create a fresh org rather than adding a second member to
+		// one of the shared seeded orgs, which other tests may rely on staying
+		// single-member.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Create organization" }).ClickAsync();
+
+		var createDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(createDialog).ToBeVisibleAsync();
+		var orgName = $"Visual1050 A11y {Guid.NewGuid():N}";
+		await createDialog.Locator("input[type='text']").FillAsync(orgName);
+		await Page.GetByTestId("modal-submit").ClickAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }))
+			.ToContainTextAsync(orgName, new() { Timeout = 15_000 });
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = Guid.Parse(match.Groups[1].Value);
+
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		await Fixture.AddPlainMemberDirectlyAsync(organizationId, vera.UserId);
+
+		// OrgAppLayout only refetches org details on organizationId change -
+		// force a refetch, same as OrganizationTests.cs's equivalent setup.
+		await Page.ReloadAsync();
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Promote to Organizer" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -153,6 +153,25 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 
 		var response = await _keycloakClient.SendAsync(request, cancellationToken);
 		await EnsureSuccessAsync(response);
+
+		// Keycloak-side membership alone isn't enough: command handlers like
+		// ChangeMemberRoleCommandHandler resolve membership via the local
+		// organization_membership table (dbContext.GetMembershipAsync), not
+		// Keycloak, so this escape hatch must seed that row too or those
+		// handlers 404 on a member this call just added.
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync(cancellationToken);
+		await using var cmd = new NpgsqlCommand(
+			"""
+			INSERT INTO organization_membership (id, organization_id, user_id, role, created_on)
+			VALUES (@id, @organizationId, @userId, @role, now())
+			ON CONFLICT (organization_id, user_id) DO NOTHING
+			""", conn);
+		cmd.Parameters.AddWithValue("id", Guid.CreateVersion7());
+		cmd.Parameters.AddWithValue("organizationId", organizationId);
+		cmd.Parameters.AddWithValue("userId", userId);
+		cmd.Parameters.AddWithValue("role", "Member");
+		await cmd.ExecuteNonQueryAsync(cancellationToken);
 	}
 
 	// Olaf's well-known seed user id (ApplicationDbContextInitializer.OlafId,

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -260,9 +260,14 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(demoteButton).ToBeVisibleAsync();
 
 		// Reload to prove the promotion was actually persisted server-side,
-		// not just an optimistic local-state update.
+		// not just an optimistic local-state update. Extended timeout here (vs.
+		// the default 30s elsewhere in this file) - this specific click is the
+		// last thing this test does before the whole ~240-test suite winds
+		// down, and has been observed timing out under end-of-run resource
+		// contention even though the identical reload+click pattern elsewhere
+		// in this file never does.
 		await Page.ReloadAsync();
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync(new() { Timeout = 60_000 });
 		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).ToBeVisibleAsync();
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -281,10 +281,19 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// intent). Verifies the role selector lets an organizer explicitly
 		// invite someone as an Organizer instead, shown on the pending
 		// invitation.
+		//
+		// Uses a throwaway org (not olaf's pinned/seeded one) because
+		// Organisator_InviteMemberFromDashboard_SendsInvitationInsteadOf403
+		// above already invites vera into that shared org, and
+		// organization_invitation rows aren't cleared between tests -
+		// inviting her there a second time would 409 with
+		// OrganizationInvitation.AlreadyInvited depending on run order.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
-		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1050 InviteRole", pinnedOrgId!.Value);
 
 		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -214,6 +214,96 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Organizer_CanPromoteAndDemoteMember_ViaMembersPage()
+	{
+		// #1050: OrganizationMembership.Role was create-only, so every member
+		// was forcibly an Organizer with no promote/demote path. Verifies the
+		// new "Promote to Organizer"/"Demote to Member" actions round-trip
+		// through the API and persist (survive a reload), not just update
+		// local state optimistically.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1050 PromoteDemote", pinnedOrgId!.Value);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = Guid.Parse(match.Groups[1].Value);
+
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		await Fixture.AddPlainMemberDirectlyAsync(organizationId, vera.UserId);
+
+		// OrgAppLayout only refetches org details on organizationId change, so
+		// the dashboard we're still on would otherwise keep showing its
+		// pre-membership snapshot - force a refetch, same as other tests above.
+		await Page.ReloadAsync();
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+
+		// Scope to vera's row by her stable seed email rather than her display
+		// name - see RemoveMember_ShowsConfirmationDialog_AndOnlyRemovesAfterConfirm
+		// above for why.
+		var veraRow = Page.Locator("li", new() { HasText = "vera@example.com" });
+		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Plain member: no Organizer badge, a "Promote" action, no "Demote".
+		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).Not.ToBeVisibleAsync();
+		var promoteButton = veraRow.GetByRole(AriaRole.Button, new() { Name = "Promote to Organizer" });
+		await Expect(promoteButton).ToBeVisibleAsync();
+
+		await promoteButton.ClickAsync();
+
+		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		var demoteButton = veraRow.GetByRole(AriaRole.Button, new() { Name = "Demote to Member" });
+		await Expect(demoteButton).ToBeVisibleAsync();
+
+		// Reload to prove the promotion was actually persisted server-side,
+		// not just an optimistic local-state update.
+		await Page.ReloadAsync();
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).ToBeVisibleAsync();
+
+		// Demote back to Member - olaf remains an organizer, so this is allowed.
+		await veraRow.GetByRole(AriaRole.Button, new() { Name = "Demote to Member" }).ClickAsync();
+
+		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(veraRow.GetByRole(AriaRole.Button, new() { Name = "Promote to Organizer" })).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task Organizer_CanInviteMemberWithOrganizerRole_ViaRoleSelector()
+	{
+		// #1050: CreateInvitation now carries an intended role, defaulting to
+		// Member (the previous behavior always granted Organizer regardless of
+		// intent). Verifies the role selector lets an organizer explicitly
+		// invite someone as an Organizer instead, shown on the pending
+		// invitation.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+
+		await Page.Locator("#member-search").FillAsync("vera");
+
+		var inviteButton = Page.GetByRole(AriaRole.Button, new() { Name = "Invite" });
+		await Expect(inviteButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.Locator("#invite-role").SelectOptionAsync("Organizer");
+		await inviteButton.First.ClickAsync();
+
+		await Expect(Page.GetByText("Invitation sent.")).ToBeVisibleAsync();
+
+		var pendingSection = Page.Locator("li", new() { HasTextString = "vera" }).First;
+		await Expect(pendingSection.GetByText("Organizer", new() { Exact = true }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
 	public async Task SoleMember_CanDeleteOrganization_FromSettingsPage()
 	{
 		// #580: the new "Delete Organization" action, enabled only for the

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -260,14 +260,13 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(demoteButton).ToBeVisibleAsync();
 
 		// Reload to prove the promotion was actually persisted server-side,
-		// not just an optimistic local-state update. Extended timeout here (vs.
-		// the default 30s elsewhere in this file) - this specific click is the
-		// last thing this test does before the whole ~240-test suite winds
-		// down, and has been observed timing out under end-of-run resource
-		// contention even though the identical reload+click pattern elsewhere
-		// in this file never does.
+		// not just an optimistic local-state update. Already on the members
+		// page (navigated here via the dashboard's member-count link earlier)
+		// - the "member" link lives only on the dashboard's SettingsWidget, not
+		// on this page, so reloading this page directly is all that's needed;
+		// re-clicking that link here would look for an element that doesn't
+		// exist on /dashboard/members and hang until timeout.
 		await Page.ReloadAsync();
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync(new() { Timeout = 60_000 });
 		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await Expect(veraRow.GetByText("Organizer", new() { Exact = true })).ToBeVisibleAsync();
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3619,6 +3619,86 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    changeMemberRole(organizationId: string, userId: string, body: ChangeMemberRoleRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/organizations/{organizationId}/members/{userId}/role";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        if (userId === undefined || userId === null)
+            throw new globalThis.Error("The parameter 'userId' must be defined.");
+        url_ = url_.replace("{userId}", encodeURIComponent("" + userId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            signal,
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processChangeMemberRole(_response);
+        });
+    }
+
+    protected processChangeMemberRole(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     adminShadowDeleteOrganization(organizationId: string, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/admin/organizations/{organizationId}";
         if (organizationId === undefined || organizationId === null)
@@ -5114,6 +5194,12 @@ export interface CancelEngagementRequest {
     [key: string]: any;
 }
 
+export interface ChangeMemberRoleRequest {
+    role: string;
+
+    [key: string]: any;
+}
+
 export interface CheckInWithPinRequest {
     pin: string;
 
@@ -5156,6 +5242,7 @@ export interface CreateEngagementResponse {
 
 export interface CreateInvitationRequest {
     inviteeId: string;
+    role: string;
 
     [key: string]: any;
 }
@@ -5470,6 +5557,7 @@ export interface OrganizationMemberDto {
     lastName: string | undefined;
     email: string;
     isOrganisator: boolean;
+    role: string;
 
     [key: string]: any;
 }
@@ -5486,6 +5574,7 @@ export interface OrgInvitationDto {
     id: string;
     inviteeId: string;
     inviteeName: string;
+    intendedRole: string;
     status: string;
     createdOn: Date;
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -453,6 +453,11 @@
       "noMembers": "Noch keine Mitglieder.",
       "noMembersHint": "Mitglieder, die dieser Organisation beitreten, erscheinen hier.",
       "organisator": "Organisator",
+      "roleMember": "Mitglied",
+      "promoteToOrganizer": "Zum Organisator befördern",
+      "demoteToMember": "Zum Mitglied zurückstufen",
+      "changeRoleError": "Rolle konnte nicht geändert werden.",
+      "changeRoleLastOrganizerHint": "Dies ist der einzige Organisator dieser Organisation - befördere zuerst ein anderes Mitglied.",
       "removeMember": "Entfernen",
       "removeMemberError": "Mitglied konnte nicht entfernt werden.",
       "leaveOrganization": "Verlassen",
@@ -463,6 +468,7 @@
       "loading": "Wird geladen…",
       "inviteLabel": "Mitglied einladen",
       "invitePlaceholder": "Nach Benutzername oder E-Mail suchen…",
+      "inviteRoleLabel": "Einladen als",
       "invite": "Einladen",
       "inviteError": "Einladung konnte nicht gesendet werden.",
       "inviteSent": "Einladung gesendet.",
@@ -1069,6 +1075,7 @@
         "MultipleMembers": "Nur das letzte verbleibende Mitglied kann die Organisation löschen. Entferne zuerst die anderen Mitglieder.",
         "HasBlockingOpportunities": "Diese Organisation hat noch Bedarfe mit zukünftigen Zeitslots oder aktiven Engagements. Bitte löse das zuerst auf.",
         "SoleOrganizer": "Du bist der einzige Organisator dieser Organisation. Lösche stattdessen die Organisation, wenn du sie schließen möchtest.",
+        "SoleOrganizerDemote": "Du kannst den einzigen Organisator dieser Organisation nicht zurückstufen. Befördere zuerst ein anderes Mitglied oder lösche die Organisation.",
         "NotOrganizer": "Du hast keine Berechtigung, diese Ressource zu ändern."
       },
       "OrganizationInvitation": {
@@ -1079,7 +1086,13 @@
         "NotDeclined": "Nur abgelehnte oder abgelaufene Einladungen können verworfen werden.",
         "NotExpired": "Nur abgelaufene Einladungen können erneut gesendet werden.",
         "AlreadyMember": "Der Benutzer ist bereits Mitglied dieser Organisation.",
-        "AlreadyInvited": "Für diesen Benutzer besteht bereits eine ausstehende Einladung."
+        "AlreadyInvited": "Für diesen Benutzer besteht bereits eine ausstehende Einladung.",
+        "InvalidRole": "Ungültige Rolle."
+      },
+      "OrganizationMembership": {
+        "NotFound": "Mitgliedschaft nicht gefunden.",
+        "RoleUnchanged": "Das Mitglied hat bereits diese Rolle.",
+        "InvalidRole": "Ungültige Rolle."
       },
       "VolunteerOpportunity": {
         "InvalidCheckInPin": "Die Check-in-PIN muss 4 bis 6 Ziffern haben.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -453,6 +453,11 @@
       "noMembers": "No members yet.",
       "noMembersHint": "Members who join this organization will appear here.",
       "organisator": "Organizer",
+      "roleMember": "Member",
+      "promoteToOrganizer": "Promote to Organizer",
+      "demoteToMember": "Demote to Member",
+      "changeRoleError": "Could not change role.",
+      "changeRoleLastOrganizerHint": "This is the only organizer of this organization - promote another member first.",
       "removeMember": "Remove",
       "removeMemberError": "Could not remove member.",
       "leaveOrganization": "Leave",
@@ -463,6 +468,7 @@
       "loading": "Loading…",
       "inviteLabel": "Invite member",
       "invitePlaceholder": "Search by username or email…",
+      "inviteRoleLabel": "Invite as",
       "invite": "Invite",
       "inviteError": "Could not send invitation.",
       "inviteSent": "Invitation sent.",
@@ -1069,6 +1075,7 @@
         "MultipleMembers": "Only the organization's sole remaining member can delete it. Remove the other members first.",
         "HasBlockingOpportunities": "This organization has opportunities with future time slots or active engagements. Resolve or cancel these first.",
         "SoleOrganizer": "You are the only organizer of this organization. Delete the organization instead of leaving it.",
+        "SoleOrganizerDemote": "You cannot demote the only organizer of this organization. Promote another member first, or delete the organization.",
         "NotOrganizer": "You do not have permission to modify this resource."
       },
       "OrganizationInvitation": {
@@ -1079,7 +1086,13 @@
         "NotDeclined": "Only declined or expired invitations can be dismissed.",
         "NotExpired": "Only expired invitations can be resent.",
         "AlreadyMember": "User is already a member of this organization.",
-        "AlreadyInvited": "A pending invitation already exists for this user."
+        "AlreadyInvited": "A pending invitation already exists for this user.",
+        "InvalidRole": "Invalid role."
+      },
+      "OrganizationMembership": {
+        "NotFound": "Membership not found.",
+        "RoleUnchanged": "Member already has this role.",
+        "InvalidRole": "Invalid role."
       },
       "VolunteerOpportunity": {
         "InvalidCheckInPin": "Check-in PIN must be 4 to 6 digits.",

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -51,6 +51,12 @@ export default function OrgMembersPage() {
 	>([]);
 	const [memberSearchLoading, setMemberSearchLoading] = useState(false);
 	const [invitingUserId, setInvitingUserId] = useState<string | null>(null);
+	const [inviteRole, setInviteRole] = useState<"Member" | "Organizer">(
+		"Member",
+	);
+	const [changingRoleUserId, setChangingRoleUserId] = useState<string | null>(
+		null,
+	);
 	const memberSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	function handleMemberSearchChange(value: string) {
@@ -91,6 +97,7 @@ export default function OrgMembersPage() {
 		try {
 			const response = await api.createInvitation(org.id, {
 				inviteeId: userId,
+				role: inviteRole,
 			});
 			const invited = memberCandidates.find((c) => c.userId === userId);
 			setInvitations((prev) => [
@@ -102,6 +109,7 @@ export default function OrgMembersPage() {
 						invited?.firstName && invited?.lastName
 							? `${invited.firstName} ${invited.lastName}`
 							: (invited?.username ?? ""),
+					intendedRole: inviteRole,
 					status: "Pending",
 					createdOn: new Date(),
 				},
@@ -115,6 +123,31 @@ export default function OrgMembersPage() {
 			setSettingsError(t("orgSettings.inviteError"));
 		} finally {
 			setInvitingUserId(null);
+		}
+	}
+
+	async function handleChangeMemberRole(
+		userId: string,
+		role: "Member" | "Organizer",
+	) {
+		setChangingRoleUserId(userId);
+		try {
+			await api.changeMemberRole(org.id, userId, { role });
+			setMembers((prev) =>
+				prev.map((m) =>
+					m.userId === userId
+						? { ...m, role, isOrganisator: role === "Organizer" }
+						: m,
+				),
+			);
+			setSettingsError(null);
+		} catch (err) {
+			setSuccessMessage(null);
+			setSettingsError(
+				getApiErrorMessage(err, t("orgSettings.changeRoleError")),
+			);
+		} finally {
+			setChangingRoleUserId(null);
 		}
 	}
 
@@ -210,6 +243,23 @@ export default function OrgMembersPage() {
 						placeholder={t("orgSettings.invitePlaceholder")}
 						className={inputClass}
 					/>
+					<label
+						htmlFor="invite-role"
+						className="mt-2 block text-xs font-medium text-gray-700"
+					>
+						{t("orgSettings.inviteRoleLabel")}
+					</label>
+					<select
+						id="invite-role"
+						value={inviteRole}
+						onChange={(e) =>
+							setInviteRole(e.target.value as "Member" | "Organizer")
+						}
+						className={inputClass}
+					>
+						<option value="Member">{t("orgSettings.roleMember")}</option>
+						<option value="Organizer">{t("orgSettings.organisator")}</option>
+					</select>
 					{memberSearchLoading && (
 						<p className="mt-1 text-xs text-gray-500">
 							{t("orgSettings.searching")}
@@ -270,6 +320,11 @@ export default function OrgMembersPage() {
 										<div className="min-w-0">
 											<p className="truncate text-sm font-medium text-gray-900">
 												{invitation.inviteeName}
+												{invitation.intendedRole === "Organizer" && (
+													<span className="ml-2 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+														{t("orgSettings.organisator")}
+													</span>
+												)}
 											</p>
 											<p className="truncate text-xs text-gray-500">
 												{t("orgSettings.invitationSentOn", {
@@ -411,21 +466,46 @@ export default function OrgMembersPage() {
 										{t("orgSettings.leaveOrganization")}
 									</button>
 								) : (
-									<button
-										type="button"
-										onClick={() =>
-											setRemoveTarget({
-												userId: member.userId,
-												name:
-													member.firstName && member.lastName
-														? `${member.firstName} ${member.lastName}`
-														: member.username,
-											})
-										}
-										className="text-xs text-red-700 hover:text-red-800"
-									>
-										{t("orgSettings.removeMember")}
-									</button>
+									<div className="flex shrink-0 items-center gap-3">
+										<button
+											type="button"
+											onClick={() =>
+												void handleChangeMemberRole(
+													member.userId,
+													member.isOrganisator ? "Member" : "Organizer",
+												)
+											}
+											disabled={
+												changingRoleUserId === member.userId ||
+												(member.isOrganisator && organizerCount <= 1)
+											}
+											title={
+												member.isOrganisator && organizerCount <= 1
+													? t("orgSettings.changeRoleLastOrganizerHint")
+													: undefined
+											}
+											className="text-xs text-brand-700 hover:text-brand-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+										>
+											{member.isOrganisator
+												? t("orgSettings.demoteToMember")
+												: t("orgSettings.promoteToOrganizer")}
+										</button>
+										<button
+											type="button"
+											onClick={() =>
+												setRemoveTarget({
+													userId: member.userId,
+													name:
+														member.firstName && member.lastName
+															? `${member.firstName} ${member.lastName}`
+															: member.username,
+												})
+											}
+											className="text-xs text-red-700 hover:text-red-800"
+										>
+											{t("orgSettings.removeMember")}
+										</button>
+									</div>
 								)}
 							</li>
 						))}


### PR DESCRIPTION
OrganizationMembership.Create() had no way to change role afterwards, so every accepted invitation hardcoded Organizer regardless of intent - OrganizationMemberRole.Member was unreachable in production and every new member got full organizational control.

- Add OrganizationMembership.ChangeRole() and a PUT /organizations/{orgId}/members/{userId}/role endpoint (organizer-only, blocks demoting the sole remaining organizer) with symmetric Keycloak realm-role sync (assign on promote, revoke on demote only once the user organizes no other org).
- CreateInvitation now carries an intended role; AcceptInvitation grants that role instead of always granting Organizer.
- OrgMembersPage gets a role selector for invites (defaulting to Member) and promote/demote actions per member.
- Fix an EF Core sentinel-value bug found while wiring this up: HasDefaultValue(Organizer) on IntendedRole would have silently coerced an explicit Member value to Organizer, since Member is the enum's CLR default - covered by a real-database integration test.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1050

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
