### PR TITLE
fix: correct Tailwind class order in LanguageSelector

### DIFF
--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -35,7 +35,7 @@ export default function LanguageSelector({
 			>
 				<span
 					aria-hidden="true"
-					className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
+					className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
 				>
 					{current.short}
 				</span>
@@ -89,7 +89,7 @@ export default function LanguageSelector({
 							>
 								<span
 									aria-hidden="true"
-									className={`rounded border px-1 py-0.5 text-xs font-bold leading-none tracking-wide ${
+									className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${
 										transparent
 											? lang.code === currentCode
 												? "border-white/50 text-white"


### PR DESCRIPTION
## What

Corrects the order of two Tailwind utility classes (`font-bold`/`leading-none`) in `LanguageSelector.tsx` to match the `tailwindcss/classnames-order` convention.

## Why

`main`'s current HEAD fails its own `frontend.yml` lint job: `eslint . --max-warnings 0` scans the whole tree regardless of PR diff scope, and this file has a stray `classnames-order` violation that #1590 introduced after #1563's mass reformat landed (the reformat ran before #1590's edit touched this file, so the new class strings it added were never re-sorted). Because the check scans the entire repo, this isn't scoped to files a PR touches - it currently fails lint for *every* PR rebased onto `main`, not just ones that touch this file. Found while rebasing several other open PRs onto latest `main` for CI-green maintenance.

Closes #1590 lint regression (no tracking issue filed - trivial, mechanically verified fix).

## Testing

- `pnpm lint` - passes (was failing on `main` before this change)
- `pnpm run format:check` - passes
- `pnpm run check` (tsc) - passes
- `pnpm test` - 128/128 passing

## Live verification

Not applicable - pure Tailwind class-order fix (both classes were already present, only their order in the class-order-sensitive lint rule changed). Tailwind's generated stylesheet cascade doesn't depend on source string order, so there is no rendered-output or behavior change to observe on staging.

## Checklist

- [x] CI is green (see Testing above)
- [ ] Documentation updated if this change affects behavior - n/a, no behavior change


---
_Generated by [Claude Code](https://claude.ai/code/session_01MeJCpy8udGiYjB6AJKy46k)_