### PR TITLE
fix: stop logging raw Keycloak admin-API error bodies at Error level

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakAdminTokenProvider.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakAdminTokenProvider.cs
@@ -1,13 +1,15 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Keycloak;
 
 internal sealed class KeycloakAdminTokenProvider(
 	IHttpClientFactory httpClientFactory,
-	IOptions<KeycloakOptions> options)
+	IOptions<KeycloakOptions> options,
+	ILogger<KeycloakAdminTokenProvider> logger)
 {
 	public const string HttpClientName = "keycloak-admin-token";
 
@@ -72,9 +74,15 @@ internal sealed class KeycloakAdminTokenProvider(
 
 		if (!response.IsSuccessStatusCode)
 		{
-			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			// The response body is never logged here, even at Debug level - unlike the
+			// admin API, this is a client-credentials token exchange and its response
+			// carries no data useful for diagnostics.
+			logger.LogWarning(
+				"Keycloak token request failed with {StatusCode}",
+				(int)response.StatusCode);
+
 			throw new HttpRequestException(
-				$"Keycloak token request failed with {(int)response.StatusCode} {response.StatusCode}: {body}",
+				$"Keycloak token request failed with {(int)response.StatusCode} {response.StatusCode}",
 				inner: null,
 				response.StatusCode);
 		}

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -8,6 +8,7 @@ using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Domain.Organizations;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Keycloak;
@@ -16,7 +17,8 @@ internal sealed class KeycloakOrganizationService(
 	HttpClient httpClient,
 	KeycloakAdminTokenProvider tokenProvider,
 	IOptions<KeycloakOptions> options,
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	ILogger<KeycloakOrganizationService> logger)
 	: IKeycloakOrganizationService
 {
 	private static readonly JsonSerializerOptions JsonOptions = new()
@@ -289,7 +291,7 @@ internal sealed class KeycloakOrganizationService(
 			: sb.ToString();
 	}
 
-	private static async Task EnsureSuccessAsync(
+	private async Task EnsureSuccessAsync(
 		HttpResponseMessage response,
 		CancellationToken cancellationToken)
 	{
@@ -298,11 +300,23 @@ internal sealed class KeycloakOrganizationService(
 			return;
 		}
 
-		var body = await response.Content.ReadAsStringAsync(cancellationToken);
+		var method = response.RequestMessage?.Method;
+		// Strip the query string - it can carry PII such as search terms - before it
+		// ever reaches the Error-level exception message that gets logged/exported.
+		var path = response.RequestMessage?.RequestUri?.GetLeftPart(UriPartial.Path);
+
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			logger.LogDebug(
+				"Keycloak error response body for {Method} {Path}: {Body}",
+				method,
+				path,
+				body);
+		}
 
 		throw new HttpRequestException(
-			$"Keycloak responded with {(int)response.StatusCode} {response.StatusCode} " +
-			$"for {response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: {body}",
+			$"Keycloak responded with {(int)response.StatusCode} {response.StatusCode} for {method} {path}",
 			inner: null,
 			response.StatusCode);
 	}

--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Application.Common.Keycloak;
 using Application.Common.Pagination;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Keycloak;
@@ -11,7 +12,8 @@ namespace Infrastructure.Keycloak;
 internal sealed class KeycloakUserService(
 	HttpClient httpClient,
 	KeycloakAdminTokenProvider tokenProvider,
-	IOptions<KeycloakOptions> options)
+	IOptions<KeycloakOptions> options,
+	ILogger<KeycloakUserService> logger)
 	: IKeycloakUserService
 {
 	private static readonly JsonSerializerOptions JsonOptions = new()
@@ -385,7 +387,7 @@ internal sealed class KeycloakUserService(
 	private static string? NullIfEmpty(string? value) =>
 		string.IsNullOrEmpty(value) ? null : value;
 
-	private static async Task EnsureSuccessAsync(
+	private async Task EnsureSuccessAsync(
 		HttpResponseMessage response,
 		CancellationToken cancellationToken)
 	{
@@ -394,11 +396,23 @@ internal sealed class KeycloakUserService(
 			return;
 		}
 
-		var body = await response.Content.ReadAsStringAsync(cancellationToken);
+		var method = response.RequestMessage?.Method;
+		// Strip the query string - it can carry PII such as search terms - before it
+		// ever reaches the Error-level exception message that gets logged/exported.
+		var path = response.RequestMessage?.RequestUri?.GetLeftPart(UriPartial.Path);
+
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			logger.LogDebug(
+				"Keycloak error response body for {Method} {Path}: {Body}",
+				method,
+				path,
+				body);
+		}
 
 		throw new HttpRequestException(
-			$"Keycloak responded with {(int)response.StatusCode} {response.StatusCode} " +
-			$"for {response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: {body}",
+			$"Keycloak responded with {(int)response.StatusCode} {response.StatusCode} for {method} {path}",
 			inner: null,
 			response.StatusCode);
 	}


### PR DESCRIPTION
## What

Stop interpolating raw Keycloak admin-API error response bodies into `HttpRequestException` messages that get logged at Error level (and exported via OTLP).

## Why

Keycloak's admin-API error responses routinely echo submitted usernames, emails, and user ids. `EnsureSuccessAsync` in `KeycloakOrganizationService` and `KeycloakUserService` interpolated that body verbatim into the exception message, which `UnhandledExceptionHandler` then logs at Error level with `IncludeFormattedMessage = true` for OTLP export - so PII ended up in container logs and any log sink, retained indefinitely. `KeycloakAdminTokenProvider`'s client-credentials token request had the same pattern.

Fix, matching the issue's suggested approach:
- The exception message now only contains the status code, method, and a sanitised path (query string stripped, since e.g. `SearchUsersAsync`'s `search` param can carry PII).
- The response body is only logged at `Debug` level, gated behind `logger.IsEnabled(LogLevel.Debug)` so it's not even read unless enabled - off by default per `appsettings.json`'s `"Default": "Information"`.
- `KeycloakAdminTokenProvider`'s token-endpoint response body is never logged, at any level, per the issue's explicit guidance.

`KeycloakUserService.EnsureSuccessAsync` had the identical anti-pattern (not explicitly cited in the issue, but same code shape, same risk - usernames/emails) so it's fixed alongside the two cited locations to avoid leaving a duplicate hole.

Closes #1181

## Testing

- Manual review of the diff (self-review skill run, no findings).
- Could not run `dotnet build`/`Application.UnitTests` locally in this session - the sandbox's egress policy blocked the .NET SDK install (`builds.dotnet.microsoft.com` returned 403 from the proxy) and no SDK was already cached. CI's `dotnet.yml` will build and run the full suite; I'll monitor and fix any failures.
- Confirmed via `grep` that no existing test asserts on the removed body content in these exception messages (the two tests that reference `"Keycloak responded with..."` mock `IKeycloakOrganizationService` directly with a hardcoded string, unrelated to `EnsureSuccessAsync`'s internals).

## Live verification

Skipped for this PR per explicit task instructions (no release candidate cut). This is a backend logging-only change - no user-visible behavior, no API contract change - so there is nothing to observe on staging; CI's build + unit/integration/architecture test suite is the verification path here.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal logging behavior only)


---
_Generated by [Claude Code](https://claude.ai/code/session_011oN9uwtPYWTUhSeY8J4ZaD)_