### PR TITLE
feat: add Unpublish and Cancel actions for volunteer opportunities

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityEndpoint.cs
@@ -1,0 +1,51 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+
+internal sealed class CancelVolunteerOpportunityEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapPost("/volunteer-opportunities/{opportunityId:guid}/cancel", CancelVolunteerOpportunityAsync)
+			.WithName("CancelVolunteerOpportunity")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> CancelVolunteerOpportunityAsync(
+		[FromRoute] Guid opportunityId,
+		[FromBody] CancelVolunteerOpportunityRequest? body,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		if (body?.Reason is { Length: > 500 })
+			return Results.Problem("Reason must not exceed 500 characters.", statusCode: StatusCodes.Status400BadRequest);
+
+		await sender.Send(
+			new CancelVolunteerOpportunityCommand(opportunityId, userId, body?.Reason),
+			cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityRequest.cs
@@ -1,0 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+
+public sealed record CancelVolunteerOpportunityRequest([MaxLength(500)] string? Reason);

--- a/backend/src/Api/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesEndpoint.cs
@@ -39,7 +39,9 @@ internal sealed class GetOrganizationOpportunitiesEndpoint
 		CancellationToken cancellationToken)
 	{
 		if (!Enum.TryParse<OpportunityStatus>(status, ignoreCase: true, out var parsedStatus))
-			return Results.Problem("Status must be 'Draft' or 'Published'.", statusCode: StatusCodes.Status400BadRequest);
+			return Results.Problem(
+				$"Status must be one of: {string.Join(", ", Enum.GetNames<OpportunityStatus>())}.",
+				statusCode: StatusCodes.Status400BadRequest);
 
 		if (pageNumber < 1)
 			return Results.Problem("PageNumber must be at least 1.", statusCode: StatusCodes.Status400BadRequest);

--- a/backend/src/Api/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityEndpoint.cs
@@ -1,0 +1,47 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+
+internal sealed class UnpublishVolunteerOpportunityEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapPost("/volunteer-opportunities/{opportunityId:guid}/unpublish", UnpublishVolunteerOpportunityAsync)
+			.WithName("UnpublishVolunteerOpportunity")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> UnpublishVolunteerOpportunityAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		await sender.Send(
+			new UnpublishVolunteerOpportunityCommand(opportunityId, userId),
+			cancellationToken);
+
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -551,6 +551,90 @@
         }
       }
     },
