### PR TITLE
fix: harden check-in PINs with crypto RNG, deny-list, and persisted lockout

### DIFF
--- a/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
+++ b/backend/src/Application/Engagements/CheckInWithPin/v1/CheckInWithPinCommandHandler.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
@@ -43,7 +45,7 @@ internal sealed class CheckInWithPinCommandHandler(
 		if (string.IsNullOrWhiteSpace(request.Pin))
 			throw new ResultFailureException(Error.Validation("Engagement.PinRequired", "PIN is required."));
 
-		if (!string.Equals(opportunity.CheckInPin, request.Pin, StringComparison.Ordinal))
+		if (!PinsMatch(opportunity.CheckInPin, request.Pin))
 		{
 			await attemptLimiter.RegisterFailedAttemptAsync(request.EngagementId, cancellationToken);
 			throw new ResultFailureException(Error.Validation("Engagement.InvalidPin", "Invalid PIN."));
@@ -54,5 +56,22 @@ internal sealed class CheckInWithPinCommandHandler(
 		engagement.CheckIn().ThrowIfFailure();
 
 		return engagement;
+	}
+
+	// CryptographicOperations.FixedTimeEquals instead of string.Equals/== (#1176)
+	// so a wrong guess can't be timed digit-by-digit to narrow down the real PIN.
+	// It requires equal-length spans, so a length mismatch is checked upfront -
+	// that alone leaks nothing an attacker doesn't already know (PIN length is
+	// public: EnsureValidPin only ever allows 4-6 digits).
+	private static bool PinsMatch(string? storedPin, string suppliedPin)
+	{
+		if (storedPin is null)
+			return false;
+
+		var storedBytes = Encoding.UTF8.GetBytes(storedPin);
+		var suppliedBytes = Encoding.UTF8.GetBytes(suppliedPin);
+
+		return storedBytes.Length == suppliedBytes.Length
+			&& CryptographicOperations.FixedTimeEquals(storedBytes, suppliedBytes);
 	}
 }

--- a/backend/src/Domain/VolunteerOpportunities/CheckInPinPolicy.cs
+++ b/backend/src/Domain/VolunteerOpportunities/CheckInPinPolicy.cs
@@ -1,0 +1,38 @@
+namespace Domain.VolunteerOpportunities;
+
+// Shared by VolunteerOpportunity.EnsureValidPin (organizer-supplied PINs) and
+// Infrastructure's RandomPinGenerator (auto-generated PINs), so both reject the
+// same set of easy-to-guess values instead of maintaining two definitions of
+// "trivial" (#1176). A 4-6 digit PIN already has a small combination space; a
+// repeated digit, a run of consecutive digits, or one of a handful of
+// well-known common PINs (DataGenetics' 2012 analysis of leaked 4-digit PINs)
+// would let an attacker skip straight to the lockout threshold on the first
+// few guesses.
+public static class CheckInPinPolicy
+{
+	private static readonly HashSet<string> WellKnownWeakPins = new(StringComparer.Ordinal)
+	{
+		"1212", "6969", "1313", "2001", "1010", "1998", "1004", "2000", "1999", "2580", "0852",
+	};
+
+	public static bool IsTrivial(string pin) =>
+		IsRepeatedDigit(pin) || IsConsecutiveRun(pin) || WellKnownWeakPins.Contains(pin);
+
+	private static bool IsRepeatedDigit(string pin) =>
+		pin.Distinct().Count() == 1;
+
+	private static bool IsConsecutiveRun(string pin)
+	{
+		var ascending = true;
+		var descending = true;
+
+		for (var i = 1; i < pin.Length; i++)
+		{
+			var diff = pin[i] - pin[i - 1];
+			ascending &= diff == 1;
+			descending &= diff == -1;
+		}
+
+		return ascending || descending;
+	}
+}

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -114,6 +114,9 @@ public sealed class VolunteerOpportunity
 		if (pin.Length is < 4 or > 6 || !pin.All(char.IsAsciiDigit))
 			return Result.Failure(Error.Validation("VolunteerOpportunity.InvalidCheckInPin", "Check-in PIN must be 4 to 6 digits."));
 
+		if (CheckInPinPolicy.IsTrivial(pin))
+			return Result.Failure(Error.Validation("VolunteerOpportunity.WeakCheckInPin", "This PIN is too easy to guess - choose a less predictable one."));
+
 		return Result.Success();
 	}
 

--- a/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneJob.cs
@@ -1,0 +1,103 @@
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.RateLimiting;
+using Infrastructure.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+// CheckInAttempt has no other cleanup path (#1176) - without this job the
+// table would grow for the lifetime of the database, one row per engagement
+// that ever had a failed check-in PIN attempt. A row is safe to drop once its
+// lockout window has fully elapsed: RegisterFailedAttemptAsync only writes a
+// new row if none exists, so pruning gives that engagement a fresh
+// FailedAttempts count on its next wrong guess - the same reset a legitimate
+// owner already gets immediately by entering the correct PIN (ResetAsync).
+internal sealed class CheckInAttemptPruneJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<CheckInAttemptPruneJob> logger,
+	IOptions<CheckInAttemptPruneOptions> options)
+	: IHostedService, IAsyncDisposable
+{
+	private readonly CheckInAttemptPruneOptions _options = options.Value;
+
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+	private PeriodicTimer? _timer;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_timer = new PeriodicTimer(TimeSpan.FromHours(_options.PollIntervalHours));
+		_executeTask = RunLoopAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_timer?.Dispose();
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunLoopAsync(CancellationToken ct)
+	{
+		if (_timer is null) return;
+
+		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+		{
+			try
+			{
+				await TickAsync(ct).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// A row that should have been pruned this tick just gets picked up
+				// again on the next one - no data is lost by skipping a tick.
+				logger.LogError(ex, "Check-in attempt prune tick failed; will retry on the next poll interval");
+			}
+		}
+	}
+
+	private async Task TickAsync(CancellationToken ct)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+		var pruned = await PruneExpiredAttemptsAsync(dbContext, DateTimeOffset.UtcNow, ct);
+
+		if (pruned > 0)
+			logger.LogInformation("Pruned {Count} expired check-in attempt record(s)", pruned);
+	}
+
+	// Exposed so IntegrationTests can exercise pruning directly against a real
+	// ApplicationDbContext instead of waiting for a real tick.
+	internal static async Task<int> PruneExpiredAttemptsAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset now,
+		CancellationToken cancellationToken = default)
+	{
+		var cutoff = now - CheckInAttemptLimiter.LockoutDuration;
+
+		return await dbContext.Set<CheckInAttempt>()
+			.Where(a => a.LastAttemptOn < cutoff)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+}

