### PR TITLE
fix: scope org switcher name min-width to sm: breakpoint

### DIFF
--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -109,4 +109,35 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 			"the org name must keep enough width on mobile to show more than just its "
 			+ "first letter - it previously rendered at ~0px wide here");
 	}
+
+	[Test]
+	public async Task MobileHeader_OrgSwitcherDoesNotOverlapControls_At320pxViewport()
+	{
+		// #1117: the org name span's `min-w-[6rem]` floor didn't shrink with the
+		// rest of the row below ~342px, so on the narrowest viewports still
+		// shipped today (iPhone SE 1st gen, Galaxy Fold cover screen: 320px) the
+		// switcher overflowed its own button box and painted over the mobile
+		// bell/hamburger - the only navigation available at this width. Fixed by
+		// scoping the min-width floor to `sm:` so it only applies once there's
+		// room for it. 320px is narrower than OrgAppMobileResponsiveTests's other
+		// cases (375px), which the fix's math shows already had enough slack.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+		await Page.SetViewportSizeAsync(320, 568);
+
+		var mobileBell = Page.GetByTestId("notification-bell-mobile");
+		await Expect(mobileBell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var hamburger = Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" });
+		await Expect(hamburger).ToBeVisibleAsync();
+
+		// A click that lands here (rather than timing out on an intercepting
+		// element, e.g. the org switcher's overflowing name span) proves the
+		// switcher isn't painting over the hamburger at this width.
+		await hamburger.ClickAsync(new() { Timeout = 10_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }))
+			.ToBeVisibleAsync();
+	}
 }

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -35,7 +35,7 @@ export default function LanguageSelector({
 			>
 				<span
 					aria-hidden="true"
-					className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
+					className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
 				>
 					{current.short}
 				</span>
@@ -89,7 +89,7 @@ export default function LanguageSelector({
 							>
 								<span
 									aria-hidden="true"
-									className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${
+									className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${
 										transparent
 											? lang.code === currentCode
 												? "border-white/50 text-white"

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -80,7 +80,7 @@ export default function OrganizationSwitcher({
 					)}
 					<span
 						data-testid="org-switcher-current-name"
-						className="max-w-50 min-w-24 flex-1 truncate"
+						className="max-w-50 flex-1 truncate sm:min-w-24"
 					>
 						{currentOrg?.name ?? t("organization.selectPlaceholder")}
 					</span>


### PR DESCRIPTION
## What

Scopes the org switcher's org-name `min-w-[6rem]` Tailwind class to `sm:min-w-[6rem]` so it no longer applies below the `sm` (640px) breakpoint.

## Why

`OrganizationSwitcher.tsx`'s org-name span had a hard `min-w-[6rem]` (96px) floor that didn't shrink with the rest of the header row. Below ~342px viewport width (iPhone SE 1st gen, Galaxy Fold cover screen, or any browser with a large default font) that floor pushed the switcher past its own button box, overlapping the mobile bell/hamburger - the only navigation an organizer has on mobile. The span already has `truncate` (which has an automatic min-content size of 0 once `overflow: hidden` is set), so it degrades gracefully without the floor; scoping the floor to `sm:` keeps the nicer minimum width on screens with room for it while letting the row shrink freely below that.

Closes #1117

## Testing

- Added `MobileHeader_OrgSwitcherDoesNotOverlapControls_At320pxViewport` to `backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs`, asserting the mobile bell/hamburger stay visible and clickable at a 320px viewport (the narrowest width the issue calls out).
- `pnpm lint`, `pnpm check`, `pnpm test` (128 tests) all pass locally.
- `dotnet build tests/VisualTests` succeeds.

## Live verification

Skipped for this PR per explicit instruction not to cut a release candidate. The fix is a pure Tailwind class change verified locally (build/lint/typecheck) plus the new automated Playwright regression test above, which directly reproduces the reported overlap scenario at 320px against the local Aspire stack. No RC was cut and no live-staging check was performed.

## Checklist

- [x] `/self-review` run and findings addressed (clean - see also the `a11y-check` subagent's pass over the `.tsx` change)
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal CSS fix, no user-facing docs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9spfztRsKRNQ8whixWcng)_