### PR TITLE
feat: link account menu to Keycloak account console

### DIFF
--- a/backend/tests/VisualTests/AccountConsoleLinkTests.cs
+++ b/backend/tests/VisualTests/AccountConsoleLinkTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// #1098: users had no in-app way to change their password or email - the
+/// account dropdown (desktop) and mobile burger menu only ever linked to
+/// /profile and (admins only) /administration. This adds an "Account
+/// Settings" entry in both menus pointing at Keycloak's own account console
+/// (`${authority}/account`), which already supports password/email changes,
+/// rather than building that functionality natively.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class AccountConsoleLinkTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task AccountDropdown_AuthenticatedUser_LinksToKeycloakAccountConsole()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var authority = $"{Fixture.GetEndpoint("keycloak").ToString().TrimEnd('/')}/realms/einsatzbereit";
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "User menu" }).ClickAsync();
+
+		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" });
+		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(link).ToHaveAttributeAsync("href", $"{authority}/account");
+		await Expect(link).ToHaveAttributeAsync("target", "_blank");
+		await Expect(link).ToHaveAttributeAsync("rel", "noopener noreferrer");
+	}
+
+	[Test]
+	public async Task MobileMenu_AuthenticatedUser_LinksToKeycloakAccountConsole()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var authority = $"{Fixture.GetEndpoint("keycloak").ToString().TrimEnd('/')}/realms/einsatzbereit";
+
+		// FastSignInAsync's own "User menu" wait needs the desktop-width nav
+		// visible (DesktopHeader.tsx's "hidden md:flex") - sign in at the
+		// default (desktop-sized) viewport, then shrink down to mobile only
+		// afterward, mirroring MobileHeaderTests' own viewport handling.
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(390, 844);
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" });
+		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(link).ToHaveAttributeAsync("href", $"{authority}/account");
+		await Expect(link).ToHaveAttributeAsync("target", "_blank");
+		await Expect(link).ToHaveAttributeAsync("rel", "noopener noreferrer");
+	}
+}

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
+import { runtimeConfig } from "../../lib/runtimeConfig";
 import NotificationDropdown from "./NotificationDropdown";
 
 export default function AccountControls({
@@ -108,6 +109,28 @@ export default function AccountControls({
 								</svg>
 								{t("nav.myProfile")}
 							</Link>
+							<a
+								href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-3 px-4 py-2.5 text-sm transition-colors text-gray-700 hover:bg-brand-50 hover:text-brand-700"
+							>
+								<svg
+									className="w-4 h-4"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth="1.5"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
+									/>
+								</svg>
+								{t("nav.accountSettings")}
+							</a>
 							{isAdmin && (
 								<Link
 									to="/administration"

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import LanguageSelector from "./LanguageSelector";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
+import { runtimeConfig } from "../../lib/runtimeConfig";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 
 // Mobile menu overlay (absolute-positioned so it doesn't push content down),
@@ -101,6 +102,15 @@ export default function MobileMenu({
 						>
 							{t("nav.myProfile")}
 						</Link>
+						<a
+							href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={onClose}
+							className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${menuItemVariant}`}
+						>
+							{t("nav.accountSettings")}
+						</a>
 						{isAdmin && (
 							<Link
 								to="/administration"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -19,6 +19,7 @@
       "primaryLabel": "Hauptnavigation",
       "userMenu": "Benutzermenü",
       "myProfile": "Mein Profil",
+      "accountSettings": "Kontoeinstellungen",
       "administration": "Administration",
       "organization": "Organisation",
       "signOut": "Abmelden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -19,6 +19,7 @@
       "primaryLabel": "Main navigation",
       "userMenu": "User menu",
       "myProfile": "My Profile",
+      "accountSettings": "Account Settings",
       "administration": "Administration",
       "organization": "Organization",
       "signOut": "Sign out",


### PR DESCRIPTION
Users have no in-app way to change their password or email (#1098). Add an "Account Settings" entry to the desktop dropdown and mobile menu pointing at Keycloak's own account console, which already supports both.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1098

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
