### PR TITLE
fix: rename stale Waitlist test identifiers left by ScheduledSlots rename

### DIFF
--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -164,7 +164,7 @@ public class CancelEngagementCommandHandlerTests
 	{
 		// Arrange
 		var engagementId = EngagementId.New();
-		var engagement = CreatePendingWaitlistEngagement();
+		var engagement = CreatePendingScheduledSlotsEngagement();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
 		_keycloakUserService
 			.GetUserAsync(engagement.VolunteerId!.Value.Value, Arg.Any<CancellationToken>())

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -161,10 +161,10 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 
 		var timeSlotId = TimeSlotId.New();
 		var opportunityA = CreateOpportunity(organizationId);
-		var engagementA = Engagement.CreateWaitlistSignUp(opportunityA.Id, UserId.New(), timeSlotId);
+		var engagementA = Engagement.CreateSlotSignUp(opportunityA.Id, UserId.New(), timeSlotId);
 		engagementA.Confirm();
 		var opportunityB = CreateOpportunity(organizationId);
-		var engagementB = Engagement.CreateWaitlistSignUp(opportunityB.Id, UserId.New(), timeSlotId);
+		var engagementB = Engagement.CreateSlotSignUp(opportunityB.Id, UserId.New(), timeSlotId);
 		engagementB.Confirm();
 
 		_dbContext

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -113,7 +113,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = CreateOpportunity();
 		var timeSlotId = TimeSlotId.New();
-		var engagement = Engagement.CreateWaitlistSignUp(
+		var engagement = Engagement.CreateSlotSignUp(
 			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
 		engagement.Confirm();
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -167,9 +167,9 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = CreateOpportunity();
 		var timeSlotId = TimeSlotId.New();
-		var pendingEngagement = Engagement.CreateWaitlistSignUp(
+		var pendingEngagement = Engagement.CreateSlotSignUp(
 			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
-		var confirmedEngagement = Engagement.CreateWaitlistSignUp(
+		var confirmedEngagement = Engagement.CreateSlotSignUp(
 			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), UserId.New(), timeSlotId);
 		confirmedEngagement.Confirm();
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -260,7 +260,7 @@ public class UpdateTimeSlotCommandHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var opportunity = CreateWaitlistOpportunity();
+		var opportunity = CreateScheduledSlotsOpportunity();
 		var editedSlot = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow).Value;
 		var opportunityId = opportunity.Id.Value;
 


### PR DESCRIPTION
## What

Rename 5 stale test call sites still using the pre-rename `Engagement.CreateWaitlistSignUp`, `CreateWaitlistOpportunity`, and `CreatePendingWaitlistEngagement` identifiers to their `#1504`-renamed equivalents (`CreateSlotSignUp`, `CreateScheduledSlotsOpportunity`, `CreatePendingScheduledSlotsEngagement`).

## Why

`#1504` renamed the `Waitlist` participation type to `ScheduledSlots` and updated most call sites, including a follow-up "fix: rename stale Waitlist test literals" commit. However `#1506` and `#1509` merged around the same time and added new test code using the old identifier names, which that follow-up commit predates - leaving `main`'s `Application.UnitTests` project uncompilable at HEAD. This blocks CI (`fast-tests`/`build`) on every open PR rebased onto current `main`.

Closes #

## Testing

`dotnet test tests/Application.UnitTests` - all 564 tests pass. `dotnet build` for `Api`, `IntegrationTests`, and `VisualTests` all succeed.

## Live verification

Not applicable - test-identifier rename only, no runtime behavior change.

## Checklist

- [x] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no behavior change)
