### PR TITLE
fix: reuse Footer.tsx as compact variant in org app shell

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,9 +1,26 @@
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 
-export default function Footer() {
+export default function Footer({ compact = false }: { compact?: boolean }) {
 	const { t } = useTranslation();
 	const currentYear = new Date().getFullYear();
+
+	// Logged-in app shells (e.g. OrgAppLayout) use this utility variant instead
+	// of the full marketing footer - same legal links, one implementation, so
+	// they can't drift out of sync (#1126).
+	if (compact) {
+		return (
+			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">
+				<Link to="/imprint" className="hover:text-gray-600">
+					{t("footer.imprint")}
+				</Link>
+				<span className="mx-2">&middot;</span>
+				<Link to="/privacy-policy" className="hover:text-gray-600">
+					{t("footer.privacy")}
+				</Link>
+			</footer>
+		);
+	}
 
 	return (
 		<footer className="bg-brand-800 text-brand-200">

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useRef, useState } from "react";
-import { Link, Outlet, useLocation, useParams } from "react-router";
+import { Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
@@ -21,6 +21,7 @@ import {
 	useQuickActionsList,
 } from "../contexts/QuickActionsContext";
 import Header from "../components/Header/Header";
+import Footer from "../components/Footer";
 import Spinner from "../components/Spinner";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
@@ -114,15 +115,7 @@ function OrgAppShell({
 				</Suspense>
 			</main>
 
-			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">
-				<Link to="/imprint" className="hover:text-gray-600">
-					{t("footer.imprint")}
-				</Link>
-				<span className="mx-2">&middot;</span>
-				<Link to="/privacy-policy" className="hover:text-gray-600">
-					{t("footer.privacy")}
-				</Link>
-			</footer>
+			<Footer compact />
 		</div>
 	);
 }


### PR DESCRIPTION
## What

`OrgAppLayout.tsx` hand-rolled its own inline `<footer>` with just Imprint/Privacy links instead of reusing `Footer.tsx`. `Footer.tsx` now accepts an optional `compact` prop that renders that same minimal markup, and `OrgAppLayout` renders `<Footer compact />` in its place.

## Why

Per the issue's verifier note, a logged-in org console being visually differentiated from the public marketing site (gray-50 canvas, tighter rhythm, utility footer) is an intentional product decision, not a defect - so this PR does not touch `OrgAppLayout`'s background/padding or attempt a shared `PageShell`. The one defensible defect was the second hand-rolled footer implementation duplicating `Footer.tsx`'s legal links, which is what this PR fixes: there is now a single implementation of the Imprint/Privacy links, so they can't drift out of sync between the two shells.

Closes #1126

## Testing

- `pnpm lint` - passes (zero warnings)
- `pnpm check` (tsc --noEmit) - passes
- `pnpm test` - 123 tests pass, no regressions
- `pnpm format:write` - no changes needed
- Ran the `a11y-check` subagent against the diff: confirmed this is a pure relocation of identical markup (same `<footer>` with two `<Link>`s, same translation keys) behind a `compact` prop - no a11y issues, no new page/route, so no new `VisualTests/AccessibilityTests.cs` test is needed.

No behavior or rendered markup changes - `Footer({ compact: true })` renders byte-for-byte the same JSX that used to live inline in `OrgAppLayout.tsx`.

## Live verification

Skipped for this change (explicitly out of scope per task instructions - no release candidate was cut). This is a pure component-reuse refactor with no rendered-output change, covered by the lint/type-check/unit-test/a11y verification above.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - reviewed as a pure, no-op-markup relocation)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VzEopbBJWDmLkoN6H3Zuqf)_