### PR TITLE
fix: store OIDC tokens in sessionStorage instead of localStorage

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -182,10 +182,10 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
 
 		var userId = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.profile?.sub) return entry.profile.sub;
 				}
 			}
@@ -212,10 +212,10 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
 
 		var userId = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.profile?.sub) return entry.profile.sub;
 				}
 			}
@@ -496,16 +496,16 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	private async Task<string> GetAccessTokenAsync()
 	{
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 		return token!;
 	}
 

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -151,22 +151,22 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		// Read inside PollUntilAsync (rather than a single raw EvaluateAsync)
-		// so a slow post-mount localStorage write can't race this check.
+		// so a slow post-mount sessionStorage write can't race this check.
 		string? token = null;
 		await PollUntilAsync(async () =>
 		{
 			token = await Page.EvaluateAsync<string?>(@"() => {
-				for (let i = 0; i < localStorage.length; i++) {
-					const key = localStorage.key(i);
+				for (let i = 0; i < sessionStorage.length; i++) {
+					const key = sessionStorage.key(i);
 					if (key && key.includes('oidc.user')) {
-						const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+						const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 						if (entry?.access_token) return entry.access_token;
 					}
 				}
 				return null;
 			}");
 			return token is not null;
-		}, () => "OIDC access token must be available in localStorage after login");
+		}, () => "OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -319,7 +319,7 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 
 	// Mints a real Keycloak token via direct grant (ROPC), bypassing the
 	// interactive login UI - see AuthHelper.FastSignInAsync, which seeds this
-	// into the browser's localStorage instead of driving Keycloak's login form.
+	// into the browser's sessionStorage instead of driving Keycloak's login form.
 	public async Task<KeycloakSession> SignInAsync(string username, string password)
 	{
 		using var client = _app.CreateHttpClient("keycloak");

--- a/backend/tests/VisualTests/AuthHelper.cs
+++ b/backend/tests/VisualTests/AuthHelper.cs
@@ -68,7 +68,7 @@ public static class AuthHelper
 	/// <summary>
 	/// Signs in without touching Keycloak's login UI: mints a real token via
 	/// <see cref="AspireFixture.SignInAsync"/> (direct grant, frontend-test client)
-	/// and seeds it into localStorage in oidc-client-ts's own storage shape
+	/// and seeds it into sessionStorage in oidc-client-ts's own storage shape
 	/// (verified against the installed oidc-client-ts package - see User.toStorageString
 	/// and UserManager._userStoreKey), so the SPA boots already authenticated with
 	/// no redirect round trip.
@@ -138,8 +138,11 @@ public static class AuthHelper
 		// AddInitScriptAsync (not EvaluateAsync after navigation) so this runs
 		// before the SPA's own bundle - by the time React/oidc-client-ts mounts,
 		// the "user" is already in storage and no anonymous render happens first.
+		// sessionStorage, not localStorage (main.tsx) - an init script re-runs on
+		// every document navigation in this page/tab, so it stays seeded across
+		// GotoAsync calls the same way it would with localStorage.
 		await page.AddInitScriptAsync(
-			$"window.localStorage.setItem({JsonSerializer.Serialize(storageKey)}, "
+			$"window.sessionStorage.setItem({JsonSerializer.Serialize(storageKey)}, "
 			+ $"{JsonSerializer.Serialize(storageValue)});");
 
 		// Computed regardless of pinActiveOrg so callers that deliberately stay

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -183,16 +183,16 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 	private async Task<string> GetAccessTokenAsync()
 	{
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 		return token!;
 	}
 }

