### PR TITLE
fix: align opportunity wizard modal chrome with the shared Modal/Button system

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -21,11 +21,14 @@ const BASE_CLASSES =
 // primary: solid brand-color CTA. secondary: borderless cancel/close action -
 // the single style every modal's cancel/close button should share (see
 // issue #847: three different visual treatments for the same action before
-// this existed).
+// this existed). tertiary: borderless brand-color action for a secondary CTA
+// alongside a primary one (e.g. "Save draft" next to "Publish") - distinct
+// from `secondary` since it needs to read as an action, not a dismissal.
 const VARIANT_CLASSES = {
 	primary: "bg-brand-700 font-semibold text-white hover:bg-brand-800",
 	secondary: "text-gray-600 hover:bg-gray-100",
 	danger: "bg-red-600 font-semibold text-white hover:bg-red-700",
+	tertiary: "font-semibold text-brand-700 hover:bg-brand-50",
 } as const;
 
 type Variant = keyof typeof VARIANT_CLASSES;

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -913,7 +913,6 @@ export default function CreateVolunteerOpportunityModal({
 				labelledBy="create-opportunity-dialog-title"
 				maxWidth="max-w-xl"
 				className="flex min-w-0 flex-col overflow-hidden rounded-card bg-white shadow-modal"
-				backdropClassName="bg-black/60 backdrop-blur-sm"
 				suspended={
 					showDiscardConfirm ||
 					pendingSlotEdit !== null ||
@@ -929,7 +928,7 @@ export default function CreateVolunteerOpportunityModal({
 				<div className="flex items-center justify-between gap-4 border-b border-gray-100 px-6 py-4">
 					<h2
 						id="create-opportunity-dialog-title"
-						className="text-lg font-bold text-gray-900"
+						className="text-lg font-semibold text-gray-900"
 					>
 						{isEditMode
 							? t("createOpportunity.editTitle")
@@ -1061,30 +1060,30 @@ export default function CreateVolunteerOpportunityModal({
 
 				{/* Footer navigation */}
 				<div className="flex items-center justify-between gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4">
-					<button
+					<Button
 						type="button"
+						variant="secondary"
 						data-testid="modal-cancel"
 						onClick={() => (step > 1 ? setStep((s) => s - 1) : requestClose())}
-						className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
 					>
 						{step === 1
 							? t("createOpportunity.cancel")
 							: t("createOpportunity.back")}
-					</button>
+					</Button>
 
 					<div className="flex items-center gap-2">
 						{canSaveDraft && (
-							<button
+							<Button
 								type="button"
+								variant="tertiary"
 								data-testid="modal-save-draft"
 								disabled={submitting !== null}
 								onClick={() => void submit(true)}
-								className="rounded-xl px-4 py-2 text-sm font-semibold text-brand-700 transition hover:bg-brand-50 disabled:opacity-40"
 							>
 								{submitting === "draft"
 									? t("createOpportunity.savingDraft")
 									: t("createOpportunity.saveDraft")}
-							</button>
+							</Button>
 						)}
 						{step < TOTAL_STEPS ? (
 							<Button

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -35,7 +35,7 @@ export default function LanguageSelector({
 			>
 				<span
 					aria-hidden="true"
-					className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
+					className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
 				>
 					{current.short}
 				</span>
@@ -89,7 +89,7 @@ export default function LanguageSelector({
 							>
 								<span
 									aria-hidden="true"
-									className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${
+									className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${
 										transparent
 											? lang.code === currentCode
 												? "border-white/50 text-white"


### PR DESCRIPTION
## What

Aligns `CreateVolunteerOpportunityModal`'s chrome with the rest of the app's modals: drops its one-off backdrop blur override, matches the shared title weight, and routes its footer Cancel/Save Draft buttons through the shared `Button` component instead of hand-rolled classes.

## Why

Closes #1114

Of the modal shell divergences the issue originally flagged, most (`rounded-2xl`/`shadow-2xl`, `CreateOrganizationModal`/`AddWidgetModal`'s radius/shadow) had already been resolved by an earlier design-token pass (`rounded-card`/`shadow-modal`) - confirmed by re-reading the current code rather than trusting the issue snapshot. What was still genuinely diverging:

- The wizard's `backdropClassName="bg-black/60 backdrop-blur-sm"` override vs. every other modal's default `bg-black/50` (no blur) - removed, now inherits `Modal`'s default.
- The wizard's title used `font-bold` where `ConfirmDialog`/`CheckInModal`/`QRScannerModal`/`AddWidgetModal` all use `font-semibold text-gray-900` - now matches.
- The footer's Cancel/Back and Save Draft buttons were plain `<button>`s with hand-written Tailwind classes instead of going through the shared `Button` component - contradicting issue #847's "one cancel style per modal" fix. Both now use `Button`: Cancel/Back uses the existing `secondary` variant, and Save Draft uses a new `tertiary` variant (borderless brand-color text action) added to `Button.tsx`, since the existing `secondary` (gray dismissal) variant didn't fit a save-as-draft action sitting next to the primary Publish/Next button.

Kept the change scoped to the fix: didn't undertake the issue's larger suggested `size`/`scrollable` Modal-prop refactor, since the verifier note on the issue itself confirmed `CreateOrganizationModal.tsx`/`AddWidgetModal.tsx`'s flex/max-h/overflow additions don't actually diverge visually from the Modal defaults - only the wizard's backdrop/title/buttons did.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest, 128 tests) - all green.
- `/self-review` run; delegated to the `a11y-check` subagent for the `.tsx` changes - no findings. Confirmed the existing `CreateVolunteerOpportunityModal_HasNoSeriousA11yViolations` Playwright/axe test in `backend/tests/VisualTests/AccessibilityTests.cs` already covers this modal (open + nested discard-confirm dialog stacked), and that `data-testid="modal-cancel"`/`"modal-save-draft"` (used by `VolunteerOpportunityTests.cs`, `AccessibilityTests.cs`, `OrganizationTests.cs`) pass through unchanged since `Button` spreads `...rest` onto the native element.

## Live verification

Not performed for this change - explicitly requested to skip cutting a release candidate for this fix. This is a scoped visual/markup change (backdrop class, title font-weight, two buttons swapped to the shared `Button` component) verified via lint/typecheck/unit tests and the existing automated a11y/E2E coverage above; no new C# TUnit visual test was added since the affected modal already has full axe coverage and no new behavior was introduced.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change, `Button.tsx`'s existing variant-purpose comment extended in place)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VSwnSRuZF6AZtEgkPK7z9M)_