### PR TITLE
fix: localize remaining hardcoded English transactional emails

### DIFF
--- a/backend/src/Application/Common/Email/EmailTemplateKind.cs
+++ b/backend/src/Application/Common/Email/EmailTemplateKind.cs
@@ -16,4 +16,6 @@ public enum EmailTemplateKind
 
 	EngagementWithdrawnNotifyOrganizer,
 	EngagementReminder,
+	InvitationReceived,
+	OpportunityUpdated,
 }

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -1,6 +1,7 @@
 using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Application.Common.Localization;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Domain.Notifications;
@@ -16,11 +17,13 @@ internal static class OpportunityNotificationHelper
 	/// has an active (pending or confirmed) engagement on the opportunity, or -
 	/// when <paramref name="timeSlotId"/> is given - only those engaged on that
 	/// specific time slot. The opportunity id is used as the related entity id.
-	/// When <paramref name="keycloakUserService"/>, <paramref name="emailService"/>
-	/// and <paramref name="opportunityTitle"/> are all supplied, also emails every
-	/// notified volunteer in a single batch (einsatzbereit#1057) - callers that
-	/// already email affected volunteers through another path (e.g. an engagement
-	/// cancellation) should omit these so the volunteer isn't emailed twice.
+	/// When <paramref name="keycloakUserService"/>, <paramref name="emailService"/>,
+	/// <paramref name="emailTemplateRenderer"/> and <paramref name="opportunityTitle"/>
+	/// are all supplied, also emails every notified volunteer in a single batch
+	/// (einsatzbereit#1057), localized per recipient's <see cref="User.PreferredLanguage"/>
+	/// - callers that already email affected volunteers through another path (e.g.
+	/// an engagement cancellation) should omit these so the volunteer isn't emailed
+	/// twice.
 	/// </summary>
 	public static async Task NotifyActiveVolunteersAsync(
 		IApplicationDbContext dbContext,
@@ -31,6 +34,7 @@ internal static class OpportunityNotificationHelper
 		TimeSlotId? timeSlotId = null,
 		IKeycloakUserService? keycloakUserService = null,
 		IEmailService? emailService = null,
+		IEmailTemplateRenderer? emailTemplateRenderer = null,
 		string? opportunityTitle = null)
 	{
 		var volunteerIds = await engagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync(
@@ -46,18 +50,30 @@ internal static class OpportunityNotificationHelper
 			await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		}
 
-		if (keycloakUserService is null || emailService is null || volunteerIds.Count == 0)
+		if (keycloakUserService is null || emailService is null || emailTemplateRenderer is null || volunteerIds.Count == 0)
 			return;
+
+		var volunteerUserIds = volunteerIds.Select(id => UserId.Create(id).GetValueOrThrow()).ToList();
+		var volunteerUsersById = (await dbContext.GetOrCreateUsersAsync(volunteerUserIds, cancellationToken))
+			.ToDictionary(u => u.Id);
 
 		var messages = new List<EmailMessage>(volunteerIds.Count);
 		foreach (var volunteerId in volunteerIds)
 		{
 			var volunteer = await keycloakUserService.GetUserAsync(volunteerId, cancellationToken);
-			messages.Add(new EmailMessage(
-				volunteer.Email,
-				$"An opportunity you signed up for has changed: \"{opportunityTitle}\"",
-				$"Hello {volunteer.FirstName ?? volunteer.Username},\n\n" +
-				$"The details for \"{opportunityTitle}\" have changed. Please check the app for the latest information.\n\nEinsatzbereit"));
+			var volunteerUser = volunteerUsersById[UserId.Create(volunteerId).GetValueOrThrow()];
+			var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
+
+			var content = emailTemplateRenderer.Render(
+				EmailTemplateKind.OpportunityUpdated,
+				volunteerLanguage,
+				new Dictionary<string, string>
+				{
+					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
+					["OpportunityTitle"] = opportunityTitle ?? string.Empty,
+				});
+
+			messages.Add(new EmailMessage(volunteer.Email, content.Subject, content.Body));
 		}
 
 		await emailService.SendBatchAsync(messages, cancellationToken);

--- a/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
@@ -2,6 +2,7 @@ using Application.Common.Authorization;
 using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Notifications;
@@ -16,7 +17,8 @@ internal sealed class CreateInvitationCommandHandler(
 	IUnitOfWork unitOfWork,
 	IKeycloakOrganizationService keycloakOrganizationService,
 	IKeycloakUserService keycloakUserService,
-	IEmailService emailService)
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer)
 	: ICommandHandler<CreateInvitationCommand, OrganizationInvitationId>
 {
 	public async ValueTask<OrganizationInvitationId> Handle(
@@ -67,13 +69,22 @@ internal sealed class CreateInvitationCommandHandler(
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
+		var inviteeUser = (await dbContext.GetOrCreateUsersAsync([request.InviteeId], cancellationToken))[0];
+		var inviteeLanguage = SupportedLanguages.Resolve(inviteeUser.PreferredLanguage);
+
+		var content = emailTemplateRenderer.Render(
+			EmailTemplateKind.InvitationReceived,
+			inviteeLanguage,
+			new Dictionary<string, string>
+			{
+				["InviteeName"] = inviteeProfile.FirstName ?? inviteeProfile.Username,
+				["OrganizationName"] = org.Name,
+			});
+
 		await emailService.SendAsync(
 			inviteeProfile.Email,
-			"You've been invited to join an organization",
-			$"Hello {inviteeProfile.FirstName ?? inviteeProfile.Username},\n\n" +
-			$"You've been invited to join \"{org.Name}\" on Einsatzbereit.\n\n" +
-			$"Log in to your account to accept or decline the invitation.\n\n" +
-			$"Einsatzbereit",
+			content.Subject,
+			content.Body,
 			cancellationToken);
 
 		return invitation.Id;

--- a/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
@@ -2,6 +2,7 @@ using Application.Common.Authorization;
 using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Notifications;
@@ -13,7 +14,8 @@ internal sealed class ResendInvitationCommandHandler(
 	IApplicationDbContext dbContext,
 	IUnitOfWork unitOfWork,
 	IKeycloakUserService keycloakUserService,
-	IEmailService emailService)
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer)
 	: ICommandHandler<ResendInvitationCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -47,13 +49,22 @@ internal sealed class ResendInvitationCommandHandler(
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
+		var inviteeUser = (await dbContext.GetOrCreateUsersAsync([invitation.InviteeId], cancellationToken))[0];
+		var inviteeLanguage = SupportedLanguages.Resolve(inviteeUser.PreferredLanguage);
+
+		var content = emailTemplateRenderer.Render(
+			EmailTemplateKind.InvitationReceived,
+			inviteeLanguage,
+			new Dictionary<string, string>
+			{
+				["InviteeName"] = invitee.FirstName ?? invitee.Username,
+				["OrganizationName"] = invitation.OrganizationName,
+			});
+
 		await emailService.SendAsync(
 			invitee.Email,
-			"You've been invited to join an organization",
-			$"Hello {invitee.FirstName ?? invitee.Username},\n\n" +
-			$"You've been invited to join \"{invitation.OrganizationName}\" on Einsatzbereit.\n\n" +
-			$"Log in to your account to accept or decline the invitation.\n\n" +
-			$"Einsatzbereit",
+			content.Subject,
+			content.Body,
 			cancellationToken);
 
 		return true;

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -16,7 +16,8 @@ internal sealed class UpdateTimeSlotCommandHandler(
 	IApplicationDbContext dbContext,
 	IEngagementReadRepository engagementReadRepository,
 	IKeycloakUserService keycloakUserService,
-	IEmailService emailService)
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer)
 	: ICommandHandler<UpdateTimeSlotCommand, UpdateTimeSlotResult>
 {
 	public async ValueTask<UpdateTimeSlotResult> Handle(
@@ -82,6 +83,7 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			timeSlotId,
 			keycloakUserService,
 			emailService,
+			emailTemplateRenderer,
 			opportunity.Title);
 
 		return new UpdateTimeSlotResult(1, []);

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -22,6 +22,7 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 	IPinGenerator pinGenerator,
 	IKeycloakUserService keycloakUserService,
 	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
 	ILogger<UpdateVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<UpdateVolunteerOpportunityCommand, bool>
 {
@@ -97,6 +98,7 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 				cancellationToken,
 				keycloakUserService: keycloakUserService,
 				emailService: emailService,
+				emailTemplateRenderer: emailTemplateRenderer,
 				opportunityTitle: opportunity.Title);
 
 		return true;

--- a/backend/src/Infrastructure/Email/Templates/de.json
+++ b/backend/src/Infrastructure/Email/Templates/de.json
@@ -30,5 +30,13 @@
   "EngagementReminder": {
     "subject": "Erinnerung: {OpportunityTitle} startet morgen",
     "body": "Hallo {DisplayName},\n\ndies ist eine Erinnerung, dass du für \"{OpportunityTitle}\" angemeldet bist, das am {StartFormatted} beginnt.\n\nWir freuen uns auf dich!\n\nDein Einsatzbereit-Team"
+  },
+  "InvitationReceived": {
+    "subject": "Du wurdest eingeladen, einer Organisation beizutreten",
+    "body": "Hallo {InviteeName},\n\ndu wurdest eingeladen, der Organisation \"{OrganizationName}\" auf Einsatzbereit beizutreten.\n\nMelde dich in deinem Konto an, um die Einladung anzunehmen oder abzulehnen.\n\nEinsatzbereit"
+  },
+  "OpportunityUpdated": {
+    "subject": "Ein Einsatz, für den du dich angemeldet hast, hat sich geändert: \"{OpportunityTitle}\"",
+    "body": "Hallo {VolunteerName},\n\ndie Details für \"{OpportunityTitle}\" haben sich geändert. Bitte sieh in der App nach den aktuellen Informationen.\n\nEinsatzbereit"
   }
 }

--- a/backend/src/Infrastructure/Email/Templates/en.json
+++ b/backend/src/Infrastructure/Email/Templates/en.json
@@ -30,5 +30,13 @@
   "EngagementReminder": {
     "subject": "Reminder: {OpportunityTitle} starts tomorrow",
     "body": "Hi {DisplayName},\n\nThis is a reminder that you are signed up for \"{OpportunityTitle}\" which starts on {StartFormatted}.\n\nWe are looking forward to seeing you!\n\nThe Einsatzbereit Team"
+  },
+  "InvitationReceived": {
+    "subject": "You've been invited to join an organization",
+    "body": "Hello {InviteeName},\n\nYou've been invited to join \"{OrganizationName}\" on Einsatzbereit.\n\nLog in to your account to accept or decline the invitation.\n\nEinsatzbereit"
+  },
+  "OpportunityUpdated": {
+    "subject": "An opportunity you signed up for has changed: \"{OpportunityTitle}\"",
+    "body": "Hello {VolunteerName},\n\nThe details for \"{OpportunityTitle}\" have changed. Please check the app for the latest information.\n\nEinsatzbereit"
   }
 }

--- a/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -19,6 +19,7 @@ public class CreateInvitationCommandHandlerTests
 	private readonly IKeycloakOrganizationService _keycloakOrgService = Substitute.For<IKeycloakOrganizationService>();
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IAggregateRepository<Organization, OrganizationId> _orgRepo =
 		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
 	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
@@ -44,8 +45,13 @@ public class CreateInvitationCommandHandlerTests
 		_keycloakUserService
 			.GetUserAsync(DefaultInviteeId.Value, Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(DefaultInviteeId.Value, "vera", "Vera", "Miller", "vera@test.de"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
 		_sut = new CreateInvitationCommandHandler(
-			_dbContext, _unitOfWork, _keycloakOrgService, _keycloakUserService, _emailService);
+			_dbContext, _unitOfWork, _keycloakOrgService, _keycloakUserService, _emailService, _emailTemplateRenderer);
 	}
 
 	[Test]
@@ -86,5 +92,44 @@ public class CreateInvitationCommandHandlerTests
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 		await _emailService.Received(1).SendAsync(
 			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderInvitationEmail_InInviteesPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitee = User.Create(DefaultInviteeId);
+		invitee.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([invitee]);
+		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, OrganizationMemberRole.Member, DefaultInvitedById);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.InvitationReceived,
+			"en",
+			Arg.Is<IReadOnlyDictionary<string, string>>(p =>
+				p!["InviteeName"] == "Vera" && p["OrganizationName"] == "Test Org"));
+	}
+
+	[Test]
+	public async Task Handle_ShouldDefaultToGerman_WhenInviteeHasNoPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new CreateInvitationCommand(DefaultOrgId, DefaultInviteeId, OrganizationMemberRole.Member, DefaultInvitedById);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.InvitationReceived,
+			"de",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
@@ -18,6 +18,7 @@ public class ResendInvitationCommandHandlerTests
 	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
 		Substitute.For<IAggregateRepository<OrganizationInvitation, OrganizationInvitationId>>();
 	private readonly ResendInvitationCommandHandler _sut;
