### PR TITLE
fix: unify the three file-upload button styles into one component

### DIFF
--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -15,6 +15,7 @@ import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
 import ImageCropModal from "./ImageCropModal";
+import FileUploadButton from "./FileUploadButton";
 
 interface Props {
 	onClose: () => void;
@@ -162,19 +163,12 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 								</span>
 							)}
 							<div>
-								<label
-									htmlFor="create-org-logo-upload"
-									className="cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-								>
-									{t("orgSettings.logoUpload")}
-								</label>
-								<input
-									ref={logoInputRef}
+								<FileUploadButton
 									id="create-org-logo-upload"
-									type="file"
+									label={t("orgSettings.logoUpload")}
 									accept="image/jpeg,image/png,image/webp"
-									className="sr-only"
 									onChange={handleLogoChange}
+									inputRef={logoInputRef}
 								/>
 								<p className="mt-1 text-xs text-gray-500">
 									{t("orgSettings.logoHint")}

--- a/frontend/src/components/FileUploadButton.tsx
+++ b/frontend/src/components/FileUploadButton.tsx
@@ -1,0 +1,46 @@
+import type { ChangeEventHandler, RefObject } from "react";
+
+// Shared button-styled trigger for a hidden (sr-only) file input - see issue
+// #1131: three different visual treatments (border radius, color, missing
+// transition) for the identical avatar/logo upload control before this
+// existed, following the same pattern as Button.tsx's BASE_CLASSES (#846/#847).
+const LABEL_CLASSES =
+	"cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50";
+
+interface Props {
+	id: string;
+	label: string;
+	accept: string;
+	onChange: ChangeEventHandler<HTMLInputElement>;
+	disabled?: boolean;
+	inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+export default function FileUploadButton({
+	id,
+	label,
+	accept,
+	onChange,
+	disabled = false,
+	inputRef,
+}: Props) {
+	return (
+		<>
+			<label
+				htmlFor={id}
+				className={`${LABEL_CLASSES} ${disabled ? "pointer-events-none opacity-50" : ""}`}
+			>
+				{label}
+			</label>
+			<input
+				ref={inputRef}
+				id={id}
+				type="file"
+				accept={accept}
+				className="sr-only"
+				onChange={onChange}
+				disabled={disabled}
+			/>
+		</>
+	);
+}

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -14,6 +14,7 @@ import ProfileFieldsView from "../../components/ProfileFieldsView";
 import Skeleton from "../../components/Skeleton";
 import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
+import FileUploadButton from "../../components/FileUploadButton";
 import AchievementsSection from "./AchievementsSection";
 import ActivitySection from "./ActivitySection";
 import NotificationPreferencesSection from "./NotificationPreferencesSection";
@@ -412,22 +413,17 @@ export default function ProfileOverviewPage() {
 													</span>
 												)}
 												<div>
-													<label
-														htmlFor="avatar-upload"
-														className={`cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 ${avatarUpload.uploading ? "opacity-50 pointer-events-none" : ""}`}
-													>
-														{avatarUpload.uploading
-															? t("profile.avatarUploading")
-															: t("profile.avatarUpload")}
-													</label>
-													<input
-														ref={avatarUpload.inputRef}
+													<FileUploadButton
 														id="avatar-upload"
-														type="file"
+														label={
+															avatarUpload.uploading
+																? t("profile.avatarUploading")
+																: t("profile.avatarUpload")
+														}
 														accept="image/jpeg,image/png,image/webp"
-														className="sr-only"
 														onChange={avatarUpload.handleChange}
 														disabled={avatarUpload.uploading}
+														inputRef={avatarUpload.inputRef}
 													/>
 													<p className="mt-1 text-xs text-gray-500">
 														{t("profile.avatarHint")}

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -13,6 +13,7 @@ import ConfirmDialog from "../../components/ConfirmDialog";
 import OrganizationProfileView from "../../components/OrganizationProfileView";
 import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
+import FileUploadButton from "../../components/FileUploadButton";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { resolveDateLocale } from "../../lib/format";
 
@@ -286,22 +287,17 @@ export default function OrgSettingsPage() {
 									)}
 									<div>
 										<div className="flex items-center gap-3">
-											<label
-												htmlFor="logo-upload"
-												className={`cursor-pointer rounded-xl border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 ${uploadingLogo || removingLogo ? "opacity-50 pointer-events-none" : ""}`}
-											>
-												{uploadingLogo
-													? t("orgSettings.logoUploading")
-													: t("orgSettings.logoUpload")}
-											</label>
-											<input
-												ref={logoInputRef}
+											<FileUploadButton
 												id="logo-upload"
-												type="file"
+												label={
+													uploadingLogo
+														? t("orgSettings.logoUploading")
+														: t("orgSettings.logoUpload")
+												}
 												accept="image/jpeg,image/png,image/webp"
-												className="sr-only"
 												onChange={handleLogoChange}
 												disabled={uploadingLogo || removingLogo}
+												inputRef={logoInputRef}
 											/>
 											{logoUrl && (
 												<button


### PR DESCRIPTION
## What

Extracts a shared `FileUploadButton` component (`frontend/src/components/FileUploadButton.tsx`) and uses it for the three button-styled file-upload triggers that previously each hand-rolled the same `<label>` + `sr-only` `<input type="file">` markup with a different visual treatment.

## Why

Closes #1131

The avatar upload trigger (`ProfileOverviewPage`), the org logo upload trigger in Settings (`OrgSettingsPage`), and the org logo upload trigger in the create-organization modal (`CreateOrganizationModal`) are functionally identical controls but had three different styles - different border radius, border color, and only two of the three had `transition-colors`, so the avatar variant's hover state visibly snapped instead of fading. `FileUploadButton` now gives all three one shared style, following the same pattern `Button.tsx` already established for the analogous "same control, N different visual treatments" bugs (#846/#847).

The fourth upload flow in the issue - the opportunity banner dropzone in `BasicsStep.tsx` - is left as-is: it's a large rectangular banner image with drag-and-drop affordance and an inline preview that replaces the dropzone, a deliberately different pattern from the small circular avatar/logo preview + button layout used by the other three, so it isn't merged into the shared button component.

## Testing

- `pnpm check` (tsc --noEmit) - pass
- `pnpm lint` - pass
- `pnpm format:write` - no changes needed
- `pnpm test` (Vitest) - 123 tests pass
- `/self-review` run, no findings
- `a11y-check` subagent run against the diff: label/input association, disabled-state handling, and focus/ref behavior are all preserved; all three call sites are already covered by existing axe-core checks in `backend/tests/VisualTests/AccessibilityTests.cs` (`ProfileOverviewPage_EditMode_HasNoSeriousA11yViolations`, `OrganizationSettingsPage_EditModeWithLogo_HasNoSeriousA11yViolations`, `CreateOrganizationModal_HasNoSeriousA11yViolations`) - no new page/route, so no new test needed

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate was cut). This is a pure visual-consistency refactor with no behavior change - the same upload/crop/submit flow runs through the same component tree, just with unified button styling - and is covered by the existing automated a11y tests listed above plus the unit/lint/type-check suite.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2zEpuDgF68pj9hYeNZwVf)_