### PR TITLE
fix: prevent long organization name from overflowing admin table row

### DIFF
--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -132,8 +132,10 @@ function OrganizationsSection() {
 					<tbody className="divide-y divide-gray-100">
 						{rows.map((row) => (
 							<tr key={row.id} className="flex items-center gap-4 px-4 py-3">
-								<td className="flex flex-1 items-center gap-2 font-medium text-gray-900">
-									{row.name}
+								<td className="min-w-0 flex-1">
+									<p className="truncate font-medium text-gray-900">
+										{row.name}
+									</p>
 								</td>
 							</tr>
 						))}


### PR DESCRIPTION
## What

Add `min-w-0` to the organizations table cell in `AdministrationPage.tsx` and wrap the organization name in a `truncate` `<p>`, so a long/unbroken name truncates with an ellipsis instead of overflowing the row.

## Why

Flex items default to `min-width: auto`, so without `min-w-0` a long organization name can't shrink and pushes the row past its `overflow-hidden` wrapper, clipping content at the container edge instead of truncating cleanly. The sibling `UsersSection` already uses the correct `min-w-0 flex-1` / `truncate` pattern a few hundred lines below; this change brings `OrganizationsSection` in line with it.

Closes #1118

## Testing

- `pnpm lint` - pass
- `pnpm check` (tsc --noEmit) - pass
- `pnpm test` (vitest) - 128 passed
- `pnpm format:write` - no changes needed beyond the edit

## Live verification

Skipped per explicit instruction for this task (no release candidate cut). This is a single Tailwind class change mirroring an existing, already-shipped pattern (`UsersSection`) in the same file, with no logic, API, or i18n changes.

## Checklist

- [x] `/self-review` run and findings addressed (none - clean mirror of the existing pattern)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no behavior/doc change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb7kk2YMFAHCEVNnZhkmac)_