### PR TITLE
fix: derive hero full-bleed offset from a shared header-offset token

### DIFF
--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -27,7 +27,7 @@ function AppLayoutInner() {
 	return (
 		<div className="min-h-screen flex flex-col">
 			<Header breadcrumb={breadcrumb} />
-			<main className="mx-auto max-w-7xl px-4 pb-16 pt-6 flex-1 w-full sm:px-6 sm:pt-10 lg:px-8 lg:pt-12">
+			<main className="mx-auto max-w-7xl px-4 pb-16 pt-[var(--header-offset)] flex-1 w-full sm:px-6 lg:px-8">
 				<Suspense
 					fallback={
 						<div className="flex justify-center py-16">

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -27,7 +27,7 @@ function AppLayoutInner() {
 	return (
 		<div className="min-h-screen flex flex-col">
 			<Header breadcrumb={breadcrumb} />
-			<main className="mx-auto max-w-7xl px-4 pb-16 pt-[var(--header-offset)] flex-1 w-full sm:px-6 lg:px-8">
+			<main className="mx-auto max-w-7xl px-4 pb-16 pt-[var(--main-top-padding)] flex-1 w-full sm:px-6 lg:px-8">
 				<Suspense
 					fallback={
 						<div className="flex justify-center py-16">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -177,8 +177,7 @@ export default function HomePage() {
 			{/* Hero */}
 			<section
 				aria-labelledby={heroTitleId}
-				className="relative mb-20 -mt-[5.5rem] overflow-hidden bg-brand-800 sm:-mt-[6.5rem] lg:-mt-32"
-				style={{ left: "50%", width: "100vw", marginLeft: "-50vw" }}
+				className="full-bleed relative mb-20 -mt-[var(--header-offset)] overflow-hidden bg-brand-800"
 			>
 				{/* Decorative glow blobs */}
 				<div

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -340,26 +340,31 @@ overflow-y-auto already handles vertical scrolling. */
 	}
 }
 
-/* ── Header offset token (issue #1130) ────────────────────────────────────
---header-offset is Header.tsx's h-16 (4rem) plus AppLayout's <main> padding-
-top at each breakpoint, i.e. exactly how far a full-bleed section (the
-HomePage hero) must pull itself up to tuck under the sticky header. Defined
-once here so neither side has to hand-recalculate the sum when Header's
-height or AppLayout's padding changes. */
+/* ── Header offset tokens (issue #1130) ───────────────────────────────────
+Header.tsx's header is `sticky`, not `fixed`, so it already occupies flow
+space above AppLayout's <main> - --main-top-padding is just <main>'s own
+breathing room below it, unchanged per breakpoint from before. --header-
+offset adds --header-height on top of that: the full distance a full-bleed
+section (the HomePage hero) must pull itself up by to cancel both <main>'s
+padding and the header's own height and reach the very top of the document,
+tucking under the sticky (and, on the hero, transparent) header. Both
+tokens are defined once here so AppLayout and the hero can no longer drift
+out of sync with each other or with Header's actual height. */
 :root {
 	--header-height: 4rem;
-	--header-offset: calc(var(--header-height) + 1.5rem);
+	--main-top-padding: 1.5rem;
+	--header-offset: calc(var(--header-height) + var(--main-top-padding));
 }
 
 @media (min-width: 640px) {
 	:root {
-		--header-offset: calc(var(--header-height) + 2.5rem);
+		--main-top-padding: 2.5rem;
 	}
 }
 
 @media (min-width: 1024px) {
 	:root {
-		--header-offset: calc(var(--header-height) + 3rem);
+		--main-top-padding: 3rem;
 	}
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -340,6 +340,37 @@ overflow-y-auto already handles vertical scrolling. */
 	}
 }
 
+/* ── Header offset token (issue #1130) ────────────────────────────────────
+--header-offset is Header.tsx's h-16 (4rem) plus AppLayout's <main> padding-
+top at each breakpoint, i.e. exactly how far a full-bleed section (the
+HomePage hero) must pull itself up to tuck under the sticky header. Defined
+once here so neither side has to hand-recalculate the sum when Header's
+height or AppLayout's padding changes. */
+:root {
+	--header-height: 4rem;
+	--header-offset: calc(var(--header-height) + 1.5rem);
+}
+
+@media (min-width: 640px) {
+	:root {
+		--header-offset: calc(var(--header-height) + 2.5rem);
+	}
+}
+
+@media (min-width: 1024px) {
+	:root {
+		--header-offset: calc(var(--header-height) + 3rem);
+	}
+}
+
+/* Full-bleed: break an element out of its centered max-w container to span
+the full viewport width, regardless of the container's own max-width. */
+.full-bleed {
+	left: 50%;
+	width: 100vw;
+	margin-left: -50vw;
+}
+
 /* ── Global focus-visible ring (issue #992) ──────────────────────────────
 A single shared token instead of the browser's inconsistent default outline
 or ad-hoc per-component ring utilities. Dual-tone (brand outline + white


### PR DESCRIPTION
## What

Fixes `HomePage`'s hero section full-bleed offset: it hardcoded three magic numbers per breakpoint derived from `Header`'s height and `AppLayout`'s padding-top, and the `lg` value had drifted 16px out of sync.

## Why

`Header.tsx`'s `h-16` (64px) plus `AppLayout.tsx`'s `<main>` padding-top (`pt-6`/`sm:pt-10`/`lg:pt-12` -> 24/40/48px) sums to 88/104/112px at base/sm/lg. `HomePage`'s hero encoded these sums by hand as `-mt-[5.5rem] sm:-mt-[6.5rem] lg:-mt-32`, and `lg:-mt-32` (128px) was 16px too large - at >=1024px the hero's solid background sat 16px above the document origin. Because the relationship was duplicated across files as unlabelled numbers, the drift went unnoticed.

This replaces the duplicated numbers with two CSS custom properties in `frontend/src/styles/global.css`:
- `--main-top-padding` - `AppLayout`'s own `<main>` padding-top (unchanged per-breakpoint values, since `Header` is `sticky` and already occupies flow space above `<main>` - it does *not* need to also encode the header's height).
- `--header-offset` - `--header-height` (4rem) plus `--main-top-padding`, i.e. the full distance the hero's negative margin needs to cancel both `<main>`'s padding and the header's own height, tucking the hero flush under the sticky/transparent header.

Both `AppLayout` and the hero now consume these shared tokens instead of duplicating numbers, so they can no longer drift apart. The inline full-bleed `style` on the hero `<section>` is also replaced with a `.full-bleed` utility class.

(An earlier commit on this branch mistakenly had `AppLayout`'s own padding consume the combined `--header-offset` instead of just `--main-top-padding`, which would have added an extra ~64px gap above content on every non-home page - caught and fixed before merge via a11y self-review.)

Closes #1130

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest), `pnpm build` all pass locally
- Verified the compiled CSS from `pnpm build`: `--header-offset` resolves to `5.5rem`/`6.5rem`/`7rem` at base/sm/lg (previously `5.5rem`/`6.5rem`/`8rem`), `--main-top-padding` resolves to the original `1.5rem`/`2.5rem`/`3rem`, and `AppLayout`'s `padding-top` / the hero's `margin-top` reference the correct token each
- CI green: lint, frontend test/build, backend build/fast-tests/integration-tests/visual-tests, format-check, editorconfig, ban-typographic-dashes, PR title validation, production container smoke test

## Live verification

Skipped for this change per explicit instruction - no release candidate was cut.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs affected, pure layout fix)
