### PR TITLE
fix: stop stale session from redirecting anonymous visitors to sign-in

### DIFF
--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Microsoft.Playwright;
@@ -99,6 +101,103 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(sessionExpiredToast).Not.ToBeVisibleAsync();
 
 		Page.Url.Should().StartWith(frontend.ToString());
+	}
+
+	// Regression: a Keycloak session that naturally lapsed (browser closed,
+	// reopened later - no explicit sign-out) leaves an already-expired user
+	// object sitting in localStorage. automaticSilentRenew (main.tsx) fires a
+	// renewal attempt for it immediately on mount regardless of which page is
+	// open, and that attempt fails right away (no live Keycloak SSO session
+	// behind it, since this session was minted out-of-band here rather than
+	// via a real browser login). useSessionExpiryHandler used to treat any
+	// addSilentRenewError as "your live session just expired" and force a
+	// signinRedirect - even though the visitor was never actually
+	// authenticated on this page, which is meant to work for anonymous
+	// visitors. Also covers VolunteerOpportunityDetailPage.tsx separately
+	// gating its organiser-only getOrganizations() call on isAuthenticated,
+	// not just on the (still-present-but-stale) profile roles.
+	[Test]
+	public async Task StaleExpiredSession_AnonymousVisitor_OpportunityDetailPage_StaysOnPage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		// Without this, oidc-client-ts's silent-renew discovery fetch gets
+		// blocked by the context-wide X-Forwarded-For header (see this
+		// method's own doc comment) before it ever reaches Keycloak, so a
+		// still-broken handleExpiry would never actually attempt the redirect
+		// this test needs to be able to observe - it would pass for the wrong
+		// reason instead of exercising the real regression.
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"Stale Session Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"Stale Session Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Seeded for the stale-session regression coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opp = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opp.GetProperty("id").GetString();
+
+		// Olaf is an organiser (has the "organisator" role), same as the real
+		// scenario this guards - a stale session whose cached profile still
+		// carries organiser claims. expires_at is set well in the past, unlike
+		// AuthHelper.FastSignInAsync's session (always in the future) - that
+		// helper covers the "still logged in" case already exercised
+		// elsewhere in this file.
+		var session = await Fixture.SignInAsync("olaf", "olaf123");
+		var profile = AuthHelper.DecodeJwtPayload(session.IdToken);
+		var storageValue = JsonSerializer.Serialize(new
+		{
+			id_token = session.IdToken,
+			session_state = (string?)null,
+			access_token = session.AccessToken,
+			refresh_token = (string?)null,
+			token_type = session.TokenType,
+			scope = "openid",
+			profile,
+			expires_at = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 3600,
+		});
+		// Must match VITE_KEYCLOAK_CLIENT_ID (frontend/.env.development) - see
+		// AuthHelper.FrontendClientId's own doc comment for why.
+		var storageKey = $"oidc.user:{session.Authority}:frontend";
+
+		await Page.AddInitScriptAsync(
+			$"window.localStorage.setItem({JsonSerializer.Serialize(storageKey)}, "
+			+ $"{JsonSerializer.Serialize(storageValue)});");
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(oppTitle, new() { Timeout = 15_000 });
+
+		// The anonymous sign-in CTA renders - the page must not treat this
+		// visitor as authenticated just because a stale profile is present.
+		await Expect(Page.GetByTestId("opportunity-signin")).ToBeVisibleAsync();
+
+		// Give automaticSilentRenew's background failure and the (old) 2s
+		// redirect timer time to fire - generous margin over that 2s under a
+		// contended CI runner - then confirm we're still on the SPA rather
+		// than having been bounced to Keycloak's login page.
+		await Page.WaitForTimeoutAsync(5000);
+		Page.Url.Should().StartWith(origin);
 	}
 
 	private async Task MockAllV1GetRequestsAsUnauthorizedAsync()

