### PR TITLE
fix: auto check-in engagements once CheckInMethod.None slot ends

### DIFF
--- a/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInJob.cs
@@ -1,0 +1,180 @@
+using Domain.Engagements;
+using Domain.VolunteerOpportunities;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.Outbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+// Opportunities using CheckInMethod.None are labelled as "automatic" check-in, but
+// until this job existed nothing ever set IsCheckedIn for them - attendance and
+// feedback (which requires IsCheckedIn) were permanently dead for that
+// configuration (einsatzbereit#1042). This job finds confirmed, not-yet-checked-in
+// engagements whose time slot has ended on a CheckInMethod.None opportunity and
+// marks them checked in, following the same atomic claim-per-row pattern as
+// EngagementReminderJob so concurrent replicas can never double-process the same
+// engagement.
+internal sealed class AutomaticCheckInJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<AutomaticCheckInJob> logger,
+	IOptions<AutomaticCheckInOptions> options)
+	: IHostedService, IAsyncDisposable
+{
+	private readonly AutomaticCheckInOptions _options = options.Value;
+
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+	private PeriodicTimer? _timer;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_timer = new PeriodicTimer(TimeSpan.FromHours(_options.PollIntervalHours));
+		_executeTask = RunLoopAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_timer?.Dispose();
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunLoopAsync(CancellationToken ct)
+	{
+		if (_timer is null) return;
+
+		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+		{
+			try
+			{
+				await TickAsync(ct).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// Mirrors EngagementReminderJob/OutboxProcessorJob: a failure here (e.g. a
+				// transient DB error) must not stop the PeriodicTimer from ever being
+				// awaited again. Any due engagement still has IsCheckedIn == false, so it
+				// is simply picked up again on the next tick.
+				logger.LogError(ex, "Automatic check-in tick failed; will retry on the next poll interval");
+			}
+		}
+	}
+
+	private async Task TickAsync(CancellationToken ct)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+		var checkedIn = await ClaimAndCheckInAsync(dbContext, DateTimeOffset.UtcNow, _options.MaxBatchSize, ct);
+
+		if (checkedIn > 0)
+			logger.LogInformation("Automatically checked in {Count} engagement(s)", checkedIn);
+	}
+
+	// Exposed so IntegrationTests can exercise the claim race directly against a real
+	// ApplicationDbContext - e.g. two concurrent calls racing over the same ended
+	// time slot, without waiting an hour for a real tick from two replicas.
+	internal static async Task<int> ClaimAndCheckInAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset now,
+		int maxBatchSize,
+		CancellationToken cancellationToken = default)
+	{
+		// One transaction for the whole claim-and-enqueue batch - see
+		// EngagementReminderJob.ClaimAndQueueRemindersAsync for why: without it, a
+		// crash between the ExecuteUpdateAsync claims and the outbox SaveChangesAsync
+		// below would leave engagements marked IsCheckedIn with no outbox row ever
+		// written for the domain event, losing it silently instead of retrying.
+		await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+		// Only ScheduledSlots engagements carry a TimeSlotId, so IndividualContact
+		// opportunities (which have no time slot, hence no well-defined "event end")
+		// are not candidates here - the same limitation EngagementReminderJob already
+		// has for its 24h-before-start window.
+		var candidates = await dbContext.Set<Engagement>()
+			.Where(e =>
+				e.Status == EngagementStatus.Confirmed &&
+				!e.IsCheckedIn &&
+				e.TimeSlotId != null)
+			.Join(
+				dbContext.Set<TimeSlot>(),
+				e => e.TimeSlotId,
+				ts => ts.Id,
+				(e, ts) => new { e.Id, e.VolunteerId, e.OpportunityId, ts.EndDateTime })
+			.Join(
+				dbContext.Set<VolunteerOpportunity>(),
+				x => x.OpportunityId,
+				vo => vo.Id,
+				(x, vo) => new { x.Id, x.VolunteerId, x.OpportunityId, x.EndDateTime, vo.CheckInMethod })
+			.Where(x => x.EndDateTime <= now && x.CheckInMethod == CheckInMethod.None)
+			.OrderBy(x => x.EndDateTime)
+			.Take(maxBatchSize)
+			.ToListAsync(cancellationToken);
+
+		if (candidates.Count == 0)
+		{
+			await transaction.CommitAsync(cancellationToken);
+			return 0;
+		}
+
+		var occurredOnUtc = now.UtcDateTime;
+		var claimedMessages = new List<OutboxMessage>(candidates.Count);
+
+		foreach (var candidate in candidates)
+		{
+			// Atomic per-row claim, same reasoning as EngagementReminderJob: if another
+			// replica's tick already claimed this engagement, this affects 0 rows
+			// instead of racing to check it in (and raise its domain event) twice.
+			var rowsAffected = await dbContext.Set<Engagement>()
+				.Where(e => e.Id == candidate.Id && !e.IsCheckedIn)
+				.ExecuteUpdateAsync(
+					s => s
+						.SetProperty(e => e.IsCheckedIn, true)
+						.SetProperty(e => e.ModifiedOn, now),
+					cancellationToken);
+
+			if (rowsAffected == 0)
+				continue;
+
+			var domainEvent = new EngagementCheckedInDomainEvent(
+				candidate.Id, candidate.VolunteerId!.Value, candidate.OpportunityId);
+			claimedMessages.Add(OutboxMessage.FromDomainEvent(domainEvent, occurredOnUtc));
+		}
+
+		if (claimedMessages.Count == 0)
+		{
+			await transaction.CommitAsync(cancellationToken);
+			return 0;
+		}
+
+		// ExecuteUpdateAsync above bypasses the ChangeTracker, so
+		// ConvertDomainEventsToOutboxMessagesInterceptor never sees these events - the
+		// outbox rows are built directly here instead, then written in a single batched
+		// SaveChangesAsync for however many this tick actually won.
+		dbContext.Set<OutboxMessage>().AddRange(claimedMessages);
+		await dbContext.SaveChangesAsync(cancellationToken);
+		await transaction.CommitAsync(cancellationToken);
+
+		return claimedMessages.Count;
+	}
+}