+    "/v1/volunteer-opportunities/{opportunityId}/unpublish": {
+      "post": {
+        "tags": [
+          "UnpublishVolunteerOpportunityEndpoint"
+        ],
+        "operationId": "UnpublishVolunteerOpportunity",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/volunteer-opportunities/{opportunityId}/color": {
       "put": {
         "tags": [
@@ -1400,6 +1484,106 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/volunteer-opportunities/{opportunityId}/cancel": {
+      "post": {
+        "tags": [
+          "CancelVolunteerOpportunityEndpoint"
+        ],
+        "operationId": "CancelVolunteerOpportunity",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CancelVolunteerOpportunityRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6161,6 +6345,20 @@
           }
         }
       },
+      "CancelVolunteerOpportunityRequest": {
+        "required": [
+          "reason"
+        ],
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "ChangeMemberRoleRequest": {
         "required": [
           "role"
@@ -9208,6 +9406,9 @@
       "name": "DeleteTimeSlotEndpoint"
     },
     {
+      "name": "UnpublishVolunteerOpportunityEndpoint"
+    },
+    {
       "name": "SetOpportunityColorEndpoint"
     },
     {
@@ -9227,6 +9428,9 @@
     },
     {
       "name": "CreateTimeSlotEndpoint"
+    },
+    {
+      "name": "CancelVolunteerOpportunityEndpoint"
     },
     {
       "name": "Admin"

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityCommand.cs
@@ -1,0 +1,10 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+
+public sealed record CancelVolunteerOpportunityCommand(
+	Guid OpportunityId,
+	UserId RequestingUserId,
+	string? Reason = null)
+	: ICommand<bool>;

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityCommandHandler.cs
@@ -1,0 +1,35 @@
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+
+internal sealed class CancelVolunteerOpportunityCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<CancelVolunteerOpportunityCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		CancelVolunteerOpportunityCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			VolunteerOpportunityId.Create(request.OpportunityId).GetValueOrThrow(), cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId}' not found."));
+
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		// Cascade-cancelling active engagements + notifying volunteers happens
+		// asynchronously via the outbox (VolunteerOpportunityCancelledDomainEventHandler),
+		// not inline here - see Cancel()'s doc comment on OpportunityStatus.
+		opportunity.Cancel(request.Reason).ThrowIfFailure();
+
+		return true;
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
@@ -1,0 +1,64 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.Common;
+using Domain.Notifications;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+
+// Consumer of VolunteerOpportunityCancelledDomainEvent (#1038): the command
+// handler only flips Status and raises the event; the engagement
+// cascade-cancel + volunteer notification happens here, dispatched by
+// OutboxProcessorJob like every other domain event (see EngagementReminderDueHandler
+// for the same pattern), so a transient failure (e.g. an email send) is
+// retried on the next poll cycle instead of being lost mid-request.
+internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
+	IApplicationDbContext dbContext,
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<VolunteerOpportunityCancelledDomainEventHandler> logger)
+	: INotificationHandler<VolunteerOpportunityCancelledDomainEvent>
+{
+	public async Task Handle(
+		VolunteerOpportunityCancelledDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			notification.OpportunityId, cancellationToken);
+
+		if (opportunity is null)
+		{
+			// Deleted between the Cancel command committing and the outbox
+			// dispatching this event - nothing left to cascade, and retrying
+			// would never resolve.
+			logger.LogWarning(
+				"Skipping cancel cascade for opportunity {OpportunityId}: it no longer exists",
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var engagementCancellationReason = string.IsNullOrWhiteSpace(notification.Reason)
+			? "Opportunity was cancelled."
+			: $"Opportunity was cancelled: {notification.Reason}";
+
+		await VolunteerOpportunityEngagementCascadeHelper.NotifyAndCancelActiveEngagementsAsync(
+			dbContext,
+			engagementReadRepository,
+			keycloakUserService,
+			emailService,
+			emailTemplateRenderer,
+			unsubscribeLinkBuilder,
+			opportunity,
+			notification.OpportunityId,
+			NotificationKind.OpportunityCancelled,
+			engagementCancellationReason,
+			cancellationToken);
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
@@ -16,8 +16,19 @@ namespace Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
 // OutboxProcessorJob like every other domain event (see EngagementReminderDueHandler
 // for the same pattern), so a transient failure (e.g. an email send) is
 // retried on the next poll cycle instead of being lost mid-request.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (Engagement.Cancel(), the new
+// Notification rows), so it must call SaveChangesAsync itself via IUnitOfWork
+// (both resolve to the same ApplicationDbContext instance within this scope -
+// see Infrastructure/ServiceCollectionExtensions.cs).
 internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
 	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
 	IEngagementReadRepository engagementReadRepository,
 	IKeycloakUserService keycloakUserService,
 	IEmailService emailService,
@@ -60,5 +71,7 @@ internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
 			NotificationKind.OpportunityCancelled,
 			engagementCancellationReason,
 			cancellationToken);
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -3,8 +3,6 @@ using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
-using Application.Engagements.Common;
-using Application.Notifications;
 using Domain.Notifications;
 using Domain.Reports;
 using Domain.Users;
@@ -80,31 +78,18 @@ internal static class VolunteerOpportunityDeletionHelper
 		DateTimeOffset now,
 		CancellationToken cancellationToken)
 	{
-		await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
+		await VolunteerOpportunityEngagementCascadeHelper.NotifyAndCancelActiveEngagementsAsync(
 			dbContext,
 			engagementReadRepository,
+			keycloakUserService,
+			emailService,
+			emailTemplateRenderer,
+			unsubscribeLinkBuilder,
+			opportunity,
 			opportunityId,
 			NotificationKind.OpportunityDeleted,
+			"Opportunity was deleted.",
 			cancellationToken);
-
-		var activeEngagements = await dbContext.GetActiveEngagementsForOpportunityAsync(
-			opportunityId, cancellationToken);
-		foreach (var engagement in activeEngagements)
-		{
-			// Same notification + email path a single organizer-triggered cancel
-			// sends (#1057) - a deletion should not leave the volunteer with only
-			// the opportunity-level "was removed" notification above.
-			await EngagementCancellationHelper.CancelAndNotifyAsync(
-				dbContext,
-				keycloakUserService,
-				emailService,
-				emailTemplateRenderer,
-				unsubscribeLinkBuilder,
-				engagement,
-				opportunity.Title,
-				"Opportunity was deleted.",
-				cancellationToken);
-		}
 
 		var openReports = await dbContext.GetOpenReportsForTargetAsync(
 			ReportTargetType.VolunteerOpportunity, opportunityId.Value, cancellationToken);

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
@@ -1,0 +1,61 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.Engagements.Common;
+using Application.Notifications;
+using Domain.Notifications;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.Common;
+
+/// <summary>
+/// Notifies affected volunteers and cancels active engagements for an
+/// opportunity that is going away or off the public listing - shared by
+/// hard delete/shadow delete (<see cref="VolunteerOpportunityDeletionHelper"/>)
+/// and the Unpublish/Cancel domain event handlers (einsatzbereit#1038), so all
+/// three flows leave volunteers notified and no engagement dangling against a
+/// listing that is no longer live.
+/// </summary>
+internal static class VolunteerOpportunityEngagementCascadeHelper
+{
+	public static async Task NotifyAndCancelActiveEngagementsAsync(
+		IApplicationDbContext dbContext,
+		IEngagementReadRepository engagementReadRepository,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
+		IEmailTemplateRenderer emailTemplateRenderer,
+		IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+		VolunteerOpportunity opportunity,
+		VolunteerOpportunityId opportunityId,
+		NotificationKind opportunityNotificationKind,
+		string engagementCancellationReason,
+		CancellationToken cancellationToken)
+	{
+		await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
+			dbContext,
+			engagementReadRepository,
+			opportunityId,
+			opportunityNotificationKind,
+			cancellationToken);
+
+		var activeEngagements = await dbContext.GetActiveEngagementsForOpportunityAsync(
+			opportunityId, cancellationToken);
+		foreach (var engagement in activeEngagements)
+		{
+			// Same notification + email path a single organizer-triggered cancel
+			// sends (#1057) - the volunteer shouldn't hear about this only via
+			// the opportunity-level notification above.
+			await EngagementCancellationHelper.CancelAndNotifyAsync(
+				dbContext,
+				keycloakUserService,
+				emailService,
+				emailTemplateRenderer,
+				unsubscribeLinkBuilder,
+				engagement,
+				opportunity.Title,
+				engagementCancellationReason,
+				cancellationToken);
+		}
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityCommand.cs
@@ -1,0 +1,9 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+
+public sealed record UnpublishVolunteerOpportunityCommand(
+	Guid OpportunityId,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityCommandHandler.cs
@@ -1,0 +1,35 @@
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+using Domain.VolunteerOpportunities;
+
+namespace Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+
+internal sealed class UnpublishVolunteerOpportunityCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<UnpublishVolunteerOpportunityCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		UnpublishVolunteerOpportunityCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			VolunteerOpportunityId.Create(request.OpportunityId).GetValueOrThrow(), cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId}' not found."));
+
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		// Cascade-cancelling active engagements + notifying volunteers happens
+		// asynchronously via the outbox (VolunteerOpportunityUnpublishedDomainEventHandler),
+		// not inline here - see Unpublish()'s doc comment on OpportunityStatus.
+		opportunity.Unpublish().ThrowIfFailure();
+
+		return true;
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
@@ -1,0 +1,60 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.Common;
+using Domain.Notifications;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+
+// Consumer of VolunteerOpportunityUnpublishedDomainEvent (#1038): the command
+// handler only flips Status and raises the event; the engagement
+// cascade-cancel + volunteer notification happens here, dispatched by
+// OutboxProcessorJob like every other domain event (see EngagementReminderDueHandler
+// for the same pattern), so a transient failure (e.g. an email send) is
+// retried on the next poll cycle instead of being lost mid-request.
+internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
+	IApplicationDbContext dbContext,
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<VolunteerOpportunityUnpublishedDomainEventHandler> logger)
+	: INotificationHandler<VolunteerOpportunityUnpublishedDomainEvent>
+{
+	public async Task Handle(
+		VolunteerOpportunityUnpublishedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			notification.OpportunityId, cancellationToken);
+
+		if (opportunity is null)
+		{
+			// Deleted between the Unpublish command committing and the outbox
+			// dispatching this event - nothing left to cascade, and retrying
+			// would never resolve.
+			logger.LogWarning(
+				"Skipping unpublish cascade for opportunity {OpportunityId}: it no longer exists",
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		await VolunteerOpportunityEngagementCascadeHelper.NotifyAndCancelActiveEngagementsAsync(
+			dbContext,
+			engagementReadRepository,
+			keycloakUserService,
+			emailService,
+			emailTemplateRenderer,
+			unsubscribeLinkBuilder,
+			opportunity,
+			notification.OpportunityId,
+			NotificationKind.OpportunityUnpublished,
+			"Opportunity was unpublished.",
+			cancellationToken);
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
@@ -16,8 +16,19 @@ namespace Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
 // OutboxProcessorJob like every other domain event (see EngagementReminderDueHandler
 // for the same pattern), so a transient failure (e.g. an email send) is
 // retried on the next poll cycle instead of being lost mid-request.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (Engagement.Cancel(), the new
+// Notification rows), so it must call SaveChangesAsync itself via IUnitOfWork
+// (both resolve to the same ApplicationDbContext instance within this scope -
+// see Infrastructure/ServiceCollectionExtensions.cs).
 internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
 	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
 	IEngagementReadRepository engagementReadRepository,
 	IKeycloakUserService keycloakUserService,
 	IEmailService emailService,
@@ -56,5 +67,7 @@ internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
 			NotificationKind.OpportunityUnpublished,
 			"Opportunity was unpublished.",
 			cancellationToken);
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 	}
 }

--- a/backend/src/Domain/Notifications/NotificationKind.cs
+++ b/backend/src/Domain/Notifications/NotificationKind.cs
@@ -8,5 +8,7 @@ public enum NotificationKind
 	EngagementWithdrawn,
 	OpportunityUpdated,
 	OpportunityDeleted,
+	OpportunityUnpublished,
+	OpportunityCancelled,
 	InvitationReceived
 }

--- a/backend/src/Domain/VolunteerOpportunities/OpportunityStatus.cs
+++ b/backend/src/Domain/VolunteerOpportunities/OpportunityStatus.cs
@@ -4,4 +4,14 @@ public enum OpportunityStatus
 {
 	Draft,
 	Published,
+
+	// Taken off public listing by the organizer but reversible - Publish()
+	// can bring it back. Active engagements are cascade-cancelled and
+	// notified, since the sign-ups they made no longer have a live listing
+	// behind them (einsatzbereit#1038).
+	Unpublished,
+
+	// Terminal - unlike Unpublished, there is no way back to Published.
+	// Active engagements are cascade-cancelled and notified the same way.
+	Cancelled,
 }

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -39,6 +39,8 @@ public sealed class VolunteerOpportunity
 
 	public OpportunityStatus Status { get; private set; }
 
+	public string? CancellationReason { get; private set; }
+
 	public string? BannerImageUrl { get; private set; }
 
 	public string? Color { get; private set; }
@@ -201,6 +203,13 @@ public sealed class VolunteerOpportunity
 		if (Status == OpportunityStatus.Published)
 			return Result.Failure(Error.Conflict("VolunteerOpportunity.AlreadyPublished", "Opportunity is already published."));
 
+		// Cancelled is terminal - unlike Unpublished, there is no way back to
+		// Published. Without this guard, calling Publish() on a Cancelled
+		// opportunity would silently resurrect it (Publish only otherwise checks
+		// for "already Published", not the source state).
+		if (Status == OpportunityStatus.Cancelled)
+			return Result.Failure(Error.Conflict("VolunteerOpportunity.CannotPublishCancelled", "A cancelled opportunity cannot be published again."));
+
 		var publishable = EnsurePublishable(Title, Description, IsRemote, Address);
 		if (publishable.IsFailure)
 			return publishable;
@@ -212,6 +221,33 @@ public sealed class VolunteerOpportunity
 
 		Status = OpportunityStatus.Published;
 		AddEvent(new VolunteerOpportunityPublishedDomainEvent(Id, OrganizationId));
+		return Result.Success();
+	}
+
+	public Result Unpublish()
+	{
+		if (Status != OpportunityStatus.Published)
+			return Result.Failure(Error.Conflict("VolunteerOpportunity.NotPublished", "Only a published opportunity can be unpublished."));
+
+		Status = OpportunityStatus.Unpublished;
+		AddEvent(new VolunteerOpportunityUnpublishedDomainEvent(Id, OrganizationId));
+		return Result.Success();
+	}
+
+	public Result Cancel(string? reason = null)
+	{
+		if (Status == OpportunityStatus.Cancelled)
+			return Result.Failure(Error.Conflict("VolunteerOpportunity.AlreadyCancelled", "Opportunity is already cancelled."));
+
+		// Draft opportunities have no engagements and no public visibility to
+		// take down - Delete already covers "give up on this draft" without
+		// needing a cancellation reason kept around for audit purposes.
+		if (Status == OpportunityStatus.Draft)
+			return Result.Failure(Error.Conflict("VolunteerOpportunity.CannotCancelDraft", "A draft opportunity cannot be cancelled - delete it instead."));
+
+		CancellationReason = reason;
+		Status = OpportunityStatus.Cancelled;
+		AddEvent(new VolunteerOpportunityCancelledDomainEvent(Id, OrganizationId, reason));
 		return Result.Success();
 	}
 

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityCancelledDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityCancelledDomainEvent.cs
@@ -1,0 +1,10 @@
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityCancelledDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	OrganizationId OrganizationId,
+	string? Reason)
+	: DomainEvent;

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityUnpublishedDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityUnpublishedDomainEvent.cs
@@ -1,0 +1,9 @@
+using Domain.Organizations;
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityUnpublishedDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	OrganizationId OrganizationId)
+	: DomainEvent;

--- a/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
@@ -67,6 +67,10 @@ internal sealed class VolunteerOpportunityConfiguration
 			.HasConversion<string>()
 			.IsRequired();
 
+		// Unconstrained at the DB level, matching Engagement.CancellationReason -
+		// the 500-char cap is enforced at the API layer (CancelVolunteerOpportunityRequest).
+		builder.Property(vo => vo.CancellationReason);
+
 		builder.Property(vo => vo.BannerImageUrl);
 
 		builder.Property(vo => vo.Color);

--- a/backend/src/Infrastructure/Persistence/Migrations/20260731051901_AddOpportunityCancellationReason.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260731051901_AddOpportunityCancellationReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260731051901_AddOpportunityCancellationReason")]
+	partial class AddOpportunityCancellationReason
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260731051901_AddOpportunityCancellationReason.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260731051901_AddOpportunityCancellationReason.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOpportunityCancellationReason : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "cancellation_reason",
+				table: "volunteer_opportunity",
+				type: "text",
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "cancellation_reason",
+				table: "volunteer_opportunity");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Outbox/OutboxMessage.cs
+++ b/backend/src/Infrastructure/Persistence/Outbox/OutboxMessage.cs
@@ -17,6 +17,14 @@ internal sealed class OutboxMessage
 
 	public string? Error { get; set; }
 
