### PR TITLE
fix: rate limit and cache /health and /alive

### DIFF
--- a/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
@@ -25,6 +25,13 @@ internal static class OutputCachingExtensions
 			cache.AddPolicy(OutputCachingPolicies.ShortPublicRead, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds)));
 
+			// Output caching only ever caches 200 responses (the framework default), so an
+			// Unhealthy/Degraded result (mapped to 503 by MapHealthChecks) is never cached -
+			// a real outage is still observed on the very next request instead of being
+			// masked for up to HealthCheckSeconds (#1172).
+			cache.AddPolicy(OutputCachingPolicies.HealthCheck, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.HealthCheckSeconds)));
+
 			cache.AddPolicy(OutputCachingPolicies.VolunteerOpportunityListing, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds))
 					.Tag(OutputCachingPolicies.VolunteerOpportunityListingTag));

--- a/backend/src/Api/Common/OutputCaching/OutputCachingOptions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingOptions.cs
@@ -4,4 +4,5 @@ internal sealed class OutputCachingOptions
 {
 	public int LongPublicReadSeconds { get; init; } = 3600;
 	public int ShortPublicReadSeconds { get; init; } = 60;
+	public int HealthCheckSeconds { get; init; } = 5;
 }

--- a/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
@@ -5,6 +5,11 @@ public static class OutputCachingPolicies
 	public const string LongPublicRead = "output-cache-long-public-read";
 	public const string ShortPublicRead = "output-cache-short-public-read";
 
+	// A few seconds only, not ShortPublicReadSeconds - /health backs the deploy gate's
+	// and docker-compose's readiness probes, both of which need to observe a real
+	// dependency outage within a handful of seconds, not up to a full minute (#1172).
+	public const string HealthCheck = "output-cache-health-check";
+
 	// Same expiry as ShortPublicRead, but tagged separately so a write that changes
 	// what the public volunteer-opportunity listing should show can evict just this
 	// endpoint's cache entries via IOutputCacheStore.EvictByTagAsync instead of

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -214,7 +214,17 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 		await initializer.SeedAsync();
 }
 
-app.MapDefaultEndpoints();
+// Both anonymous and previously exempt from every rate limiting/caching policy -
+// /health additionally ran a DB connect + an outbound Keycloak HTTP call on every
+// single hit, so a trivial unauthenticated flood could exhaust the Npgsql pool and
+// starve Keycloak (#1172). RequireRateLimiting caps the request rate itself;
+// CacheOutput on /health also bounds how often the underlying dependency checks run
+// at all, independent of how many distinct callers/IPs are behind a flood.
+app.MapDefaultEndpoints(
+	health => health
+		.RequireRateLimiting(RateLimitingPolicies.Read)
+		.CacheOutput(OutputCachingPolicies.HealthCheck),
+	alive => alive.RequireRateLimiting(RateLimitingPolicies.Read));
 
 // Must run before anything that reads Connection.RemoteIpAddress (HTTP logging,
 // the rate limiter's anonymous partition key) - see TrustedNetworksOptions for why

--- a/backend/src/Aspire/ServiceDefaults/Extensions.cs
+++ b/backend/src/Aspire/ServiceDefaults/Extensions.cs
@@ -118,7 +118,16 @@ public static class ServiceDefaultsExtensions
 	private static bool TryGetMetricsPort(IConfiguration configuration, out int port) =>
 		int.TryParse(configuration["Metrics:Port"], out port);
 
