### PR TITLE
fix: enforce MaxLength validation on organization/user profile fields

### DIFF
--- a/backend/src/Api/Organizations/UpdateOrganization/v1/UpdateOrganizationEndpoint.cs
+++ b/backend/src/Api/Organizations/UpdateOrganization/v1/UpdateOrganizationEndpoint.cs
@@ -41,12 +41,6 @@ internal sealed class UpdateOrganizationEndpoint
 		if (string.IsNullOrWhiteSpace(request.Name))
 			return Results.Problem("Name is required.", statusCode: StatusCodes.Status400BadRequest);
 
-		if (request.Name.Length > 100)
-			return Results.Problem("Name must not exceed 100 characters.", statusCode: StatusCodes.Status400BadRequest);
-
-		if (request.Description is { Length: > 1000 })
-			return Results.Problem("Description must not exceed 1000 characters.", statusCode: StatusCodes.Status400BadRequest);
-
 		var addressCommand = request.Address is null
 			? null
 			: new UpdateAddressCommand(

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -92,6 +92,12 @@ builder.Services.AddEndpoints();
 builder.Services.AddRateLimitingPolicies(builder.Configuration);
 builder.Services.AddOutputCachingPolicies(builder.Configuration);
 
+// Minimal APIs never evaluate [MaxLength]/[Required]/etc. DataAnnotations on
+// request records unless validation is explicitly registered (#1173) - this
+// wires the built-in .NET 10 validation pipeline so every endpoint's request
+// type is checked before its handler runs.
+builder.Services.AddValidation();
+
 // EnableForHttps is safe here: this API is a pure JSON/token (Bearer, not cookie) API,
 // so there's no session secret reflected back into a compressible response body that a
 // BREACH-style attack could exploit (#1391).

--- a/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
+++ b/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileEndpoint.cs
@@ -36,17 +36,17 @@ internal sealed class UpdateUserProfileEndpoint
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
 		}
 
-		if (request.FirstName is { Length: > 100 })
-			return Results.Problem("FirstName must not exceed 100 characters.", statusCode: StatusCodes.Status400BadRequest);
+		if (request.Skills is { Count: > UpdateUserProfileRequest.MaxSkillsCount })
+			return Results.Problem($"Skills must not contain more than {UpdateUserProfileRequest.MaxSkillsCount} entries.", statusCode: StatusCodes.Status400BadRequest);
 
-		if (request.LastName is { Length: > 100 })
-			return Results.Problem("LastName must not exceed 100 characters.", statusCode: StatusCodes.Status400BadRequest);
+		if (request.Skills?.Any(skill => skill.Length > UpdateUserProfileRequest.MaxSkillLength) is true)
+			return Results.Problem($"Each skill must not exceed {UpdateUserProfileRequest.MaxSkillLength} characters.", statusCode: StatusCodes.Status400BadRequest);
 
-		if (request.Bio is { Length: > 1000 })
-			return Results.Problem("Bio must not exceed 1000 characters.", statusCode: StatusCodes.Status400BadRequest);
+		if (request.Languages is { Count: > UpdateUserProfileRequest.MaxLanguagesCount })
+			return Results.Problem($"Languages must not contain more than {UpdateUserProfileRequest.MaxLanguagesCount} entries.", statusCode: StatusCodes.Status400BadRequest);
 
