### PR TITLE
feat: add Terms of Use page and require acceptance at registration

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -689,6 +689,18 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task TermsOfUsePage_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/terms-of-use");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task ContactPage_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/backend/tests/VisualTests/TermsOfUsePageTests.cs
+++ b/backend/tests/VisualTests/TermsOfUsePageTests.cs
@@ -64,9 +64,13 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Page.GotoAsync($"{origin}/terms-of-use");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await Expect(Page.Locator("a[href='/contact']")).ToBeVisibleAsync();
-		await Expect(Page.Locator("a[href='/privacy-policy']")).ToBeVisibleAsync();
-		await Expect(Page.Locator("a[href='/imprint']")).ToBeVisibleAsync();
+		// Scoped to <main> - the footer on every page also links /contact,
+		// /privacy-policy, and /imprint, which would otherwise make these
+		// locators match two elements each (Playwright strict mode).
+		var main = Page.Locator("main");
+		await Expect(main.Locator("a[href='/contact']")).ToBeVisibleAsync();
+		await Expect(main.Locator("a[href='/privacy-policy']")).ToBeVisibleAsync();
+		await Expect(main.Locator("a[href='/imprint']")).ToBeVisibleAsync();
 	}
 
 	[Test]
@@ -81,5 +85,31 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Expect(footer.Locator("a[href='/terms-of-use']")).ToBeVisibleAsync();
 		await Expect(footer.GetByText("Terms of Use", new() { Exact = true }))
 			.ToBeVisibleAsync();
+	}
+
+	// #1079: the acceptance step lives in the registration form itself (a
+	// "registration-terms-and-conditions" execution on Keycloak's built-in
+	// "registration" flow, requirement REQUIRED) rather than a realm-wide
+	// required action with defaultAction=true - the latter would attach to
+	// every newly created Keycloak user, including the ad-hoc accounts other
+	// integration/visual tests create via the admin API, breaking their
+	// ROPC token grant with "Account is not fully set up". Stops short of
+	// submitting the form (like Header_Anonymous_RegisterButton_Redirects...
+	// in AuthGuardTests.cs) so this doesn't leave a dangling Keycloak user
+	// behind with no cleanup mechanism.
+	[Test]
+	public async Task KeycloakRegistrationForm_RequiresAcceptingTermsOfUse()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Register" }).First.ClickAsync();
+
+		await Expect(Page.Locator("#kc-register-form")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+		await Expect(Page.Locator("#kc-registration-terms-text")).ToBeVisibleAsync();
+		await Expect(Page.Locator("#termsAccepted")).ToBeVisibleAsync();
 	}
 }

--- a/backend/tests/VisualTests/TermsOfUsePageTests.cs
+++ b/backend/tests/VisualTests/TermsOfUsePageTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// #1079: the platform had no Terms of Use page, no route, and no acceptance
+/// step anywhere - these tests pin the new /terms-of-use route, its footer
+/// link, its breadcrumb bar, and its EN/DE content so the page can't silently
+/// regress or go missing again.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task TermsOfUsePage_ShowsBreadcrumbBar_AndCoreSections()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/terms-of-use");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var actionBar = Page.Locator("header + div nav[aria-label='Breadcrumb']");
+		await Expect(actionBar).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(actionBar.GetByText("Terms of Use", new() { Exact = true }))
+			.ToBeVisibleAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "Terms of Use", Level = 1 })).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "Our role as a platform" })).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "Suspension and termination" })).ToBeVisibleAsync();
+		await Expect(Page.GetByText("at your own risk", new() { Exact = false }))
+			.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task TermsOfUsePage_ShowsGermanContent_WhenLanguageSwitched()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/terms-of-use");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch language" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Option, new() { Name = "Deutsch" }).ClickAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "Nutzungsbedingungen", Level = 1 })).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading,
+			new() { Name = "Unsere Rolle als Plattform" })).ToBeVisibleAsync();
+		await Expect(Page.GetByText("auf eigenes Risiko", new() { Exact = false }))
+			.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task TermsOfUsePage_CrossLinksToContactPrivacyAndImprint()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/terms-of-use");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.Locator("a[href='/contact']")).ToBeVisibleAsync();
+		await Expect(Page.Locator("a[href='/privacy-policy']")).ToBeVisibleAsync();
+		await Expect(Page.Locator("a[href='/imprint']")).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task Footer_LegalLinks_IncludeTermsOfUse()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var footer = Page.Locator("footer");
+		await Expect(footer.Locator("a[href='/terms-of-use']")).ToBeVisibleAsync();
+		await Expect(footer.GetByText("Terms of Use", new() { Exact = true }))
+			.ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import HomePage from "./pages/HomePage";
 // fires twice instead of once.
 const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
 const ImprintPage = lazy(() => import("./pages/ImprintPage"));
