### PR TITLE
fix: filter anonymous engagement calendar feed to Published opportunities

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -348,7 +348,8 @@ internal sealed class EngagementReadRepository(
 		CancellationToken cancellationToken = default)
 	{
 		var engagement = await dbContext.EngagementsQuery
-			.Where(e => e.Id == engagementId)
+			.Where(e => e.Id == engagementId &&
+				(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 			.Select(e => new { e.OpportunityId, e.TimeSlotId })
 			.FirstOrDefaultAsync(cancellationToken);
 
@@ -356,7 +357,7 @@ internal sealed class EngagementReadRepository(
 			return null;
 
 		var opportunity = await dbContext.VolunteerOpportunitiesQuery
-			.Where(o => o.Id == engagement.OpportunityId)
+			.Where(o => o.Id == engagement.OpportunityId && o.Status == OpportunityStatus.Published)
 			.Select(o => new { o.Id, o.Title, o.Description, o.IsRemote, o.Address })
 			.FirstOrDefaultAsync(cancellationToken);
 

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -3,6 +3,7 @@ using AwesomeAssertions;
 using Domain.Engagements;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Infrastructure.Persistence;
 using Infrastructure.Persistence.Repositories;
 using Infrastructure.VolunteerOpportunities;
 using TUnit.Core.Interfaces;
@@ -143,6 +144,107 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 	private sealed class NoOpPinGenerator : IPinGenerator
 	{
 		public string GeneratePin() => "0000";
+	}
+
+	// Regression for #1184: the anonymous .ics calendar feed (AllowAnonymous,
+	// engagementId as capability token) must not leak title/description/address
+	// for an opportunity the organizer has taken off Published, nor keep serving
+	// a withdrawn/cancelled engagement's feed - both must 404 via a null return.
+	//
+	// ScheduledSlots opportunities can't be created directly as Published (Create()
+	// requires at least one time slot to exist first), so every case here starts as
+	// Draft, adds a slot, then Publish()es before being driven to the case's status.
+	private async Task<(VolunteerOpportunity Opportunity, TimeSlot Slot)> CreatePublishedOpportunityWithSlotAsync(
+		ApplicationDbContext dbContext,
+		CancellationToken cancellationToken)
+	{
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"CalendarOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.Recurring,
+			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var slot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		opportunity.Publish().ThrowIfFailure();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		return (opportunity, slot);
+	}
+
+	[Test]
+	public async Task GetCalendarInfoAsync_ShouldReturnInfo_WhenOpportunityPublishedAndEngagementConfirmed(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var (opportunity, slot) = await CreatePublishedOpportunityWithSlotAsync(dbContext, cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), slot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var info = await repository.GetCalendarInfoAsync(engagement.Id, cancellationToken);
+
+		info.Should().NotBeNull();
+		info!.OpportunityTitle.Should().Be("Titel");
+	}
+
+	[Test]
+	[Arguments(OpportunityStatus.Unpublished)]
+	[Arguments(OpportunityStatus.Cancelled)]
+	public async Task GetCalendarInfoAsync_ShouldReturnNull_WhenOpportunityNotPublished(
+		OpportunityStatus status,
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var (opportunity, slot) = await CreatePublishedOpportunityWithSlotAsync(dbContext, cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), slot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		if (status == OpportunityStatus.Unpublished)
+			opportunity.Unpublish().ThrowIfFailure();
+		else
+			opportunity.Cancel().ThrowIfFailure();
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var info = await repository.GetCalendarInfoAsync(engagement.Id, cancellationToken);
+
+		info.Should().BeNull();
+	}
+
+	[Test]
+	[Arguments(EngagementStatus.Cancelled)]
+	[Arguments(EngagementStatus.Withdrawn)]
+	public async Task GetCalendarInfoAsync_ShouldReturnNull_WhenEngagementInTerminalStatus(
+		EngagementStatus terminalStatus,
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var (opportunity, slot) = await CreatePublishedOpportunityWithSlotAsync(dbContext, cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), slot.Id);
+		if (terminalStatus == EngagementStatus.Cancelled)
+			engagement.Cancel().ThrowIfFailure();
+		else
+			engagement.Withdraw().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var info = await repository.GetCalendarInfoAsync(engagement.Id, cancellationToken);
+
+		info.Should().BeNull();
 	}
 
 	// Regression for #1051: EngagementSummary never carried CancellationReason,


### PR DESCRIPTION
## What

`EngagementReadRepository.GetCalendarInfoAsync` (backing the anonymous `.ics` calendar feed) now filters the opportunity to `Status == Published` and the engagement to a non-terminal status (`Pending`/`Confirmed`) before returning calendar details.

## Why

The `.ics` calendar endpoint is deliberately `AllowAnonymous()` - an engagement's unguessable v7 GUID acts as a capability token, since Apple/Google calendar clients re-fetch the URL without a Bearer token. `GetCalendarInfoAsync` never checked the opportunity's `Status`, unlike `VolunteerOpportunityReadRepository.GetDetailsAsync`, so it kept serving title, description, and address for opportunities the organizer had unpublished or cancelled - and kept serving a withdrawn/cancelled engagement's feed indefinitely, since the row is never deleted.

Closes #1184

## Testing

Added `EngagementReadRepositoryTests` cases (integration tests against real Postgres, `backend/tests/IntegrationTests/`):
- `GetCalendarInfoAsync_ShouldReturnInfo_WhenOpportunityPublishedAndEngagementConfirmed` - baseline positive case still works
- `GetCalendarInfoAsync_ShouldReturnNull_WhenOpportunityNotPublished` (`Unpublished`, `Cancelled`) - opportunity-status filter
- `GetCalendarInfoAsync_ShouldReturnNull_WhenEngagementInTerminalStatus` (`Cancelled`, `Withdrawn`) - engagement-status filter

Ran `/self-review` on the diff; delegated to `ef-migration-check` since the change touches `Infrastructure/Persistence/` - confirmed no migration needed (pure query-filter change, no schema/model changes). No findings.

Could not run `dotnet build`/tests locally in this sandbox (outbound access to the .NET SDK installer is blocked by this environment's network policy) - relied on CI (`dotnet.yml`) to validate the build and the new integration tests. CI is green (see checklist below).

## Live verification

Skipped per task instructions for this change - no release candidate was cut.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - internal fix, no user-facing behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDmYAeW69GYXEz8UMfMSED)_