### PR TITLE
fix(test): poll for scroll settle in achievements deep-link visual test

### DIFF
--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -89,9 +89,19 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		var badgesHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Badges" });
 		await Expect(badgesHeading).ToBeVisibleAsync(new() { Timeout = 20_000 });
 
-		var badgesBox = await badgesHeading.BoundingBoxAsync();
-		badgesBox.Should().NotBeNull();
-		badgesBox!.Y.Should().BeLessThan(300, "the page should have scrolled the Badges section near the top of the viewport");
+		// The deep-link effect scrolls via scrollIntoView({ behavior: "smooth" })
+		// (unless the OS/browser prefers reduced motion), so the heading can still
+		// be mid-animation the instant it becomes visible - poll instead of reading
+		// the bounding box once, the same pattern used above for other
+		// layout-settling assertions in this file.
+		float? badgesY = null;
+		await PollUntilAsync(async () =>
+		{
+			var badgesBox = await badgesHeading.BoundingBoxAsync();
+			badgesY = badgesBox?.Y;
+			return badgesBox is not null && badgesBox.Y < 300;
+		}, () => "the page should have scrolled the Badges section near the top of the viewport "
+			+ $"(last observed Y = {badgesY?.ToString() ?? "null"})");
 	}
 
 	[Test]


### PR DESCRIPTION
## What

Hardens `ProfileAchievementsTabDeepLink_ScrollsToBadgesSection` in `backend/tests/VisualTests/ProfileOverviewTests.cs` so it polls for the Badges heading's scroll position to settle instead of reading its bounding box once.

## Why

Cutting `v1.0.0-rc.336` from `main` turned the CI/CD pipeline red: the `Backend Visual Tests` job in `publish.yml` failed on this exact test, off by only 5px (`badgesBox.Y` was `305`, assertion required `< 300`), which blocked `publish-backend`/`publish-frontend`/`publish-keycloak`/`deploy-staging` for that tag.

The `?tab=achievements` deep link scrolls to the Badges section via `scrollIntoView({ behavior: "smooth" })`. The test asserted the heading's bounding box the instant it became visible, but visibility doesn't imply the smooth-scroll animation has finished - a race, not a functional regression (the diff between the last green RC and this one didn't touch this page's scroll behavior). This follows the same polling pattern already used elsewhere in this file (`AssertContentWrapperIsCentered`/`AssertContentWrapperIsLeftAligned`) for other layout-settling assertions, via the existing `PollUntilAsync` helper in `VisualTestBase.cs`.

## Testing

- `dotnet build` - succeeds
- `/self-review` run - no findings

## Live verification

Not applicable - this is a test-only reliability fix with no user-facing behavior change. CI itself (this PR's `Backend Visual Tests` job, and the next release candidate cut from `main` once merged) is the verification that the flake is resolved.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - test-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVQFodT1aHYU8V2riXeoV3)_