### PR TITLE
fix: preserve security headers on error responses, add no-store for authenticated responses

### DIFF
--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -223,26 +223,46 @@ app.UseForwardedHeaders();
 
 app.UseHttpLogging();
 app.UseResponseCompression();
-
-app.Use(async (context, next) =>
-{
-	context.Response.Headers["X-Content-Type-Options"] = "nosniff";
-	context.Response.Headers["X-Frame-Options"] = "DENY";
-	context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
-
-	// Bearer tokens must never travel over a downgraded HTTP connection - skipped in
-	// Development since local dev runs over plain HTTP (#1370).
-	if (!app.Environment.IsDevelopment())
-		context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
-
-	context.Response.Headers["X-Trace-Id"] =
-		Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
-	await next();
-});
-
 app.UseExceptionHandler();
 app.UseCors();
 app.UseAuthentication();
+
+// Registered after UseAuthentication (Cache-Control needs context.User) and via
+// Response.OnStarting rather than set directly - ExceptionHandlerMiddleware calls
+// Response.Clear() before writing a caught exception's ProblemDetails body, which
+// wipes any header set directly before next() regardless of where in the pipeline
+// this middleware sits. OnStarting callbacks run right before the response is
+// actually sent, after that Clear(), so these headers decorate error responses too
+// (#1180).
+app.Use(async (context, next) =>
+{
+	context.Response.OnStarting(() =>
+	{
+		context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+		context.Response.Headers["X-Frame-Options"] = "DENY";
+		context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+		// Bearer tokens must never travel over a downgraded HTTP connection - skipped in
+		// Development since local dev runs over plain HTTP (#1370).
+		if (!app.Environment.IsDevelopment())
+			context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+
+		// PII-bearing authenticated responses (GET /v1/users/me, member search, the
+		// check-in PIN, etc.) must never be retained by a shared proxy or a browser's
+		// back/forward cache. AllowAnonymous endpoints are unaffected and opt into
+		// caching explicitly via OutputCachingPolicies instead (#1180).
+		if (context.User.Identity?.IsAuthenticated == true)
+			context.Response.Headers["Cache-Control"] = "no-store";
+
+		context.Response.Headers["X-Trace-Id"] =
+			Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
+
+		return Task.CompletedTask;
+	});
+
+	await next();
+});
+
 app.UseRateLimiter();
 app.UseAuthorization();
 

--- a/backend/tests/IntegrationTests/SecurityHeadersTests.cs
+++ b/backend/tests/IntegrationTests/SecurityHeadersTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using AwesomeAssertions;
 
 namespace IntegrationTests;