@@ -35,8 +36,13 @@ public class ResendInvitationCommandHandlerTests
 		_keycloakUserService
 			.GetUserAsync(DefaultInviteeId.Value, Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(DefaultInviteeId.Value, "vera", "Vera", "Miller", "vera@test.de"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
 		_sut = new ResendInvitationCommandHandler(
-			_dbContext, _unitOfWork, _keycloakUserService, _emailService);
+			_dbContext, _unitOfWork, _keycloakUserService, _emailService, _emailTemplateRenderer);
 	}
 
 	private static OrganizationInvitation CreateExpiredInvitation(OrganizationId orgId)
@@ -148,5 +154,29 @@ public class ResendInvitationCommandHandlerTests
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderInvitationEmail_InInviteesPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateExpiredInvitation(DefaultOrgId);
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var invitee = User.Create(DefaultInviteeId);
+		invitee.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([invitee]);
+		var command = new ResendInvitationCommand(DefaultOrgId, invitation.Id, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.InvitationReceived,
+			"en",
+			Arg.Is<IReadOnlyDictionary<string, string>>(p =>
+				p!["InviteeName"] == "Vera" && p["OrganizationName"] == "Test Org"));
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -26,6 +26,7 @@ public class UpdateTimeSlotCommandHandlerTests
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly UpdateTimeSlotCommandHandler _sut;
 
 	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
