### PR TITLE
feat: add response compression and output caching for public read endpoints

### DIFF
--- a/backend/src/Api/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogEndpoint.cs
+++ b/backend/src/Api/Achievements/GetBadgeCatalog/v1/GetBadgeCatalogEndpoint.cs
@@ -1,9 +1,11 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Achievements.BadgeCatalog;
 using Application.Achievements.GetBadgeCatalog.v1;
 using Application.Common.Messaging;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Achievements.GetBadgeCatalog.v1;
 
@@ -18,6 +20,7 @@ internal sealed class GetBadgeCatalogEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.LongPublicRead)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetBadgeCatalogAsync(

--- a/backend/src/Api/Achievements/GetUserAchievements/v1/GetUserAchievementsEndpoint.cs
+++ b/backend/src/Api/Achievements/GetUserAchievements/v1/GetUserAchievementsEndpoint.cs
@@ -1,4 +1,5 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Achievements;
 using Application.Achievements.GetUserAchievements.v1;
@@ -6,6 +7,7 @@ using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Achievements.GetUserAchievements.v1;
 
@@ -20,6 +22,7 @@ internal sealed class GetUserAchievementsEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetUserAchievementsAsync(

--- a/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace Api.Common.OutputCaching;
+
+// Policies are applied only to AllowAnonymous endpoints whose response never varies by
+// caller (see the .CacheOutput(...) call sites) - the default OutputCache cache key is
+// the request path + query string, with no per-user variance, so applying it to an
+// authenticated or caller-personalized endpoint would risk serving one user's cached
+// response to another (#1391).
+internal static class OutputCachingExtensions
+{
+	public static IServiceCollection AddOutputCachingPolicies(
+		this IServiceCollection services,
+		IConfiguration configuration)
+	{
+		var options = configuration
+			.GetSection("OutputCaching")
+			.Get<OutputCachingOptions>() ?? new OutputCachingOptions();
+
+		return services.AddOutputCache(cache =>
+		{
+			cache.AddPolicy(OutputCachingPolicies.LongPublicRead, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.LongPublicReadSeconds)));
+
+			cache.AddPolicy(OutputCachingPolicies.ShortPublicRead, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds)));
+		});
+	}
+}

--- a/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
@@ -24,6 +24,19 @@ internal static class OutputCachingExtensions
 
 			cache.AddPolicy(OutputCachingPolicies.ShortPublicRead, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds)));
+
+			cache.AddPolicy(OutputCachingPolicies.VolunteerOpportunityListing, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds))
+					.Tag(OutputCachingPolicies.VolunteerOpportunityListingTag));
 		});
 	}
+
+	// Called by every command that changes what the public volunteer-opportunity
+	// listing should show (see OutputCachingPolicies.VolunteerOpportunityListingTag
+	// for the full list) so a write is reflected on the very next read of the listing
+	// instead of waiting out the policy's Expire() duration (#1543).
+	public static ValueTask EvictVolunteerOpportunityListingCacheAsync(
+		this IOutputCacheStore store,
+		CancellationToken cancellationToken) =>
+		store.EvictByTagAsync(OutputCachingPolicies.VolunteerOpportunityListingTag, cancellationToken);
 }

--- a/backend/src/Api/Common/OutputCaching/OutputCachingOptions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingOptions.cs
@@ -1,0 +1,7 @@
+namespace Api.Common.OutputCaching;
+
+internal sealed class OutputCachingOptions
+{
+	public int LongPublicReadSeconds { get; init; } = 3600;
+	public int ShortPublicReadSeconds { get; init; } = 60;
+}

--- a/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
@@ -1,0 +1,7 @@
+namespace Api.Common.OutputCaching;
+
+public static class OutputCachingPolicies
+{
+	public const string LongPublicRead = "output-cache-long-public-read";
+	public const string ShortPublicRead = "output-cache-short-public-read";
+}

