### PR TITLE
fix: reject sign-ups on unpublished volunteer opportunities

### DIFF
--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -31,6 +31,9 @@ internal sealed class CreateEngagementCommandHandler(
 		if (opportunity is null)
 			throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity with id '{request.OpportunityId.Value}' was not found."));
 
+		if (opportunity.Status != OpportunityStatus.Published)
+			throw new ResultFailureException(Error.Conflict("Engagement.OpportunityNotPublished", "Only a published opportunity can be signed up for."));
+
 		var alreadySignedUp = await dbContext.HasEngagementAsync(
 			request.VolunteerId, request.OpportunityId, request.TimeSlotId, cancellationToken);
 

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -38,8 +38,10 @@ public class CreateEngagementCommandHandlerTests
 
 	private static readonly Address TestAddress = Address.Create("Main St", "1", "12345", "Berlin").Value;
 
-	private VolunteerOpportunity CreateTestOpportunity(VolunteerOpportunityId id) =>
-		VolunteerOpportunity.Create(
+	private VolunteerOpportunity CreateTestOpportunity(
+		VolunteerOpportunityId id, OpportunityStatus status = OpportunityStatus.Published)
+	{
+		var opportunity = VolunteerOpportunity.Create(
 			OrganizationId.New(),
 			"Test Opportunity",
 			"Description",
@@ -50,6 +52,28 @@ public class CreateEngagementCommandHandlerTests
 			CheckInMethod.None,
 			_pinGenerator,
 			status: OpportunityStatus.Draft).Value;
+
+		if (status == OpportunityStatus.Draft)
+			return opportunity;
+
+		// Published is unreachable at construction time for ScheduledSlots (see
+		// Create's ScheduledSlotsMustStartAsDraft guard) - add a throwaway slot
+		// so Publish()'s own ScheduledSlotsRequiresTimeSlot check is satisfied,
+		// then walk to the requested terminal status the same way real code would.
+		opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1),
+			DateTimeOffset.UtcNow.AddDays(1).AddHours(2),
+			maxParticipants: 10,
+			DateTimeOffset.UtcNow).Value;
+		opportunity.Publish().ThrowIfFailure();
+
+		if (status == OpportunityStatus.Unpublished)
+			opportunity.Unpublish().ThrowIfFailure();
+		else if (status == OpportunityStatus.Cancelled)
+			opportunity.Cancel().ThrowIfFailure();
+
+		return opportunity;
+	}
 
 	public CreateEngagementCommandHandlerTests()
 	{
@@ -74,16 +98,18 @@ public class CreateEngagementCommandHandlerTests
 		_sut = new CreateEngagementCommandHandler(_dbContext, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer, _unsubscribeLinkBuilder);
 	}
 
-	private void SetupOpportunityExists(VolunteerOpportunityId opportunityId)
+	private void SetupOpportunityExists(
+		VolunteerOpportunityId opportunityId, OpportunityStatus status = OpportunityStatus.Published)
 	{
-		var opportunity = CreateTestOpportunity(opportunityId);
+		var opportunity = CreateTestOpportunity(opportunityId, status);
 		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>())
 			.Returns(opportunity);
 	}
 
