### PR TITLE
fix: crop and compress avatar/logo/banner uploads client-side

### DIFF
--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -14,6 +14,7 @@ import type { OrganizationFormValues } from "../lib/organizationFormSchema";
 import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
+import ImageCropModal from "./ImageCropModal";
 
 interface Props {
 	onClose: () => void;
@@ -42,6 +43,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 	const [logoFile, setLogoFile] = useState<File | null>(null);
 	const [logoPreview, setLogoPreview] = useState<string | null>(null);
 	const [logoError, setLogoError] = useState<string | null>(null);
+	const [croppingLogoFile, setCroppingLogoFile] = useState<File | null>(null);
 	const logoInputRef = useRef<HTMLInputElement>(null);
 	const nameFieldRef = useRef<HTMLDivElement>(null);
 	const [loading, setLoading] = useState(false);
@@ -66,8 +68,13 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 			return;
 		}
 		setLogoError(null);
-		setLogoFile(file);
-		setLogoPreview(URL.createObjectURL(file));
+		setCroppingLogoFile(file);
+	}
+
+	function handleLogoCropped(croppedFile: File) {
+		setCroppingLogoFile(null);
+		setLogoFile(croppedFile);
+		setLogoPreview(URL.createObjectURL(croppedFile));
 	}
 
 	const onSubmit = async (values: OrganizationFormValues) => {
@@ -124,6 +131,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 			maxWidth="max-w-md"
 			className="flex max-h-[min(85vh,720px)] flex-col overflow-hidden rounded-card bg-white shadow-modal"
 			initialFocusRef={nameFieldRef}
+			suspended={croppingLogoFile !== null}
 		>
 			<h2
 				id="create-org-dialog-title"
@@ -144,6 +152,8 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								<img
 									src={logoPreview}
 									alt=""
+									width={56}
+									height={56}
 									className="h-14 w-14 rounded-lg object-contain ring-1 ring-gray-200"
 								/>
 							) : (
@@ -449,6 +459,19 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					</Button>
 				</div>
 			</form>
+
+			{croppingLogoFile && (
+				<ImageCropModal
+					file={croppingLogoFile}
+					aspectRatio={1}
+					shape="circle"
+					outputWidth={320}
+					outputHeight={320}
+					title={t("orgSettings.logoUpload")}
+					onCancel={() => setCroppingLogoFile(null)}
+					onCropped={handleLogoCropped}
+				/>
+			)}
 		</Modal>
 	);
 }

