### PR TITLE
fix: rotate container logs, check MinIO health, and alert on outages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 # Required secrets in the `staging` GitHub Environment:
 #   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD,
 #   MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, SMTP_HOST, SMTP_PORT, SMTP_USERNAME,
-#   SMTP_PASSWORD, SMTP_FROM_ADDRESS, SMTP_FROM_NAME, GRAFANA_ADMIN_PASSWORD
+#   SMTP_PASSWORD, SMTP_FROM_ADDRESS, SMTP_FROM_NAME, GRAFANA_ADMIN_PASSWORD,
+#   ALERT_NOTIFICATION_EMAIL
 #   (GRAFANA_ADMIN_USER optional)
 # (Plus deploy creds: STAGING_SSH_KEY/HOST/USER, GHCR_USERNAME, GHCR_TOKEN.)
 #
@@ -35,6 +36,11 @@ SMTP_USERNAME=change-me
 SMTP_PASSWORD=change-me
 SMTP_FROM_ADDRESS=change-me
 SMTP_FROM_NAME=Einsatzbereit
+
+# Recipient address for Prometheus Alertmanager's email notifications
+# (docker-compose.yml's alertmanager-config, #1081) - routed over the same
+# SMTP relay as above, so no separate mail credentials are needed here.
+ALERT_NOTIFICATION_EMAIL=change-me
 
 # Grafana admin login. GRAFANA_ADMIN_USER defaults to "admin" if unset.
 # These only apply the FIRST time Grafana boots against an empty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -451,6 +451,11 @@ jobs:
           SMTP_FROM_NAME: ${{ secrets.SMTP_FROM_NAME }}
           GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          # Where Alertmanager sends alert emails (docker-compose.yml's
+          # alertmanager-config, #1081) - not a mailbox credential, just the
+          # recipient address, but still per-environment so it isn't a
+          # committed literal.
+          ALERT_NOTIFICATION_EMAIL: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
         run: |
           umask 077
           # Wrap each value in double quotes and escape \ and " so secrets that
@@ -478,6 +483,7 @@ jobs:
             printf 'SMTP_FROM_NAME="%s"\n' "$(escape "$SMTP_FROM_NAME")"
             printf 'GRAFANA_ADMIN_USER="%s"\n' "$(escape "$GRAFANA_ADMIN_USER")"
             printf 'GRAFANA_ADMIN_PASSWORD="%s"\n' "$(escape "$GRAFANA_ADMIN_PASSWORD")"
+            printf 'ALERT_NOTIFICATION_EMAIL="%s"\n' "$(escape "$ALERT_NOTIFICATION_EMAIL")"
             # Not a secret - staging is meant to come back seeded with demo
             # organizations/opportunities on every deploy/reset (see
             # reset-staging.yml). docker-compose.yml defaults this to
@@ -584,7 +590,7 @@ jobs:
           ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
             set +e
             cd /opt/einsatzbereit
-            for svc in backend keycloak postgres prometheus node-exporter grafana loki alloy; do
+            for svc in backend keycloak postgres prometheus alertmanager node-exporter grafana loki alloy; do
               echo "::group::docker inspect ${svc} (state)"
               docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Health={{if .State.Health}}{{.State.Health.Status}}{{end}}' "${svc}" 2>&1 || true
               echo "::endgroup::"

--- a/backend/src/Api/Common/Health/StorageHealthCheck.cs
+++ b/backend/src/Api/Common/Health/StorageHealthCheck.cs
@@ -1,0 +1,25 @@
+using Application.Common.Storage;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Api.Common.Health;
+
+internal sealed class StorageHealthCheck(
+	IFileStorageService fileStorageService)
+	: IHealthCheck
+{
+	public async Task<HealthCheckResult> CheckHealthAsync(
+		HealthCheckContext context,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await fileStorageService.PingAsync(cancellationToken);
+
+			return HealthCheckResult.Healthy("Storage is reachable.");
+		}
+		catch (Exception exception)
+		{
+			return HealthCheckResult.Unhealthy("Storage is not reachable.", exception);
+		}
+	}
+}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -72,7 +72,8 @@ builder.Services.AddHttpClient(KeycloakHealthCheck.HttpClientName, client =>
 
 builder.Services.AddHealthChecks()
 	.AddCheck<DatabaseHealthCheck>("database", tags: ["ready"])
-	.AddCheck<KeycloakHealthCheck>("keycloak", tags: ["ready"]);
+	.AddCheck<KeycloakHealthCheck>("keycloak", tags: ["ready"])
+	.AddCheck<StorageHealthCheck>("storage", tags: ["ready"]);
 
 builder.Services.AddEndpoints();
 builder.Services.AddRateLimitingPolicies(builder.Configuration);

--- a/backend/src/Application/Common/Storage/IFileStorageService.cs
+++ b/backend/src/Application/Common/Storage/IFileStorageService.cs
@@ -12,4 +12,8 @@ public interface IFileStorageService
 	Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default);
 
 	string GetPublicUrl(string objectKey);