+	// See ValueObjectIdJsonConverterFactory: without it, the Guid-backed value-object IDs
+	// (VolunteerOpportunityId, UserId, ...) that domain events carry silently deserialize as
+	// Guid.Empty instead of round-tripping their real value.
+	private static readonly JsonSerializerOptions SerializerOptions = new()
+	{
+		Converters = { new ValueObjectIdJsonConverterFactory() },
+	};
+
 	public static OutboxMessage FromDomainEvent(
 		DomainEvent domainEvent,
 		DateTime occurredOnUtc) =>
@@ -24,7 +32,7 @@ internal sealed class OutboxMessage
 		{
 			Id = Guid.NewGuid(),
 			Type = domainEvent.GetType().FullName!,
-			Content = JsonSerializer.Serialize(domainEvent, domainEvent.GetType()),
+			Content = JsonSerializer.Serialize(domainEvent, domainEvent.GetType(), SerializerOptions),
 			OccurredOnUtc = occurredOnUtc,
 		};
 
@@ -33,7 +41,7 @@ internal sealed class OutboxMessage
 		var type = typeof(DomainEvent).Assembly.GetType(Type)
 			?? throw new InvalidOperationException($"Unknown domain event type '{Type}'.");
 
-		return (DomainEvent)(JsonSerializer.Deserialize(Content, type)
+		return (DomainEvent)(JsonSerializer.Deserialize(Content, type, SerializerOptions)
 			?? throw new InvalidOperationException($"Failed to deserialize outbox message '{Id}' of type '{Type}'."));
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Outbox/ValueObjectIdJsonConverter.cs
+++ b/backend/src/Infrastructure/Persistence/Outbox/ValueObjectIdJsonConverter.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Domain.Primitives;
+
+namespace Infrastructure.Persistence.Outbox;
+
+// Domain events carry Guid-backed value-object IDs (VolunteerOpportunityId, UserId, ...) -
+// readonly record structs with a private constructor and a get-only Value property (see e.g.
+// Domain.VolunteerOpportunities.VolunteerOpportunityId). System.Text.Json's default
+// reflection-based (de)serializer has no public constructor or settable member to populate on
+// deserialize, so OutboxMessage.ToDomainEvent() was silently producing a Guid.Empty-backed
+// instance instead of throwing - only surfaced by einsatzbereit#1038's cascade-cancel tests,
+// the first outbox-dispatched handler to actually look an entity up by the deserialized id
+// rather than just logging it. This converter round-trips them as a plain JSON Guid string.
+internal sealed class ValueObjectIdJsonConverterFactory : JsonConverterFactory
+{
+	public override bool CanConvert(Type typeToConvert) =>
+		typeToConvert.IsValueType
+		&& typeof(IValueObject).IsAssignableFrom(typeToConvert)
+		&& typeToConvert.GetProperty("Value")?.PropertyType == typeof(Guid)
+		&& FindGuidConstructor(typeToConvert) is not null;
+
+	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+		(JsonConverter)Activator.CreateInstance(
+			typeof(ValueObjectIdJsonConverter<>).MakeGenericType(typeToConvert))!;
+
+	internal static ConstructorInfo? FindGuidConstructor(Type type) =>
+		type.GetConstructor(
+			BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+			binder: null,
+			types: [typeof(Guid)],
+			modifiers: null);
+
+	private sealed class ValueObjectIdJsonConverter<T> : JsonConverter<T>
+		where T : struct, IValueObject
+	{
+		private static readonly ConstructorInfo Constructor =
+			FindGuidConstructor(typeof(T))
+			?? throw new InvalidOperationException($"{typeof(T)} has no single-Guid constructor.");
+
+		private static readonly PropertyInfo ValueProperty =
+			typeof(T).GetProperty("Value")
+			?? throw new InvalidOperationException($"{typeof(T)} has no Value property.");
+
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			(T)Constructor.Invoke([reader.GetGuid()]);
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+			writer.WriteStringValue((Guid)ValueProperty.GetValue(value)!);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/CancelVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/CancelVolunteerOpportunityCommandHandlerTests.cs
@@ -1,0 +1,199 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.CancelVolunteerOpportunity;
+
+public class CancelVolunteerOpportunityCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly CancelVolunteerOpportunityCommandHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public CancelVolunteerOpportunityCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new CancelVolunteerOpportunityCommandHandler(_dbContext);
+	}
+
+	private static VolunteerOpportunity CreatePublishedOpportunity()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
+		opportunity.Publish();
+		return opportunity;
+	}
+
+	private void SetupOpportunity(Guid opportunityId, VolunteerOpportunity opportunity) =>
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<CancellationToken>())
+			.Returns(opportunity);
+
+	[Test]
+	public async Task Handle_ShouldReturnTrue_AndSetStatusToCancelled_WithReason(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		var result = await _sut.Handle(
+			new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId, "Funding fell through"), cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
+		opportunity.CancellationReason.Should().Be("Funding fell through");
+	}
+
+	[Test]
+	public async Task Handle_ShouldSetStatusToCancelled_WithoutReason(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
+		opportunity.CancellationReason.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldRaiseCancelledDomainEvent_WithReason(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId, "Venue cancelled"), cancellationToken);
+
+		// Assert - opportunity.Events also carries the Published event raised by
+		// CreatePublishedOpportunity()'s own Publish() call, so assert the
+		// Cancelled event was added rather than that it's the only one.
+		var cancelled = opportunity.Events.OfType<VolunteerOpportunityCancelledDomainEvent>().Should().ContainSingle().Which;
+		cancelled.Reason.Should().Be("Venue cancelled");
+	}
+
+	[Test]
+	public async Task Handle_ShouldAllowCancel_WhenOpportunityIsUnpublished(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		opportunity.Unpublish();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		var result = await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityIsDraft(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		opportunity.Status.Should().Be(OpportunityStatus.Draft);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenAlreadyCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		opportunity.Cancel();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns((VolunteerOpportunity?)null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage($"*{opportunityId}*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
+			.Returns(false);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new CancelVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.Status.Should().Be(OpportunityStatus.Published);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
@@ -1,0 +1,148 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.CancelVolunteerOpportunity;
+
+public class VolunteerOpportunityCancelledDomainEventHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IEngagementReadRepository _engagementReadRepository =
+		Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly VolunteerOpportunityCancelledDomainEventHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+
+	public VolunteerOpportunityCancelledDomainEventHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Engagement>());
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new VolunteerOpportunityCancelledDomainEventHandler(
+			_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<VolunteerOpportunityCancelledDomainEventHandler>.Instance);
+	}
+
+	private static VolunteerOpportunity CreatePublishedOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published).Value;
+
+	[Test]
+	public async Task Handle_ShouldNotifyActiveVolunteers_WithOpportunityCancelledKind(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreatePublishedOpportunity();
+		var volunteerId = Guid.NewGuid();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunity.Id, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([volunteerId]);
+
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunity.Id, DefaultOrgId, "No longer needed");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityCancelled && n.RelatedEntityId == opportunity.Id.Value),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCancelActiveEngagements_WithOrganizerReasonIncluded(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreatePublishedOpportunity();
+		var timeSlotId = TimeSlotId.New();
+		var pendingEngagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), timeSlotId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunity.Id, cancellationToken)
+			.Returns([pendingEngagement]);
+
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunity.Id, DefaultOrgId, "Venue flooded");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		pendingEngagement.Status.Should().Be(EngagementStatus.Cancelled);
+		pendingEngagement.CancellationReason.Should().Be("Opportunity was cancelled: Venue flooded");
+	}
+
+	[Test]
+	public async Task Handle_ShouldCancelActiveEngagements_WithDefaultReason_WhenNoOrganizerReasonGiven(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreatePublishedOpportunity();
+		var timeSlotId = TimeSlotId.New();
+		var pendingEngagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), timeSlotId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunity.Id, cancellationToken)
+			.Returns([pendingEngagement]);
+
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunity.Id, DefaultOrgId, null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		pendingEngagement.CancellationReason.Should().Be("Opportunity was cancelled.");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunityId, DefaultOrgId, "reason");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
@@ -18,6 +18,7 @@ namespace Application.UnitTests.VolunteerOpportunities.CancelVolunteerOpportunit
 public class VolunteerOpportunityCancelledDomainEventHandlerTests
 {
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
 	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
@@ -52,7 +53,7 @@ public class VolunteerOpportunityCancelledDomainEventHandlerTests
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new VolunteerOpportunityCancelledDomainEventHandler(
-			_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			_dbContext, _unitOfWork, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
 			NullLogger<VolunteerOpportunityCancelledDomainEventHandler>.Instance);
 	}
 
