### PR TITLE
fix: stop logging recipient email/subject on SMTP send failure

### DIFF
--- a/backend/src/Application/Common/Email/IEmailService.cs
+++ b/backend/src/Application/Common/Email/IEmailService.cs
@@ -1,6 +1,10 @@
 namespace Application.Common.Email;
 
-public sealed record EmailMessage(string To, string Subject, string Body);
+// CorrelationId ties a send back to the domain object it was sent for (an
+// engagement, invitation, or user id) so a failure can still be investigated
+// without the recipient's address or subject - which may itself contain PII
+// like a volunteer's name - ever reaching the logs (einsatzbereit#1189).
+public sealed record EmailMessage(string To, string Subject, string Body, string CorrelationId);
 
 public interface IEmailService
 {
@@ -8,6 +12,7 @@ public interface IEmailService
 		string to,
 		string subject,
 		string body,
+		string correlationId,
 		CancellationToken cancellationToken = default);
 
 	// Sends every message over a single connection instead of one connect/

--- a/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
@@ -67,6 +67,7 @@ internal static class EngagementCancellationHelper
 				volunteer.Email,
 				content.Subject,
 				EmailFooter.Append(content.Body, unsubscribeUrl),
+				engagement.Id.Value.ToString(),
 				cancellationToken);
 		}
 	}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -80,6 +80,7 @@ internal sealed class ConfirmEngagementCommandHandler(
 				volunteer.Email,
 				content.Subject,
 				EmailFooter.Append(content.Body, unsubscribeUrl),
+				engagement.Id.Value.ToString(),
 				cancellationToken);
 		}
 

--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -101,7 +101,8 @@ internal sealed class CreateEngagementCommandHandler(
 		// response to the volunteer's own just-submitted action, not a repeatable
 		// notification about someone else's activity - equivalent to an order
 		// receipt, which platforms conventionally don't let users opt out of.
-		await emailService.SendAsync(volunteer.Email, volunteerContent.Subject, volunteerContent.Body, cancellationToken);
+		await emailService.SendAsync(
+			volunteer.Email, volunteerContent.Subject, volunteerContent.Body, engagement.Id.Value.ToString(), cancellationToken);
 
 		var organizerIds = members
 			.Where(m => m.IsOrganisator)
@@ -138,6 +139,7 @@ internal sealed class CreateEngagementCommandHandler(
 				organizer.Email,
 				organizerContent.Subject,
 				EmailFooter.Append(organizerContent.Body, unsubscribeUrl),
+				engagement.Id.Value.ToString(),
 				cancellationToken);
 		}
 

--- a/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
+++ b/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
@@ -84,14 +84,14 @@ internal sealed class EngagementReminderDueHandler(
 		// SendBatchAsync with a single message (rather than SendAsync) so a failed send
 		// is observable as a bool - SendAsync never throws and never reports outcome,
 		// which would make it impossible to know whether to let the outbox retry.
-		var results = await emailService.SendBatchAsync([new EmailMessage(user.Email, subject, body)], cancellationToken);
+		var results = await emailService.SendBatchAsync(
+			[new EmailMessage(user.Email, subject, body, notification.EngagementId.Value.ToString())], cancellationToken);
 		if (!results[0])
 			throw new InvalidOperationException(
 				$"Failed to send 24h reminder email for engagement {notification.EngagementId.Value}");
 
 		logger.LogInformation(
-			"Sent 24h reminder to {Email} for engagement {EngagementId}",
-			user.Email,
+			"Sent 24h reminder for engagement {EngagementId}",
 			notification.EngagementId.Value);
 	}
 

--- a/backend/src/Application/Engagements/WithdrawEngagement/v1/WithdrawEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/WithdrawEngagement/v1/WithdrawEngagementCommandHandler.cs
@@ -84,6 +84,7 @@ internal sealed class WithdrawEngagementCommandHandler(
 					organizer.Email,
 					content.Subject,
 					EmailFooter.Append(content.Body, unsubscribeUrl),
+					engagement.Id.Value.ToString(),
 					cancellationToken);
 			}
 		}

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -73,7 +73,7 @@ internal static class OpportunityNotificationHelper
 					["OpportunityTitle"] = opportunityTitle ?? string.Empty,
 				});
 
-			messages.Add(new EmailMessage(volunteer.Email, content.Subject, content.Body));
+			messages.Add(new EmailMessage(volunteer.Email, content.Subject, content.Body, volunteerId.ToString()));
 		}
 
 		await emailService.SendBatchAsync(messages, cancellationToken);