-	public static WebApplication MapDefaultEndpoints(this WebApplication app)
+	// configureHealthEndpoint/configureAliveEndpoint let the Api layer (which owns
+	// RateLimitingPolicies/OutputCachingPolicies) opt these anonymous, unauthenticated
+	// endpoints into its rate limiting and output caching conventions without this
+	// shared project taking a reference back onto Api - ServiceDefaults is also
+	// referenced standalone (MetricsPortListenerTests.cs), where both stay null and
+	// behavior is unchanged (#1172).
+	public static WebApplication MapDefaultEndpoints(
+		this WebApplication app,
+		Action<IEndpointConventionBuilder>? configureHealthEndpoint = null,
+		Action<IEndpointConventionBuilder>? configureAliveEndpoint = null)
 	{
 		// Exposed in all environments so deployment health checks and live smoke
 		// tests have a target.
@@ -127,14 +136,17 @@ public static class ServiceDefaultsExtensions
 		//            reachable. Returns non-200 when a dependency is down so uptime
 		//            monitors and the docker-compose healthcheck see the real state.
 		// /alive   = liveness: the process is up. Stays 200 regardless of deps.
-		app.MapHealthChecks("/health", new HealthCheckOptions
+		var healthEndpoint = app.MapHealthChecks("/health", new HealthCheckOptions
 		{
 			Predicate = r => r.Tags.Contains("ready")
 		});
-		app.MapHealthChecks("/alive", new HealthCheckOptions
+		var aliveEndpoint = app.MapHealthChecks("/alive", new HealthCheckOptions
 		{
 			Predicate = r => r.Tags.Contains("live")
 		});
+
+		configureHealthEndpoint?.Invoke(healthEndpoint);
+		configureAliveEndpoint?.Invoke(aliveEndpoint);
 
 		if (TryGetMetricsPort(app.Configuration, out var metricsPort))
 		{

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -77,6 +77,22 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 			"instead of leaving the previous (stale) response cached for ShortPublicReadSeconds");
 	}
 
+	// Regression coverage for #1172: /health ran a DB connect + an outbound Keycloak
+	// HTTP call on every single hit with no result caching, so a flood of requests
+	// (even one spread across many IPs, which per-IP rate limiting alone wouldn't
+	// bound) could exhaust the Npgsql pool and starve Keycloak.
+	[Test]
+	public async Task GetHealth_ShouldBeServedFromOutputCache_OnASecondRequest(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		await httpClient.GetAsync("/health", cancellationToken);
+		var second = await httpClient.GetAsync("/health", cancellationToken);
+
+		second.Headers.TryGetValues("Age", out _).Should().BeTrue();
+	}
+
 	// The default output cache key is method + path + query string with no per-route-parameter
 	// awareness beyond that, so this also proves two different organizations don't collide on
 	// (or get served) each other's cached profile response.

--- a/backend/tests/IntegrationTests/RateLimitingTests.cs
+++ b/backend/tests/IntegrationTests/RateLimitingTests.cs
@@ -32,4 +32,44 @@ public class RateLimitingTests(IntegrationTestFixture fixture)
 
 		statusCodes.Should().Contain(HttpStatusCode.TooManyRequests);
 	}
+
+	// Regression coverage for #1172: /health used to be exempt from every rate
+	// limiting policy while running a DB connect + an outbound Keycloak HTTP call on
+	// every hit - a trivial unauthenticated flood could exhaust the Npgsql pool and
+	// starve Keycloak. Own test IP so this quota is isolated from the test above.
+	[Test]
+	public async Task GetHealth_ShouldReturn429_WhenAnonymousRateLimitExceeded(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Add("X-Forwarded-For", "10.0.0.100");
+
+		var statusCodes = new List<HttpStatusCode>();
+
+		for (var i = 0; i < 65; i++)
+		{
+			var response = await httpClient.GetAsync("/health", cancellationToken);
+			statusCodes.Add(response.StatusCode);
+		}
+
+		statusCodes.Should().Contain(HttpStatusCode.TooManyRequests);
+	}
+
+	[Test]
+	public async Task GetAlive_ShouldReturn429_WhenAnonymousRateLimitExceeded(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Add("X-Forwarded-For", "10.0.0.101");
+
+		var statusCodes = new List<HttpStatusCode>();
+
+		for (var i = 0; i < 65; i++)
+		{
+			var response = await httpClient.GetAsync("/alive", cancellationToken);
+			statusCodes.Add(response.StatusCode);
+		}
+
+		statusCodes.Should().Contain(HttpStatusCode.TooManyRequests);
+	}
 }


### PR DESCRIPTION
## What

Chains rate limiting onto `/health` and `/alive`, and adds a short-TTL output cache to `/health`.

## Why