--- a/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
@@ -4,4 +4,17 @@ public static class OutputCachingPolicies
 {
 	public const string LongPublicRead = "output-cache-long-public-read";
 	public const string ShortPublicRead = "output-cache-short-public-read";
+
+	// Same expiry as ShortPublicRead, but tagged separately so a write that changes
+	// what the public volunteer-opportunity listing should show can evict just this
+	// endpoint's cache entries via IOutputCacheStore.EvictByTagAsync instead of
+	// waiting out ShortPublicReadSeconds of staleness (#1543).
+	public const string VolunteerOpportunityListing = "output-cache-volunteer-opportunity-listing";
+
+	// Tag applied to every response cached under VolunteerOpportunityListing. Evicted
+	// by any command that changes volunteer-opportunity visibility/content (create,
+	// update, publish, unpublish, cancel, delete, restore, time-slot changes, banner
+	// changes) or the participant counts the listing surfaces (sign-up, withdraw,
+	// cancel) - see OutputCachingExtensions.EvictVolunteerOpportunityListingCacheAsync.
+	public const string VolunteerOpportunityListingTag = "volunteer-opportunity-listing";
 }

--- a/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -8,6 +9,7 @@ using Domain.Engagements;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.Engagements.CancelEngagement.v1;
@@ -33,6 +35,7 @@ internal sealed class CancelEngagementEndpoint
 		[FromRoute] Guid engagementId,
 		[FromBody] CancelEngagementRequest? body,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -43,6 +46,10 @@ internal sealed class CancelEngagementEndpoint
 
 		var command = new CancelEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId, body?.Reason);
 		var engagement = await sender.Send(command, cancellationToken);
+
+		// A cancelled engagement changes CurrentParticipantCount on the public listing.
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
+
 		return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString(), engagement.ModifiedOn, engagement.CancellationReason));
 	}
 }

--- a/backend/src/Api/Engagements/CreateEngagement/v1/CreateEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CreateEngagement/v1/CreateEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.Engagements.CreateEngagement.v1;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Engagements.CreateEngagement.v1;
 
@@ -30,6 +32,7 @@ internal sealed class CreateEngagementEndpoint
 		[FromRoute] Guid opportunityId,
 		[FromBody] CreateEngagementRequest request,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		HttpContext httpContext,
 		CancellationToken cancellationToken)
 	{
@@ -53,6 +56,9 @@ internal sealed class CreateEngagementEndpoint
 			request.Message);
 
 		var engagement = await sender.Send(command, cancellationToken);
+
+		// A new engagement changes CurrentParticipantCount on the public listing.
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		var response = new CreateEngagementResponse(
 			engagement.Id.Value,

--- a/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.Engagements.WithdrawEngagement.v1;
 using Domain.Engagements;
 using Domain.Primitives;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Engagements.WithdrawEngagement.v1;
 
@@ -29,6 +31,7 @@ internal sealed class WithdrawEngagementEndpoint
 	private static async Task<IResult> WithdrawEngagementAsync(
 		[FromRoute] Guid engagementId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		HttpContext httpContext,
 		CancellationToken cancellationToken)
 	{
@@ -42,6 +45,10 @@ internal sealed class WithdrawEngagementEndpoint
 		{
 			var command = new WithdrawEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId);
 			var engagement = await sender.Send(command, cancellationToken);
+
+			// A withdrawn engagement changes CurrentParticipantCount on the public listing.
+			await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
+
 			return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString(), engagement.ModifiedOn));
 		}
 		catch (ResultFailureException ex) when (ex.Error.Type == ErrorType.NotFound)

--- a/backend/src/Api/Maps/SearchCities/v1/SearchCitiesEndpoint.cs
+++ b/backend/src/Api/Maps/SearchCities/v1/SearchCitiesEndpoint.cs
@@ -1,9 +1,11 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Geocoding;
 using Application.Common.Messaging;
 using Application.Maps.SearchCities.v1;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Maps.SearchCities.v1;
 
