### PR TITLE
fix: unify clickable-card hover states to shadow-resting/shadow-raised

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -31,7 +31,7 @@ export default function OpportunityListItem({
 			: null;
 
 	return (
-		<li className="group relative flex h-full flex-col overflow-hidden rounded-card border border-gray-100 bg-white shadow-resting transition-all hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-raised">
+		<li className="group relative flex h-full flex-col overflow-hidden rounded-card border border-gray-100 bg-white shadow-resting transition-shadow hover:shadow-raised">
 			<Link
 				to={`/volunteer-opportunities/${item.id}`}
 				className="absolute inset-0 z-10"

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -107,7 +107,7 @@ function UpcomingOpportunitiesWidget({
 					{items.map((item) => (
 						<li
 							key={item.id}
-							className="relative rounded-xl border border-gray-100 p-3 transition hover:bg-gray-50"
+							className="relative rounded-xl border border-gray-100 bg-white p-3 shadow-resting transition-shadow hover:shadow-raised"
 						>
 							<Link
 								to={`/app/${organizationId}/dashboard/opportunities/${item.id}/engagements`}

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -324,7 +324,7 @@ export default function OrgOpportunitiesPage() {
 				ref={isHighlighted ? highlightRef : null}
 				data-highlighted={isHighlighted ? "true" : undefined}
 				data-testid="opportunity-row"
-				className={`flex h-full scroll-mt-24 flex-col gap-3 rounded-card border bg-white p-4 shadow-resting transition ${
+				className={`flex h-full scroll-mt-24 flex-col gap-3 rounded-card border bg-white p-4 shadow-resting transition-shadow hover:shadow-raised ${
 					isHighlighted
 						? "border-brand-400 ring-2 ring-brand-500 ring-offset-2"
 						: "border-gray-100"


### PR DESCRIPTION
## What

Unify the hover state of all clickable opportunity/organization cards to a single, consistent language.

## Why

Clickable cards used three different hover "languages":
- `OpportunityListItem.tsx` lifted 2px, changed border color to brand, and jumped to `shadow-lg`
- `OrganizationsPage.tsx`, `OrganizationProfilePage.tsx`, `VolunteerOpportunityDetailPage.tsx`, and `ActivitySection.tsx` had already converged on the project's `shadow-resting` -> `hover:shadow-raised` elevation tokens (`transition-shadow`)
- `UpcomingOpportunitiesWidget.tsx` only tinted its background on hover, with no shadow at rest at all
- `OrgOpportunitiesPage.tsx`'s rows had no hover feedback whatsoever

Hover is the app's main "this is clickable" affordance, so having it mean four different things across nearly-identical cards is confusing. Since the majority pattern already used the `--shadow-resting`/`--shadow-raised` elevation tokens defined in `global.css` (explicitly documented there as "resting cards, raised/hover state"), this brings the three outliers in line with that existing pattern rather than inventing a new one.

Closes #1123

## Testing

- `pnpm lint` - clean
- `pnpm check` (tsc --noEmit) - clean
- `pnpm format:write` - no changes needed elsewhere
- `/self-review` run, including the `a11y-check` subagent (diff touches `.tsx` files) - no regressions found; all changes are `className`-only, no structural/JSX changes, clickable-card `Link` pattern untouched, no contrast/focus/motion impact (the removed `hover:-translate-y-0.5` transform is a net motion reduction)

No behavioral/logic change, so no new automated test coverage is needed - this is a pure CSS class consistency fix.

## Live verification

Skipped per explicit instruction for this task (no release candidate cut). This is a low-risk, purely cosmetic CSS class change with no interaction/behavior differences, verified locally via lint/typecheck and manual diff review instead.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_014FHdKy88yz3zS2E4NSnG86)_