--- a/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateInvitation/v1/CreateInvitationCommandHandler.cs
@@ -85,6 +85,7 @@ internal sealed class CreateInvitationCommandHandler(
 			inviteeProfile.Email,
 			content.Subject,
 			content.Body,
+			invitation.Id.Value.ToString(),
 			cancellationToken);
 
 		return invitation.Id;

--- a/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
@@ -65,6 +65,7 @@ internal sealed class ResendInvitationCommandHandler(
 			invitee.Email,
 			content.Subject,
 			content.Body,
+			invitation.Id.Value.ToString(),
 			cancellationToken);
 
 		return true;

--- a/backend/src/Infrastructure/Email/SmtpEmailService.cs
+++ b/backend/src/Infrastructure/Email/SmtpEmailService.cs
@@ -19,6 +19,7 @@ internal sealed class SmtpEmailService(
 		string to,
 		string subject,
 		string body,
+		string correlationId,
 		CancellationToken cancellationToken = default)
 	{
 		try
@@ -46,7 +47,11 @@ internal sealed class SmtpEmailService(
 		}
 		catch (Exception ex)
 		{
-			logger.LogError(ex, "Failed to send email to {To} with subject {Subject}", to, subject);
+			// Deliberately not {To}/{Subject} - both can carry a real user's email
+			// address or another user's name (einsatzbereit#1189). The correlation
+			// id (an engagement/invitation/user GUID) is enough to trace the failure
+			// back to its source without writing PII into logs or the OTLP sink.
+			logger.LogError(ex, "Failed to send email (correlationId: {CorrelationId})", correlationId);
 			metrics.RecordFailed();
 		}
 	}
