### PR TITLE
fix: unify tag/status pill styling with a shared Chip component

### DIFF
--- a/frontend/src/components/Chip.tsx
+++ b/frontend/src/components/Chip.tsx
@@ -1,0 +1,84 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+// Shared pill primitive for tags, categories, and status indicators - see
+// issue #1125: the same "tag" concept previously had a different
+// background/size/weight in the wizard, the profile view, and the
+// opportunity detail page.
+const TONE_CLASSES = {
+	brand: "bg-brand-50 text-brand-700",
+	neutral: "bg-gray-100 text-gray-600",
+	success: "bg-green-50 text-green-700",
+	warning: "bg-amber-50 text-amber-700",
+	danger: "bg-red-50 text-red-600",
+} as const;
+
+export type ChipTone = keyof typeof TONE_CLASSES;
+
+const SIZE_CLASSES = {
+	sm: "px-2 py-0.5 text-xs",
+	md: "px-3 py-1 text-xs",
+} as const;
+
+export type ChipSize = keyof typeof SIZE_CLASSES;
+
+interface CommonProps {
+	tone?: ChipTone;
+	size?: ChipSize;
+	children: ReactNode;
+}
+
+type ChipProps = CommonProps &
+	Omit<HTMLAttributes<HTMLSpanElement>, "className" | "children"> & {
+		className?: string;
+	} & (
+		| { onRemove?: undefined; removeLabel?: undefined }
+		| { onRemove: () => void; removeLabel: string }
+	);
+
+export default function Chip({
+	tone = "neutral",
+	size = "md",
+	className = "",
+	children,
+	onRemove,
+	removeLabel,
+	...rest
+}: ChipProps) {
+	const classes = [
+		"inline-flex items-center gap-1 rounded-full font-medium",
+		TONE_CLASSES[tone],
+		SIZE_CLASSES[size],
+		className,
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	return (
+		<span className={classes} {...rest}>
+			{children}
+			{onRemove && (
+				<button
+					type="button"
+					onClick={onRemove}
+					aria-label={removeLabel}
+					className="rounded-full opacity-70 hover:opacity-100"
+				>
+					<svg
+						aria-hidden="true"
+						className="h-3 w-3"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth={2.5}
+						viewBox="0 0 24 24"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</button>
+			)}
+		</span>
+	);
+}

--- a/frontend/src/components/ProfileFieldsView.tsx
+++ b/frontend/src/components/ProfileFieldsView.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import Chip from "./Chip";
 
 interface ProfileFieldsViewProps {
 	bio?: string | null;
@@ -37,12 +38,9 @@ export default function ProfileFieldsView({
 					</p>
 					<div className="flex flex-wrap gap-2">
 						{skills.map((s) => (
-							<span
-								key={s}
-								className="rounded-full bg-brand-50 px-3 py-1 text-sm text-brand-700"
-							>
+							<Chip key={s} tone="brand">
 								{s}
-							</span>
+							</Chip>
 						))}
 					</div>
 				</div>
@@ -55,12 +53,9 @@ export default function ProfileFieldsView({
 					</p>
 					<div className="flex flex-wrap gap-2">
 						{languages.map((l) => (
-							<span
-								key={l}
-								className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600"
-							>
+							<Chip key={l} tone="neutral">
 								{l}
-							</span>
+							</Chip>
 						))}
 					</div>
 				</div>

--- a/frontend/src/components/TagsInput.tsx
+++ b/frontend/src/components/TagsInput.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
+import Chip from "./Chip";
 
 interface Props {
 	id: string;
@@ -58,33 +59,14 @@ export default function TagsInput({
 			</label>
 			<div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-sm transition focus-within:border-brand-400 focus-within:ring-2 focus-within:ring-brand-400/30">
 				{value.map((tag) => (
-					<span
+					<Chip
 						key={tag}
-						className="inline-flex items-center gap-1 rounded-full bg-brand-100 px-3 py-0.5 text-xs font-medium text-brand-800"
+						tone="neutral"
+						onRemove={() => removeTag(tag)}
+						removeLabel={t("createOpportunity.removeTag", { tag })}
 					>
 						{tag}
-						<button
-							type="button"
-							onClick={() => removeTag(tag)}
-							aria-label={t("createOpportunity.removeTag", { tag })}
-							className="rounded-full text-brand-600 hover:text-brand-900"
-						>
-							<svg
-								aria-hidden="true"
-								className="h-3 w-3"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth={2.5}
-								viewBox="0 0 24 24"
-							>
-								<path
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									d="M6 18L18 6M6 6l12 12"
-								/>
-							</svg>
-						</button>
-					</span>
+					</Chip>
 				))}
 				<input
 					id={id}

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -5,6 +5,7 @@ import type { VolunteerOpportunitySummary } from "../../client/api-client";
 import { formatDate, formatDateTime, formatOccurrence } from "../../lib/format";
 import { getOpportunityCategoryBannerClassName } from "../../lib/opportunityCategoryTheme";
 import { useApiClient } from "../../hooks/useApiClient";
+import Chip from "../Chip";
 import ReportFlagButton from "../ReportFlagButton";
 import { CalendarIcon, CategoryGlyph, GlobeIcon, PinIcon } from "./icons";
 
@@ -76,31 +77,31 @@ export default function OpportunityListItem({
 				{/* Content */}
 				<div className="flex min-w-0 flex-1 flex-col p-4 sm:p-5">
 					<div className="mb-2 flex items-center gap-2">
-						<span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+						<Chip tone="neutral" size="sm" className="shrink-0">
 							{formatOccurrence(item.occurrence, t)}
-						</span>
+						</Chip>
 						{isUnlimited ? (
-							<span className="ml-auto shrink-0 rounded-full bg-teal-50 px-2 py-0.5 text-xs font-medium text-teal-700">
+							<Chip tone="brand" size="sm" className="ml-auto shrink-0">
 								{t("opportunities.unlimitedSpots")}
-							</span>
+							</Chip>
 						) : (
 							spotsLeft !== null &&
 							(spotsLeft <= 0 ? (
-								<span className="ml-auto shrink-0 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600">
+								<Chip tone="danger" size="sm" className="ml-auto shrink-0">
 									{t("opportunities.full")}
-								</span>
+								</Chip>
 							) : spotsLeft <= 3 ? (
-								<span className="ml-auto shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+								<Chip tone="warning" size="sm" className="ml-auto shrink-0">
 									{t("opportunities.spotsLeft", {
 										count: spotsLeft,
 									})}
-								</span>
+								</Chip>
 							) : (
-								<span className="ml-auto shrink-0 rounded-full bg-gray-50 px-2 py-0.5 text-xs text-gray-500">
+								<Chip tone="neutral" size="sm" className="ml-auto shrink-0">
 									{t("opportunities.spotsLeft", {
 										count: spotsLeft,
 									})}
-								</span>
+								</Chip>
 							))
 						)}
 						{auth.isAuthenticated && (

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -15,6 +15,7 @@ import { pageTitleClass } from "../lib/headingClasses";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
+import Chip from "../components/Chip";
 import Spinner from "../components/Spinner";
 import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
@@ -312,9 +313,9 @@ function UsersSection() {
 												<p className="truncate font-medium text-gray-900">
 													{displayName}
 													{isAdmin && (
-														<span className="ml-2 inline-block rounded-full bg-amber-50 px-2 py-0.5 text-xs font-normal text-amber-700">
+														<Chip tone="warning" size="sm" className="ml-2">
 															{t("administration.users.adminBadge")}
-														</span>
+														</Chip>
 													)}
 												</p>
 												<p className="truncate text-xs text-gray-500">
@@ -322,17 +323,15 @@ function UsersSection() {
 												</p>
 											</td>
 											<td className="flex items-center justify-between gap-3 sm:shrink-0 sm:justify-end">
-												<span
-													className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
-														row.enabled
-															? "bg-green-50 text-green-700"
-															: "bg-red-50 text-red-700"
-													}`}
+												<Chip
+													tone={row.enabled ? "success" : "danger"}
+													size="sm"
+													className="shrink-0"
 												>
 													{row.enabled
 														? t("administration.users.statusActive")
 														: t("administration.users.statusBlocked")}
-												</span>
+												</Chip>
 												<div className="flex shrink-0 items-center gap-2">
 													{isSelf ? (
 														<span
@@ -558,20 +557,14 @@ function ReportsSection() {
 											{row.targetTitle ||
 												t("administration.reports.unknownTarget")}
 										</Link>
-										<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+										<Chip tone="neutral" size="sm">
 											{t(`administration.reports.targetType.${row.targetType}`)}
-										</span>
-										<span
-											className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-												row.isDeleted
-													? "bg-red-50 text-red-600"
-													: "bg-green-50 text-green-700"
-											}`}
-										>
+										</Chip>
+										<Chip tone={row.isDeleted ? "danger" : "success"} size="sm">
 											{row.isDeleted
 												? t("administration.reports.statusDeleted")
 												: t("administration.reports.statusActive")}
-										</span>
+										</Chip>
 									</div>
 									<p className="mt-1 text-xs text-gray-500">
 										{t("administration.reports.openFlags", {
@@ -748,9 +741,9 @@ function ReportHistoryModal({
 								<span className="text-sm font-medium text-gray-900">
 									{t(`administration.reports.reason.${entry.reason}`)}
 								</span>
-								<span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+								<Chip tone="neutral" size="sm" className="shrink-0">
 									{t(`administration.reports.status.${entry.status}`)}
-								</span>
+								</Chip>
 							</div>
 							{entry.details && (
 								<p className="mt-1 text-sm text-gray-600">{entry.details}</p>

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -9,6 +9,7 @@ import { usePageToolbar } from "../../contexts/ToolbarContext";
 import { useEditModeQuickActions } from "../../hooks/useEditModeQuickActions";
 import { inputClass, textareaClass } from "../../lib/formClasses";
 import { pageTitleClass } from "../../lib/headingClasses";
+import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
 import Skeleton from "../../components/Skeleton";
@@ -66,6 +67,7 @@ function ChipInput({
 	onAdd,
 	onRemove,
 	removeLabel,
+	tone = "brand",
 }: {
 	inputRef: React.RefObject<HTMLInputElement | null>;
 	inputId: string;
@@ -76,6 +78,7 @@ function ChipInput({
 	onAdd: (v: string) => void;
 	onRemove: (v: string) => void;
 	removeLabel: string;
+	tone?: ChipTone;
 }) {
 	function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
 		if (e.key === "Enter") {
@@ -89,20 +92,14 @@ function ChipInput({
 			{chips.length > 0 && (
 				<div className="mb-2 flex flex-wrap gap-2">
 					{chips.map((chip) => (
-						<span
+						<Chip
 							key={chip}
-							className="inline-flex items-center gap-1 rounded-full bg-brand-50 px-3 py-1 text-sm text-brand-700"
+							tone={tone}
+							onRemove={() => onRemove(chip)}
+							removeLabel={`${removeLabel} ${chip}`}
 						>
 							{chip}
-							<button
-								type="button"
-								aria-label={`${removeLabel} ${chip}`}
-								onClick={() => onRemove(chip)}
-								className="ml-1 text-brand-400 hover:text-brand-700"
-							>
-								&times;
-							</button>
-						</span>
+						</Chip>
 					))}
 				</div>
 			)}
@@ -527,6 +524,7 @@ export default function ProfileOverviewPage() {
 											onAdd={form.addLanguage}
 											onRemove={form.removeLanguage}
 											removeLabel={t("profile.removeChip")}
+											tone="neutral"
 										/>
 									</Field>
 

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 	formatPostedAgo,
 } from "../lib/format";
 import { pageTitleClass } from "../lib/headingClasses";
+import Chip from "../components/Chip";
 import SignUpModal from "../components/SignUpModal";
 import ReportContentModal, {
 	type ReportReason,
@@ -417,18 +418,15 @@ export default function VolunteerOpportunityDetailPage() {
 				(opportunity.tags && opportunity.tags.length > 0)) && (
 				<div className="mb-6 flex flex-wrap gap-2">
 					{opportunity.category && (
-						<span className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700">
+						<Chip tone="brand">
 							{t(`opportunities.category.${opportunity.category}`)}
-						</span>
+						</Chip>
 					)}
 					{opportunity.tags &&
 						opportunity.tags.map((tag) => (
-							<span
-								key={tag}
-								className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600"
-							>
+							<Chip key={tag} tone="neutral">
 								{tag}
-							</span>
+							</Chip>
 						))}
 				</div>
 			)}
@@ -508,15 +506,12 @@ export default function VolunteerOpportunityDetailPage() {
 							<p className="mb-1 text-xs text-gray-500">
 								{t("opportunities.yourApplication")}
 							</p>
-							<span
-								className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${
-									cue.status === "Confirmed"
-										? "bg-green-50 text-green-700 border-green-100"
-										: "bg-yellow-50 text-yellow-700 border-yellow-100"
-								}`}
+							<Chip
+								tone={cue.status === "Confirmed" ? "success" : "warning"}
+								size="sm"
 							>
 								{t(`myEngagements.status.${cue.status}`)}
-							</span>
+							</Chip>
 						</div>
 						<button
 							onClick={() => setShowWithdrawConfirm(true)}
@@ -741,20 +736,20 @@ export default function VolunteerOpportunityDetailPage() {
 									</p>
 								)}
 								<div className="mt-2 flex flex-wrap gap-2">
-									<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+									<Chip tone="neutral" size="sm">
 										{formatOccurrence(opp.occurrence, t)}
-									</span>
-									<span className="rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
+									</Chip>
+									<Chip tone="brand" size="sm">
 										{formatParticipationType(opp.participationType, t)}
-									</span>
+									</Chip>
 									{opp.isRemote ? (
-										<span className="rounded-full bg-green-50 px-2 py-0.5 text-xs text-green-700">
+										<Chip tone="success" size="sm">
 											{t("opportunities.remote")}
-										</span>
+										</Chip>
 									) : opp.street ? (
-										<span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+										<Chip tone="neutral" size="sm">
 											{opp.street} {opp.houseNumber}, {opp.zipCode} {opp.city}
-										</span>
+										</Chip>
 									) : null}
 								</div>
 							</li>

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -9,6 +9,7 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { useLoadMore } from "../../hooks/useLoadMore";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
+import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
@@ -22,11 +23,11 @@ import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const OPPORTUNITIES_PAGE_SIZE = 10;
 
-const STATUS_BADGE_CLASSES: Record<string, string> = {
-	Draft: "bg-amber-100 text-amber-800",
-	Published: "bg-green-100 text-green-800",
-	Unpublished: "bg-gray-200 text-gray-700",
-	Cancelled: "bg-red-100 text-red-800",
+const STATUS_BADGE_TONE: Record<string, ChipTone> = {
+	Draft: "warning",
+	Published: "success",
+	Unpublished: "neutral",
+	Cancelled: "danger",
 };
 
 export default function OrgOpportunitiesPage() {
@@ -337,14 +338,14 @@ export default function OrgOpportunitiesPage() {
 						>
 							{item.title || t("orgDashboard.unnamedDraft")}
 						</Link>
-						<span
+						<Chip
 							data-testid="opportunity-status-badge"
-							className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-								STATUS_BADGE_CLASSES[status] ?? "bg-gray-100 text-gray-700"
-							}`}
+							tone={STATUS_BADGE_TONE[status] ?? "neutral"}
+							size="sm"
+							className="shrink-0"
 						>
 							{badgeLabel}
-						</span>
+						</Chip>
 					</div>
 					{item.description && (
 						<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">


### PR DESCRIPTION
## What

Add a shared `Chip` component (`frontend/src/components/Chip.tsx`, `tone`: brand/neutral/success/warning/danger, `size`: sm/md) and migrate every tag/category/status pill onto it, so the same concept renders identically wherever it appears.

## Why

The same "tag" concept had a different background, size, padding, and font weight depending on where it appeared - most visibly, the opportunity wizard's tag editor (`TagsInput`, brand-100/12px) didn't match the published opportunity page's tags (gray-100), so an organizer's editing preview didn't match the published result. Related divergence existed for profile skills/languages chips (edit form vs. profile view) and for status pills (opportunity status badge, admin/user status, report status, spots-left indicators) that varied in color, padding, and weight for no reason beyond copy-paste drift.

Closes #1125.

## Changes

- New `Chip` component with a fixed tone/size scale, an optional `onRemove` action (used by the two removable-tag inputs), and pass-through HTML attributes (e.g. `data-testid`).
- `TagsInput.tsx` (opportunity tag editor) and `VolunteerOpportunityDetailPage.tsx` (published tags) both now use `tone="neutral"`, matching each other and staying visually distinct from the adjacent `tone="brand"` category chip.
- `ProfileFieldsView.tsx` (profile view) and `ProfileOverviewPage`'s `ChipInput` (profile edit form) now share the same tone per field - skills stay `brand`, languages moved to `neutral` to match the view.
- Status/indicator pills in `OrgOpportunitiesPage.tsx`, `AdministrationPage.tsx`, `OpportunityListItem.tsx`, and the remaining pills in `VolunteerOpportunityDetailPage.tsx` migrated onto `Chip` with a semantic tone (e.g. Published -> success, Draft -> warning, Cancelled -> danger) instead of one-off Tailwind class strings.

## Testing

- `pnpm check` (tsc), `pnpm lint` (eslint, zero warnings), `pnpm test` (vitest, 123 tests), `pnpm build`, and `pnpm format:check` all pass.
- `a11y-check` subagent reviewed the diff: no accessibility regressions - the removable-chip's `aria-label`/`aria-hidden` pattern and existing `data-testid` hooks (e.g. `opportunity-status-badge`, asserted in `backend/tests/VisualTests/`) are preserved.
- No backend/API/locale changes, so no new EF migration, NSwag regen, or i18n keys were needed.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut, per the task request) - this is a pure frontend restyle with no new route/page, covered by the existing `AccessibilityTests.cs`/Playwright suite in CI (`dotnet.yml`'s `visual-tests` job) rather than a new live-staging check.

## Checklist

- [x] `/self-review` run and findings addressed (a11y-check subagent + tone-consistency fix)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal component only)


---
_Generated by [Claude Code](https://claude.ai/code/session_013PbPD2qnm8riBNUfZAUT2M)_