### PR TITLE
fix: extract SpinnerIcon so the near-me spinner matches the shared component

### DIFF
--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -13,31 +13,37 @@ const SIZE_CONFIG: Record<
 	lg: { icon: "h-8 w-8", text: "" },
 };
 
+export function SpinnerIcon({ className = "" }: { className?: string }) {
+	return (
+		<svg
+			className={`shrink-0 animate-spin text-brand-500 motion-reduce:animate-none ${className}`}
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<circle
+				className="opacity-25"
+				cx="12"
+				cy="12"
+				r="10"
+				stroke="currentColor"
+				strokeWidth="4"
+			/>
+			<path
+				className="opacity-75"
+				fill="currentColor"
+				d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Z"
+			/>
+		</svg>
+	);
+}
+
 export default function Spinner({ label, size = "md", className = "" }: Props) {
 	const { icon, text } = SIZE_CONFIG[size];
 
 	return (
 		<div role="status" className={`flex items-center gap-2 ${className}`}>
-			<svg
-				className={`${icon} shrink-0 animate-spin text-brand-500 motion-reduce:animate-none`}
-				viewBox="0 0 24 24"
-				fill="none"
-				aria-hidden="true"
-			>
-				<circle
-					className="opacity-25"
-					cx="12"
-					cy="12"
-					r="10"
-					stroke="currentColor"
-					strokeWidth="4"
-				/>
-				<path
-					className="opacity-75"
-					fill="currentColor"
-					d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Z"
-				/>
-			</svg>
+			<SpinnerIcon className={icon} />
 			<span className={`${text} text-gray-500`}>{label}</span>
 		</div>
 	);

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -12,6 +12,7 @@ import OpportunityResultsList from "./OpportunityResultsList";
 import { useVolunteerOpportunitiesData } from "./useVolunteerOpportunitiesData";
 import { useCitySuggestions, type CitySuggestion } from "./useCitySuggestions";
 import { resolveDateLocale } from "../../lib/format";
+import { SpinnerIcon } from "../Spinner";
 import {
 	BroomIcon,
 	CalendarIcon,
@@ -422,26 +423,7 @@ export default function VolunteerOpportunitiesList() {
 								className="mb-3 flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gray-50 py-2 text-sm text-gray-600 transition-colors hover:border-brand-300 hover:bg-brand-50 hover:text-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
 							>
 								{locationLoading ? (
-									<svg
-										className="h-4 w-4 animate-spin"
-										fill="none"
-										viewBox="0 0 24 24"
-										aria-hidden="true"
-									>
-										<circle
-											className="opacity-25"
-											cx="12"
-											cy="12"
-											r="10"
-											stroke="currentColor"
-											strokeWidth="4"
-										/>
-										<path
-											className="opacity-75"
-											fill="currentColor"
-											d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z"
-										/>
-									</svg>
+									<SpinnerIcon className="h-4 w-4" />
 								) : (
 									<PinIcon className="h-4 w-4" />
 								)}


### PR DESCRIPTION
## What

Extracted the spinner SVG markup out of `Spinner.tsx` into a new named export `SpinnerIcon`, and replaced the hand-inlined duplicate SVG in the "Near me" filter button (`VolunteerOpportunitiesList.tsx`) with `<SpinnerIcon />`.

## Why

`VolunteerOpportunitiesList.tsx` re-inlined a copy of `Spinner`'s SVG by hand for the "Near me" button, but the copy was missing `text-brand-500` and `motion-reduce:animate-none`. As a result that spinner rendered in the button's grey text color instead of brand-500 (inconsistent with every other spinner in the app), and it kept animating for users with `prefers-reduced-motion: reduce` set, while every other spinner correctly respects that preference.

Closes #1134

## Testing

- `pnpm lint` - passes
- `pnpm check` (tsc --noEmit) - passes
- `pnpm test` (Vitest) - 123/123 passing
- `pnpm format:write` - no changes needed beyond the edit itself
- No new test added: this is a pure visual/markup consistency fix with no new behavior to unit test; existing `backend/tests/VisualTests/LoadingStateTests.cs` already asserts on the shared `Spinner` component's `svg.animate-spin` contract, which is unaffected by this refactor.

## Live verification

Skipped for this change per explicit instruction (no release candidate cut). This is a low-risk, purely visual/markup consistency fix (same SVG, same classes, now deduplicated into one source of truth) verified via lint/typecheck/unit tests and a background `a11y-check` review confirming `aria-hidden`, the button's `aria-label`, and the icon swap between `SpinnerIcon`/`PinIcon` are all unaffected.

## Checklist

- [x] `/self-review` run and findings addressed (no issues found; a11y-check subagent confirmed no regressions)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal component refactor, no behavior/doc change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DC311ig6S68ZLVCqqDY5r2)_