@@ -35,5 +36,73 @@ public class SecurityHeadersTests(IntegrationTestFixture fixture)
 		var response = await httpClient.GetAsync("/alive", cancellationToken);
 
 		response.Headers.TryGetValues("Strict-Transport-Security", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public async Task GetAlive_ShouldNotIncludeCacheControl_WhenAnonymous(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync("/alive", cancellationToken);
+
+		response.Headers.TryGetValues("Cache-Control", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public async Task GetUserProfile_ShouldIncludeCacheControlNoStore_WhenAuthenticated(CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		var token = await fixture.GetAccessTokenAsync("vera", "vera123");
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		var response = await httpClient.GetAsync("/v1/users/me", cancellationToken);
+
+		response.Headers.TryGetValues("Cache-Control", out var cacheControl).Should().BeTrue();
+		cacheControl.Should().ContainSingle().Which.Should().Be("no-store");
+	}
+
+	// Regression for #1180: the security-header middleware used to set headers
+	// directly before calling next(), with app.UseExceptionHandler() registered
+	// after it. ExceptionHandlerMiddleware calls Response.Clear() when it catches
+	// an exception (here, CreateEngagement's ResultFailureException for a
+	// nonexistent opportunity, mapped to a 404 ProblemDetails body) - which wiped
+	// any header set that way, regardless of the two middlewares' relative order.
+	// The header middleware now registers via Response.OnStarting instead, which
+	// runs after that Clear() and so survives it.
+	[Test]
+	public async Task CreateEngagement_ShouldIncludeBaselineSecurityHeaders_OnErrorResponse(
+		CancellationToken cancellationToken)
+	{
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => veraClient.CreateEngagementAsync(
+			Guid.NewGuid(),
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+
+		exception.Which.Headers.TryGetValue("X-Content-Type-Options", out var contentTypeOptions).Should().BeTrue();
+		contentTypeOptions.Should().ContainSingle().Which.Should().Be("nosniff");
+
+		exception.Which.Headers.TryGetValue("X-Frame-Options", out var frameOptions).Should().BeTrue();
+		frameOptions.Should().ContainSingle().Which.Should().Be("DENY");
+
+		// Not asserted as a single exact value: ASP.NET Core's own
+		// ExceptionHandlerMiddleware also clears Cache-Control on exception
+		// responses via its own OnStarting registration, so the header may carry
+		// both its directives and ours - only that "no-store" is present matters.
+		exception.Which.Headers.TryGetValue("Cache-Control", out var cacheControl).Should().BeTrue();
+		cacheControl.Should().Contain(value => value.Contains("no-store"));
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
 	}
 }

--- a/backend/tests/IntegrationTests/SecurityHeadersTests.cs
+++ b/backend/tests/IntegrationTests/SecurityHeadersTests.cs
@@ -38,17 +38,20 @@ public class SecurityHeadersTests(IntegrationTestFixture fixture)
 		response.Headers.TryGetValues("Strict-Transport-Security", out _).Should().BeFalse();
 	}
 
-	// Uses /v1/organizations/directory rather than /alive: ASP.NET Core's own
-	// health-check middleware sets its own Cache-Control on every /alive response
-	// regardless of authentication, which would make this assertion fail for a
-	// reason unrelated to what it's testing.
+	// Uses a successful (200) anonymous request specifically: /alive's health-check
+	// middleware, and a bad-request ProblemDetails response, both independently carry
+	// their own cache-prevention headers regardless of authentication - unrelated to
+	// the Cache-Control:no-store logic this test targets, but enough to make the
+	// assertion fail for the wrong reason. A plain 200 avoids both.
 	[Test]
 	public async Task GetPublicOrganizations_ShouldNotIncludeCacheControl_WhenAnonymous(CancellationToken cancellationToken)
 	{
 		using var httpClient = fixture.CreateHttpClient();
 
-		var response = await httpClient.GetAsync("/v1/organizations/directory", cancellationToken);
+		var response = await httpClient.GetAsync(
+			"/v1/organizations/directory?pageNumber=1&pageSize=10", cancellationToken);
 
+		response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 		response.Headers.TryGetValues("Cache-Control", out _).Should().BeFalse();
 	}
 

--- a/backend/tests/IntegrationTests/SecurityHeadersTests.cs
+++ b/backend/tests/IntegrationTests/SecurityHeadersTests.cs
@@ -38,12 +38,16 @@ public class SecurityHeadersTests(IntegrationTestFixture fixture)
 		response.Headers.TryGetValues("Strict-Transport-Security", out _).Should().BeFalse();
 	}
 
+	// Uses /v1/organizations/directory rather than /alive: ASP.NET Core's own
+	// health-check middleware sets its own Cache-Control on every /alive response
+	// regardless of authentication, which would make this assertion fail for a
+	// reason unrelated to what it's testing.
 	[Test]
-	public async Task GetAlive_ShouldNotIncludeCacheControl_WhenAnonymous(CancellationToken cancellationToken)
+	public async Task GetPublicOrganizations_ShouldNotIncludeCacheControl_WhenAnonymous(CancellationToken cancellationToken)
 	{
 		using var httpClient = fixture.CreateHttpClient();
 
-		var response = await httpClient.GetAsync("/alive", cancellationToken);
+		var response = await httpClient.GetAsync("/v1/organizations/directory", cancellationToken);
 
 		response.Headers.TryGetValues("Cache-Control", out _).Should().BeFalse();
 	}


### PR DESCRIPTION
## What

`backend/src/Api/Program.cs`'s security-header middleware now registers its headers via `Response.OnStarting(...)` instead of setting them directly before `next()`, and adds `Cache-Control: no-store` for authenticated responses.

## Why

Closes #1180

The middleware set `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security` (added earlier for #1370), and `X-Trace-Id` directly on `context.Response.Headers` before calling `next()`, with `app.UseExceptionHandler()` registered after it. ASP.NET Core's `ExceptionHandlerMiddleware` calls `Response.Clear()` when it catches an exception (e.g. a `ResultFailureException` mapped to a 404/409/etc. `ProblemDetails` body) before writing its own response - which wipes any header set that way, **regardless of the two middlewares' relative order** (moving the middleware to run after `UseExceptionHandler()` alone would not have fixed this, since `Response.Clear()` runs on the same shared `HttpContext.Response` either way). Registering via `Response.OnStarting(...)` instead makes the headers survive that clear, since `OnStarting` callbacks run right before the response is actually sent - after any exception handling has already happened. This is the same technique ASP.NET Core's own `ExceptionHandlerMiddleware` uses internally to clear `Cache-Control` on error responses.

The middleware also moved to run after `app.UseAuthentication()` so it can read `context.User` and scope the new `Cache-Control: no-store` header to authenticated requests - PII-bearing responses (`GET /v1/users/me`, `GET /v1/organizations/{id}/members/search`, `GET /v1/volunteer-opportunities/{id}/check-in-pin`, etc.) must never be retained by a shared corporate proxy or a browser's back/forward cache. `AllowAnonymous` endpoints are unaffected - they opt into caching explicitly via `OutputCachingPolicies` instead, and output caching is never applied to authenticated endpoints (see the comment in `OutputCachingExtensions.cs`), so there's no conflict between the two.

## Testing

Added to `backend/tests/IntegrationTests/SecurityHeadersTests.cs`:
- `GetAlive_ShouldNotIncludeCacheControl_WhenAnonymous` - anonymous responses are unaffected
- `GetUserProfile_ShouldIncludeCacheControlNoStore_WhenAuthenticated` - authenticated success responses get `Cache-Control: no-store`
- `CreateEngagement_ShouldIncludeBaselineSecurityHeaders_OnErrorResponse` - regression test proving the baseline security headers (and `Cache-Control: no-store`) survive an exception-handled error response (a `ResultFailureException`-driven 404), which is exactly the bug this PR fixes

I don't have a working local `dotnet` toolchain in this sandbox (network policy blocks the SDK installer), so these tests are unverified locally - CI's `dotnet.yml` will run the full suite including `IntegrationTests` on a real runner. I'll watch the PR and fix anything CI turns up.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). The `dotnet.yml` integration test suite is the verification path for this change instead.

## Checklist

- [x] `/self-review` run and findings addressed (also ran `architecture-check` given the middleware-pipeline reordering - no violations found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (none of `docs/`/`wiki/` reference these headers, so no doc updates needed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FiCa9jzespNqJnTZNygCtU)_