--- a/backend/tests/VisualTests/EngagementCalendarTests.cs
+++ b/backend/tests/VisualTests/EngagementCalendarTests.cs
@@ -25,16 +25,16 @@ public class EngagementCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/backend/tests/VisualTests/EngagementTimezoneTests.cs
+++ b/backend/tests/VisualTests/EngagementTimezoneTests.cs
@@ -20,19 +20,19 @@ public class EngagementTimezoneTests(AspireFixture fixture) : VisualTestBase(fix
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 
-		// Extract the OIDC access token stored by oidc-client-ts in localStorage.
+		// Extract the OIDC access token stored by oidc-client-ts in sessionStorage.
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
 
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		// Probe the confirm endpoint with a non-existent engagement ID and an
 		// IANA timezone that differs from Europe/Berlin to exercise the header path.

--- a/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
+++ b/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
@@ -75,10 +75,10 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
 
 		var userId = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.profile?.sub) return entry.profile.sub;
 				}
 			}

--- a/backend/tests/VisualTests/ListLayoutGridTests.cs
+++ b/backend/tests/VisualTests/ListLayoutGridTests.cs
@@ -28,16 +28,16 @@ public class ListLayoutGridTests(AspireFixture fixture) : VisualTestBase(fixture
 	private static async Task<string> GetAccessTokenAsync(IPage page)
 	{
 		var token = await page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 		return token!;
 	}
 

--- a/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
@@ -24,16 +24,16 @@ public class MyEngagementsTimeSlotTests(AspireFixture fixture) : VisualTestBase(
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -108,12 +108,14 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
 		await Page.Locator("textarea").FillAsync("First sign-up attempt.");
 
-		// A second page in the same browser context: the OIDC user store is
-		// localStorage (frontend/src/main.tsx), shared across pages in one
-		// context, so this page is already authenticated as vera too - it
-		// simulates a second tab racing the first to sign up for the same
-		// opportunity.
+		// A second page in the same browser context, simulating a second tab
+		// racing the first to sign up for the same opportunity. Unlike
+		// localStorage, the OIDC user store (sessionStorage, frontend/src/main.tsx)
+		// is scoped per top-level browsing context, not shared context-wide -
+		// Context.NewPageAsync creates an independent one, so this page needs
+		// its own sign-in rather than inheriting vera's session from Page.
 		var page2 = await Context.NewPageAsync();
+		await AuthHelper.FastSignInAsync(page2, Fixture, frontend, "vera", "vera123", pinActiveOrg: false);
 		await page2.GotoAsync(detailUrl);
 		await page2.WaitForLoadStateAsync(LoadState.NetworkIdle);
 		await page2.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();

--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -1130,16 +1130,16 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	private async Task<string> GetAccessTokenAsync()
 	{
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 		return token!;
 	}
 }

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -208,16 +208,16 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
@@ -317,16 +317,16 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
@@ -438,16 +438,16 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
+++ b/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
@@ -29,16 +29,16 @@ public class OrganizationEngagementsTabTests(AspireFixture fixture) : VisualTest
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -168,10 +168,10 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
 
 		var userId = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.profile?.sub) return entry.profile.sub;
 				}
 			}
