### PR TITLE
fix: constrain imprint/privacy page width and match shared heading style

### DIFF
--- a/backend/tests/VisualTests/LegalPagesLayoutTests.cs
+++ b/backend/tests/VisualTests/LegalPagesLayoutTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1127: the imprint and privacy policy pages rendered their
+/// h1 without the shared `text-gray-900` color, and their body copy had no
+/// width constraint inside AppLayout's `max-w-7xl` main - a roughly
+/// 180-character line measure on desktop. Both pages now match the heading
+/// color used everywhere else and wrap their content in a
+/// `data-content-wrapper` reading-width column, left-aligned like the other
+/// document-style pages (settings, profile) rather than centered like a
+/// detail page - see VisualTestBase.AssertMaxWidthContentLeftAlignedAsync.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class LegalPagesLayoutTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task ImprintPage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/imprint");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var heading = Page.Locator("h1");
+		await Expect(heading).ToBeVisibleAsync();
+		await Expect(heading).ToContainClassAsync("text-gray-900");
+
+		await AssertMaxWidthContentLeftAlignedAsync("Imprint page");
+	}
+
+	[Test]
+	public async Task PrivacyPolicyPage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/privacy-policy");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var heading = Page.Locator("h1");
+		await Expect(heading).ToBeVisibleAsync();
+		await Expect(heading).ToContainClassAsync("text-gray-900");
+
+		await AssertMaxWidthContentLeftAlignedAsync("Privacy policy page");
+	}
+}

--- a/frontend/src/pages/ImprintPage.tsx
+++ b/frontend/src/pages/ImprintPage.tsx
@@ -9,8 +9,10 @@ export default function ImprintPage() {
 	usePageToolbar([{ label: t("imprint.title") }]);
 
 	return (
-		<>
-			<h1 className={`mb-8 ${pageTitleClass}`}>{t("imprint.title")}</h1>
+		<div data-content-wrapper className="max-w-2xl">
+			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
+				{t("imprint.title")}
+			</h1>
 
 			<section className="mb-8">
 				<h2 className="mb-2 text-xl font-semibold">
@@ -65,6 +67,6 @@ export default function ImprintPage() {
 					{t("imprint.section4bBody")}
 				</p>
 			</section>
-		</>
+		</div>
 	);
 }

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -9,8 +9,10 @@ export default function PrivacyPolicyPage() {
 	usePageToolbar([{ label: t("privacyPolicy.title") }]);
 
 	return (
-		<>
-			<h1 className={`mb-8 ${pageTitleClass}`}>{t("privacyPolicy.title")}</h1>
+		<div data-content-wrapper className="max-w-2xl">
+			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
+				{t("privacyPolicy.title")}
+			</h1>
 
 			<section className="mb-8">
 				<h2 className="mb-2 text-xl font-semibold">
@@ -88,6 +90,6 @@ export default function PrivacyPolicyPage() {
 					{t("privacyPolicy.section5Body")}
 				</p>
 			</section>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
## What

Fixes the imprint and privacy policy pages' off-scale heading and unbounded body-text width.

## Why

`ImprintPage.tsx` and `PrivacyPolicyPage.tsx` rendered their `<h1>` without the shared `text-gray-900` color used by every other page's heading (`OrganizationsPage.tsx`, `AdministrationPage.tsx`, `ProfileOverviewPage/index.tsx`, `UserProfilePage.tsx`, `UserAchievementsPage.tsx`), and their body copy had no width constraint inside `AppLayout.tsx`'s `max-w-7xl` `<main>` - at a 1280px viewport that's roughly 180 characters per line, about 2.5x the comfortable 45-75 character reading measure. As the two pages every German site is legally required to publish, they were also the least readable pages in the product.

Closes #1127

## Changes

- Wrapped each page's content in `<div data-content-wrapper className="max-w-2xl">`, matching the left-aligned reading-width convention already used by `OrgSettingsPage.tsx`, `OrgMembersPage.tsx`, and `OrganizationProfileView.tsx` (as opposed to the centered convention used by detail/card pages like `VolunteerOpportunityDetailPage.tsx`).
- Changed the `<h1>` className from `` `mb-8 ${pageTitleClass}` `` to `` `mb-6 text-gray-900 ${pageTitleClass}` ``, matching `AdministrationPage.tsx`, `UserAchievementsPage.tsx`, and `ProfileOverviewPage/index.tsx`.

## Testing

- `pnpm format:write`, `pnpm lint`, `pnpm check` all pass locally.
- Added `backend/tests/VisualTests/LegalPagesLayoutTests.cs` - two new TUnit/Playwright tests asserting the `<h1>` carries `text-gray-900` and the content wrapper is left-aligned within `<main>` (via `VisualTestBase.AssertMaxWidthContentLeftAlignedAsync`, the same helper used for the analogous org settings/profile regressions). Could not run this locally (no Docker/Aspire in this sandbox, and the `.NET SDK` download host `builds.dotnet.microsoft.com` is blocked by this session's egress policy) - relying on CI's `dotnet.yml` to execute it.
- An a11y self-review pass confirmed no landmark/heading-order regression and that `/imprint` and `/privacy-policy` already have `AccessibilityTests.cs` coverage (`ImprintPage_HasNoSeriousA11yViolations`, `PrivacyPolicyPage_HasNoSeriousA11yViolations`), so no new a11y test entry was needed.

## Live verification

Skipped for this change at the requester's explicit direction (no release candidate cut). The new `LegalPagesLayoutTests.cs` assertions are the durable regression coverage in place of a live-staging check.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - purely visual/layout fix, no documented behavior changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcLTRaUnksPHUSrTUtWriJ)_