@@ -53,7 +54,12 @@ public class UpdateTimeSlotCommandHandlerTests
 		_emailService
 			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
 			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
-		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService);
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer);
 	}
 
 	private VolunteerOpportunity CreateScheduledSlotsOpportunity() =>

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -29,6 +29,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly UpdateVolunteerOpportunityCommandHandler _sut;
 
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
@@ -54,6 +55,15 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		_emailService
 			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
 			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(callInfo =>
+			{
+				var placeholders = (IReadOnlyDictionary<string, string>)callInfo[2]!;
+				return new EmailContent("Test Subject", $"Test Body {string.Join(" ", placeholders.Values)}");
+			});
 		_sut = new UpdateVolunteerOpportunityCommandHandler(
 			_dbContext,
 			_engagementReadRepository,
@@ -61,6 +71,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			_pinGenerator,
 			_keycloakUserService,
 			_emailService,
+			_emailTemplateRenderer,
 			NullLogger<UpdateVolunteerOpportunityCommandHandler>.Instance);
 	}
 
@@ -371,6 +382,46 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			Arg.Is<IReadOnlyList<EmailMessage>>(messages =>
 				messages!.Count == 1 && messages[0].To == "user@example.com" && messages[0].Body.Contains("Neues Thema")),
 			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderOpportunityUpdatedEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		var activeVolunteerId = UserId.New();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteerId.Value]);
