### PR TITLE
fix: disable frontend-test ROPC client in the shipped Keycloak realm

### DIFF
--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -33,7 +33,7 @@ var keycloakThemePath = Path.GetFullPath(
 	Path.Combine(builder.AppHostDirectory, "..", "..", "..", "..", "keycloak", "themes", "einsatzbereit"));
 
 // The committed realm keeps production security settings; some break the local
-// Aspire + Playwright flow. Write a dev-only copy with three relaxations and import
+// Aspire + Playwright flow. Write a dev-only copy with these relaxations and import
 // that. Production never runs this AppHost - it uses the baked image + committed realm.
 //  - webOrigins: Aspire serves the frontend on a dynamic http://localhost:<port>
 //    origin that no fixed webOrigins entry matches (Keycloak webOrigins are exact CORS
@@ -45,6 +45,13 @@ var keycloakThemePath = Path.GetFullPath(
 //    production) - add it back here, local dev only.
 //  - bruteForceProtected: the parallel VisualTests log in concurrently as the shared
 //    seed users, which trips brute-force protection and gets rejected. Disable it.
+//  - frontend-test's "enabled": the committed realm ships it disabled (#1167 - a
+//    public ROPC-enabled client in the same realm baked into the staging/production
+//    image turns credential stuffing into a single scriptable token request, no
+//    browser or PKCE needed). IntegrationTestFixture.GetAccessTokenAsync and
+//    AspireFixture.SignInAsync both need it live to mint tokens for the test suites,
+//    and both boot Keycloak through this AppHost, never the baked image - so
+//    re-enable it only here.
 var localRealm = JsonNode.Parse(
 	File.ReadAllText(Path.Combine(keycloakRealmPath, "einsatzbereit-realm.json")))!;
 if (localRealm["clients"] is JsonArray realmClients)
@@ -64,6 +71,9 @@ if (localRealm["clients"] is JsonArray realmClients)
 			if (clientObject["attributes"] is JsonObject frontendAttributes)
 				frontendAttributes["post.logout.redirect.uris"] = "http://localhost:*";
 		}
+
+		if (clientId == "frontend-test")
+			clientObject["enabled"] = true;
 
 		if (clientId == "backend")
 			clientObject["secret"] = "backend-secret";

--- a/keycloak/AGENTS.md
+++ b/keycloak/AGENTS.md
@@ -37,7 +37,8 @@ Imported on container startup. This file IS the auth configuration - edit here, 
   - `backend-audience` - adds `backend` client to audience in access tokens
 
 **`frontend-test`** (public OIDC client, integration tests only)