--- a/frontend/src/hooks/useSessionExpiryHandler.ts
+++ b/frontend/src/hooks/useSessionExpiryHandler.ts
@@ -21,6 +21,8 @@ export function useSessionExpiryHandler() {
 	const handledRef = useRef(false);
 	const locationRef = useRef(location);
 	locationRef.current = location;
+	const authRef = useRef(auth);
+	authRef.current = auth;
 
 	useEffect(() => {
 		handledRef.current = false;
@@ -30,6 +32,16 @@ export function useSessionExpiryHandler() {
 		let redirectTimer: ReturnType<typeof setTimeout> | null = null;
 
 		function handleExpiry() {
+			// A stale/expired user object can still sit in localStorage from an
+			// earlier login - automaticSilentRenew fires a renewal attempt for it
+			// on mount regardless of what page is open, and that attempt fails
+			// immediately when there's no live Keycloak SSO session behind it
+			// (e.g. login_required). That is not "your active session just
+			// expired" - the user was never authenticated on this page to begin
+			// with, so there's nothing to interrupt them for. Only react when
+			// they actually still look logged in.
+			if (!authRef.current.isAuthenticated) return;
+
 			// Several concurrent API calls (or a bus event racing a silent-renew
 			// failure) can all report expiry around the same time - only act once.
 			if (handledRef.current) return;

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -61,10 +61,17 @@ export default function VolunteerOpportunityDetailPage() {
 	const [withdrawing, setWithdrawing] = useState(false);
 	const [withdrawError, setWithdrawError] = useState<string | null>(null);
 
+	const isAuthenticated = auth.isAuthenticated;
 	const roles = (
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
-	const isOrganisator = roles.includes("organisator");
+	// A stale Keycloak session left in localStorage from an earlier login still
+	// populates auth.user.profile after the token has expired, so this must
+	// gate on isAuthenticated too - otherwise an anonymous visitor with old
+	// organisator claims fires an authenticated getOrganizations() call below,
+	// 401s, and gets force-redirected to sign-in on a page that's meant to
+	// work without being logged in.
+	const isOrganisator = isAuthenticated && roles.includes("organisator");
 	const [userOrgIds, setUserOrgIds] = useState<string[]>([]);
 
 	useEffect(() => {
@@ -187,7 +194,6 @@ export default function VolunteerOpportunityDetailPage() {
 	if (!opportunity)
 		return <p className="text-gray-500">{t("opportunities.notFound")}</p>;
 
-	const isAuthenticated = auth.isAuthenticated;
 	const isOwner =
 		isOrganisator && userOrgIds.includes(opportunity.organizationId);
 	const isDraft = opportunity.status === "Draft";


### PR DESCRIPTION
## What

Anonymous visitors could no longer view a volunteer opportunity's detail page without being redirected to Keycloak sign-in almost immediately, if their browser had a Keycloak session that had naturally lapsed (not an explicit sign-out).

## Why

A Keycloak session that lapses without an explicit sign-out leaves an already-expired user object sitting in `localStorage`. `automaticSilentRenew` (`main.tsx`) fires a renewal attempt for it on mount regardless of which page is open, and that attempt fails immediately since there's no live Keycloak SSO session behind it. `useSessionExpiryHandler` treated *any* such failure as "your live session just expired" and force-redirected to sign-in via `signinRedirect()` - even on pages meant to work for anonymous visitors, like the volunteer opportunity detail page.

`VolunteerOpportunityDetailPage.tsx` had the same root cause locally: it read organiser roles off `auth.user.profile` without checking `auth.isAuthenticated`, so a stale-but-present profile with old `organisator` claims fired an authenticated `getOrganizations()` call, which 401s and triggers the same forced redirect.

Both are now gated on `auth.isAuthenticated`, so a visitor who isn't actually authenticated (even if some stale session data is lying around) is left alone instead of getting bounced to a login screen for a page that never required one.

## Testing

- `dotnet build` (whole solution) - passes
- `dotnet test tests/Application.UnitTests` - 612/612 passing
- `dotnet test tests/ArchitectureTests` - 352/352 passing
- `pnpm check` / `pnpm lint` / `pnpm test` (frontend) - all passing
- Added `SessionExpiryTests.StaleExpiredSession_AnonymousVisitor_OpportunityDetailPage_StaysOnPage` (`backend/tests/VisualTests/SessionExpiryTests.cs`): seeds an already-expired, organiser-role-carrying session into `localStorage` (mirroring a naturally lapsed login) and asserts the opportunity detail page renders the anonymous sign-in CTA and never redirects to Keycloak. This needs Aspire/Docker so it runs in CI, not locally in this sandbox - see "Live verification" below.

## Live verification

Pending - will cut a release candidate, deploy to staging, and verify against the live site per root `AGENTS.md`'s mandatory deploy-and-verify flow, then update this section.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no docs changes needed - internal session-handling bug fix, no user-facing behavior/API contract change to document)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q96w1Z99oqtkeTf2wBBVJ2)_