### PR TITLE
fix: move engagement email/Keycloak side effects off the open DB transaction

### DIFF
--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -1,22 +1,14 @@
 using Application.Common.Authorization;
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
-using Application.Engagements.Common;
 using Domain.Engagements;
 using Domain.Primitives;
-using Domain.Users;
 
 namespace Application.Engagements.CancelEngagement.v1;
 
 internal sealed class CancelEngagementCommandHandler(
-	IApplicationDbContext dbContext,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer,
-	IUnsubscribeLinkBuilder unsubscribeLinkBuilder)
+	IApplicationDbContext dbContext)
 	: ICommandHandler<CancelEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -35,16 +27,7 @@ internal sealed class CancelEngagementCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		await EngagementCancellationHelper.CancelAndNotifyAsync(
-			dbContext,
-			keycloakUserService,
-			emailService,
-			emailTemplateRenderer,
-			unsubscribeLinkBuilder,
-			engagement,
-			opportunity.Title,
-			request.Reason,
-			cancellationToken);
+		engagement.Cancel(request.Reason, notifyVolunteer: true).ThrowIfFailure();
 
 		return engagement;
 	}

--- a/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledByOrganizerNotificationHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledByOrganizerNotificationHandler.cs
@@ -1,0 +1,98 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.CancelEngagement.v1;
+
+// Consumer of EngagementCancelledByOrganizerDomainEvent (einsatzbereit#1382):
+// CancelEngagementCommandHandler only cancels the Engagement and raises the
+// event (via Cancel(reason, notifyVolunteer: true) - distinct from the plain
+// EngagementCancelledDomainEvent that cascade cancellations also raise, so
+// this handler never double-notifies a cascade-cancelled engagement); the
+// volunteer's in-app notification, Keycloak lookup, and cancellation email -
+// previously sent synchronously inside the command's own DB transaction via
+// EngagementCancellationHelper - happen here, dispatched by OutboxProcessorJob
+// after that transaction has already committed.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (the new Notification row), so
+// it must call SaveChangesAsync itself via IUnitOfWork.
+internal sealed class EngagementCancelledByOrganizerNotificationHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<EngagementCancelledByOrganizerNotificationHandler> logger)
+	: INotificationHandler<EngagementCancelledByOrganizerDomainEvent>
+{
+	public async Task Handle(
+		EngagementCancelledByOrganizerDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken);
+
+		if (opportunity is null)
+		{
+			logger.LogWarning(
+				"Skipping cancellation notification for engagement {EngagementId}: opportunity {OpportunityId} no longer exists",
+				notification.EngagementId.Value,
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var inAppNotification = Notification.Create(
+			notification.VolunteerId,
+			NotificationKind.EngagementCancelled,
+			notification.EngagementId.Value);
+
+		await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+
+		var volunteerUser = (await dbContext.GetOrCreateUsersAsync([notification.VolunteerId], cancellationToken))[0];
+
+		if (volunteerUser.IsSubscribedTo(EmailNotificationType.EngagementCancelled))
+		{
+			var volunteer = await keycloakUserService.GetUserAsync(notification.VolunteerId.Value, cancellationToken);
+			var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
+
+			var reasonBlock = string.IsNullOrWhiteSpace(notification.Reason)
+				? string.Empty
+				: emailTemplateRenderer.Render(
+					EmailTemplateKind.EngagementCancelledReasonSuffix,
+					volunteerLanguage,
+					new Dictionary<string, string> { ["Reason"] = notification.Reason }).Body;
+
+			var content = emailTemplateRenderer.Render(
+				EmailTemplateKind.EngagementCancelled,
+				volunteerLanguage,
+				new Dictionary<string, string>
+				{
+					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
+					["OpportunityTitle"] = opportunity.Title,
+					["ReasonBlock"] = reasonBlock,
+				});
+
+			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
+				notification.VolunteerId, volunteerUser.UnsubscribeToken, EmailNotificationType.EngagementCancelled);
+
+			await emailService.SendAsync(
+				volunteer.Email,
+				content.Subject,
+				EmailFooter.Append(content.Body, unsubscribeUrl),
+				cancellationToken);
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -1,13 +1,9 @@
 using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Authorization;
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
-using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Primitives;
 using Domain.Users;
 
@@ -15,10 +11,6 @@ namespace Application.Engagements.ConfirmEngagement.v1;
 
 internal sealed class ConfirmEngagementCommandHandler(
 	IApplicationDbContext dbContext,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer,
-	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
 	ISender sender)
 	: ICommandHandler<ConfirmEngagementCommand, Engagement>
 {
@@ -42,13 +34,6 @@ internal sealed class ConfirmEngagementCommandHandler(
 
 		var volunteerId = engagement.VolunteerId!.Value;
 
-		var notification = Notification.Create(
-			volunteerId,
-			NotificationKind.EngagementConfirmed,
-			engagement.Id.Value);
-
-		await dbContext.Notifications.AddAsync(notification, cancellationToken);
-
 		var tz = ResolveTimeZone(request.Timezone);
 		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
@@ -57,31 +42,6 @@ internal sealed class ConfirmEngagementCommandHandler(
 			volunteerId, isoYear, isoWeek, cancellationToken);
 
 		await EvaluateMilestoneAchievementsAsync(volunteerId, totalConfirmedEngagements, cancellationToken);
-
-		var volunteer = await keycloakUserService.GetUserAsync(volunteerId.Value, cancellationToken);
-		var volunteerUser = (await dbContext.GetOrCreateUsersAsync([volunteerId], cancellationToken))[0];
-		var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
-
-		if (volunteerUser.IsSubscribedTo(EmailNotificationType.EngagementConfirmed))
-		{
-			var content = emailTemplateRenderer.Render(
-				EmailTemplateKind.EngagementConfirmed,
-				volunteerLanguage,
-				new Dictionary<string, string>
-				{
-					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
-					["OpportunityTitle"] = opportunity.Title,
-				});
-
-			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
-				volunteerId, volunteerUser.UnsubscribeToken, EmailNotificationType.EngagementConfirmed);
-
-			await emailService.SendAsync(
-				volunteer.Email,
-				content.Subject,
-				EmailFooter.Append(content.Body, unsubscribeUrl),
-				cancellationToken);
-		}
 
 		return engagement;
 	}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
@@ -1,0 +1,87 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.ConfirmEngagement.v1;
+
+// Consumer of EngagementConfirmedDomainEvent (einsatzbereit#1382):
+// ConfirmEngagementCommandHandler only flips Status and raises the event; the
+// volunteer's in-app notification, Keycloak lookup, and confirmation email -
+// previously sent synchronously inside the command's own DB transaction -
+// happen here, dispatched by OutboxProcessorJob after that transaction has
+// already committed.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (the new Notification row), so
+// it must call SaveChangesAsync itself via IUnitOfWork.
+internal sealed class EngagementConfirmedNotificationHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<EngagementConfirmedNotificationHandler> logger)
+	: INotificationHandler<EngagementConfirmedDomainEvent>
+{
+	public async Task Handle(
+		EngagementConfirmedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken);
+
+		if (opportunity is null)
+		{
+			logger.LogWarning(
+				"Skipping confirmation notification for engagement {EngagementId}: opportunity {OpportunityId} no longer exists",
+				notification.EngagementId.Value,
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var inAppNotification = Notification.Create(
+			notification.VolunteerId,
+			NotificationKind.EngagementConfirmed,
+			notification.EngagementId.Value);
+
+		await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+
+		var volunteerUser = (await dbContext.GetOrCreateUsersAsync([notification.VolunteerId], cancellationToken))[0];
+
+		if (volunteerUser.IsSubscribedTo(EmailNotificationType.EngagementConfirmed))
+		{
+			var volunteer = await keycloakUserService.GetUserAsync(notification.VolunteerId.Value, cancellationToken);
+			var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
+
+			var content = emailTemplateRenderer.Render(
+				EmailTemplateKind.EngagementConfirmed,
+				volunteerLanguage,
+				new Dictionary<string, string>
+				{
+					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
+					["OpportunityTitle"] = opportunity.Title,
+				});
+
+			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
+				notification.VolunteerId, volunteerUser.UnsubscribeToken, EmailNotificationType.EngagementConfirmed);
+
+			await emailService.SendAsync(
+				volunteer.Email,
+				content.Subject,
+				EmailFooter.Append(content.Body, unsubscribeUrl),
+				cancellationToken);
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -1,24 +1,13 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
-using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Primitives;
-using Domain.Users;
-using Domain.VolunteerOpportunities;
 
 namespace Application.Engagements.CreateEngagement.v1;
 
 internal sealed class CreateEngagementCommandHandler(
-	IApplicationDbContext dbContext,
-	IKeycloakOrganizationService keycloakOrganizationService,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer,
-	IUnsubscribeLinkBuilder unsubscribeLinkBuilder)
+	IApplicationDbContext dbContext)
 	: ICommandHandler<CreateEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -66,79 +55,6 @@ internal sealed class CreateEngagementCommandHandler(
 					?? throw new ResultFailureException(Error.Validation("Engagement.MessageRequired", "Message is required for individual contact."))).GetValueOrThrow();
 
 			await dbContext.Engagements.AddAsync(engagement, cancellationToken);
-		}
-
-		var members = await keycloakOrganizationService
-			.GetMembersAsync(opportunity.OrganizationId.Value, cancellationToken);
-
-		foreach (var organizer in members.Where(m => m.IsOrganisator))
-		{
-			var notification = Notification.Create(
-				UserId.Create(organizer.UserId).GetValueOrThrow(),
-				NotificationKind.EngagementCreated,
-				engagement.Id.Value);
-
-			await dbContext.Notifications.AddAsync(notification, cancellationToken);
-		}
-
-		var volunteer = await keycloakUserService.GetUserAsync(request.VolunteerId.Value, cancellationToken);
-		var volunteerName = volunteer.FirstName ?? volunteer.Username;
-		var isSlotSignUp = request.TimeSlotId is not null;
-
-		var volunteerUser = await dbContext.Users.FindAsync(request.VolunteerId, cancellationToken);
-		var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser?.PreferredLanguage);
-
-		var volunteerContent = emailTemplateRenderer.Render(
-			isSlotSignUp ? EmailTemplateKind.EngagementWaitlisted : EmailTemplateKind.EngagementRequestReceived,
-			volunteerLanguage,
-			new Dictionary<string, string>
-			{
-				["VolunteerName"] = volunteerName,
-				["OpportunityTitle"] = opportunity.Title,
-			});
-
-		// Never gated by preference (#1055): this is the direct, synchronous
-		// response to the volunteer's own just-submitted action, not a repeatable
-		// notification about someone else's activity - equivalent to an order
-		// receipt, which platforms conventionally don't let users opt out of.
-		await emailService.SendAsync(volunteer.Email, volunteerContent.Subject, volunteerContent.Body, cancellationToken);
-
-		var organizerIds = members
-			.Where(m => m.IsOrganisator)
-			.Select(m => UserId.Create(m.UserId).GetValueOrThrow())
-			.ToList();
-		var organizerUsersById = (await dbContext.GetOrCreateUsersAsync(organizerIds, cancellationToken))
-			.ToDictionary(u => u.Id);
-
-		foreach (var organizer in members.Where(m => m.IsOrganisator))
-		{
-			var organizerId = UserId.Create(organizer.UserId).GetValueOrThrow();
-			var organizerUser = organizerUsersById[organizerId];
-
-			if (!organizerUser.IsSubscribedTo(EmailNotificationType.NewSignUp))
-				continue;
-
-			var organizerName = organizer.FirstName ?? organizer.Username;
-			var organizerLanguage = SupportedLanguages.Resolve(organizerUser.PreferredLanguage);
-
-			var organizerContent = emailTemplateRenderer.Render(
-				EmailTemplateKind.EngagementSignupNotifyOrganizer,
-				organizerLanguage,
-				new Dictionary<string, string>
-				{
-					["OrganizerName"] = organizerName,
-					["VolunteerName"] = volunteerName,
-					["OpportunityTitle"] = opportunity.Title,
-				});
-
-			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
-				organizerId, organizerUser.UnsubscribeToken, EmailNotificationType.NewSignUp);
-
-			await emailService.SendAsync(
-				organizer.Email,
-				organizerContent.Subject,
-				EmailFooter.Append(organizerContent.Body, unsubscribeUrl),
-				cancellationToken);
 		}
 
 		return engagement;

--- a/backend/src/Application/Engagements/CreateEngagement/v1/EngagementSignUpNotificationHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/EngagementSignUpNotificationHandler.cs
@@ -1,0 +1,144 @@
+using Application.Common.Email;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.CreateEngagement.v1;
+
+// Consumer of EngagementCreatedDomainEvent and EngagementReactivatedDomainEvent
+// (einsatzbereit#1382): CreateEngagementCommandHandler only validates and
+// creates/reactivates the Engagement; the organizer Keycloak lookup, in-app
+// notifications, and volunteer/organizer emails - previously done inline
+// inside the command's own DB transaction (2-3 blocking Keycloak round trips
+// plus a new SmtpClient per recipient, all while row locks were held) -
+// happen here instead, dispatched by OutboxProcessorJob after that
+// transaction has already committed.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (the new Notification rows),
+// so it must call SaveChangesAsync itself via IUnitOfWork.
+internal sealed class EngagementSignUpNotificationHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	IKeycloakOrganizationService keycloakOrganizationService,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<EngagementSignUpNotificationHandler> logger)
+	: INotificationHandler<EngagementCreatedDomainEvent>,
+		INotificationHandler<EngagementReactivatedDomainEvent>
+{
+	public Task Handle(EngagementCreatedDomainEvent notification, CancellationToken cancellationToken) =>
+		NotifyAsync(notification.EngagementId, notification.VolunteerId, notification.OpportunityId, cancellationToken);
+
+	public Task Handle(EngagementReactivatedDomainEvent notification, CancellationToken cancellationToken) =>
+		NotifyAsync(notification.EngagementId, notification.VolunteerId, notification.OpportunityId, cancellationToken);
+
+	private async Task NotifyAsync(
+		EngagementId engagementId,
+		UserId volunteerId,
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(opportunityId, cancellationToken);
+		var engagement = await dbContext.Engagements.FindAsync(engagementId, cancellationToken);
+
+		if (opportunity is null || engagement is null)
+		{
+			// Deleted/withdrawn between the sign-up committing and the outbox
+			// dispatching this event - nothing left to notify about, and
+			// retrying would never resolve.
+			logger.LogWarning(
+				"Skipping sign-up notification for engagement {EngagementId}: opportunity or engagement no longer exists",
+				engagementId.Value);
+			return;
+		}
+
+		var isSlotSignUp = engagement.TimeSlotId is not null;
+
+		var members = await keycloakOrganizationService.GetMembersAsync(opportunity.OrganizationId.Value, cancellationToken);
+		var organizers = members.Where(m => m.IsOrganisator).ToList();
+
+		foreach (var organizer in organizers)
+		{
+			var organizerNotification = Notification.Create(
+				UserId.Create(organizer.UserId).GetValueOrThrow(),
+				NotificationKind.EngagementCreated,
+				engagementId.Value);
+
+			await dbContext.Notifications.AddAsync(organizerNotification, cancellationToken);
+		}
+
+		var volunteer = await keycloakUserService.GetUserAsync(volunteerId.Value, cancellationToken);
+		var volunteerName = volunteer.FirstName ?? volunteer.Username;
+
+		var volunteerUser = (await dbContext.GetOrCreateUsersAsync([volunteerId], cancellationToken))[0];
+		var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
+
+		var volunteerContent = emailTemplateRenderer.Render(
+			isSlotSignUp ? EmailTemplateKind.EngagementWaitlisted : EmailTemplateKind.EngagementRequestReceived,
+			volunteerLanguage,
+			new Dictionary<string, string>
+			{
+				["VolunteerName"] = volunteerName,
+				["OpportunityTitle"] = opportunity.Title,
+			});
+
+		// Never gated by preference (#1055): this is the direct response to the
+		// volunteer's own just-submitted action, not a repeatable notification
+		// about someone else's activity - equivalent to an order receipt, which
+		// platforms conventionally don't let users opt out of.
+		await emailService.SendAsync(volunteer.Email, volunteerContent.Subject, volunteerContent.Body, cancellationToken);
+
+		var organizerIds = organizers
+			.Select(m => UserId.Create(m.UserId).GetValueOrThrow())
+			.ToList();
+		var organizerUsersById = (await dbContext.GetOrCreateUsersAsync(organizerIds, cancellationToken))
+			.ToDictionary(u => u.Id);
+
+		foreach (var organizer in organizers)
+		{
+			var organizerId = UserId.Create(organizer.UserId).GetValueOrThrow();
+			var organizerUser = organizerUsersById[organizerId];
+
+			if (!organizerUser.IsSubscribedTo(EmailNotificationType.NewSignUp))
+				continue;
+
+			var organizerName = organizer.FirstName ?? organizer.Username;
+			var organizerLanguage = SupportedLanguages.Resolve(organizerUser.PreferredLanguage);
+
+			var organizerContent = emailTemplateRenderer.Render(
+				EmailTemplateKind.EngagementSignupNotifyOrganizer,
+				organizerLanguage,
+				new Dictionary<string, string>
+				{
+					["OrganizerName"] = organizerName,
+					["VolunteerName"] = volunteerName,
+					["OpportunityTitle"] = opportunity.Title,
+				});
+
+			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
+				organizerId, organizerUser.UnsubscribeToken, EmailNotificationType.NewSignUp);
+
+			await emailService.SendAsync(
+				organizer.Email,
+				organizerContent.Subject,
+				EmailFooter.Append(organizerContent.Body, unsubscribeUrl),
+				cancellationToken);
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Engagements/WithdrawEngagement/v1/EngagementWithdrawnNotificationHandler.cs
+++ b/backend/src/Application/Engagements/WithdrawEngagement/v1/EngagementWithdrawnNotificationHandler.cs
@@ -1,0 +1,105 @@
+using Application.Common.Email;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.WithdrawEngagement.v1;
+
+// Consumer of EngagementWithdrawnDomainEvent (einsatzbereit#1382):
+// WithdrawEngagementCommandHandler only flips Status and raises the event;
+// the organizer Keycloak lookup, in-app notifications, and withdrawal emails
+// - previously sent synchronously inside the command's own DB transaction -
+// happen here, dispatched by OutboxProcessorJob after that transaction has
+// already committed.
+//
+// Publisher.Publish() resolves this handler from its own fresh child scope
+// (see Application/Common/Messaging/Publisher.cs), not the scope
+// OutboxProcessorJob itself is running in - so the IApplicationDbContext
+// injected here is a *different* DbContext instance than the one
+// OutboxProcessorJob.ProcessBatchAsync later calls SaveChangesAsync on.
+// Nothing else persists this handler's writes (the new Notification rows),
+// so it must call SaveChangesAsync itself via IUnitOfWork.
+internal sealed class EngagementWithdrawnNotificationHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	IKeycloakOrganizationService keycloakOrganizationService,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	IUnsubscribeLinkBuilder unsubscribeLinkBuilder,
+	ILogger<EngagementWithdrawnNotificationHandler> logger)
+	: INotificationHandler<EngagementWithdrawnDomainEvent>
+{
+	public async Task Handle(
+		EngagementWithdrawnDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken);
+
+		if (opportunity is null)
+		{
+			logger.LogWarning(
+				"Skipping withdrawal notification for engagement {EngagementId}: opportunity {OpportunityId} no longer exists",
+				notification.EngagementId.Value,
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var volunteer = await keycloakUserService.GetUserAsync(notification.VolunteerId.Value, cancellationToken);
+		var volunteerName = volunteer.FirstName ?? volunteer.Username;
+
+		var members = await keycloakOrganizationService.GetMembersAsync(opportunity.OrganizationId.Value, cancellationToken);
+		var organizers = members.Where(m => m.IsOrganisator).ToList();
+
+		var organizerIds = organizers
+			.Select(m => UserId.Create(m.UserId).GetValueOrThrow())
+			.ToList();
+		var organizerUsersById = (await dbContext.GetOrCreateUsersAsync(organizerIds, cancellationToken))
+			.ToDictionary(u => u.Id);
+
+		foreach (var organizer in organizers)
+		{
+			var organizerId = UserId.Create(organizer.UserId).GetValueOrThrow();
+			var inAppNotification = Notification.Create(
+				organizerId,
+				NotificationKind.EngagementWithdrawn,
+				notification.EngagementId.Value);
+
+			await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+
+			var organizerUser = organizerUsersById[organizerId];
+			if (!organizerUser.IsSubscribedTo(EmailNotificationType.Withdrawal))
+				continue;
+
+			var organizerName = organizer.FirstName ?? organizer.Username;
+			var organizerLanguage = SupportedLanguages.Resolve(organizerUser.PreferredLanguage);
+
+			var content = emailTemplateRenderer.Render(
+				EmailTemplateKind.EngagementWithdrawnNotifyOrganizer,
+				organizerLanguage,
+				new Dictionary<string, string>
+				{
+					["OrganizerName"] = organizerName,
+					["VolunteerName"] = volunteerName,
+					["OpportunityTitle"] = opportunity.Title,
+				});
+
+			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
+				organizerId, organizerUser.UnsubscribeToken, EmailNotificationType.Withdrawal);
+
+			await emailService.SendAsync(
+				organizer.Email,
+				content.Subject,
+				EmailFooter.Append(content.Body, unsubscribeUrl),
+				cancellationToken);
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Engagements/WithdrawEngagement/v1/WithdrawEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/WithdrawEngagement/v1/WithdrawEngagementCommandHandler.cs
@@ -1,23 +1,13 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
-using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Primitives;
-using Domain.Users;
 
 namespace Application.Engagements.WithdrawEngagement.v1;
 
 internal sealed class WithdrawEngagementCommandHandler(
-	IApplicationDbContext dbContext,
-	IKeycloakOrganizationService keycloakOrganizationService,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer,
-	IUnsubscribeLinkBuilder unsubscribeLinkBuilder)
+	IApplicationDbContext dbContext)
 	: ICommandHandler<WithdrawEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -31,62 +21,6 @@ internal sealed class WithdrawEngagementCommandHandler(
 			throw new ResultFailureException(Error.Forbidden("Engagement.NotOwner", "Only the volunteer who created this engagement can withdraw it."));
 
 		engagement.Withdraw().ThrowIfFailure();
-
-		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
-			engagement.OpportunityId, cancellationToken);
-
-		if (opportunity is not null)
-		{
-			var volunteer = await keycloakUserService.GetUserAsync(request.VolunteerId, cancellationToken);
-			var volunteerName = volunteer.FirstName ?? volunteer.Username;
-
-			var members = await keycloakOrganizationService
-				.GetMembersAsync(opportunity.OrganizationId.Value, cancellationToken);
-
-			var organizerIds = members
-				.Where(m => m.IsOrganisator)
-				.Select(m => UserId.Create(m.UserId).GetValueOrThrow())
-				.ToList();
-			var organizerUsersById = (await dbContext.GetOrCreateUsersAsync(organizerIds, cancellationToken))
-				.ToDictionary(u => u.Id);
-
-			foreach (var organizer in members.Where(m => m.IsOrganisator))
-			{
-				var organizerId = UserId.Create(organizer.UserId).GetValueOrThrow();
-				var notification = Notification.Create(
-					organizerId,
-					NotificationKind.EngagementWithdrawn,
-					engagement.Id.Value);
-
-				await dbContext.Notifications.AddAsync(notification, cancellationToken);
-
-				var organizerUser = organizerUsersById[organizerId];
-				if (!organizerUser.IsSubscribedTo(EmailNotificationType.Withdrawal))
-					continue;
-
-				var organizerName = organizer.FirstName ?? organizer.Username;
-				var organizerLanguage = SupportedLanguages.Resolve(organizerUser.PreferredLanguage);
-
-				var content = emailTemplateRenderer.Render(
-					EmailTemplateKind.EngagementWithdrawnNotifyOrganizer,
-					organizerLanguage,
-					new Dictionary<string, string>
-					{
-						["OrganizerName"] = organizerName,
-						["VolunteerName"] = volunteerName,
-						["OpportunityTitle"] = opportunity.Title,
-					});
-
-				var unsubscribeUrl = unsubscribeLinkBuilder.Build(
-					organizerId, organizerUser.UnsubscribeToken, EmailNotificationType.Withdrawal);
-
-				await emailService.SendAsync(
-					organizer.Email,
-					content.Subject,
-					EmailFooter.Append(content.Body, unsubscribeUrl),
-					cancellationToken);
-			}
-		}
 
 		return engagement;
 	}

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -63,13 +63,16 @@ public sealed class Engagement
 		UserId volunteerId,
 		TimeSlotId timeSlotId)
 	{
-		return new Engagement(
+		var engagement = new Engagement(
 			EngagementId.New(),
 			opportunityId,
 			volunteerId,
 			timeSlotId,
 			message: null,
 			EngagementStatus.Pending);
+
+		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId));
+		return engagement;
 	}
 
 	public static Result<Engagement> CreateIndividualContact(
@@ -82,13 +85,16 @@ public sealed class Engagement
 				"Engagement.MessageRequired",
 				"A message is required when expressing interest via individual contact."));
 
