### PR TITLE
fix: validate Organization.Website as an absolute http/https URL

### DIFF
--- a/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
@@ -45,7 +45,7 @@ internal sealed class CreateOrganizationCommandHandler(
 				request.Address.City).GetValueOrThrow();
 
 		organization.ChangeDescription(request.Description);
-		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website);
+		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website).ThrowIfFailure();
 		organization.Relocate(address);
 
 		await dbContext.Organizations.AddAsync(organization, cancellationToken);

--- a/backend/src/Application/Organizations/UpdateOrganization/v1/UpdateOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/UpdateOrganization/v1/UpdateOrganizationCommandHandler.cs
@@ -36,7 +36,7 @@ internal sealed class UpdateOrganizationCommandHandler(
 
 		organization.Rename(request.Name).ThrowIfFailure();
 		organization.ChangeDescription(request.Description);
-		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website);
+		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website).ThrowIfFailure();
 		organization.Relocate(address);
 
 		return true;

--- a/backend/src/Domain/Organizations/Organization.cs
+++ b/backend/src/Domain/Organizations/Organization.cs
@@ -71,11 +71,22 @@ public sealed class Organization
 		Description = description;
 	}
 
-	public void ChangeContactInfo(string? contactEmail, string? contactPhone, string? website)
+	public Result ChangeContactInfo(string? contactEmail, string? contactPhone, string? website)
 	{
+		if (!string.IsNullOrWhiteSpace(website))
+		{
+			if (website.Length > 500)
+				return Result.Failure(Error.Validation("Organization.WebsiteTooLong", "Website must not exceed 500 characters."));
+
+			if (!Uri.TryCreate(website, UriKind.Absolute, out var uri)
+				|| (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+				return Result.Failure(Error.Validation("Organization.WebsiteInvalid", "Website must be a valid http or https URL."));
+		}
+
 		ContactEmail = contactEmail;
 		ContactPhone = contactPhone;
 		Website = website;
+		return Result.Success();
 	}
 
 	public void Relocate(Address? address)

--- a/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
@@ -221,6 +221,28 @@ public class CreateOrganizationCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldThrow_WhenWebsiteIsInvalid(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var keycloakId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		var command = new CreateOrganizationCommand(
+			"Test Org", userId, null, null, null, "javascript:alert(1)", null);
+
+		_keycloakService
+			.CreateOrganizationAsync("Test Org", cancellationToken)
+			.Returns(keycloakId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*Website must be a valid http or https URL*");
+	}
+
+	[Test]
 	public async Task Handle_ShouldPropagateException_WhenAddMemberFails(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/OrganizationTests.cs
@@ -67,4 +67,56 @@ public class OrganizationTests
 		result.IsFailure.Should().BeTrue();
 	}
 
+	[Test]
+	[Arguments(null)]
+	[Arguments("")]
+	[Arguments("   ")]
+	public void ChangeContactInfo_ShouldSucceed_WhenWebsiteIsNotProvided(string? website)
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+
+		// Act
+		var result = org.ChangeContactInfo("mail@test.de", "+49 30 123", website);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		org.Website.Should().Be(website);
+	}
+
+	[Test]
+	[Arguments("not-a-url")]
+	[Arguments("javascript:alert(1)")]
+	[Arguments("ftp://test.de")]
+	[Arguments("//test.de")]
+	public void ChangeContactInfo_ShouldFail_WhenWebsiteIsNotAnHttpOrHttpsUrl(string website)
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+
+		// Act
+		var result = org.ChangeContactInfo(null, null, website);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Website must be a valid http or https URL.");
+		org.Website.Should().BeNull();
+	}
+
+	[Test]
+	public void ChangeContactInfo_ShouldFail_WhenWebsiteExceedsMaxLength()
+	{
+		// Arrange
+		var org = Organization.Create(OrganizationId.New(), "Org").Value;
+		var website = "https://test.de/" + new string('a', 500);
+
+		// Act
+		var result = org.ChangeContactInfo(null, null, website);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("Website must not exceed 500 characters.");
+		org.Website.Should().BeNull();
+	}
+
 }

--- a/backend/tests/Application.UnitTests/Organizations/UpdateOrganization/UpdateOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/UpdateOrganization/UpdateOrganizationCommandHandlerTests.cs
@@ -127,4 +127,25 @@ public class UpdateOrganizationCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>()
 			.WithMessage("*Name must not be empty*");
 	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenWebsiteIsInvalid(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = DefaultOrgId;
+		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Org").Value;
+
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(org);
+
+		var command = new UpdateOrganizationCommand(
+			orgId, "Org", null, null, null, "javascript:alert(1)", null, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*Website must be a valid http or https URL*");
+	}
 }

--- a/frontend/src/lib/organizationFormSchema.test.ts
+++ b/frontend/src/lib/organizationFormSchema.test.ts
@@ -116,6 +116,30 @@ describe("buildOrganizationFormSchema", () => {
 		);
 		expect(result.success).toBe(true);
 	});