+
+	// Throws if the storage backend is unreachable; used by StorageHealthCheck
+	// (Api/Common/Health) to back the "ready" readiness probe (#1081).
+	Task PingAsync(CancellationToken cancellationToken = default);
 }

--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -82,6 +82,16 @@ internal sealed class MinioFileStorageService : IFileStorageService
 		return $"{baseUrl}/{_settings.BucketName}/{objectKey}";
 	}
 
+	// BucketExistsAsync's own bool result only distinguishes "bucket present"
+	// from "bucket absent" - both are a reachable server and neither should fail
+	// a readiness probe on a fresh deployment before EnsureBucketReadyAsync has
+	// ever run. Unreachability (the thing the probe actually cares about) surfaces
+	// as a thrown exception instead, which callers are expected to catch.
+	public async Task PingAsync(CancellationToken cancellationToken = default) =>
+		await _minio.BucketExistsAsync(
+			new BucketExistsArgs().WithBucket(_settings.BucketName),
+			cancellationToken);
+
 	// Object keys don't change on re-upload, so the version query param is
 	// what invalidates a browser's cached copy once the underlying object
 	// changes - without it, CacheControlHeaderValue's max-age would let a

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -95,6 +95,15 @@ public class IntegrationTestFixture
 	public HttpClient CreateHttpClient() =>
 		_app.CreateHttpClient("backend", "http");
 
