### PR TITLE
fix: use shared Button component and brand color on crash screen

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ReactNode } from "react";
 import i18next from "i18next";
 import { statusTitleClass } from "../lib/headingClasses";
+import Button from "./Button";
 
 interface Props {
 	children: ReactNode;
@@ -39,23 +40,17 @@ export default class ErrorBoundary extends Component<Props, State> {
 			const t = i18next.t.bind(i18next);
 			return (
 				<div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
-					<h1 className={`text-gray-900 ${statusTitleClass}`}>
+					<h1 className={`text-brand-700 ${statusTitleClass}`}>
 						{t("error.boundaryTitle")}
 					</h1>
 					<p className="max-w-md text-gray-500">{t("error.boundaryMessage")}</p>
 					<div className="flex gap-3">
-						<button
-							onClick={this.handleBack}
-							className="rounded border border-gray-300 px-4 py-2 text-sm hover:bg-gray-50"
-						>
+						<Button variant="secondary" onClick={this.handleBack}>
 							{t("error.goBack")}
-						</button>
-						<button
-							onClick={() => window.location.reload()}
-							className="rounded bg-black px-4 py-2 text-sm text-white hover:bg-gray-800"
-						>
+						</Button>
+						<Button onClick={() => window.location.reload()}>
 							{t("error.reload")}
-						</button>
+						</Button>
 					</div>
 				</div>
 			);


### PR DESCRIPTION
## What

`ErrorBoundary` (the app's crash-screen fallback) now uses the shared `Button` component instead of raw off-brand `<button>` markup, and its heading uses the same brand color as `NotFoundPage`.

## Why

`ErrorBoundary.tsx` rendered two raw buttons: one with `bg-black` (the brand primary is `bg-brand-700`, used everywhere else via `Button.tsx`) and plain `rounded` (0.25rem, vs the app's `rounded-xl`), with no focus-visible style. The heading used `text-gray-900`, a size/color not used by any other page-level heading. The one screen a user reaches after something has already gone wrong is the screen that most needs to look deliberate and trustworthy - it should match the rest of the app's brand, like `NotFoundPage.tsx` does.

Closes #1128

## Testing

- `pnpm check` (tsc --noEmit) - passes
- `pnpm lint` - passes, zero warnings
- `pnpm test` (Vitest) - 123/123 passing
- `pnpm format:write` - no changes needed
- Ran the `a11y-check` subagent against the diff: no a11y regressions (the shared `Button` component adds the global focus-visible ring the raw buttons lacked); `ErrorBoundary` is not a routed page, so no new `AccessibilityTests.cs` test is needed.

## Live verification

Skipped for this PR per explicit task instruction (no release candidate cut). This is a pure visual/markup swap to an already-used, already-tested shared component (`Button.tsx`, used on `NotFoundPage` and throughout the app) with no behavioral change to the error-recovery logic (`handleBack`/`reload` handlers untouched).

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_011K7vZGWAfHyHjcQPKjR7j8)_