### PR TITLE
fix: replace emoji iconography with monochrome SVG icons

### DIFF
--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -6,12 +6,75 @@ import type {
 import Spinner from "./Spinner";
 import { resolveDateLocale } from "../lib/format";
 
-const TYPE_ICON: Record<string, string> = {
-	Milestone: "🏆",
-	Streak: "🔥",
-	Social: "🤝",
-	Hidden: "✨",
-};
+function AchievementTypeIcon({
+	type,
+	className = "h-7 w-7",
+}: {
+	type: string;
+	className?: string;
+}) {
+	const svgProps = {
+		className,
+		fill: "none" as const,
+		viewBox: "0 0 24 24",
+		strokeWidth: 1.5,
+		stroke: "currentColor",
+		"aria-hidden": true,
+	};
+
+	switch (type) {
+		case "Milestone":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0"
+					/>
+				</svg>
+			);
+		case "Streak":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z"
+					/>
+				</svg>
+			);
+		case "Social":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+					/>
+				</svg>
+			);
+		case "Hidden":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z"
+					/>
+				</svg>
+			);
+		default:
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+					/>
+				</svg>
+			);
+	}
+}
 
 const TYPE_NUM_MAP: Record<number, string> = {
 	0: "Milestone",
@@ -36,7 +99,6 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 	const isEarned = !!earned;
 	const isHidden = catalog.isHidden && !isEarned;
 	const typeName = isEarned ? typeLabel(earned.type) : typeLabel(catalog.type);
-	const icon = TYPE_ICON[typeName] ?? "🏅";
 	const tooltipId = `badge-tooltip-${catalog.key}`;
 	const nameId = `badge-name-${catalog.key}`;
 
@@ -53,11 +115,20 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 			aria-describedby={!isHidden ? tooltipId : undefined}
 		>
 			<div
-				className={`mb-3 flex h-14 w-14 items-center justify-center rounded-full text-2xl ${
+				className={`mb-3 flex h-14 w-14 items-center justify-center rounded-full ${
 					isEarned ? "bg-brand-50" : "bg-gray-100"
 				}`}
 			>
-				{isHidden ? "?" : icon}
+				{isHidden ? (
+					<span className="text-2xl" aria-hidden="true">
+						?
+					</span>
+				) : (
+					<AchievementTypeIcon
+						type={typeName}
+						className={`h-7 w-7 ${isEarned ? "text-brand-600" : "text-gray-400"}`}
+					/>
+				)}
 			</div>
 			<p
 				id={nameId}

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 
 const LANGUAGES = [
-	{ code: "en", flag: "🇬🇧" },
-	{ code: "de", flag: "🇩🇪" },
+	{ code: "en", short: "EN" },
+	{ code: "de", short: "DE" },
 ] as const;
 
 type LangCode = (typeof LANGUAGES)[number]["code"];
@@ -33,7 +33,12 @@ export default function LanguageSelector({
 				aria-label={t("language.switchLanguage")}
 				className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm transition-colors ${transparent ? "border-white/30 text-white hover:bg-white/10" : "border-gray-200 text-gray-700 hover:bg-gray-50"}`}
 			>
-				<span>{current.flag}</span>
+				<span
+					aria-hidden="true"
+					className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
+				>
+					{current.short}
+				</span>
 				<span className="font-medium">{t(`language.${current.code}`)}</span>
 				<svg
 					className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""} ${transparent ? "text-white/70" : "text-gray-400"}`}
@@ -82,7 +87,20 @@ export default function LanguageSelector({
 											: "text-gray-700 hover:bg-gray-50"
 								}`}
 							>