@@ -144,5 +145,40 @@ public class VolunteerOpportunityCancelledDomainEventHandlerTests
 		// Assert
 		await act.Should().NotThrowAsync();
 		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterCascade(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the engagement
+		// cancellation/notification writes unless this handler saves them itself.
+		var opportunity = CreatePublishedOpportunity();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunity.Id, DefaultOrgId, "reason");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotSaveChanges_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunityId, DefaultOrgId, "reason");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/UnpublishVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/UnpublishVolunteerOpportunityCommandHandlerTests.cs
@@ -1,0 +1,143 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.UnpublishVolunteerOpportunity;
+
+public class UnpublishVolunteerOpportunityCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly UnpublishVolunteerOpportunityCommandHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+
+	public UnpublishVolunteerOpportunityCommandHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_sut = new UnpublishVolunteerOpportunityCommandHandler(_dbContext);
+	}
+
+	private static VolunteerOpportunity CreatePublishedOpportunity()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
+		opportunity.Publish();
+		return opportunity;
+	}
+
+	private void SetupOpportunity(Guid opportunityId, VolunteerOpportunity opportunity) =>
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<CancellationToken>())
+			.Returns(opportunity);
+
+	[Test]
+	public async Task Handle_ShouldReturnTrue_AndSetStatusToUnpublished_WhenOpportunityIsPublished(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		var result = await _sut.Handle(new UnpublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Unpublished);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRaiseUnpublishedDomainEvent_WhenOpportunityIsPublished(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		await _sut.Handle(new UnpublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert - opportunity.Events also carries the Published event raised by
+		// CreatePublishedOpportunity()'s own Publish() call, so assert the
+		// Unpublished event was added rather than that it's the only one.
+		opportunity.Events.Should().ContainSingle(e => e is VolunteerOpportunityUnpublishedDomainEvent);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityIsDraft(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		SetupOpportunity(opportunityId, opportunity);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new UnpublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns((VolunteerOpportunity?)null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new UnpublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage($"*{opportunityId}*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreatePublishedOpportunity();
+		SetupOpportunity(opportunityId, opportunity);
+
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
+			.Returns(false);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new UnpublishVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+		opportunity.Status.Should().Be(OpportunityStatus.Published);
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
@@ -18,6 +18,7 @@ namespace Application.UnitTests.VolunteerOpportunities.UnpublishVolunteerOpportu
 public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
 {
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
 	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
@@ -52,7 +53,7 @@ public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new VolunteerOpportunityUnpublishedDomainEventHandler(
-			_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			_dbContext, _unitOfWork, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
 			NullLogger<VolunteerOpportunityUnpublishedDomainEventHandler>.Instance);
 	}
 
@@ -122,5 +123,40 @@ public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
 		// Assert
 		await act.Should().NotThrowAsync();
 		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterCascade(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the engagement
+		// cancellation/notification writes unless this handler saves them itself.
+		var opportunity = CreatePublishedOpportunity();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new VolunteerOpportunityUnpublishedDomainEvent(opportunity.Id, DefaultOrgId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotSaveChanges_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new VolunteerOpportunityUnpublishedDomainEvent(opportunityId, DefaultOrgId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
@@ -1,0 +1,126 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.UnpublishVolunteerOpportunity;
+
+public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IEngagementReadRepository _engagementReadRepository =
+		Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly VolunteerOpportunityUnpublishedDomainEventHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+
+	public VolunteerOpportunityUnpublishedDomainEventHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Engagement>());
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new VolunteerOpportunityUnpublishedDomainEventHandler(
+			_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<VolunteerOpportunityUnpublishedDomainEventHandler>.Instance);
+	}
+
+	private static VolunteerOpportunity CreatePublishedOpportunity() =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published).Value;
+
+	[Test]
+	public async Task Handle_ShouldNotifyActiveVolunteers_WithOpportunityUnpublishedKind(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreatePublishedOpportunity();
+		var volunteerId = Guid.NewGuid();
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunity.Id, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([volunteerId]);
+
+		var domainEvent = new VolunteerOpportunityUnpublishedDomainEvent(opportunity.Id, DefaultOrgId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUnpublished && n.RelatedEntityId == opportunity.Id.Value),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldCancelActiveEngagements_WithUnpublishedReason(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreatePublishedOpportunity();
+		var timeSlotId = TimeSlotId.New();
+		var pendingEngagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), timeSlotId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunity.Id, cancellationToken)
+			.Returns([pendingEngagement]);
+
+		var domainEvent = new VolunteerOpportunityUnpublishedDomainEvent(opportunity.Id, DefaultOrgId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		pendingEngagement.Status.Should().Be(EngagementStatus.Cancelled);
+		pendingEngagement.CancellationReason.Should().Be("Opportunity was unpublished.");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new VolunteerOpportunityUnpublishedDomainEvent(opportunityId, DefaultOrgId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Domain.Common;
 using Domain.Organizations;
+using Domain.Primitives;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
 
@@ -303,6 +304,125 @@ public class VolunteerOpportunityTests
 
 		// Assert
 		opportunity.Status.Should().Be(OpportunityStatus.Published);
+	}
+
+	// --- Unpublish / Cancel (einsatzbereit#1038) ---
+
+	[Test]
+	public void Unpublish_ShouldSetStatusToUnpublished_WhenPublished()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+
+		var result = opportunity.Unpublish();
+
+		result.IsSuccess.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Unpublished);
+	}
+
+	[Test]
+	public void Unpublish_ShouldFail_WhenDraft()
+	{
+		var opportunity = CreateDraftScheduledSlotsOpportunity();
+
+		var result = opportunity.Unpublish();
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public void Unpublish_ShouldFail_WhenAlreadyUnpublished()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Unpublish();
+
+		var result = opportunity.Unpublish();
+
+		result.IsFailure.Should().BeTrue();
+	}
+
+	[Test]
+	public void Unpublish_ShouldFail_WhenCancelled()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Cancel();
+
+		var result = opportunity.Unpublish();
+
+		result.IsFailure.Should().BeTrue();
+	}
+
+	[Test]
+	public void Publish_ShouldRepublish_AnUnpublishedOpportunity()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Unpublish();
+
+		var result = opportunity.Publish();
+
+		result.IsSuccess.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Published);
+	}
+
+	[Test]
+	public void Cancel_ShouldSetStatusToCancelled_WhenPublished()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+
+		var result = opportunity.Cancel("No longer needed");
+
+		result.IsSuccess.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
+		opportunity.CancellationReason.Should().Be("No longer needed");
+	}
+
+	[Test]
+	public void Cancel_ShouldSetStatusToCancelled_WhenUnpublished()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Unpublish();
+
+		var result = opportunity.Cancel();
+
+		result.IsSuccess.Should().BeTrue();
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
+		opportunity.CancellationReason.Should().BeNull();
+	}
+
+	[Test]
+	public void Cancel_ShouldFail_WhenDraft()
+	{
+		var opportunity = CreateDraftScheduledSlotsOpportunity();
+
+		var result = opportunity.Cancel();
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Type.Should().Be(ErrorType.Conflict);
+		opportunity.Status.Should().Be(OpportunityStatus.Draft);
+	}
+
+	[Test]
+	public void Cancel_ShouldFail_WhenAlreadyCancelled()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Cancel();
+
+		var result = opportunity.Cancel();
+
+		result.IsFailure.Should().BeTrue();
+	}
+
+	[Test]
+	public void Publish_ShouldFail_WhenCancelled_AndNotResurrectOpportunity()
+	{
+		var opportunity = CreatePublishedScheduledSlotsOpportunity();
+		opportunity.Cancel();
+
+		var result = opportunity.Publish();
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Type.Should().Be(ErrorType.Conflict);
+		opportunity.Status.Should().Be(OpportunityStatus.Cancelled);
 	}
 
 	// --- Update (granular methods) ---

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -70,6 +70,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task UnpublishVolunteerOpportunityAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task SetOpportunityColorAsync(System.Guid opportunityId, SetOpportunityColorRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -111,6 +116,11 @@ namespace IntegrationTests
         /// <returns>Created</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<CreateTimeSlotResponse>> CreateTimeSlotAsync(System.Guid opportunityId, CreateTimeSlotRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task CancelVolunteerOpportunityAsync(System.Guid opportunityId, CancelVolunteerOpportunityRequest? body = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
@@ -1332,6 +1342,137 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task UnpublishVolunteerOpportunityAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/unpublish"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/unpublish");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task SetOpportunityColorAsync(System.Guid opportunityId, SetOpportunityColorRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (opportunityId == null)
@@ -2437,6 +2578,140 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task CancelVolunteerOpportunityAsync(System.Guid opportunityId, CancelVolunteerOpportunityRequest? body = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/cancel"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/cancel");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -10224,6 +10499,24 @@ namespace IntegrationTests
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CancelEngagementRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("reason")]
+        public string? Reason { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CancelVolunteerOpportunityRequest
     {
 
         [System.Text.Json.Serialization.JsonPropertyName("reason")]

--- a/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
+++ b/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
@@ -70,6 +70,33 @@ public class OutboxProcessorJobTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task ProcessBatchAsync_RoundTripsGuidBackedValueObjectIds_NotAsGuidEmpty(
+		CancellationToken cancellationToken)
+	{
+		// Regression test: these Guid-backed value-object IDs have a private constructor and
+		// a get-only Value property, so System.Text.Json's default reflection-based
+		// deserializer has no way to populate them - it was silently producing a
+		// Guid.Empty-backed instance instead of throwing (see
+		// ValueObjectIdJsonConverterFactory), which einsatzbereit#1038's cascade-cancel tests
+		// caught: the first outbox-dispatched handler to actually look an entity up by the
+		// deserialized id rather than just logging it.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(dbContext, domainEvent, cancellationToken);
+
+		var dispatcher = new RecordingDispatcher();
+		await OutboxProcessorJob.ProcessBatchAsync(
+			dbContext, dispatcher, NullLogger.Instance, batchSize: 20, cancellationToken);
+
+		var redispatched = dispatcher.DispatchedEvents.Should().ContainSingle().Subject
+			.Should().BeOfType<EngagementConfirmedDomainEvent>().Subject;
+
+		redispatched.EngagementId.Should().Be(domainEvent.EngagementId);
+		redispatched.VolunteerId.Should().Be(domainEvent.VolunteerId);
+		redispatched.OpportunityId.Should().Be(domainEvent.OpportunityId);
+	}
+
+	[Test]
 	public async Task ProcessBatchAsync_TwoConcurrentCalls_OnlyOneDispatchesTheLockedMessage(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1033,4 +1033,56 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var result = await Page.RunAxe();
 		AssertNoViolations(result);
 	}
+
+	[Test]
+	public async Task OrgOpportunitiesPage_CancelDialog_HasNoSeriousA11yViolations()
+	{
+		// einsatzbereit#1038: the org opportunities hub gained an Unpublish
+		// action (a plain confirm, same shape as the existing unscanned Delete
+		// dialog on this page) and a Cancel action whose ConfirmDialog carries
+		// an optional reason <label>/<textarea> + character-counter <p> - the
+		// same "new form control on a previously plain confirm" gap
+		// EngagementManagementPage_CancelDialog_HasNoSeriousA11yViolations
+		// above exists to cover. OrgOpportunitiesPage_AsOlaf_... never opens
+		// this dialog, so seed a fresh published opportunity here instead of
+		// relying on olaf's shared seed data.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"CancelOpportunityDialogA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"CancelOpportunityDialogA11y Opportunity {suffix}",
+			description = "Created by AccessibilityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByTestId("opportunity-cancel").First.ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await Expect(dialog.Locator("#cancel-opportunity-reason")).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
 }

--- a/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
+++ b/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
@@ -1,0 +1,177 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Coverage for einsatzbereit#1038: a published opportunity previously had no
+/// exit besides hard delete, which silently mass-cancelled every active
+/// engagement with no audit trail and no volunteer notification. Unpublish()
+/// and Cancel(reason) give the organizer a reversible take-down and a
+/// terminal cancellation respectively - both cascade-cancel active
+/// engagements, but asynchronously via the outbox (see
+/// VolunteerOpportunityUnpublishedDomainEventHandler /
+/// VolunteerOpportunityCancelledDomainEventHandler), so these tests poll
+/// rather than assert immediately after the UI action returns.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityUnpublishCancelTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Unpublish_MovesToUnpublishedSection_CascadeCancelsEngagement_AndCanBeRepublished()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var (opportunityId, organizationId, title) = await CreatePublishedOpportunityAsync(olafHttp, "Unpublish Flow");
+		var engagementId = await ApplyAsVeraAsync(backend, opportunityId);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var publishedSection = Page.GetByTestId("published-section");
+		var row = publishedSection.Locator("li", new() { HasText = title });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await row.GetByTestId("opportunity-unpublish").ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Yes, unpublish" }).ClickAsync();
+
+		var unpublishedSection = Page.GetByTestId("unpublished-section");
+		var unpublishedRow = unpublishedSection.Locator("li", new() { HasText = title });
+		await Expect(unpublishedRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(unpublishedRow.GetByTestId("opportunity-status-badge")).ToHaveTextAsync("Unpublished");
+
+		// The outbox job polls every 5s (appsettings.json Outbox:PollIntervalSeconds) -
+		// give it real headroom rather than asserting immediately.
+		await PollUntilAsync(
+			async () => await GetEngagementStatusAsync(olafHttp, opportunityId, engagementId) == "Cancelled",
+			() => $"Expected engagement {engagementId} to be cascade-cancelled after unpublishing opportunity {opportunityId}.",
+			timeoutMs: 20_000);
+
+		// Unpublished is reversible - Publish() works again from this state.
+		await unpublishedRow.GetByTestId("opportunity-publish").ClickAsync();
+		await Expect(publishedSection.Locator("li", new() { HasText = title })).ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task Cancel_MovesToCancelledSection_CascadeCancelsEngagementWithReason_AndIsTerminal()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var (opportunityId, organizationId, title) = await CreatePublishedOpportunityAsync(olafHttp, "Cancel Flow");
+		var engagementId = await ApplyAsVeraAsync(backend, opportunityId);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var publishedSection = Page.GetByTestId("published-section");
+		var row = publishedSection.Locator("li", new() { HasText = title });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await row.GetByTestId("opportunity-cancel").ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+		await Page.Locator("#cancel-opportunity-reason").FillAsync("Venue is no longer available");
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Yes, cancel opportunity" }).ClickAsync();
+
+		var cancelledSection = Page.GetByTestId("cancelled-section");
+		var cancelledRow = cancelledSection.Locator("li", new() { HasText = title });
+		await Expect(cancelledRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(cancelledRow.GetByTestId("opportunity-status-badge")).ToHaveTextAsync("Cancelled");
+
+		// Terminal - Cancelled offers no Edit/Publish/Unpublish/Cancel, only Delete.
+		await Expect(cancelledRow.GetByTestId("opportunity-edit")).Not.ToBeVisibleAsync();
+		await Expect(cancelledRow.GetByTestId("opportunity-publish")).Not.ToBeVisibleAsync();
+		await Expect(cancelledRow.GetByTestId("opportunity-unpublish")).Not.ToBeVisibleAsync();
+		await Expect(cancelledRow.GetByTestId("opportunity-cancel")).Not.ToBeVisibleAsync();
+		await Expect(cancelledRow.GetByTestId("opportunity-delete")).ToBeVisibleAsync();
+
+		await PollUntilAsync(
+			async () =>
+			{
+				var (status, reason) = await GetEngagementStatusAndReasonAsync(olafHttp, opportunityId, engagementId);
+				return status == "Cancelled" && reason == "Opportunity was cancelled: Venue is no longer available";
+			},
+			() => $"Expected engagement {engagementId} to be cascade-cancelled with the organizer's reason after cancelling opportunity {opportunityId}.",
+			timeoutMs: 20_000);
+	}
+
+	private static async Task<(string OpportunityId, string OrganizationId, string Title)> CreatePublishedOpportunityAsync(
+		HttpClient olafHttp, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"{label} Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		var title = $"{label} {suffix}";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title,
+			description = $"Created by {nameof(OpportunityUnpublishCancelTests)}",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return (opportunity.GetProperty("id").GetString()!, organizationId, title);
+	}
+
+	private async Task<string> ApplyAsVeraAsync(Uri backend, string opportunityId)
+	{
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+
+		var response = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Please let me help." });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<string?> GetEngagementStatusAsync(HttpClient olafHttp, string opportunityId, string engagementId)
+	{
+		var (status, _) = await GetEngagementStatusAndReasonAsync(olafHttp, opportunityId, engagementId);
+		return status;
+	}
+
+	private static async Task<(string? Status, string? CancellationReason)> GetEngagementStatusAndReasonAsync(
+		HttpClient olafHttp, string opportunityId, string engagementId)
+	{
+		var response = await olafHttp.GetAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements?pageNumber=1&pageSize=50");
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		foreach (var item in body.GetProperty("items").EnumerateArray())
+		{
+			if (item.GetProperty("id").GetString() == engagementId)
+			{
+				var reason = item.TryGetProperty("cancellationReason", out var r) ? r.GetString() : null;
+				return (item.GetProperty("status").GetString(), reason);
+			}
+		}
+		return (null, null);
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -495,6 +495,79 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    unpublishVolunteerOpportunity(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/unpublish";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "POST",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUnpublishVolunteerOpportunity(_response);
+        });
+    }
+
+    protected processUnpublishVolunteerOpportunity(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     setOpportunityColor(opportunityId: string, body: SetOpportunityColorRequest, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/color";
         if (opportunityId === undefined || opportunityId === null)
@@ -1170,6 +1243,84 @@ export class EinsatzbereitApi {
             });
         }
         return Promise.resolve<CreateTimeSlotResponse[]>(null as any);
+    }
+
+    /**
+     * @param body (optional) 
+     * @return No Content
+     */
+    cancelVolunteerOpportunity(opportunityId: string, body: CancelVolunteerOpportunityRequest | null | undefined, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/cancel";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            signal,
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCancelVolunteerOpportunity(_response);
+        });
+    }
+
+    protected processCancelVolunteerOpportunity(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -5351,6 +5502,12 @@ export interface CalendarTimeSlotDto {
 }
 
 export interface CancelEngagementRequest {
+    reason: string | undefined;
+
+    [key: string]: any;
+}
+
+export interface CancelVolunteerOpportunityRequest {
     reason: string | undefined;
 
     [key: string]: any;

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -160,10 +160,17 @@ export default function CreateVolunteerOpportunityModal({
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const isEditMode = initialOpportunity !== undefined;
-	// A still-unpublished draft accepts lenient partial saves from any step,
-	// same as during initial creation - an already-published opportunity
-	// keeps the stricter publish-level validation on its single "Save" button.
-	const canSaveDraft = !isEditMode || initialOpportunity.status === "Draft";
+	// A Draft, and an Unpublished opportunity (taken off the public listing but
+	// not re-validated the way Publish() would), accept lenient partial saves
+	// from any step, same as during initial creation - the backend's own
+	// Rename/ChangeDescription/Relocate only re-run publishability checks when
+	// Status is Published (see VolunteerOpportunity.cs), so a Cancelled or
+	// Published opportunity keeps the stricter validation on its single "Save"
+	// button.
+	const canSaveDraft =
+		!isEditMode ||
+		initialOpportunity.status === "Draft" ||
+		initialOpportunity.status === "Unpublished";
 
 	const schema = useMemo(() => buildOpportunityFormSchema(t), [t]);
 	const {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -176,6 +176,10 @@
       "publish": "Veröffentlichen",
       "publishing": "Wird veröffentlicht…",
       "publishSuccess": "Bedarf veröffentlicht.",
+      "unpublish": "Zurückziehen",
+      "unpublishSuccess": "Bedarf zurückgezogen.",
+      "cancel": "Absagen",
+      "cancelSuccess": "Bedarf abgesagt.",
       "loginPrompt": "Melde dich an, um dich für diesen Einsatz anzumelden.",
       "yourApplication": "Deine Bewerbung",
       "aboutOrganization": "Über diese Organisation",
@@ -355,6 +359,12 @@
       "publishedHeading": "Veröffentlicht",
       "publishedDesc": "Live und für Freiwillige sichtbar.",
       "publishedBadge": "Veröffentlicht",
+      "unpublishedHeading": "Zurückgezogen",
+      "unpublishedDesc": "Von der öffentlichen Liste entfernt. Veröffentliche erneut, um ihn wieder sichtbar zu machen.",
+      "unpublishedBadge": "Zurückgezogen",
+      "cancelledHeading": "Abgesagt",
+      "cancelledDesc": "Endgültig abgesagt. Dies kann nicht rückgängig gemacht werden - lege stattdessen einen neuen Bedarf an, falls die Pläne wieder aufgenommen werden.",
+      "cancelledBadge": "Abgesagt",
       "manageApplications": "Bewerbungen verwalten",
       "participants": "{{booked}}/{{max}} Teilnehmende",
       "participantsUnlimited": "{{booked}} Anmeldungen (kein Limit)",
@@ -672,6 +682,8 @@
         "EngagementWithdrawn": "Eine Bewerbung für {{title}} wurde zurückgezogen",
         "OpportunityUpdated": "{{title}} wurde aktualisiert",
         "OpportunityDeleted": "Ein Bedarf, für den du dich angemeldet hast, wurde entfernt",
+        "OpportunityUnpublished": "{{title}} wurde zurückgezogen und dein Engagement wurde abgesagt",
+        "OpportunityCancelled": "{{title}} wurde abgesagt und dein Engagement wurde abgesagt",
         "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten"
       }
     },
@@ -726,6 +738,18 @@
         "confirm": "Ja, absagen",
         "reasonLabel": "Grund (optional)",
         "reasonPlaceholder": "Teile dem Freiwilligen den Grund mit…"
+      },
+      "unpublish": {
+        "title": "Bedarf zurückziehen?",
+        "message": "Dies entfernt ihn von der öffentlichen Liste und sagt alle ausstehenden oder bestätigten Anmeldungen ab - Freiwillige werden informiert. Du kannst ihn später erneut veröffentlichen.",
+        "confirm": "Ja, zurückziehen"
+      },
+      "cancelOpportunity": {
+        "title": "Bedarf absagen?",
+        "message": "Dies sagt den Bedarf endgültig ab und alle ausstehenden oder bestätigten Anmeldungen werden ebenfalls abgesagt - Freiwillige werden informiert. Dies kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, Bedarf absagen",
+        "reasonLabel": "Grund (optional)",
+        "reasonPlaceholder": "Teile den Freiwilligen den Grund mit…"
       },
       "editTimeSlot": {
         "title": "Zeitslot bearbeiten?",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -176,6 +176,10 @@
       "publish": "Publish",
       "publishing": "Publishing…",
       "publishSuccess": "Opportunity published.",
+      "unpublish": "Unpublish",
+      "unpublishSuccess": "Opportunity unpublished.",
+      "cancel": "Cancel",
+      "cancelSuccess": "Opportunity cancelled.",
       "loginPrompt": "Sign in to sign up for this opportunity.",
       "yourApplication": "Your application",
       "aboutOrganization": "About this organization",
@@ -355,6 +359,12 @@
       "publishedHeading": "Published",
       "publishedDesc": "Live and visible to volunteers.",
       "publishedBadge": "Published",
+      "unpublishedHeading": "Unpublished",
+      "unpublishedDesc": "Taken off the public listing. Publish again to make it visible once more.",
+      "unpublishedBadge": "Unpublished",
+      "cancelledHeading": "Cancelled",
+      "cancelledDesc": "Permanently cancelled. This cannot be undone - create a new opportunity if plans resume.",
+      "cancelledBadge": "Cancelled",
       "manageApplications": "Manage applications",
       "participants": "{{booked}}/{{max}} participants",
       "participantsUnlimited": "{{booked}} participants (no cap)",
@@ -672,6 +682,8 @@
         "EngagementWithdrawn": "An application for {{title}} was withdrawn",
         "OpportunityUpdated": "{{title}} was updated",
         "OpportunityDeleted": "An opportunity you signed up for was removed",
+        "OpportunityUnpublished": "{{title}} was taken down and your engagement was cancelled",
+        "OpportunityCancelled": "{{title}} was cancelled and your engagement was cancelled",
         "InvitationReceived": "You've been invited to join {{title}}"
       }
     },
@@ -726,6 +738,18 @@
         "confirm": "Yes, cancel",
         "reasonLabel": "Reason (optional)",
         "reasonPlaceholder": "Let the volunteer know why…"
+      },
+      "unpublish": {
+        "title": "Unpublish opportunity?",
+        "message": "This removes it from the public listing and cancels any pending or confirmed sign-ups - volunteers will be informed. You can publish it again later.",
+        "confirm": "Yes, unpublish"
+      },
+      "cancelOpportunity": {
+        "title": "Cancel opportunity?",
+        "message": "This permanently cancels the opportunity and cancels any pending or confirmed sign-ups - volunteers will be informed. This cannot be undone.",
+        "confirm": "Yes, cancel opportunity",
+        "reasonLabel": "Reason (optional)",
+        "reasonPlaceholder": "Let volunteers know why…"
       },
       "editTimeSlot": {
         "title": "Edit time slot?",

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -201,7 +201,12 @@ export default function ProfileOverviewPage() {
 	// Legacy ?tab= deep links (App.tsx's /my-engagements and /achievements
 	// redirects still land here with ?tab=engagements/achievements) scroll to
 	// the section that now contains that content instead of switching tabs.
+	// Gated on profileLoading/streaks rather than firing once on mount ([]):
+	// the identity hero and "Profile details" section below it only render
+	// their full height once those finish loading, so scrolling before then
+	// targets a layout that's about to shift and never re-fires afterward.
 	useEffect(() => {
+		if (profileLoading) return;
 		const sectionId = LEGACY_TAB_SECTIONS[searchParams.get("tab") ?? ""];
 		if (!sectionId) return;
 		const reduceMotion = window.matchMedia(
@@ -215,7 +220,7 @@ export default function ProfileOverviewPage() {
 		});
 		return () => cancelAnimationFrame(frame);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [profileLoading, streaks]);
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -22,6 +22,13 @@ import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const OPPORTUNITIES_PAGE_SIZE = 10;
 
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+	Draft: "bg-amber-100 text-amber-800",
+	Published: "bg-green-100 text-green-800",
+	Unpublished: "bg-gray-200 text-gray-700",
+	Cancelled: "bg-red-100 text-red-800",
+};
+
 export default function OrgOpportunitiesPage() {
 	const { org } = useOutletContext<OrgAppContext>();
 	const { t } = useTranslation();
@@ -76,9 +83,59 @@ export default function OrgOpportunitiesPage() {
 		},
 	);
 
+	const {
+		items: unpublished,
+		loading: unpublishedLoading,
+		loadingMore: unpublishedLoadingMore,
+		error: unpublishedError,
+		loadMoreError: unpublishedLoadMoreError,
+		hasMore: hasMoreUnpublished,
+		loadMore: loadMoreUnpublished,
+		retryLoadMore: retryLoadMoreUnpublished,
+		reset: resetUnpublished,
+	} = useLoadMore<VolunteerOpportunitySummary>(
+		(page) =>
+			api.getOrganizationOpportunities(
+				organizationId,
+				"Unpublished",
+				page,
+				OPPORTUNITIES_PAGE_SIZE,
+			),
+		{
+			deps: [organizationId],
+			getErrorMessage: (e) => getApiErrorMessage(e, t("error.serverError")),
+		},
+	);
+
+	const {
+		items: cancelled,
+		loading: cancelledLoading,
+		loadingMore: cancelledLoadingMore,
+		error: cancelledError,
+		loadMoreError: cancelledLoadMoreError,
+		hasMore: hasMoreCancelled,
+		loadMore: loadMoreCancelled,
+		retryLoadMore: retryLoadMoreCancelled,
+		reset: resetCancelled,
+	} = useLoadMore<VolunteerOpportunitySummary>(
+		(page) =>
+			api.getOrganizationOpportunities(
+				organizationId,
+				"Cancelled",
+				page,
+				OPPORTUNITIES_PAGE_SIZE,
+			),
+		{
+			deps: [organizationId],
+			getErrorMessage: (e) => getApiErrorMessage(e, t("error.serverError")),
+		},
+	);
+
 	function reloadAll() {
 		resetDrafts();
 		resetPublished();
+		resetUnpublished();
+		resetCancelled();
 	}
 
 	const [showCreate, setShowCreate] = useState(false);
@@ -89,6 +146,15 @@ export default function OrgOpportunitiesPage() {
 	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 	const [deleting, setDeleting] = useState(false);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
+	const [unpublishTargetId, setUnpublishTargetId] = useState<string | null>(
+		null,
+	);
+	const [unpublishing, setUnpublishing] = useState(false);
+	const [unpublishError, setUnpublishError] = useState<string | null>(null);
+	const [cancelTargetId, setCancelTargetId] = useState<string | null>(null);
+	const [cancelReason, setCancelReason] = useState("");
+	const [cancelling, setCancelling] = useState(false);
+	const [cancelError, setCancelError] = useState<string | null>(null);
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	// Id of a just-saved / just-arrived-at draft to reveal, so the organizer
@@ -141,7 +207,7 @@ export default function OrgOpportunitiesPage() {
 		});
 		const timer = setTimeout(() => setHighlightedId(null), 2500);
 		return () => clearTimeout(timer);
-	}, [highlightedId, drafts, published]);
+	}, [highlightedId, drafts, published, unpublished, cancelled]);
 
 	async function openEdit(id: string) {
 		setEditLoadingId(id);
@@ -195,9 +261,62 @@ export default function OrgOpportunitiesPage() {
 		}
 	}
 