-		return new Engagement(
+		var engagement = new Engagement(
 			EngagementId.New(),
 			opportunityId,
 			volunteerId,
 			timeSlotId: null,
 			message,
 			EngagementStatus.Pending);
+
+		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId));
+		return engagement;
 	}
 
 	public Result Confirm()
@@ -101,7 +107,12 @@ public sealed class Engagement
 		return Result.Success();
 	}
 
-	public Result Cancel(string? reason = null)
+	// notifyVolunteer distinguishes a direct, organizer-triggered cancellation
+	// (CancelEngagementCommandHandler) from a cascade cancellation (opportunity/
+	// time-slot deletion) that already notifies the volunteer itself as part of
+	// its own async handler - raising EngagementCancelledByOrganizerDomainEvent
+	// for both would double-send the notification for cascades.
+	public Result Cancel(string? reason = null, bool notifyVolunteer = false)
 	{
 		if (IsTerminated)
 			return Result.Failure(Error.Conflict("Engagement.AlreadyTerminated", "Engagement is already terminated."));
@@ -109,6 +120,8 @@ public sealed class Engagement
 		CancellationReason = reason;
 		Status = EngagementStatus.Cancelled;
 		AddEvent(new EngagementCancelledDomainEvent(Id, VolunteerId!.Value, OpportunityId, reason));
+		if (notifyVolunteer)
+			AddEvent(new EngagementCancelledByOrganizerDomainEvent(Id, VolunteerId!.Value, OpportunityId, reason));
 		return Result.Success();
 	}
 