-								<span>{lang.flag}</span>
+								<span
+									aria-hidden="true"
+									className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${
+										transparent
+											? lang.code === currentCode
+												? "border-white/50 text-white"
+												: "border-white/30 text-white/80"
+											: lang.code === currentCode
+												? "border-brand-300 text-brand-700"
+												: "border-gray-300 text-gray-600"
+									}`}
+								>
+									{lang.short}
+								</span>
 								<span>{t(`language.${lang.code}`)}</span>
 								{lang.code === currentCode && (
 									<span

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -39,6 +39,44 @@ const LEGACY_TAB_SECTIONS: Record<string, string> = {
 	achievements: "achievements",
 };
 
+function FireIcon({ className = "h-5 w-5" }: { className?: string }) {
+	return (
+		<svg
+			className={className}
+			fill="none"
+			viewBox="0 0 24 24"
+			strokeWidth={1.5}
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z"
+			/>
+		</svg>
+	);
+}
+
+function CalendarIcon({ className = "h-5 w-5" }: { className?: string }) {
+	return (
+		<svg
+			className={className}
+			fill="none"
+			viewBox="0 0 24 24"
+			strokeWidth={1.5}
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+			/>
+		</svg>
+	);
+}
+
 function Field({
 	label,
 	id,
@@ -333,8 +371,8 @@ export default function ProfileOverviewPage() {
 							{streaks && (
 								<div className="flex flex-wrap gap-3">
 									<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
-										<span className="text-2xl" aria-hidden="true">
-											🔥
+										<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+											<FireIcon />
 										</span>
 										<div>
 											<p className="text-xl font-bold text-gray-900">
@@ -348,8 +386,8 @@ export default function ProfileOverviewPage() {
 										</div>
 									</div>
 									<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
-										<span className="text-2xl" aria-hidden="true">
-											📅
+										<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+											<CalendarIcon />
 										</span>
 										<div>
 											<p className="text-xl font-bold text-gray-900">


### PR DESCRIPTION
## What

Replaces emoji used as first-class iconography with icons that match the app's existing monochrome, stroked SVG icon set (or a plain text badge for the language flags).

## Why

Windows (Segoe UI Emoji) ships no regional-indicator flag glyphs, so on the primary desktop platform for a German-market product the language switcher rendered "GB"/"DE" as two bare letter pairs instead of flags - it looked broken, not localized. More broadly, emoji render in a different visual language (multi-colour, platform-specific shapes, no stroke weight) from the app's monochrome stroked icon set, so the achievements grid and profile streak chips looked inconsistent across macOS, Windows, and Android.

Closes #1116

## Changes

- `frontend/src/components/Header/LanguageSelector.tsx` - replaced the flag emoji (🇬🇧/🇩🇪) with a small "EN"/"DE" text badge. Marked `aria-hidden="true"` since the full language name (e.g. "English"/"Deutsch") is already rendered as visible text next to it.
- `frontend/src/components/BadgeGrid.tsx` - replaced the `TYPE_ICON` emoji map (🏆🔥🤝✨, fallback 🏅) with a new `AchievementTypeIcon` component rendering stroked SVG icons (trophy/fire/user-group/sparkles/star), matching the existing 24x24 viewBox / `stroke="currentColor"` convention used elsewhere in the app (e.g. `VolunteerOpportunitiesList/icons.tsx`).
- `frontend/src/pages/ProfileOverviewPage/index.tsx` - replaced the 🔥 (login streak) and 📅 (activity streak) emoji with local `FireIcon`/`CalendarIcon` SVG components in a `bg-brand-100 text-brand-700` icon badge, matching the icon-badge convention used elsewhere (e.g. `OrgDashboardPage/SettingsWidget.tsx`).

## Testing

- `pnpm lint` - passes (0 warnings)
- `pnpm check` (tsc --noEmit) - passes
- `pnpm format:check` - passes
- `pnpm test` - 128/128 existing unit tests pass
- Ran the `a11y-check` subagent against all three changed files - no violations found; all new decorative icons/badges are `aria-hidden="true"` with the meaningful info already present as visible sibling text. No new page/route was added, so no new `AccessibilityTests.cs` entry is needed - existing axe-core coverage (`ProfileOverviewPage_HasNoSeriousA11yViolations`, `UserAchievementsPage_HasNoSeriousA11yViolations`, etc.) already exercises the touched surfaces.

## Live verification

Per explicit instruction on this task, no release candidate was cut for this change - the deploy-and-verify flow in root `AGENTS.md` was intentionally skipped. This is a self-contained frontend visual fix (icon swap, no behavioral/API change) verified via lint/typecheck/unit tests and a manual review of the rendered markup/classes above.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M1y2HvHoXzDaxUWu32DhpF)_