### PR TITLE
fix: set KC_PROXY_HEADERS so Keycloak sees real client IPs behind Traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,12 @@ services:
       KC_HOSTNAME: https://login.maik-hasler.de
       KC_HTTP_ENABLED: "true"
       KC_HOSTNAME_STRICT: "false"
+      # Without this, Keycloak 26 ignores X-Forwarded-For and attributes every
+      # request to the Traefik container's internal IP, so login/admin-event
+      # records and any IP-based brute-force policy are useless (#1187).
+      # Safe only because Traefik is the sole ingress on the `proxy` network -
+      # nothing else can reach Keycloak to spoof the header end-to-end.
+      KC_PROXY_HEADERS: xforwarded
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN_USER:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
       # Deliberately keeps the einsatzbereit realm's baked-in vera/olaf/admin demo


### PR DESCRIPTION
## What

Adds `KC_PROXY_HEADERS: xforwarded` to the `keycloak` service's environment in `docker-compose.yml`.

## Why

Keycloak 26 ignores `X-Forwarded-For` unless `KC_PROXY_HEADERS` is explicitly set, so every request reaching Keycloak through Traefik was attributed to Traefik's internal container IP instead of the real client IP. That meant login/admin-event records carried a useless source address, and the realm's brute-force protection (`bruteForceProtected: true`, `failureFactor: 5`, etc. in `keycloak/realms/einsatzbereit-realm.json`) couldn't key on real client IPs. Traefik is the only ingress registered for the `keycloak` service (see its `traefik.*` labels in `docker-compose.yml`, on the shared `proxy` network), so trusting the forwarded header here doesn't open up a spoofing path.

Closes #1187

## Testing

Config-only change (no application code). Verified:
- `docker-compose.yml` still parses correctly with the new env entry (`docker compose config` equivalent via `yaml.safe_load`).
- No YAML indentation or ASCII-dash lint violations (`.editorconfig`, `lint.yml`'s dash check).
- Confirmed `KC_PROXY_HEADERS: xforwarded` is the correct Quarkus-based Keycloak 26 value for trusting `X-Forwarded-*` headers, matching the issue's suggested fix.
- Confirmed the Keycloak container healthcheck (`localhost:9000`, bypasses Traefik) is unaffected.

## Live verification

Skipped for this PR per explicit instruction - no release candidate was cut and no live-staging verification was run. This is a one-line `docker-compose.yml` env var change; the effect (Keycloak correctly attributing client IPs from behind Traefik) is only observable once deployed via a real RC, which was intentionally out of scope for this task.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - env var is self-documented with an inline comment; no other docs reference proxy-header config)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKYEG415Y2sL6adDzbxg4J)_