### PR TITLE
fix: darken remaining low-contrast text-gray-400 body copy to gray-500

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -172,6 +172,7 @@ Key conventions:
 - **SVG icons**: Decorative SVGs get `aria-hidden="true"`. Meaningful standalone SVGs need a `<title>` or `aria-label`.
 - **Form labels**: Every form control must have an associated `<label htmlFor="...">` or `aria-label`.
 - **`<a href="#">`**: Never use `href="#"`. Use a `<button>` if there is no navigation target.
+- **Color contrast**: `text-gray-400` (2.6:1 on white) fails the WCAG AA 4.5:1 floor for text - reserve it for decorative icons and input placeholders only, never for body copy, labels, timestamps, or other real content. Use `text-gray-500` (4.9:1) or darker for content; an interactive control's resting label needs to clear at least the 3:1 UI-component floor too.
 
 Automated axe-core checks run in the Playwright visual tests (`backend/tests/VisualTests/AccessibilityTests.cs`) on every major page and several stateful views (edit mode, modals, widget dialogs) - grep that file for `HasNoSeriousA11yViolations` for the current, authoritative list rather than trusting a copy of it here. Tests fail on any "serious" or "critical" axe violation. A new page/route needs a matching test in that file - `a11y-check` flags a missing one.
 

--- a/frontend/src/components/ReportContentModal.tsx
+++ b/frontend/src/components/ReportContentModal.tsx
@@ -98,7 +98,7 @@ export default function ReportContentModal({
 						placeholder={t("report.detailsPlaceholder")}
 						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
 					/>
-					<p className="mt-1 text-right text-xs text-gray-400">
+					<p className="mt-1 text-right text-xs text-gray-500">
 						{details.length}/1000
 					</p>
 				</div>

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -756,7 +756,7 @@ function ReportHistoryModal({
 								<p className="mt-1 text-sm text-gray-600">{entry.details}</p>
 							)}
 							<div className="mt-2 flex items-center justify-between gap-2">
-								<p className="text-xs text-gray-400">
+								<p className="text-xs text-gray-500">
 									{formatDateTime(
 										entry.createdOn as unknown as string,
 										i18n.language,


### PR DESCRIPTION
## What

Replaces `text-gray-400` (2.6:1 contrast on white, below the 4.5:1 WCAG AA text floor) with `text-gray-500` (4.9:1, passes) on two remaining body-copy sites, and documents the contrast rule in `frontend/AGENTS.md`.

## Why

Closes #1137

The seven content sites the issue's audit originally flagged (`TagsInput.tsx` hint, `NotificationDropdown.tsx` empty-state message, `NotificationItem.tsx` timestamp, `DetailsStep.tsx` `noSlots` text, `SubmitFeedbackModal.tsx` char counter, `MiniCalendar.tsx` weekday header + Clear control) turned out to already be fixed on `main` by an earlier, broader accessibility batch (#1531) - verified each one directly in the current source rather than trusting the issue's stale line numbers/snapshot.

While confirming that, two more sites with the identical defect pattern (a real-content `<p>` using `text-gray-400`) turned up that weren't part of that batch:
- `frontend/src/components/ReportContentModal.tsx` - the report-detail character counter (`{details.length}/1000`)
- `frontend/src/pages/AdministrationPage.tsx` - the flagged-content report timestamp in `ReportHistoryModal`

Both are fixed here, and the issue's suggested `frontend/AGENTS.md` documentation step (scoping `text-gray-400` to decorative icons/placeholders only) is added so this doesn't regress.

## Testing

- `pnpm lint` - clean
- `pnpm check` (tsc --noEmit) - clean
- `pnpm test` (Vitest) - 123/123 passing
- `pnpm format:write` - no changes needed
- `/self-review` run, including the `a11y-check` subagent against both changed files - no violations found; no new page/route was added so no new `AccessibilityTests.cs` entry is needed

## Live verification

Skipped for this change per explicit task instructions (no release candidate was cut). This is a color-token-only change (two Tailwind class swaps) to already-tested, existing UI - no new page, route, or interactive behavior was introduced.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated (`frontend/AGENTS.md` contrast rule)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FvixEU1P3gbbEcCXbVNHz)_