--- a/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
@@ -62,6 +62,9 @@ export default function BasicsStep({
 						<img
 							src={bannerPreview}
 							alt={t("createOpportunity.fieldBanner")}
+							width={1200}
+							height={480}
+							loading="lazy"
 							className="h-36 w-full object-cover"
 						/>
 						<button

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -15,6 +15,7 @@ import { getApiErrorMessage, isApiErrorCode } from "../../lib/apiError";
 import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
 import Button from "../Button";
+import ImageCropModal from "../ImageCropModal";
 import { Stepper } from "./shared";
 import BasicsStep from "./BasicsStep";
 import LocationStep from "./LocationStep";
@@ -229,6 +230,9 @@ export default function CreateVolunteerOpportunityModal({
 	);
 	const [bannerError, setBannerError] = useState<string | null>(null);
 	const [bannerRemoved, setBannerRemoved] = useState(false);
+	const [croppingBannerFile, setCroppingBannerFile] = useState<File | null>(
+		null,
+	);
 
 	// Time slots: pending = not yet persisted (create mode); existing = already saved (edit mode)
 	const [pendingSlots, setPendingSlots] = useState<PendingTimeSlot[]>([]);
@@ -395,8 +399,13 @@ export default function CreateVolunteerOpportunityModal({
 			return;
 		}
 		setBannerError(null);
-		setBannerFile(file);
-		setBannerPreview(URL.createObjectURL(file));
+		setCroppingBannerFile(file);
+	}
+
+	function handleBannerCropped(croppedFile: File) {
+		setCroppingBannerFile(null);
+		setBannerFile(croppedFile);
+		setBannerPreview(URL.createObjectURL(croppedFile));
 	}
 
 	function removeBanner() {
@@ -908,7 +917,8 @@ export default function CreateVolunteerOpportunityModal({
 				suspended={
 					showDiscardConfirm ||
 					pendingSlotEdit !== null ||
-					pendingSeriesDelete !== null
+					pendingSeriesDelete !== null ||
+					croppingBannerFile !== null
 				}
 				initialFocusRef={bodyRef}
 			>
@@ -1137,6 +1147,19 @@ export default function CreateVolunteerOpportunityModal({
 					error={seriesDeleteError}
 					onConfirm={(scope) => void performSeriesDelete(scope)}
 					onClose={() => setPendingSeriesDelete(null)}
+				/>
+			)}
+
+			{croppingBannerFile && (
+				<ImageCropModal
+					file={croppingBannerFile}
+					aspectRatio={2.5}
+					shape="rect"
+					outputWidth={1200}
+					outputHeight={480}
+					title={t("createOpportunity.fieldBanner")}
+					onCancel={() => setCroppingBannerFile(null)}
+					onCropped={handleBannerCropped}
 				/>
 			)}
 		</>

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -60,6 +60,8 @@ export default function AccountControls({
 						<img
 							src={avatarUrl}
 							alt=""
+							width={36}
+							height={36}
 							className="w-9 h-9 rounded-full object-cover"
 						/>
 					) : (

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -82,6 +82,9 @@ export default function MobileMenu({
 								<img
 									src={avatarUrl}
 									alt=""
+									width={36}
+									height={36}
+									loading="lazy"
 									className="w-9 h-9 rounded-full object-cover"
 								/>
 							) : (

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -66,6 +66,8 @@ export default function OrganizationSwitcher({
 						<img
 							src={currentOrg.logoUrl}
 							alt=""
+							width={24}
+							height={24}
 							className="h-6 w-6 shrink-0 rounded-md object-cover"
 						/>
 					) : (
@@ -117,6 +119,9 @@ export default function OrganizationSwitcher({
 											<img
 												src={org.logoUrl}
 												alt=""
+												width={24}
+												height={24}
+												loading="lazy"
 												className="h-6 w-6 shrink-0 rounded-md object-cover"
 											/>
 										) : (

--- a/frontend/src/components/ImageCropModal.tsx
+++ b/frontend/src/components/ImageCropModal.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+	blobToFile,
+	clampOffset,
+	computeSourceRect,
+	coverScale,
+	cropImageToBlob,
+	loadImage,
+	recenterOffsetForScale,
+} from "../lib/imageCrop";
+import type { Offset } from "../lib/imageCrop";
+import Modal from "./Modal";
+import Button from "./Button";
+
+const FRAME_MAX_WIDTH = 320;
+const MAX_ZOOM = 4;
+const KEYBOARD_PAN_STEP = 12;
+
+interface ImageCropModalProps {
+	file: File;
+	/** width / height of both the crop frame and the final output. */
+	aspectRatio: number;
+	/** Purely a visual guide - the raster output is always the full frame rect. */
+	shape: "circle" | "rect";
+	outputWidth: number;
+	outputHeight: number;
+	title: string;
+	onCancel: () => void;
+	onCropped: (file: File) => void;
+}
+
+export default function ImageCropModal({
+	file,
+	aspectRatio,
+	shape,
+	outputWidth,
+	outputHeight,
+	title,
+	onCancel,
+	onCropped,
+}: ImageCropModalProps) {
+	const { t } = useTranslation();
+	const frameWidth = FRAME_MAX_WIDTH;
+	const frameHeight = FRAME_MAX_WIDTH / aspectRatio;
+
+	const [image, setImage] = useState<HTMLImageElement | null>(null);
+	const [loadError, setLoadError] = useState(false);
+	const [applying, setApplying] = useState(false);
+	const [zoom, setZoom] = useState(1);
+	const [offset, setOffset] = useState<Offset>({ x: 0, y: 0 });
+	const [panAnnouncement, setPanAnnouncement] = useState("");
+	const dragState = useRef<{
+		start: { x: number; y: number };
+		offset: Offset;
+	} | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		let ownedUrl: string | null = null;
+		void loadImage(file)
+			.then(({ image: img, objectUrl }) => {
+				if (cancelled) {
+					URL.revokeObjectURL(objectUrl);
+					return;
+				}
+				ownedUrl = objectUrl;
+				const baseScale = coverScale(
+					img.naturalWidth,
+					img.naturalHeight,
+					frameWidth,
+					frameHeight,
+				);
+				const scaledWidth = img.naturalWidth * baseScale;
+				const scaledHeight = img.naturalHeight * baseScale;
+				setImage(img);
+				setZoom(1);
+				setOffset({
+					x: (frameWidth - scaledWidth) / 2,
+					y: (frameHeight - scaledHeight) / 2,
+				});
+			})
+			.catch(() => {
+				if (!cancelled) setLoadError(true);
+			});
+		return () => {
+			cancelled = true;
+			if (ownedUrl) URL.revokeObjectURL(ownedUrl);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [file]);
+
+	if (!image) {
+		return (
+			<Modal
+				onClose={onCancel}
+				labelledBy="image-crop-title"
+				maxWidth="max-w-sm"
+			>
+				<h2 id="image-crop-title" className="text-lg font-semibold">
+					{title}
+				</h2>
+				<p className="mt-4 text-sm text-gray-600">
+					{loadError ? t("imageCrop.loadError") : t("imageCrop.loading")}
+				</p>
+				<div className="mt-4 flex justify-end">
+					<Button variant="secondary" onClick={onCancel}>
+						{t("imageCrop.cancel")}
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+
+	const baseScale = coverScale(
+		image.naturalWidth,
+		image.naturalHeight,
+		frameWidth,
+		frameHeight,
+	);
+	const scale = baseScale * zoom;
+	const scaledWidth = image.naturalWidth * scale;
+	const scaledHeight = image.naturalHeight * scale;
+
+	function moveBy(dx: number, dy: number) {
+		setOffset((prev) => {
+			const next = clampOffset(
+				{ x: prev.x + dx, y: prev.y + dy },
+				scaledWidth,
+				scaledHeight,
+				frameWidth,
+				frameHeight,
+			);
+			setPanAnnouncement(
+				next.x === prev.x && next.y === prev.y
+					? t("imageCrop.panBoundary")
+					: "",
+			);
+			return next;
+		});
+	}
+
+	function handlePointerDown(e: React.PointerEvent<HTMLButtonElement>) {
+		e.currentTarget.setPointerCapture(e.pointerId);
+		dragState.current = { start: { x: e.clientX, y: e.clientY }, offset };
+	}
+
+	function handlePointerMove(e: React.PointerEvent<HTMLButtonElement>) {
+		if (!dragState.current) return;
+		const dx = e.clientX - dragState.current.start.x;
+		const dy = e.clientY - dragState.current.start.y;
+		setOffset(
+			clampOffset(
+				{
+					x: dragState.current.offset.x + dx,
+					y: dragState.current.offset.y + dy,
+				},
+				scaledWidth,
+				scaledHeight,
+				frameWidth,
+				frameHeight,
+			),
+		);
+	}
+
+	function handlePointerUp() {
+		dragState.current = null;
+	}
+
+	function handleFrameKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+		switch (e.key) {
+			case "ArrowLeft":
+				e.preventDefault();
+				moveBy(KEYBOARD_PAN_STEP, 0);
+				break;
+			case "ArrowRight":
+				e.preventDefault();
+				moveBy(-KEYBOARD_PAN_STEP, 0);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveBy(0, KEYBOARD_PAN_STEP);
+				break;
+			case "ArrowDown":
+				e.preventDefault();
+				moveBy(0, -KEYBOARD_PAN_STEP);
+				break;
+		}
+	}
+
+	function handleZoomChange(next: number) {
+		if (!image) return;
+		const newScale = baseScale * next;
+		const recentered = recenterOffsetForScale(
+			offset,
+			scale,
+			newScale,
+			frameWidth,
+			frameHeight,
+		);
+		setZoom(next);
+		setOffset(
+			clampOffset(
+				recentered,
+				image.naturalWidth * newScale,
+				image.naturalHeight * newScale,
+				frameWidth,
+				frameHeight,
+			),
+		);
+	}
+
+	async function handleApply() {
+		if (!image) return;
+		setApplying(true);
+		try {
+			const source = computeSourceRect(offset, scale, frameWidth, frameHeight);
+			const blob = await cropImageToBlob(
+				image,
+				source,
+				outputWidth,
+				outputHeight,
+			);
+			const ext = blob.type === "image/webp" ? "webp" : "png";
+			onCropped(
+				blobToFile(blob, `${file.name.replace(/\.[^.]+$/, "")}.${ext}`),
+			);
+		} finally {
+			setApplying(false);
+		}
+	}
+
+	return (
+		<Modal onClose={onCancel} labelledBy="image-crop-title" maxWidth="max-w-sm">
+			<h2 id="image-crop-title" className="text-lg font-semibold">
+				{title}
+			</h2>
+			<p className="mt-1 text-xs text-gray-500">{t("imageCrop.dragHint")}</p>
+
+			<button
+				type="button"
+				aria-label={t("imageCrop.frameLabel")}
+				className="relative mt-4 block touch-none overflow-hidden rounded-card border-0 bg-gray-100 p-0 outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+				style={{ width: frameWidth, height: frameHeight }}
+				onPointerDown={handlePointerDown}
+				onPointerMove={handlePointerMove}
+				onPointerUp={handlePointerUp}
+				onPointerCancel={handlePointerUp}
+				onKeyDown={handleFrameKeyDown}
+			>
+				<img
+					src={image.src}
+					alt=""
+					draggable={false}
+					className="absolute max-w-none select-none"
+					style={{
+						left: offset.x,
+						top: offset.y,
+						width: scaledWidth,
+						height: scaledHeight,
+					}}
+				/>
+				{shape === "circle" && (
+					<div
+						aria-hidden="true"
+						className="pointer-events-none absolute rounded-full"
+						style={{
+							width: Math.min(frameWidth, frameHeight),
+							height: Math.min(frameWidth, frameHeight),
+							left: (frameWidth - Math.min(frameWidth, frameHeight)) / 2,
+							top: (frameHeight - Math.min(frameWidth, frameHeight)) / 2,
+							boxShadow: "0 0 0 9999px rgba(0,0,0,0.5)",
+						}}
+					/>
+				)}
+			</button>
+			<div aria-live="polite" className="sr-only">
+				{panAnnouncement}
+			</div>
+
+			<div className="mt-4">
+				<label
+					htmlFor="image-crop-zoom"
+					className="block text-xs font-medium text-gray-600"
+				>
+					{t("imageCrop.zoomLabel")}
+				</label>
+				<input
+					id="image-crop-zoom"
+					type="range"
+					min={1}
+					max={MAX_ZOOM}
+					step={0.01}
+					value={zoom}
+					onChange={(e) => handleZoomChange(Number(e.target.value))}
+					className="mt-1 w-full accent-brand-700"
+				/>
+			</div>
+
+			<div className="mt-4 flex justify-end gap-2">
+				<Button variant="secondary" onClick={onCancel} disabled={applying}>
+					{t("imageCrop.cancel")}
+				</Button>
+				<Button onClick={() => void handleApply()} disabled={applying}>
+					{applying ? t("imageCrop.applying") : t("imageCrop.apply")}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -53,6 +53,8 @@ export default function OrganizationProfileView({
 						<img
 							src={logoUrl}
 							alt=""
+							width={64}
+							height={64}
 							className="h-16 w-16 rounded-full object-cover"
 						/>
 					) : (

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -45,6 +45,9 @@ export default function OpportunityListItem({
 						<img
 							src={item.bannerImageUrl}
 							alt=""
+							width={1200}
+							height={480}
+							loading="lazy"
 							className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
 						/>
 					) : (
@@ -159,6 +162,9 @@ export default function OpportunityListItem({
 								<img
 									src={item.organizationLogoUrl}
 									alt=""
+									width={28}
+									height={28}
+									loading="lazy"
 									className="h-7 w-7 shrink-0 rounded-full object-cover"
 								/>
 							) : (

--- a/frontend/src/lib/imageCrop.test.ts
+++ b/frontend/src/lib/imageCrop.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+	clampOffset,
+	computeSourceRect,
+	coverScale,
+	recenterOffsetForScale,
+} from "./imageCrop";
+
+describe("coverScale", () => {
+	it("picks the width ratio when the image is relatively taller than the frame", () => {
+		// 1000x2000 image into a 200x200 frame - height ratio (0.1) would leave
+		// gaps on the sides, so the wider width ratio (0.2) must win.
+		expect(coverScale(1000, 2000, 200, 200)).toBe(0.2);
+	});
+
+	it("picks the height ratio when the image is relatively wider than the frame", () => {
+		expect(coverScale(2000, 1000, 200, 200)).toBe(0.2);
+	});
+
+	it("returns 1 for an image that already exactly matches the frame", () => {
+		expect(coverScale(320, 320, 320, 320)).toBe(1);
+	});
+});
+
+describe("clampOffset", () => {
+	it("leaves an offset unchanged when it is already within bounds", () => {
+		// 400x400 scaled image in a 320x320 frame: valid x/y range is [-80, 0].
+		expect(clampOffset({ x: -40, y: -20 }, 400, 400, 320, 320)).toEqual({
+			x: -40,
+			y: -20,
+		});
+	});
+
+	it("pulls a positive offset back to 0 so no gap opens on the left/top", () => {
+		expect(clampOffset({ x: 50, y: 50 }, 400, 400, 320, 320)).toEqual({
+			x: 0,
+			y: 0,
+		});
+	});
+
+	it("pulls an offset that scrolled too far back to the minimum bound", () => {
+		expect(clampOffset({ x: -500, y: -500 }, 400, 400, 320, 320)).toEqual({
+			x: -80,
+			y: -80,
+		});
+	});
+
+	it("pins both axes to 0 when the scaled image exactly fills the frame", () => {
+		expect(clampOffset({ x: -5, y: 5 }, 320, 320, 320, 320)).toEqual({
+			x: 0,
+			y: 0,
+		});
+	});
+});
+
+describe("recenterOffsetForScale", () => {
+	it("keeps the frame's center point fixed on the image when zooming in", () => {
+		// 320x320 frame, image centered at scale 1 (offset -40,-40 for a 400x400
+		// scaled image) - the point at natural-space center of the visible
+		// region should still be at the frame's center after zooming to scale 2.
+		const offset = { x: -40, y: -40 };
+		const recentered = recenterOffsetForScale(offset, 1, 2, 320, 320);
+
+		// centerImgX/Y at scale 1 was (160 - -40) / 1 = 200; at scale 2 the
+		// offset needed to keep that point at the frame center is 160 - 200*2.
+		expect(recentered).toEqual({ x: 160 - 200 * 2, y: 160 - 200 * 2 });
+	});
+
+	it("is a no-op when the scale doesn't change", () => {
+		const offset = { x: -30, y: -70 };
+		expect(recenterOffsetForScale(offset, 1.5, 1.5, 320, 320)).toEqual(offset);
+	});
+});
+
+describe("computeSourceRect", () => {
+	it("maps a centered offset at cover scale to the full natural image extent on the wider axis", () => {
+		// 1000x2000 natural image, cover scale into a 200x200 frame is 0.2
+		// (width-constrained), centered vertically: scaledH = 2000*0.2 = 400,
+		// offset.y = (200-400)/2 = -100.
+		const scale = coverScale(1000, 2000, 200, 200);
+		const offset = { x: 0, y: -100 };
+
+		const rect = computeSourceRect(offset, scale, 200, 200);
+
+		expect(rect.sx).toBeCloseTo(0);
+		expect(rect.sw).toBeCloseTo(1000);
+		expect(rect.sy).toBeCloseTo(500);
+		expect(rect.sh).toBeCloseTo(1000);
+	});
+
+	it("shrinks the visible source rect as scale increases (zooming in)", () => {
+		const frameSize = 320;
+		const base = computeSourceRect({ x: 0, y: 0 }, 1, frameSize, frameSize);
+		const zoomed = computeSourceRect({ x: 0, y: 0 }, 2, frameSize, frameSize);
+
+		expect(zoomed.sw).toBeCloseTo(base.sw / 2);
+		expect(zoomed.sh).toBeCloseTo(base.sh / 2);
+	});
+});

--- a/frontend/src/lib/imageCrop.ts
+++ b/frontend/src/lib/imageCrop.ts
@@ -1,0 +1,143 @@
+export interface Offset {
+	x: number;
+	y: number;
+}
+
+export interface SourceRect {
+	sx: number;
+	sy: number;
+	sw: number;
+	sh: number;
+}
+
+// The scale at which an image of (naturalWidth, naturalHeight) fully covers a
+// frame of (frameWidth, frameHeight) with no empty gaps at any edge - the
+// same "cover" behavior CSS object-fit: cover gives, but computed explicitly
+// so it can be combined with an adjustable zoom on top.
+export function coverScale(
+	naturalWidth: number,
+	naturalHeight: number,
+	frameWidth: number,
+	frameHeight: number,
+): number {
+	return Math.max(frameWidth / naturalWidth, frameHeight / naturalHeight);
+}
+
+// Clamps the image's top-left offset (relative to the frame's top-left) so
+// the scaled image always fully covers the frame - dragging or zooming can
+// never open a gap at an edge.
+export function clampOffset(
+	offset: Offset,
+	scaledWidth: number,
+	scaledHeight: number,
+	frameWidth: number,
+	frameHeight: number,
+): Offset {
+	const minX = frameWidth - scaledWidth;
+	const minY = frameHeight - scaledHeight;
+	return {
+		x: Math.min(0, Math.max(minX, offset.x)),
+		y: Math.min(0, Math.max(minY, offset.y)),
+	};
+}
+
+// Recomputes the offset when the scale changes (zoom slider) so the point
+// currently at the frame's center stays fixed, rather than the image
+// jumping to a new position. Caller still needs to clamp the result.
+export function recenterOffsetForScale(
+	offset: Offset,
+	oldScale: number,
+	newScale: number,
+	frameWidth: number,
+	frameHeight: number,
+): Offset {
+	const centerImgX = (frameWidth / 2 - offset.x) / oldScale;
+	const centerImgY = (frameHeight / 2 - offset.y) / oldScale;
+	return {
+		x: frameWidth / 2 - centerImgX * newScale,
+		y: frameHeight / 2 - centerImgY * newScale,
+	};
+}
+
+// The natural-pixel-space rectangle of the source image currently visible
+// inside the frame, given the image is rendered at `scale` and positioned at
+// `offset` (top-left, relative to the frame's top-left).
+export function computeSourceRect(
+	offset: Offset,
+	scale: number,
+	frameWidth: number,
+	frameHeight: number,
+): SourceRect {
+	return {
+		sx: -offset.x / scale,
+		sy: -offset.y / scale,
+		sw: frameWidth / scale,
+		sh: frameHeight / scale,
+	};
+}
+
+export interface LoadedImage {
+	image: HTMLImageElement;
+	// Caller owns this and must URL.revokeObjectURL it once the image is no
+	// longer displayed - `image.src` is reused as the crop preview's <img>
+	// src, so revoking too early (e.g. right after decode) can break that
+	// second consumer of the same URL.
+	objectUrl: string;
+}
+
+export function loadImage(file: File): Promise<LoadedImage> {
+	return new Promise((resolve, reject) => {
+		const objectUrl = URL.createObjectURL(file);
+		const img = new Image();
+		img.onload = () => resolve({ image: img, objectUrl });
+		img.onerror = () => {
+			URL.revokeObjectURL(objectUrl);
+			reject(new Error("Failed to load image"));
+		};
+		img.src = objectUrl;
+	});
+}
+
+// Draws the given source rect from `img` onto an offscreen canvas sized
+// (outputWidth, outputHeight) and re-encodes it as WebP - this is what turns
+// a multi-MB original into a small, appropriately-sized upload (einsatzbereit#1380).
+export function cropImageToBlob(
+	img: HTMLImageElement,
+	source: SourceRect,
+	outputWidth: number,
+	outputHeight: number,
+	quality = 0.85,
+): Promise<Blob> {
+	const canvas = document.createElement("canvas");
+	canvas.width = outputWidth;
+	canvas.height = outputHeight;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) throw new Error("Canvas 2D context unavailable");
+
+	ctx.drawImage(
+		img,
+		source.sx,
+		source.sy,
+		source.sw,
+		source.sh,
+		0,
+		0,
+		outputWidth,
+		outputHeight,
+	);
+
+	return new Promise((resolve, reject) => {
+		canvas.toBlob(
+			(blob) => {
+				if (blob) resolve(blob);
+				else reject(new Error("Canvas toBlob failed"));
+			},
+			"image/webp",
+			quality,
+		);
+	});
+}
+
+export function blobToFile(blob: Blob, fileName: string): File {
+	return new File([blob], fileName, { type: blob.type });
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -823,6 +823,17 @@
         "confirm": "Ja, wiederherstellen"
       }
     },
+    "imageCrop": {
+      "loading": "Bild wird geladen…",
+      "loadError": "Dieses Bild konnte nicht geladen werden.",
+      "dragHint": "Zum Verschieben ziehen, mit dem Regler zoomen.",
+      "frameLabel": "Bildausschnitt - mit der Maus oder den Pfeiltasten verschieben",
+      "panBoundary": "Bildrand erreicht.",
+      "zoomLabel": "Zoom",
+      "cancel": "Abbrechen",
+      "apply": "Übernehmen",
+      "applying": "Wird übernommen…"
+    },
     "orgProfile": {
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -823,6 +823,17 @@
         "confirm": "Yes, restore"
       }
     },
+    "imageCrop": {
+      "loading": "Loading image…",
+      "loadError": "Could not load this image.",
+      "dragHint": "Drag to reposition, use the slider to zoom.",
+      "frameLabel": "Image crop area - drag or use arrow keys to reposition",
+      "panBoundary": "Reached the edge of the image.",
+      "zoomLabel": "Zoom",
+      "cancel": "Cancel",
+      "apply": "Apply",
+      "applying": "Applying…"
+    },
     "orgProfile": {
       "loading": "Loading…",
       "error": "Error: {{message}}",

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -161,6 +161,9 @@ export default function OrganizationsPage() {
 											<img
 												src={org.logoUrl}
 												alt=""
+												width={48}
+												height={48}
+												loading="lazy"
 												className="h-12 w-12 shrink-0 rounded-full object-cover"
 											/>
 										) : (

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -13,6 +13,7 @@ import Dropdown from "../../components/Dropdown";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
 import Skeleton from "../../components/Skeleton";
 import ErrorBanner from "../../components/ErrorBanner";
+import ImageCropModal from "../../components/ImageCropModal";
 import AchievementsSection from "./AchievementsSection";
 import ActivitySection from "./ActivitySection";
 import NotificationPreferencesSection from "./NotificationPreferencesSection";
@@ -311,6 +312,8 @@ export default function ProfileOverviewPage() {
 									<img
 										src={avatarUrl}
 										alt=""
+										width={64}
+										height={64}
 										className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-brand-100"
 									/>
 								) : (
@@ -399,6 +402,8 @@ export default function ProfileOverviewPage() {
 													<img
 														src={avatarUrl}
 														alt=""
+														width={64}
+														height={64}
 														className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
 													/>
 												) : (
@@ -604,6 +609,19 @@ export default function ProfileOverviewPage() {
 			<NotificationPreferencesSection />
 
 			<DangerZoneCard />
+
+			{avatarUpload.croppingFile && (
+				<ImageCropModal
+					file={avatarUpload.croppingFile}
+					aspectRatio={1}
+					shape="circle"
+					outputWidth={320}
+					outputHeight={320}
+					title={t("profile.avatarUpload")}
+					onCancel={avatarUpload.handleCropCancel}
+					onCropped={(f) => void avatarUpload.handleCropped(f)}
+				/>
+			)}
 		</>
 	);
 }

--- a/frontend/src/pages/ProfileOverviewPage/useAvatarUpload.ts
+++ b/frontend/src/pages/ProfileOverviewPage/useAvatarUpload.ts
@@ -6,17 +6,19 @@ const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 const AVATAR_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 // Owns the avatar-upload-in-progress state (upload flag, error, file input
-// ref) so ProfileOverviewPage doesn't have to - see #872. avatarUrl itself
-// stays with the caller since it's also shown outside edit mode.
+// ref, crop step) so ProfileOverviewPage doesn't have to - see #872. avatarUrl
+// itself stays with the caller since it's also shown outside edit mode.
 export function useAvatarUpload(onUploaded: (url: string) => void) {
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const [uploading, setUploading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [croppingFile, setCroppingFile] = useState<File | null>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+	function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
+		e.target.value = "";
 		if (!file) return;
 		if (!AVATAR_TYPES.includes(file.type)) {
 			setError(t("profile.avatarHint"));
@@ -26,18 +28,37 @@ export function useAvatarUpload(onUploaded: (url: string) => void) {
 			setError(t("profile.avatarHint"));
 			return;
 		}
-		setUploading(true);
 		setError(null);
+		setCroppingFile(file);
+	}
+
+	async function handleCropped(croppedFile: File) {
+		setCroppingFile(null);
+		setUploading(true);
 		try {
-			await api.uploadUserAvatar({ data: file, fileName: file.name });
-			onUploaded(URL.createObjectURL(file));
+			await api.uploadUserAvatar({
+				data: croppedFile,
+				fileName: croppedFile.name,
+			});
+			onUploaded(URL.createObjectURL(croppedFile));
 		} catch {
 			setError(t("profile.avatarUploadError"));
 		} finally {
 			setUploading(false);
-			if (inputRef.current) inputRef.current.value = "";
 		}
 	}
 
-	return { uploading, error, inputRef, handleChange };
+	function handleCropCancel() {
+		setCroppingFile(null);
+	}
+
+	return {
+		uploading,
+		error,
+		inputRef,
+		handleChange,
+		croppingFile,
+		handleCropped,
+		handleCropCancel,
+	};
 }

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -62,6 +62,8 @@ export default function UserProfilePage() {
 					<img
 						src={profile.avatarUrl}
 						alt={profile.displayName}
+						width={64}
+						height={64}
 						className="h-16 w-16 rounded-full object-cover"
 					/>
 				) : (

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -235,6 +235,8 @@ export default function VolunteerOpportunityDetailPage() {
 				<img
 					src={opportunity.bannerImageUrl}
 					alt=""
+					width={1200}
+					height={480}
 					className="mb-6 h-56 w-full rounded-card object-cover shadow-resting sm:h-72"
 				/>
 			)}

--- a/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
@@ -19,6 +19,8 @@ function SettingsWidget({ org, size }: Props) {
 		<img
 			src={org.logoUrl}
 			alt=""
+			width={48}
+			height={48}
 			className="h-12 w-12 shrink-0 rounded-lg object-contain ring-1 ring-gray-200"
 		/>
 	) : (

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -12,6 +12,7 @@ import type { OrganizationFormValues } from "../../lib/organizationFormSchema";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import OrganizationProfileView from "../../components/OrganizationProfileView";
 import ErrorBanner from "../../components/ErrorBanner";
+import ImageCropModal from "../../components/ImageCropModal";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const MAX_LOGO_BYTES = 2 * 1024 * 1024;
@@ -73,6 +74,7 @@ export default function OrgSettingsPage() {
 	const [uploadingLogo, setUploadingLogo] = useState(false);
 	const [removingLogo, setRemovingLogo] = useState(false);
 	const [logoError, setLogoError] = useState<string | null>(null);
+	const [croppingLogoFile, setCroppingLogoFile] = useState<File | null>(null);
 	const logoInputRef = useRef<HTMLInputElement>(null);
 	const formRef = useRef<HTMLFormElement>(null);
 
@@ -103,21 +105,27 @@ export default function OrgSettingsPage() {
 		setEditing(false);
 	}
 
-	async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+	function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
 		if (!file) return;
 		if (!LOGO_TYPES.includes(file.type) || file.size > MAX_LOGO_BYTES) {
 			setLogoError(t("orgSettings.logoHint"));
+			if (logoInputRef.current) logoInputRef.current.value = "";
 			return;
 		}
-		setUploadingLogo(true);
 		setLogoError(null);
+		setCroppingLogoFile(file);
+	}
+
+	async function handleLogoCropped(croppedFile: File) {
+		setCroppingLogoFile(null);
+		setUploadingLogo(true);
 		try {
 			await api.uploadOrganizationLogo(org.id, {
-				data: file,
-				fileName: file.name,
+				data: croppedFile,
+				fileName: croppedFile.name,
 			});
-			setLogoUrl(URL.createObjectURL(file));
+			setLogoUrl(URL.createObjectURL(croppedFile));
 		} catch {
 			setLogoError(t("orgSettings.logoUploadError"));
 		} finally {
@@ -266,6 +274,8 @@ export default function OrgSettingsPage() {
 										<img
 											src={logoUrl}
 											alt=""
+											width={64}
+											height={64}
 											className="h-16 w-16 rounded-lg object-contain ring-1 ring-gray-200"
 										/>
 									) : (
@@ -555,6 +565,19 @@ export default function OrgSettingsPage() {
 					onConfirm={handleDeleteOrganization}
 					onClose={() => setShowDeleteConfirm(false)}
 					loading={deleting}
+				/>
+			)}
+
+			{croppingLogoFile && (
+				<ImageCropModal
+					file={croppingLogoFile}
+					aspectRatio={1}
+					shape="circle"
+					outputWidth={320}
+					outputHeight={320}
+					title={t("orgSettings.logoUpload")}
+					onCancel={() => setCroppingLogoFile(null)}
+					onCropped={(f) => void handleLogoCropped(f)}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
Full-resolution images (up to 2MB) were uploaded as-is and served into tiny 28px/176px display slots, wasting bandwidth on every list view. Adds a reusable pan/zoom crop tool (Canvas-based, no server changes or new dependency) that resizes and re-encodes to WebP before upload: square 320x320 for avatars/logos, 1200x480 for banners. Also adds explicit width/height and loading="lazy" to the affected <img> tags as defense-in-depth against layout shift and unnecessary off-screen loads.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1380

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
