### PR TITLE
fix: replace native select with Dropdown in QuickCheckInWidget

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -573,7 +573,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// widgetCatalog.ts), so a fresh org's dashboard scan above never
 		// renders them for real - only AddWidgetModal's static mockup preview
 		// gets scanned incidentally as part of that dialog. Add both here so
-		// their actual rendered content (the opportunity <select> + scan
+		// their actual rendered content (the opportunity dropdown + scan
 		// button, and the settings shortcut tile) gets its own axe pass.
 		var frontend = Fixture.GetEndpoint("frontend");
 		await NavigateToOrgAppDashboardAsOlafAsync(frontend);

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -5,6 +5,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import { dispatchToast } from "../../../lib/toastBus";
 import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
+import Dropdown from "../../../components/Dropdown";
 import ErrorBanner from "../../../components/ErrorBanner";
 import ModalLoadingFallback from "../../../components/ModalLoadingFallback";
 import WidgetCard from "./WidgetCard";
@@ -87,18 +88,16 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 						<label htmlFor="quick-checkin-opportunity" className="sr-only">
 							{t("orgDashboard.quickCheckInSelectOpportunity")}
 						</label>
-						<select
+						<Dropdown
 							id="quick-checkin-opportunity"
 							value={selectedId}
-							onChange={(e) => setSelectedId(e.target.value)}
-							className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
-						>
-							{opportunities.map((o) => (
-								<option key={o.id} value={o.id}>
-									{o.title || t("orgDashboard.unnamedDraft")}
-								</option>
-							))}
-						</select>
+							onChange={setSelectedId}
+							className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+							options={opportunities.map((o) => ({
+								value: o.id,
+								label: o.title || t("orgDashboard.unnamedDraft"),
+							}))}
+						/>
 					</div>
 					<Button
 						type="button"


### PR DESCRIPTION
## What

Replaces the native `<select>` in the org dashboard's Quick Check-In widget with the app's shared, accessible `Dropdown` component.

## Why

`Dropdown.tsx` is documented as an accessible replacement for a native `<select>`, styled to match the app's inputs, and is used everywhere else in the app (`ProfileOverviewPage`, `SignUpModal`, `DetailsStep`). `QuickCheckInWidget.tsx` was the one remaining native `<select>` - `rounded-lg`/`border-gray-300` sitting right next to a `Dropdown`-styled `Button` (`rounded-xl`) in the same flex row on the dashboard, the surface most likely to be shown in a demo.

Closes #1133

## Testing

- `pnpm lint` and `pnpm check` (tsc --noEmit) pass locally.
- Ran the `a11y-check` subagent against the diff: the kept `<label htmlFor="quick-checkin-opportunity">` still associates correctly (`Dropdown` places `id` on its trigger `<button role="combobox">`), and the existing `AccessibilityTests.cs` test `OrgDashboardPage_QuickCheckInAndSettingsIconWidgets_AsOlaf_HasNoSeriousA11yViolations` already runs a full axe scan on this widget's rendered DOM without hardcoding selectors for the old `<select>`/`<option>` markup, so it exercises the new `Dropdown` output automatically - no new test needed. Updated a stale in-line comment in that test referencing the old `<select>` markup.
- Could not run `dotnet build`/the backend test suite locally in this sandbox (no Docker/dotnet available in this environment) - CI's `dotnet.yml` will cover it.

## Live verification

Per this task's instructions, cutting a release candidate and live-staging verification were explicitly skipped for this change - it's a small, purely presentational widget swap with no behavior change (same `selectedId` state, same options data), covered by the existing automated axe test above.

## Checklist

- [x] `/self-review` run and findings addressed (clean - no findings)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UFGe7MvYS9N9iiGx36T15A)_