### PR TITLE
fix: give ConfirmDialog's destructive button a danger Button variant

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -25,6 +25,7 @@ const BASE_CLASSES =
 const VARIANT_CLASSES = {
 	primary: "bg-brand-700 font-semibold text-white hover:bg-brand-800",
 	secondary: "text-gray-600 hover:bg-gray-100",
+	danger: "bg-red-600 font-semibold text-white hover:bg-red-700",
 } as const;
 
 type Variant = keyof typeof VARIANT_CLASSES;

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -61,13 +61,14 @@ export default function ConfirmDialog({
 				>
 					{t("confirmDialog.keep")}
 				</Button>
-				<button
+				<Button
+					type="button"
+					variant="danger"
 					onClick={onConfirm}
 					disabled={loading}
-					className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
 				>
-					{loading ? "…" : confirmLabel}
-				</button>
+					{loading ? t("common.saving") : confirmLabel}
+				</Button>
 			</div>
 		</Modal>
 	);


### PR DESCRIPTION
## What

Adds a `danger` variant to the shared `Button` component and switches `ConfirmDialog`'s destructive/confirm button to use it instead of a hand-rolled `<button>`.

## Why

`ConfirmDialog`'s confirm button was hand-rolled with `rounded` (0.25rem) instead of the shared `Button` component's `rounded-xl` (0.75rem), and had no `focus-visible` styling at all, while the adjacent "Keep" button (which uses `Button variant="secondary"`) gets both. This produced a 3x corner-radius mismatch between the two buttons and left the *destructive* action - the one a keyboard user most needs clear focus feedback on - with only the unbranded browser-default focus ring. It also rendered its loading state as a literal `"…"` string instead of a translated label.

`ConfirmDialog` backs eight destructive flows (withdraw engagement, cancel/revoke engagement, delete opportunity, delete organization, delete account, leave organization, discard wizard changes, edit a booked time slot), so all eight now get the consistent, on-system treatment.

Closes #1103

## Testing

- `pnpm lint` - clean
- `pnpm check` (tsc --noEmit) - clean
- `pnpm test` (Vitest) - 128/128 passing
- `pnpm format:write` - no changes needed
- Ran the `a11y-check` subagent against the diff: no a11y regressions, and no new/updated test needed in `backend/tests/VisualTests/AccessibilityTests.cs` since `ConfirmDialog` is already exercised by existing axe scans (`EngagementManagementPage_CancelDialog_HasNoSeriousA11yViolations`, `OrgOpportunitiesPage_CancelDialog_HasNoSeriousA11yViolations`).

No local Aspire/Docker stack available in this sandbox (see root `AGENTS.md`'s Sandbox Limitations), so this wasn't run against a live dev server.

## Live verification

Skipped per explicit instruction for this task (no release candidate was cut). The change is a pure CSS-class swap onto the already-proven shared `Button` component (used elsewhere for `variant="primary"`/`"secondary"`) plus a translation-key swap for the loading label - both existing keys/patterns already exercised by CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green (pending)
- [x] Documentation updated if this change affects behavior (n/a - no behavior/doc change beyond visual consistency)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZT3shxAmFBdacB7G6eG1z)_