-		if (request.Phone is { Length: > 30 })
-			return Results.Problem("Phone must not exceed 30 characters.", statusCode: StatusCodes.Status400BadRequest);
+		if (request.Languages?.Any(language => language.Length > UpdateUserProfileRequest.MaxLanguageLength) is true)
+			return Results.Problem($"Each language must not exceed {UpdateUserProfileRequest.MaxLanguageLength} characters.", statusCode: StatusCodes.Status400BadRequest);
 
 		Domain.Users.PreferredContact? preferredContact = null;
 		if (request.PreferredContact is not null &&

--- a/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileRequest.cs
+++ b/backend/src/Api/Users/UpdateUserProfile/v1/UpdateUserProfileRequest.cs
@@ -10,4 +10,16 @@ public sealed record UpdateUserProfileRequest(
 	IReadOnlyList<string>? Skills = null,
 	IReadOnlyList<string>? Languages = null,
 	[MaxLength(200)] string? PreferredContact = null,
-	[MaxLength(5)] string? PreferredLanguage = null);
+	[MaxLength(5)] string? PreferredLanguage = null)
+{
+	// Skills/Languages carry no DataAnnotations attribute - MaxLengthAttribute
+	// only checks a collection's item Count, not each item's string length, so
+	// both caps are enforced manually in UpdateUserProfileEndpoint (#1173).
+	public const int MaxSkillsCount = 50;
+
+	public const int MaxSkillLength = 100;
+
+	public const int MaxLanguagesCount = 20;
+
+	public const int MaxLanguageLength = 50;
+}

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationConfiguration.cs
@@ -20,24 +20,29 @@ internal sealed class OrganizationConfiguration
 			.ValueGeneratedNever();
 
 		builder.Property(org => org.Name)
+			.HasMaxLength(100)
 			.IsRequired();
 
-		builder.Property(org => org.Description);
+		builder.Property(org => org.Description)
+			.HasMaxLength(1000);
 
-		builder.Property(org => org.ContactEmail);
+		builder.Property(org => org.ContactEmail)
+			.HasMaxLength(254);
 
-		builder.Property(org => org.ContactPhone);
+		builder.Property(org => org.ContactPhone)
+			.HasMaxLength(30);
 
-		builder.Property(org => org.Website);
+		builder.Property(org => org.Website)
+			.HasMaxLength(500);
 
 		builder.Property(org => org.LogoUrl);
 
 		builder.OwnsOne(org => org.Address, address =>
 		{
-			address.Property(a => a.Street).IsRequired();
-			address.Property(a => a.HouseNumber).IsRequired();
+			address.Property(a => a.Street).HasMaxLength(200).IsRequired();
+			address.Property(a => a.HouseNumber).HasMaxLength(20).IsRequired();
 			address.Property(a => a.ZipCode).HasMaxLength(5).IsRequired();
-			address.Property(a => a.City).IsRequired();
+			address.Property(a => a.City).HasMaxLength(100).IsRequired();
 			address.Property(a => a.Latitude);
 			address.Property(a => a.Longitude);
 		});

--- a/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -23,9 +23,11 @@ internal sealed class UserConfiguration
 
 		builder.Property(u => u.AvatarUrl);
 
-		builder.Property(u => u.Bio);
+		builder.Property(u => u.Bio)
+			.HasMaxLength(1000);
 
-		builder.Property(u => u.Phone);
+		builder.Property(u => u.Phone)
+			.HasMaxLength(30);
 
 		var listComparer = new ValueComparer<IReadOnlyList<string>>(
 			(a, b) => a != null && b != null && a.SequenceEqual(b),

--- a/backend/src/Infrastructure/Persistence/Migrations/20260802124338_AddOrganizationAndUserStringMaxLengths.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260802124338_AddOrganizationAndUserStringMaxLengths.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260802124338_AddOrganizationAndUserStringMaxLengths")]
+	partial class AddOrganizationAndUserStringMaxLengths
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260802124338_AddOrganizationAndUserStringMaxLengths.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260802124338_AddOrganizationAndUserStringMaxLengths.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOrganizationAndUserStringMaxLengths : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<string>(
+				name: "phone",
+				table: "user",
+				type: "character varying(30)",
+				maxLength: 30,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "bio",
+				table: "user",
+				type: "character varying(1000)",
+				maxLength: 1000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "website",
+				table: "organization",
+				type: "character varying(500)",
+				maxLength: 500,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "name",
+				table: "organization",
+				type: "character varying(100)",
+				maxLength: 100,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "text");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "description",
+				table: "organization",
+				type: "character varying(1000)",
+				maxLength: 1000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "contact_phone",
+				table: "organization",
+				type: "character varying(30)",
+				maxLength: 30,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "contact_email",
+				table: "organization",
+				type: "character varying(254)",
+				maxLength: 254,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_street",
+				table: "organization",
+				type: "character varying(200)",
+				maxLength: 200,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_house_number",
+				table: "organization",
+				type: "character varying(20)",
+				maxLength: 20,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_city",
+				table: "organization",
+				type: "character varying(100)",
+				maxLength: 100,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "text",
+				oldNullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<string>(
+				name: "phone",
+				table: "user",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(30)",
+				oldMaxLength: 30,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "bio",
+				table: "user",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(1000)",
+				oldMaxLength: 1000,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "website",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(500)",
+				oldMaxLength: 500,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "name",
+				table: "organization",
+				type: "text",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "character varying(100)",
+				oldMaxLength: 100);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "description",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(1000)",
+				oldMaxLength: 1000,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "contact_phone",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(30)",
+				oldMaxLength: 30,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "contact_email",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(254)",
+				oldMaxLength: 254,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_street",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(200)",
+				oldMaxLength: 200,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_house_number",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(20)",
+				oldMaxLength: 20,
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "address_city",
+				table: "organization",
+				type: "text",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "character varying(100)",
+				oldMaxLength: 100,
+				oldNullable: true);
+		}
+	}
+}

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -141,6 +141,28 @@ public class OrganizationSettingsTests(
 	}
 
 	[Test]