--- a/backend/src/Domain/Engagements/EngagementCancelledByOrganizerDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementCancelledByOrganizerDomainEvent.cs
@@ -1,0 +1,18 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+// Distinct from EngagementCancelledDomainEvent (raised by every Cancel() call,
+// including opportunity/time-slot cascade cancellations that already notify
+// the volunteer inline as part of their own async handler): this one is
+// raised only when an organizer directly cancels a single engagement
+// (Cancel(notifyVolunteer: true)), so the outbox-dispatched notification
+// handler for it never double-sends for a cascade cancellation.
+public sealed record EngagementCancelledByOrganizerDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId,
+	string? Reason)
+	: DomainEvent;

--- a/backend/src/Domain/Engagements/EngagementCreatedDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementCreatedDomainEvent.cs
@@ -1,0 +1,11 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+public sealed record EngagementCreatedDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId)
+	: DomainEvent;

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -1,12 +1,9 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements.CancelEngagement.v1;
 using AwesomeAssertions;
 using Domain.Common;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
@@ -20,17 +17,9 @@ public class CancelEngagementCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
-	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
-		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
-	private readonly IAggregateRepository<User, UserId> _userRepo =
-		Substitute.For<IAggregateRepository<User, UserId>>();
-	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
-	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
 	private readonly CancelEngagementCommandHandler _sut;
 
 	private static readonly UserId DefaultRequestingUserId = UserId.New();