@@ -98,7 +103,7 @@ internal sealed class SmtpEmailService(
 			}
 			catch (Exception ex)
 			{
-				logger.LogError(ex, "Failed to send email to {To} with subject {Subject}", email.To, email.Subject);
+				logger.LogError(ex, "Failed to send email (correlationId: {CorrelationId})", email.CorrelationId);
 				metrics.RecordFailed();
 			}
 		}

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -193,6 +193,7 @@ public class CancelEngagementCommandHandlerTests
 			"vera@example.com",
 			"Test Subject",
 			Arg.Is<string>(body => body!.StartsWith("Test Body")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 
@@ -242,6 +243,7 @@ public class CancelEngagementCommandHandlerTests
 			"user@example.com",
 			Arg.Any<string>(),
 			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 
@@ -309,6 +311,6 @@ public class CancelEngagementCommandHandlerTests
 
 		// Assert
 		await _emailService.DidNotReceive().SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -366,6 +366,7 @@ public class ConfirmEngagementCommandHandlerTests
 			"user@example.com",
 			Arg.Any<string>(),
 			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 
@@ -393,7 +394,7 @@ public class ConfirmEngagementCommandHandlerTests
 
 		// Assert
 		await _emailService.DidNotReceive().SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -428,6 +428,7 @@ public class CreateEngagementCommandHandlerTests
 			"olaf@example.com",
 			Arg.Any<string>(),
 			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 
@@ -458,6 +459,6 @@ public class CreateEngagementCommandHandlerTests
 
 		// Assert
 		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
@@ -275,6 +275,7 @@ public class WithdrawEngagementCommandHandlerTests
 			"olaf@example.com",
 			Arg.Any<string>(),
 			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 
@@ -309,6 +310,6 @@ public class WithdrawEngagementCommandHandlerTests
 
 		// Assert
 		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -192,6 +192,7 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 			"user@example.com",
 			"Test Subject",
 			Arg.Is<string>(body => body!.StartsWith("Test Body")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -91,7 +91,7 @@ public class CreateInvitationCommandHandlerTests
 			cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 		await _emailService.Received(1).SendAsync(
-			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ResendInvitation/ResendInvitationCommandHandlerTests.cs
@@ -96,7 +96,7 @@ public class ResendInvitationCommandHandlerTests
 		invitation.ExpiresOn.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(OrganizationInvitation.ExpiryWindowDays - 1));
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 		await _emailService.Received(1).SendAsync(
-			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+			"vera@test.de", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
 	}
 
 	[Test]
@@ -153,7 +153,7 @@ public class ResendInvitationCommandHandlerTests
 			.Which.Error.Type.Should().Be(ErrorType.Conflict);
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 		await _emailService.DidNotReceive().SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -144,6 +144,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 			"user@example.com",
 			"Test Subject",
 			Arg.Is<string>(body => body!.StartsWith("Test Body")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -205,6 +205,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 			"user@example.com",
 			"Test Subject",
 			Arg.Is<string>(body => body!.StartsWith("Test Body")),
+			Arg.Any<string>(),
 			cancellationToken);
 	}
 

--- a/backend/tests/IntegrationTests/IntegrationTests.csproj
+++ b/backend/tests/IntegrationTests/IntegrationTests.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="Aspire.Hosting.Testing" />
 		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
 		<PackageReference Include="Respawn" />
 		<PackageReference Include="TUnit" />
 	</ItemGroup>

--- a/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
+++ b/backend/tests/IntegrationTests/SmtpEmailServiceTests.cs
@@ -6,7 +6,9 @@ using Application.Common.Email;
 using AwesomeAssertions;
 using Infrastructure.Email;
 using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 
 namespace IntegrationTests;
@@ -39,7 +41,7 @@ public class SmtpEmailServiceTests
 		var recorded = RecordEmailSendMeasurements(meterFactory);
 
 		var sut = CreateService(server.Port, metrics);
-		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body");
+		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body", "test-correlation-id");
 
 		await act.Should().NotThrowAsync();
 
@@ -55,11 +57,34 @@ public class SmtpEmailServiceTests
 		var recorded = RecordEmailSendMeasurements(meterFactory);
 
 		var sut = CreateService(unusedPort, metrics);
-		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body");
+		var act = () => sut.SendAsync("volunteer@example.com", "Test subject", "Test body", "test-correlation-id");
 
 		await act.Should().NotThrowAsync();
 
 		recorded.Should().ContainSingle(m => m.Status == "failed" && m.Value == 1);
+	}
+
+	// Regression coverage for einsatzbereit#1189: a failed send used to log the
+	// recipient's raw email address plus the subject line (which can itself carry
+	// a volunteer's name), landing real PII in container logs and the OTLP sink on
+	// every misconfigured-SMTP send. The failure log must now carry only the
+	// correlation id the caller supplied, never the address or subject.
+	[Test]
+	public async Task SendAsync_ServerUnreachable_LogsCorrelationIdWithoutRecipientOrSubject()
+	{
+		var unusedPort = GetUnusedLoopbackPort();
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var logger = new FakeLogger<SmtpEmailService>();
+
+		var sut = CreateService(unusedPort, metrics, logger);
+		await sut.SendAsync("volunteer@example.com", "New sign-up: Vera joined \"Beach Cleanup\"", "Test body", "engagement-correlation-id");
+
+		var record = logger.Collector.GetSnapshot().Should().ContainSingle(r => r.Level == LogLevel.Error).Subject;
+		record.Message.Should().Contain("engagement-correlation-id");
+		record.Message.Should().NotContain("volunteer@example.com");
+		record.Message.Should().NotContain("Vera");
+		record.Message.Should().NotContain("Beach Cleanup");
 	}
 
 	// Regression coverage for #1400: SendBatchAsync must share one SMTP connection
@@ -79,9 +104,9 @@ public class SmtpEmailServiceTests
 		var sut = CreateService(server.Port, metrics);
 		var messages = new[]
 		{
-			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
-			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
-			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1", "corr-1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2", "corr-2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3", "corr-3"),
 		};
 
 		var results = await sut.SendBatchAsync(messages);
@@ -102,9 +127,9 @@ public class SmtpEmailServiceTests
 		var sut = CreateService(server.Port, metrics);
 		var messages = new[]
 		{
-			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
-			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
-			new EmailMessage("admin@example.com", "Reminder 3", "Body 3"),
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1", "corr-1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2", "corr-2"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3", "corr-3"),
 		};
 
 		var results = await sut.SendBatchAsync(messages);
@@ -112,6 +137,31 @@ public class SmtpEmailServiceTests
 		results.Should().Equal(true, false, true);
 		recorded.Count(m => m.Status == "succeeded").Should().Be(2);
 		recorded.Count(m => m.Status == "failed").Should().Be(1);