--- a/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInOptions.cs
@@ -1,0 +1,8 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class AutomaticCheckInOptions
+{
+	public int MaxBatchSize { get; init; } = 500;
+
+	public int PollIntervalHours { get; init; } = 1;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/AutomaticCheckInOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class AutomaticCheckInOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<AutomaticCheckInOptions>
+{
+	public void Configure(AutomaticCheckInOptions options) =>
+		configuration.GetSection("AutomaticCheckIn").Bind(options);
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -97,6 +97,8 @@ public static class ServiceCollectionExtensions
 		services.AddSingleton<IUnsubscribeLinkBuilder, UnsubscribeLinkBuilder>();
 		services.ConfigureOptions<EngagementReminderOptionsSetup>();
 		services.AddHostedService<EngagementReminderJob>();
+		services.ConfigureOptions<AutomaticCheckInOptionsSetup>();
+		services.AddHostedService<AutomaticCheckInJob>();
 		services.ConfigureOptions<OutboxOptionsSetup>();
 		services.AddHostedService<OutboxProcessorJob>();
 		services.AddHostedService<GeocodingRetryJob>();

--- a/backend/tests/IntegrationTests/AutomaticCheckInJobTests.cs
+++ b/backend/tests/IntegrationTests/AutomaticCheckInJobTests.cs
@@ -1,0 +1,201 @@
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
+// "Organization"/"OrganizationId" DTO types, which would otherwise shadow the domain
+// types of the same name pulled in via the "Domain.Organizations" using above.
+using DomainOrganization = Domain.Organizations.Organization;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.AutomaticCheckInJob.ClaimAndCheckInAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres - the job's own PeriodicTimer only fires hourly, and the interesting behavior
+// here (einsatzbereit#1042) is the atomic per-row claim that prevents two replicas'
+// ticks from both checking in (and raising a duplicate domain event for) the same
+// engagement, which is only provable by calling it twice concurrently against two
+// independent ApplicationDbContexts/connections.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class AutomaticCheckInJobTests(IntegrationTestFixture fixture)
+{
+	private const string CheckedInDomainEventType = "Domain.Engagements.EngagementCheckedInDomainEvent";
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task ClaimAndCheckInAsync_EndedSlotWithCheckInMethodNone_ChecksInAndQueuesOutboxMessage(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotEnd: now.AddHours(-1), CheckInMethod.None, isCheckedIn: false, cancellationToken);
+
+		var checkedIn = await AutomaticCheckInJob.ClaimAndCheckInAsync(dbContext, now, 500, cancellationToken);
+
+		checkedIn.Should().Be(1);
+
+		var isCheckedIn = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.IsCheckedIn)
+			.SingleAsync(cancellationToken);
+		isCheckedIn.Should().BeTrue("an ended slot on a CheckInMethod.None opportunity must be auto-checked-in");
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(CheckedInDomainEventType)).Should().Be(1);
+	}
+
+	[Test]
+	public async Task ClaimAndCheckInAsync_TimeSlotNotYetEnded_DoesNotClaim(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotEnd: now.AddHours(1), CheckInMethod.None, isCheckedIn: false, cancellationToken);
+
+		var checkedIn = await AutomaticCheckInJob.ClaimAndCheckInAsync(dbContext, now, 500, cancellationToken);
+
+		checkedIn.Should().Be(0);
+
+		var isCheckedIn = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.IsCheckedIn)
+			.SingleAsync(cancellationToken);
+		isCheckedIn.Should().BeFalse();
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(CheckedInDomainEventType)).Should().Be(0);
+	}
+
+	[Test]
+	public async Task ClaimAndCheckInAsync_CheckInMethodNotNone_DoesNotClaim(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotEnd: now.AddHours(-1), CheckInMethod.Manual, isCheckedIn: false, cancellationToken);
+
+		var checkedIn = await AutomaticCheckInJob.ClaimAndCheckInAsync(dbContext, now, 500, cancellationToken);
+
+		checkedIn.Should().Be(0, "an opportunity with an explicit check-in method must not be auto-checked-in");
+
+		var isCheckedIn = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.IsCheckedIn)
+			.SingleAsync(cancellationToken);
+		isCheckedIn.Should().BeFalse();
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(CheckedInDomainEventType)).Should().Be(0);
+	}
+
+	[Test]
+	public async Task ClaimAndCheckInAsync_AlreadyCheckedIn_DoesNotClaimAgain(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		await SeedConfirmedEngagementAsync(
+			dbContext, timeSlotEnd: now.AddHours(-1), CheckInMethod.None, isCheckedIn: true, cancellationToken);
+
+		var checkedIn = await AutomaticCheckInJob.ClaimAndCheckInAsync(dbContext, now, 500, cancellationToken);
+
+		checkedIn.Should().Be(0);
+		(await fixture.CountOutboxMessagesOfTypeAsync(CheckedInDomainEventType)).Should().Be(0);
+	}
+
+	[Test]
+	public async Task ClaimAndCheckInAsync_TwoConcurrentCallsAgainstTheSameEngagement_OnlyOneClaimsIt(
+		CancellationToken cancellationToken)
+	{
+		// Simulates two replicas' AutomaticCheckInJob ticks racing over the same ended
+		// slot - two independent ApplicationDbContexts (separate connections) so the
+		// atomic per-row claim is genuinely exercised at the database level, not just
+		// serialized by sharing one DbContext/connection.
+		await using var seedContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			seedContext, timeSlotEnd: now.AddHours(-1), CheckInMethod.None, isCheckedIn: false, cancellationToken);
+
+		await using var contextA = fixture.CreateApplicationDbContext();
+		await using var contextB = fixture.CreateApplicationDbContext();
+
+		var results = await Task.WhenAll(
+			AutomaticCheckInJob.ClaimAndCheckInAsync(contextA, now, 500, cancellationToken),
+			AutomaticCheckInJob.ClaimAndCheckInAsync(contextB, now, 500, cancellationToken));
+
+		results.Sum().Should().Be(1, "exactly one of the two concurrent ticks should have won the claim");
+
+		var isCheckedIn = await seedContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == engagementId)
+			.Select(e => e.IsCheckedIn)
+			.SingleAsync(cancellationToken);
+		isCheckedIn.Should().BeTrue();
+
+		(await fixture.CountOutboxMessagesOfTypeAsync(CheckedInDomainEventType)).Should().Be(
+			1, "the losing replica must not have queued a second check-in event for the same engagement");
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private static async Task<(EngagementId EngagementId, VolunteerOpportunityId OpportunityId, TimeSlotId TimeSlotId)> SeedConfirmedEngagementAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset timeSlotEnd,
+		CheckInMethod checkInMethod,
+		bool isCheckedIn,
+		CancellationToken cancellationToken)
+	{
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"AutoCheckInTestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		// ScheduledSlots opportunities can't be created directly as Published (they must have
+		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
+		// here since nothing in this test path depends on the opportunity being published.
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Beach Cleanup", "Help clean the beach", true, null,
+			Occurrence.OneTime, ParticipationType.ScheduledSlots, checkInMethod, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).Value;
+
+		var timeSlotStart = timeSlotEnd.AddHours(-2);
+		// TimeSlot.Create rejects a start date <= "now" (see TimeSlot.Validate), so an
+		// already-ended slot can't be created against the real clock - pass an
+		// artificially-past "now" here instead, well before timeSlotStart, so domain
+		// validation passes regardless of whether timeSlotStart/timeSlotEnd are
+		// themselves in the past relative to the real clock.
+		var creationNow = timeSlotStart.AddDays(-1);
+		var timeSlot = opportunity.AddTimeSlot(timeSlotStart, timeSlotEnd, 10, creationNow).Value;
+		dbContext.Set<VolunteerOpportunity>().Add(opportunity);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), timeSlot.Id);
+		engagement.Confirm();
+		dbContext.Set<Engagement>().Add(engagement);
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		if (isCheckedIn)
+		{
+			await dbContext.Set<Engagement>()
+				.Where(e => e.Id == engagement.Id)
+				.ExecuteUpdateAsync(s => s.SetProperty(e => e.IsCheckedIn, true), cancellationToken);
+		}
+
+		return (engagement.Id, opportunity.Id, timeSlot.Id);
+	}
+
+	private sealed class NoOpPinGenerator : IPinGenerator
+	{
+		public string GeneratePin() => "0000";
+	}
+}

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -130,9 +130,23 @@ export default function CheckInModal({
 				</p>
 			)}
 