@@ -40,24 +29,14 @@ public class CancelEngagementCommandHandlerTests
 	public CancelEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
-		_dbContext.Notifications.Returns(_notifRepo);
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
-		_dbContext.Users.Returns(_userRepo);
 		_opportunityRepo
 			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(CreateDefaultOpportunity());
-		_keycloakUserService
-			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_sut = new CancelEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder);
+		_sut = new CancelEngagementCommandHandler(_dbContext);
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
@@ -168,147 +147,31 @@ public class CancelEngagementCommandHandlerTests
 		result.Should().BeSameAs(engagement);
 	}
 
+	// --- Notification/email dispatch moved to EngagementCancelledByOrganizerNotificationHandler (#1382) ---
+
 	[Test]
-	public async Task Handle_ShouldNotifyAndEmailVolunteer_WhenEngagementCancelled(
+	public async Task Handle_ShouldRaiseEngagementCancelledByOrganizerDomainEvent(
 		CancellationToken cancellationToken)
 	{
-		// Arrange
+		// Arrange - the Keycloak lookup, in-app notification, and cancellation
+		// email that used to run inline (inside the open DB transaction) now
+		// happen in EngagementCancelledByOrganizerNotificationHandler,
+		// dispatched post-commit via the outbox once this event lands on the
+		// aggregate. It must be the *ByOrganizer* event specifically (not just
+		// the plain EngagementCancelledDomainEvent shared with cascade
+		// cancellations), or the async consumer would double-notify cascades.
 		var engagementId = EngagementId.New();
 		var engagement = CreatePendingScheduledSlotsEngagement();
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		_keycloakUserService
-			.GetUserAsync(engagement.VolunteerId!.Value.Value, Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(engagement.VolunteerId!.Value.Value, "vera", "Vera", null, "vera@example.com"));
-
-		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId, "No longer needed."), cancellationToken);
-
-		// Assert
-		await _notifRepo.Received(1).AddAsync(
-			Arg.Is<Notification>(n => n!.RecipientId == engagement.VolunteerId!.Value
-				&& n.Kind == NotificationKind.EngagementCancelled
-				&& n.RelatedEntityId == engagement.Id.Value),
-			cancellationToken);
-		await _emailService.Received(1).SendAsync(
-			"vera@example.com",
-			"Test Subject",
-			Arg.Is<string>(body => body!.StartsWith("Test Body")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldRenderCancellationEmail_InVolunteersPreferredLanguage(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		var volunteer = User.Create(volunteerId);
-		volunteer.SetPreferredLanguage("en");
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([volunteer]);
-
-		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementCancelled,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	// --- Volunteer email notification preferences (#1055) ---
-
-	[Test]
-	public async Task Handle_ShouldEmailVolunteer_WhenSubscribedToEngagementCancelled(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
-			.Returns("https://example.com/unsubscribe");
-
-		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		await _emailService.Received(1).SendAsync(
-			"user@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldRenderReasonSuffix_WhenReasonIsGiven(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
+		engagement.ClearEvents();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
 
 		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId, "Not enough sign-ups"), cancellationToken);
+		var result = await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId, "No longer needed."), cancellationToken);
 
 		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementCancelledReasonSuffix,
-			Arg.Any<string>(),
-			Arg.Is<IReadOnlyDictionary<string, string>>(p => p!["Reason"] == "Not enough sign-ups"));
-	}
-
-	[Test]
-	public async Task Handle_ShouldNotRenderReasonSuffix_WhenNoReasonIsGiven(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-
-		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.DidNotReceive().Render(
-			EmailTemplateKind.EngagementCancelledReasonSuffix,
-			Arg.Any<string>(),
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	[Test]
-	public async Task Handle_ShouldNotEmailVolunteer_WhenOptedOutOfEngagementCancelled(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		var optedOutVolunteer = User.Create(volunteerId);
-		optedOutVolunteer.UpdateNotificationPreferences(
-			notifyOnNewSignUp: true,
-			notifyOnWithdrawal: true,
-			notifyOnEngagementConfirmed: true,
-			notifyOnEngagementCancelled: false,
-			notifyOnEngagementReminder: true);
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([optedOutVolunteer]);
-
-		// Act
-		await _sut.Handle(new CancelEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		result.Events.Should().ContainSingle(e => e is EngagementCancelledByOrganizerDomainEvent
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).VolunteerId == engagement.VolunteerId!.Value
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).OpportunityId == engagement.OpportunityId
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).Reason == "No longer needed.");
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledByOrganizerNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledByOrganizerNotificationHandlerTests.cs
@@ -1,0 +1,233 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.CancelEngagement.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.CancelEngagement;
+
+public class EngagementCancelledByOrganizerNotificationHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly EngagementCancelledByOrganizerNotificationHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
+
+	public EngagementCancelledByOrganizerNotificationHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new EngagementCancelledByOrganizerNotificationHandler(
+			_dbContext, _unitOfWork, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<EngagementCancelledByOrganizerNotificationHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldNotifyAndEmailVolunteer_WhenEngagementCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = EngagementId.New();
+		var volunteerId = UserId.New();
+		_keycloakUserService
+			.GetUserAsync(volunteerId.Value, Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(volunteerId.Value, "vera", "Vera", null, "vera@example.com"));
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			engagementId, volunteerId, VolunteerOpportunityId.New(), "No longer needed.");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == volunteerId
+				&& n.Kind == NotificationKind.EngagementCancelled
+				&& n.RelatedEntityId == engagementId.Value),
+			cancellationToken);
+		await _emailService.Received(1).SendAsync(
+			"vera@example.com",
+			"Test Subject",
+			Arg.Is<string>(body => body!.StartsWith("Test Body")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderCancellationEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var volunteer = User.Create(volunteerId);
+		volunteer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([volunteer]);
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), volunteerId, VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementCancelled,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	// --- Volunteer email notification preferences (#1055) ---
+
+	[Test]
+	public async Task Handle_ShouldEmailVolunteer_WhenSubscribedToEngagementCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
+			.Returns("https://example.com/unsubscribe");
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), volunteerId, VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"user@example.com",
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderReasonSuffix_WhenReasonIsGiven(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), "Not enough sign-ups");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementCancelledReasonSuffix,
+			Arg.Any<string>(),
+			Arg.Is<IReadOnlyDictionary<string, string>>(p => p!["Reason"] == "Not enough sign-ups"));
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotRenderReasonSuffix_WhenNoReasonIsGiven(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.DidNotReceive().Render(
+			EmailTemplateKind.EngagementCancelledReasonSuffix,
+			Arg.Any<string>(),
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEmailVolunteer_WhenOptedOutOfEngagementCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var optedOutVolunteer = User.Create(volunteerId);
+		optedOutVolunteer.UpdateNotificationPreferences(
+			notifyOnNewSignUp: true,
+			notifyOnWithdrawal: true,
+			notifyOnEngagementConfirmed: true,
+			notifyOnEngagementCancelled: false,
+			notifyOnEngagementReminder: true);
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([optedOutVolunteer]);
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), volunteerId, VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), UserId.New(), opportunityId, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the notification
+		// write unless this handler saves it itself.
+		var domainEvent = new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -1,8 +1,6 @@
 using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Authorization;
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements.ConfirmEngagement.v1;
@@ -23,20 +21,12 @@ public class ConfirmEngagementCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
-	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
-		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IAggregateRepository<UserStreak, UserStreakId> _streakRepo =
 		Substitute.For<IAggregateRepository<UserStreak, UserStreakId>>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
-	private readonly IAggregateRepository<User, UserId> _userRepo =
-		Substitute.For<IAggregateRepository<User, UserId>>();
-	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly ISender _sender = Substitute.For<ISender>();
-	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
 	private readonly ConfirmEngagementCommandHandler _sut;
 
 	private static readonly UserId DefaultRequestingUserId = UserId.New();
@@ -46,25 +36,15 @@ public class ConfirmEngagementCommandHandlerTests
 	public ConfirmEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
-		_dbContext.Notifications.Returns(_notifRepo);
 		_dbContext.UserStreaks.Returns(_streakRepo);
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
-		_dbContext.Users.Returns(_userRepo);
 		_opportunityRepo
 			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(CreateDefaultOpportunity());
-		_keycloakUserService
-			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_sut = new ConfirmEngagementCommandHandler(_dbContext, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder, _sender);
+		_sut = new ConfirmEngagementCommandHandler(_dbContext, _sender);
 	}
 
 	[Test]
