### PR TITLE
fix: guard FilterDropdown popover against left-edge viewport overflow

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { ChevronIcon, ChipXIcon, CheckMiniIcon } from "./icons";
+
+const EDGE_MARGIN = 8;
 
 export function DropdownOption({
 	label,
@@ -92,13 +94,30 @@ export default function FilterDropdown({
 }) {
 	const active = !!displayValue;
 	const containerRef = useRef<HTMLDivElement>(null);
-	const [alignRight, setAlignRight] = useState(false);
+	const panelRef = useRef<HTMLDivElement>(null);
+	const [panelLeft, setPanelLeft] = useState(0);
 
-	useEffect(() => {
-		if (isOpen && containerRef.current) {
-			const rect = containerRef.current.getBoundingClientRect();
-			setAlignRight(rect.left + 300 > window.innerWidth - 8);
-		}
+	useLayoutEffect(() => {
+		const container = containerRef.current;
+		const panel = panelRef.current;
+		if (!isOpen || !container || !panel) return;
+
+		const containerRect = container.getBoundingClientRect();
+		const panelWidth = panel.getBoundingClientRect().width;
+
+		// Prefer aligning the panel's left edge with the trigger's left edge,
+		// flipping to the trigger's right edge only if that would overflow the
+		// viewport - then clamp so neither edge can end up off-screen.
+		const leftAligned = 0;
+		const rightAligned = containerRect.width - panelWidth;
+		const overflowsRight =
+			containerRect.left + panelWidth > window.innerWidth - EDGE_MARGIN;
+		const preferred = overflowsRight ? rightAligned : leftAligned;
+
+		const minLeft = EDGE_MARGIN - containerRect.left;
+		const maxLeft =
+			window.innerWidth - EDGE_MARGIN - panelWidth - containerRect.left;
+		setPanelLeft(Math.min(Math.max(preferred, minLeft), maxLeft));
 	}, [isOpen]);
 
 	return (
@@ -149,7 +168,9 @@ export default function FilterDropdown({
 			</div>
 			{isOpen && (
 				<div
-					className={`absolute ${alignRight ? "right-0" : "left-0"} top-full z-[200] mt-1.5 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-modal`}
+					ref={panelRef}
+					style={{ left: panelLeft }}
+					className="absolute top-full z-[200] mt-1.5 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-modal"
 				>
 					{children}
 				</div>


### PR DESCRIPTION
## What

`FilterDropdown`'s popover-alignment check only guarded the right viewport edge, using a hardcoded 300px width assumption. On narrow viewports, a chip near the left edge could still flip to right-aligned and get its own panel clipped off the left, since `overflow-x: clip` on `html` makes any left overflow unreachable (not scrollable).

## Why

Closes #1132

The fix replaces the hardcoded-width `right-0`/`left-0` className toggle with a `useLayoutEffect` that measures the panel's actual rendered width (via a new `panelRef`) and the trigger's position, then computes a clamped inline `left` pixel offset so neither edge can end up off-screen - regardless of which filter's panel is open (`w-72` location panel, `w-64` date panel, or the narrower option lists), and regardless of locale string length shifting the chip's position in the centered, wrapping filter bar.

`useLayoutEffect` (vs. the previous `useEffect`) also closes a pre-existing flash-of-wrong-position window, since it runs synchronously before paint.

## Testing

- `pnpm lint` - passed
- `pnpm check` (tsc --noEmit) - passed
- `pnpm format:write` - no changes needed
- `/self-review` run, including the `a11y-check` subagent (positioning-only change, no JSX/ARIA touched) - no findings

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). `FilterDropdown` popovers are already covered by an axe pass in `backend/tests/VisualTests/AccessibilityTests.cs` (`HomePage_DateRangeFilterOpen_HasNoSeriousA11yViolations`), which will continue to exercise the fixed positioning code path in CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - internal positioning logic only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvfjAMqbkpr8fEyUxfVHxt)_