+
+		var activeVolunteer = User.Create(activeVolunteerId);
+		activeVolunteer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([activeVolunteer]);
+
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
+
+		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.OpportunityUpdated,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/Email/EmailTemplateRendererTests.cs
+++ b/backend/tests/IntegrationTests/Email/EmailTemplateRendererTests.cs
@@ -28,6 +28,8 @@ public class EmailTemplateRendererTests
 				["StartFormatted"] = "Monday, 1. January 2027 at 10:00",
 				["Reason"] = "Not enough sign-ups",
 				["ReasonBlock"] = "",
+				["InviteeName"] = "Vera",
+				["OrganizationName"] = "Beach Cleanup Crew",
 			};
 
 			var content = _sut.Render(kind, language, placeholders);
@@ -50,6 +52,30 @@ public class EmailTemplateRendererTests
 			});
 
 		content.Subject.Should().Be("Your engagement has been confirmed");
+		content.Body.Should().Contain("Vera").And.Contain("Beach Cleanup");
+	}
+
+	[Test]
+	public void Render_ShouldInterpolateEveryPlaceholder_ForInvitationReceived_InGerman()
+	{
+		var content = _sut.Render(
+			EmailTemplateKind.InvitationReceived,
+			"de",
+			new Dictionary<string, string> { ["InviteeName"] = "Vera", ["OrganizationName"] = "Strandreinigung e.V." });
+
+		content.Subject.Should().Be("Du wurdest eingeladen, einer Organisation beizutreten");
+		content.Body.Should().Contain("Vera").And.Contain("Strandreinigung e.V.");
+	}
+
+	[Test]
+	public void Render_ShouldInterpolateEveryPlaceholder_ForOpportunityUpdated_InEnglish()
+	{
+		var content = _sut.Render(
+			EmailTemplateKind.OpportunityUpdated,
+			"en",
+			new Dictionary<string, string> { ["VolunteerName"] = "Vera", ["OpportunityTitle"] = "Beach Cleanup" });
+
+		content.Subject.Should().Contain("Beach Cleanup");
 		content.Body.Should().Contain("Vera").And.Contain("Beach Cleanup");
 	}
 


### PR DESCRIPTION
Organization invitation (create/resend) and opportunity-details-changed emails were the last hardcoded English strings; #1052/#1513 already localized the other five email flows this issue named. Wires these three call sites into the existing IEmailTemplateRenderer/User.PreferredLanguage pattern instead of introducing a new one.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1082

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
