### PR TITLE
fix: declare a self-hosted typeface instead of the OS default UI font

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "check:pwa-precache": "node scripts/check-pwa-precache.js"
   },
   "dependencies": {
+    "@fontsource-variable/lexend": "5.3.0",
     "@hookform/resolvers": "5.5.7",
     "date-fns": "4.4.0",
     "i18next": "26.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "check:pwa-precache": "node scripts/check-pwa-precache.js"
   },
   "dependencies": {
-    "@fontsource-variable/lexend": "5.3.0",
+    "@fontsource-variable/source-sans-3": "5.3.0",
     "@hookform/resolvers": "5.5.7",
     "date-fns": "4.4.0",
     "i18next": "26.3.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/lexend':
+        specifier: 5.3.0
+        version: 5.3.0
       '@hookform/resolvers':
         specifier: 5.5.7
         version: 5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.82.0(react@19.2.8))(zod@4.4.3)
@@ -779,6 +782,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource-variable/lexend@5.3.0':
+    resolution: {integrity: sha512-3SXtiZ8rFbT0oaPzEboCG5RM3jtyhpNxandh1jWNLqvrJRfV/eP3R+GGw+o5e3hS1uqmAGutKxSvaWG5oyrimA==}
 
   '@hookform/resolvers@5.5.7':
     resolution: {integrity: sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==}
@@ -4142,6 +4148,8 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.1': {}
+
+  '@fontsource-variable/lexend@5.3.0': {}
 
   '@hookform/resolvers@5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.82.0(react@19.2.8))(zod@4.4.3)':
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     dependencies:
-      '@fontsource-variable/lexend':
+      '@fontsource-variable/source-sans-3':
         specifier: 5.3.0
         version: 5.3.0
       '@hookform/resolvers':
@@ -783,8 +783,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fontsource-variable/lexend@5.3.0':
-    resolution: {integrity: sha512-3SXtiZ8rFbT0oaPzEboCG5RM3jtyhpNxandh1jWNLqvrJRfV/eP3R+GGw+o5e3hS1uqmAGutKxSvaWG5oyrimA==}
+  '@fontsource-variable/source-sans-3@5.3.0':
+    resolution: {integrity: sha512-dpi0GZk7EQe2tYpg6Q0Fx0OmUgnuGu+0rHPgtXqtKhglYmJuP7jZ12Mu1uN+NfRaJRY1Emn8AQJEWzmoZ4wa9g==}
 
   '@hookform/resolvers@5.5.7':
     resolution: {integrity: sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==}
@@ -4149,7 +4149,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@fontsource-variable/lexend@5.3.0': {}
+  '@fontsource-variable/source-sans-3@5.3.0': {}
 
   '@hookform/resolvers@5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.82.0(react@19.2.8))(zod@4.4.3)':
     dependencies:

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,6 +16,7 @@ import { runtimeConfig } from "./lib/runtimeConfig";
 // wins, and a lazy-chunk-scoped import made that order load-timing-
 // dependent instead of fixed.
 import "react-big-calendar/lib/css/react-big-calendar.css";