-- ROPC enabled (`directAccessGrantsEnabled: true`) - used by `IntegrationTestFixture.GetAccessTokenAsync`
+- `enabled: false` in the committed realm - it ships in the same realm baked into the staging/production image (#1167: a public client with ROPC enabled there turns credential stuffing into a single scriptable `grant_type=password` request, no browser, no PKCE, no redirect-URI constraint). `backend/src/Aspire/AppHost/AppHost.cs` flips it back to `enabled: true` in the dev-only realm copy it writes before import, since that's the only path that ever needs it live - see below
+- ROPC enabled (`directAccessGrantsEnabled: true`) - used by `IntegrationTestFixture.GetAccessTokenAsync` and `VisualTests/AspireFixture.SignInAsync`, both of which boot Keycloak through the Aspire AppHost, never the baked image
 - Redirect URIs: `http://localhost:*` only (never production)
 - Same protocol mappers as `frontend` (roles, realm-name, backend-audience)
 

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -117,7 +117,7 @@
     },
     {
       "clientId": "frontend-test",
-      "enabled": true,
+      "enabled": false,
       "publicClient": true,
       "standardFlowEnabled": false,
       "directAccessGrantsEnabled": true,

--- a/wiki/bundle/log.md
+++ b/wiki/bundle/log.md
@@ -10,6 +10,10 @@ dates and a bold action-word prefix, e.g. `**Added**`, `**Updated**`,
 - **Added** - <one-line description of what changed and why>
 ```
 
+## 2026-08-02
+
+- **Fixed** - `reference/keycloak-realm-config.md`: `frontend-test`'s ROPC access was documented as always-on, but #1167 found it shipping enabled in the same realm baked into the staging/production image, letting anyone mint a real `backend`-audience access token via a single `grant_type=password` HTTP call with no browser or PKCE. Fixed by shipping the client `enabled: false` in the committed realm and having `AppHost.cs` flip it back to `enabled: true` only in the dev-only realm copy it writes before import for local Aspire runs and the IntegrationTests/VisualTests fixtures, which both boot Keycloak through the AppHost rather than the baked image.
+
 ## 2026-07-24
 
 - **Fixed** - `reference/keycloak-realm-config.md`: the `backend` client secret and its service-account roles changed with #805 - `secret` is now the placeholder `${KEYCLOAK_BACKEND_SECRET}` (resolved via Keycloak's realm-import env var substitution, sourced from a GitHub Environment secret on staging) instead of the committed literal `backend-secret`, and the service account holds `view-realm` instead of `manage-realm`.

--- a/wiki/bundle/reference/keycloak-realm-config.md
+++ b/wiki/bundle/reference/keycloak-realm-config.md
@@ -19,7 +19,7 @@ timestamp: 2026-07-24
 There are three OIDC clients, and picking the wrong one for a task is the common mistake.
 
 - **frontend** (public): Authorization Code + PKCE with S256 enforced, and nothing else. ROPC is off (`directAccessGrantsEnabled: false`). This is the real app client.
-- **frontend-test** (public): identical mappers to `frontend` but with ROPC enabled (`directAccessGrantsEnabled: true`). It is the password-grant client for the test suites - `IntegrationTestFixture.GetAccessTokenAsync` and the many VisualTests that request their own token both use it. Its redirect URIs are `http://localhost:*` only, never production. Do not enable ROPC on `frontend` to shortcut a test; use this client.
+- **frontend-test** (public): identical mappers to `frontend` but with ROPC enabled (`directAccessGrantsEnabled: true`). It is the password-grant client for the test suites - `IntegrationTestFixture.GetAccessTokenAsync` and the many VisualTests that request their own token both use it. Its redirect URIs are `http://localhost:*` only, never production. Do not enable ROPC on `frontend` to shortcut a test; use this client. The committed realm ships it with `enabled: false` (#1167: a public ROPC client baked into the same realm as staging/production turns credential stuffing into a single scriptable token request); `AppHost.cs` flips it back to `enabled: true` in the dev-only realm copy it writes before import, since both fixtures above boot Keycloak through the AppHost and never through the baked image.
 - **backend** (confidential service account): no user login flow, server-to-server only. Its service account holds `view-realm`, `manage-users`, and `manage-organizations` (not `manage-realm` - the backend never touches realm-level config, so that role was dropped as unnecessary privilege, see #805), and `KeycloakOrganizationService` uses it. Dev secret is `backend-secret` (`AppHost.cs` overwrites the realm JSON's value before import for local Aspire runs and tests); the checked-in realm JSON instead carries the placeholder `"secret": "${KEYCLOAK_BACKEND_SECRET}"`, which Keycloak's realm import resolves from an env var of the same name at container startup - staging sources that env var from a `KEYCLOAK_BACKEND_SECRET` GitHub Environment secret rather than a committed literal.
 
 # The mappers backend auth depends on
@@ -60,6 +60,8 @@ The split that matters at request time: whether a user is an organizer of a give
 # Citations
 
 - #805 - hardcoded `backend` client secret and excessive `manage-realm` service-account role, fixed by sourcing the secret from a `KEYCLOAK_BACKEND_SECRET` GitHub Environment secret and dropping `manage-realm` in favor of `view-realm`
+- #1167 - `frontend-test`'s ROPC access shipped enabled in the same realm baked into staging/production; fixed by shipping it `enabled: false` and having `AppHost.cs` re-enable it only for local dev/test realm imports
+- backend/src/Aspire/AppHost/AppHost.cs - the `frontend-test` re-enable override
 - keycloak/AGENTS.md:16-62
 - keycloak/AGENTS.md:30-48
 - keycloak/AGENTS.md:50-56


### PR DESCRIPTION
## What

`keycloak/realms/einsatzbereit-realm.json` now ships the `frontend-test` client with `"enabled": false`. `backend/src/Aspire/AppHost/AppHost.cs` (which already rewrites a dev-only realm copy before importing it for local Aspire runs) flips it back to `enabled: true` in that copy only.

## Why

`frontend-test` is a public OIDC client with `directAccessGrantsEnabled: true` (Resource Owner Password Credentials / ROPC), and it was shipped enabled in the single realm baked into the Keycloak image deployed to staging/production. Redirect URIs don't constrain the password grant, so `POST https://login.maik-hasler.de/realms/einsatzbereit/protocol/openid-connect/token` with `client_id=frontend-test&grant_type=password&username=...&password=...` returned a real `aud: backend` access token for any realm user - no browser, no PKCE, no login theme. This also defeated the `frontend` client's deliberate `directAccessGrantsEnabled: false` hardening.

Closes #1167

## Testing

- `IntegrationTestFixture.GetAccessTokenAsync` and `VisualTests/AspireFixture.SignInAsync` both mint tokens via `frontend-test` through Keycloak booted by `AppHost.cs`, never the baked image, so they keep working with the AppHost's `enabled: true` override.
- `.github/workflows/keycloak-realm-import.yml` verifies the committed realm still imports and serves on the production Keycloak version regardless of `frontend-test`'s enabled state.
- Could not run `dotnet build` / the local test suites in this sandbox - outbound access to `builds.dotnet.microsoft.com` (needed to install the .NET SDK) is blocked by this environment's egress policy. The change mirrors the file's existing override pattern exactly (`localRealm["bruteForceProtected"] = false;` right above it), so I'm relying on CI to compile and exercise it.

## Live verification

Skipped per explicit instruction on this task - no release candidate was cut for this change.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (`keycloak/AGENTS.md`, `wiki/bundle/reference/keycloak-realm-config.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4hndNbrxjRex1igjivMea)_