### PR TITLE
fix: keep filter dropdown panel below the sticky header

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -66,7 +66,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
-	public async Task FrequencyFilter_ClosesOnScroll_AndPanelStaysBelowHeader()
+	public async Task FrequencyFilter_PanelStaysBelowHeader()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 
@@ -84,13 +84,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		// it (#1119).
 		var panel = oneTimeOption.Locator("xpath=..");
 		await Expect(panel).ToHaveCSSAsync("z-index", "30");
-
-		// The panel is positioned relative to its trigger, not the viewport,
-		// so it would otherwise drift toward (and under) the sticky header as
-		// the page scrolls - closing it on scroll is what actually prevents
-		// the collision.
-		await Page.EvaluateAsync("() => window.scrollBy(0, 300)");
-		await Expect(oneTimeOption).Not.ToBeVisibleAsync();
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -66,6 +66,34 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task FrequencyFilter_ClosesOnScroll_AndPanelStaysBelowHeader()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByTestId("filter-frequency").ClickAsync();
+		var oneTimeOption = Page.GetByRole(AriaRole.Button, new() { Name = "One-time" });
+		await Expect(oneTimeOption).ToBeVisibleAsync();
+
+		// The panel's own ancestors (the filter bar, <main>) are all
+		// unpositioned, so its z-index competes directly with Header.tsx's
+		// sticky z-40 at the document root instead of nesting inside it - pin
+		// it below the header rather than the old z-[200] that painted over
+		// it (#1119).
+		var panel = oneTimeOption.Locator("xpath=..");
+		await Expect(panel).ToHaveCSSAsync("z-index", "30");
+
+		// The panel is positioned relative to its trigger, not the viewport,
+		// so it would otherwise drift toward (and under) the sticky header as
+		// the page scrolls - closing it on scroll is what actually prevents
+		// the collision.
+		await Page.EvaluateAsync("() => window.scrollBy(0, 300)");
+		await Expect(oneTimeOption).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task HomePage_OpportunitiesSection_IsCenteredWithStyledCards()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -35,7 +35,7 @@ export default function LanguageSelector({
 			>
 				<span
 					aria-hidden="true"
-					className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
+					className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
 				>
 					{current.short}
 				</span>
@@ -89,7 +89,7 @@ export default function LanguageSelector({
 							>
 								<span
 									aria-hidden="true"
-									className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${
+									className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${
 										transparent
 											? lang.code === currentCode
 												? "border-white/50 text-white"

--- a/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { ChevronIcon, ChipXIcon, CheckMiniIcon } from "./icons";
 
 const EDGE_MARGIN = 8;
@@ -119,23 +119,6 @@ export default function FilterDropdown({
 			window.innerWidth - EDGE_MARGIN - panelWidth - containerRect.left;
 		setPanelLeft(Math.min(Math.max(preferred, minLeft), maxLeft));
 	}, [isOpen]);
-
-	// The panel is positioned relative to its trigger (top-full), not the
-	// viewport, so scrolling drags it along instead of leaving it anchored in
-	// place - close it rather than let it drift over the sticky header or the
-	// results below (#1119). Skipped while focus is inside the panel: a
-	// keyboard user tabbing through a panel taller than the viewport can
-	// trigger the browser's own focus-follow auto-scroll, and closing under
-	// them mid-navigation would drop focus to <body> with no warning.
-	useEffect(() => {
-		if (!isOpen) return;
-		function handleScroll() {
-			if (panelRef.current?.contains(document.activeElement)) return;
-			onToggle();
-		}
-		window.addEventListener("scroll", handleScroll, { passive: true });
-		return () => window.removeEventListener("scroll", handleScroll);
-	}, [isOpen, onToggle]);
 
 	return (
 		<div ref={containerRef} className="relative shrink-0">

--- a/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ChevronIcon, ChipXIcon, CheckMiniIcon } from "./icons";
 
 const EDGE_MARGIN = 8;
@@ -120,6 +120,23 @@ export default function FilterDropdown({
 		setPanelLeft(Math.min(Math.max(preferred, minLeft), maxLeft));
 	}, [isOpen]);
 
+	// The panel is positioned relative to its trigger (top-full), not the
+	// viewport, so scrolling drags it along instead of leaving it anchored in
+	// place - close it rather than let it drift over the sticky header or the
+	// results below (#1119). Skipped while focus is inside the panel: a
+	// keyboard user tabbing through a panel taller than the viewport can
+	// trigger the browser's own focus-follow auto-scroll, and closing under
+	// them mid-navigation would drop focus to <body> with no warning.
+	useEffect(() => {
+		if (!isOpen) return;
+		function handleScroll() {
+			if (panelRef.current?.contains(document.activeElement)) return;
+			onToggle();
+		}
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, [isOpen, onToggle]);
+
 	return (
 		<div ref={containerRef} className="relative shrink-0">
 			<div
@@ -170,7 +187,11 @@ export default function FilterDropdown({
 				<div
 					ref={panelRef}
 					style={{ left: panelLeft }}
-					className="absolute top-full z-200 mt-1.5 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-modal"
+					// Below Header.tsx's sticky z-40 - this panel's ancestors (the
+					// filter bar, <main>) are all unpositioned, so its z-index
+					// competes with the header directly at the document root instead
+					// of nesting inside it (#1119).
+					className="absolute top-full z-30 mt-1.5 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-modal"
 				>
 					{children}
 				</div>


### PR DESCRIPTION
## What

`FilterDropdown`'s popover panel now sits below the sticky header in the stacking order, instead of painting over the header's logo, sign-in buttons, and notification bell.

## Why

`FilterDropdown.tsx`'s panel used `z-[200]` with no positioned ancestor between it and the document root (the filter bar and `<main>` are both unpositioned), so its z-index competed directly with `Header.tsx`'s sticky `z-40` at the root stacking context - and 200 beats 40.

Fix: `FilterDropdown.tsx`: `z-[200]` -> `z-30` - below the header (`z-40`), still above the result cards (`z-10`/`z-20`), matching the layer this same file already uses for its nested location-suggestions listbox.

An earlier version of this PR also closed the panel on scroll (since it's anchored to its trigger, not the viewport, and would otherwise drift under the header while scrolling). That broke CI: Playwright's `ClickAsync()` scrolls its target into view as part of its actionability checks before clicking, firing a genuine native `scroll` event - since the click hadn't landed yet, focus wasn't inside the panel yet either, so the close-on-scroll handler fired and closed the panel right before the click landed, breaking every existing filter-interaction test. The z-30 fix alone already fully resolves the reported bug regardless of scroll state, so the scroll-close behavior was dropped rather than chasing a robust way to distinguish "the user scrolled" from "the browser scrolled to make something clickable."

Closes #1119

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest, 128 tests) - all green
- `dotnet build` (full solution, including the updated `VisualTests` project) - green
- Added `FrequencyFilter_PanelStaysBelowHeader` to `backend/tests/VisualTests/VolunteerOpportunityTests.cs`, asserting the panel's `z-index: 30` (runs against the full Aspire stack in CI's `dotnet.yml`)

## Live verification

Skipped per explicit instruction for this task (no release candidate cut). Verification for this change relies on the new automated Playwright regression test above (`dotnet.yml`'s `visual-tests` job, which boots the full Aspire stack) plus the local frontend lint/typecheck/unit-test/build and backend build runs listed above.

## Checklist

- [x] `/self-review` run and findings addressed (a11y-check subagent flagged a keyboard-focus edge case in an earlier scroll-close approach; that approach was subsequently dropped entirely after it broke CI for an unrelated reason - see "Why" above)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no documented behavior changed beyond the bug itself)