+	// Resolves the real (Aspire-assigned) base address of the test MinIO
+	// container, for tests that construct a MinioFileStorageService directly
+	// against it (StorageHealthCheckTests.cs) rather than through the backend.
+	public string GetMinioEndpoint()
+	{
+		using var client = _app.CreateHttpClient("minio", "api");
+		return client.BaseAddress!.ToString();
+	}
+
 	public async Task<string> GetAccessTokenAsync(string username, string password)
 	{
 		var content = new FormUrlEncodedContent([

--- a/backend/tests/IntegrationTests/StorageHealthCheckTests.cs
+++ b/backend/tests/IntegrationTests/StorageHealthCheckTests.cs
@@ -1,0 +1,57 @@
+using AwesomeAssertions;
+using Infrastructure.Storage;
+using Microsoft.Extensions.Options;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+public class StorageHealthCheckTests(IntegrationTestFixture fixture)
+{
+	[Test]
+	public async Task PingAsync_ShouldSucceed_WhenMinioIsReachable(CancellationToken cancellationToken)
+	{
+		var storage = new MinioFileStorageService(Options.Create(new StorageSettings
+		{
+			Endpoint = fixture.GetMinioEndpoint(),
+			AccessKey = "minio",
+			SecretKey = "minio123",
+			BucketName = "einsatzbereit",
+		}));
+
+		var act = () => storage.PingAsync(cancellationToken);
+
+		await act.Should().NotThrowAsync();
+	}
+
+	// Regression guard for #1081: before this, nothing in the backend's own
+	// readiness probe checked storage connectivity at all, so /health reported
+	// Healthy even while MinIO was completely unreachable and every upload/image
+	// fetch was failing.
+	[Test]
+	public async Task PingAsync_ShouldThrow_WhenMinioIsUnreachable(CancellationToken cancellationToken)
+	{
+		var storage = new MinioFileStorageService(Options.Create(new StorageSettings
+		{
+			// Nothing listens on this port - connection refused immediately, no
+			// real network round trip to wait out.
+			Endpoint = "http://127.0.0.1:1",
+			AccessKey = "minio",
+			SecretKey = "minio123",
+			BucketName = "einsatzbereit",
+		}));
+
+		var act = () => storage.PingAsync(cancellationToken);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Test]
+	public async Task GetHealth_ShouldReturnHealthy_WhenStorageIsReachable(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync("/health", cancellationToken);
+
+		response.IsSuccessStatusCode.Should().BeTrue();
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,16 @@
 # multiple projects on the same host). Our services attach to the existing
 # proxy network and register routes via labels - they expect a Traefik
 # instance with the `myresolver` ACME resolver already configured.
+#
+# Every service below shares the same `logging: *default-logging` driver
+# config (json-file, capped at 10m x 3 files) - without it, container stdout
+# grows unbounded on the host disk (#1081).
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: 10m
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:18
@@ -9,6 +19,7 @@ services:
     restart: unless-stopped
     networks:
       - db
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -35,6 +46,7 @@ services:
     networks:
       - proxy
       - db
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -101,6 +113,7 @@ services:
     restart: unless-stopped
     networks:
       - db
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -128,6 +141,7 @@ services:
     command: server /data --console-address ":9001"
     networks:
       - proxy
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -176,6 +190,7 @@ services:
       - proxy
       - db
       - monitoring
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -259,6 +274,7 @@ services:
     restart: unless-stopped
     networks:
       - proxy
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -289,6 +305,7 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    logging: *default-logging
     # Only a handful of scrape targets (itself, node-exporter, backend), so a
     # low ceiling is plenty - trimmed down from 256m to leave more host
     # headroom on a memory-constrained box (staging runs on a 4GB VM).
@@ -302,8 +319,38 @@ services:
     configs:
       - source: prometheus-config
         target: /etc/prometheus/prometheus.yml
+      - source: prometheus-rules
+        target: /etc/prometheus/alert.rules.yml
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:9090/-/healthy || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # Routes firing alerts (prometheus-config's `alerting:` block + the rules in
+  # prometheus-rules below) to email over the same SMTP relay the backend and
+  # Keycloak already use (#1341) - no new third-party notification channel,
+  # consistent with this stack's self-hosted-over-SaaS precedent (ADR-6, #1081).
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    restart: unless-stopped
+    networks:
+      - monitoring
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 64m
+          cpus: "0.10"
+    volumes:
+      - alertmanager_data:/alertmanager
+    configs:
+      - source: alertmanager-config
+        target: /etc/alertmanager/alertmanager.yml
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:9093/-/healthy || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -319,6 +366,7 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -341,6 +389,7 @@ services:
     networks:
       - proxy
       - monitoring
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -380,6 +429,7 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    logging: *default-logging
     # Now scoped to just this stack's own ~6 containers (see alloy's
     # discovery filter below), so log volume is small - trimmed down from
     # 256m to leave more host headroom on a memory-constrained box
@@ -412,6 +462,7 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -447,6 +498,7 @@ services:
     restart: unless-stopped
     networks:
       - monitoring
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -479,6 +531,7 @@ volumes:
   postgres_backups:
   minio_data:
   prometheus_data:
+  alertmanager_data:
   grafana_data:
   loki_data:
   alloy_data:
@@ -494,6 +547,14 @@ configs:
       global:
         scrape_interval: 15s
         evaluation_interval: 15s
+
+      alerting:
+        alertmanagers:
+          - static_configs:
+              - targets: ["alertmanager:9093"]
+
+      rule_files:
+        - /etc/prometheus/alert.rules.yml
 
       scrape_configs:
         - job_name: prometheus
@@ -517,6 +578,49 @@ configs:
               type: A
               port: 8081
               refresh_interval: 30s
+  # Kept to a single, well-established signal (staleness) rather than guessing
+  # at application metric names/thresholds that haven't been validated against
+  # real staging traffic - see #1081. Fires whenever any scrape target
+  # (prometheus/node-exporter/backend) stops responding.
+  #
+  # "$$labels" (not "$labels"): this whole block is compose-interpolated
+  # before Prometheus ever sees it, so a literal "$" for Prometheus's own Go
+  # template syntax must be escaped the same way node-exporter's regex above
+  # escapes its own literal "$".
+  prometheus-rules:
+    content: |
+      groups:
+        - name: staging-availability
+          rules:
+            - alert: InstanceDown
+              expr: up == 0
+              for: 2m
+              labels:
+                severity: critical
+              annotations:
+                summary: "{{ $$labels.job }} instance {{ $$labels.instance }} is down"
+                description: "Prometheus has not been able to scrape {{ $$labels.job }} ({{ $$labels.instance }}) for more than 2 minutes."
+  alertmanager-config:
+    content: |
+      global:
+        smtp_smarthost: '${SMTP_HOST:?set SMTP_HOST in .env}:${SMTP_PORT:?set SMTP_PORT in .env}'
+        smtp_from: '${SMTP_FROM_ADDRESS:?set SMTP_FROM_ADDRESS in .env}'
+        smtp_auth_username: '${SMTP_USERNAME:?set SMTP_USERNAME in .env}'
+        smtp_auth_password: '${SMTP_PASSWORD:?set SMTP_PASSWORD in .env}'
+        smtp_require_tls: true
+
+      route:
+        receiver: default
+        group_by: ['alertname']
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+
+      receivers:
+        - name: default
+          email_configs:
+            - to: '${ALERT_NOTIFICATION_EMAIL:?set ALERT_NOTIFICATION_EMAIL in .env}'
+              send_resolved: true
   grafana-datasources:
     content: |
       apiVersion: 1
@@ -538,6 +642,13 @@ configs:
           access: proxy
           url: http://tempo:3200
           editable: false
+        - name: Alertmanager
+          type: alertmanager
+          access: proxy
+          url: http://alertmanager:9093
+          editable: false
+          jsonData:
+            implementation: prometheus
   alloy-config:
     content: |
       discovery.docker "containers" {

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -158,12 +158,17 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Grafana
 |`grafana/grafana`
 |`grafana.maik-hasler.de`
-|Dashboards; datasources are Prometheus (metrics), Loki (logs), and Tempo (traces)
+|Dashboards; datasources are Prometheus (metrics), Loki (logs), Tempo (traces), and Alertmanager (alerts)
 
 |Prometheus
 |`prom/prometheus`
 |internal only
-|Metrics store; scrapes node-exporter, not exposed via Traefik
+|Metrics store; scrapes node-exporter, not exposed via Traefik; evaluates alert rules and forwards firing alerts to Alertmanager
+
+|Alertmanager
+|`prom/alertmanager`
+|internal only
+|Routes firing alerts to email over the same SMTP relay as the backend/Keycloak, not exposed via Traefik
 
 |node-exporter
 |`prom/node-exporter`
@@ -193,4 +198,4 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 
 Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`). The deploy is health-gated (backend `/alive` and `/health`) and rolls back to the previous images on failure.
 
-Prometheus, node-exporter, Loki, and Tempo sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics, log, or trace content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads Prometheus (metrics), Loki (logs), and Tempo (traces) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient. Tempo has no equivalent shipper: the backend pushes traces to it directly over OTLP (see ADR 6), since the app already speaks OTLP natively via the Aspire service defaults.
+Prometheus, Alertmanager, node-exporter, Loki, and Tempo sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics, log, trace, or alert content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads Prometheus (metrics), Loki (logs), Tempo (traces), and Alertmanager (alerts) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient. Tempo has no equivalent shipper: the backend pushes traces to it directly over OTLP (see ADR 6), since the app already speaks OTLP natively via the Aspire service defaults. Alertmanager notifies over email (SMTP) rather than a push-based shipper, since alerts are pulled from Prometheus's own rule evaluation, not scraped or streamed from elsewhere.

--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -120,3 +120,5 @@ Key logged events:
 * Slow requests (flagged by the performance pipeline behavior)
 
 No third-party observability SaaS (Datadog, Grafana Cloud, etc.) is wired in by default - a deliberate trade-off to keep operational complexity minimal; any OTLP backend can be pointed at the exporter, and the self-hosted Grafana stack (Prometheus, Loki, Tempo) already deployed alongside the app is what it points at in staging/production.
+
+Prometheus evaluates alert rules (`docker-compose.yml`'s `prometheus-rules` config, mounted at `/etc/prometheus/alert.rules.yml`) and forwards firing alerts to a self-hosted Alertmanager, which emails them out over the same SMTP relay the backend and Keycloak already use (#1081) - again keeping the "self-hosted over SaaS" trade-off above rather than adding a third-party alerting/incident vendor. The only rule shipped so far is `InstanceDown` (any scrape target unreachable for 2 minutes); it is deliberately the one signal that needs no application-specific metric knowledge, left minimal until real staging traffic justifies additional thresholds.


### PR DESCRIPTION
docker-compose.yml had no logging driver configured anywhere, so container stdout grew unbounded on the staging host disk. Add a shared json-file logging config (10m x 3 files) to every service.

The backend's /health readiness probe checked database and Keycloak reachability but never MinIO, despite uploads/image fetches depending on it - readiness could report healthy while storage was completely down. Add IFileStorageService.PingAsync (MinioFileStorageService backs it with a BucketExistsAsync connectivity probe) and a StorageHealthCheck registered alongside the existing database/keycloak checks.

Add a self-hosted Prometheus Alertmanager to the staging stack, consistent with ADR-6's self-hosted-over-SaaS precedent: Prometheus now evaluates alert rules and forwards firing alerts to Alertmanager, which emails them over the existing SMTP relay. Ships with a single InstanceDown rule (any scrape target unreachable for 2m) rather than guessing at unvalidated application-metric thresholds. Requires a new ALERT_NOTIFICATION_EMAIL secret in the staging GitHub Environment.

The OTLP-exporter-never-configured and MinIO-docker-healthcheck-absent complaints from the original issue report were already fixed on main (ADR-6/#1488, and MinIO's container healthcheck has existed since #513)
- not touched here.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1081

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