+	public async Task UpdateOrganization_ShouldReturn400_WhenContactEmailExceedsMaxLength(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1173: [MaxLength] attributes on request records were
+		// never enforced (no validation was registered), so an oversized value
+		// here used to reach the DB unbounded instead of being rejected.
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+
+		var created = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Oversized Contact Email Org" }, cancellationToken);
+
+		var act = () => client.UpdateOrganizationAsync(created.Id.Value, new UpdateOrganizationRequest
+		{
+			Name = "Oversized Contact Email Org",
+			ContactEmail = new string('a', 255) + "@example.com",
+		}, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
 	public async Task UpdateOrganization_ShouldReturn401_WhenNotAuthenticated(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/UpdateUserProfileTests.cs
+++ b/backend/tests/IntegrationTests/UpdateUserProfileTests.cs
@@ -55,6 +55,80 @@ public class UpdateUserProfileTests(
 		exception.Which.StatusCode.Should().Be(401);
 	}
 
+	// Regression for #1173: [MaxLength] attributes on request records were
+	// never enforced (no validation was registered), so oversized values used
+	// to reach the DB unbounded instead of being rejected.
+
+	[Test]
+	public async Task UpdateUserProfile_ShouldReturn400_WhenBioExceedsMaxLength(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.UpdateUserProfileAsync(
+			new UpdateUserProfileRequest { Bio = new string('a', 1001) },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task UpdateUserProfile_ShouldReturn400_WhenSkillsExceedMaxCount(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.UpdateUserProfileAsync(
+			new UpdateUserProfileRequest { Skills = Enumerable.Range(0, 51).Select(i => $"skill-{i}").ToList() },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task UpdateUserProfile_ShouldReturn400_WhenASkillExceedsMaxLength(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.UpdateUserProfileAsync(
+			new UpdateUserProfileRequest { Skills = [new string('a', 101)] },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task UpdateUserProfile_ShouldReturn400_WhenLanguagesExceedMaxCount(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.UpdateUserProfileAsync(
+			new UpdateUserProfileRequest { Languages = Enumerable.Range(0, 21).Select(i => $"lang-{i}").ToList() },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
+	[Test]
+	public async Task UpdateUserProfile_ShouldReturn400_WhenALanguageExceedsMaxLength(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => client.UpdateUserProfileAsync(
+			new UpdateUserProfileRequest { Languages = [new string('a', 51)] },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(400);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
 	{
 		var token = await fixture.GetAccessTokenAsync(username, password);


### PR DESCRIPTION
## What

Wires up .NET 10's built-in minimal-API validation (`builder.Services.AddValidation()`) so `[MaxLength]` DataAnnotations on request records are actually enforced, closes the unvalidated Skills/Languages gap on the user profile endpoint, and adds matching `character varying(n)` DB column limits (with an EF Core migration) as a last line of defense.

## Why

Minimal APIs never evaluate `[MaxLength]`/`[Required]`/etc. DataAnnotations unless validation is explicitly registered - no such registration existed anywhere in `Program.cs`. `UpdateOrganizationRequest`'s attributes were dead weight (`UpdateOrganizationEndpoint` hand-checked only `Name`/`Description`, missing `ContactEmail`/`ContactPhone`/`Website`/`Address.Street`/`Address.City` entirely), and the same pattern hit `UpdateUserProfileRequest`, where `Skills`/`Languages` had no attribute *or* manual check at all. There was also no DB-level backstop - every affected `Organization`/`User` string column was mapped as unbounded Postgres `text`.

Changes:
- `Program.cs`: `builder.Services.AddValidation()` - enforces every `[MaxLength]`-annotated request record repo-wide (not just the two named here), returning 400 automatically before the handler runs.
- `UpdateOrganizationEndpoint`/`UpdateUserProfileEndpoint`: removed the now-redundant manual length checks that duplicated what validation now enforces (kept the empty/whitespace check, which `[MaxLength]` doesn't cover).
- `UpdateUserProfileRequest`/`UpdateUserProfileEndpoint`: `Skills`/`Languages` have no natural DataAnnotations attribute for per-item string length, so both item-count and per-item-length caps are enforced manually (50 skills/100 chars, 20 languages/50 chars).
- `OrganizationConfiguration`/`UserConfiguration`: added `.HasMaxLength(...)` matching each field's request-record limit (`Organization.Name/Description/ContactEmail/ContactPhone/Website` + its owned `Address.Street/HouseNumber/City`, `User.Bio/Phone`), plus a new EF Core migration.

## Testing

- `Application.UnitTests` (709 passed) and `ArchitectureTests` (366 passed) run locally after installing a .NET 10 SDK build in-session (this sandbox has no SDK preinstalled and network policy blocks Microsoft's own CDN, so I installed Ubuntu's packaged `dotnet-sdk-10.0` instead - `global.json`'s `rollForward: latestMinor` was temporarily bypassed only to run these checks, and the file itself was restored to its committed state before pushing).
- `dotnet build` succeeds for `Api`, `Infrastructure`, and `IntegrationTests` with 0 warnings/0 errors; confirmed via `nswag-check` that no NSwag-generated client needs regeneration (no request/response shape changed).
- The migration was generated for real via `dotnet ef migrations add` (not hand-authored blind) after installing the matching `dotnet-ef` tool, then reformatted from the tool's default 4-space indent to this repo's tab convention. `dotnet ef migrations script` was used to render both the up and down SQL and confirm they're exactly the expected `ALTER COLUMN ... TYPE character varying(n)` statements with no unintended `NOT NULL` changes (the owned `Address` value object's columns are nullable at the DB level regardless of `.IsRequired()` in Fluent config, since `Organization.Address` itself is optional - the first hand-written draft of this migration got that wrong, which is exactly why generating it for real mattered).
- Added integration test coverage in `OrganizationSettingsTests.cs` (oversized `ContactEmail`) and `UpdateUserProfileTests.cs` (oversized `Bio`, and both count/length caps for `Skills`/`Languages`) asserting 400 - these need a live Postgres/Keycloak via Aspire, which isn't available in this sandbox, so they'll get their first real run in CI's `integration-tests` job.
- Confirmed via a dedicated read-only sweep of `IntegrationTests`/`VisualTests` that no existing test sends a value close to any of the pre-existing `[MaxLength]` limits across other endpoints (VolunteerOpportunity/Engagement/Report/etc.) - so enforcing validation repo-wide doesn't newly break anything already covered.

## Live verification

Skipped for this PR at the requester's explicit instruction (no RC cut, no live-staging pass) - will rely on CI instead.

## Checklist

- [x] `/self-review` run (`nswag-check` and `ef-migration-check` sub-agents both came back clean; findings folded into the Testing notes above)
- [ ] CI is green - pending, will monitor and fix
- [ ] Documentation updated if this change affects behavior - N/A, no user-facing docs describe these limits today

Closes #1173

---
_Generated by [Claude Code](https://claude.ai/code/session_01XziN5wVVXNBFPrGb5JezTu)_