### PR TITLE
fix: reject oversized avatar/logo/banner uploads at Kestrel before buffering

### DIFF
--- a/backend/src/Api/Common/Middleware/RequestSizeLimitMiddleware.cs
+++ b/backend/src/Api/Common/Middleware/RequestSizeLimitMiddleware.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Common.Middleware;
+
+// Minimal API endpoints don't run through MVC's filter pipeline, so RequestSizeLimitAttribute
+// metadata (chained via .WithMetadata() on individual endpoints) is otherwise never read -
+// unlike MVC controllers, nothing applies it to Kestrel's IHttpMaxRequestBodySizeFeature.
+// Without this bridge, Kestrel's default 30 MB body limit is what actually applies, so an
+// oversized upload gets fully buffered before an endpoint's own validation ever runs (#1177).
+internal sealed class RequestSizeLimitMiddleware(RequestDelegate next)
+{
+	public async Task InvokeAsync(HttpContext context)
+	{
+		var sizeLimit = context.GetEndpoint()?.Metadata.GetMetadata<IRequestSizeLimitMetadata>();
+		var maxRequestBodySizeFeature = context.Features.Get<IHttpMaxRequestBodySizeFeature>();
+
+		if (sizeLimit is not null && maxRequestBodySizeFeature is { IsReadOnly: false })
+			maxRequestBodySizeFeature.MaxRequestBodySize = sizeLimit.MaxRequestBodySize;
+
+		await next(context);
+	}
+}

--- a/backend/src/Api/Common/Middleware/RequestSizeLimitMiddleware.cs
+++ b/backend/src/Api/Common/Middleware/RequestSizeLimitMiddleware.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Metadata;
 
 namespace Api.Common.Middleware;
 