+
+	it("accepts an empty website", () => {
+		const result = schema.safeParse(values({ name: "Org", website: "" }));
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an absolute https website", () => {
+		const result = schema.safeParse(
+			values({ name: "Org", website: "https://example.org" }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it.each(["not-a-url", "javascript:alert(1)", "ftp://example.org"])(
+		"rejects a website that is not an absolute http(s) URL: %s",
+		(website) => {
+			const result = schema.safeParse(values({ name: "Org", website }));
+			expect(result.success).toBe(false);
+			const websiteIssue = result.error?.issues.find(
+				(issue) => issue.path[0] === "website",
+			);
+			expect(websiteIssue?.message).toBe("orgSettings.websiteInvalid");
+		},
+	);
 });
 
 describe("ORGANIZATION_FORM_DEFAULT_VALUES", () => {

--- a/frontend/src/lib/organizationFormSchema.ts
+++ b/frontend/src/lib/organizationFormSchema.ts
@@ -10,6 +10,7 @@ import type { TFunction } from "i18next";
 export function buildOrganizationFormSchema(t: TFunction) {
 	const required = t("orgSettings.fieldRequired");
 	const invalidZip = t("orgSettings.zipInvalid");
+	const invalidWebsite = t("orgSettings.websiteInvalid");
 
 	return z
 		.object({
@@ -26,6 +27,27 @@ export function buildOrganizationFormSchema(t: TFunction) {
 		.superRefine((data, ctx) => {
 			if (!data.name.trim())
 				ctx.addIssue({ code: "custom", path: ["name"], message: required });
+
+			// Optional, but if provided it's rendered as an anonymous-visible
+			// href (OrganizationProfileView) - only an absolute http(s) URL is
+			// accepted, mirroring Organization.ChangeContactInfo server-side.
+			const website = data.website.trim();
+			if (website) {
+				let isValidWebsite: boolean;
+				try {
+					isValidWebsite = ["http:", "https:"].includes(
+						new URL(website).protocol,
+					);
+				} catch {
+					isValidWebsite = false;
+				}
+				if (!isValidWebsite)
+					ctx.addIssue({
+						code: "custom",
+						path: ["website"],
+						message: invalidWebsite,
+					});
+			}
 
 			// The address is optional as a whole, but once any one part of it is
 			// filled in the backend requires all of street/houseNumber/zipCode/city

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -426,6 +426,7 @@
       "fieldCity": "Stadt",
       "fieldRequired": "Erforderlich",
       "zipInvalid": "Die PLZ muss genau 5 Zeichen lang sein.",
+      "websiteInvalid": "Die Website muss eine gültige http:// oder https:// URL sein.",
       "savedSuccess": "Änderungen gespeichert.",
       "saveError": "Speichern fehlgeschlagen.",
       "noMembers": "Noch keine Mitglieder.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -426,6 +426,7 @@
       "fieldCity": "City",
       "fieldRequired": "Required",
       "zipInvalid": "ZIP code must be exactly 5 characters.",
+      "websiteInvalid": "Website must be a valid http:// or https:// URL.",
       "savedSuccess": "Changes saved.",
       "saveError": "Failed to save.",
       "noMembers": "No members yet.",


### PR DESCRIPTION
## What

Validate `Organization.Website` server-side (and mirror it client-side) so it must be an absolute `http`/`https` URL within the existing 500-character cap.

## Why

`Organization.ChangeContactInfo` accepted any string for `Website` with zero server-side validation (`backend/src/Domain/Organizations/Organization.cs:74`), and the client-side schema only checked length (`frontend/src/lib/organizationFormSchema.ts:20`). The value is surfaced on the anonymous `GET /v1/organizations/{id}/profile` endpoint and rendered as an `href` (`frontend/src/components/OrganizationProfileView.tsx:148-155`). Any organizer could place an arbitrary attacker-chosen destination (phishing, malware, tracker) behind their organization's name on a page served to anonymous visitors, with no scheme allow-list and no server-enforced length - lent extra credibility for verified organizations.

Closes #1183

## Changes

- `Organization.ChangeContactInfo` now returns a `Result` and rejects `Website` values that exceed 500 characters or aren't an absolute `http`/`https` URI (`Uri.TryCreate` + scheme check), mirroring the existing `Rename` pattern. Empty/null/whitespace is still allowed (no website).
- `CreateOrganizationCommandHandler` and `UpdateOrganizationCommandHandler` now call `.ThrowIfFailure()` on the result, consistent with how `Rename`'s result is already handled - an invalid website now surfaces as a 400 via the existing `ResultFailureExceptionHandler`.
- `buildOrganizationFormSchema` (shared by `CreateOrganizationModal` and `OrgSettingsPage`) now rejects the same invalid websites client-side before the request ever reaches the server, with a new `orgSettings.websiteInvalid` translation key (`en.json`/`de.json`).

## Testing

- New backend unit tests in `OrganizationTests.cs` covering: no website (null/empty/whitespace) succeeds, non-http(s) schemes (`javascript:`, `ftp:`, protocol-relative `//host`, malformed) fail, and the 500-char boundary fails.
- New handler tests in `CreateOrganizationCommandHandlerTests.cs` and `UpdateOrganizationCommandHandlerTests.cs` asserting an invalid website throws `ResultFailureException`.
- New frontend tests in `organizationFormSchema.test.ts` covering empty/valid/invalid websites.
- Ran locally: `dotnet build` (0 errors/warnings), `Application.UnitTests` (719/719 passed), `ArchitectureTests` (366/366 passed), `pnpm lint`, `pnpm check`, `pnpm test` (128/128 passed), `pnpm i18n:check` (991/991 keys match).
- `/self-review` run, plus the `architecture-check` and `i18n-check` subagents - no findings.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). This is a validation-only change (new `Result` failure path + a mirrored client-side schema check), fully covered by the unit/handler/schema tests above.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs beyond the new inline validation message)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GAZvW77w8e9LWG1cw1G23P)_