### PR TITLE
fix: randomise user avatar object keys and delete by exact key

### DIFF
--- a/backend/src/Application/Common/Storage/IFileStorageService.cs
+++ b/backend/src/Application/Common/Storage/IFileStorageService.cs
@@ -11,6 +11,13 @@ public interface IFileStorageService
 
 	Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default);
 
+	// Reverse of the storage backend's own (private, backend-specific) public
+	// URL builder - lets a caller that only has a previously stored public URL
+	// (e.g. User.AvatarUrl) recover the exact object key to delete, instead of
+	// guessing it back from a naming convention. Returns null if the URL
+	// doesn't match this service's own public URL format.
+	string? GetObjectKeyFromPublicUrl(string publicUrl);
+
 	// Throws if the storage backend is unreachable; used by StorageHealthCheck
 	// (Api/Common/Health) to back the "ready" readiness probe (#1081).
 	Task PingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
+++ b/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
@@ -14,8 +14,6 @@ internal sealed class DeleteMyAccountCommandHandler(
 	IFileStorageService fileStorage)
 	: ICommandHandler<DeleteMyAccountCommand, bool>
 {
-	private static readonly string[] AvatarExtensions = [".jpg", ".png", ".webp"];
-
 	public async ValueTask<bool> Handle(
 		DeleteMyAccountCommand request,
 		CancellationToken cancellationToken = default)
@@ -38,15 +36,22 @@ internal sealed class DeleteMyAccountCommandHandler(
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 		if (user is not null)
 		{
-			foreach (var ext in AvatarExtensions)
+			// The avatar's random object key (issue #1175) can't be reconstructed
+			// from the user id, so it has to come from the stored AvatarUrl instead
+			// of a guessed extension.
+			var avatarObjectKey = user.AvatarUrl is not null
+				? fileStorage.GetObjectKeyFromPublicUrl(user.AvatarUrl)
+				: null;
+
+			if (avatarObjectKey is not null)
 			{
 				try
 				{
-					await fileStorage.DeleteAsync($"user-avatars/{request.UserId.Value}{ext}", cancellationToken);
+					await fileStorage.DeleteAsync(avatarObjectKey, cancellationToken);
 				}
 				catch
 				{
-					// Object may not exist for this extension; continue
+					// Object may already be gone or storage may be transiently unavailable; continue.
 				}
 			}
 

--- a/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
+++ b/backend/src/Application/Users/UploadUserAvatar/v1/UploadUserAvatarCommandHandler.cs
@@ -17,6 +17,7 @@ internal sealed class UploadUserAvatarCommandHandler(
 		var contentType = ImageUploadValidator.EnsureValid(request.Content, request.ContentType, "Avatar");
 
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
+		var previousAvatarUrl = user?.AvatarUrl;
 
 		if (user is null)
 		{
@@ -25,13 +26,42 @@ internal sealed class UploadUserAvatarCommandHandler(
 		}
 
 		var ext = ImageUploadValidator.GetExtension(contentType);
-		var objectKey = $"user-avatars/{request.UserId.Value}{ext}";
+		// Random suffix, not just "{userId}{ext}" - the user id is a public
+		// identifier surfaced by member search and public-profile endpoints, and
+		// avatars are face photos, so the object key must not be guessable from it
+		// (issue #1175).
+		var objectKey = $"user-avatars/{request.UserId.Value}/{Guid.NewGuid():N}{ext}";
 
 		using var stream = new MemoryStream(request.Content);
 		var url = await fileStorage.UploadAsync(objectKey, stream, request.Content.Length, contentType, cancellationToken);
 
 		user.SetAvatarUrl(url);
 
+		await DeletePreviousAvatarAsync(previousAvatarUrl, cancellationToken);
+
 		return true;
+	}
+
+	// Every upload gets a fresh random object key (see above), so the previous
+	// one is orphaned unless explicitly removed here. Best-effort: the new
+	// avatar is already live by this point, so a failed cleanup just leaves an
+	// unreferenced object in storage rather than a broken avatar.
+	private async Task DeletePreviousAvatarAsync(string? previousAvatarUrl, CancellationToken cancellationToken)
+	{
+		if (previousAvatarUrl is null)
+			return;
+
+		var previousObjectKey = fileStorage.GetObjectKeyFromPublicUrl(previousAvatarUrl);
+		if (previousObjectKey is null)
+			return;
+
+		try
+		{
+			await fileStorage.DeleteAsync(previousObjectKey, cancellationToken);
+		}
+		catch
+		{
+			// Object may already be gone or storage may be transiently unavailable; continue.
+		}
 	}
 }

--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -7,8 +7,8 @@ namespace Infrastructure.Storage;
 
 internal sealed class MinioFileStorageService : IFileStorageService
 {
-	// Object keys are stable (e.g. "user-avatars/{UserId}{ext}"), so a long
-	// max-age would serve a stale image after re-upload. A moderate TTL plus
+	// Object keys are stable for some callers (e.g. "organization-logos/{OrganizationId}{ext}"),
+	// so a long max-age would serve a stale image after re-upload. A moderate TTL plus
 	// the "?v=" cache-busting query param below (which changes on every
 	// upload) keeps caching effective without that staleness risk.
 	internal const string CacheControlHeaderValue = "public, max-age=3600";
@@ -90,10 +90,24 @@ internal sealed class MinioFileStorageService : IFileStorageService
 			cancellationToken);
 	}
 
-	private string GetPublicUrl(string objectKey)
+	// Not on IFileStorageService (#1011 - no callers through the interface);
+	// internal rather than private so GetObjectKeyFromPublicUrl's inverse-of-this
+	// relationship stays directly testable from IntegrationTests.
+	internal string GetPublicUrl(string objectKey)
 	{
 		var baseUrl = (_settings.PublicEndpoint ?? _settings.Endpoint).TrimEnd('/');
 		return $"{baseUrl}/{_settings.BucketName}/{PublicPrefix}{objectKey}";
+	}
+
+	public string? GetObjectKeyFromPublicUrl(string publicUrl)
+	{
+		var prefix = GetPublicUrl(string.Empty);
+		if (!publicUrl.StartsWith(prefix, StringComparison.Ordinal))
+			return null;
+
+		var withoutPrefix = publicUrl[prefix.Length..];
+		var queryIndex = withoutPrefix.IndexOf('?');
+		return queryIndex >= 0 ? withoutPrefix[..queryIndex] : withoutPrefix;
 	}
 
 	// BucketExistsAsync's own bool result only distinguishes "bucket present"

--- a/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
@@ -77,14 +77,18 @@ public class DeleteMyAccountCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldDeleteAvatarForEveryKnownExtension_AndSwallowFailures(
+	public async Task Handle_ShouldDeleteAvatarByItsExactObjectKey_AndSwallowFailures(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var user = User.Create(DefaultUserId);
+		user.SetAvatarUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png");
 		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
 		_fileStorage
-			.DeleteAsync($"user-avatars/{DefaultUserId.Value}.jpg", Arg.Any<CancellationToken>())
+			.GetObjectKeyFromPublicUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png")
+			.Returns($"user-avatars/{DefaultUserId.Value}/abc123.png");
+		_fileStorage
+			.DeleteAsync($"user-avatars/{DefaultUserId.Value}/abc123.png", Arg.Any<CancellationToken>())
 			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
@@ -93,11 +97,42 @@ public class DeleteMyAccountCommandHandlerTests
 
 		// Assert
 		await act.Should().NotThrowAsync();
-		// Issue #829: a failure deleting one avatar extension is swallowed rather than rolled back -
-		// the remaining extensions are still attempted even though the .jpg deletion threw.
-		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.jpg", cancellationToken);
-		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.png", cancellationToken);
-		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}.webp", cancellationToken);
+		// Issue #829: a failure deleting the avatar is swallowed rather than rolled back.
+		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}/abc123.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptAvatarDeletion_WhenUserHasNoAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var user = User.Create(DefaultUserId);
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptAvatarDeletion_WhenStoredAvatarUrlDoesNotMatchAnyKnownObjectKey(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: a malformed/legacy AvatarUrl that GetObjectKeyFromPublicUrl can't parse back
+		// into an object key - defaults to null via the unconfigured NSubstitute mock.
+		var user = User.Create(DefaultUserId);
+		user.SetAvatarUrl("not-a-valid-storage-url");
+		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
@@ -122,10 +122,13 @@ public class DeleteMyAccountCommandHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange: a malformed/legacy AvatarUrl that GetObjectKeyFromPublicUrl can't parse back
-		// into an object key - defaults to null via the unconfigured NSubstitute mock.
+		// into an object key. Explicitly configured to return null - NSubstitute's unconfigured
+		// default for a string-returning method is "", not null, even though this method's
+		// return type is string?.
 		var user = User.Create(DefaultUserId);
 		user.SetAvatarUrl("not-a-valid-storage-url");
 		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_fileStorage.GetObjectKeyFromPublicUrl("not-a-valid-storage-url").Returns((string?)null);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act

--- a/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
@@ -87,7 +87,7 @@ public class UploadUserAvatarCommandHandlerTests
 
 		// Assert
 		await _fileStorage.Received(1).UploadAsync(
-			Arg.Is<string>(key => key.StartsWith($"user-avatars/{userId.Value}/", StringComparison.Ordinal)
+			Arg.Is<string>(key => key!.StartsWith($"user-avatars/{userId.Value}/", StringComparison.Ordinal)
 				&& key != $"user-avatars/{userId.Value}/"),
 			Arg.Any<Stream>(),
 			Arg.Any<long>(),

--- a/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using AwesomeAssertions;
 using Domain.Primitives;
 using Domain.Users;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Users.UploadUserAvatar;
 
@@ -67,6 +68,95 @@ public class UploadUserAvatarCommandHandlerTests
 		await _usersRepo.Received(1).AddAsync(
 			Arg.Is<User>(u => u!.Id == userId && u.AvatarUrl == "https://example.com/user-avatars/avatar.png"),
 			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldUseARandomObjectKeyUnderTheUserId_NotOnlyTheUserId(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the avatar object key must not be reconstructible from the user id
+		// alone (issue #1175) - it's a public identifier exposed by member search and
+		// public-profile endpoints.
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		_usersRepo.FindAsync(userId, cancellationToken).Returns(user);
+		var command = new UploadUserAvatarCommand(userId, PngBytes, "image/png");
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).UploadAsync(
+			Arg.Is<string>(key => key.StartsWith($"user-avatars/{userId.Value}/", StringComparison.Ordinal)
+				&& key != $"user-avatars/{userId.Value}/"),
+			Arg.Any<Stream>(),
+			Arg.Any<long>(),
+			Arg.Any<string>(),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteThePreviousAvatarObject_WhenUserAlreadyHadOne(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		user.SetAvatarUrl("https://example.com/user-avatars/old-key/old.png");
+		_usersRepo.FindAsync(userId, cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/old-key/old.png")
+			.Returns("user-avatars/old-key/old.png");
+		var command = new UploadUserAvatarCommand(userId, PngBytes, "image/png");
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _fileStorage.Received(1).DeleteAsync("user-avatars/old-key/old.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptDeletion_WhenUserHadNoPreviousAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		_usersRepo.FindAsync(userId, cancellationToken).Returns(user);
+		var command = new UploadUserAvatarCommand(userId, PngBytes, "image/png");
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenDeletingThePreviousAvatarObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the new avatar is already live at this point, so a cleanup failure
+		// for the orphaned old object must not fail the whole upload.
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		user.SetAvatarUrl("https://example.com/user-avatars/old-key/old.png");
+		_usersRepo.FindAsync(userId, cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/old-key/old.png")
+			.Returns("user-avatars/old-key/old.png");
+		_fileStorage
+			.DeleteAsync("user-avatars/old-key/old.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+		var command = new UploadUserAvatarCommand(userId, PngBytes, "image/png");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
+++ b/backend/tests/IntegrationTests/MinioFileStorageServiceUrlTests.cs
@@ -1,10 +1,66 @@
 using AwesomeAssertions;
 using Infrastructure.Storage;
+using Microsoft.Extensions.Options;
 
 namespace IntegrationTests;
 
 public class MinioFileStorageServiceUrlTests
 {
+	private static MinioFileStorageService CreateSut() =>
+		new(Options.Create(new StorageSettings
+		{
+			Endpoint = "http://minio:9000",
+			AccessKey = "access-key",
+			SecretKey = "secret-key",
+			BucketName = "einsatzbereit",
+			PublicEndpoint = "https://storage.example.com",
+		}));
+
+	[Test]
+	public void GetPublicUrl_ShouldPrefixWithPublicEndpointBucketAndPublicPrefix()
+	{
+		var sut = CreateSut();
+
+		var result = sut.GetPublicUrl("user-avatars/user-1/abc.png");
+
+		result.Should().Be("https://storage.example.com/einsatzbereit/public/user-avatars/user-1/abc.png");
+	}
+
+	[Test]
+	public void GetObjectKeyFromPublicUrl_ShouldRecoverTheObjectKey_PassedToGetPublicUrl()
+	{
+		var sut = CreateSut();
+		const string objectKey = "user-avatars/user-1/abc.png";
+
+		var url = sut.GetPublicUrl(objectKey);
+		var result = sut.GetObjectKeyFromPublicUrl(url);
+
+		result.Should().Be(objectKey);
+	}
+
+	[Test]
+	public void GetObjectKeyFromPublicUrl_ShouldStripTheVersionQueryParam()
+	{
+		var sut = CreateSut();
+		const string objectKey = "user-avatars/user-1/abc.png";
+		var uploadedOn = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		var versionedUrl = MinioFileStorageService.AppendVersionQuery(sut.GetPublicUrl(objectKey), uploadedOn);
+
+		var result = sut.GetObjectKeyFromPublicUrl(versionedUrl);
+
+		result.Should().Be(objectKey);
+	}
+
+	[Test]
+	public void GetObjectKeyFromPublicUrl_ShouldReturnNull_WhenUrlDoesNotMatchThisServicesPublicUrlFormat()
+	{
+		var sut = CreateSut();
+
+		var result = sut.GetObjectKeyFromPublicUrl("https://not-our-storage.example.com/some/other/path.png");
+
+		result.Should().BeNull();
+	}
+
 	[Test]
 	public void AppendVersionQuery_ShouldAppendUnixSecondsAsVersionQueryParam()
 	{


### PR DESCRIPTION
## What

User avatar uploads now get a random object key (`user-avatars/{userId}/{guid}{ext}`) instead of a deterministic one derived only from the user id, and avatar deletion (on re-upload and on account deletion) now deletes by the exact object key recovered from the stored `AvatarUrl` instead of guessing.

## Why

Closes #1175

The MinIO root-credentials part of #1175 was already fixed by #1353 (backend authenticates with a bucket-scoped service account, not root), and the anonymous bucket policy is already scoped to a `public/` prefix rather than the whole bucket. The remaining concrete issue was that avatar object keys were fully deterministic (`user-avatars/{userId}{ext}`) - since the Keycloak subject id is a public identifier surfaced by `GET /v1/organizations/{id}/members/search` and `GET /v1/users/{id}/public-profile`, anyone could construct the URL of a user's avatar (a face photo) without authorization, and it could survive account deletion if the old extension-guessing delete missed the actual extension.

This PR implements the issue's own "at minimum" suggested fix: randomise the object key so it isn't derivable from the user id, plus delete by the exact key instead of guessing.

Scoped to user avatars only (not organization logos / opportunity banners), since those are already served publicly via the organization directory and opportunity listings - randomising their keys wouldn't reduce any exposure, only avatars are personally identifying, unauthorized-access-prone content.

### Changes

- `IFileStorageService.GetObjectKeyFromPublicUrl(url)` - reverse of `GetPublicUrl`, recovers the exact object key from a previously stored public URL.
- `UploadUserAvatarCommandHandler` - object key is now `user-avatars/{userId}/{guid}{ext}`; the previous avatar object (if any) is deleted after the new one is live (best-effort, swallowed on failure).
- `DeleteMyAccountCommandHandler` - deletes the avatar by its exact object key (via `GetObjectKeyFromPublicUrl(user.AvatarUrl)`) instead of looping over `.jpg`/`.png`/`.webp` guesses.

## Testing

- `Application.UnitTests`: updated `UploadUserAvatarCommandHandlerTests` (random key format, previous-avatar cleanup incl. failure-swallowing) and `DeleteMyAccountCommandHandlerTests` (exact-key delete, no-avatar case, unparsable-URL case).
- `IntegrationTests`: added `MinioFileStorageServiceUrlTests` cases for `GetPublicUrl`/`GetObjectKeyFromPublicUrl` round-tripping, version-query stripping, and the no-match case.
- Not run locally in this session - the sandbox can't reach `builds.dotnet.microsoft.com` to install the .NET SDK (network policy), so verification relies on CI (`dotnet.yml`).

## Live verification

Skipped for this change at the requester's explicit instruction (no RC cut this round). This is a backend-only object-key/storage change with no user-visible behavior difference (avatars still upload, display, and get cleaned up the same way from the UI's perspective) and is covered by the unit/integration tests above.

## Checklist

- [x] `/self-review` run and findings addressed (clean pass, no P1/P2 findings)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal storage detail, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_019wWmVq3xdfzBr5feqScq8G)_