### PR TITLE
fix: allow dismissing pending organization invitations

### DIFF
--- a/backend/src/Application/Organizations/DismissInvitation/v1/DismissInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DismissInvitation/v1/DismissInvitationCommandHandler.cs
@@ -28,8 +28,13 @@ internal sealed class DismissInvitationCommandHandler(
 		if (invitation.OrganizationId != request.OrganizationId)
 			throw new ResultFailureException(Error.Validation("OrganizationInvitation.WrongOrganization", "Invitation does not belong to this organization."));
 
-		if (invitation.Status != InvitationStatus.Declined && invitation.Status != InvitationStatus.Expired)
-			throw new ResultFailureException(Error.Conflict("OrganizationInvitation.NotDeclined", "Only declined or expired invitations can be dismissed."));
+		// #1040: Pending must be dismissible too, not just Declined/Expired - an
+		// organizer who invited the wrong person otherwise has no way to revoke
+		// it, and accepting grants full Organizer capability (#826). Only a
+		// finalized Accepted invitation - now a real membership row, removed via
+		// RemoveMember instead - is excluded.
+		if (invitation.Status == InvitationStatus.Accepted)
+			throw new ResultFailureException(Error.Conflict("OrganizationInvitation.AlreadyAccepted", "Accepted invitations cannot be dismissed."));
 
 		dbContext.OrganizationInvitations.Delete(invitation);
 		await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
@@ -108,11 +108,33 @@ public class DismissInvitationCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrowConflict_WhenInvitationIsStillPending(
+	public async Task Handle_ShouldDeleteInvitation_WhenRequestingUserIsOrgMemberAndInvitationIsPending(
+		CancellationToken cancellationToken)
+	{
+		// #1040: a pending invitation must be revocable, not just Declined/Expired
+		// ones - previously an organizer had no way to undo a wrong invite before
+		// the invitee acted on it.
+		// Arrange
+		var invitation = CreatePendingInvitation(DefaultOrgId);
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new DismissInvitationCommand(DefaultOrgId, invitation.Id, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		_invitationRepo.Received(1).Delete(invitation);
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenInvitationIsAlreadyAccepted(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var invitation = CreatePendingInvitation(DefaultOrgId);
+		invitation.Accept();
 		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
 		var command = new DismissInvitationCommand(DefaultOrgId, invitation.Id, DefaultRequestingUserId);
 
@@ -121,7 +143,7 @@ public class DismissInvitationCommandHandlerTests
 
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>()
-			.WithMessage("*declined or expired*");
+			.WithMessage("*Accepted invitations*");
 		_invitationRepo.DidNotReceive().Delete(Arg.Any<OrganizationInvitation>());
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 	}

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -558,6 +558,56 @@ public class OrganizationSettingsTests(
 		invitations.Should().NotContain(i => i.Id == invitation.InvitationId);
 	}
 
+	[Test]
+	public async Task DismissInvitation_ShouldReturn204AndRemoveIt_WhenInvitationIsPending(
+		CancellationToken cancellationToken)
+	{
+		// #1040: a pending invitation must be revocable by the organizer before
+		// the invitee acts on it - previously only Declined/Expired invitations
+		// could be dismissed, so an organizer who invited the wrong person had
+		// no way to undo it before they accepted and gained Organizer access.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Dismiss Pending Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Organizer" }, cancellationToken);
+
+		await olafClient.DismissInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);
+
+		var invitations = await olafClient.GetOrgInvitationsAsync(org.Id.Value, cancellationToken);
+		invitations.Should().NotContain(i => i.Id == invitation.InvitationId);
+
+		// The revoked invitation can no longer be accepted.
+		var act = () => veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task DismissInvitation_ShouldReturn409_WhenInvitationIsAlreadyAccepted(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Dismiss Accepted Test Org" }, cancellationToken);
+
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var act = () => olafClient.DismissInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(409);
+	}
+
 	// ── Invitation expiry + resend (#1053) ───────────────────────────────────
 
 	[Test]

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -317,6 +317,50 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Organizer_CanDismissPendingInvitation_RevokingItBeforeAcceptance()
+	{
+		// Regression for #1040: a pending invitation had no dismiss control at
+		// all (only Declined/Expired rows did), and the backend explicitly
+		// rejected dismissing one - so an organizer who invited the wrong
+		// person had no way to revoke it before that person could accept and
+		// gain full Organizer access. Verifies the same "Dismiss" control
+		// already available on Declined/Expired rows now also appears - and
+		// works - for a still-Pending one, and that the removal survives a
+		// reload (persisted, not just optimistic local state).
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Throwaway org, not olaf's pinned/seeded one - other tests in this
+		// shared session already invite vera into that org, and
+		// organization_invitation rows aren't cleared between tests, so
+		// reusing it here could 409 with AlreadyInvited depending on run order.
+		await CreateOrganizationAsync("Visual1040 DismissPending", pinnedOrgId!.Value);
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+
+		await Page.Locator("#member-search").FillAsync("vera");
+		var inviteButton = Page.GetByRole(AriaRole.Button, new() { Name = "Invite" });
+		await Expect(inviteButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await inviteButton.First.ClickAsync();
+
+		await Expect(Page.GetByText("Invitation sent.")).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Pending Invitations")).ToBeVisibleAsync();
+
+		var dismissButton = Page.GetByRole(AriaRole.Button, new() { Name = "Dismiss" });
+		await Expect(dismissButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await dismissButton.ClickAsync();
+
+		await Expect(Page.GetByText("Could not dismiss invitation.")).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByText("Pending Invitations")).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.ReloadAsync();
+		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByText("Pending Invitations")).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task SoleMember_CanDeleteOrganization_FromSettingsPage()
 	{
 		// #580: the new "Delete Organization" action, enabled only for the

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -338,6 +338,14 @@ export default function OrgMembersPage() {
 												})}
 											</p>
 										</div>
+										<button
+											type="button"
+											onClick={() => handleDismissInvitation(invitation.id)}
+											disabled={dismissingInvitationId === invitation.id}
+											className="ml-3 shrink-0 text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+										>
+											{t("orgSettings.dismissInvitation")}
+										</button>
 									</li>
 								))}
 						</ul>


### PR DESCRIPTION
An organizer could not revoke a pending invitation - the backend explicitly rejected it and the UI had no dismiss control for it, unlike the Declined/Expired sections. Since accepting grants full Organizer capability, an accidental invite was irrevocable until the recipient acted on it (#1040).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1040

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
