### PR TITLE
fix: parallelize per-volunteer Keycloak lookups in GetEngagements

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -21,6 +21,12 @@ internal sealed class KeycloakUserService(
 
 	private const int RoleLookupConcurrency = 8;
 
+	// Keycloak's admin API isn't built for a burst of concurrent per-user
+	// lookups; this caps how many of the (up to MaxPageSize) volunteer profile
+	// lookups run at once so a large page doesn't fire e.g. 100 simultaneous
+	// requests at it.
+	private const int MaxConcurrentUserLookups = 8;
+
 	private readonly KeycloakOptions _options = options.Value;
 
 	public async Task<KeycloakUserProfile> GetUserAsync(
@@ -50,21 +56,34 @@ internal sealed class KeycloakUserService(
 		IReadOnlyList<Guid> userIds,
 		CancellationToken cancellationToken = default)
 	{
-		var result = new Dictionary<Guid, string>(userIds.Count);
-		foreach (var userId in userIds.Distinct())
+		var distinctIds = userIds.Distinct().ToList();
+		var names = new string?[distinctIds.Count];
+
+		// Each slot is written by exactly one iteration, so no cross-task
+		// synchronization is needed for the array itself.
+		await Parallel.ForEachAsync(
+			Enumerable.Range(0, distinctIds.Count),
+			new ParallelOptions { MaxDegreeOfParallelism = MaxConcurrentUserLookups, CancellationToken = cancellationToken },
+			async (i, ct) =>
+			{
+				try
+				{
+					var profile = await GetUserAsync(distinctIds[i], ct);
+					names[i] = profile.FirstName is not null || profile.LastName is not null
+						? $"{profile.FirstName} {profile.LastName}".Trim()
+						: profile.Username;
+				}
+				catch
+				{
+					// ignore individual lookup failures
+				}
+			});
+
+		var result = new Dictionary<Guid, string>(distinctIds.Count);
+		for (var i = 0; i < distinctIds.Count; i++)
 		{
-			try
-			{
-				var profile = await GetUserAsync(userId, cancellationToken);
-				var name = profile.FirstName is not null || profile.LastName is not null
-					? $"{profile.FirstName} {profile.LastName}".Trim()
-					: profile.Username;
-				result[userId] = name;
-			}
-			catch
-			{
-				// ignore individual lookup failures
-			}
+			if (names[i] is { } name)
+				result[distinctIds[i]] = name;
 		}
 		return result;
 	}
@@ -73,17 +92,29 @@ internal sealed class KeycloakUserService(
 		IReadOnlyList<Guid> userIds,
 		CancellationToken cancellationToken = default)
 	{
-		var result = new Dictionary<Guid, KeycloakUserProfile>(userIds.Count);
-		foreach (var userId in userIds.Distinct())
+		var distinctIds = userIds.Distinct().ToList();
+		var profiles = new KeycloakUserProfile?[distinctIds.Count];
+
+		await Parallel.ForEachAsync(
+			Enumerable.Range(0, distinctIds.Count),
+			new ParallelOptions { MaxDegreeOfParallelism = MaxConcurrentUserLookups, CancellationToken = cancellationToken },
+			async (i, ct) =>
+			{
+				try
+				{
+					profiles[i] = await GetUserAsync(distinctIds[i], ct);
+				}
+				catch
+				{
+					// ignore individual lookup failures - same tolerance as GetDisplayNamesAsync above
+				}
+			});
+
+		var result = new Dictionary<Guid, KeycloakUserProfile>(distinctIds.Count);
+		for (var i = 0; i < distinctIds.Count; i++)
 		{
-			try
-			{
-				result[userId] = await GetUserAsync(userId, cancellationToken);
-			}
-			catch
-			{
-				// ignore individual lookup failures - same tolerance as GetDisplayNamesAsync above
-			}
+			if (profiles[i] is { } profile)
+				result[distinctIds[i]] = profile;
 		}
 		return result;
 	}

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -289,6 +289,36 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		result.TotalItems.Should().Be(0);
 	}
 
+	// #1381: KeycloakUserService.GetUserProfilesAsync resolves one volunteer per
+	// entry concurrently now (was a sequential loop). This guards against the
+	// obvious way that could go wrong - a result ending up under the wrong
+	// volunteer's id because of an indexing/ordering bug in the parallel fetch.
+	[Test]
+	public async Task GetEngagements_ShouldResolveEachVolunteersOwnName_WhenLookedUpConcurrently(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		const int volunteerCount = 10;
+		var expectedUsernameByEngagementId = new Dictionary<Guid, string>();
+		for (var i = 0; i < volunteerCount; i++)
+		{
+			var (engagementId, username) = await SignUpEphemeralVolunteerAsync(opportunity.Id, cancellationToken);
+			expectedUsernameByEngagementId[engagementId] = username;
+		}
+
+		var result = await olafClient.GetEngagementsAsync(
+			opportunity.Id, 1, volunteerCount, cancellationToken: cancellationToken);
+
+		result.Items.Should().HaveCount(volunteerCount);
+		foreach (var item in result.Items)
+		{
+			item.VolunteerName.Should().Be(expectedUsernameByEngagementId[item.Id]);
+		}
+	}
+
 	// ── ConfirmEngagement ─────────────────────────────────────────────────────
 
 	[Test]
@@ -1318,15 +1348,16 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		return org.Id.Value;
 	}
 
-	private async Task SignUpEphemeralVolunteerAsync(
+	private async Task<(Guid EngagementId, string Username)> SignUpEphemeralVolunteerAsync(
 		Guid opportunityId, CancellationToken cancellationToken)
 	{
 		var (_, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
 		var volunteerClient = await CreateAuthenticatedClientAsync(username, password);
-		await volunteerClient.CreateEngagementAsync(
+		var engagement = await volunteerClient.CreateEngagementAsync(
 			opportunityId,
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
+		return (engagement.Id, username);
 	}
 
 	private static Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(


### PR DESCRIPTION
GetEngagementsQueryHandler resolved each page's volunteer profiles via KeycloakUserService.GetUserProfilesAsync, which looped one sequential Keycloak HTTP call per distinct volunteer - up to 100 calls at 20-50ms each on a full page.

The loop was sequential because SendAuthorizedAsync mutated the shared httpClient.DefaultRequestHeaders.Authorization, which concurrent calls would race on. GetUserAsync now attaches the bearer token per-request instead, making it safe to fan out with a bounded Parallel.ForEachAsync (capped at 8 concurrent lookups). GetDisplayNamesAsync (used by the admin report) gets the same fix since it has the identical shape.

Closes #1381

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
