### PR TITLE
fix: use EmptyState component for dashboard widgets and dropdowns

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -599,13 +599,15 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	public async Task OrgDashboardPage_EmptyOpportunitiesCreateOpportunityCta_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// #1122: UpcomingOpportunitiesWidget and QuickCheckInWidget's empty
-		// states gained a "Create opportunity" CTA (EmptyState's new
-		// compact variant) that opens CreateVolunteerOpportunityModal
-		// directly from the widget. Olaf's seeded org (used by
-		// NavigateToOrgAppDashboardAsOlafAsync above) almost certainly
-		// already has opportunities by the time this suite runs - a fresh,
-		// otherwise-untouched org is the only deterministic way to reach
-		// this branch.
+		// states gained a "Create one" CTA (EmptyState's new compact
+		// variant) that opens CreateVolunteerOpportunityModal directly from
+		// the widget - worded distinctly from CreateOpportunityWidget's own
+		// "Create opportunity" button (also on this dashboard by default)
+		// so the two don't collide as duplicate accessible names. Olaf's
+		// seeded org (used by NavigateToOrgAppDashboardAsOlafAsync above)
+		// almost certainly already has opportunities by the time this suite
+		// runs - a fresh, otherwise-untouched org is the only deterministic
+		// way to reach this branch.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var backend = Fixture.GetEndpoint("backend");
 
@@ -627,7 +629,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(upcomingWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var upcomingCreateButton = upcomingWidget.GetByRole(
-			AriaRole.Button, new() { Name = "Create opportunity" });
+			AriaRole.Button, new() { Name = "Create one" });
 		await Expect(upcomingCreateButton).ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();