+const TermsOfUsePage = lazy(() => import("./pages/TermsOfUsePage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));
 const VolunteerOpportunityDetailPage = lazy(
 	() => import("./pages/VolunteerOpportunityDetailPage"),
@@ -118,6 +119,7 @@ export default function App() {
 				<Route path="/" element={<HomePage />} />
 				<Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
 				<Route path="/imprint" element={<ImprintPage />} />
+				<Route path="/terms-of-use" element={<TermsOfUsePage />} />
 				<Route path="/contact" element={<ContactPage />} />
 				<Route
 					path="/volunteer-opportunities/:opportunityId"

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -60,6 +60,14 @@ export default function Footer() {
 							</li>
 							<li>
 								<Link
+									to="/terms-of-use"
+									className="hover:text-white transition-colors"
+								>
+									{t("footer.terms")}
+								</Link>
+							</li>
+							<li>
+								<Link
 									to="/privacy-policy"
 									className="hover:text-white transition-colors"
 								>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -33,6 +33,7 @@
       "browseOrganizations": "Organisationen durchsuchen",
       "legal": "Rechtliches",
       "imprint": "Impressum",
+      "terms": "Nutzungsbedingungen",
       "privacy": "Datenschutz",
       "contact": "Kontakt",
       "followUs": "Folge uns",
@@ -672,6 +673,23 @@
       "reportSectionBody": "Wenn dir ein Bedarf oder eine Organisation auffällt, die wie Spam, Betrug oder anderweitig illegale Inhalte aussieht, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Bedarfs-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Unsere Administratoren prüfen jede Meldung und können die Inhalte entfernen.",
       "otherSectionTitle": "Andere Fragen oder Anliegen",
       "otherSectionBody": "Bei allen anderen Anliegen wende dich bitte direkt an die Organisation, bei der du dich engagierst, oder an den im Impressum genannten Betreiber der Plattform."
+    },
+    "termsOfUse": {
+      "title": "Nutzungsbedingungen",
+      "section1Title": "Geltungsbereich und Zustimmung",
+      "section1Body": "Diese Nutzungsbedingungen regeln die Nutzung von Einsatzbereit (die \"Plattform\"). Mit der Erstellung eines Kontos, der Anmeldung zu einem Einsatz oder der sonstigen Nutzung der Plattform erklären Sie sich mit diesen Bedingungen einverstanden. Wenn Sie nicht einverstanden sind, nutzen Sie die Plattform bitte nicht.",
+      "section2Title": "Unsere Rolle als Plattform",
+      "section2Body": "Einsatzbereit vermittelt zwischen Freiwilligen und Einsätzen, die von unabhängigen Organisationen veröffentlicht werden. Wir organisieren, beaufsichtigen oder begleiten die auf der Plattform gelisteten Aktivitäten nicht und sind keine Vertragspartei einer Vereinbarung zwischen Freiwilligen und Organisationen. Organisationen sind allein verantwortlich für die von ihnen veröffentlichten Einsätze, einschließlich deren Inhalt, Sicherheit und Eignung.",
+      "section3Title": "Zulässige Nutzung",
+      "section3Body": "Bei der Nutzung der Plattform verpflichten Sie sich, korrekte Angaben zu Ihrer Person zu machen und diese aktuell zu halten, andere Nutzerinnen und Nutzer, Organisationen und die Menschen, denen Sie helfen, respektvoll zu behandeln, den Anweisungen der veranstaltenden Organisation vor Ort zu folgen und keine Inhalte zu veröffentlichen oder zu teilen, die rechtswidrig, betrügerisch, belästigend oder anderweitig schädlich sind. Sie dürfen die Plattform nicht nutzen, um bezahlte Arbeit anzubieten, personenbezogene Daten für plattformfremde Zwecke zu sammeln oder Ihre Identität oder Zugehörigkeit zu einer Organisation falsch darzustellen.",
+      "section4Title": "Organisationen und Einsätze",
+      "section4Body": "Organisationen, die Einsätze veröffentlichen, sind verantwortlich für die Richtigkeit ihrer Angebote und für ein sicheres Umfeld am angegebenen Ort und zur angegebenen Zeit. Ein Verifizierungs-Badge im Profil einer Organisation bestätigt, dass wir deren Identität geprüft haben; es garantiert nicht die Qualität, Sicherheit oder Rechtmäßigkeit eines von ihr veröffentlichten Einsatzes. Wenn Ihnen Inhalte auffallen, die wie Spam, Betrug oder anderweitig rechtswidrig wirken, nutzen Sie bitte die auf unserer <contactLink>Kontaktseite</contactLink> beschriebene Meldefunktion.",
+      "section5Title": "Haftung",
+      "section5Body": "Die Plattform wird nach bestem Bemühen und nicht gewerblich zur Verfügung gestellt. Wir übernehmen keine Gewähr für die Verfügbarkeit, Richtigkeit oder Vollständigkeit von Angeboten und haften nicht für das Verhalten von Freiwilligen oder Organisationen oder für Verluste, Verletzungen oder Schäden, die aus der Teilnahme an einem Einsatz entstehen. Die Teilnahme an Einsätzen erfolgt auf eigenes Risiko. Nichts in diesem Abschnitt beschränkt eine Haftung, die nach geltendem Recht nicht ausgeschlossen werden kann.",
+      "section6Title": "Sperrung und Kündigung",
+      "section6Body": "Wir können ein Konto sperren oder deaktivieren, das gegen diese Bedingungen verstößt, betrügerische oder unsichere Inhalte veröffentlicht oder Gegenstand belegter Meldungen anderer Nutzerinnen und Nutzer ist. Wo möglich, informieren wir das betroffene Konto über den Grund. Sie können die Nutzung der Plattform jederzeit beenden und die Löschung Ihres Kontos beantragen; Einzelheiten zum Umgang mit Ihren Daten finden Sie in unserer <privacyLink>Datenschutzerklärung</privacyLink>.",
+      "section7Title": "Änderungen dieser Bedingungen",
+      "section7Body": "Wir können diese Bedingungen von Zeit zu Zeit aktualisieren, um Änderungen der Plattform oder rechtlicher Vorgaben widerzuspiegeln. Die fortgesetzte Nutzung der Plattform nach einer Aktualisierung gilt als Zustimmung zu den geänderten Bedingungen. Bei Fragen zu diesen Bedingungen kontaktieren Sie uns bitte über die in unserem <imprintLink>Impressum</imprintLink> genannten Angaben."
     },
     "notifications": {
       "bellLabel": "Benachrichtigungen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -33,6 +33,7 @@
       "browseOrganizations": "Browse organizations",
       "legal": "Legal",
       "imprint": "Imprint",
+      "terms": "Terms of Use",
       "privacy": "Privacy Policy",
       "contact": "Contact",
       "followUs": "Follow us",
@@ -672,6 +673,23 @@
       "reportSectionBody": "If you come across an opportunity or organization that looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on its <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. Our administrators review every report and can remove the content.",
       "otherSectionTitle": "Other questions or concerns",
       "otherSectionBody": "For anything else, please reach out to the organization you are volunteering with directly, or contact the platform operator listed in the imprint."
+    },
+    "termsOfUse": {
+      "title": "Terms of Use",
+      "section1Title": "Scope and acceptance",
+      "section1Body": "These Terms of Use govern your use of Einsatzbereit (the \"Platform\"). By creating an account, registering for a volunteer opportunity, or otherwise using the Platform, you agree to be bound by these Terms. If you do not agree, please do not use the Platform.",
+      "section2Title": "Our role as a platform",
+      "section2Body": "Einsatzbereit is an intermediary that connects volunteers with opportunities published by independent organizations. We do not organize, supervise, or take part in the activities listed on the Platform, and we are not a party to any arrangement made between a volunteer and an organization. Organizations are solely responsible for the opportunities they publish, including their content, safety, and suitability.",
+      "section3Title": "Acceptable use",
+      "section3Body": "When using the Platform, you agree to provide accurate information about yourself and keep it up to date, to treat other users, organizations, and the people you assist with respect, to follow the on-site instructions of the organization hosting an opportunity, and to refrain from posting or sharing content that is illegal, fraudulent, harassing, or otherwise harmful. You may not use the Platform to solicit paid work, collect personal data for unrelated purposes, or misrepresent your identity or affiliation with an organization.",
+      "section4Title": "Organizations and volunteer opportunities",
+      "section4Body": "Organizations that publish volunteer opportunities are responsible for the accuracy of their listings and for providing a safe environment at the location and time stated. A verification badge on an organization's profile confirms that we have reviewed its identity; it does not guarantee the quality, safety, or legality of any opportunity it publishes. If you come across content that looks like spam, fraud, or otherwise illegal, please use the report function described on our <contactLink>Contact page</contactLink>.",
+      "section5Title": "Liability",
+      "section5Body": "The Platform is provided on a best-effort, non-commercial basis. We do not guarantee the availability, accuracy, or completeness of any listing, and we are not liable for the conduct of volunteers or organizations, or for any loss, injury, or damage arising from participation in a volunteer opportunity. You take part in volunteer opportunities at your own risk. Nothing in this section limits liability that cannot be excluded under applicable law.",
+      "section6Title": "Suspension and termination",
+      "section6Body": "We may suspend or disable an account that violates these Terms, publishes fraudulent or unsafe content, or is the subject of substantiated reports from other users. Wherever possible, we will inform the affected account of the reason. You may stop using the Platform and request deletion of your account at any time; see our <privacyLink>Privacy Policy</privacyLink> for details on how your data is handled.",
+      "section7Title": "Changes to these terms",
+      "section7Body": "We may update these Terms from time to time to reflect changes to the Platform or legal requirements. Continued use of the Platform after an update constitutes acceptance of the revised Terms. For questions about these Terms, please contact us via the details listed in our <imprintLink>Imprint</imprintLink>."
     },
     "notifications": {
       "bellLabel": "Notifications",

--- a/frontend/src/pages/TermsOfUsePage.tsx
+++ b/frontend/src/pages/TermsOfUsePage.tsx
@@ -1,0 +1,97 @@
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { usePageToolbar } from "../contexts/ToolbarContext";
+import { pageTitleClass } from "../lib/headingClasses";
+
+export default function TermsOfUsePage() {
+	const { t } = useTranslation();
+	usePageTitle(t("termsOfUse.title"));
+	usePageToolbar([{ label: t("termsOfUse.title") }]);
+
+	const linkClass = "text-brand-700 underline";
+
+	return (
+		<>
+			<h1 className={`mb-8 ${pageTitleClass}`}>{t("termsOfUse.title")}</h1>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section1Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					{t("termsOfUse.section1Body")}
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section2Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					{t("termsOfUse.section2Body")}
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section3Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					{t("termsOfUse.section3Body")}
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section4Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					<Trans
+						i18nKey="termsOfUse.section4Body"
+						components={{
+							contactLink: <Link to="/contact" className={linkClass} />,
+						}}
+					/>
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section5Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					{t("termsOfUse.section5Body")}
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section6Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					<Trans
+						i18nKey="termsOfUse.section6Body"
+						components={{
+							privacyLink: <Link to="/privacy-policy" className={linkClass} />,
+						}}
+					/>
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("termsOfUse.section7Title")}
+				</h2>
+				<p className="text-gray-700 leading-relaxed">
+					<Trans
+						i18nKey="termsOfUse.section7Body"
+						components={{
+							imprintLink: <Link to="/imprint" className={linkClass} />,
+						}}
+					/>
+				</p>
+			</section>
+		</>
+	);
+}

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -194,6 +194,7 @@
     ]
   },
   "browserFlow": "einsatzbereit browser",
+  "registrationFlow": "einsatzbereit registration",
   "authenticationFlows": [
     {
       "alias": "einsatzbereit browser",
@@ -236,17 +237,65 @@
           "userSetupAllowed": false
         }
       ]
-    }
-  ],
-  "requiredActions": [
+    },
     {
-      "alias": "TERMS_AND_CONDITIONS",
-      "name": "Terms and Conditions",
-      "providerId": "TERMS_AND_CONDITIONS",
-      "enabled": true,
-      "defaultAction": true,
-      "priority": 20,
-      "config": {}
+      "alias": "einsatzbereit registration",
+      "description": "Registration flow - Terms of Use required (#1079)",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "einsatzbereit registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "einsatzbereit registration form",
+      "description": "Registration form - Terms of Use required (#1079)",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
     }
   ],
   "users": [

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -238,6 +238,17 @@
       ]
     }
   ],