`/health` and `/alive` were anonymous and exempt from every rate limiting policy (`RateLimitingExtensions.cs` never sets a `GlobalLimiter`, and neither `MapHealthChecks` call chained `.RequireRateLimiting(...)`). Worse, `/health`'s readiness checks ran a real DB connect (`DatabaseHealthCheck`) and an outbound Keycloak HTTP call (`KeycloakHealthCheck`) on **every single hit**, with no result caching. The backend is capped at 512 MB / 0.5 CPU (same for Postgres), and Keycloak is shared with the real login flow - a trivial unauthenticated flood against `/health` could exhaust the Npgsql pool and starve Keycloak, taking down login for real users, with no authentication, no rate limit, and no per-IP cap.

Closes #1172

## Changes

- `Program.cs`: chains `.RequireRateLimiting(RateLimitingPolicies.Read)` onto both `/health` and `/alive`, and additionally `.CacheOutput(OutputCachingPolicies.HealthCheck)` (new, 5-second TTL) onto `/health` - this bounds how often the DB/Keycloak checks actually run, independent of how many distinct callers/IPs are behind a flood (rate limiting alone only bounds a single IP; caching bounds the underlying work regardless of caller count).
- `Aspire/ServiceDefaults/Extensions.cs`: `MapDefaultEndpoints` now takes two optional `Action<IEndpointConventionBuilder>?` callbacks so the `Api` layer (which owns `RateLimitingPolicies`/`OutputCachingPolicies`) can opt these endpoints into its conventions without `ServiceDefaults` taking a reference back onto `Api` (that would be circular - `Api` already references `ServiceDefaults`). Both default to `null`/no-op, so the existing standalone caller (`MetricsPortListenerTests.cs`, which builds a bare app without a rate limiter/output cache registered at all) is unaffected.
- `OutputCaching{Extensions,Options,Policies}.cs`: new `HealthCheck` policy, deliberately much shorter than the existing `ShortPublicRead` (60s) - `/health` backs the deploy gate's and docker-compose's readiness probes, which need to observe a real dependency outage within a handful of seconds, not up to a full minute. Since output caching only ever caches 200 responses, an Unhealthy/Degraded result (mapped to 503) is never cached, so a real outage is still visible on the very next request.
- Reused the existing `RateLimitingPolicies.Read` policy rather than adding a new dedicated one - its anonymous ceiling (60 req/min per IP) already gives ample headroom for every legitimate caller (docker-compose's `/alive` probe at 10s intervals, the deploy gate's `/health` poll at 10s intervals), while still bounding the blast radius described above. Rate limiting partitions by client IP, so these infra callers don't collide with real end-user traffic on the same policy.

Deliberately out of scope: the issue's third suggestion (binding `/health` to a private/management port, off the public Traefik router) would be a larger deployment/routing change and would break the existing deploy gate (`publish.yml` polls `https://api.maik-hasler.de/health` publicly) and `/live-verify`'s smoke test. Rate limiting + caching directly addresses the amplification impact described in the issue without that blast radius.

## Testing

- `dotnet build` (Api, ArchitectureTests, Application.UnitTests) - 0 warnings, 0 errors.
- `dotnet run --project tests/ArchitectureTests` - 366/366 passed, including `RateLimitingConventionTests` (unaffected - it only scans `IEndpoint`-based routes, not `MapHealthChecks` endpoints).
- `dotnet run --project tests/Application.UnitTests` - 709/709 passed.
- Added `RateLimitingTests.GetHealth_ShouldReturn429_WhenAnonymousRateLimitExceeded` and `GetAlive_ShouldReturn429_WhenAnonymousRateLimitExceeded` (each with its own unique test IP, following the existing convention).
- Added `OutputCachingTests.GetHealth_ShouldBeServedFromOutputCache_OnASecondRequest`.
- `IntegrationTests`/`VisualTests` need real container networking (Testcontainers/Aspire), not available in this sandbox - will be verified by CI's `dotnet.yml`.
- Ran `nswag-check` and `architecture-check` agents against the diff: no NSwag regeneration needed (these are raw `MapHealthChecks` middleware endpoints, never part of the `IEndpoint`/OpenAPI surface), and no Clean Architecture/naming/rate-limiting convention violations.

## Live verification

Not performed - explicitly out of scope for this task (no RC cut). CI's `IntegrationTests` job will exercise the new rate-limiting/caching behavior against a real Postgres + Keycloak stack.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal security hardening, no public-facing behavior/docs change)


---
_Generated by [Claude Code](https://claude.ai/code/session_014rmusobE2XyVsrFAk82k2Z)_