### PR TITLE
fix: allowlist imageCrop.zoomLabel as a German loanword in i18n check

### DIFF
--- a/frontend/scripts/check-i18n-keys.js
+++ b/frontend/scripts/check-i18n-keys.js
@@ -84,6 +84,7 @@ const ALLOWED_IDENTICAL_KEYS = new Set(
 		"report.reasons.Spam",
 		"invitations.accepting",
 		"invitations.declining",
+		"imageCrop.zoomLabel",
 		"profile.preferredLanguageDe",
 		"profile.preferredLanguageEn",
 		"administration.title",


### PR DESCRIPTION
## What

Adds `imageCrop.zoomLabel` to `ALLOWED_IDENTICAL_KEYS` in `check-i18n-keys.js`.

## Why

`main`'s frontend CI (`Build Frontend` -> `lint` job -> `Check i18n key parity` step) has been failing since #1533 merged. `imageCrop.zoomLabel` is `"Zoom"` in both `en.json` and `de.json` - "Zoom" is a standard German loanword (same category as the already-allowlisted `opportunities.remote`), not a forgotten translation, so it needs to be on the allowlist rather than flagged as copy-paste drift.

This was blocking `pnpm i18n:check` for every commit touching frontend files on `main`, and would have broken the frontend build on every PR rebased onto current `main` too (the offending strings are already merged).

Closes #

## Testing

- `node scripts/check-i18n-keys.js` locally - now passes (990 keys match, no drift)

## Live verification

Not applicable - CI-check-only fix, no user-facing behavior change.

## Checklist

- [x] CI is green (verify after push)
- [ ] Documentation updated if this change affects behavior (n/a)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VNdFqLcUFchK3QqjH3zW1w)_