+  "requiredActions": [
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 20,
+      "config": {}
+    }
+  ],
   "users": [
     {
       "id": "00000000-0000-0000-0000-000000000002",

--- a/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
@@ -6,3 +6,4 @@ alreadyHaveAccount=Haben Sie bereits ein Konto?
 backToLogin=Zurück zur Anmeldung
 termsTitle=Nutzungsbedingungen
 termsText=<p>Bevor Sie Einsatzbereit nutzen können, bestätigen Sie bitte, dass Sie unsere Nutzungsbedingungen akzeptieren.</p><p>Einsatzbereit vermittelt zwischen Freiwilligen und Einsätzen, die von unabhängigen Organisationen veröffentlicht werden - wir organisieren, beaufsichtigen oder begleiten diese Aktivitäten nicht selbst. Sie verpflichten sich, korrekte Angaben zu machen, andere Nutzerinnen und Nutzer sowie Organisationen respektvoll zu behandeln und den Anweisungen der veranstaltenden Organisation vor Ort zu folgen. Die Teilnahme an Einsätzen erfolgt auf eigenes Risiko; Organisationen sind verantwortlich für die von ihnen veröffentlichten Angebote.</p><p>Den vollständigen Text finden Sie jederzeit unter Rechtliches in der App.</p>
+acceptTerms=Ich stimme den Nutzungsbedingungen zu

--- a/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
@@ -4,3 +4,5 @@ emailForgotTitle=Passwort zurücksetzen
 noAccount=Noch kein Konto?
 alreadyHaveAccount=Haben Sie bereits ein Konto?
 backToLogin=Zurück zur Anmeldung
+termsTitle=Nutzungsbedingungen
+termsText=<p>Bevor Sie Einsatzbereit nutzen können, bestätigen Sie bitte, dass Sie unsere Nutzungsbedingungen akzeptieren.</p><p>Einsatzbereit vermittelt zwischen Freiwilligen und Einsätzen, die von unabhängigen Organisationen veröffentlicht werden - wir organisieren, beaufsichtigen oder begleiten diese Aktivitäten nicht selbst. Sie verpflichten sich, korrekte Angaben zu machen, andere Nutzerinnen und Nutzer sowie Organisationen respektvoll zu behandeln und den Anweisungen der veranstaltenden Organisation vor Ort zu folgen. Die Teilnahme an Einsätzen erfolgt auf eigenes Risiko; Organisationen sind verantwortlich für die von ihnen veröffentlichten Angebote.</p><p>Den vollständigen Text finden Sie jederzeit unter Rechtliches in der App.</p>

--- a/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
@@ -4,3 +4,5 @@ emailForgotTitle=Reset Password
 noAccount=Don't have an account yet?
 alreadyHaveAccount=Already have an account?
 backToLogin=Back to Sign In
+termsTitle=Terms of Use
+termsText=<p>Before you can use Einsatzbereit, please confirm that you accept our Terms of Use.</p><p>Einsatzbereit is an intermediary that connects volunteers with opportunities published by independent organizations - we do not organize, supervise, or take part in those activities ourselves. You agree to provide accurate information, treat other users and organizations with respect, and follow the on-site instructions of the organization hosting an opportunity. Participation in volunteer opportunities is at your own risk; organizations are responsible for the listings they publish.</p><p>The full text is available at any time under Legal in the app.</p>

--- a/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
@@ -6,3 +6,4 @@ alreadyHaveAccount=Already have an account?
 backToLogin=Back to Sign In
 termsTitle=Terms of Use
 termsText=<p>Before you can use Einsatzbereit, please confirm that you accept our Terms of Use.</p><p>Einsatzbereit is an intermediary that connects volunteers with opportunities published by independent organizations - we do not organize, supervise, or take part in those activities ourselves. You agree to provide accurate information, treat other users and organizations with respect, and follow the on-site instructions of the organization hosting an opportunity. Participation in volunteer opportunities is at your own risk; organizations are responsible for the listings they publish.</p><p>The full text is available at any time under Legal in the app.</p>
+acceptTerms=I agree to the Terms of Use

--- a/keycloak/themes/einsatzbereit/login/register-user-profile.ftl
+++ b/keycloak/themes/einsatzbereit/login/register-user-profile.ftl
@@ -125,6 +125,29 @@
 				</div>
 			</#if>
 
+			<#-- Terms of Use -->
+			<div class="form-group">
+				<div id="kc-registration-terms-text">
+					${kcSanitize(msg("termsText"))?no_esc}
+				</div>
+			</div>
+			<div class="form-group">
+				<div class="form-field">
+					<input
+						type="checkbox"
+						id="termsAccepted"
+						name="termsAccepted"
+						aria-invalid="<#if messagesPerField.existsError('termsAccepted')>true</#if>"
+					/>
+					<label for="termsAccepted">${msg("acceptTerms")}</label>
+				</div>
+				<#if messagesPerField.existsError('termsAccepted')>
+					<span id="input-error-termsAccepted" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+						${kcSanitize(messagesPerField.get('termsAccepted'))?no_esc}
+					</span>
+				</#if>
+			</div>
+
 			<div class="${properties.kcFormButtonsClass!}">
 				<input
 					class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"

--- a/keycloak/themes/einsatzbereit/login/register.ftl
+++ b/keycloak/themes/einsatzbereit/login/register.ftl
@@ -125,6 +125,29 @@
 				</div>
 			</#if>
 
+			<#-- Terms of Use -->
+			<div class="form-group">
+				<div id="kc-registration-terms-text">
+					${kcSanitize(msg("termsText"))?no_esc}
+				</div>
+			</div>
+			<div class="form-group">
+				<div class="form-field">
+					<input
+						type="checkbox"
+						id="termsAccepted"
+						name="termsAccepted"
+						aria-invalid="<#if messagesPerField.existsError('termsAccepted')>true</#if>"
+					/>
+					<label for="termsAccepted">${msg("acceptTerms")}</label>
+				</div>
+				<#if messagesPerField.existsError('termsAccepted')>
+					<span id="input-error-termsAccepted" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+						${kcSanitize(messagesPerField.get('termsAccepted'))?no_esc}
+					</span>
+				</#if>
+			</div>
+
 			<div class="${properties.kcFormButtonsClass!}">
 				<input
 					class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"


### PR DESCRIPTION
Adds a new /terms-of-use page (route, footer link, EN/DE content) and enables Keycloak's built-in Terms and Conditions required action as a default action, so new registrations must accept before completing signup. Existing seeded accounts (vera/olaf/admin) keep their explicit empty requiredActions list on realm import and are unaffected.

Closes #1079

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