+	}
+
+	[Test]
+	public async Task SendBatchAsync_ServerRejectsOneRecipient_LogsCorrelationIdWithoutRecipientOrSubject()
+	{
+		await using var server = await FakeSmtpServer.StartAsync(rejectRecipient: "olaf@example.com");
+		using var meterFactory = new TestMeterFactory();
+		var metrics = new EmailMetrics(meterFactory);
+		var logger = new FakeLogger<SmtpEmailService>();
+
+		var sut = CreateService(server.Port, metrics, logger);
+		var messages = new[]
+		{
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1", "corr-1"),
+			new EmailMessage("olaf@example.com", "New sign-up: Vera joined \"Beach Cleanup\"", "Body 2", "corr-2-rejected"),
+			new EmailMessage("admin@example.com", "Reminder 3", "Body 3", "corr-3"),
+		};
+
+		await sut.SendBatchAsync(messages);
+
+		var record = logger.Collector.GetSnapshot().Should().ContainSingle(r => r.Level == LogLevel.Error).Subject;
+		record.Message.Should().Contain("corr-2-rejected");
+		record.Message.Should().NotContain("olaf@example.com");
+		record.Message.Should().NotContain("Vera");
+		record.Message.Should().NotContain("Beach Cleanup");
 	}
 
 	[Test]
@@ -125,8 +175,8 @@ public class SmtpEmailServiceTests
 		var sut = CreateService(unusedPort, metrics);
 		var messages = new[]
 		{
-			new EmailMessage("vera@example.com", "Reminder 1", "Body 1"),
-			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2"),
+			new EmailMessage("vera@example.com", "Reminder 1", "Body 1", "corr-1"),
+			new EmailMessage("olaf@example.com", "Reminder 2", "Body 2", "corr-2"),
 		};
 
 		var results = await sut.SendBatchAsync(messages);
@@ -152,7 +202,7 @@ public class SmtpEmailServiceTests
 		recorded.Should().BeEmpty();
 	}
 
-	private static SmtpEmailService CreateService(int port, EmailMetrics metrics) =>
+	private static SmtpEmailService CreateService(int port, EmailMetrics metrics, ILogger<SmtpEmailService>? logger = null) =>
 		new(
 			Options.Create(new SmtpOptions
 			{
@@ -162,7 +212,7 @@ public class SmtpEmailServiceTests
 				FromName = "Test",
 				EnableSsl = false,
 			}),
-			NullLogger<SmtpEmailService>.Instance,
+			logger ?? NullLogger<SmtpEmailService>.Instance,
 			metrics);
 
 	private static List<(string Status, long Value)> RecordEmailSendMeasurements(IMeterFactory meterFactory)


### PR DESCRIPTION
## What

`SmtpEmailService` logged the recipient's raw email address plus the email subject on every failed send. `IEmailService.SendAsync`/`EmailMessage` now take a `correlationId` (the related engagement/invitation/user id) so a failure is still traceable without writing PII into logs.

## Why

`backend/src/Api/appsettings.json` is the only source of SMTP settings, and there is no SMTP relay listening on staging, so every notification email fails and previously logged:

```csharp
logger.LogWarning(ex, "Failed to send email to {To} with subject {Subject}", to, subject);
```

`subject` is not opaque - e.g. `CreateEngagementCommandHandler` builds it as `New sign-up: {volunteerName} joined "{opportunity.Title}"`. Because the SMTP misconfiguration means *every* sign-up, withdrawal, and reminder hits this catch block, this was the highest-volume PII path in the system, writing a real user's email address and another user's name into container logs and the OTLP sink on every send.

The `docker-compose.yml` half of the originally suggested fix (fail-loud `Smtp__*`/`KC_SMTP_*` env vars sourced from `.env`) already shipped in #1494, so this PR only addresses the logging side.

Closes #1189

## Changes

- `IEmailService.SendAsync` and `EmailMessage` gain a `correlationId` parameter/field.
- `SmtpEmailService`'s failure logs now emit only the exception and `correlationId`, never the recipient address or subject.
- All 9 call sites now pass the related engagement/invitation/user GUID as the correlation id.
- `EngagementReminderDueHandler`'s success log also dropped the recipient email (same category of issue, adjacent to the flagged line) - the engagement id it already logs is enough to correlate.

## Testing

- `dotnet build` (all backend projects) - clean, 0 warnings/errors.
- `Application.UnitTests` - 709/709 passed.
- `ArchitectureTests` - 366/366 passed.
- `IntegrationTests`' `SmtpEmailServiceTests` (no Docker needed, exercises `SmtpEmailService` directly) - 8/8 passed, including two new regression tests asserting the failure log contains the correlation id but not the recipient address/subject/name.
- `/self-review` run; only finding was the adjacent `EngagementReminderDueHandler` log line above, fixed in this PR.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed for this PR - the RC/live-verify steps in root `AGENTS.md`'s deploy-and-verify flow were skipped intentionally. This is a backend-only logging change with no user-visible behavior, verified instead via the unit/integration test coverage above.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing or documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8w5j7yc6yjasXLHoV4wds)_