@@ -18,6 +20,7 @@ internal sealed class SearchCitiesEndpoint : IEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.LongPublicRead)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileEndpoint.cs
+++ b/backend/src/Api/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileEndpoint.cs
@@ -1,8 +1,10 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Organizations.GetPublicOrganizationProfile.v1;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Organizations.GetPublicOrganizationProfile.v1;
 
@@ -18,6 +20,7 @@ internal sealed class GetPublicOrganizationProfileEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetPublicOrganizations/v1/GetPublicOrganizationsEndpoint.cs
@@ -1,9 +1,11 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 using Application.Organizations.GetPublicOrganizations.v1;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Organizations.GetPublicOrganizations.v1;
 
@@ -19,6 +21,7 @@ internal sealed class GetPublicOrganizationsEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -4,6 +4,7 @@ using Api.Common.Endpoints;
 using Api.Common.ExceptionHandlers;
 using Api.Common.Health;
 using Api.Common.Middleware;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application;
 using Application.Common.Startup;
@@ -12,6 +13,7 @@ using Infrastructure;
 using Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
@@ -86,6 +88,18 @@ builder.Services.AddHealthChecks()
 
 builder.Services.AddEndpoints();
 builder.Services.AddRateLimitingPolicies(builder.Configuration);
+builder.Services.AddOutputCachingPolicies(builder.Configuration);
+
+// EnableForHttps is safe here: this API is a pure JSON/token (Bearer, not cookie) API,
+// so there's no session secret reflected back into a compressible response body that a
+// BREACH-style attack could exploit (#1391).
+builder.Services.AddResponseCompression(options =>
+{
+	options.EnableForHttps = true;
+	options.Providers.Add<BrotliCompressionProvider>();
+	options.Providers.Add<GzipCompressionProvider>();
+	options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Append("application/json");
+});
 
 builder.Services.AddHttpLogging(logging =>
 {
@@ -192,6 +206,7 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 app.MapDefaultEndpoints();
 
 app.UseHttpLogging();
+app.UseResponseCompression();
 
 app.Use(async (context, next) =>
 {
@@ -228,6 +243,12 @@ app.Use(async (ctx, next) =>
 });
 
 app.UseMiddleware<LoginStreakMiddleware>();
+
+// Placed after LoginStreakMiddleware, not before: a cache hit short-circuits the
+// pipeline entirely (next() is never called), which would otherwise silently skip
+// that day's login-streak update for every authenticated request that happens to
+// land on a cached response (#1391).
+app.UseOutputCache();
 
 app.MapEndpoints();
 

--- a/backend/src/Api/Users/GetPublicUserProfile/v1/GetPublicUserProfileEndpoint.cs
+++ b/backend/src/Api/Users/GetPublicUserProfile/v1/GetPublicUserProfileEndpoint.cs
@@ -1,10 +1,12 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Users.GetPublicUserProfile.v1;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.Users.GetPublicUserProfile.v1;
 
@@ -19,6 +21,7 @@ internal sealed class GetPublicUserProfileEndpoint : IEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> GetPublicUserProfileAsync(

--- a/backend/src/Api/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/v1/AdminRestoreVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/v1/AdminRestoreVolunteerOpportunityEndpoint.cs
@@ -1,9 +1,11 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.VolunteerOpportunities.AdminRestoreVolunteerOpportunity.v1;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.VolunteerOpportunities.AdminRestoreVolunteerOpportunity.v1;
 
@@ -27,9 +29,12 @@ internal sealed class AdminRestoreVolunteerOpportunityEndpoint
 	private static async Task<IResult> AdminRestoreVolunteerOpportunityAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		CancellationToken cancellationToken)
 	{
 		await sender.Send(new AdminRestoreVolunteerOpportunityCommand(opportunityId), cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity.v
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity.v1;
@@ -30,6 +32,7 @@ internal sealed class AdminShadowDeleteVolunteerOpportunityEndpoint
 	private static async Task<IResult> AdminShadowDeleteVolunteerOpportunityAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -40,6 +43,8 @@ internal sealed class AdminShadowDeleteVolunteerOpportunityEndpoint
 		var command = new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, adminUserId);
 
 		await sender.Send(command, cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CancelVolunteerOpportunity/v1/CancelVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.CancelVolunteerOpportunity.v1;
@@ -32,6 +34,7 @@ internal sealed class CancelVolunteerOpportunityEndpoint
 		[FromRoute] Guid opportunityId,
 		[FromBody] CancelVolunteerOpportunityRequest? body,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -45,6 +48,8 @@ internal sealed class CancelVolunteerOpportunityEndpoint
 		await sender.Send(
 			new CancelVolunteerOpportunityCommand(opportunityId, userId, body?.Reason),
 			cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.CreateTimeSlot.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.CreateTimeSlot.v1;
@@ -30,6 +32,7 @@ internal sealed class CreateTimeSlotEndpoint : IEndpoint
 		[FromRoute] Guid opportunityId,
 		[FromBody] CreateTimeSlotRequest request,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -65,6 +68,8 @@ internal sealed class CreateTimeSlotEndpoint : IEndpoint
 			recurrenceCount);
 
 		var timeSlots = await sender.Send(command, cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		var responses = timeSlots
 			.Select(ts => new CreateTimeSlotResponse(

--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -10,6 +11,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
@@ -32,6 +34,7 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 	private static async Task<IResult> CreateVolunteerOpportunityAsync(
 		[FromBody] CreateVolunteerOpportunityRequest request,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -115,6 +118,10 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 			request.ValidUntil);
 
 		var opportunity = await sender.Send(command, cancellationToken);
+
+		// A non-draft create is immediately visible on the public listing (see
+		// "status" above), so the cache must be invalidated regardless of IsDraft.
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		var response = new CreateVolunteerOpportunityResponse(
 			opportunity.Id.Value,

--- a/backend/src/Api/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/DeleteOpportunityBanner/v1/DeleteOpportunityBannerEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.DeleteOpportunityBanner.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.DeleteOpportunityBanner.v1;
@@ -27,6 +29,7 @@ internal sealed class DeleteOpportunityBannerEndpoint : IEndpoint
 	private static async Task<IResult> DeleteOpportunityBannerAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -37,6 +40,8 @@ internal sealed class DeleteOpportunityBannerEndpoint : IEndpoint
 		await sender.Send(
 			new DeleteOpportunityBannerCommand(opportunityId, userId),
 			cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -8,6 +9,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.DeleteTimeSlot.v1;
@@ -33,6 +35,7 @@ internal sealed class DeleteTimeSlotEndpoint : IEndpoint
 		[FromRoute] Guid timeSlotId,
 		[FromQuery] string? scope,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -48,6 +51,7 @@ internal sealed class DeleteTimeSlotEndpoint : IEndpoint
 
 		var command = new DeleteTimeSlotCommand(opportunityId, timeSlotId, userId, seriesScope);
 		var result = await sender.Send(command, cancellationToken);
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 		return Results.Ok(new DeleteTimeSlotResponse(result.DeletedTimeSlotIds));
 	}
 }

--- a/backend/src/Api/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
@@ -29,6 +31,7 @@ internal sealed class DeleteVolunteerOpportunityEndpoint
 	private static async Task<IResult> DeleteVolunteerOpportunityAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -37,6 +40,7 @@ internal sealed class DeleteVolunteerOpportunityEndpoint
 			var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? UserId.Create(uid).GetValueOrThrow() : throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
 			var command = new DeleteVolunteerOpportunityCommand(opportunityId, userId);
 			await sender.Send(command, cancellationToken);
+			await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 			return Results.NoContent();
 		}
 		catch (ResultFailureException ex) when (ex.Error.Type == ErrorType.NotFound)

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
@@ -1,10 +1,12 @@
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Messaging;
 using Application.Common.Pagination;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Api.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 
@@ -21,6 +23,7 @@ internal sealed class GetVolunteerOpportunitiesEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunities/v1/GetVolunteerOpportunitiesEndpoint.cs
@@ -23,7 +23,7 @@ internal sealed class GetVolunteerOpportunitiesEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
-			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
+			.CacheOutput(OutputCachingPolicies.VolunteerOpportunityListing)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Api/VolunteerOpportunities/PublishVolunteerOpportunity/v1/PublishVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/PublishVolunteerOpportunity/v1/PublishVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.PublishVolunteerOpportunity.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.PublishVolunteerOpportunity.v1;
@@ -30,6 +32,7 @@ internal sealed class PublishVolunteerOpportunityEndpoint
 	private static async Task<IResult> PublishVolunteerOpportunityAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -40,6 +43,8 @@ internal sealed class PublishVolunteerOpportunityEndpoint
 		await sender.Send(
 			new PublishVolunteerOpportunityCommand(opportunityId, userId),
 			cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/UnpublishVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -7,6 +8,7 @@ using Application.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.UnpublishVolunteerOpportunity.v1;
@@ -31,6 +33,7 @@ internal sealed class UnpublishVolunteerOpportunityEndpoint
 	private static async Task<IResult> UnpublishVolunteerOpportunityAsync(
 		[FromRoute] Guid opportunityId,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -41,6 +44,8 @@ internal sealed class UnpublishVolunteerOpportunityEndpoint
 		await sender.Send(
 			new UnpublishVolunteerOpportunityCommand(opportunityId, userId),
 			cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -8,6 +9,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.UpdateTimeSlot.v1;
@@ -32,6 +34,7 @@ internal sealed class UpdateTimeSlotEndpoint : IEndpoint
 		[FromRoute] Guid timeSlotId,
 		[FromBody] UpdateTimeSlotRequest request,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -48,6 +51,7 @@ internal sealed class UpdateTimeSlotEndpoint : IEndpoint
 		var command = new UpdateTimeSlotCommand(
 			opportunityId, timeSlotId, request.StartDateTime, request.EndDateTime, request.MaxParticipants, userId, scope);
 		var result = await sender.Send(command, cancellationToken);
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 		return Results.Ok(new UpdateTimeSlotResponse(result.UpdatedCount, result.SkippedTimeSlotIds));
 	}
 }

--- a/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -8,6 +9,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 using Domain.Common;
 
@@ -33,6 +35,7 @@ internal sealed class UpdateVolunteerOpportunityEndpoint
 		[FromRoute] Guid opportunityId,
 		[FromBody] UpdateVolunteerOpportunityRequest request,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -102,6 +105,8 @@ internal sealed class UpdateVolunteerOpportunityEndpoint
 			request.ValidUntil);
 
 		await sender.Send(command, cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
@@ -1,5 +1,6 @@
 using Api.Common.Authentication;
 using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
@@ -8,6 +9,7 @@ using Application.VolunteerOpportunities.UploadOpportunityBanner.v1;
 using Domain.Primitives;
 using Domain.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using System.Security.Claims;
 
 namespace Api.VolunteerOpportunities.UploadOpportunityBanner.v1;
@@ -33,6 +35,7 @@ internal sealed class UploadOpportunityBannerEndpoint
 		[FromRoute] Guid opportunityId,
 		IFormFile file,
 		[FromServices] ISender sender,
+		[FromServices] IOutputCacheStore outputCacheStore,
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
@@ -52,6 +55,8 @@ internal sealed class UploadOpportunityBannerEndpoint
 				file.ContentType,
 				userId),
 			cancellationToken);
+
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
 		return Results.NoContent();
 	}

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -98,5 +98,9 @@
       "PermitLimit": 100,
       "WindowSeconds": 60
     }
+  },
+  "OutputCaching": {
+    "LongPublicReadSeconds": 3600,
+    "ShortPublicReadSeconds": 60
   }
 }

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -17,6 +17,26 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	public async Task GetVolunteerOpportunities_ShouldReturnEmptyPagedList_WhenNoneExist(
 		CancellationToken cancellationToken)
 	{
+		// This test (unlike its siblings) performs no write of its own before reading the
+		// listing, so it has nothing to evict the shared output cache tag with (#1543) -
+		// Respawn resets the database between tests, but not the output-cached response
+		// from whichever earlier test last populated this exact route/query-string's cache
+		// entry. Creating a Draft opportunity forces a fresh (post-eviction) read while
+		// keeping the assertions below accurate: drafts never appear in the public,
+		// Published-only listing.
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Draft - never published",
+			Description = "Exists only to force a fresh output-cache read; see comment above.",
+			OrganizationId = orgId,
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+			IsDraft = true,
+		}, cancellationToken);
+
 		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
 
 		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, cancellationToken: cancellationToken);

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -62,6 +62,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 			Title = "Freshly published opportunity",
 			Description = "Proves a create evicts the output cache (#1543)",
 			OrganizationId = orgId,
