### PR TITLE
fix: bound LoginStreakMiddleware and CheckInAttemptLimiter memory growth

### DIFF
--- a/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
+++ b/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
@@ -2,26 +2,31 @@ using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Users.RecordLogin.v1;
 using Domain.Users;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Api.Common.Middleware;
 
-internal sealed class LoginStreakMiddleware(RequestDelegate next)
+internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache cache, TimeProvider timeProvider)
 {
-	private static readonly HashSet<string> _todayUpdated = [];
-	private static DateOnly _currentDate = DateOnly.FromDateTime(DateTime.UtcNow);
+	// Fixed anchor for the shared dedup cache below - deliberately NOT derived from
+	// the request's X-Timezone header. The header is attacker-controlled and used
+	// to previously reset a single process-wide "today" variable, so alternating
+	// timezones across requests could thrash it and force RecordLoginCommand (a DB
+	// write) to refire for every user on every request (#1185).
+	private static readonly TimeZoneInfo ServerTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
 	private static readonly Lock _lock = new();
 
 	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
 	{
 		if (string.IsNullOrWhiteSpace(ianaId))
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+			return ServerTimeZone;
 		try
 		{
 			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
 		}
 		catch
 		{
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+			return ServerTimeZone;
 		}
 	}
 
@@ -32,19 +37,26 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next)
 			var subClaim = context.User.FindFirst("sub")?.Value;
 			if (subClaim is not null && Guid.TryParse(subClaim, out var userId))
 			{
+				// X-Timezone only shapes which calendar day this login counts toward
+				// for the user's streak - it never influences the cache entry below.
 				var tzHeader = context.Request.Headers["X-Timezone"].FirstOrDefault();
 				var tz = ResolveTimeZone(tzHeader);
-				var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime);
+				var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), tz).DateTime);
+
+				// Per-user cache entry (not a single shared collection) expiring at
+				// the next server-timezone midnight, so a user who never logs in
+				// again does not sit in memory forever, and no request input can
+				// force an early reset.
+				var cacheKey = $"login-streak-recorded:{subClaim}";
 
 				bool shouldUpdate;
 				lock (_lock)
 				{
-					if (_currentDate != today)
+					shouldUpdate = !cache.TryGetValue(cacheKey, out _);
+					if (shouldUpdate)
 					{
-						_todayUpdated.Clear();
-						_currentDate = today;
+						cache.Set(cacheKey, true, NextServerMidnight());
 					}
-					shouldUpdate = _todayUpdated.Add(subClaim);
 				}
 
 				if (shouldUpdate)
@@ -64,5 +76,13 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next)
 		}
 
 		await next(context);
+	}
+
+	private DateTimeOffset NextServerMidnight()
+	{
+		var serverNow = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), ServerTimeZone);
+		var nextMidnight = serverNow.Date.AddDays(1);
+
+		return new DateTimeOffset(nextMidnight, ServerTimeZone.GetUtcOffset(nextMidnight));
 	}
 }

--- a/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
+++ b/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
@@ -8,7 +8,7 @@ namespace Infrastructure.RateLimiting;
 // per-user/IP rate limiting policies in Api/Common/RateLimiting. A 4-digit PIN
 // has only 10,000 combinations, so a much tighter, engagement-scoped lockout is
 // needed to make brute-forcing infeasible even for an authenticated owner.
-internal sealed class CheckInAttemptLimiter : ICheckInAttemptLimiter
+internal sealed class CheckInAttemptLimiter(TimeProvider timeProvider) : ICheckInAttemptLimiter
 {
 	private const int MaxFailedAttempts = 5;
 	private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
@@ -19,25 +19,29 @@ internal sealed class CheckInAttemptLimiter : ICheckInAttemptLimiter
 	{
 		var isLockedOut = _attempts.TryGetValue(engagementId.Value, out var state)
 			&& state.LockedUntil is { } lockedUntil
-			&& lockedUntil > DateTimeOffset.UtcNow;
+			&& lockedUntil > timeProvider.GetUtcNow();
 
 		return Task.FromResult(isLockedOut);
 	}
 
 	public Task RegisterFailedAttemptAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
 	{
+		var now = timeProvider.GetUtcNow();
+
 		_attempts.AddOrUpdate(
 			engagementId.Value,
-			_ => new AttemptState(1, null),
+			_ => new AttemptState(1, null, now),
 			(_, existing) =>
 			{
 				var failedAttempts = existing.FailedAttempts + 1;
 				var lockedUntil = failedAttempts >= MaxFailedAttempts
-					? DateTimeOffset.UtcNow.Add(LockoutDuration)
+					? now.Add(LockoutDuration)
 					: existing.LockedUntil;
 
-				return new AttemptState(failedAttempts, lockedUntil);
+				return new AttemptState(failedAttempts, lockedUntil, now);
 			});
+
+		EvictStaleEntries(now);
 
 		return Task.CompletedTask;
 	}
@@ -49,5 +53,17 @@ internal sealed class CheckInAttemptLimiter : ICheckInAttemptLimiter
 		return Task.CompletedTask;
 	}
 
