### PR TITLE
fix: derive brand colors from @theme tokens instead of hardcoded hex

### DIFF
--- a/frontend/src/components/SingleMarkerMap.tsx
+++ b/frontend/src/components/SingleMarkerMap.tsx
@@ -1,6 +1,8 @@
+import { useMemo } from "react";
 import L from "leaflet";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import { runtimeConfig } from "../lib/runtimeConfig";
+import { brandColor } from "../lib/brandColor";
 // Colocated with this component (not styles/global.css) - see #1383 and the
 // comment atop SingleMarkerMap.css for why the overrides moved here too, and
 // why this doesn't split into its own CSS chunk (cssCodeSplit is off).
@@ -13,14 +15,6 @@ const TILE_URL = `${runtimeConfig.apiUrl}/v1/maps/tiles/{z}/{x}/{y}.png`;
 const ATTRIBUTION =
 	'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
-const brandMarker = L.divIcon({
-	html: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 36" width="28" height="36" style="display:block"><path d="M14 1C7.9 1 3 5.9 3 12c0 8.5 11 23 11 23S25 20.5 25 12C25 5.9 20.1 1 14 1z" fill="#2d8a5e" stroke="white" stroke-width="1.5"/><circle cx="14" cy="12" r="5" fill="white"/></svg>',
-	className: "",
-	iconSize: [28, 36],
-	iconAnchor: [14, 36],
-	popupAnchor: [0, -38],
-});
-
 interface Props {
 	latitude: number;
 	longitude: number;
@@ -28,6 +22,21 @@ interface Props {
 }
 
 export default function SingleMarkerMap({ latitude, longitude, label }: Props) {
+	// Built lazily (not at module scope) so brandColor()'s getComputedStyle
+	// read happens after the component has actually mounted in the browser,
+	// once global.css's @theme tokens are guaranteed to be applied (#1129).
+	const brandMarker = useMemo(
+		() =>
+			L.divIcon({
+				html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 36" width="28" height="36" style="display:block"><path d="M14 1C7.9 1 3 5.9 3 12c0 8.5 11 23 11 23S25 20.5 25 12C25 5.9 20.1 1 14 1z" fill="${brandColor("600")}" stroke="white" stroke-width="1.5"/><circle cx="14" cy="12" r="5" fill="white"/></svg>`,
+				className: "",
+				iconSize: [28, 36],
+				iconAnchor: [14, 36],
+				popupAnchor: [0, -38],
+			}),
+		[],
+	);
+
 	return (
 		<div className="isolate h-64 w-full overflow-hidden rounded-card border border-gray-200 shadow-resting">
 			<MapContainer

--- a/frontend/src/lib/brandColor.ts
+++ b/frontend/src/lib/brandColor.ts
@@ -1,0 +1,18 @@
+// Brand color tokens live in one place - styles/global.css's @theme block -
+// so retheming (or just darkening a shade for contrast) doesn't silently
+// miss a spot. Plain CSS can read them directly via var(--color-brand-700);
+// the few call sites that need an actual hex string instead (Leaflet's SVG
+// marker markup, react-big-calendar's inline eventPropGetter, a native
+// <input type="color"> value) read the same custom properties at runtime
+// here rather than re-typing the literals a third time (#1129).
+const brandColorCache = new Map<string, string>();
+
+export function brandColor(shade: "600" | "700" | "800"): string {
+	const cached = brandColorCache.get(shade);
+	if (cached) return cached;
+	const value = getComputedStyle(document.documentElement)
+		.getPropertyValue(`--color-brand-${shade}`)
+		.trim();
+	brandColorCache.set(shade, value);
+	return value;
+}

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -22,6 +22,7 @@ import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import { visibleCalendarRange } from "../../../lib/calendarRange";
 import { formatDateTime } from "../../../lib/format";
+import { brandColor } from "../../../lib/brandColor";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 // The *default* view a fresh mount opens on - a narrow tile can't usefully
@@ -45,8 +46,6 @@ const localizer = dateFnsLocalizer({
 	getDay,
 	locales: rbcLocales,
 });
-
-const DEFAULT_EVENT_COLOR = "#226947";
 
 interface CalEvent {
 	id: string;
@@ -115,12 +114,12 @@ function CalEventChip({
 
 function calendarEventPropGetter(event: object) {
 	const e = event as CalEvent;
-	const bg = e.color ?? DEFAULT_EVENT_COLOR;
+	const bg = e.color ?? brandColor("700");
 	return {
 		style: {
 			backgroundColor: bg,
 			borderColor: bg,
-			color: "#ffffff",
+			color: "white",
 		},
 	};
 }
@@ -227,7 +226,9 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 	);
 	const calLoading = calData === null && !calError;
 	const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
-	const [pickerColor, setPickerColor] = useState(DEFAULT_EVENT_COLOR);
+	const [pickerColor, setPickerColor] = useState<string>(() =>
+		brandColor("700"),
+	);
 	const [savingColor, setSavingColor] = useState(false);
 	const [colorSaveError, setColorSaveError] = useState<string | null>(null);
 	const colorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -282,7 +283,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 		const e = event as CalEvent;
 		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
 		setSelectedEvent(e);
-		setPickerColor(e.color ?? DEFAULT_EVENT_COLOR);
+		setPickerColor(e.color ?? brandColor("700"));
 		setColorSaveError(null);
 	}, []);
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -122,7 +122,7 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 .rbc-btn-group button:focus-visible {
-	outline: 2px solid #226947;
+	outline: 2px solid var(--color-brand-700);
 	outline-offset: -1px;
 	z-index: 1;
 	position: relative;
@@ -130,17 +130,17 @@ input[type="number"]::-webkit-outer-spin-button {
 
 /* Active view button */
 .rbc-btn-group button.rbc-active {
-	background: #226947;
+	background: var(--color-brand-700);
 	color: white;
-	border-color: #226947;
+	border-color: var(--color-brand-700);
 }
 
 .rbc-btn-group button.rbc-active + button {
-	border-left-color: #1a3c2b;
+	border-left-color: var(--color-brand-800);
 }
 
 .rbc-btn-group button.rbc-active:hover {
-	background: #1a3c2b;
+	background: var(--color-brand-800);
 }
 
 /* Grid borders */
@@ -202,14 +202,14 @@ overflow-y-auto already handles vertical scrolling. */
 }
 
 .rbc-event:focus-visible {
-	outline: 2px solid #226947;
+	outline: 2px solid var(--color-brand-700);
 	outline-offset: 1px;
 }
 
 .rbc-event.rbc-selected {
 	box-shadow:
 		0 0 0 2px white,
-		0 0 0 4px #226947;
+		0 0 0 4px var(--color-brand-700);
 }
 
 /* Off-range days */
@@ -230,7 +230,7 @@ overflow-y-auto already handles vertical scrolling. */
 
 .rbc-date-cell.rbc-now {
 	font-weight: 700;
-	color: #226947;
+	color: var(--color-brand-700);
 }
 
 /* Time gutter */
@@ -280,13 +280,13 @@ overflow-y-auto already handles vertical scrolling. */
 .rbc-show-more {
 	font-size: 0.75rem;
 	font-weight: 500;
-	color: #226947;
+	color: var(--color-brand-700);
 	background: transparent;
 	padding: 0.125rem 0.375rem;
 }
 
 .rbc-show-more:hover {
-	color: #1a3c2b;
+	color: var(--color-brand-800);
 }
 
 /* Mobile: stack toolbar vertically */
@@ -350,7 +350,7 @@ over Tailwind's layered focus-visible:outline-none/ring-* utilities
 regardless of specificity (see .rbc-btn-group/.rbc-event above for the
 same unlayered-override pattern already used in this file). */
 :root {
-	--focus-ring-color: #226947;
+	--focus-ring-color: var(--color-brand-700);
 }
 
 :focus-visible {


### PR DESCRIPTION
## What

Replaces every hardcoded brand hex literal (`#226947` / `#1a3c2b` / `#2d8a5e`) in `global.css`, `CalendarWidget.tsx`, and `SingleMarkerMap.tsx` with reads of the `@theme` tokens (`--color-brand-600/700/800`) they were duplicating.

## Why

`global.css`'s `@theme` block defines `--color-brand-700`/`--color-brand-800`, but the react-big-calendar overrides below it re-typed those same values as raw hex nine separate times instead of reading the token. `CalendarWidget.tsx`'s `DEFAULT_EVENT_COLOR` and `SingleMarkerMap.tsx`'s marker `fill` duplicated brand-700 and brand-600 again outside CSS entirely. Retheming - or just darkening a shade for contrast - would silently miss the calendar toolbar, event chips, focus outlines, "show more" link, and the map marker, since none of them actually read the token.

Closes #1129

## Changes

- `global.css`: all 10 hex literals under `.rbc-*`/`:root` now read `var(--color-brand-700)` / `var(--color-brand-800)` directly; only the `@theme` block itself still defines the literal values (the intended single source of truth).
- New `frontend/src/lib/brandColor.ts`: a small cached helper (`brandColor("600" | "700" | "800")`) that reads the same CSS custom properties at runtime via `getComputedStyle`, for the few call sites that need an actual hex string rather than a CSS value (a native `<input type="color">` value, react-big-calendar's inline `eventPropGetter`, Leaflet's SVG marker markup).
- `CalendarWidget.tsx`: `DEFAULT_EVENT_COLOR` constant removed in favor of `brandColor("700")` calls at its three use sites. Also normalized an adjacent `"#ffffff"` literal to the `"white"` keyword already used elsewhere in the same style object (no color change).
- `SingleMarkerMap.tsx`: the Leaflet marker icon moved from a module-level constant into a `useMemo` inside the component, so `brandColor()`'s `getComputedStyle` read happens after mount (once `global.css`'s tokens are guaranteed applied) rather than at import time.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (vitest, 123 tests) - all green.
- `pnpm format:write` - no changes needed.
- `/self-review` run, plus the `a11y-check` subagent (two `.tsx` files touched) - no findings; confirmed no new `AccessibilityTests.cs` entry needed since both are existing, already-covered pages/components and no markup changed.

No new automated test added - this is a pure color-value-source refactor (same rendered colors, just centralized), not new behavior to assert on.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). This is a purely internal refactor of *where* the brand color values come from - the rendered colors are unchanged (same hex values, now read from the `@theme` token instead of re-typed) - so there is no new visible behavior to verify on staging.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal refactor, no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZvLJLWdL3maCLJfcSE3x8)_