--- a/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneOptions.cs
@@ -1,0 +1,6 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class CheckInAttemptPruneOptions
+{
+	public int PollIntervalHours { get; init; } = 1;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/CheckInAttemptPruneOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class CheckInAttemptPruneOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<CheckInAttemptPruneOptions>
+{
+	public void Configure(CheckInAttemptPruneOptions options) =>
+		configuration.GetSection("CheckInAttemptPrune").Bind(options);
+}

--- a/backend/src/Infrastructure/Persistence/Configurations/CheckInAttemptConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/CheckInAttemptConfiguration.cs
@@ -1,0 +1,24 @@
+using Infrastructure.Persistence.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+internal sealed class CheckInAttemptConfiguration
+	: IEntityTypeConfiguration<CheckInAttempt>
+{
+	public void Configure(
+		EntityTypeBuilder<CheckInAttempt> builder)
+	{
+		builder.HasKey(a => a.EngagementId);
+
+		builder.Property(a => a.EngagementId).ValueGeneratedNever();
+
+		builder.Property(a => a.FailedAttempts).IsRequired();
+
+		builder.Property(a => a.LastAttemptOn).IsRequired();
+
+		// CheckInAttemptPruneJob queries and deletes by this column.
+		builder.HasIndex(a => a.LastAttemptOn);
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Migrations/20260802124346_AddCheckInAttempts.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260802124346_AddCheckInAttempts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260802124346_AddCheckInAttempts")]
+	partial class AddCheckInAttempts
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
@@ -224,13 +227,11 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnName("id");
 
 					b.Property<string>("ContactEmail")
-						.HasMaxLength(254)
-						.HasColumnType("character varying(254)")
+						.HasColumnType("text")
 						.HasColumnName("contact_email");
 
 					b.Property<string>("ContactPhone")
-						.HasMaxLength(30)
-						.HasColumnType("character varying(30)")
+						.HasColumnType("text")
 						.HasColumnName("contact_phone");
 
 					b.Property<DateTimeOffset>("CreatedOn")
@@ -242,8 +243,7 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnName("deleted_on");
 
 					b.Property<string>("Description")
-						.HasMaxLength(1000)
-						.HasColumnType("character varying(1000)")
+						.HasColumnType("text")
 						.HasColumnName("description");
 
 					b.Property<bool>("IsDeleted")
@@ -262,13 +262,11 @@ namespace Infrastructure.Persistence.Migrations
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasMaxLength(100)
-						.HasColumnType("character varying(100)")
+						.HasColumnType("text")
 						.HasColumnName("name");
 
 					b.Property<string>("Website")
-						.HasMaxLength(500)
-						.HasColumnType("character varying(500)")
+						.HasColumnType("text")
 						.HasColumnName("website");
 
 					b.HasKey("Id")
@@ -486,8 +484,7 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnName("avatar_url");
 
 					b.Property<string>("Bio")
-						.HasMaxLength(1000)
-						.HasColumnType("character varying(1000)")
+						.HasColumnType("text")
 						.HasColumnName("bio");
 
 					b.Property<DateTimeOffset?>("DeletedOn")
@@ -536,8 +533,7 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnName("notify_on_withdrawal");
 
 					b.Property<string>("Phone")
-						.HasMaxLength(30)
-						.HasColumnType("character varying(30)")
+						.HasColumnType("text")
 						.HasColumnName("phone");
 
 					b.Property<string>("PreferredContact")
@@ -892,14 +888,12 @@ namespace Infrastructure.Persistence.Migrations
 
 							b1.Property<string>("City")
 								.IsRequired()
-								.HasMaxLength(100)
-								.HasColumnType("character varying(100)")
+								.HasColumnType("text")
 								.HasColumnName("address_city");
 
 							b1.Property<string>("HouseNumber")
 								.IsRequired()
-								.HasMaxLength(20)
-								.HasColumnType("character varying(20)")
+								.HasColumnType("text")
 								.HasColumnName("address_house_number");
 
 							b1.Property<double?>("Latitude")
@@ -912,8 +906,7 @@ namespace Infrastructure.Persistence.Migrations
 
 							b1.Property<string>("Street")
 								.IsRequired()
-								.HasMaxLength(200)
-								.HasColumnType("character varying(200)")
+								.HasColumnType("text")
 								.HasColumnName("address_street");
 
 							b1.Property<string>("ZipCode")

--- a/backend/src/Infrastructure/Persistence/Migrations/20260802124346_AddCheckInAttempts.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260802124346_AddCheckInAttempts.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddCheckInAttempts : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateTable(
+				name: "check_in_attempt",
+				columns: table => new
+				{
+					engagement_id = table.Column<Guid>(type: "uuid", nullable: false),
+					failed_attempts = table.Column<int>(type: "integer", nullable: false),
+					locked_until = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+					last_attempt_on = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+				},
+				constraints: table =>
+				{
+					table.PrimaryKey("pk_check_in_attempt", x => x.engagement_id);
+				});
+
+			migrationBuilder.CreateIndex(
+				name: "ix_check_in_attempt_last_attempt_on",
+				table: "check_in_attempt",
+				column: "last_attempt_on");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropTable(
+				name: "check_in_attempt");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/RateLimiting/CheckInAttempt.cs
+++ b/backend/src/Infrastructure/Persistence/RateLimiting/CheckInAttempt.cs
@@ -1,0 +1,17 @@
+namespace Infrastructure.Persistence.RateLimiting;
+
+// Persisted counterpart of the old in-memory ConcurrentDictionary-based lockout
+// (#1176) - one row per engagement that has ever had a failed check-in PIN
+// attempt, so the lockout survives a container restart or a scale-out to
+// multiple replicas. CheckInAttemptPruneJob removes rows once their lockout
+// window has fully elapsed.
+internal sealed class CheckInAttempt
+{
+	public Guid EngagementId { get; set; }
+
+	public int FailedAttempts { get; set; }
+
+	public DateTimeOffset? LockedUntil { get; set; }
+
+	public DateTimeOffset LastAttemptOn { get; set; }
+}

--- a/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
+++ b/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
@@ -132,8 +132,22 @@ internal sealed class CheckInAttemptLimiter(
 	internal static async Task ResetAsync(
 		ApplicationDbContext dbContext,
 		Guid engagementId,
-		CancellationToken cancellationToken = default) =>
-		await dbContext.Set<CheckInAttempt>()
-			.Where(a => a.EngagementId == engagementId)
-			.ExecuteDeleteAsync(cancellationToken);
+		CancellationToken cancellationToken = default)
+	{
+		// A tracked fetch-then-Remove, not ExecuteDeleteAsync: ExecuteDelete
+		// issues a raw DELETE that bypasses the change tracker entirely, which
+		// would leave a CheckInAttempt instance a caller already tracked on this
+		// same DbContext (e.g. from a prior RegisterFailedAttemptAsync call)
+		// stale - believing the now-deleted row still exists - and throw an
+		// "already tracked" conflict the next time this engagement's row is
+		// looked up on that DbContext.
+		var attempt = await dbContext.Set<CheckInAttempt>()
+			.FirstOrDefaultAsync(a => a.EngagementId == engagementId, cancellationToken);
+
+		if (attempt is null)
+			return;
+
+		dbContext.Set<CheckInAttempt>().Remove(attempt);
+		await dbContext.SaveChangesAsync(cancellationToken);
+	}
 }

--- a/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
+++ b/backend/src/Infrastructure/RateLimiting/CheckInAttemptLimiter.cs
@@ -1,69 +1,139 @@
-using System.Collections.Concurrent;
 using Application.Common.RateLimiting;
 using Domain.Engagements;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.RateLimiting;
 
-// In-memory per-engagement PIN attempt tracking, independent of the generic
-// per-user/IP rate limiting policies in Api/Common/RateLimiting. A 4-digit PIN
-// has only 10,000 combinations, so a much tighter, engagement-scoped lockout is
-// needed to make brute-forcing infeasible even for an authenticated owner.
-internal sealed class CheckInAttemptLimiter(TimeProvider timeProvider) : ICheckInAttemptLimiter
+// Persisted per-engagement PIN attempt tracking (#1176), independent of the
+// generic per-user/IP rate limiting policies in Api/Common/RateLimiting. A
+// 4-6 digit PIN has only a small combination space, so a much tighter,
+// engagement-scoped lockout is needed to make brute-forcing infeasible even
+// for an authenticated owner.
+//
+// Every operation opens its own scope/DbContext (a fresh connection and
+// transaction) instead of reusing the caller's ambient, request-scoped one.
+// This is deliberate: CheckInWithPinCommandHandler registers a failed attempt
+// and then immediately throws to signal the invalid PIN, which rolls back the
+// TransactionPipelineBehavior-owned transaction wrapping the whole command -
+// an attempt tracked on that same connection would be rolled back right along
+// with it, silently disabling the lockout on every wrong guess.
+internal sealed class CheckInAttemptLimiter(
+	IServiceScopeFactory scopeFactory)
+	: ICheckInAttemptLimiter
 {
-	private const int MaxFailedAttempts = 5;
-	private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
+	internal const int MaxFailedAttempts = 5;
 
-	private readonly ConcurrentDictionary<Guid, AttemptState> _attempts = new();
+	internal static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
 
-	public Task<bool> IsLockedOutAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	public async Task<bool> IsLockedOutAsync(
+		EngagementId engagementId,
+		CancellationToken cancellationToken = default)
 	{
-		var isLockedOut = _attempts.TryGetValue(engagementId.Value, out var state)
-			&& state.LockedUntil is { } lockedUntil
-			&& lockedUntil > timeProvider.GetUtcNow();
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-		return Task.FromResult(isLockedOut);
+		return await IsLockedOutAsync(dbContext, engagementId.Value, DateTimeOffset.UtcNow, cancellationToken);
 	}
 
-	public Task RegisterFailedAttemptAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	public async Task RegisterFailedAttemptAsync(
+		EngagementId engagementId,
+		CancellationToken cancellationToken = default)
 	{
-		var now = timeProvider.GetUtcNow();
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-		_attempts.AddOrUpdate(
-			engagementId.Value,
-			_ => new AttemptState(1, null, now),
-			(_, existing) =>
-			{
-				var failedAttempts = existing.FailedAttempts + 1;
-				var lockedUntil = failedAttempts >= MaxFailedAttempts
-					? now.Add(LockoutDuration)
-					: existing.LockedUntil;
-
-				return new AttemptState(failedAttempts, lockedUntil, now);
-			});
-
-		EvictStaleEntries(now);
-
-		return Task.CompletedTask;
+		await RegisterFailedAttemptAsync(dbContext, engagementId.Value, DateTimeOffset.UtcNow, cancellationToken);
 	}
 
-	public Task ResetAsync(EngagementId engagementId, CancellationToken cancellationToken = default)
+	public async Task ResetAsync(
+		EngagementId engagementId,
+		CancellationToken cancellationToken = default)
 	{
-		_attempts.TryRemove(engagementId.Value, out _);
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-		return Task.CompletedTask;
+		await ResetAsync(dbContext, engagementId.Value, cancellationToken);
 	}
 
-	// Bounds dictionary growth for engagements that never succeed (ResetAsync only
-	// runs on a correct PIN) - an entry untouched for longer than LockoutDuration is
-	// forgotten, so a fresh failed attempt afterwards starts counting from zero.
-	private void EvictStaleEntries(DateTimeOffset now)
+	// Exposed so IntegrationTests can exercise the lockout logic directly
+	// against a real ApplicationDbContext instead of standing up the full DI
+	// container just to obtain an IServiceScopeFactory.
+	internal static async Task<bool> IsLockedOutAsync(
+		ApplicationDbContext dbContext,
+		Guid engagementId,
+		DateTimeOffset now,
+		CancellationToken cancellationToken = default)
 	{
-		foreach (var (engagementId, state) in _attempts)
+		var lockedUntil = await dbContext.Set<CheckInAttempt>()
+			.AsNoTracking()
+			.Where(a => a.EngagementId == engagementId)
+			.Select(a => a.LockedUntil)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		return lockedUntil is { } value && value > now;
+	}
+
+	internal static async Task RegisterFailedAttemptAsync(
+		ApplicationDbContext dbContext,
+		Guid engagementId,
+		DateTimeOffset now,
+		CancellationToken cancellationToken = default)
+	{
+		var attempt = await dbContext.Set<CheckInAttempt>()
+			.FirstOrDefaultAsync(a => a.EngagementId == engagementId, cancellationToken);
+
+		var isNew = attempt is null;
+		if (attempt is null)
 		{
-			if (now - state.LastAttemptAt >= LockoutDuration)
-				_attempts.TryRemove(engagementId, out _);
+			attempt = new CheckInAttempt { EngagementId = engagementId };
+			dbContext.Set<CheckInAttempt>().Add(attempt);
+		}
+
+		attempt.FailedAttempts++;
+		attempt.LastAttemptOn = now;
+		if (attempt.FailedAttempts >= MaxFailedAttempts)
+			attempt.LockedUntil = now.Add(LockoutDuration);
+
+		if (!isNew)
+		{
+			await dbContext.SaveChangesAsync(cancellationToken);
+			return;
+		}
+
+		try
+		{
+			await dbContext.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException)
+		{
+			// Two concurrent wrong guesses for the same engagement (a double-click,
+			// or an attacker racing the lockout itself) can both find no existing
+			// row and race to insert one - the loser hits a primary key violation
+			// here. Detach the failed insert and fall through to a plain update
+			// against the row the winner just created, instead of losing this
+			// attempt or surfacing an unhandled 500.
+			dbContext.Entry(attempt).State = EntityState.Detached;
+
+			attempt = await dbContext.Set<CheckInAttempt>()
+				.SingleAsync(a => a.EngagementId == engagementId, cancellationToken);
+
+			attempt.FailedAttempts++;
+			attempt.LastAttemptOn = now;
+			if (attempt.FailedAttempts >= MaxFailedAttempts)
+				attempt.LockedUntil = now.Add(LockoutDuration);
+
+			await dbContext.SaveChangesAsync(cancellationToken);
 		}
 	}
 
-	private sealed record AttemptState(int FailedAttempts, DateTimeOffset? LockedUntil, DateTimeOffset LastAttemptAt);
+	internal static async Task ResetAsync(
+		ApplicationDbContext dbContext,
+		Guid engagementId,
+		CancellationToken cancellationToken = default) =>
+		await dbContext.Set<CheckInAttempt>()
+			.Where(a => a.EngagementId == engagementId)
+			.ExecuteDeleteAsync(cancellationToken);
 }

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -118,6 +118,8 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<OrganizationMembershipBackfillJob>();
 		services.ConfigureOptions<InvitationExpiryOptionsSetup>();
 		services.AddHostedService<InvitationExpiryJob>();
+		services.ConfigureOptions<CheckInAttemptPruneOptionsSetup>();
+		services.AddHostedService<CheckInAttemptPruneJob>();
 
 
 		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see

--- a/backend/src/Infrastructure/VolunteerOpportunities/RandomPinGenerator.cs
+++ b/backend/src/Infrastructure/VolunteerOpportunities/RandomPinGenerator.cs
@@ -1,9 +1,24 @@
+using System.Security.Cryptography;
 using Domain.VolunteerOpportunities;
 
 namespace Infrastructure.VolunteerOpportunities;
 
 internal sealed class RandomPinGenerator : IPinGenerator
 {
-	public string GeneratePin() =>
-		Random.Shared.Next(1000, 10000).ToString("D4");
+	// RandomNumberGenerator (not Random.Shared, a non-cryptographic xoshiro
+	// PRNG) over a 6-digit space (#1176) - 1,000,000 combinations instead of
+	// the previous 9,000. Looping past a CheckInPinPolicy-trivial draw is
+	// cheap: fewer than 30 of the 1,000,000 possible values are trivial, so
+	// this essentially never iterates more than once.
+	public string GeneratePin()
+	{
+		string pin;
+
+		do
+		{
+			pin = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
+		} while (CheckInPinPolicy.IsTrivial(pin));
+
+		return pin;
+	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CheckInPinPolicyTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CheckInPinPolicyTests.cs
@@ -1,0 +1,43 @@
+using AwesomeAssertions;
+using Domain.VolunteerOpportunities;
+
+namespace Application.UnitTests.VolunteerOpportunities;
+
+public class CheckInPinPolicyTests
+{
+	[Test]
+	[Arguments("0000")]
+	[Arguments("1111")]
+	[Arguments("999999")]
+	[Arguments("1234")]
+	[Arguments("2345")]
+	[Arguments("123456")]
+	[Arguments("9876")]
+	[Arguments("654321")]
+	[Arguments("1212")]
+	[Arguments("6969")]
+	[Arguments("1313")]
+	[Arguments("2001")]
+	[Arguments("1010")]
+	[Arguments("1998")]
+	[Arguments("1004")]
+	[Arguments("2000")]
+	[Arguments("1999")]
+	[Arguments("2580")]
+	[Arguments("0852")]
+	public void IsTrivial_ShouldReturnTrue_ForEasyToGuessPins(string pin)
+	{
+		CheckInPinPolicy.IsTrivial(pin).Should().BeTrue();
+	}
+
+	[Test]
+	[Arguments("4827")]
+	[Arguments("6193")]
+	[Arguments("13579")]
+	[Arguments("482170")]
+	[Arguments("135790")]
+	public void IsTrivial_ShouldReturnFalse_ForUnpredictablePins(string pin)
+	{
+		CheckInPinPolicy.IsTrivial(pin).Should().BeFalse();
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
@@ -33,7 +33,7 @@ public class GetOpportunityCheckInPinQueryHandlerTests
 	private VolunteerOpportunity CreateOpportunityWithPin() =>
 		VolunteerOpportunity.Create(
 			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.PINCode, _pinGenerator,
-			status: OpportunityStatus.Draft, checkInPin: "12345").Value;
+			status: OpportunityStatus.Draft, checkInPin: "48213").Value;
 
 	[Test]
 	public async Task Handle_ShouldReturnCheckInPin_WhenOrganizer(
@@ -49,7 +49,7 @@ public class GetOpportunityCheckInPinQueryHandlerTests
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
-		result.Should().Be("12345");
+		result.Should().Be("48213");
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -842,16 +842,56 @@ public class VolunteerOpportunityTests
 		result.Error.Description.Should().Be("Check-in PIN must be 4 to 6 digits.");
 	}
 
+	// --- CheckInPin triviality (#1176) ---
+
+	[Test]
+	[Arguments("0000")]
+	[Arguments("1111")]
+	[Arguments("9999")]
+	[Arguments("000000")]
+	[Arguments("555555")]
+	[Arguments("1234")]
+	[Arguments("4321")]
+	[Arguments("123456")]
+	[Arguments("654321")]
+	[Arguments("1212")]
+	[Arguments("6969")]
+	[Arguments("2000")]
+	[Arguments("1010")]
+	public void Create_ShouldFail_WhenPinIsTrivial(string pin)
+	{
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.PINCode, PinGenerator, checkInPin: pin);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("This PIN is too easy to guess - choose a less predictable one.");
+	}
+
+	[Test]
+	public void ChangeCheckInMethod_ShouldFail_WhenPinIsTrivial()
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
+
+		var result = opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "1111");
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be("This PIN is too easy to guess - choose a less predictable one.");
+		opportunity.CheckInPin.Should().Be("4827");
+	}
+
 	[Test]
 	public void ChangeCheckInMethod_ShouldOverwritePin_WhenCustomPinGiven()
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
-			CheckInMethod.PINCode, PinGenerator, checkInPin: "1111", validUntil: Now.AddDays(30)).Value;
+			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
-		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "2222");
+		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "6193");
 