@@ -317,83 +297,30 @@ public class ConfirmEngagementCommandHandlerTests
 			Arg.Any<CancellationToken>());
 	}
 
-	[Test]
-	public async Task Handle_ShouldRenderConfirmationEmail_InVolunteersPreferredLanguage(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(
-			VolunteerOpportunityId.New(),
-			volunteerId,
-			TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		var volunteer = User.Create(volunteerId);
-		volunteer.SetPreferredLanguage("en");
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([volunteer]);
-
-		// Act
-		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementConfirmed,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	// --- Volunteer email notification preferences (#1055) ---
+	// --- Notification/email dispatch moved to EngagementConfirmedNotificationHandler (#1382) ---
 
 	[Test]
-	public async Task Handle_ShouldEmailVolunteer_WhenSubscribedToEngagementConfirmed(
+	public async Task Handle_ShouldRaiseEngagementConfirmedDomainEvent(
 		CancellationToken cancellationToken)
 	{
-		// Arrange
+		// Arrange - the Keycloak lookup, in-app notification, and confirmation
+		// email that used to run inline (inside the open DB transaction) now
+		// happen in EngagementConfirmedNotificationHandler, dispatched
+		// post-commit via the outbox once this event lands on the aggregate.
 		var engagementId = EngagementId.New();
 		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
+		var opportunityId = VolunteerOpportunityId.New();
+		var engagement = Engagement.CreateSlotSignUp(opportunityId, volunteerId, TimeSlotId.New());
+		engagement.ClearEvents();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
-			.Returns("https://example.com/unsubscribe");
 
 		// Act
-		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+		var result = await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		// Assert
-		await _emailService.Received(1).SendAsync(
-			"user@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldNotEmailVolunteer_WhenOptedOutOfEngagementConfirmed(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagementId = EngagementId.New();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		var optedOutVolunteer = User.Create(volunteerId);
-		optedOutVolunteer.UpdateNotificationPreferences(
-			notifyOnNewSignUp: true,
-			notifyOnWithdrawal: true,
-			notifyOnEngagementConfirmed: false,
-			notifyOnEngagementCancelled: true,
-			notifyOnEngagementReminder: true);
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([optedOutVolunteer]);
-
-		// Act
-		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
-
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		result.Events.Should().ContainSingle(e => e is EngagementConfirmedDomainEvent
+			&& ((EngagementConfirmedDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementConfirmedDomainEvent)e).OpportunityId == opportunityId);
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
@@ -1,0 +1,183 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.ConfirmEngagement.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.ConfirmEngagement;
+
+public class EngagementConfirmedNotificationHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly EngagementConfirmedNotificationHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
+
+	public EngagementConfirmedNotificationHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "user", null, null, "user@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new EngagementConfirmedNotificationHandler(
+			_dbContext, _unitOfWork, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<EngagementConfirmedNotificationHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForVolunteer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = EngagementId.New();
+		var volunteerId = UserId.New();
+		var domainEvent = new EngagementConfirmedDomainEvent(engagementId, volunteerId, VolunteerOpportunityId.New());
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == volunteerId
+				&& n.Kind == NotificationKind.EngagementConfirmed
+				&& n.RelatedEntityId == engagementId.Value),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderConfirmationEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var volunteer = User.Create(volunteerId);
+		volunteer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([volunteer]);
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), volunteerId, VolunteerOpportunityId.New());
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementConfirmed,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	// --- Volunteer email notification preferences (#1055) ---
+
+	[Test]
+	public async Task Handle_ShouldEmailVolunteer_WhenSubscribedToEngagementConfirmed(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
+			.Returns("https://example.com/unsubscribe");
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), volunteerId, VolunteerOpportunityId.New());
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"user@example.com",
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEmailVolunteer_WhenOptedOutOfEngagementConfirmed(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var optedOutVolunteer = User.Create(volunteerId);
+		optedOutVolunteer.UpdateNotificationPreferences(
+			notifyOnNewSignUp: true,
+			notifyOnWithdrawal: true,
+			notifyOnEngagementConfirmed: false,
+			notifyOnEngagementCancelled: true,
+			notifyOnEngagementReminder: true);
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([optedOutVolunteer]);
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), volunteerId, VolunteerOpportunityId.New());
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), opportunityId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the notification
+		// write unless this handler saves it itself.
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -1,6 +1,4 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements.CreateEngagement.v1;
 using AwesomeAssertions;
@@ -18,12 +16,6 @@ namespace Application.UnitTests.Engagements.CreateEngagement;
 public class CreateEngagementCommandHandlerTests
 {
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
-	private readonly IKeycloakOrganizationService _keycloakService =
-		Substitute.For<IKeycloakOrganizationService>();
-	private readonly IKeycloakUserService _keycloakUserService =
-		Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
@@ -33,7 +25,6 @@ public class CreateEngagementCommandHandlerTests
 	private readonly IAggregateRepository<User, UserId> _userRepo =
 		Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
-	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
 	private readonly CreateEngagementCommandHandler _sut;
 
 	private static readonly Address TestAddress = Address.Create("Main St", "1", "12345", "Berlin").Value;
@@ -57,21 +48,11 @@ public class CreateEngagementCommandHandlerTests
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
 		_dbContext.Users.Returns(_userRepo);
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([]);
-		_keycloakUserService
-			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
 		_dbContext.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
 			.Returns(0);
 		_dbContext.GetTerminalEngagementAsync(Arg.Any<UserId>(), Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns((Engagement?)null);
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_sut = new CreateEngagementCommandHandler(_dbContext, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder);
+		_sut = new CreateEngagementCommandHandler(_dbContext);
 	}
 
 	private void SetupOpportunityExists(VolunteerOpportunityId opportunityId)
@@ -356,108 +337,49 @@ public class CreateEngagementCommandHandlerTests
 		await _engagementRepo.Received(1).AddAsync(Arg.Any<Engagement>(), cancellationToken);
 	}
 
-	// --- Localized emails (#1052) ---
+	// --- Notification/email dispatch moved to EngagementSignUpNotificationHandler (#1382) ---
 
 	[Test]
