### PR TITLE
fix: declare document-level color-scheme to guard against auto-dark inversion

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="color-scheme" content="light" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="apple-touch-icon" href="/icons/icon-192.png" />
 		<meta name="theme-color" content="#2d8a5e" />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* ── Document color-scheme guard (issue #1120) ────────────────────────────
+No dark theme exists yet - every surface is hard-coded light (bg-white,
+text-gray-900, etc.). Without an explicit color-scheme, browsers/OSes that
+auto-invert unstyled pages (e.g. Chromium's opt-in Android "force dark")
+treat this as fair game and algorithmically invert brand colors and
+overlays into something broken. Declaring light here (mirrored by the
+<meta name="color-scheme"> tag in index.html) tells the browser this page
+is intentionally light-only, so it renders as authored instead of guessing. */
+:root {
+	color-scheme: light;
+}
+
 html {
 	scroll-behavior: smooth;
 	overflow-x: clip;


### PR DESCRIPTION
## What

Declares `color-scheme: light` at the document level - both as a CSS `:root` property in `global.css` and as a `<meta name="color-scheme">` tag in `index.html`.

## Why

The app has no dark theme; every surface is hard-coded light (`bg-white`, `text-gray-900`, etc.). Because `color-scheme` was never declared at the document level (the only existing declaration was scoped to `date`/`time`/`datetime-local` inputs), browsers/OSes with auto-dark heuristics (e.g. Chromium's opt-in Android "force dark") had no signal that this page is intentionally light-only, and could algorithmically invert brand colors and overlays into something broken. This is the minimal "one-line 1.0 guard" suggested in the issue - it does not attempt the larger semantic-token/dark-theme work also mentioned there, which is out of scope for this minor fix.

Closes #1120

## Testing

- `pnpm lint` - clean
- `pnpm check` (`tsc --noEmit`) - clean
- `pnpm format:write` - no changes needed (already formatted)
- No unit tests apply; this is a CSS/HTML-only change with no runtime logic.

## Live verification

Skipped for this PR per explicit instruction not to cut a release candidate. The change is a static `color-scheme` declaration with no behavioral logic to exercise - correctness is visible directly in the rendered `<meta>` tag and computed `:root` style.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no behavior change beyond the guard itself)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SdmchyJaphJAuCLTd9XHx8)_