+import "@fontsource-variable/lexend";
 import "./styles/global.css";
 
 const oidcConfig = {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,7 @@ import { runtimeConfig } from "./lib/runtimeConfig";
 // wins, and a lazy-chunk-scoped import made that order load-timing-
 // dependent instead of fixed.
 import "react-big-calendar/lib/css/react-big-calendar.css";
-import "@fontsource-variable/lexend";
+import "@fontsource-variable/source-sans-3";
 import "./styles/global.css";
 
 const oidcConfig = {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -362,6 +362,18 @@ same unlayered-override pattern already used in this file). */
 }
 
 @theme {
+	/* Lexend (self-hosted via @fontsource-variable/lexend, imported once in
+	main.tsx) replaces Tailwind's default OS-UI-font stack everywhere -
+	Preflight derives html's font-family from --font-sans (see
+	tailwindcss/preflight.css), so this one override is enough. Chosen over
+	the more common Inter/system-ui defaults for its research backing on
+	reading speed/fluency, which fits a platform that already treats
+	legibility and a11y as first-class (see frontend/AGENTS.md's a11y
+	conventions) - not just a stylistic pick. Variable weight axis covers
+	100-900 in one file, matching every font-weight utility already in use
+	(font-medium through font-black) without extra @font-face declarations. */
+	--font-sans: "Lexend Variable", ui-sans-serif, system-ui, sans-serif;
+
 	--color-brand-50: #f0faf5;
 	--color-brand-100: #d6f0e3;
 	--color-brand-200: #a8dfc3;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -362,17 +362,21 @@ same unlayered-override pattern already used in this file). */
 }
 
 @theme {
-	/* Lexend (self-hosted via @fontsource-variable/lexend, imported once in
-	main.tsx) replaces Tailwind's default OS-UI-font stack everywhere -
-	Preflight derives html's font-family from --font-sans (see
-	tailwindcss/preflight.css), so this one override is enough. Chosen over
-	the more common Inter/system-ui defaults for its research backing on
-	reading speed/fluency, which fits a platform that already treats
-	legibility and a11y as first-class (see frontend/AGENTS.md's a11y
-	conventions) - not just a stylistic pick. Variable weight axis covers
-	100-900 in one file, matching every font-weight utility already in use
-	(font-medium through font-black) without extra @font-face declarations. */
-	--font-sans: "Lexend Variable", ui-sans-serif, system-ui, sans-serif;
+	/* Source Sans 3 (self-hosted via @fontsource-variable/source-sans-3,
+	imported once in main.tsx) replaces Tailwind's default OS-UI-font stack
+	everywhere - Preflight derives html's font-family from --font-sans (see
+	tailwindcss/preflight.css), so this one override is enough. Adobe's
+	first open-source type family, purpose-built for legibility at small UI
+	sizes rather than display use - a deliberate fit for a form/table/modal-
+	dense app over a flashier display face. Its glyph widths track close to
+	(if anything, slightly narrower than) the OS-UI stack it replaces, which
+	matters here: several fixed-size surfaces (toasts, modals) sit close
+	enough to each other at common viewport sizes that a visibly wider
+	typeface can shift a toast's fitted width enough to newly overlap a
+	nearby control. Variable weight axis covers 200-900 in one file,
+	matching every font-weight utility already in use (font-medium through
+	font-black) without extra @font-face declarations. */
+	--font-sans: "Source Sans 3 Variable", ui-sans-serif, system-ui, sans-serif;
 
 	--color-brand-50: #f0faf5;
 	--color-brand-100: #d6f0e3;


### PR DESCRIPTION
## What

Declares an explicit, self-hosted typeface for the whole app instead of silently falling back to whatever OS UI font the visitor has installed.

## Why

`frontend/src/styles/global.css`'s `@theme` block defined only color tokens - no `--font-sans`, no `@font-face`, and `index.html` loaded no webfont. Tailwind's Preflight then fell through to its own generic `-apple-system, BlinkMacSystemFont, "Segoe UI", ...` stack, so every surface rendered in the OS default UI font rather than anything the product actually chose.

Fixed by self-hosting a typeface via `@fontsource-variable/*` (imported once in `main.tsx`) and setting it as Tailwind's `--font-sans` theme token in `global.css`, which Preflight already threads through to `html`'s `font-family` (and to every `font-sans` utility) for free - one override, no per-component changes needed. Self-hosting (rather than a `<link>` to Google Fonts) means this needed zero CSP or nginx changes - `font-src 'self'` already covers it, since the woff2 files ship as regular hashed Vite assets from the app's own origin.

**Typeface iteration:** the first push used Lexend (chosen for its reading-fluency research backing, fitting this platform's existing a11y focus), but CI's `visual-tests` caught a real regression - see "CI failure and fix" below. The PR now ships Adobe's **Source Sans 3** instead: purpose-built for UI legibility at small sizes, same 200-900 variable weight axis covering every `font-weight` utility already in use (`font-medium` through `font-black`), and empirically the safer choice for this app's layout (see below).

## CI failure and fix

The first push's `visual-tests` run failed one test: `CreateOpportunityRetryTests.PublishScheduledSlots_TimeSlotFailureMidPublish_RetryUpdatesSameDraftInsteadOfDuplicating`, timing out because the modal's retry click on `modal-submit` was intercepted by a leftover error toast.

Root cause: the global toast (`ToastContext.tsx`) is `fixed bottom-4 right-4 z-[9999]`, sized to fit its text, sitting *above* `CreateVolunteerOpportunityModal`'s `z-[2000]` overlay. That modal's scrollable body is capped at `max-h-[min(70vh,640px)]`, so on the CI viewport it's already close to the toast's corner. Lexend's noticeably wider glyphs (measured with a standalone Playwright harness rendering the exact toast markup/text at the exact font-size: **~30px wider** than the old OS-UI stack for the real `error.serverError` message) pushed the toast's fitted width far enough left to newly overlap the submit button.

I compared several accessible, well-regarded alternatives with the same harness before picking a replacement:

| Typeface | Width vs. old OS-UI stack |
|---|---|
| Public Sans | +14.0px |
| Lexend | +29.8px |
| Work Sans | +33.6px |
| **Source Sans 3** | **-23.7px (narrower)** |

Source Sans 3 was the only candidate that came in *narrower* than the stack that was already proven safe across the full test suite, so it removes this risk rather than just shrinking it. Confirmed after the swap: `pnpm build`/`lint`/`check`/`test` all green, and the compiled CSS resolves `--font-sans` -> `--default-font-family` -> `html`'s `font-family` to `"Source Sans 3 Variable"` end to end.

Closes #1136

## Testing

- `pnpm lint`, `pnpm check`, `pnpm test` (123 tests), `pnpm build`, `pnpm check:nginx-csp`, `pnpm check:pwa-precache` - all green after the Source Sans 3 swap
- Standalone Playwright measurement harness comparing rendered toast width across candidate typefaces (see table above) before picking a replacement
- Verified in the compiled CSS that `--font-sans` resolves to `"Source Sans 3 Variable"` end to end, and that no `fonts.googleapis.com`/`fonts.gstatic.com` references exist anywhere in the build output (fully self-hosted)
- No new application logic was added (a theme token + one import), so no new automated test was needed beyond the existing lint/build/unit-test/E2E gates - the E2E regression this PR's own change caused is exactly what `visual-tests` is for, and it caught it

## Live verification

Per explicit instruction for this task, no release candidate was cut and staging was not touched.

Instead, verified locally: ran `pnpm dev`, loaded the homepage in a Playwright-driven Chromium against `localhost:4321`, and confirmed via `getComputedStyle` that both `body` and `h1` resolve to `"Source Sans 3 Variable", ui-sans-serif, system-ui, sans-serif`. Screenshot confirmed the typeface renders as expected across the hero, body copy, and buttons.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no doc/behavior change beyond the visual typeface)