-			{details && !success && checkInMethod === "None" && (
-				<p className="text-sm text-gray-600">{t("checkIn.noneInstruction")}</p>
-			)}
+			{details &&
+				!success &&
+				checkInMethod === "None" &&
+				details.participationType === "ScheduledSlots" && (
+					<p className="text-sm text-gray-600">
+						{t("checkIn.noneInstruction")}
+					</p>
+				)}
+
+			{details &&
+				!success &&
+				checkInMethod === "None" &&
+				details.participationType !== "ScheduledSlots" && (
+					<p className="text-sm text-gray-600">
+						{t("checkIn.noneIndividualInstruction")}
+					</p>
+				)}
 
 			{success && (
 				<p className="text-sm font-medium text-green-700">

--- a/frontend/src/components/CreateVolunteerOpportunityModal/FormatStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/FormatStep.tsx
@@ -108,6 +108,17 @@ export default function FormatStep({
 						["Manual", t("checkInMethod.manual")],
 					]}
 				/>
+				{checkInMethod === "None" && participationType === "ScheduledSlots" && (
+					<p className="mt-2 text-xs text-gray-500">
+						{t("createOpportunity.checkInMethodNoneHint")}
+					</p>
+				)}
+				{checkInMethod === "None" &&
+					participationType === "IndividualContact" && (
+						<p className="mt-2 text-xs text-amber-600">
+							{t("createOpportunity.checkInMethodNoneIndividualWarning")}
+						</p>
+					)}
 			</div>
 
 			{checkInMethod === "PINCode" && (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -218,6 +218,8 @@
       "fieldCheckInMethod": "Check-in-Methode",
       "fieldCheckInPin": "Check-in-PIN",
       "checkInPinHint": "4 bis 6 Ziffern. Leer lassen, um automatisch eine zu erzeugen.",
+      "checkInMethodNoneHint": "Teilnehmende werden während des Einsatzes nicht eingecheckt. Sie werden automatisch als eingecheckt markiert, sobald der Zeitslot beendet ist - das schaltet für sie auch das Feedback frei.",
+      "checkInMethodNoneIndividualWarning": "Einsätze mit individueller Kontaktaufnahme haben keinen Zeitslot, daher gibt es keinen automatischen Zeitpunkt zum Einchecken - Teilnehmende werden nie als eingecheckt markiert und können kein Feedback abgeben. Wähle stattdessen Manuell, wenn du die Anwesenheit erfassen möchtest.",
       "checkInPinInvalid": "Die PIN muss 4 bis 6 Ziffern haben.",
       "generateRandomPin": "Zufällig generieren",
       "fieldCategory": "Kategorie",
@@ -256,7 +258,7 @@
       "discardChanges": "Änderungen verwerfen"
     },
     "checkInMethod": {
-      "none": "Keine (automatisch)",
+      "none": "Automatisch (nach dem Einsatz)",
       "qrCode": "QR-Code",
       "pinCode": "PIN-Code",
       "manual": "Manuell"
@@ -535,7 +537,8 @@
       "success": "Erfolgreich eingecheckt!",
       "invalidPin": "Falsche PIN. Bitte erneut versuchen.",
       "manualInstruction": "Der Veranstalter wird dich manuell einchecken.",
-      "noneInstruction": "Für diesen Einsatz ist kein ausdrücklicher Check-in erforderlich.",
+      "noneInstruction": "Kein ausdrücklicher Check-in erforderlich - du wirst automatisch als eingecheckt markiert, sobald der Einsatz beendet ist.",
+      "noneIndividualInstruction": "Für diesen Einsatz ist kein ausdrücklicher Check-in erforderlich.",
       "close": "Fertig",
       "organizerPin": "Eincheck-PIN",
       "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen, damit sie einchecken können.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -218,6 +218,8 @@
       "fieldCheckInMethod": "Check-in method",
       "fieldCheckInPin": "Check-in PIN",
       "checkInPinHint": "4 to 6 digits. Leave blank to generate one automatically.",
+      "checkInMethodNoneHint": "Participants aren't checked in during the event. They're automatically marked as checked in once the time slot has ended, which also unlocks feedback for them.",
+      "checkInMethodNoneIndividualWarning": "Individual-contact opportunities have no time slot, so there's no automatic point to check participants in - they will never be marked as checked in or able to leave feedback. Choose Manual instead if you need attendance tracking.",
       "checkInPinInvalid": "PIN must be 4 to 6 digits.",
       "generateRandomPin": "Generate random",
       "fieldCategory": "Category",
@@ -256,7 +258,7 @@
       "discardChanges": "Discard changes"
     },
     "checkInMethod": {
-      "none": "None (automatic)",
+      "none": "Automatic (after the event)",
       "qrCode": "QR Code",
       "pinCode": "PIN Code",
       "manual": "Manual"
@@ -535,7 +537,8 @@
       "success": "Checked in successfully!",
       "invalidPin": "Invalid PIN. Please try again.",
       "manualInstruction": "The organizer will check you in manually.",
-      "noneInstruction": "This opportunity doesn't require an explicit check-in step.",
+      "noneInstruction": "No explicit check-in is needed - you'll be marked as checked in automatically once the event has ended.",
+      "noneIndividualInstruction": "This opportunity doesn't require an explicit check-in step.",
       "close": "Done",
       "organizerPin": "Check-in PIN",
       "organizerPinHint": "Share this PIN with your volunteers so they can check in.",


### PR DESCRIPTION
Opportunities defaulting to CheckInMethod.None were labelled "automatic" but nothing ever set IsCheckedIn, permanently killing attendance and feedback for that configuration (#1042). AutomaticCheckInJob now marks confirmed engagements checked in once their time slot ends, mirroring EngagementReminderJob's atomic per-row claim. Relabel "None" and its check-in copy to describe the real (now automatic) behavior, and warn organizers that individual-contact opportunities have no time slot to trigger it.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1042

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