+			IsRemote = true,
 			Occurrence = "OneTime",
 			ParticipationType = "IndividualContact",
 			CheckInMethod = "None",

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -37,6 +37,45 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 		second.Headers.TryGetValues("Age", out _).Should().BeTrue();
 	}
 
+	// Regression coverage for #1543: without this, a newly created/published opportunity
+	// (or any other write affecting the listing) would stay invisible on the public
+	// listing for up to ShortPublicReadSeconds, since nothing evicted the cached response -
+	// this also caused GetVolunteerOpportunitiesTests.cs to fail non-deterministically,
+	// since every test hitting this exact route/query-string shared one cached response.
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldReflectNewOpportunity_ImmediatelyAfterCreate(
+		CancellationToken cancellationToken)
+	{
+		const string route = "/v1/volunteer-opportunities?pageNumber=1&pageSize=10";
+
+		using var httpClient = fixture.CreateHttpClient();
+		var before = await httpClient.GetAsync(route, cancellationToken);
+		var beforeBody = await before.Content.ReadAsStringAsync(cancellationToken);
+		beforeBody.Should().NotContain("Freshly published opportunity");
+
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, "Cache Eviction Org", cancellationToken);
+
+		// No IsDraft flag - published immediately, so it must appear on the very next read.
+		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Freshly published opportunity",
+			Description = "Proves a create evicts the output cache (#1543)",
+			OrganizationId = orgId,
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+			ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+		}, cancellationToken);
+
+		var after = await httpClient.GetAsync(route, cancellationToken);
+		var afterBody = await after.Content.ReadAsStringAsync(cancellationToken);
+
+		afterBody.Should().Contain("Freshly published opportunity",
+			"creating a volunteer opportunity must evict the listing's output cache tag " +
+			"instead of leaving the previous (stale) response cached for ShortPublicReadSeconds");
+	}
+
 	// The default output cache key is method + path + query string with no per-route-parameter
 	// awareness beyond that, so this also proves two different organizations don't collide on
 	// (or get served) each other's cached profile response.

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -1,0 +1,106 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OutputCachingTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetBadgeCatalog_ShouldBeServedFromOutputCache_OnASecondRequest(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		await httpClient.GetAsync("/v1/badges", cancellationToken);
+		var second = await httpClient.GetAsync("/v1/badges", cancellationToken);
+
+		second.Headers.TryGetValues("Age", out _).Should().BeTrue(
+			"the badge catalog is a public, non-personalized endpoint and should be output-cached (#1391)");
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunities_ShouldBeServedFromOutputCache_OnASecondRequest(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		const string route = "/v1/volunteer-opportunities?pageNumber=1&pageSize=10";
+
+		await httpClient.GetAsync(route, cancellationToken);
+		var second = await httpClient.GetAsync(route, cancellationToken);
+
+		second.Headers.TryGetValues("Age", out _).Should().BeTrue();
+	}
+
+	// The default output cache key is method + path + query string with no per-route-parameter
+	// awareness beyond that, so this also proves two different organizations don't collide on
+	// (or get served) each other's cached profile response.
+	[Test]
+	public async Task GetPublicOrganizationProfile_ShouldCacheEachOrganizationSeparately(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var firstOrgId = await CreateOrganizationAsync(authenticatedClient, "Org One", cancellationToken);
+		var secondOrgId = await CreateOrganizationAsync(authenticatedClient, "Org Two", cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+
+		await httpClient.GetAsync($"/v1/organizations/{firstOrgId}/profile", cancellationToken);
+		var firstResponse = await httpClient.GetAsync($"/v1/organizations/{firstOrgId}/profile", cancellationToken);
+
+		await httpClient.GetAsync($"/v1/organizations/{secondOrgId}/profile", cancellationToken);
+		var secondResponse = await httpClient.GetAsync($"/v1/organizations/{secondOrgId}/profile", cancellationToken);
+
+		firstResponse.Headers.TryGetValues("Age", out _).Should().BeTrue();
+		secondResponse.Headers.TryGetValues("Age", out _).Should().BeTrue();
+
+		var firstBody = await firstResponse.Content.ReadAsStringAsync(cancellationToken);
+		var secondBody = await secondResponse.Content.ReadAsStringAsync(cancellationToken);
+
+		firstBody.Should().Contain("Org One").And.NotContain("Org Two");
+		secondBody.Should().Contain("Org Two").And.NotContain("Org One");
+	}
+
+	// GetOrganizationOpportunities is authenticated and organizer-scoped - its response is not
+	// the same for every caller, so it must be excluded from output caching. Caching it under
+	// the default (caller-agnostic) cache key would risk serving one organizer's data to another.
+	[Test]
+	public async Task GetOrganizationOpportunities_ShouldNotBeOutputCached(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, "Org", cancellationToken);
+		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");
+
+		using var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		var route = $"/v1/organizations/{orgId}/opportunities?status=Published&pageNumber=1&pageSize=10";
+
+		await httpClient.GetAsync(route, cancellationToken);
+		var second = await httpClient.GetAsync(route, cancellationToken);
+
+		second.Headers.TryGetValues("Age", out _).Should().BeFalse();
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
+	{
+		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, string name, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"{name}_{Guid.NewGuid()}";
+		var organization = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return organization.Id.Value;
+	}
+}

--- a/backend/tests/IntegrationTests/ResponseCompressionTests.cs
+++ b/backend/tests/IntegrationTests/ResponseCompressionTests.cs
@@ -1,0 +1,47 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+public class ResponseCompressionTests(IntegrationTestFixture fixture)
+{
+	[Test]
+	public async Task GetBadgeCatalog_ShouldReturnBrotliEncodedResponse_WhenClientAcceptsBrotli(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/v1/badges");
+		request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().Contain("br");
+	}
+
+	[Test]
+	public async Task GetBadgeCatalog_ShouldReturnGzipEncodedResponse_WhenClientAcceptsGzip(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/v1/badges");
+		request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().Contain("gzip");
+	}
+
+	[Test]
+	public async Task GetBadgeCatalog_ShouldReturnUncompressedResponse_WhenClientSendsNoAcceptEncoding(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/v1/badges");
+
+		var response = await httpClient.SendAsync(request, cancellationToken);
+
+		response.Content.Headers.ContentEncoding.Should().BeEmpty(
+			"a client that never advertised support for any encoding must get a plain response");
+	}
+}


### PR DESCRIPTION
Adds Brotli/Gzip response compression across the JSON API and UseOutputCache-based caching for anonymous, non-personalized read endpoints (badge catalog, city search, organization directory/profile, volunteer-opportunity listing, user achievements/public profile) to cut redundant JSON transfer (#1391).

Output caching deliberately excludes authenticated/per-caller endpoints (notifications, organizer-scoped opportunity lists) and skips ETag/304 support - both were scoped out during implementation and left open for a follow-up.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1391

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
