### PR TITLE
fix: add lint guard against arbitrary Tailwind text sizes

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -21,6 +21,26 @@ export default tseslint.config(
 		rules: jsxA11y.flatConfigs.recommended.rules,
 	},
 	{
+		// #1124: arbitrary Tailwind text sizes (text-[10px], text-[11px], ...)
+		// bypass the @theme type scale, so nothing stops the ramp below 14px
+		// (text-xs, currently 12px) from fragmenting into one-off pixel values
+		// per component. Round to the nearest scale step instead; add a named
+		// @theme step (e.g. --text-2xs) if a size below text-xs is genuinely
+		// needed somewhere.
+		files: ["src/**/*.{ts,tsx}"],
+		rules: {
+			"no-restricted-syntax": [
+				"error",
+				{
+					selector:
+						":matches(Literal[value=/text-\\[/], TemplateElement[value.raw=/text-\\[/])",
+					message:
+						"Arbitrary Tailwind text size (text-[...]) bypasses the type scale defined in @theme - use a scale step (text-xs, text-sm, ...) instead, or add a named step to @theme if the scale genuinely needs one.",
+				},
+			],
+		},
+	},
+	{
 		files: ["src/**/*.{ts,tsx}"],
 		plugins: { i18next },
 		rules: {


### PR DESCRIPTION
## What

Add an ESLint `no-restricted-syntax` rule that flags arbitrary Tailwind text-size utilities (`text-[10px]`, `text-[11px]`, ...) in `frontend/src/**/*.{ts,tsx}`.

## Why

#1124 flagged that arbitrary `text-[...]` sizes bypass the type scale defined in `@theme`, letting one-off pixel sizes fragment the ramp below `text-xs` (5 distinct sizes under 14px at the time of the audit, across `OpportunityListItem.tsx`, `NotificationDropdown.tsx`, `MiniCalendar.tsx`, and `shared.tsx`).

By the time this branch was cut from `main`, all seven flagged sites had already been rounded to `text-xs` as a side effect of unrelated commits (notably the a11y contrast fixes in #1531) - I verified there are currently zero `text-[` usages anywhere in `frontend/src`. What was still missing was the second half of the issue's suggested fix: nothing stopped the next `text-[13px]` from being added back. This PR closes that gap with a lint rule (the issue's suggested `no-restricted-syntax` regex alternative, rather than `eslint-plugin-tailwindcss`, which doesn't yet have solid Tailwind CSS 4 support).

Closes #1124

## Testing

- `pnpm lint` - passes (rule active, zero existing violations)
- `pnpm format:check` - passes
- `pnpm check` (tsc) - passes
- Manually verified the rule fires: temporarily swapped an existing class to `text-[10px]` in a scratch edit, confirmed `eslint` reported the new error, then reverted the scratch edit (not part of this diff)

## Live verification

Skipped per explicit task instruction (no RC cut for this change). This is a lint-only, dev-tooling change with no runtime/UI behavior to verify on staging - nothing in the built frontend output changes.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - single, self-contained config change)
- [ ] CI is green (monitoring)
- [x] Documentation updated if this change affects behavior (n/a - lint config, self-documenting via inline comment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXFLAx42GC9oo4Bw3xQbQd)_