--- a/backend/src/Api/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoEndpoint.cs
+++ b/backend/src/Api/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoEndpoint.cs
@@ -28,6 +28,7 @@ internal sealed class UploadOrganizationLogoEndpoint
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.DisableAntiforgery()
+			.WithMetadata(new RequestSizeLimitAttribute(ImageUploadValidator.MaxRequestBodySizeBytes))
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> UploadOrganizationLogoAsync(

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -221,6 +221,13 @@ app.MapDefaultEndpoints();
 // only these known networks are trusted to set X-Forwarded-For (#1332).
 app.UseForwardedHeaders();
 
+// Bridges RequestSizeLimitAttribute metadata (set per-endpoint via .WithMetadata()) to
+// Kestrel's IHttpMaxRequestBodySizeFeature - see RequestSizeLimitMiddleware for why minimal
+// API endpoints need this explicitly. Placed before anything that could read the request
+// body; endpoint metadata is already resolved this early since UseRouting() is never called
+// explicitly, so WebApplication runs routing at the very start of the pipeline (#1177).
+app.UseMiddleware<RequestSizeLimitMiddleware>();
+
 app.UseHttpLogging();
 app.UseResponseCompression();
 

--- a/backend/src/Api/Users/UploadUserAvatar/v1/UploadUserAvatarEndpoint.cs
+++ b/backend/src/Api/Users/UploadUserAvatar/v1/UploadUserAvatarEndpoint.cs
@@ -26,6 +26,7 @@ internal sealed class UploadUserAvatarEndpoint
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.DisableAntiforgery()
+			.WithMetadata(new RequestSizeLimitAttribute(ImageUploadValidator.MaxRequestBodySizeBytes))
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> UploadUserAvatarAsync(

--- a/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerEndpoint.cs
@@ -29,6 +29,7 @@ internal sealed class UploadOpportunityBannerEndpoint
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.DisableAntiforgery()
+			.WithMetadata(new RequestSizeLimitAttribute(ImageUploadValidator.MaxRequestBodySizeBytes))
 			.MapToApiVersion(1);
 
 	private static async Task<IResult> UploadOpportunityBannerAsync(

--- a/backend/src/Application/Common/Storage/ImageUploadValidator.cs
+++ b/backend/src/Application/Common/Storage/ImageUploadValidator.cs
@@ -7,6 +7,12 @@ public static class ImageUploadValidator
 {
 	public const long MaxFileSizeBytes = 2 * 1024 * 1024;
 
+	// Multipart form-data adds a boundary marker and per-part headers on top of the raw file
+	// bytes; this small allowance is for the Kestrel-level request body limit (see
+	// RequestSizeLimitMiddleware) so well-formed uploads at the cap don't get rejected by
+	// Kestrel before EnsureValid gets a chance to return its own, more specific error (#1177).
+	public const long MaxRequestBodySizeBytes = MaxFileSizeBytes + 4096;
+
 	public static readonly string[] AllowedContentTypes =
 		["image/jpeg", "image/png", "image/webp"];
 

--- a/backend/tests/ArchitectureTests/RequestSizeLimitConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RequestSizeLimitConventionTests.cs
@@ -1,6 +1,5 @@
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace ArchitectureTests;

--- a/backend/tests/ArchitectureTests/RequestSizeLimitConventionTests.cs
+++ b/backend/tests/ArchitectureTests/RequestSizeLimitConventionTests.cs
@@ -1,0 +1,29 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace ArchitectureTests;
+
+public sealed class RequestSizeLimitConventionTests
+{
+	[Test]
+	public void AllMultipartFormEndpoints_ShouldHaveRequestSizeLimitApplied()
+	{
+		var app = EndpointTestHelper.BuildMinimalAppWithAllEndpoints();
+
+		var endpointsWithoutSizeLimit = EndpointTestHelper.GetAllRouteEndpoints(app)
+			.Where(AcceptsMultipartFormData)
+			.Where(e => e.Metadata.GetMetadata<IRequestSizeLimitMetadata>() is null)
+			.Select(e => e.RoutePattern.RawText)
+			.ToList();
+
+		endpointsWithoutSizeLimit.Should().BeEmpty(
+			"file-upload endpoints must chain .WithMetadata(new RequestSizeLimitAttribute(...)) so " +
+			"Kestrel rejects an oversized body before it is fully buffered (#1177)");
+	}
+
+	private static bool AcceptsMultipartFormData(RouteEndpoint endpoint) =>
+		endpoint.Metadata.GetMetadata<IAcceptsMetadata>()?.ContentTypes
+			.Contains("multipart/form-data") == true;
+}


### PR DESCRIPTION
## What

Reject oversized avatar/logo/banner uploads at the Kestrel level, before the request body is fully buffered - not just after, in `ImageUploadValidator.EnsureValid`.

## Why

`IFormFile` binding reads and buffers the whole multipart body before `file.Length` is ever available, so the existing 2 MB check in `ImageUploadValidator.EnsureValid` ran too late to matter. With no request-body limit configured anywhere, Kestrel's 30 MB default applied instead - an authenticated user could send repeated 30 MB multipart requests that each get fully buffered to disk before the 2 MB check rejects them, at up to the `Write` rate limit.

Closes #1177

The suggested fix (chain `RequestSizeLimitAttribute` onto the three endpoints) doesn't work as-is for Minimal APIs: unlike MVC controllers, minimal API endpoints don't run through a filter pipeline that reads `IRequestSizeLimitMetadata`, so the attribute alone is inert (the same reason `.DisableAntiforgery()` on these endpoints is currently a no-op - there's no `UseAntiforgery()` middleware in the pipeline to read it). This PR adds the missing bridge:

- `ImageUploadValidator.MaxRequestBodySizeBytes` (2 MB + 4 KB multipart overhead allowance)
- `.WithMetadata(new RequestSizeLimitAttribute(...))` chained onto `UploadUserAvatarEndpoint`, `UploadOrganizationLogoEndpoint`, `UploadOpportunityBannerEndpoint`
- `RequestSizeLimitMiddleware` - reads that metadata off the matched endpoint and applies it to Kestrel's `IHttpMaxRequestBodySizeFeature` before anything reads the body, wired in early in `Program.cs`
- An `ArchitectureTests` convention test asserting every `multipart/form-data` endpoint carries `RequestSizeLimitAttribute` metadata, so a future upload endpoint can't reintroduce this gap silently

## Testing

- Added `RequestSizeLimitConventionTests.AllMultipartFormEndpoints_ShouldHaveRequestSizeLimitApplied` (`backend/tests/ArchitectureTests/`), mirroring the existing `RateLimitingConventionTests` pattern, confirmed by two independent review passes (`nswag-check`, `architecture-check`) as correctly wired against this repo's actual test helpers and conventions.
- Could not run `dotnet build`/`ArchitectureTests` locally in this session - the .NET SDK isn't installed and this session's network policy blocks `builds.dotnet.microsoft.com`, so the usual SessionStart SDK bootstrap didn't happen. Relying on CI (`dotnet.yml`) to validate the build and test suite; will monitor and fix any failures.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut, no live-staging verification). Behavior should still be confirmed against staging before this is considered fully verified end-to-end.

## Checklist

- [x] `/self-review` run and findings addressed (clean - see `nswag-check` and `architecture-check` passes above)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no documented behavior changed, only a latent gap closed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsCQ6JnQwbDUktZvwXTNXi)_