### PR TITLE
fix: darken Dropdown's unselected-placeholder text for WCAG AA contrast

### DIFF
--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -170,7 +170,7 @@ export default function Dropdown({
 				onKeyDown={handleKeyDown}
 				className={`flex w-full items-center justify-between gap-2 text-left disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
 			>
-				<span className={`truncate ${selected ? "" : "text-gray-400"}`}>
+				<span className={`truncate ${selected ? "" : "text-gray-500"}`}>
 					{selected ? selected.label : (placeholder ?? "")}
 				</span>
 				<svg


### PR DESCRIPTION
## What

`Dropdown.tsx`'s unselected-placeholder span uses `text-gray-400` (#9CA3AF), which is ~2.5:1 contrast against white - well under the 4.5:1 WCAG AA minimum for normal text. Changed to `text-gray-500` (#6B7280), ~4.8:1.

## Why

Discovered while rebasing unrelated PRs onto `main`: `VisualTests.AccessibilityTests.SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations` reproducibly fails axe-core's `color-contrast` check on this exact element whenever the shared `Dropdown` component is scanned with nothing selected. Since `Dropdown` is used broadly (filters, sign-up modal, etc.), any other page/test exercising an unselected dropdown would hit the same failure - this isn't specific to one PR's diff, it's a pre-existing bug in the shared component.

## Testing

- `pnpm lint` / `pnpm check` / `pnpm format:check` / `pnpm test` - all clean
- Manually computed WCAG contrast ratio for both colors against white background (2.5:1 -> 4.8:1)

## Live verification

Not applicable - a color-only accessibility tweak with no behavioral change; will be exercised by the existing `SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations` VisualTest in CI.

## Checklist

- [x] CI is green (verify after push)
- [ ] Documentation updated if this change affects behavior (n/a)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VNdFqLcUFchK3QqjH3zW1w)_