-	private TimeSlotId SetupOpportunityExistsWithTimeSlot(VolunteerOpportunityId opportunityId, int? maxParticipants = 10)
+	private TimeSlotId SetupOpportunityExistsWithTimeSlot(
+		VolunteerOpportunityId opportunityId, int? maxParticipants = 10, OpportunityStatus status = OpportunityStatus.Published)
 	{
-		var opportunity = CreateTestOpportunity(opportunityId);
+		var opportunity = CreateTestOpportunity(opportunityId, status);
 		var timeSlot = opportunity.AddTimeSlot(
 			DateTimeOffset.UtcNow.AddDays(1),
 			DateTimeOffset.UtcNow.AddDays(1).AddHours(2),
@@ -110,6 +136,29 @@ public class CreateEngagementCommandHandlerTests
 
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*not found*");
+	}
+
+	// --- Publish status gate (#1182) ---
+
+	[Test]
+	[Arguments(OpportunityStatus.Draft)]
+	[Arguments(OpportunityStatus.Unpublished)]
+	[Arguments(OpportunityStatus.Cancelled)]
+	public async Task Handle_ShouldThrow_WhenOpportunityIsNotPublished(
+		OpportunityStatus status, CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		SetupOpportunityExists(opportunityId, status);
+		var command = new CreateEngagementCommand(opportunityId, UserId.New(), TimeSlotId: null, "Ich helfe gerne!");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _engagementRepo.DidNotReceive().AddAsync(Arg.Any<Engagement>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -60,7 +60,7 @@ public class CreateEngagementCommandHandlerTests
 		// Create's ScheduledSlotsMustStartAsDraft guard) - add a throwaway slot
 		// so Publish()'s own ScheduledSlotsRequiresTimeSlot check is satisfied,
 		// then walk to the requested terminal status the same way real code would.
-		opportunity.AddTimeSlot(
+		_ = opportunity.AddTimeSlot(
 			DateTimeOffset.UtcNow.AddDays(1),
 			DateTimeOffset.UtcNow.AddDays(1).AddHours(2),
 			maxParticipants: 10,

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -237,6 +237,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			cancellationToken);
 		var firstSlotId = timeSlots.ElementAt(0).Id;
 		var secondSlotId = timeSlots.ElementAt(1).Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var firstEngagement = await veraClient.CreateEngagementAsync(
@@ -1019,6 +1020,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			},
 			cancellationToken);
 		var slotId = timeSlots.First().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var olafEngagement = await olafClient.CreateEngagementAsync(
 			opportunity.Id,
@@ -1055,6 +1057,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			},
 			cancellationToken);
 		var slotId = timeSlots.First().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var olafEngagement = await olafClient.CreateEngagementAsync(
 			opportunity.Id,
@@ -1173,6 +1176,21 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var opportunityA = await CreateScheduledSlotsOpportunityAsync(olafClient, orgId, cancellationToken);
 		var opportunityB = await CreateScheduledSlotsOpportunityAsync(olafClient, orgId, cancellationToken);
 
+		// opportunityA needs a slot of its own purely so it can be published -
+		// the request below targets opportunityA with a time slot id from
+		// opportunityB, and that mismatch is what the test is exercising.
+		await olafClient.CreateTimeSlotAsync(
+			opportunityA.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+		await olafClient.PublishVolunteerOpportunityAsync(opportunityA.Id, cancellationToken);
+
 		var slotsB = await olafClient.CreateTimeSlotAsync(
 			opportunityB.Id,
 			new CreateTimeSlotRequest
@@ -1218,6 +1236,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			cancellationToken);
 		var firstSlotId = timeSlots.ElementAt(0).Id;
 		var secondSlotId = timeSlots.ElementAt(1).Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var firstEngagement = await veraClient.CreateEngagementAsync(
@@ -1254,6 +1273,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			},
 			cancellationToken);
 		var slotId = timeSlots.First().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		await veraClient.CreateEngagementAsync(
@@ -1292,6 +1312,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			cancellationToken);
 		var firstSlotId = timeSlots.ElementAt(0).Id;
 		var secondSlotId = timeSlots.ElementAt(1).Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var firstEngagement = await veraClient.CreateEngagementAsync(

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -65,6 +65,7 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 				RecurrenceCount = 1,
 			},
 			cancellationToken)).Single().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunityB.Id, cancellationToken);
 
 		// Pending: vera signs up for opportunityA and is left untouched.
 		await veraClient.CreateEngagementAsync(

--- a/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
@@ -79,6 +79,7 @@ public class OrganizationCalendarEventsTests(IntegrationTestFixture fixture)
 				RecurrenceCount = 1,
 			},
 			cancellationToken)).Single().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 
 		// Pending engagement counts toward bookedCount.
 		await veraClient.CreateEngagementAsync(

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1176,6 +1176,7 @@
         "NotOwner": "Du kannst nur deine eigenen Engagements verwalten.",
         "AlreadySignedUp": "Du bist für diesen Einsatz bereits angemeldet.",
         "TimeSlotNotInOpportunity": "Der ausgewählte Zeitslot gehört nicht zu diesem Einsatz.",
+        "OpportunityNotPublished": "Für diesen Einsatz kann man sich nur anmelden, wenn er veröffentlicht ist.",
         "TimeSlotFull": "Dieser Zeitslot hat seine Kapazität erreicht und kann keine weiteren Anmeldungen annehmen.",
         "InvalidPin": "Falsche PIN. Bitte erneut versuchen.",
         "CheckInLocked": "Zu viele fehlgeschlagene PIN-Versuche. Bitte versuche es später erneut."

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1178,7 +1178,8 @@
         "TimeSlotNotInOpportunity": "The selected time slot does not belong to this opportunity.",
         "TimeSlotFull": "This time slot has reached its capacity and cannot accept more sign-ups.",
         "InvalidPin": "Invalid PIN. Please try again.",
-        "CheckInLocked": "Too many failed PIN attempts. Try again later."
+        "CheckInLocked": "Too many failed PIN attempts. Try again later.",
+        "OpportunityNotPublished": "Only a published opportunity can be signed up for."
       },
       "DashboardLayout": {
         "InvalidWidgetKey": "Unknown widget.",


### PR DESCRIPTION
## What

`CreateEngagementCommandHandler` now rejects sign-ups against a `VolunteerOpportunity` that isn't `Published` (Draft, Unpublished, or Cancelled), returning a 409 Conflict (`Engagement.OpportunityNotPublished`) instead of silently allowing the engagement.

## Why

`CreateEngagementCommandHandler` never inspected `opportunity.Status`, so anyone who obtained a draft/unpublished/cancelled opportunity's GUID (an ex-organizer, a shared preview link, a leaked log line) could sign up for it - firing the notification and email fan-out to every organizer of an event they never announced. The read path (`VolunteerOpportunityReadRepository`) already gated non-organizers behind `Status == Published`; the write path had no equivalent check.

Closes #1182

## Testing

- Added `Handle_ShouldThrow_WhenOpportunityIsNotPublished` (parameterized over Draft/Unpublished/Cancelled) to `CreateEngagementCommandHandlerTests`, asserting a `Conflict` error and that no engagement is persisted.
- Several existing integration tests (`EngagementTests`, `GetOrganizationDashboardTests`, `OrganizationCalendarEventsTests`) were unknowingly relying on the bug: they created `ScheduledSlots` opportunities and signed volunteers up for them without ever publishing. Updated each to call `PublishVolunteerOpportunityAsync` after adding the required time slot(s), before signing up, so they now exercise the real, fixed flow.
- Added the matching `apiError.Engagement.OpportunityNotPublished` translation key to `en.json`/`de.json` (`pnpm i18n:check` passes) so the conflict surfaces a translated message in the sign-up modal instead of falling back to a generic error.
- Could not run `dotnet build`/the TUnit suites locally in this sandbox (outbound access to the .NET SDK download host is blocked by this session's network policy); relying on CI's `dotnet.yml` for the authoritative run. Ran `pnpm lint`, `pnpm i18n:check`, and `pnpm format:write` (no changes) locally.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut, no live-staging verification).

## Checklist

- [x] `/self-review`-equivalent manual review done (architecture-check and i18n-check subagents run against the diff; findings addressed - see error-code rename below)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no user-facing docs describe this internal validation gap)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKmyRPtjjq5oSFFb7iCwzc)_