-	public async Task Handle_ShouldRenderVolunteerEmail_InVolunteersPreferredLanguage(
+	public async Task Handle_ShouldRaiseEngagementCreatedDomainEvent_WhenCreatingNewEngagement(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the Keycloak lookups, in-app notifications, and emails that
+		// used to run inline (inside the open DB transaction) now happen in
+		// EngagementSignUpNotificationHandler, dispatched post-commit via the
+		// outbox once this event lands on the aggregate.
+		var opportunityId = VolunteerOpportunityId.New();
+		var volunteerId = UserId.New();
+		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Events.Should().ContainSingle(e => e is EngagementCreatedDomainEvent
+			&& ((EngagementCreatedDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementCreatedDomainEvent)e).OpportunityId == opportunityId);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRaiseEngagementReactivatedDomainEvent_WhenReusingATerminalEngagement(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var opportunityId = VolunteerOpportunityId.New();
 		var volunteerId = UserId.New();
-		SetupOpportunityExists(opportunityId);
-		var volunteer = User.Create(volunteerId);
-		volunteer.SetPreferredLanguage("en");
-		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns(volunteer);
-		var command = new CreateEngagementCommand(opportunityId, volunteerId, TimeSlotId: null, "Hi!");
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementRequestReceived,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	[Test]
-	public async Task Handle_ShouldDefaultVolunteerEmailToGerman_WhenNoProfileExistsYet(
-		CancellationToken cancellationToken)
-	{
-		// Arrange - a volunteer who signs up without ever having loaded their
-		// profile page has no User row yet, so PreferredLanguage can't have
-		// been seeded; the recipient's language must still resolve, never NRE.
-		var opportunityId = VolunteerOpportunityId.New();
-		var volunteerId = UserId.New();
-		SetupOpportunityExists(opportunityId);
-		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns((User?)null);
-		var command = new CreateEngagementCommand(opportunityId, volunteerId, TimeSlotId: null, "Hi!");
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementRequestReceived,
-			"de",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	// --- Organizer email notification preferences (#1055) ---
-
-	[Test]
-	public async Task Handle_ShouldEmailOrganizer_WhenSubscribedToNewSignUp(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunityId = VolunteerOpportunityId.New();
 		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
-		var organizerId = Guid.NewGuid();
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
-		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
-			.Returns("https://example.com/unsubscribe");
-		var command = new CreateEngagementCommand(opportunityId, UserId.New(), timeSlotId, Message: null);
+		var terminalEngagement = Engagement.CreateSlotSignUp(opportunityId, volunteerId, timeSlotId);
+		terminalEngagement.Withdraw();
+		terminalEngagement.ClearEvents();
+		_dbContext.GetTerminalEngagementAsync(volunteerId, opportunityId, timeSlotId, Arg.Any<CancellationToken>())
+			.Returns(terminalEngagement);
+		var command = new CreateEngagementCommand(opportunityId, volunteerId, timeSlotId, Message: null);
 
 		// Act
-		await _sut.Handle(command, cancellationToken);
+		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
-		await _emailService.Received(1).SendAsync(
-			"olaf@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldNotEmailOrganizer_WhenOptedOutOfNewSignUp(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunityId = VolunteerOpportunityId.New();
-		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
-		var organizerId = Guid.NewGuid();
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
-		var organizerUserId = UserId.Create(organizerId).GetValueOrThrow();
-		var optedOutOrganizer = User.Create(organizerUserId);
-		optedOutOrganizer.UpdateNotificationPreferences(
-			notifyOnNewSignUp: false,
-			notifyOnWithdrawal: true,
-			notifyOnEngagementConfirmed: true,
-			notifyOnEngagementCancelled: true,
-			notifyOnEngagementReminder: true);
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([optedOutOrganizer]);
-		var command = new CreateEngagementCommand(opportunityId, UserId.New(), timeSlotId, Message: null);
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		result.Events.Should().ContainSingle(e => e is EngagementReactivatedDomainEvent);
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementSignUpNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementSignUpNotificationHandlerTests.cs
@@ -1,0 +1,327 @@
+using Application.Common.Email;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.CreateEngagement.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.CreateEngagement;
+
+public class EngagementSignUpNotificationHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
+		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly EngagementSignUpNotificationHandler _sut;
+
+	private static readonly Address TestAddress = Address.Create("Main St", "1", "12345", "Berlin").Value;
+
+	public EngagementSignUpNotificationHandlerTests()
+	{
+		_dbContext.Engagements.Returns(_engagementRepo);
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new EngagementSignUpNotificationHandler(
+			_dbContext, _unitOfWork, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<EngagementSignUpNotificationHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateTestOpportunity(VolunteerOpportunityId id) =>
+		VolunteerOpportunity.Create(
+			OrganizationId.New(),
+			"Test Opportunity",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			_pinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+	private (VolunteerOpportunity opportunity, Engagement engagement) SetupSlotSignUp(UserId volunteerId)
+	{
+		var opportunity = CreateTestOpportunity(VolunteerOpportunityId.New());
+		var timeSlot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 10, DateTimeOffset.UtcNow).Value;
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, timeSlot.Id);
+		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
+		_engagementRepo.FindAsync(engagement.Id, Arg.Any<CancellationToken>()).Returns(engagement);
+		return (opportunity, engagement);
+	}
+
+	private (VolunteerOpportunity opportunity, Engagement engagement) SetupIndividualContact(UserId volunteerId)
+	{
+		var opportunity = CreateTestOpportunity(VolunteerOpportunityId.New());
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, volunteerId, "Hi!").GetValueOrThrow();
+		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
+		_engagementRepo.FindAsync(engagement.Id, Arg.Any<CancellationToken>()).Returns(engagement);
+		return (opportunity, engagement);
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunityId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenEngagementNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateTestOpportunity(VolunteerOpportunityId.New());
+		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, Arg.Any<CancellationToken>()).Returns((Engagement?)null);
+		var domainEvent = new EngagementCreatedDomainEvent(engagementId, UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderRequestReceivedTemplate_ForIndividualContact(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupIndividualContact(volunteerId);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementRequestReceived,
+			Arg.Any<string>(),
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderWaitlistedTemplate_ForSlotSignUp(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupSlotSignUp(volunteerId);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementWaitlisted,
+			Arg.Any<string>(),
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderVolunteerEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupIndividualContact(volunteerId);
+		var volunteer = User.Create(volunteerId);
+		volunteer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Is<IReadOnlyCollection<UserId>>(ids => ids!.Contains(volunteerId)), Arg.Any<CancellationToken>())
+			.Returns([volunteer]);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementRequestReceived,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDefaultVolunteerEmailToGerman_WhenNoProfileExistsYet(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a volunteer who signs up without ever having loaded their
+		// profile page has no User row yet, so PreferredLanguage can't have
+		// been seeded; the recipient's language must still resolve, never NRE.
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupIndividualContact(volunteerId);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementRequestReceived,
+			"de",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	// --- Organizer email notification preferences (#1055) ---
+
+	[Test]
+	public async Task Handle_ShouldEmailOrganizer_WhenSubscribedToNewSignUp(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupSlotSignUp(volunteerId);
+		var organizerId = Guid.NewGuid();
+		_keycloakService.GetMembersAsync(opportunity.OrganizationId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
+		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
+			.Returns("https://example.com/unsubscribe");
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"olaf@example.com",
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEmailOrganizer_WhenOptedOutOfNewSignUp(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupSlotSignUp(volunteerId);
+		var organizerId = Guid.NewGuid();
+		_keycloakService.GetMembersAsync(opportunity.OrganizationId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
+		var organizerUserId = UserId.Create(organizerId).GetValueOrThrow();
+		var optedOutOrganizer = User.Create(organizerUserId);
+		optedOutOrganizer.UpdateNotificationPreferences(
+			notifyOnNewSignUp: false,
+			notifyOnWithdrawal: true,
+			notifyOnEngagementConfirmed: true,
+			notifyOnEngagementCancelled: true,
+			notifyOnEngagementReminder: true);
+		_dbContext.GetOrCreateUsersAsync(Arg.Is<IReadOnlyCollection<UserId>>(ids => ids!.Contains(organizerUserId)), Arg.Any<CancellationToken>())
+			.Returns([optedOutOrganizer]);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(
+			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForEachOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupSlotSignUp(volunteerId);
+		var organizerId = Guid.NewGuid();
+		var organizerUserId = UserId.Create(organizerId).GetValueOrThrow();
+		_keycloakService.GetMembersAsync(opportunity.OrganizationId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == organizerUserId
+				&& n.Kind == NotificationKind.EngagementCreated
+				&& n.RelatedEntityId == engagement.Id.Value),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the notification
+		// writes unless this handler saves them itself.
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupIndividualContact(volunteerId);
+		var domainEvent = new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotifyVolunteer_WhenReactivatedEventReceived(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - EngagementReactivatedDomainEvent goes through the same
+		// notification path as EngagementCreatedDomainEvent.
+		var volunteerId = UserId.New();
+		var (opportunity, engagement) = SetupIndividualContact(volunteerId);
+		var domainEvent = new EngagementReactivatedDomainEvent(engagement.Id, volunteerId, opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"volunteer@example.com", Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
@@ -86,6 +86,37 @@ public class EngagementTests
 		result.IsFailure.Should().BeTrue();
 	}
 
+	// --- Domain events (einsatzbereit#1382) ---
+	// Notification/email side effects moved off the command handlers'
+	// open DB transaction into async, outbox-dispatched consumers of these
+	// events - see Application/Engagements/*/v1/Engagement*NotificationHandler.
+
+	[Test]
+	public void CreateSlotSignUp_ShouldRaiseEngagementCreatedDomainEvent()
+	{
+		var volunteerId = AnyUserId();
+		var opportunityId = AnyOpportunityId();
+
+		var engagement = Engagement.CreateSlotSignUp(opportunityId, volunteerId, AnyTimeSlotId());
+
+		engagement.Events.Should().ContainSingle(e => e is EngagementCreatedDomainEvent
+			&& ((EngagementCreatedDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementCreatedDomainEvent)e).OpportunityId == opportunityId);
+	}
+
+	[Test]
+	public void CreateIndividualContact_ShouldRaiseEngagementCreatedDomainEvent()
+	{
+		var volunteerId = AnyUserId();
+		var opportunityId = AnyOpportunityId();
+
+		var result = Engagement.CreateIndividualContact(opportunityId, volunteerId, "Ich bin verfügbar.");
+
+		result.Value.Events.Should().ContainSingle(e => e is EngagementCreatedDomainEvent
+			&& ((EngagementCreatedDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementCreatedDomainEvent)e).OpportunityId == opportunityId);
+	}
+
 	// --- Confirm ---
 
 	[Test]
@@ -179,6 +210,36 @@ public class EngagementTests
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Match("*already terminated*");
+	}
+
+	[Test]
+	public void Cancel_ShouldNotRaiseEngagementCancelledByOrganizerDomainEvent_ByDefault()
+	{
+		// A cascade cancellation (opportunity/time-slot deletion) already
+		// notifies the volunteer inline as part of its own async handler -
+		// raising this event too would double-send the notification.
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.ClearEvents();
+
+		engagement.Cancel("reason");
+
+		engagement.Events.Should().NotContain(e => e is EngagementCancelledByOrganizerDomainEvent);
+	}
+
+	[Test]
+	public void Cancel_ShouldRaiseEngagementCancelledByOrganizerDomainEvent_WhenNotifyVolunteerIsTrue()
+	{
+		var volunteerId = AnyUserId();
+		var opportunityId = AnyOpportunityId();
+		var engagement = Engagement.CreateSlotSignUp(opportunityId, volunteerId, AnyTimeSlotId());
+		engagement.ClearEvents();
+
+		engagement.Cancel("reason", notifyVolunteer: true);
+
+		engagement.Events.Should().ContainSingle(e => e is EngagementCancelledByOrganizerDomainEvent
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).OpportunityId == opportunityId
+			&& ((EngagementCancelledByOrganizerDomainEvent)e).Reason == "reason");
 	}
 
 	// --- Withdraw ---

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnNotificationHandlerTests.cs
@@ -1,0 +1,198 @@
+using Application.Common.Email;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.WithdrawEngagement.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.WithdrawEngagement;
+
+public class EngagementWithdrawnNotificationHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly EngagementWithdrawnNotificationHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
+
+	public EngagementWithdrawnNotificationHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_keycloakUserService
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_sut = new EngagementWithdrawnNotificationHandler(
+			_dbContext, _unitOfWork, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder,
+			NullLogger<EngagementWithdrawnNotificationHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateOpportunityForOrganizerNotification(out Guid organizerUserId)
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			OrganizationId.New(), "Test", "Test", false, DefaultAddress,
+			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None,
+			_pinGenerator, status: OpportunityStatus.Draft).Value;
+		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
+
+		organizerUserId = Guid.NewGuid();
+		_keycloakService.GetMembersAsync(opportunity.OrganizationId.Value, Arg.Any<CancellationToken>())
+			.Returns([new KeycloakOrganizationMember(organizerUserId, "organizer", "Org", "Anizer", "organizer@example.com", true)]);
+		return opportunity;
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new EngagementWithdrawnDomainEvent(EngagementId.New(), UserId.New(), opportunityId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _emailService.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderOrganizerEmail_InOrganizersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityForOrganizerNotification(out var organizerUserId);
+		var organizerId = UserId.Create(organizerUserId).GetValueOrThrow();
+		var organizer = User.Create(organizerId);
+		organizer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([organizer]);
+		var domainEvent = new EngagementWithdrawnDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert - the organizer's own language, not the withdrawing volunteer's,
+		// governs this email since the organizer is the recipient.
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementWithdrawnNotifyOrganizer,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForEachOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityForOrganizerNotification(out var organizerUserId);
+		var organizerId = UserId.Create(organizerUserId).GetValueOrThrow();
+		var engagementId = EngagementId.New();
+		var domainEvent = new EngagementWithdrawnDomainEvent(engagementId, UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == organizerId
+				&& n.Kind == NotificationKind.EngagementWithdrawn
+				&& n.RelatedEntityId == engagementId.Value),
+			cancellationToken);
+	}
+
+	// --- Organizer email notification preferences (#1055) ---
+
+	[Test]
+	public async Task Handle_ShouldEmailOrganizer_WhenSubscribedToWithdrawal(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityForOrganizerNotification(out _);
+		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
+			.Returns("https://example.com/unsubscribe");
+		var domainEvent = new EngagementWithdrawnDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"organizer@example.com",
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEmailOrganizer_WhenOptedOutOfWithdrawal(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunity = CreateOpportunityForOrganizerNotification(out var organizerUserId);
+		var optedOutOrganizer = User.Create(UserId.Create(organizerUserId).GetValueOrThrow());
+		optedOutOrganizer.UpdateNotificationPreferences(
+			notifyOnNewSignUp: true,
+			notifyOnWithdrawal: false,
+			notifyOnEngagementConfirmed: true,
+			notifyOnEngagementCancelled: true,
+			notifyOnEngagementReminder: true);
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([optedOutOrganizer]);
+		var domainEvent = new EngagementWithdrawnDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendAsync(
+			"organizer@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - regression: Publisher.Publish() resolves this handler from
+		// its own child scope (a different IApplicationDbContext instance than
+		// OutboxProcessorJob's), so nothing else persists the notification
+		// writes unless this handler saves them itself.
+		var opportunity = CreateOpportunityForOrganizerNotification(out _);
+		var domainEvent = new EngagementWithdrawnDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
@@ -1,13 +1,8 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements.WithdrawEngagement.v1;
 using AwesomeAssertions;
-using Domain.Common;
 using Domain.Engagements;
-using Domain.Notifications;
-using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
@@ -18,55 +13,14 @@ namespace Application.UnitTests.Engagements.WithdrawEngagement;
 public class WithdrawEngagementCommandHandlerTests
 {
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
-	private readonly IKeycloakOrganizationService _keycloakService =
-		Substitute.For<IKeycloakOrganizationService>();
-	private readonly IKeycloakUserService _keycloakUserService =
-		Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
-	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
-		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
-	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
-		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
-	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
-	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly WithdrawEngagementCommandHandler _sut;
-
-	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
-	private static readonly Address TestAddress = Address.Create("Main St", "1", "12345", "Berlin").Value;
 
 	public WithdrawEngagementCommandHandlerTests()
 	{
 		_dbContext.Engagements.Returns(_engagementRepo);
-		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
-		_dbContext.Notifications.Returns(_notifRepo);
-		_keycloakUserService
-			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([]);
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_sut = new WithdrawEngagementCommandHandler(_dbContext, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder);
-	}
-
-	private VolunteerOpportunity CreateOpportunityForOrganizerNotification(VolunteerOpportunityId opportunityId, out Guid organizerUserId)
-	{
-		var opportunity = VolunteerOpportunity.Create(
-			OrganizationId.New(), "Test", "Test", false, DefaultAddress,
-			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None,
-			_pinGenerator, status: OpportunityStatus.Draft).Value;
-		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns(opportunity);
-
-		organizerUserId = Guid.NewGuid();
-		_keycloakService.GetMembersAsync(opportunity.OrganizationId.Value, Arg.Any<CancellationToken>())
-			.Returns([new KeycloakOrganizationMember(organizerUserId, "organizer", "Org", "Anizer", "organizer@example.com", true)]);
-		return opportunity;
+		_sut = new WithdrawEngagementCommandHandler(_dbContext);
 	}
 
 	private static (Engagement engagement, UserId volunteerId) CreatePendingEngagementWithVolunteer()
@@ -78,12 +32,6 @@ public class WithdrawEngagementCommandHandlerTests
 			TimeSlotId.New());
 		return (engagement, volunteerId);
 	}
-
-	private VolunteerOpportunity CreateOpportunity() =>
-		VolunteerOpportunity.Create(
-			OrganizationId.New(), "Test Opportunity", "Description", false, TestAddress,
-			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
-			status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldWithdrawEngagement_WhenCalledByOwner(
@@ -218,97 +166,29 @@ public class WithdrawEngagementCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*checked-in*");
 	}
 
+	// --- Notification/email dispatch moved to EngagementWithdrawnNotificationHandler (#1382) ---
+
 	[Test]
-	public async Task Handle_ShouldRenderOrganizerEmail_InOrganizersPreferredLanguage(
+	public async Task Handle_ShouldRaiseEngagementWithdrawnDomainEvent(
 		CancellationToken cancellationToken)
 	{
-		// Arrange
+		// Arrange - the Keycloak lookups, in-app notifications, and organizer
+		// emails that used to run inline (inside the open DB transaction) now
+		// happen in EngagementWithdrawnNotificationHandler, dispatched
+		// post-commit via the outbox once this event lands on the aggregate.
 		var (engagement, volunteerId) = CreatePendingEngagementWithVolunteer();
+		engagement.ClearEvents();
 		var engagementId = EngagementId.New();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		var opportunity = CreateOpportunityForOrganizerNotification(engagement.OpportunityId, out var organizerUserId);
-		var organizerId = UserId.Create(organizerUserId).GetValueOrThrow();
-		var organizer = User.Create(organizerId);
-		organizer.SetPreferredLanguage("en");
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([organizer]);
 
 		var command = new WithdrawEngagementCommand(engagementId, volunteerId.Value);
 
 		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert - the organizer's own language, not the withdrawing volunteer's,
-		// governs this email since the organizer is the recipient.
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementWithdrawnNotifyOrganizer,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	// --- Organizer email notification preferences (#1055) ---
-
-	[Test]
-	public async Task Handle_ShouldEmailOrganizer_WhenSubscribedToWithdrawal(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunity = CreateOpportunity();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, TimeSlotId.New());
-		var engagementId = EngagementId.New();
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
-		var organizerId = Guid.NewGuid();
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
-		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
-			.Returns("https://example.com/unsubscribe");
-
-		var command = new WithdrawEngagementCommand(engagementId, volunteerId.Value);
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
+		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
-		await _emailService.Received(1).SendAsync(
-			"olaf@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldNotEmailOrganizer_WhenOptedOutOfWithdrawal(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunity = CreateOpportunity();
-		var volunteerId = UserId.New();
-		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, TimeSlotId.New());
-		var engagementId = EngagementId.New();
-		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
-		_opportunityRepo.FindAsync(opportunity.Id, Arg.Any<CancellationToken>()).Returns(opportunity);
-		var organizerId = Guid.NewGuid();
-		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns([new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "Organizer", "olaf@example.com", true)]);
-		var optedOutOrganizer = User.Create(UserId.Create(organizerId).GetValueOrThrow());
-		optedOutOrganizer.UpdateNotificationPreferences(
-			notifyOnNewSignUp: true,
-			notifyOnWithdrawal: false,
-			notifyOnEngagementConfirmed: true,
-			notifyOnEngagementCancelled: true,
-			notifyOnEngagementReminder: true);
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([optedOutOrganizer]);
-
-		var command = new WithdrawEngagementCommand(engagementId, volunteerId.Value);
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		result.Events.Should().ContainSingle(e => e is EngagementWithdrawnDomainEvent
+			&& ((EngagementWithdrawnDomainEvent)e).VolunteerId == volunteerId
+			&& ((EngagementWithdrawnDomainEvent)e).OpportunityId == engagement.OpportunityId);
 	}
 }

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -174,18 +174,22 @@ public class IntegrationTestFixture
 	// Polls for OutboxProcessorJob (Infrastructure/BackgroundJobs/OutboxProcessorJob.cs)
 	// to have picked up and dispatched a message - proving the full write -> background
 	// dispatch -> INotificationHandler<T> round trip, not just the transactional write.
+	// minCount lets a caller that triggered several events of the same type (e.g. two
+	// sign-ups, each raising its own EngagementCreatedDomainEvent) wait for all of them
+	// to have been dispatched, not just the first - checking for any single processed
+	// row would already be true after only one of them lands.
 	public async Task<bool> WaitForOutboxMessageProcessedAsync(
-		string domainEventTypeFullName, TimeSpan timeout)
+		string domainEventTypeFullName, TimeSpan timeout, int minCount = 1)
 	{
 		var deadline = DateTime.UtcNow.Add(timeout);
 
 		while (DateTime.UtcNow < deadline)
 		{
 			await using var context = CreateApplicationDbContext();
-			var processed = await context.Set<OutboxMessage>()
-				.AnyAsync(m => m.Type == domainEventTypeFullName && m.ProcessedOnUtc != null);
+			var processedCount = await context.Set<OutboxMessage>()
+				.CountAsync(m => m.Type == domainEventTypeFullName && m.ProcessedOnUtc != null);
 
-			if (processed) return true;
+			if (processedCount >= minCount) return true;
 
 			await Task.Delay(500);
 		}

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -7,6 +7,20 @@ namespace IntegrationTests;
 [NotInParallel("IntegrationDb")]
 public class NotificationTests(IntegrationTestFixture fixture)
 {
+	// einsatzbereit#1382: engagement sign-up/confirmation notifications are no
+	// longer created inline inside the command handler's own transaction - they're
+	// raised as domain events (Domain/Engagements/EngagementCreatedDomainEvent.cs,
+	// EngagementConfirmedDomainEvent.cs) and only turned into Notification rows by
+	// EngagementSignUpNotificationHandler/EngagementConfirmedNotificationHandler
+	// once OutboxProcessorJob dispatches them post-commit (see OutboxTests.cs for
+	// the same pattern against EngagementCheckedInDomainEvent). Tests that assert
+	// on a resulting notification must wait for that dispatch instead of racing it.
+	private const string EngagementCreatedDomainEventType = "Domain.Engagements.EngagementCreatedDomainEvent";
+	private const string EngagementConfirmedDomainEventType = "Domain.Engagements.EngagementConfirmedDomainEvent";
+	private const string EngagementCancelledByOrganizerDomainEventType = "Domain.Engagements.EngagementCancelledByOrganizerDomainEvent";
+	private const string EngagementWithdrawnDomainEventType = "Domain.Engagements.EngagementWithdrawnDomainEvent";
+	private static readonly TimeSpan OutboxDispatchTimeout = TimeSpan.FromSeconds(45);
+
 	[Before(Test)]
 	public Task ResetAsync() => fixture.ResetAsync();
 
@@ -25,6 +39,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			opportunity.Id,
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCreatedDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementSignUpNotificationHandler should have created the organizer notification by now");
 
 		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 
@@ -52,6 +70,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementConfirmedDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementConfirmedNotificationHandler should have created the volunteer notification by now");
+
 		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 
 		var notification = veraNotifications.Items.Single(n => n.Kind == "EngagementConfirmed");
@@ -77,6 +99,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 
 		await olafClient.CancelEngagementAsync(engagement.Id, cancellationToken: cancellationToken);
 
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCancelledByOrganizerDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementCancelledByOrganizerNotificationHandler should have created the volunteer notification by now");
+
 		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 
 		var notification = veraNotifications.Items.Single(n => n.Kind == "EngagementCancelled");
@@ -101,6 +127,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			cancellationToken);
 
 		await veraClient.WithdrawEngagementAsync(engagement.Id, cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementWithdrawnDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementWithdrawnNotificationHandler should have created the organizer notification by now");
 
 		// The organizer, not the withdrawing volunteer, is the recipient here.
 		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
@@ -153,6 +183,13 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		await veraClient.CreateEngagementAsync(
 			opportunityTwo.Id, new CreateEngagementRequest { Message = "Second" }, cancellationToken);
 
+		// minCount: 2 - both sign-ups raise their own EngagementCreatedDomainEvent, and
+		// the test needs both notifications, not just whichever the outbox happens to
+		// dispatch first.
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCreatedDomainEventType, OutboxDispatchTimeout, minCount: 2);
+		processed.Should().BeTrue("EngagementSignUpNotificationHandler should have created both organizer notifications by now");
+
 		var firstPage = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 		var ordered = firstPage.Items
 			.Where(n => n.Kind == "EngagementCreated")
@@ -179,6 +216,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		await veraClient.CreateEngagementAsync(
 			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
 
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCreatedDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementSignUpNotificationHandler should have created the organizer notification by now");
+
 		var countBeforeRead = await olafClient.GetUnreadNotificationCountAsync(cancellationToken);
 		countBeforeRead.Should().Be(1);
 
@@ -204,6 +245,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCreatedDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementSignUpNotificationHandler should have created the organizer notification by now");
+
 		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
 
@@ -228,6 +273,10 @@ public class NotificationTests(IntegrationTestFixture fixture)
 			opportunity.Id,
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			EngagementCreatedDomainEventType, OutboxDispatchTimeout);
+		processed.Should().BeTrue("EngagementSignUpNotificationHandler should have created the organizer notification by now");
 
 		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
 		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");

--- a/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
+++ b/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
@@ -59,6 +59,10 @@ public class OutboxMessageSerializationTests
 	{
 		yield return new EngagementCancelledDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), "Reason");
+		yield return new EngagementCancelledByOrganizerDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), "Reason");
+		yield return new EngagementCreatedDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		yield return new EngagementCheckInUndoneDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		yield return new EngagementCheckedInDomainEvent(

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -83,6 +83,14 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 			new { message = "Notify Olaf please." });
 		applyResponse.EnsureSuccessStatusCode();
 
+		// The EngagementCreated notification is now raised post-commit via the
+		// outbox (not created synchronously within the apply request above), so
+		// wait for it to actually exist server-side before opening the panel -
+		// the frontend only fetches the notification list once, when the panel
+		// opens (einsatzbereit#1384), and won't retry if it beat the outbox's
+		// dispatch.
+		await WaitForNotificationAsync(olafHttp, oppTitle);
+
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 
 		var bell = Page.GetByTestId("notification-bell");
@@ -154,6 +162,11 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 			new { message = "Notify Olaf please." });
 		applyResponse.EnsureSuccessStatusCode();
 
+		// See the identical wait in EngagementCreatedNotification_NavigatesToEngagementManagementPage
+		// above - the EngagementCreated notification is raised post-commit via the outbox now, so
+		// it must exist before the panel's one-shot fetch on open, or it never appears.
+		await WaitForNotificationAsync(olafHttp, oppTitle);
+
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 
 		await Page.RouteAsync("**/v1/notifications/*/read", async route =>
@@ -191,5 +204,33 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var errorToast = Page.GetByRole(AriaRole.Alert)
 			.Filter(new() { HasTextString = "Failed to mark notification as read." });
 		await Expect(errorToast).ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+
+	// Polls the recipient's own notification list (rather than trusting the
+	// triggering request's HTTP response alone) so tests fail loudly instead
+	// of racing the outbox - same rationale as EmailDeliveryTests'
+	// AssertMailpitReceivedMessageToAsync for the equally-async email side
+	// effect.
+	private static async Task WaitForNotificationAsync(HttpClient authenticatedClient, string relatedTitleContains)
+	{
+		var deadline = DateTime.UtcNow.AddSeconds(30);
+
+		while (DateTime.UtcNow < deadline)
+		{
+			var response = await authenticatedClient.GetAsync("/v1/notifications");
+			if (response.IsSuccessStatusCode)
+			{
+				var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+				if (body.TryGetProperty("items", out var items) &&
+					items.EnumerateArray().Any(item =>
+						item.TryGetProperty("relatedTitle", out var relatedTitle) &&
+						(relatedTitle.GetString()?.Contains(relatedTitleContains, StringComparison.Ordinal) ?? false)))
+					return;
+			}
+
+			await Task.Delay(500);
+		}
+
+		throw new TimeoutException($"No notification with relatedTitle containing '{relatedTitleContains}' appeared within 30s.");
 	}
 }


### PR DESCRIPTION
CreateEngagement/ConfirmEngagement/CancelEngagement/WithdrawEngagement handlers ran 1-3 blocking Keycloak calls plus per-recipient SMTP sends inside TransactionPipelineBehavior's open transaction, holding row locks for the duration. Handlers now only validate and mutate the Engagement, raising a domain event; new EngagementSignUpNotificationHandler, EngagementConfirmedNotificationHandler, EngagementWithdrawnNotificationHandler, and EngagementCancelledByOrganizerNotificationHandler do the Keycloak lookups, in-app notifications, and email sends post-commit via the existing outbox, matching VolunteerOpportunityCancelledDomainEventHandler's pattern.

Cancel() gained a notifyVolunteer flag so the new
EngagementCancelledByOrganizerDomainEvent only fires for a direct, organizer-triggered cancel - not for cascade cancellations (opportunity/ time-slot deletion), which already notify inline in their own async handler and would otherwise be double-notified.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1382

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