-	private sealed record AttemptState(int FailedAttempts, DateTimeOffset? LockedUntil);
+	// Bounds dictionary growth for engagements that never succeed (ResetAsync only
+	// runs on a correct PIN) - an entry untouched for longer than LockoutDuration is
+	// forgotten, so a fresh failed attempt afterwards starts counting from zero.
+	private void EvictStaleEntries(DateTimeOffset now)
+	{
+		foreach (var (engagementId, state) in _attempts)
+		{
+			if (now - state.LastAttemptAt >= LockoutDuration)
+				_attempts.TryRemove(engagementId, out _);
+		}
+	}
+
+	private sealed record AttemptState(int FailedAttempts, DateTimeOffset? LockedUntil, DateTimeOffset LastAttemptAt);
 }

--- a/backend/tests/IntegrationTests/CheckInAttemptLimiterTests.cs
+++ b/backend/tests/IntegrationTests/CheckInAttemptLimiterTests.cs
@@ -1,0 +1,109 @@
+using AwesomeAssertions;
+using Domain.Engagements;
+using Infrastructure.RateLimiting;
+
+namespace IntegrationTests;
+
+// Pure in-memory logic - no database needed - but CheckInAttemptLimiter is
+// internal to Infrastructure (InternalsVisibleTo only grants IntegrationTests,
+// see Infrastructure.csproj), so this has to live here rather than in a
+// project that can't see it.
+public class CheckInAttemptLimiterTests
+{
+	[Test]
+	public async Task IsLockedOutAsync_ShouldReturnFalse_ForEngagementWithNoAttempts(
+		CancellationToken cancellationToken)
+	{
+		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
+
+		var isLockedOut = await sut.IsLockedOutAsync(EngagementId.New(), cancellationToken);
+
+		isLockedOut.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task IsLockedOutAsync_ShouldReturnFalse_WhenFailedAttemptsAreBelowMax(
+		CancellationToken cancellationToken)
+	{
+		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
+		var engagementId = EngagementId.New();
+
+		for (var i = 0; i < 4; i++)
+			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
+
+		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
+
+		isLockedOut.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task IsLockedOutAsync_ShouldReturnTrue_WhenFailedAttemptsReachMax(
+		CancellationToken cancellationToken)
+	{
+		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
+		var engagementId = EngagementId.New();
+
+		for (var i = 0; i < 5; i++)
+			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
+
+		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
+
+		isLockedOut.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task ResetAsync_ShouldClearLockout(
+		CancellationToken cancellationToken)
+	{
+		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
+		var engagementId = EngagementId.New();
+
+		for (var i = 0; i < 5; i++)
+			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
+
+		await sut.ResetAsync(engagementId, cancellationToken);
+
+		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
+		isLockedOut.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task RegisterFailedAttemptAsync_ShouldForgetStaleAttempts_OnceLockoutDurationElapses(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1185: an engagement that never succeeds (ResetAsync only
+		// runs on a correct PIN) must not keep its failed-attempt count forever -
+		// otherwise the underlying dictionary grows without bound for the
+		// container's lifetime. Four failed attempts is below the five-attempt
+		// lockout threshold, so if the stale entry is never evicted, a single
+		// additional attempt after LockoutDuration has passed would still push the
+		// (never-reset) count to five and lock the engagement out immediately.
+		var timeProvider = new FakeTimeProvider();
+		var sut = new CheckInAttemptLimiter(timeProvider);
+		var staleEngagementId = EngagementId.New();
+		var otherEngagementId = EngagementId.New();
+
+		for (var i = 0; i < 4; i++)
+			await sut.RegisterFailedAttemptAsync(staleEngagementId, cancellationToken);
+
+		timeProvider.Advance(TimeSpan.FromMinutes(16));
+
+		// Any write sweeps stale entries - use an unrelated engagement so this
+		// doesn't itself contribute to staleEngagementId's attempt count.
+		await sut.RegisterFailedAttemptAsync(otherEngagementId, cancellationToken);
+
+		await sut.RegisterFailedAttemptAsync(staleEngagementId, cancellationToken);
+
+		var isLockedOut = await sut.IsLockedOutAsync(staleEngagementId, cancellationToken);
+		isLockedOut.Should().BeFalse("the stale 4-attempt count should have been evicted, leaving only this one fresh attempt");
+	}
+
+	private sealed class FakeTimeProvider : TimeProvider
+	{
+		private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+
+		public override DateTimeOffset GetUtcNow() => _utcNow;
+
+		public void Advance(TimeSpan by) => _utcNow += by;
+	}
+}

--- a/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
+++ b/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
@@ -1,0 +1,146 @@
+using System.Security.Claims;
+using Api.Common.Middleware;
+using Application.Common.Messaging;
+using Application.Users.RecordLogin.v1;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace IntegrationTests;
+
+// LoginStreakMiddleware is internal to Api (InternalsVisibleTo only grants
+// ArchitectureTests and IntegrationTests, see Api.csproj), so this has to live
+// here rather than in a project that can't see it. Pure logic - no database,
+// no real request pipeline needed.
+//
+// Regression coverage for #1185: the middleware used to dedupe "have we
+// recorded today's login for this user" with a single process-wide static
+// HashSet, cleared whenever the client-supplied X-Timezone header produced a
+// different calendar date than the previous request. Because that header is
+// attacker-controlled, alternating between two far-apart zones could thrash
+// the reset and force RecordLoginCommand (a DB write) to refire on every
+// request for every user. The fix keys dedup per user in an IMemoryCache
+// entry that expires at a fixed server-timezone midnight, never a
+// header-derived one.
+public class LoginStreakMiddlewareTests
+{
+	[Test]
+	public async Task InvokeAsync_ShouldRecordLogin_OnFirstRequestForUser()
+	{
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+
+		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), sender);
+
+		sender.SentRequests.Should().ContainSingle().Which.Should().BeOfType<RecordLoginCommand>();
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldNotRecordLoginAgain_OnSecondRequestSameDay()
+	{
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var subClaim = Guid.NewGuid().ToString();
+
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
+
+		sender.SentRequests.Should().ContainSingle();
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldNotRecordLoginRepeatedly_WhenXTimezoneHeaderAlternatesAcrossRequests()
+	{
+		// The exact pair of near-antipodal zones from the issue report - about 25
+		// hours apart, so alternating between them almost always produced a
+		// different local calendar date on the old, vulnerable code path.
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var subClaim = Guid.NewGuid().ToString();
+
+		for (var i = 0; i < 10; i++)
+		{
+			var tzHeader = i % 2 == 0 ? "Pacific/Kiritimati" : "Pacific/Niue";
+			await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, tzHeader), sender);
+		}
+
+		sender.SentRequests.Should().ContainSingle(
+			"X-Timezone must only shape the streak's local date, never thrash the shared dedup cache");
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldRecordLoginAgain_AfterServerMidnightRollover()
+	{
+		// 2026-06-15 10:00 UTC = 12:00 in Europe/Berlin (CEST, UTC+2) - well clear of
+		// its own midnight. Advancing 13 hours crosses the next Berlin midnight
+		// (2026-06-15 22:00 UTC), so the per-user cache entry must have expired.
+		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero));
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), timeProvider);
+		var subClaim = Guid.NewGuid().ToString();
+
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
+		timeProvider.Advance(TimeSpan.FromHours(13));
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
+
+		sender.SentRequests.Should().HaveCount(2);
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldNotCallSender_WhenUserIsNotAuthenticated()
+	{
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var context = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
+
+		await sut.InvokeAsync(context, sender);
+
+		sender.SentRequests.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldAlwaysCallNext()
+	{
+		var nextCalled = false;
+		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+
+		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), new RecordingSender());
+
+		nextCalled.Should().BeTrue();
+	}
+
+	private static DefaultHttpContext CreateAuthenticatedContext(string subClaim, string? tzHeader = null)
+	{
+		var context = new DefaultHttpContext
+		{
+			User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("sub", subClaim)], authenticationType: "Test")),
+		};
+
+		if (tzHeader is not null)
+			context.Request.Headers["X-Timezone"] = tzHeader;
+
+		return context;
+	}
+
+	private sealed class RecordingSender : ISender
+	{
+		public List<object?> SentRequests { get; } = [];
+
+		public ValueTask<TResponse> Send<TResponse>(
+			IRequest<TResponse> request,
+			CancellationToken cancellationToken = default)
+		{
+			SentRequests.Add(request);
+			return ValueTask.FromResult<TResponse>(default!);
+		}
+	}
+
+	private sealed class FakeTimeProvider(DateTimeOffset? initialUtcNow = null) : TimeProvider
+	{
+		private DateTimeOffset _utcNow = initialUtcNow ?? DateTimeOffset.UtcNow;
+
+		public override DateTimeOffset GetUtcNow() => _utcNow;
+
+		public void Advance(TimeSpan by) => _utcNow += by;
+	}
+}