+	async function handleUnpublishConfirm() {
+		if (!unpublishTargetId) return;
+		setUnpublishing(true);
+		setUnpublishError(null);
+		try {
+			await api.unpublishVolunteerOpportunity(unpublishTargetId);
+			setUnpublishTargetId(null);
+			dispatchToast("success", t("opportunities.unpublishSuccess"));
+			reloadAll();
+		} catch (err) {
+			setUnpublishError(getApiErrorMessage(err, t("error.serverError")));
+		} finally {
+			setUnpublishing(false);
+		}
+	}
+
+	function handleCancelClose() {
+		if (cancelling) return;
+		setCancelTargetId(null);
+		setCancelReason("");
+		setCancelError(null);
+	}
+
+	async function handleCancelConfirm() {
+		if (!cancelTargetId) return;
+		setCancelling(true);
+		setCancelError(null);
+		try {
+			const trimmedReason = cancelReason.trim();
+			await api.cancelVolunteerOpportunity(cancelTargetId, {
+				reason: trimmedReason.length > 0 ? trimmedReason : undefined,
+			});
+			setCancelTargetId(null);
+			setCancelReason("");
+			dispatchToast("success", t("opportunities.cancelSuccess"));
+			reloadAll();
+		} catch (err) {
+			setCancelError(getApiErrorMessage(err, t("error.serverError")));
+		} finally {
+			setCancelling(false);
+		}
+	}
+
 	function renderRow(item: VolunteerOpportunitySummary) {
-		const isDraft = item.status === "Draft";
+		const status = item.status;
 		const isHighlighted = item.id === highlightedId;
+		const badgeLabel =
+			status === "Draft"
+				? t("opportunities.draftBadge")
+				: status === "Published"
+					? t("orgOpportunities.publishedBadge")
+					: status === "Unpublished"
+						? t("orgOpportunities.unpublishedBadge")
+						: status === "Cancelled"
+							? t("orgOpportunities.cancelledBadge")
+							: status;
 		return (
 			<li
 				key={item.id}
@@ -221,14 +340,10 @@ export default function OrgOpportunitiesPage() {
 						<span
 							data-testid="opportunity-status-badge"
 							className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-								isDraft
-									? "bg-amber-100 text-amber-800"
-									: "bg-green-100 text-green-800"
+								STATUS_BADGE_CLASSES[status] ?? "bg-gray-100 text-gray-700"
 							}`}
 						>
-							{isDraft
-								? t("opportunities.draftBadge")
-								: t("orgOpportunities.publishedBadge")}
+							{badgeLabel}
 						</span>
 					</div>
 					{item.description && (
@@ -254,17 +369,19 @@ export default function OrgOpportunitiesPage() {
 					)}
 				</div>
 				<div className="mt-auto flex flex-wrap items-center gap-2">
-					<button
-						type="button"
-						onClick={() => void openEdit(item.id)}
-						disabled={editLoadingId === item.id}
-						data-testid="opportunity-edit"
-						className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 transition hover:bg-gray-50 disabled:opacity-50"
-					>
-						{editLoadingId === item.id
-							? t("orgOpportunities.editLoading")
-							: t("opportunities.edit")}
-					</button>
+					{status !== "Cancelled" && (
+						<button
+							type="button"
+							onClick={() => void openEdit(item.id)}
+							disabled={editLoadingId === item.id}
+							data-testid="opportunity-edit"
+							className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 transition hover:bg-gray-50 disabled:opacity-50"
+						>
+							{editLoadingId === item.id
+								? t("orgOpportunities.editLoading")
+								: t("opportunities.edit")}
+						</button>
+					)}
 					<button
 						type="button"
 						onClick={() => {
@@ -276,7 +393,7 @@ export default function OrgOpportunitiesPage() {
 					>
 						{t("opportunities.delete")}
 					</button>
-					{isDraft ? (
+					{(status === "Draft" || status === "Unpublished") && (
 						<Button
 							type="button"
 							onClick={() => void publish(item.id)}
@@ -288,7 +405,35 @@ export default function OrgOpportunitiesPage() {
 								? t("opportunities.publishing")
 								: t("opportunities.publish")}
 						</Button>
-					) : (
+					)}
+					{status === "Published" && (
+						<button
+							type="button"
+							onClick={() => {
+								setUnpublishTargetId(item.id);
+								setUnpublishError(null);
+							}}
+							data-testid="opportunity-unpublish"
+							className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 transition hover:bg-gray-50"
+						>
+							{t("opportunities.unpublish")}
+						</button>
+					)}
+					{(status === "Published" || status === "Unpublished") && (
+						<button
+							type="button"
+							onClick={() => {
+								setCancelTargetId(item.id);
+								setCancelReason("");
+								setCancelError(null);
+							}}
+							data-testid="opportunity-cancel"
+							className="rounded-lg border border-red-200 px-3 py-1.5 text-sm text-red-600 transition hover:bg-red-50"
+						>
+							{t("opportunities.cancel")}
+						</button>
+					)}
+					{status !== "Draft" && (
 						<Link
 							to={`/app/${organizationId}/dashboard/opportunities/${item.id}/engagements`}
 							className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-brand-700 transition hover:bg-brand-50"
@@ -315,11 +460,61 @@ export default function OrgOpportunitiesPage() {
 		);
 	}
 
-	const initialLoading = draftsLoading || publishedLoading;
+	function renderSection(
+		testId: string,
+		heading: string,
+		description: string,
+		items: VolunteerOpportunitySummary[],
+		loading: boolean,
+		error: string | null,
+		hasMore: boolean,
+		loadMoreError: string | null,
+		loadingMore: boolean,
+		onLoadMore: () => void,
+		onRetryLoadMore: () => void,
+	) {
+		if (loading || error || items.length === 0) return null;
+		return (
+			<section data-testid={testId}>
+				<h2 className="text-lg font-semibold text-gray-900">{heading}</h2>
+				<p className="mt-1 text-sm text-gray-500">{description}</p>
+				<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					{items.map(renderRow)}
+				</ul>
+				{hasMore &&
+					(loadMoreError ? (
+						<LoadMoreError
+							message={t("orgOpportunities.error", { message: loadMoreError })}
+							retrying={loadingMore}
+							onRetry={onRetryLoadMore}
+						/>
+					) : (
+						<div className="mt-4 flex justify-center">
+							<button
+								onClick={onLoadMore}
+								disabled={loadingMore}
+								className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
+							>
+								{loadingMore
+									? t("orgOpportunities.loading")
+									: t("orgOpportunities.loadMore")}
+							</button>
+						</div>
+					))}
+			</section>
+		);
+	}
+
+	const initialLoading =
+		draftsLoading || publishedLoading || unpublishedLoading || cancelledLoading;
+	const anyError =
+		draftsError || publishedError || unpublishedError || cancelledError;
+	const totalCount =
+		drafts.length + published.length + unpublished.length + cancelled.length;
 
 	return (
 		<div>
-			{initialLoading && !draftsError && !publishedError && (
+			{initialLoading && !anyError && (
 				<div className="flex items-center justify-center py-16">
 					<Spinner label={t("orgOpportunities.loading")} />
 				</div>
@@ -335,94 +530,81 @@ export default function OrgOpportunitiesPage() {
 					message={t("orgOpportunities.error", { message: publishedError })}
 				/>
 			)}
+			{unpublishedError && (
+				<ErrorBanner
+					message={t("orgOpportunities.error", { message: unpublishedError })}
+				/>
+			)}
+			{cancelledError && (
+				<ErrorBanner
+					message={t("orgOpportunities.error", { message: cancelledError })}
+				/>
+			)}
 
-			{!initialLoading &&
-				!draftsError &&
-				!publishedError &&
-				drafts.length === 0 &&
-				published.length === 0 && (
-					<EmptyState
-						title={t("orgOpportunities.emptyTitle")}
-						message={t("orgOpportunities.emptyDesc")}
-						action={{
-							label: t("orgOverview.createOpportunity"),
-							onClick: () => setShowCreate(true),
-						}}
-					/>
-				)}
+			{!initialLoading && !anyError && totalCount === 0 && (
+				<EmptyState
+					title={t("orgOpportunities.emptyTitle")}
+					message={t("orgOpportunities.emptyDesc")}
+					action={{
+						label: t("orgOverview.createOpportunity"),
+						onClick: () => setShowCreate(true),
+					}}
+				/>
+			)}
 
-			{(drafts.length > 0 || published.length > 0) && (
+			{totalCount > 0 && (
 				<div className="space-y-8">
-					{!draftsLoading && !draftsError && drafts.length > 0 && (
-						<section data-testid="drafts-section">
-							<h2 className="text-lg font-semibold text-gray-900">
-								{t("orgOpportunities.draftsHeading")}
-							</h2>
-							<p className="mt-1 text-sm text-gray-500">
-								{t("orgOpportunities.draftsDesc")}
-							</p>
-							<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-								{drafts.map(renderRow)}
-							</ul>
-							{hasMoreDrafts &&
-								(draftsLoadMoreError ? (
-									<LoadMoreError
-										message={t("orgOpportunities.error", {
-											message: draftsLoadMoreError,
-										})}
-										retrying={draftsLoadingMore}
-										onRetry={retryLoadMoreDrafts}
-									/>
-								) : (
-									<div className="mt-4 flex justify-center">
-										<button
-											onClick={loadMoreDrafts}
-											disabled={draftsLoadingMore}
-											className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-										>
-											{draftsLoadingMore
-												? t("orgOpportunities.loading")
-												: t("orgOpportunities.loadMore")}
-										</button>
-									</div>
-								))}
-						</section>
+					{renderSection(
+						"drafts-section",
+						t("orgOpportunities.draftsHeading"),
+						t("orgOpportunities.draftsDesc"),
+						drafts,
+						draftsLoading,
+						draftsError,
+						hasMoreDrafts,
+						draftsLoadMoreError,
+						draftsLoadingMore,
+						loadMoreDrafts,
+						retryLoadMoreDrafts,
 					)}
-
-					{!publishedLoading && !publishedError && published.length > 0 && (
-						<section data-testid="published-section">
-							<h2 className="text-lg font-semibold text-gray-900">
-								{t("orgOpportunities.publishedHeading")}
-							</h2>
-							<p className="mt-1 text-sm text-gray-500">
-								{t("orgOpportunities.publishedDesc")}
-							</p>
-							<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-								{published.map(renderRow)}
-							</ul>
-							{hasMorePublished &&
-								(publishedLoadMoreError ? (
-									<LoadMoreError
-										message={t("orgOpportunities.error", {
-											message: publishedLoadMoreError,
-										})}
-										retrying={publishedLoadingMore}
-										onRetry={retryLoadMorePublished}
-									/>
-								) : (
-									<div className="mt-4 flex justify-center">
-										<button
-											onClick={loadMorePublished}
-											disabled={publishedLoadingMore}
-											className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-										>
-											{publishedLoadingMore
-												? t("orgOpportunities.loading")
-												: t("orgOpportunities.loadMore")}
-										</button>
-									</div>
-								))}
-						</section>
+					{renderSection(
+						"published-section",
+						t("orgOpportunities.publishedHeading"),
+						t("orgOpportunities.publishedDesc"),
+						published,
+						publishedLoading,
+						publishedError,
+						hasMorePublished,
+						publishedLoadMoreError,
+						publishedLoadingMore,
+						loadMorePublished,
+						retryLoadMorePublished,
+					)}
+					{renderSection(
+						"unpublished-section",
+						t("orgOpportunities.unpublishedHeading"),
+						t("orgOpportunities.unpublishedDesc"),
+						unpublished,
+						unpublishedLoading,
+						unpublishedError,
+						hasMoreUnpublished,
+						unpublishedLoadMoreError,
+						unpublishedLoadingMore,
+						loadMoreUnpublished,
+						retryLoadMoreUnpublished,
+					)}
+					{renderSection(
+						"cancelled-section",
+						t("orgOpportunities.cancelledHeading"),
+						t("orgOpportunities.cancelledDesc"),
+						cancelled,
+						cancelledLoading,
+						cancelledError,
+						hasMoreCancelled,
+						cancelledLoadMoreError,
+						cancelledLoadingMore,
+						loadMoreCancelled,
+						retryLoadMoreCancelled,
 					)}
 				</div>
 			)}
@@ -458,6 +640,54 @@ export default function OrgOpportunitiesPage() {
 					loading={deleting}
 					error={deleteError}
 				/>
+			)}
+
+			{unpublishTargetId && (
+				<ConfirmDialog
+					title={t("confirmDialog.unpublish.title")}
+					message={t("confirmDialog.unpublish.message")}
+					confirmLabel={t("confirmDialog.unpublish.confirm")}
+					onConfirm={handleUnpublishConfirm}
+					onClose={() => {
+						if (unpublishing) return;
+						setUnpublishTargetId(null);
+						setUnpublishError(null);
+					}}
+					loading={unpublishing}
+					error={unpublishError}
+				/>
+			)}
+
+			{cancelTargetId && (
+				<ConfirmDialog
+					title={t("confirmDialog.cancelOpportunity.title")}
+					message={t("confirmDialog.cancelOpportunity.message")}
+					confirmLabel={t("confirmDialog.cancelOpportunity.confirm")}
+					onConfirm={handleCancelConfirm}
+					onClose={handleCancelClose}
+					loading={cancelling}
+					error={cancelError}
+				>
+					<label
+						htmlFor="cancel-opportunity-reason"
+						className="block text-xs font-medium text-gray-700"
+					>
+						{t("confirmDialog.cancelOpportunity.reasonLabel")}
+					</label>
+					<textarea
+						id="cancel-opportunity-reason"
+						rows={3}
+						maxLength={500}
+						value={cancelReason}
+						onChange={(e) => setCancelReason(e.target.value)}
+						placeholder={t("confirmDialog.cancelOpportunity.reasonPlaceholder")}
+						disabled={cancelling}
+						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+					/>
+					<p className="mt-1 text-right text-xs text-gray-500">
+						{cancelReason.length}/500
+					</p>
+				</ConfirmDialog>
 			)}
 		</div>
 	);


### PR DESCRIPTION
A published opportunity previously had no exit besides hard delete, which silently mass-cancelled every active engagement with no audit trail or volunteer notification. Add OpportunityStatus.Unpublished (reversible take-down, can be republished) and .Cancelled (terminal), each cascade- cancelling active engagements and notifying volunteers asynchronously via the outbox. Organizers get new Unpublish/Cancel controls on the Opportunities hub alongside the existing Draft/Published sections.

Closes #1038

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
