### PR TITLE
fix: unify loading states on skeletons for known-shape content

### DIFF
--- a/backend/tests/VisualTests/LoadingStateTests.cs
+++ b/backend/tests/VisualTests/LoadingStateTests.cs
@@ -75,19 +75,21 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task AdministrationPage_ShowsSpinnerForOrganizationsSection_WhileOrganizationsFetch()
+	public async Task AdministrationPage_ShowsLoadingSkeletonForOrganizationsSection_WhileOrganizationsFetch()
 	{
-		// Covers the shared Spinner component's contract (role="status", a
-		// visible label, an aria-hidden spin icon) used by every other
-		// converted loading spot in this diff (ProtectedRoute, OrgAppLayout,
-		// EngagementManagementPage, etc.) - they all render the exact same
-		// component, so exercising it once here is representative.
+		// Covers the shared Skeleton component's contract (role="status", a
+		// sr-only visible label, aria-hidden animate-pulse placeholder rows)
+		// used by every other converted loading spot in #1121 (BadgeGrid,
+		// OrgOpportunitiesPage, EngagementManagementPage, dashboard widgets,
+		// etc.) - they all render the same shape, so exercising it once here
+		// is representative. This test used to assert a Spinner here; #1121
+		// replaced it with a Skeleton since this list has a known shape.
 		//
 		// /admin/organizations was consolidated into /administration (single
 		// page, Organizations + Users sections stacked) after this test was
 		// written, backed by a real admin-wide GET /v1/admin/organizations
 		// instead of the old caller-scoped GET /v1/organizations - only the
-		// route/URL changed here, the Spinner contract being tested has not.
+		// route/URL changed here, the loading contract being tested has not.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
@@ -101,12 +103,17 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/administration");
 
-		// The Organizations section renders before the Users section, so its
-		// Spinner (the one actually delayed above) is the first [role='status'].
-		var loadingStatus = Page.Locator("[role='status']").First;
+		// See the comment in HomePage_ShowsLoadingSkeleton_WhileOpportunitiesFetch
+		// above on why this is scoped to ":has(.animate-pulse)" - AdministrationPage
+		// is lazy-loaded (#1403), so AppLayout's own Suspense fallback (a spinner,
+		// also role="status") briefly races this one for "first role='status' on
+		// the page". The Organizations section renders before the Users section,
+		// so its skeleton (the one actually delayed above) is the first match once
+		// that race resolves.
+		var loadingStatus = Page.Locator("[role='status']:has(.animate-pulse)").First;
 		await Expect(loadingStatus).ToBeVisibleAsync();
 		await Expect(loadingStatus).ToContainTextAsync("Loading");
-		await Expect(loadingStatus.Locator("svg.animate-spin")).ToBeVisibleAsync();
+		await Expect(loadingStatus.Locator(".animate-pulse")).Not.ToHaveCountAsync(0);
 
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 		await Expect(loadingStatus).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -3,7 +3,7 @@ import type {
 	AchievementSummary,
 	BadgeCatalogEntry,
 } from "../client/api-client";
-import Spinner from "./Spinner";
+import Skeleton from "./Skeleton";
 import { resolveDateLocale } from "../lib/format";
 
 const TYPE_ICON: Record<string, string> = {
@@ -127,8 +127,14 @@ export default function BadgeGrid({
 
 	if (loading) {
 		return (
-			<div className="flex items-center justify-center py-6">
-				<Spinner label={t("achievements.loading")} size="sm" />
+			<div
+				role="status"
+				className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6"
+			>
+				<span className="sr-only">{t("achievements.loading")}</span>
+				{Array.from({ length: 6 }).map((_, i) => (
+					<Skeleton key={i} className="h-28 w-full" />
+				))}
 			</div>
 		);
 	}

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -8,6 +8,7 @@ import type {
 import { orgTabPath } from "../../lib/orgTabs";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 import CreateOrganizationModal from "../CreateOrganizationModal";
+import Skeleton from "../Skeleton";
 
 export default function OrganizationSwitcher({
 	currentOrgId,
@@ -49,7 +50,7 @@ export default function OrganizationSwitcher({
 	}
 
 	if (loading) {
-		return <div className="h-9 w-48 animate-pulse rounded-lg bg-gray-100" />;
+		return <Skeleton className="h-9 w-48 rounded-lg" />;
 	}
 
 	return (

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -16,7 +16,7 @@ import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import Chip from "../components/Chip";
-import Spinner from "../components/Spinner";
+import Skeleton from "../components/Skeleton";
 import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
@@ -114,8 +114,20 @@ function OrganizationsSection() {
 
 	if (loading) {
 		return (
-			<div className="flex items-center justify-center py-16">
-				<Spinner label={t("administration.organizations.loading")} />
+			<div
+				role="status"
+				className="overflow-hidden rounded-card border border-gray-200"
+			>
+				<span className="sr-only">
+					{t("administration.organizations.loading")}
+				</span>
+				<div className="divide-y divide-gray-100">
+					{Array.from({ length: 5 }).map((_, i) => (
+						<div key={i} aria-hidden="true" className="px-4 py-3">
+							<Skeleton className="h-4 w-1/3" />
+						</div>
+					))}
+				</div>
 			</div>
 		);
 	}
@@ -283,8 +295,23 @@ function UsersSection() {
 			</p>
 
 			{loading ? (
-				<div className="flex items-center justify-center py-16">
-					<Spinner label={t("administration.users.loading")} />
+				<div
+					role="status"
+					className="overflow-hidden rounded-card border border-gray-200"
+				>
+					<span className="sr-only">{t("administration.users.loading")}</span>
+					<div className="divide-y divide-gray-100">
+						{Array.from({ length: 5 }).map((_, i) => (
+							<div
+								key={i}
+								aria-hidden="true"
+								className="flex items-center gap-3 px-4 py-3"
+							>
+								<Skeleton className="h-4 w-1/3" />
+								<Skeleton className="h-4 w-16 rounded-full" />
+							</div>
+						))}
+					</div>
 				</div>
 			) : error ? (
 				<ErrorBanner message={error} />
@@ -529,8 +556,19 @@ function ReportsSection() {
 
 	if (loading) {
 		return (
-			<div className="flex items-center justify-center py-16">
-				<Spinner label={t("administration.reports.loading")} />
+			<div
+				role="status"
+				className="overflow-hidden rounded-card border border-gray-200"
+			>
+				<span className="sr-only">{t("administration.reports.loading")}</span>
+				<div className="divide-y divide-gray-100">
+					{Array.from({ length: 5 }).map((_, i) => (
+						<div key={i} aria-hidden="true" className="space-y-2 px-4 py-3">
+							<Skeleton className="h-4 w-1/2" />
+							<Skeleton className="h-3 w-2/3" />
+						</div>
+					))}
+				</div>
 			</div>
 		);
 	}
@@ -727,8 +765,11 @@ function ReportHistoryModal({
 			{loadError ? (
 				<ErrorBanner message={loadError} />
 			) : entries === null ? (
-				<div className="flex justify-center py-8">
-					<Spinner label={t("administration.reports.loading")} />
+				<div role="status" className="space-y-3">
+					<span className="sr-only">{t("administration.reports.loading")}</span>
+					{Array.from({ length: 3 }).map((_, i) => (
+						<Skeleton key={i} className="h-14 w-full" />
+					))}
 				</div>
 			) : (
 				<ul className="max-h-96 space-y-3 overflow-y-auto">

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -11,7 +11,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
-import Spinner from "../components/Spinner";
+import Skeleton from "../components/Skeleton";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
@@ -393,8 +393,18 @@ export default function EngagementManagementPage() {
 			</div>
 
 			{loading && (
-				<div className="flex items-center justify-center py-16">
-					<Spinner label={t("engagementManagement.loading")} />
+				<div role="status" className="space-y-3">
+					<span className="sr-only">{t("engagementManagement.loading")}</span>
+					{Array.from({ length: 3 }).map((_, i) => (
+						<div
+							key={i}
+							aria-hidden="true"
+							className="space-y-2 rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting"
+						>
+							<Skeleton className="h-4 w-1/3" />
+							<Skeleton className="h-3 w-1/2" />
+						</div>
+					))}
 				</div>
 			)}
 			{error && (

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -7,7 +7,7 @@ import OrganizationProfileView from "../components/OrganizationProfileView";
 import ReportContentModal, {
 	type ReportReason,
 } from "../components/ReportContentModal";
-import Spinner from "../components/Spinner";
+import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
 import { useApiClient } from "../hooks/useApiClient";
 import { formatOccurrence, formatParticipationType } from "../lib/format";
@@ -46,8 +46,22 @@ export default function OrganizationProfilePage() {
 
 	if (loading)
 		return (
-			<div className="flex items-center justify-center py-16">
-				<Spinner label={t("orgProfile.loading")} />
+			<div role="status">
+				<span className="sr-only">{t("orgProfile.loading")}</span>
+				<div className="mb-6 flex items-center gap-4">
+					<Skeleton className="h-16 w-16 shrink-0 rounded-full" />
+					<Skeleton className="h-6 w-48" />
+				</div>
+				<div className="max-w-2xl">
+					<Skeleton className="mb-2 h-4 w-full" />
+					<Skeleton className="mb-6 h-4 w-2/3" />
+					<Skeleton className="mb-3 h-3 w-32" />
+					<div className="space-y-3">
+						{Array.from({ length: 2 }).map((_, i) => (
+							<Skeleton key={i} className="h-20 w-full" />
+						))}
+					</div>
+				</div>
 			</div>
 		);
 	if (error)

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -9,7 +9,7 @@ import type {
 import BadgeGrid from "../components/BadgeGrid";
 import ProfileFieldsView from "../components/ProfileFieldsView";
 import ReportFlagButton from "../components/ReportFlagButton";
-import Spinner from "../components/Spinner";
+import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -47,8 +47,21 @@ export default function UserProfilePage() {
 
 	if (loading)
 		return (
-			<div className="flex items-center justify-center py-16">
-				<Spinner label={t("userProfile.loading")} />
+			<div role="status">
+				<span className="sr-only">{t("userProfile.loading")}</span>
+				<div className="mb-8 flex items-center gap-4">
+					<Skeleton className="h-16 w-16 shrink-0 rounded-full" />
+					<div className="space-y-2">
+						<Skeleton className="h-6 w-40" />
+						<Skeleton className="h-4 w-32" />
+					</div>
+				</div>
+				<Skeleton className="mb-4 h-4 w-32" />
+				<div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
+					{Array.from({ length: 6 }).map((_, i) => (
+						<Skeleton key={i} className="h-28 w-full" />
+					))}
+				</div>
 			</div>
 		);
 	if (error) return <ErrorBanner message={error} />;

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -15,7 +15,7 @@ import { enUS, de } from "date-fns/locale";
 import type { OrganizationCalendarEventDto } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import Modal from "../../../components/Modal";
-import Spinner from "../../../components/Spinner";
+import Skeleton from "../../../components/Skeleton";
 import Button from "../../../components/Button";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
@@ -345,8 +345,18 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 			[] run found a null ref and never got a second chance to attach. */}
 			<div ref={calendarContainerRef} className="contents">
 				{calLoading && (
-					<div className="flex items-center justify-center py-16">
-						<Spinner label={t("orgOverview.calendarLoading")} />
+					<div role="status" className="space-y-3">
+						<span className="sr-only">{t("orgOverview.calendarLoading")}</span>
+						<div
+							aria-hidden="true"
+							className="flex items-center justify-between gap-2"
+						>
+							<Skeleton className="h-6 w-32" />
+							<Skeleton className="h-6 w-24" />
+						</div>
+						{Array.from({ length: 3 }).map((_, i) => (
+							<Skeleton key={i} className="h-10 w-full" />
+						))}
 					</div>
 				)}
 				{calError && (

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import { dispatchToast } from "../../../lib/toastBus";
-import Spinner from "../../../components/Spinner";
+import Skeleton from "../../../components/Skeleton";
 import Button from "../../../components/Button";
 import Dropdown from "../../../components/Dropdown";
 import ErrorBanner from "../../../components/ErrorBanner";
@@ -64,7 +64,20 @@ function QuickCheckInWidget({ organizationId, refreshKey, size }: Props) {
 			title={t("orgDashboard.quickCheckInWidgetTitle")}
 		>
 			{opportunities === null && !error && (
-				<Spinner label={t("orgDashboard.loading")} size="sm" />
+				<div
+					role="status"
+					className={
+						size !== "compact" ? "flex items-center gap-3" : "space-y-3"
+					}
+				>
+					<span className="sr-only">{t("orgDashboard.loading")}</span>
+					<Skeleton
+						className={`h-9 rounded-xl ${size !== "compact" ? "min-w-0 flex-1" : "w-full"}`}
+					/>
+					<Skeleton
+						className={`h-9 rounded-lg ${size !== "compact" ? "w-24 shrink-0" : "w-full"}`}
+					/>
+				</div>
 			)}
 			{error && <ErrorBanner message={error} />}
 			{opportunities !== null && !error && opportunities.length === 0 && (

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../../hooks/useApiClient";
-import Spinner from "../../../components/Spinner";
+import Skeleton from "../../../components/Skeleton";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import type { WidgetSizeClass } from "./widgetCatalog";
@@ -46,7 +46,24 @@ function ToDoWidget({ organizationId, size }: Props) {
 			titleId="widget-todo-title"
 			title={t("orgDashboard.todoWidgetTitle")}
 		>
-			{loading && <Spinner label={t("orgDashboard.loading")} />}
+			{loading && (
+				<div
+					role="status"
+					className={
+						size === "compact" ? "space-y-4" : "grid grid-cols-2 gap-4"
+					}
+				>
+					<span className="sr-only">{t("orgDashboard.loading")}</span>
+					<div aria-hidden="true" className="space-y-2">
+						<Skeleton className="h-8 w-12" />
+						<Skeleton className="h-3 w-24" />
+					</div>
+					<div aria-hidden="true" className="space-y-2">
+						<Skeleton className="h-8 w-12" />
+						<Skeleton className="h-3 w-24" />
+					</div>
+				</div>
+			)}
 			{!loading && error && <ErrorBanner message={error} />}
 			{!loading && !error && kpis && (
 				// Side by side once there's room for two columns to breathe;

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
-import Spinner from "../../../components/Spinner";
+import Skeleton from "../../../components/Skeleton";
 import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
@@ -86,7 +86,19 @@ function UpcomingOpportunitiesWidget({
 			title={t("orgDashboard.upcomingWidgetTitle")}
 		>
 			{items === null && !error && (
-				<Spinner label={t("orgDashboard.upcomingLoading")} />
+				<div role="status" className="space-y-3">
+					<span className="sr-only">{t("orgDashboard.upcomingLoading")}</span>
+					{Array.from({ length: 3 }).map((_, i) => (
+						<div
+							key={i}
+							aria-hidden="true"
+							className="rounded-xl border border-gray-100 p-3"
+						>
+							<Skeleton className="h-4 w-2/3" />
+							{size !== "compact" && <Skeleton className="mt-2 h-3 w-1/2" />}
+						</div>
+					))}
+				</div>
 			)}
 			{error && <ErrorBanner message={t("orgDashboard.upcomingError")} />}
 			{items !== null && !error && items.length === 0 && (

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -13,7 +13,7 @@ import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
-import Spinner from "../../components/Spinner";
+import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
 import ErrorBanner from "../../components/ErrorBanner";
 import LoadMoreError from "../../components/LoadMoreError";
@@ -516,8 +516,22 @@ export default function OrgOpportunitiesPage() {
 	return (
 		<div>
 			{initialLoading && !anyError && (
-				<div className="flex items-center justify-center py-16">
-					<Spinner label={t("orgOpportunities.loading")} />
+				<div
+					role="status"
+					className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+				>
+					<span className="sr-only">{t("orgOpportunities.loading")}</span>
+					{Array.from({ length: 3 }).map((_, i) => (
+						<div
+							key={i}
+							aria-hidden="true"
+							className="space-y-2 rounded-card border border-gray-100 bg-white p-4 shadow-resting"
+						>
+							<Skeleton className="h-4 w-2/3" />
+							<Skeleton className="h-3 w-1/2" />
+							<Skeleton className="h-3 w-1/3" />
+						</div>
+					))}
 				</div>
 			)}
 


### PR DESCRIPTION
## What

Adopts one consistent rule for loading states across the frontend: skeletons for content with a known shape (lists, grids, detail pages, dashboard widgets), spinners reserved for genuinely indeterminate states (auth gating, lazy route/modal chunk loading, where the destination's shape isn't known yet).

## Why

`Spinner`, `Skeleton`, and one bespoke pulse `div` were being chosen per-page with no consistent rule, so navigating between pages (e.g. the organizations list's skeleton rows into an organization profile's centered spinner) felt like two different products, and spinner sites caused a layout jump when content landed instead of previewing the eventual shape.

Closes #1121

## Changes

- `OrganizationProfilePage.tsx`, `UserProfilePage.tsx`: detail-page spinner -> skeleton matching the real layout (avatar/logo, name, description, list/grid below).
- `AdministrationPage.tsx` (organizations, users, reports tabs + the report-history modal), `EngagementManagementPage.tsx`, `OrgOpportunitiesPage.tsx`: list/grid loading spinners -> skeleton rows/cards matching each list's real shape.
- `BadgeGrid.tsx`: spinner -> skeleton grid matching the real badge-tile layout (used by both `UserProfilePage` and the achievements pages).
- Dashboard widgets (`ToDoWidget`, `UpcomingOpportunitiesWidget`, `QuickCheckInWidget`, `CalendarWidget`): spinner -> skeleton matching each widget's own content shape.
- `OrganizationSwitcher.tsx`: replaced the bespoke `bg-gray-100`/`rounded-lg` pulse `div` (a visibly different shade from the shared `Skeleton`'s `bg-gray-200`/`rounded-md`) with the shared `Skeleton` component.
- Left as spinners (intentional, not an oversight): `ProtectedRoute` (auth gate, no shell mounted yet), `AppLayout`/`OrgAppLayout` Suspense fallbacks and `ModalLoadingFallback` (lazy route/modal chunk of unknown shape), `CheckInModal`/`QRScannerModal` (small in-place modal actions, not flagged in the issue). `VolunteerOpportunitiesList.tsx`'s "near me" button already reused the shared `SpinnerIcon` rather than a hand-rolled SVG - that part of the issue was already fixed by an earlier, unrelated change.
- Every new skeleton block keeps the same accessible loading announcement the `Spinner` it replaces gave screen-reader users: a `role="status"` wrapper with a `sr-only` span carrying the same translation key `Spinner`'s `label` prop used to render visibly.

## Testing

- `pnpm lint` (zero warnings), `pnpm check` (tsc), `pnpm i18n:check`, `pnpm test` (128 tests), `pnpm build` - all pass locally.
- No new translation keys were needed; every skeleton reuses the same `t(...)` key the `Spinner` it replaces already used.
- Manually reviewed an independent `a11y-check` pass on the diff for live-region/duplication issues - none found.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. This is a purely visual/markup change (Spinner/skeleton swap, same data-fetching logic, same conditional rendering), verified locally via the full lint/typecheck/i18n/unit-test/build suite above. No new `backend/tests/VisualTests/` assertions were added since no new page/route was introduced - only internal loading-state markup on existing, already-tested pages.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change, no docs to update)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACLvCRs2icJEE7P8JoK6EQ)_