### PR DESCRIPTION
## What

Bounds two process-wide in-memory collections that previously grew for the container's lifetime: `LoginStreakMiddleware`'s login-dedup set and `CheckInAttemptLimiter`'s per-engagement PIN attempt tracker.

## Why

`LoginStreakMiddleware` cleared its shared `_todayUpdated` set based on a date derived from the client-supplied `X-Timezone` header. Since that header is attacker-controlled, alternating requests between two far-apart zones (e.g. `Pacific/Kiritimati` and `Pacific/Niue`) could thrash the reset and force `RecordLoginCommand` (a DB write) to refire for every authenticated user on every request, instead of once per calendar day.

`CheckInAttemptLimiter`'s `ConcurrentDictionary<Guid, AttemptState>` only removed an entry via `ResetAsync`, which runs on a correct PIN. An engagement whose PIN check-in never succeeds (attacker gives up, or never reaches the lockout threshold) kept its entry forever.

Closes #1185

## Changes

- `LoginStreakMiddleware`: replaced the static `HashSet`/`DateOnly` pair with a per-user `IMemoryCache` entry that expires at a fixed server-timezone (`Europe/Berlin`) midnight. `X-Timezone` still shapes which calendar day a login counts toward for the user's own streak, but no longer has any influence over the shared cache's reset.
- `CheckInAttemptLimiter`: sweeps entries untouched for longer than `LockoutDuration` on every write, so engagements that never succeed don't accumulate indefinitely.
- Both now take `TimeProvider` (via constructor) instead of reading `DateTimeOffset.UtcNow` directly, matching the existing convention in `AuditableEntityInterceptor`/`ConvertDomainEventsToOutboxMessagesInterceptor` - this is what makes the new tests deterministic.