@@ -314,12 +314,12 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		var originalAccessToken = await Page.EvaluateAsync<string>(
 			"""
 			() => {
-				for (let i = 0; i < localStorage.length; i++) {
-					const key = localStorage.key(i);
+				for (let i = 0; i < sessionStorage.length; i++) {
+					const key = sessionStorage.key(i);
 					if (key && key.startsWith('oidc.user:')) {
-						const entry = JSON.parse(localStorage.getItem(key));
+						const entry = JSON.parse(sessionStorage.getItem(key));
 						entry.expires_at = Math.floor(Date.now() / 1000) + 80;
-						localStorage.setItem(key, JSON.stringify(entry));
+						sessionStorage.setItem(key, JSON.stringify(entry));
 						return entry.access_token;
 					}
 				}
@@ -346,10 +346,10 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 			renewedAccessToken = await Page.EvaluateAsync<string?>(
 				"""
 				() => {
-					for (let i = 0; i < localStorage.length; i++) {
-						const key = localStorage.key(i);
+					for (let i = 0; i < sessionStorage.length; i++) {
+						const key = sessionStorage.key(i);
 						if (key && key.startsWith('oidc.user:')) {
-							return JSON.parse(localStorage.getItem(key)).access_token;
+							return JSON.parse(sessionStorage.getItem(key)).access_token;
 						}
 					}
 					return null;

--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -105,7 +105,7 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 	// Regression: a Keycloak session that naturally lapsed (browser closed,
 	// reopened later - no explicit sign-out) leaves an already-expired user
-	// object sitting in localStorage. automaticSilentRenew (main.tsx) fires a
+	// object sitting in sessionStorage. automaticSilentRenew (main.tsx) fires a
 	// renewal attempt for it immediately on mount regardless of which page is
 	// open, and that attempt fails right away (no live Keycloak SSO session
 	// behind it, since this session was minted out-of-band here rather than
@@ -183,7 +183,7 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var storageKey = $"oidc.user:{session.Authority}:frontend";
 
 		await Page.AddInitScriptAsync(
-			$"window.localStorage.setItem({JsonSerializer.Serialize(storageKey)}, "
+			$"window.sessionStorage.setItem({JsonSerializer.Serialize(storageKey)}, "
 			+ $"{JsonSerializer.Serialize(storageValue)});");
 
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -578,16 +578,16 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var token = await Page.EvaluateAsync<string?>(@"() => {
-			for (let i = 0; i < localStorage.length; i++) {
-				const key = localStorage.key(i);
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
 				if (key && key.includes('oidc.user')) {
-					const entry = JSON.parse(localStorage.getItem(key) ?? 'null');
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
 					if (entry?.access_token) return entry.access_token;
 				}
 			}
 			return null;
 		}");
-		token.Should().NotBeNull("OIDC access token must be available in localStorage after login");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");

--- a/frontend/src/hooks/useSessionExpiryHandler.ts
+++ b/frontend/src/hooks/useSessionExpiryHandler.ts
@@ -32,7 +32,7 @@ export function useSessionExpiryHandler() {
 		let redirectTimer: ReturnType<typeof setTimeout> | null = null;
 
 		function handleExpiry() {
-			// A stale/expired user object can still sit in localStorage from an
+			// A stale/expired user object can still sit in sessionStorage from an
 			// earlier login - automaticSilentRenew fires a renewal attempt for it
 			// on mount regardless of what page is open, and that attempt fails
 			// immediately when there's no live Keycloak SSO session behind it

--- a/frontend/src/lib/keycloakRegistration.ts
+++ b/frontend/src/lib/keycloakRegistration.ts
@@ -8,8 +8,9 @@ let registrationUserManager: UserManager | null = null;
 // OIDC authorization params as the login endpoint and completes with the
 // same authorization-code callback. A dedicated UserManager lets us override
 // just authorization_endpoint (via metadataSeed, which wins over the fetched
-// discovery document) while sharing localStorage-backed state/user stores
-// with the app's default UserManager so /callback can still validate it.
+// discovery document) while sharing sessionStorage-backed state/user stores
+// with the app's default UserManager (main.tsx) so /callback can still
+// validate it.
 function getRegistrationUserManager(): UserManager {
 	if (!registrationUserManager) {
 		registrationUserManager = new UserManager({
@@ -17,7 +18,7 @@ function getRegistrationUserManager(): UserManager {
 			client_id: runtimeConfig.keycloakClientId,
 			redirect_uri: window.location.origin + "/callback",
 			scope: "openid profile email",
-			userStore: new WebStorageStateStore({ store: window.localStorage }),
+			userStore: new WebStorageStateStore({ store: window.sessionStorage }),
 			metadataSeed: {
 				authorization_endpoint: `${runtimeConfig.keycloakAuthorityUrl}/protocol/openid-connect/registrations`,
 			},

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,8 +25,13 @@ const oidcConfig = {
 	post_logout_redirect_uri: window.location.origin,
 	scope: "openid profile email",
 	automaticSilentRenew: true,
-	// Use localStorage so Playwright storageState captures the session
-	userStore: new WebStorageStateStore({ store: window.localStorage }),
+	// sessionStorage, not localStorage: tokens (incl. refresh_token, since the
+	// realm has "rememberMe": true) must not survive tab close or browser
+	// restart on a shared/kiosk machine - a realistic setting for a
+	// volunteer-coordination app used at events (#1171). Playwright seeds
+	// sessionStorage directly via page.addInitScript instead of relying on
+	// storageState (see AuthHelper.FastSignInAsync in backend/tests/VisualTests).
+	userStore: new WebStorageStateStore({ store: window.sessionStorage }),
 	onSigninCallback: async (user: User | undefined) => {
 		// Only fall back to the Keycloak login page's locale on a browser
 		// that has never had an explicit in-app language choice - otherwise a

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -66,7 +66,7 @@ export default function VolunteerOpportunityDetailPage() {
 	const roles = (
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
-	// A stale Keycloak session left in localStorage from an earlier login still
+	// A stale Keycloak session left in sessionStorage from an earlier login still
 	// populates auth.user.profile after the token has expired, so this must
 	// gate on isAuthenticated too - otherwise an anonymous visitor with old
 	// organisator claims fires an authenticated getOrganizations() call below,


### PR DESCRIPTION
## What

Switch react-oidc-context's `userStore` (and the separate registration-flow `UserManager`) from `localStorage` to `sessionStorage` in `frontend/src/main.tsx` and `frontend/src/lib/keycloakRegistration.ts`, and update the Playwright test suite in `backend/tests/VisualTests/` to match.

## Why

Access, ID, and refresh tokens were persisted in `localStorage`, keyed only on origin - they survive tab close and browser restart. Combined with the realm's `"rememberMe": true`, that means the next person to open the site on a shared/kiosk machine (a realistic setting for a volunteer-coordination app used at events) is silently signed in as the previous volunteer, with a refresh token that keeps renewing indefinitely. Switching to `sessionStorage` scopes the session to the current tab and clears it on close, without weakening the existing `automaticSilentRenew` behavior within a session.

Closes #1171

## Testing

- `pnpm lint`, `pnpm check` (tsc --noEmit), and `pnpm test` (123 tests) all pass locally in `frontend/`.
- `pnpm format:write` produced no diff.
- Updated every `backend/tests/VisualTests/*.cs` helper that reads the OIDC access token / `profile.sub` out of browser storage (previously scanning `localStorage` for the `oidc.user` key) to scan `sessionStorage` instead - this includes `AuthHelper.FastSignInAsync`'s direct-seed path, `SessionExpiryTests`'s stale-session seeding, and `ProfileOverviewTests`'s silent-renewal test (which reads, mutates, and writes the stored entry back).
- Fixed `OpportunityApplicationStateTests.SignUpModal_ShowsBackendConflictMessage_OnDuplicateSignUp`: it previously relied on a second Playwright page (`Context.NewPageAsync()`) inheriting the first page's session because `localStorage` is shared context-wide. `sessionStorage` is scoped per top-level browsing context instead, so the second page now signs in independently via `AuthHelper.FastSignInAsync` to keep exercising the same duplicate-signup race.
- Could not run `dotnet build`/the backend test suite in this sandbox - this session's egress policy blocks `builds.dotnet.microsoft.com`, so the .NET SDK couldn't be installed. Relying on CI's `dotnet.yml` (which runs on a runner with full network access) to verify the backend/VisualTests changes, and will monitor and fix any failures there.

## Live verification

Skipped for this change at the requester's explicit instruction (no release candidate cut). The frontend-only behavior change (token storage location) is covered by the updated Playwright suite in `backend/tests/VisualTests/`, which CI runs against a real browser and the full Aspire stack.

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 findings - see PR description above for what was checked)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no docs reference the token storage location)


---
_Generated by [Claude Code](https://claude.ai/code/session_013Hn9yaf6Pa1M9hNEQfp8x3)_