@@ -663,7 +665,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(quickCheckInWidget).ToBeVisibleAsync();
 
 		var quickCheckInCreateButton = quickCheckInWidget.GetByRole(
-			AriaRole.Button, new() { Name = "Create opportunity" });
+			AriaRole.Button, new() { Name = "Create one" });
 		await Expect(quickCheckInCreateButton).ToBeVisibleAsync();
 
 		await quickCheckInCreateButton.ClickAsync();

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -596,6 +596,88 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrgDashboardPage_EmptyOpportunitiesCreateOpportunityCta_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1122: UpcomingOpportunitiesWidget and QuickCheckInWidget's empty
+		// states gained a "Create opportunity" CTA (EmptyState's new
+		// compact variant) that opens CreateVolunteerOpportunityModal
+		// directly from the widget. Olaf's seeded org (used by
+		// NavigateToOrgAppDashboardAsOlafAsync above) almost certainly
+		// already has opportunities by the time this suite runs - a fresh,
+		// otherwise-untouched org is the only deterministic way to reach
+		// this branch.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"EmptyDashA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = Guid.Parse(org.GetProperty("id").GetProperty("value").GetString()!);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, organizationId);
+
+		var upcomingWidget = Page.GetByTestId("widget-tile-UpcomingOpportunities");
+		await Expect(upcomingWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var upcomingCreateButton = upcomingWidget.GetByRole(
+			AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(upcomingCreateButton).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+
+		await upcomingCreateButton.ClickAsync();
+		var upcomingDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(upcomingDialog).ToBeVisibleAsync();
+
+		var upcomingDialogResult = await Page.RunAxe();
+		AssertNoViolations(upcomingDialogResult);
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(upcomingDialog).Not.ToBeVisibleAsync();
+
+		// QuickCheckIn isn't in DEFAULT_LAYOUT (see widgetCatalog.ts) - add it
+		// via the picker, save to leave edit mode (widget content is inert
+		// while editing - see EditableWidgetTile), then reach its own,
+		// separately-wired empty-state CTA.
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var addWidgetDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(addWidgetDialog).ToBeVisibleAsync();
+		await addWidgetDialog.GetByTestId("add-widget-option-QuickCheckIn").ClickAsync();
+		await addWidgetDialog.GetByTestId("add-widget-done").ClickAsync();
+		await Expect(addWidgetDialog).Not.ToBeVisibleAsync();
+
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var quickCheckInWidget = Page.GetByTestId("widget-tile-QuickCheckIn");
+		await Expect(quickCheckInWidget).ToBeVisibleAsync();
+
+		var quickCheckInCreateButton = quickCheckInWidget.GetByRole(
+			AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(quickCheckInCreateButton).ToBeVisibleAsync();
+
+		await quickCheckInCreateButton.ClickAsync();
+		var quickCheckInDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(quickCheckInDialog).ToBeVisibleAsync();
+
+		var quickCheckInDialogResult = await Page.RunAxe();
+		AssertNoViolations(quickCheckInDialogResult);
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(quickCheckInDialog).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task EngagementManagementPage_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// Engagement management is nested in the org app (#751) - reachable

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -7,15 +7,45 @@ interface Props {
 		label: string;
 		onClick: () => void;
 	};
+	// Smaller padding/type for dashboard widgets and dropdown panels, where
+	// the default py-12 is too much space for the room available - #1122.
+	compact?: boolean;
 }
 
-export default function EmptyState({ title, message, action }: Props) {
+export default function EmptyState({
+	title,
+	message,
+	action,
+	compact = false,
+}: Props) {
 	return (
-		<div className="py-12 text-center">
-			<p className="font-medium text-gray-900">{title}</p>
-			{message && <p className="mt-1 text-sm text-gray-500">{message}</p>}
+		<div className={compact ? "py-4 text-center" : "py-12 text-center"}>
+			<p
+				className={
+					compact
+						? "text-sm font-medium text-gray-900"
+						: "font-medium text-gray-900"
+				}
+			>
+				{title}
+			</p>
+			{message && (
+				<p
+					className={
+						compact
+							? "mt-1 text-xs text-gray-500"
+							: "mt-1 text-sm text-gray-500"
+					}
+				>
+					{message}
+				</p>
+			)}
 			{action && (
-				<Button onClick={action.onClick} className="mt-4">
+				<Button
+					onClick={action.onClick}
+					size={compact ? "sm" : "md"}
+					className={compact ? "mt-3" : "mt-4"}
+				>
 					{action.label}
 				</Button>
 			)}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -42,6 +42,7 @@ export default function EmptyState({
 			)}
 			{action && (
 				<Button
+					type="button"
 					onClick={action.onClick}
 					size={compact ? "sm" : "md"}
 					className={compact ? "mt-3" : "mt-4"}

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
 import type { NotificationSummary } from "../../client/api-client";
+import EmptyState from "../EmptyState";
 import NotificationItem from "./NotificationItem";
 
 // Single notification bell + dropdown panel, rendered twice: once inside
@@ -122,8 +123,8 @@ export default function NotificationDropdown({
 					</div>
 					<ul className="max-h-80 overflow-y-auto divide-y divide-gray-50">
 						{notifications.length === 0 ? (
-							<li className="px-4 py-6 text-center text-sm text-gray-500">
-								{t("notifications.empty")}
+							<li className="px-4">
+								<EmptyState compact title={t("notifications.empty")} />
 							</li>
 						) : (
 							<>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -373,6 +373,7 @@
       "upcomingError": "Einsätze konnten nicht geladen werden.",
       "upcomingEmpty": "Keine bevorstehenden Einsätze.",
       "upcomingViewAll": "Alle Einsätze anzeigen →",
+      "emptyStateCreateAction": "Einen erstellen",
       "settingsWidgetTitle": "Organisation",
       "settingsWidgetDesc": "Identität deiner Organisation, Mitgliederzahl und ein Link zu den Einstellungen.",
       "settingsMemberCount": "{{count}} Mitglieder",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -373,6 +373,7 @@
       "upcomingError": "Failed to load opportunities.",
       "upcomingEmpty": "No upcoming opportunities.",
       "upcomingViewAll": "View all opportunities →",
+      "emptyStateCreateAction": "Create one",
       "settingsWidgetTitle": "Organization",
       "settingsWidgetDesc": "Your organization's identity, member count and a link to settings.",
       "settingsMemberCount": "{{count}} members",

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -9,6 +9,7 @@ import ReportContentModal, {
 } from "../components/ReportContentModal";
 import Spinner from "../components/Spinner";
 import ErrorBanner from "../components/ErrorBanner";
+import EmptyState from "../components/EmptyState";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatOccurrence, formatParticipationType } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -107,7 +108,7 @@ export default function OrganizationProfilePage() {
 				</h2>
 
 				{profile.openOpportunities.length === 0 ? (
-					<p className="text-gray-500">{t("orgProfile.noOpportunities")}</p>
+					<EmptyState title={t("orgProfile.noOpportunities")} />
 				) : (
 					<ul className="space-y-3">
 						{profile.openOpportunities.map((opp) => (

--- a/frontend/src/pages/app/OrgDashboardPage/AddWidgetModal.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/AddWidgetModal.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import Modal from "../../../components/Modal";
 import Button from "../../../components/Button";
+import EmptyState from "../../../components/EmptyState";
 import { WIDGET_CATALOG, type WidgetKey } from "./widgetCatalog";
 
 const WIDGET_DESC_KEY: Record<WidgetKey, string> = {
@@ -129,9 +130,7 @@ export default function AddWidgetModal({
 
 			<div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
 				{availableKeys.length === 0 ? (
-					<p className="py-8 text-center text-sm text-gray-500">
-						{t("orgDashboard.addWidgetAllAdded")}
-					</p>
+					<EmptyState compact title={t("orgDashboard.addWidgetAllAdded")} />
 				) : (
 					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
 						{availableKeys.map((key) => {

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -7,7 +7,9 @@ import Spinner from "../../../components/Spinner";
 import Button from "../../../components/Button";
 import Dropdown from "../../../components/Dropdown";
 import ErrorBanner from "../../../components/ErrorBanner";
+import EmptyState from "../../../components/EmptyState";
 import ModalLoadingFallback from "../../../components/ModalLoadingFallback";
+import CreateVolunteerOpportunityModal from "../../../components/CreateVolunteerOpportunityModal";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -22,12 +24,18 @@ interface Props {
 	organizationId: string;
 	refreshKey: number;
 	size: WidgetSizeClass;
+	onOpportunityCreated: (createdDraftId?: string) => void;
 }
 
 // Lets an organizer jump straight to the QR scanner for any of their
 // published opportunities, instead of navigating to that opportunity's
 // engagement management page first.
-function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
+function QuickCheckInWidget({
+	organizationId,
+	refreshKey,
+	size,
+	onOpportunityCreated,
+}: Props) {
 	const { t } = useTranslation();
 	const api = useApiClient();
 
@@ -47,6 +55,7 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 	);
 	const [selectedId, setSelectedId] = useState("");
 	const [scannerOpen, setScannerOpen] = useState(false);
+	const [showCreateModal, setShowCreateModal] = useState(false);
 
 	useEffect(() => {
 		if (opportunities === null) return;
@@ -68,9 +77,14 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 			)}
 			{error && <ErrorBanner message={error} />}
 			{opportunities !== null && !error && opportunities.length === 0 && (
-				<p className="text-sm text-gray-500">
-					{t("orgDashboard.quickCheckInNoOpportunities")}
-				</p>
+				<EmptyState
+					compact
+					title={t("orgDashboard.quickCheckInNoOpportunities")}
+					action={{
+						label: t("orgOverview.createOpportunity"),
+						onClick: () => setShowCreateModal(true),
+					}}
+				/>
 			)}
 			{opportunities !== null && !error && opportunities.length > 0 && (
 				// Side by side once there's enough width for both to stay
@@ -123,6 +137,14 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 						onClose={() => setScannerOpen(false)}
 					/>
 				</Suspense>
+			)}
+
+			{showCreateModal && (
+				<CreateVolunteerOpportunityModal
+					organizationId={organizationId}
+					onClose={() => setShowCreateModal(false)}
+					onSuccess={onOpportunityCreated}
+				/>
 			)}
 		</WidgetCard>
 	);

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -81,7 +81,7 @@ function QuickCheckInWidget({
 					compact
 					title={t("orgDashboard.quickCheckInNoOpportunities")}
 					action={{
-						label: t("orgOverview.createOpportunity"),
+						label: t("orgDashboard.emptyStateCreateAction"),
 						onClick: () => setShowCreateModal(true),
 					}}
 				/>

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -1,10 +1,12 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Spinner from "../../../components/Spinner";
 import ErrorBanner from "../../../components/ErrorBanner";
+import EmptyState from "../../../components/EmptyState";
+import CreateVolunteerOpportunityModal from "../../../components/CreateVolunteerOpportunityModal";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -25,16 +27,19 @@ interface Props {
 	organizationId: string;
 	refreshKey: number;
 	size: WidgetSizeClass;
+	onOpportunityCreated: (createdDraftId?: string) => void;
 }
 
 function UpcomingOpportunitiesWidget({
 	organizationId,
 	refreshKey,
 	size,
+	onOpportunityCreated,
 }: Props) {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const locale = resolveDateLocale(i18n.language);
+	const [showCreateModal, setShowCreateModal] = useState(false);
 
 	// Shared with QuickCheckInWidget, which fetches the same organization-wide
 	// opportunities on the same mount - see useSharedOrgFetch. Only one of the
@@ -90,9 +95,14 @@ function UpcomingOpportunitiesWidget({
 			)}
 			{error && <ErrorBanner message={t("orgDashboard.upcomingError")} />}
 			{items !== null && !error && items.length === 0 && (
-				<p className="text-sm text-gray-500">
-					{t("orgDashboard.upcomingEmpty")}
-				</p>
+				<EmptyState
+					compact
+					title={t("orgDashboard.upcomingEmpty")}
+					action={{
+						label: t("orgOverview.createOpportunity"),
+						onClick: () => setShowCreateModal(true),
+					}}
+				/>
 			)}
 			{items !== null && !error && items.length > 0 && (
 				<ul className="space-y-3">
@@ -153,6 +163,14 @@ function UpcomingOpportunitiesWidget({
 			>
 				{t("orgDashboard.upcomingViewAll")}
 			</Link>
+
+			{showCreateModal && (
+				<CreateVolunteerOpportunityModal
+					organizationId={organizationId}
+					onClose={() => setShowCreateModal(false)}
+					onSuccess={onOpportunityCreated}
+				/>
+			)}
 		</WidgetCard>
 	);
 }

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -99,7 +99,7 @@ function UpcomingOpportunitiesWidget({
 					compact
 					title={t("orgDashboard.upcomingEmpty")}
 					action={{
-						label: t("orgOverview.createOpportunity"),
+						label: t("orgDashboard.emptyStateCreateAction"),
 						onClick: () => setShowCreateModal(true),
 					}}
 				/>

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -285,6 +285,7 @@ export default function OrgDashboardPage() {
 						organizationId={organizationId}
 						refreshKey={refreshKey}
 						size={size}
+						onOpportunityCreated={handleOpportunityCreated}
 					/>
 				);
 			case "Calendar":
@@ -311,6 +312,7 @@ export default function OrgDashboardPage() {
 						organizationId={organizationId}
 						refreshKey={refreshKey}
 						size={size}
+						onOpportunityCreated={handleOpportunityCreated}
 					/>
 				);
 			case "SettingsIcon":


### PR DESCRIPTION
## What

`EmptyState` (the designed, centred "nothing here yet" component with an optional title/message/action) was bypassed by five bare, unstyled `<p>`/`<li>` empty states across the org dashboard and elsewhere. This adds a `compact` variant to `EmptyState` for tight widget/dropdown contexts and swaps all five sites over to it, giving the two dashboard widgets a "Create one" action that opens the create-opportunity modal directly.

## Why

Closes #1122

The organizer's dashboard - a brand-new organization's home screen - was entirely in the "unstyled grey paragraph" category, so a fresh org's dashboard widgets looked unfinished rather than intentionally empty, and offered no next action.

Changes:
- `EmptyState.tsx`: new `compact?: boolean` prop (smaller padding/type: `py-4` instead of `py-12`, `text-xs`/`text-sm` instead of `text-sm`/base, `size="sm"` action button, `type="button"` on the action) for the widget/dropdown context, where the default `py-12` doesn't fit.
- `UpcomingOpportunitiesWidget.tsx` / `QuickCheckInWidget.tsx`: bare `<p>` empty states replaced with compact `EmptyState` + a "Create one" action that opens `CreateVolunteerOpportunityModal` directly from the widget (same underlying pattern as the existing `CreateOpportunityWidget`), wired back through `OrgDashboardPage`'s existing `handleOpportunityCreated` callback so the widgets refetch after a successful create. The CTA is worded "Create one" rather than reusing `CreateOpportunityWidget`'s own "Create opportunity" label - CI caught a real strict-mode Playwright ambiguity from having two identically-labelled buttons on the same default dashboard (see Testing below), and it's better for a screen-reader user too.
- `AddWidgetModal.tsx` / `NotificationDropdown.tsx`: bare `<p>`/`<li>` empty states replaced with compact `EmptyState` (no action - "all widgets added" / "no notifications" have no next step).
- `OrganizationProfilePage.tsx`: the public "current needs" empty state ("No current opportunities available.") replaced with the standard (non-compact) `EmptyState`. The issue's other three cited sites (`OrganizationProfilePage.tsx`'s not-found branch, `UserProfilePage.tsx`, `VolunteerOpportunityDetailPage.tsx`) are not-found error states rather than empty states per the issue's own verifier note, so they were left as-is - `EmptyState` would be the wrong component there.

Per explicit instruction for this task, no release candidate was cut for this change.

## Testing

- `pnpm check` (tsc), `pnpm lint` (zero warnings), `pnpm format:write`, `pnpm test` (128 tests), `pnpm i18n:check` - all green.
- `dotnet build` + `dotnet format --verify-no-changes` on `VisualTests` - builds clean, no formatting violations.
- Added `OrgDashboardPage_EmptyOpportunitiesCreateOpportunityCta_AsOlaf_HasNoSeriousA11yViolations` to `backend/tests/VisualTests/AccessibilityTests.cs`: creates a fresh, zero-opportunity org and exercises the new "Create one" CTA (and the modal it opens) in both `UpcomingOpportunitiesWidget` and `QuickCheckInWidget`'s empty states via axe-core. The existing dashboard a11y tests all run against orgs that already have opportunities by the time the suite runs, so this branch was previously never scanned.
- First CI run caught a real regression: `OrganizationTests.Directory_ShowsOpenOpportunityCount_ForOrgWithPublishedOpportunity` creates a brand-new org and hit a Playwright strict-mode violation because the dashboard then showed *two* buttons labelled "Create opportunity" (the pre-existing `CreateOpportunityWidget` button plus this PR's new widget CTA, which originally reused the same label). Renamed the new CTA to "Create one" to disambiguate - fixed, pushed, and confirmed no other locale/lint/build regressions.

## Live verification

Skipped for this change - explicitly no release candidate was cut, so there is nothing on staging to verify against yet.

## Checklist

- [x] `/self-review` run and findings addressed (including a11y-check subagent - no blocking issues, two findings fixed: `type="button"` on the new CTA, and the VisualTests coverage gap above)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no doc-affecting behavior change)