## Testing

- `backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs` (new) - covers first-request dedup, no double-fire on a second same-day request, the exact `Pacific/Kiritimati`/`Pacific/Niue` alternating-header regression from the issue, cache rollover at the fixed server midnight, unauthenticated requests, and that `next()` always runs. Sanity-checked: these tests fail to even compile against the original constructor signature, confirming they exercise the fixed code path.
- `backend/tests/IntegrationTests/CheckInAttemptLimiterTests.cs` (new) - covers lockout at the 5-attempt threshold, no lockout below it, `ResetAsync`, and the stale-entry eviction behavior (a 4-attempt count that's gone stale must be forgotten, not carried into a fresh attempt).
- Both live in `IntegrationTests` (no Testcontainers needed for these particular tests) since the classes under test are `internal` and only that project has `InternalsVisibleTo` from `Api`/`Infrastructure`.
- Ran locally: `Application.UnitTests` (709 passed), `ArchitectureTests` (366 passed), and both new test classes (11 passed) via `--treenode-filter`.
- `/self-review` run - no findings.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut this time). Both fixes are pure in-memory/timing logic covered by the new deterministic tests above; there's no user-facing behavior to observe on staging beyond what those tests already assert.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal implementation detail, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UShD3j3HQZeKtBuA7wT2pY)_