-		opportunity.CheckInPin.Should().Be("2222");
+		opportunity.CheckInPin.Should().Be("6193");
 	}
 
 	[Test]
@@ -859,11 +899,11 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
-			CheckInMethod.PINCode, PinGenerator, checkInPin: "1111", validUntil: Now.AddDays(30)).Value;
+			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator);
 
-		opportunity.CheckInPin.Should().Be("1111");
+		opportunity.CheckInPin.Should().Be("4827");
 	}
 
 	[Test]
@@ -886,7 +926,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
-			CheckInMethod.PINCode, PinGenerator, checkInPin: "1111", validUntil: Now.AddDays(30)).Value;
+			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		var result = opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "abc");
 

--- a/backend/tests/IntegrationTests/CheckInAttemptLimiterTests.cs
+++ b/backend/tests/IntegrationTests/CheckInAttemptLimiterTests.cs
@@ -1,109 +1,158 @@
 using AwesomeAssertions;
-using Domain.Engagements;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.RateLimiting;
 using Infrastructure.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
 
 namespace IntegrationTests;
 
-// Pure in-memory logic - no database needed - but CheckInAttemptLimiter is
-// internal to Infrastructure (InternalsVisibleTo only grants IntegrationTests,
-// see Infrastructure.csproj), so this has to live here rather than in a
-// project that can't see it.
-public class CheckInAttemptLimiterTests
+// Exercises Infrastructure.RateLimiting.CheckInAttemptLimiter's static core
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real
+// integration Postgres - the persisted replacement for the old in-memory
+// ConcurrentDictionary-backed lockout (#1176). CheckInWithPinCommandHandlerTests
+// (Application.UnitTests) covers the handler's orchestration against a mocked
+// ICheckInAttemptLimiter; this covers the lockout arithmetic and persistence
+// itself.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class CheckInAttemptLimiterTests(IntegrationTestFixture fixture)
 {
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
 	[Test]
 	public async Task IsLockedOutAsync_ShouldReturnFalse_ForEngagementWithNoAttempts(
 		CancellationToken cancellationToken)
 	{
-		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
 
-		var isLockedOut = await sut.IsLockedOutAsync(EngagementId.New(), cancellationToken);
-
-		isLockedOut.Should().BeFalse();
-	}
-
-	[Test]
-	public async Task IsLockedOutAsync_ShouldReturnFalse_WhenFailedAttemptsAreBelowMax(
-		CancellationToken cancellationToken)
-	{
-		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
-		var engagementId = EngagementId.New();
-
-		for (var i = 0; i < 4; i++)
-			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
-
-		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(dbContext, Guid.NewGuid(), now, cancellationToken);
 
 		isLockedOut.Should().BeFalse();
 	}
 
 	[Test]
-	public async Task IsLockedOutAsync_ShouldReturnTrue_WhenFailedAttemptsReachMax(
+	public async Task RegisterFailedAttemptAsync_FewerThanMaxAttempts_DoesNotLockOut(
 		CancellationToken cancellationToken)
 	{
-		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
-		var engagementId = EngagementId.New();
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
 
-		for (var i = 0; i < 5; i++)
-			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
+		for (var i = 0; i < CheckInAttemptLimiter.MaxFailedAttempts - 1; i++)
+			await CheckInAttemptLimiter.RegisterFailedAttemptAsync(dbContext, engagementId, now, cancellationToken);
 
-		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(dbContext, engagementId, now, cancellationToken);
+
+		isLockedOut.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task RegisterFailedAttemptAsync_ReachingMaxAttempts_LocksOut(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
+
+		for (var i = 0; i < CheckInAttemptLimiter.MaxFailedAttempts; i++)
+			await CheckInAttemptLimiter.RegisterFailedAttemptAsync(dbContext, engagementId, now, cancellationToken);
+
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(dbContext, engagementId, now, cancellationToken);
 
 		isLockedOut.Should().BeTrue();
 	}
 
 	[Test]
-	public async Task ResetAsync_ShouldClearLockout(
+	public async Task IsLockedOutAsync_AfterLockoutWindowElapses_IsNoLongerLockedOut(
 		CancellationToken cancellationToken)
 	{
-		var sut = new CheckInAttemptLimiter(new FakeTimeProvider());
-		var engagementId = EngagementId.New();
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
 
-		for (var i = 0; i < 5; i++)
-			await sut.RegisterFailedAttemptAsync(engagementId, cancellationToken);
+		for (var i = 0; i < CheckInAttemptLimiter.MaxFailedAttempts; i++)
+			await CheckInAttemptLimiter.RegisterFailedAttemptAsync(dbContext, engagementId, now, cancellationToken);
 
-		await sut.ResetAsync(engagementId, cancellationToken);
+		var afterLockoutWindow = now.Add(CheckInAttemptLimiter.LockoutDuration).AddSeconds(1);
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(dbContext, engagementId, afterLockoutWindow, cancellationToken);
 
-		var isLockedOut = await sut.IsLockedOutAsync(engagementId, cancellationToken);
 		isLockedOut.Should().BeFalse();
 	}
 
 	[Test]
-	public async Task RegisterFailedAttemptAsync_ShouldForgetStaleAttempts_OnceLockoutDurationElapses(
+	public async Task ResetAsync_ClearsFailedAttempts_SoSubsequentAttemptsStartFresh(
 		CancellationToken cancellationToken)
 	{
-		// Regression for #1185: an engagement that never succeeds (ResetAsync only
-		// runs on a correct PIN) must not keep its failed-attempt count forever -
-		// otherwise the underlying dictionary grows without bound for the
-		// container's lifetime. Four failed attempts is below the five-attempt
-		// lockout threshold, so if the stale entry is never evicted, a single
-		// additional attempt after LockoutDuration has passed would still push the
-		// (never-reset) count to five and lock the engagement out immediately.
-		var timeProvider = new FakeTimeProvider();
-		var sut = new CheckInAttemptLimiter(timeProvider);
-		var staleEngagementId = EngagementId.New();
-		var otherEngagementId = EngagementId.New();
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
 
-		for (var i = 0; i < 4; i++)
-			await sut.RegisterFailedAttemptAsync(staleEngagementId, cancellationToken);
+		for (var i = 0; i < CheckInAttemptLimiter.MaxFailedAttempts; i++)
+			await CheckInAttemptLimiter.RegisterFailedAttemptAsync(dbContext, engagementId, now, cancellationToken);
 
-		timeProvider.Advance(TimeSpan.FromMinutes(16));
+		await CheckInAttemptLimiter.ResetAsync(dbContext, engagementId, cancellationToken);
+		await CheckInAttemptLimiter.RegisterFailedAttemptAsync(dbContext, engagementId, now, cancellationToken);
 
-		// Any write sweeps stale entries - use an unrelated engagement so this
-		// doesn't itself contribute to staleEngagementId's attempt count.
-		await sut.RegisterFailedAttemptAsync(otherEngagementId, cancellationToken);
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(dbContext, engagementId, now, cancellationToken);
 
-		await sut.RegisterFailedAttemptAsync(staleEngagementId, cancellationToken);
-
-		var isLockedOut = await sut.IsLockedOutAsync(staleEngagementId, cancellationToken);
-		isLockedOut.Should().BeFalse("the stale 4-attempt count should have been evicted, leaving only this one fresh attempt");
+		isLockedOut.Should().BeFalse("Reset must clear the prior failure count, not just the lock");
 	}
 
-	private sealed class FakeTimeProvider : TimeProvider
+	[Test]
+	public async Task RegisterFailedAttemptAsync_PersistsAcrossIndependentDbContexts(
+		CancellationToken cancellationToken)
 	{
-		private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+		// Regression for #1176: the old ConcurrentDictionary-backed limiter lost
+		// all state on a process restart. Using two independent
+		// ApplicationDbContexts (separate connections, like CheckInAttemptLimiter's
+		// own per-call scope) proves the state actually round-trips through
+		// Postgres rather than surviving only in a shared in-process dictionary.
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
 
-		public override DateTimeOffset GetUtcNow() => _utcNow;
+		await using (var writeContext = fixture.CreateApplicationDbContext())
+		{
+			for (var i = 0; i < CheckInAttemptLimiter.MaxFailedAttempts; i++)
+				await CheckInAttemptLimiter.RegisterFailedAttemptAsync(writeContext, engagementId, now, cancellationToken);
+		}
 
-		public void Advance(TimeSpan by) => _utcNow += by;
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var isLockedOut = await CheckInAttemptLimiter.IsLockedOutAsync(readContext, engagementId, now, cancellationToken);
+
+		isLockedOut.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task RegisterFailedAttemptAsync_TwoConcurrentFirstAttemptsForTheSameEngagement_BothCount(
+		CancellationToken cancellationToken)
+	{
+		// Two independent ApplicationDbContexts (separate connections), like two
+		// near-simultaneous wrong PIN guesses for the same engagement (a
+		// double-click, or an attacker racing the lockout) would each get from
+		// CheckInAttemptLimiter's own per-call scope. Both find no existing row
+		// and race to insert one; the loser must recover from the primary key
+		// conflict and still record its attempt instead of throwing or being
+		// silently dropped.
+		var engagementId = Guid.NewGuid();
+		var now = DateTimeOffset.UtcNow;
+
+		await using var contextA = fixture.CreateApplicationDbContext();
+		await using var contextB = fixture.CreateApplicationDbContext();
+
+		await Task.WhenAll(
+			CheckInAttemptLimiter.RegisterFailedAttemptAsync(contextA, engagementId, now, cancellationToken),
+			CheckInAttemptLimiter.RegisterFailedAttemptAsync(contextB, engagementId, now, cancellationToken));
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var failedAttempts = await readContext.Set<CheckInAttempt>()
+			.AsNoTracking()
+			.Where(a => a.EngagementId == engagementId)
+			.Select(a => a.FailedAttempts)
+			.SingleAsync(cancellationToken);
+
+		failedAttempts.Should().Be(2, "neither concurrent attempt should be lost to the insert race");
 	}
 }

--- a/backend/tests/IntegrationTests/CheckInAttemptPruneJobTests.cs
+++ b/backend/tests/IntegrationTests/CheckInAttemptPruneJobTests.cs
@@ -1,0 +1,74 @@
+using AwesomeAssertions;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Infrastructure.Persistence.RateLimiting;
+using Infrastructure.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.CheckInAttemptPruneJob.PruneExpiredAttemptsAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres, rather than waiting a real 15-minute lockout window plus a real hourly tick
+// for the pruning behavior (#1176) to become observable.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class CheckInAttemptPruneJobTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task PruneExpiredAttemptsAsync_AttemptPastTheLockoutWindow_IsRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var engagementId = await SeedAttemptAsync(
+			dbContext, lastAttemptOn: now.Add(-CheckInAttemptLimiter.LockoutDuration).AddMinutes(-1), cancellationToken);
+
+		var pruned = await CheckInAttemptPruneJob.PruneExpiredAttemptsAsync(dbContext, now, cancellationToken);
+
+		pruned.Should().Be(1);
+		var stillExists = await dbContext.Set<CheckInAttempt>()
+			.AsNoTracking()
+			.AnyAsync(a => a.EngagementId == engagementId, cancellationToken);
+		stillExists.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task PruneExpiredAttemptsAsync_AttemptStillWithinTheLockoutWindow_IsNotRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var engagementId = await SeedAttemptAsync(dbContext, lastAttemptOn: now.AddMinutes(-1), cancellationToken);
+
+		var pruned = await CheckInAttemptPruneJob.PruneExpiredAttemptsAsync(dbContext, now, cancellationToken);
+
+		pruned.Should().Be(0);
+		var stillExists = await dbContext.Set<CheckInAttempt>()
+			.AsNoTracking()
+			.AnyAsync(a => a.EngagementId == engagementId, cancellationToken);
+		stillExists.Should().BeTrue();
+	}
+
+	private static async Task<Guid> SeedAttemptAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset lastAttemptOn,
+		CancellationToken cancellationToken)
+	{
+		var engagementId = Guid.NewGuid();
+		dbContext.Set<CheckInAttempt>().Add(new CheckInAttempt
+		{
+			EngagementId = engagementId,
+			FailedAttempts = 1,
+			LastAttemptOn = lastAttemptOn,
+		});
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		return engagementId;
+	}
+}

--- a/backend/tests/IntegrationTests/RandomPinGeneratorTests.cs
+++ b/backend/tests/IntegrationTests/RandomPinGeneratorTests.cs
@@ -1,0 +1,47 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Domain.VolunteerOpportunities;
+using Infrastructure.VolunteerOpportunities;
+
+namespace IntegrationTests;
+
+// Pure generation logic - no database needed - but RandomPinGenerator is internal
+// to Infrastructure (InternalsVisibleTo only grants IntegrationTests, see
+// Infrastructure.csproj), so this has to live here rather than in a project that
+// can't see it.
+public partial class RandomPinGeneratorTests
+{
+	private readonly RandomPinGenerator _sut = new();
+
+	[Test]
+	public void GeneratePin_ShouldReturnSixDigits()
+	{
+		var pin = _sut.GeneratePin();
+
+		SixDigitsRegex().IsMatch(pin).Should().BeTrue($"'{pin}' must be exactly 6 digits");
+	}
+
+	[Test]
+	public void GeneratePin_ShouldNeverReturnATrivialPin()
+	{
+		// 500 draws over a 1,000,000-value space gives no realistic chance of
+		// missing a bug that let a trivial PIN slip through, without making the
+		// test itself slow.
+		for (var i = 0; i < 500; i++)
+		{
+			var pin = _sut.GeneratePin();
+			CheckInPinPolicy.IsTrivial(pin).Should().BeFalse($"'{pin}' should have been rejected and re-rolled");
+		}
+	}
+
+	[Test]
+	public void GeneratePin_ShouldVaryAcrossCalls()
+	{
+		var pins = Enumerable.Range(0, 20).Select(_ => _sut.GeneratePin()).ToHashSet();
+
+		pins.Count.Should().BeGreaterThan(1, "a cryptographically random generator should not repeatedly draw the same value");
+	}
+
+	[GeneratedRegex(@"^\d{6}$")]
+	private static partial Regex SixDigitsRegex();
+}

--- a/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
+++ b/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
@@ -126,7 +126,7 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Generate random" }).ClickAsync();
 		var generatedPin = await pinInput.InputValueAsync();
-		generatedPin.Should().MatchRegex(@"^\d{4}$", "Generate random must fill in a 4-digit PIN");
+		generatedPin.Should().MatchRegex(@"^\d{6}$", "Generate random must fill in a 6-digit PIN");
 		generatedPin.Should().NotBe("135790");
 
 		await Page.GetByTestId("wizard-stepper-4").ClickAsync();

--- a/frontend/src/components/CreateVolunteerOpportunityModal/FormatStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/FormatStep.tsx
@@ -4,7 +4,10 @@ import { FloatingField } from "./shared";
 import type { OpportunityFormValues } from "./schema";
 
 function generateRandomPin(): string {
-	return String(Math.floor(1000 + Math.random() * 9000));
+	// crypto.getRandomValues (not Math.random, not cryptographically strong)
+	// over a 6-digit space, matching the backend's RandomPinGenerator (#1176).
+	const [value] = crypto.getRandomValues(new Uint32Array(1));
+	return String(100000 + (value % 900000));
 }
 
 function RadioCardGroup<T extends string>({

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1131,6 +1131,7 @@
       },
       "VolunteerOpportunity": {
         "InvalidCheckInPin": "Die Check-in-PIN muss 4 bis 6 Ziffern haben.",
+        "WeakCheckInPin": "Diese PIN ist zu leicht zu erraten - wähle eine weniger vorhersehbare PIN.",
         "TitleTooLong": "Der Titel darf 200 Zeichen nicht überschreiten.",
         "DescriptionTooLong": "Die Beschreibung darf 5000 Zeichen nicht überschreiten.",
         "ScheduledSlotsMustStartAsDraft": "Ein Einsatz mit der Teilnahmeart Zeitslots muss zunächst als Entwurf angelegt werden und kann erst nach Hinzufügen mindestens eines Zeitslots veröffentlicht werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1131,6 +1131,7 @@
       },
       "VolunteerOpportunity": {
         "InvalidCheckInPin": "Check-in PIN must be 4 to 6 digits.",
+        "WeakCheckInPin": "This PIN is too easy to guess - choose a less predictable one.",
         "TitleTooLong": "Title must not exceed 200 characters.",
         "DescriptionTooLong": "Description must not exceed 5000 characters.",
         "ScheduledSlotsMustStartAsDraft": "A Scheduled slots opportunity must be created as a draft and published after adding at least one time slot.",


### PR DESCRIPTION
## What

Hardens check-in PIN security: PINs are now generated with a cryptographic RNG at 6 digits by default, both organizer-supplied and auto-generated PINs are checked against a trivial/easy-to-guess deny-list, the per-engagement brute-force lockout is persisted to Postgres instead of an in-memory dictionary (with a background prune job), and PIN comparison uses a fixed-time equality check.

## Why

Closes #1176

`CheckInAttemptLimiter` was a singleton-scoped `ConcurrentDictionary` - the lockout (the only thing making a 9,000-value PIN space defensible) was lost on every restart/redeploy and would not exist at all across replicas. `RandomPinGenerator` used `Random.Shared` (a non-cryptographic PRNG) over a 9,000-value space, and an organizer-supplied PIN like `0000`/`1234` was accepted verbatim.

## Changes

- `Domain/VolunteerOpportunities/CheckInPinPolicy.cs` (new): shared trivial-PIN policy (repeated digits, consecutive runs, a curated deny-list of well-known weak PINs) used by both organizer-supplied PIN validation and PIN generation.
- `VolunteerOpportunity.EnsureValidPin` now rejects trivial PINs in addition to the existing 4-6 digit format check (new `VolunteerOpportunity.WeakCheckInPin` error code, translated in both locales).
- `RandomPinGenerator` now uses `RandomNumberGenerator.GetInt32` (not `Random.Shared`) over a 6-digit space by default, looping past any trivial draw.
- `CheckInAttemptLimiter` is now backed by a new `check_in_attempt` table instead of an in-memory `ConcurrentDictionary`, so the lockout survives restarts and works across replicas. Each operation opens its own DB scope/connection (independent of the ambient request transaction) - a failed attempt is recorded durably even when the triggering command throws and its own transaction rolls back, which is exactly what happens on every wrong guess.
- New `CheckInAttemptPruneJob` background job evicts attempt rows once their lockout window has fully elapsed, so the table doesn't grow unbounded.
- `CheckInWithPinCommandHandler` now compares PINs with `CryptographicOperations.FixedTimeEquals` instead of `string.Equals`.
- Frontend's "Generate random" PIN button (`FormatStep.tsx`) widened to 6 digits using `crypto.getRandomValues` instead of `Math.random()`, matching the backend default.
- EF Core migration `AddCheckInAttempts` adds the new table.

## Testing

- `Application.UnitTests` (747 tests) - new coverage for `CheckInPinPolicy`, trivial-PIN rejection in `VolunteerOpportunity`/`ChangeCheckInMethod`; existing fixtures using trivial PINs (`1111`, `2222`, `12345`) updated to non-trivial values.
- `ArchitectureTests` (366 tests) - unaffected, all green.
- `IntegrationTests` (new, run against real Postgres in CI - can't run Aspire/Docker locally per this repo's sandbox limitations) - `CheckInAttemptLimiterTests` (lockout arithmetic, cross-process persistence, a concurrent-insert-race regression test), `CheckInAttemptPruneJobTests`, `RandomPinGeneratorTests`.
- `VisualTests` - `CheckInPinOrganizerSetTests` updated for the widened 6-digit "Generate random" button. The existing `EngagementCheckInStatusCodeTests.CheckInWithPin_Returns403_AfterTooManyFailedAttempts` E2E test already exercises the persisted lockout end-to-end and needed no changes.
- Frontend: `pnpm lint`, `pnpm check`, `pnpm test` (123 tests), `pnpm i18n:check` all green; `pnpm format:write` clean.
- Ran `/self-review`, which surfaced and I fixed two real issues before opening this PR: a concurrency race in the new persisted lockout (two simultaneous wrong guesses for the same engagement could throw an unhandled exception instead of the expected 400 - now recovers and both attempts count, with a regression test), and a migration-file formatting issue (generated migration came out space-indented with a BOM instead of this repo's tab/ASCII convention - would have failed CI's `editorconfig` job; verified clean with a local `editorconfig-checker` run).

## Live verification

Skipped per explicit instruction for this task - no release candidate was cut. `dotnet build` + `Application.UnitTests` + `ArchitectureTests` were run locally (all green); `IntegrationTests`/`VisualTests` will run in CI's `dotnet.yml` against a real Postgres/Aspire stack.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (new locale key, translated in both `en.json`/`de.json`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbuZW3zVxDhwdJ4fActmkJ)_