### PR TITLE
fix: drop localhost redirect/origin wildcard from production Keycloak realm

### DIFF
--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -33,12 +33,16 @@ var keycloakThemePath = Path.GetFullPath(
 	Path.Combine(builder.AppHostDirectory, "..", "..", "..", "..", "keycloak", "themes", "einsatzbereit"));
 
 // The committed realm keeps production security settings; some break the local
-// Aspire + Playwright flow. Write a dev-only copy with two relaxations and import
+// Aspire + Playwright flow. Write a dev-only copy with three relaxations and import
 // that. Production never runs this AppHost - it uses the baked image + committed realm.
 //  - webOrigins: Aspire serves the frontend on a dynamic http://localhost:<port>
 //    origin that no fixed webOrigins entry matches (Keycloak webOrigins are exact CORS
 //    origins, not port wildcards), so the browser OIDC token exchange is CORS-blocked.
 //    Allow all origins for the public frontend client.
+//  - redirectUris / post.logout.redirect.uris: same dynamic-port problem as webOrigins
+//    above. The committed realm only lists the production callback (#1190 removed the
+//    "http://localhost:*" wildcard from the deployed realm to keep it out of
+//    production) - add it back here, local dev only.
 //  - bruteForceProtected: the parallel VisualTests log in concurrently as the shared
 //    seed users, which trips brute-force protection and gets rejected. Disable it.
 var localRealm = JsonNode.Parse(
@@ -53,7 +57,13 @@ if (localRealm["clients"] is JsonArray realmClients)
 		var clientId = clientObject["clientId"]?.GetValue<string>();
 
 		if (clientId == "frontend")
+		{
 			clientObject["webOrigins"] = new JsonArray("*");
+			clientObject["redirectUris"] = new JsonArray("http://localhost:*");
+
+			if (clientObject["attributes"] is JsonObject frontendAttributes)
+				frontendAttributes["post.logout.redirect.uris"] = "http://localhost:*";
+		}
 
 		if (clientId == "backend")
 			clientObject["secret"] = "backend-secret";

--- a/keycloak/AGENTS.md
+++ b/keycloak/AGENTS.md
@@ -30,7 +30,7 @@ Imported on container startup. This file IS the auth configuration - edit here, 
 **`frontend`** (public OIDC client)
 - Authorization Code + PKCE (S256 enforced) flow only
 - ROPC disabled (`directAccessGrantsEnabled: false`) - use `frontend-test` for integration tests
-- Redirect URIs: `http://localhost:*`, `https://einsatzbereit.maik-hasler.de/callback`
+- Redirect URIs / web origins / post-logout redirect URIs: `https://einsatzbereit.maik-hasler.de` only in the committed realm - the same file ships baked into the production Keycloak image (`Dockerfile`), so a `http://localhost:*` entry here would be live on `login.maik-hasler.de` (#1190). `AppHost.cs` overlays `http://localhost:*` (and `webOrigins: ["*"]`, since Aspire's dynamic port can't be matched by a fixed origin) back in for local Aspire/Playwright runs only - see its comment above the realm-patching block
 - Protocol mappers:
   - `realm-roles` - injects `roles: [...]` into id_token, access_token, userinfo
   - `realm-name` - injects hardcoded claim `realm: "einsatzbereit"` (used by backend auth policies)

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -66,15 +66,13 @@
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
       "redirectUris": [
-        "http://localhost:*",
         "https://einsatzbereit.maik-hasler.de/callback"
       ],
       "webOrigins": [
-        "http://localhost:*",
         "https://einsatzbereit.maik-hasler.de"
       ],
       "attributes": {
-        "post.logout.redirect.uris": "http://localhost:*##https://einsatzbereit.maik-hasler.de",
+        "post.logout.redirect.uris": "https://einsatzbereit.maik-hasler.de",
         "pkce.code.challenge.method": "S256"
       },
       "protocol": "openid-connect",


### PR DESCRIPTION
## What

Removes the dev-only `http://localhost:*` wildcard from the `frontend` public client's `redirectUris`, `webOrigins`, and `post.logout.redirect.uris` in the committed Keycloak realm, and re-adds it as a local-only overlay in `AppHost.cs`.

## Why

`keycloak/realms/einsatzbereit-realm.json` is the single realm baked into the shipped Keycloak image (`keycloak/Dockerfile`), so the `http://localhost:*` dev convenience entries on the `frontend` client were live on `login.maik-hasler.de` in production. With PKCE S256 enforced this isn't remotely exploitable on its own, but it hands any local process on a victim's loopback interface (malware, another user on a shared/kiosk machine) a supported path into an authorization-code flow against the production realm, and the matching `webOrigins` entry relaxed CORS the same way. Keeping dev redirect URIs out of the deployed realm is standard hardening.

`AppHost.cs` already patches a dev-only copy of the realm at local-Aspire-boot time for other prod/dev mismatches (it already forces `webOrigins` to `"*"` there, since Aspire's dynamic `http://localhost:<port>` frontend origin can't be matched by any fixed entry). This change extends that same overlay to `redirectUris` and `post.logout.redirect.uris`, so local dev and the Playwright/integration test suites (which all boot through the same `AppHost`) keep working, while the committed realm - and therefore the production image - now only ever lists the real `https://einsatzbereit.maik-hasler.de` origin.

Closes #1190

## Testing

Config-only change (realm JSON + the AppHost dev-realm-patching code) plus a doc update - no new test surface. Verified the edited realm JSON is well-formed, verified no other code (tests, docs) hardcodes the removed `http://localhost:*` entries on the `frontend` client, and reviewed the `AppHost.cs` addition against the existing `webOrigins` override it mirrors. Could not run a full local `dotnet build`/Aspire boot in this sandbox (no Docker networking; see root `AGENTS.md`'s Sandbox Limitations) - CI's `dotnet.yml` (including `VisualTests`, which exercises the real login flow through this same `AppHost` realm patch) and `keycloak-realm-import.yml` (imports the committed realm on the production Keycloak version) cover this.

## Live verification

Skipped for this PR at the requester's explicit direction (no release candidate cut). CI's `keycloak-realm-import.yml` job already imports the committed realm on the exact Keycloak version used in production and asserts it's served, which is the most direct available check that this realm still imports cleanly with the wildcard removed.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (`keycloak/AGENTS.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEPd4eXod3awGUmfLQ1ZeP)_