### PR TITLE
fix: stop leaking email addresses via member candidate search

### DIFF
--- a/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
+++ b/backend/src/Api/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesEndpoint.cs
@@ -32,7 +32,10 @@ internal sealed class SearchMemberCandidatesEndpoint
 		ClaimsPrincipal user,
 		CancellationToken cancellationToken)
 	{
-		if (string.IsNullOrWhiteSpace(q) || q.Length < 2)
+		// A longer minimum query length raises the cost of using this endpoint
+		// to enumerate the realm-wide user directory rather than find a
+		// specific invite candidate.
+		if (string.IsNullOrWhiteSpace(q) || q.Length < 4)
 			return Results.Ok(Array.Empty<MemberCandidateDto>());
 
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7312,8 +7312,7 @@
           "userId",
           "username",
           "firstName",
-          "lastName",
-          "email"
+          "lastName"
         ],
         "type": "object",
         "properties": {
@@ -7335,9 +7334,6 @@
               "null",
               "string"
             ]
-          },
-          "email": {
-            "type": "string"
           }
         }
       },

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
@@ -13,5 +13,4 @@ public sealed record MemberCandidateDto(
 	Guid UserId,
 	string Username,
 	string? FirstName,
-	string? LastName,
-	string Email);
+	string? LastName);

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
@@ -36,8 +36,7 @@ internal sealed class SearchMemberCandidatesQueryHandler(
 				u.UserId,
 				u.Username,
 				u.FirstName,
-				u.LastName,
-				u.Email))
+				u.LastName))
 			.ToList();
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -11437,10 +11437,6 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("lastName")]
         public string? LastName { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("email")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Email { get; set; } = default!;
-
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -76,6 +76,35 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task MemberSearch_RequiresFourCharacters_AndNeverExposesCandidateEmail()
+	{
+		// Regression for #1170: any authenticated user could self-create an
+		// organization to become an organizer, then abuse this search - a
+		// 2-char minimum, each result carrying the candidate's email address -
+		// to enumerate the realm-wide user directory. Verifies a 3-char query
+		// returns nothing and a matching search never renders an email
+		// address in the results.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1170 MemberSearch", pinnedOrgId!.Value);
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+
+		await Page.Locator("#member-search").FillAsync("ver");
+		await Page.WaitForTimeoutAsync(800);
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Invite" })).Not.ToBeVisibleAsync();
+
+		await Page.Locator("#member-search").FillAsync("vera");
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Invite" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Expect(Page.GetByText("vera@example.com")).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task SoleMember_MembersPage_ShowsDisabledLeaveInsteadOfRemove()
 	{
 		// #580: the org's sole member must see a disabled "Leave" action on

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5801,7 +5801,6 @@ export interface MemberCandidateDto {
     username: string;
     firstName: string | undefined;
     lastName: string | undefined;
-    email: string;
 
     [key: string]: any;
 }

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -63,7 +63,7 @@ export default function OrgMembersPage() {
 	function handleMemberSearchChange(value: string) {
 		setMemberSearch(value);
 		if (memberSearchTimer.current) clearTimeout(memberSearchTimer.current);
-		if (value.length < 2) {
+		if (value.length < 4) {
 			setMemberCandidates([]);
 			return;
 		}
@@ -279,9 +279,11 @@ export default function OrgMembersPage() {
 												? `${candidate.firstName} ${candidate.lastName}`
 												: candidate.username}
 										</p>
-										<p className="truncate text-xs text-gray-500">
-											{candidate.email}
-										</p>
+										{candidate.firstName && candidate.lastName && (
+											<p className="truncate text-xs text-gray-500">
+												@{candidate.username}
+											</p>
+										)}
 									</div>
 									<Button
 										type="button"
@@ -296,7 +298,7 @@ export default function OrgMembersPage() {
 							))}
 						</ul>
 					)}
-					{memberSearch.length >= 2 &&
+					{memberSearch.length >= 4 &&
 						!memberSearchLoading &&
 						memberCandidates.length === 0 && (
 							<p className="mt-1 text-xs text-gray-500">


### PR DESCRIPTION
## What

`GET /v1/organizations/{organizationId}/members/search` no longer returns each candidate's email address, and now requires a 4-character minimum query instead of 2.

## Why

Any authenticated user can create an organization and immediately become its organizer, then call this search endpoint (scoped only by "is organizer of the org id in the route" - trivially satisfied by their own throwaway org) to run an unscoped, realm-wide Keycloak user search. Every match included the candidate's email address, gated by a mere 2-character minimum - enough to enumerate essentially the whole platform user directory (username, first/last name, and email) in well under a minute. This is a GDPR-relevant PII disclosure on a platform whose users are volunteers.

`MemberCandidateDto` now omits `Email` entirely (the invite flow already keys on `userId`, not email, so nothing downstream needed it), and the minimum query length is raised from 2 to 4 characters to raise the cost of using the endpoint for directory enumeration rather than finding a specific invite candidate. The frontend candidate list shows the searched user's `@username` instead of their email as the secondary disambiguating line.

Closes #1170

## Testing

- `dotnet run --project tests/Application.UnitTests` - 709 passed
- `dotnet run --project tests/ArchitectureTests` - 366 passed
- `pnpm check` / `pnpm lint` / `pnpm test` (123 passed) / `pnpm i18n:check` - all clean
- Added `MemberSearch_RequiresFourCharacters_AndNeverExposesCandidateEmail` to `backend/tests/VisualTests/OrganizationTests.cs` - asserts a 3-char query returns no candidates and a matching search never renders `vera@example.com` anywhere in the results. Compiles clean; not runnable locally (this sandbox has no Docker/Aspire networking), so it runs for the first time in CI's `dotnet.yml`.
- `openapi-v1.json` / `frontend/src/client/api-client.ts` / `backend/tests/IntegrationTests/ApiClient.cs` regenerated via `dotnet build` and diffed to confirm they only drop the `email` field, nothing else drifted.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). Coverage instead comes from the automated unit/architecture/frontend suites above plus the new `VisualTests` regression test, which will get its first real run in CI.

## Checklist

- [x] `/self-review` run and findings addressed (also fanned out to `nswag-check` and `a11y-check` - both passed clean)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (none needed - no docs reference this DTO/endpoint's field list)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JR1Lyv6RboACfJE2vxMzp8)_