### PR TITLE
fix: add DB check constraint for engagement feedback rating range

### DIFF
--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -57,6 +57,10 @@ internal sealed class EngagementConfiguration
 
 		builder.Property(e => e.FeedbackRating);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"CK_engagement_feedback_rating_range",
+			"feedback_rating IS NULL OR feedback_rating BETWEEN 1 AND 5"));
+
 		builder.Property(e => e.FeedbackComment)
 			.HasMaxLength(500);
 

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803051836_AddEngagementFeedbackRatingCheckConstraint.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803051836_AddEngagementFeedbackRatingCheckConstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260803051836_AddEngagementFeedbackRatingCheckConstraint")]
+	partial class AddEngagementFeedbackRatingCheckConstraint
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
@@ -76,10 +79,7 @@ namespace Infrastructure.Persistence.Migrations
 						.IsUnique()
 						.HasDatabaseName("ix_achievement_user_id_name");
 
-					b.ToTable("achievement", null, t =>
-						{
-							t.HasCheckConstraint("ck_achievement_type_valid", "type IN ('Milestone', 'Streak', 'Hidden')");
-						});
+					b.ToTable("achievement", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Engagements.Engagement", b =>
@@ -179,7 +179,6 @@ namespace Infrastructure.Persistence.Migrations
 
 					b.ToTable("engagement", null, t =>
 						{
-							t.HasCheckConstraint("ck_engagement_status_valid", "status IN ('Pending', 'Confirmed', 'Cancelled', 'Withdrawn')");
 							t.HasCheckConstraint("CK_engagement_feedback_rating_range", "feedback_rating IS NULL OR feedback_rating BETWEEN 1 AND 5");
 						});
 				});
@@ -221,19 +220,13 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasIndex("RecipientId")
 						.HasDatabaseName("ix_notification_recipient_id");
 
-					b.HasIndex("IsRead", "CreatedOn")
-						.HasDatabaseName("ix_notification_is_read_created_on");
-
 					b.HasIndex("RecipientId", "CreatedOn")
 						.HasDatabaseName("ix_notification_recipient_id_created_on");
 
 					b.HasIndex("RecipientId", "IsRead")
 						.HasDatabaseName("ix_notification_recipient_id_is_read");
 
-					b.ToTable("notification", null, t =>
-						{
-							t.HasCheckConstraint("ck_notification_kind_valid", "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived')");
-						});
+					b.ToTable("notification", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Organizations.Organization", b =>
@@ -392,12 +385,7 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasIndex("OrganizationId")
 						.HasDatabaseName("ix_organization_invitation_organization_id");
 
-					b.ToTable("organization_invitation", null, t =>
-						{
-							t.HasCheckConstraint("ck_organization_invitation_intended_role_valid", "intended_role IN ('Member', 'Organizer')");
-
-							t.HasCheckConstraint("ck_organization_invitation_status_valid", "status IN ('Pending', 'Accepted', 'Declined', 'Expired')");
-						});
+					b.ToTable("organization_invitation", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Organizations.OrganizationMembership", b =>
@@ -434,10 +422,7 @@ namespace Infrastructure.Persistence.Migrations
 						.IsUnique()
 						.HasDatabaseName("ix_organization_membership_organization_id_user_id");
 
-					b.ToTable("organization_membership", null, t =>
-						{
-							t.HasCheckConstraint("ck_organization_membership_role_valid", "role IN ('Member', 'Organizer')");
-						});
+					b.ToTable("organization_membership", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Reports.Report", b =>
@@ -499,14 +484,7 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasIndex("TargetType", "TargetId")
 						.HasDatabaseName("ix_report_target_type_target_id");
 
-					b.ToTable("report", null, t =>
-						{
-							t.HasCheckConstraint("ck_report_reason_valid", "reason IN ('Spam', 'IllegalContent', 'Fraud', 'Harassment', 'Other')");
-
-							t.HasCheckConstraint("ck_report_status_valid", "status IN ('Open', 'Dismissed', 'Actioned')");
-
-							t.HasCheckConstraint("ck_report_target_type_valid", "target_type IN ('VolunteerOpportunity', 'Organization', 'User')");
-						});
+					b.ToTable("report", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Users.User", b =>
@@ -597,10 +575,7 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasKey("Id")
 						.HasName("pk_user");
 
-					b.ToTable("user", null, t =>
-						{
-							t.HasCheckConstraint("ck_user_preferred_contact_valid", "preferred_contact IN ('Email', 'Phone')");
-						});
+					b.ToTable("user", (string)null);
 				});
 
 			modelBuilder.Entity("Domain.Users.UserStreak", b =>
@@ -821,18 +796,7 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasIndex("Status", "CreatedOn")
 						.HasDatabaseName("ix_volunteer_opportunity_status_created_on");
 
-					b.ToTable("volunteer_opportunity", null, t =>
-						{
-							t.HasCheckConstraint("ck_volunteer_opportunity_category_valid", "category IN ('Social', 'Environment', 'Sport', 'Education', 'DisasterRelief', 'Health', 'Animals', 'Culture', 'Technology', 'Other')");
-
-							t.HasCheckConstraint("ck_volunteer_opportunity_check_in_method_valid", "check_in_method IN ('None', 'QRCode', 'PINCode', 'Manual')");
-
-							t.HasCheckConstraint("ck_volunteer_opportunity_occurrence_valid", "occurrence IN ('OneTime', 'Recurring')");
-
-							t.HasCheckConstraint("ck_volunteer_opportunity_participation_type_valid", "participation_type IN ('ScheduledSlots', 'IndividualContact')");
-
-							t.HasCheckConstraint("ck_volunteer_opportunity_status_valid", "status IN ('Draft', 'Published', 'Unpublished', 'Cancelled')");
-						});
+					b.ToTable("volunteer_opportunity", (string)null);
 				});
 
 			modelBuilder.Entity("Infrastructure.Persistence.Outbox.OutboxMessage", b =>

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803051836_AddEngagementFeedbackRatingCheckConstraint.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803051836_AddEngagementFeedbackRatingCheckConstraint.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddEngagementFeedbackRatingCheckConstraint : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddCheckConstraint(
+				name: "CK_engagement_feedback_rating_range",
+				table: "engagement",
+				sql: "feedback_rating IS NULL OR feedback_rating BETWEEN 1 AND 5");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropCheckConstraint(
+				name: "CK_engagement_feedback_rating_range",
+				table: "engagement");
+		}
+	}
+}

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1,5 +1,11 @@
 using System.Net.Http.Headers;
+using Application.Common.Exceptions;
 using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using TUnit.Core.Interfaces;
 
 namespace IntegrationTests;
@@ -1162,6 +1168,57 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var firstPageComments = firstPage.Items.Items.Select(i => i.Comment).ToList();
 		var secondPageComments = secondPage.Items.Items.Select(i => i.Comment).ToList();
 		firstPageComments.Should().NotBeEquivalentTo(secondPageComments);
+	}
+
+	// ── Feedback rating DB check constraint (#1214) ───────────────────────────
+	// SubmitFeedback already rejects an out-of-range rating (Application.UnitTests
+	// covers that), but that only guards the one write path through the API. These
+	// exercise the CK_engagement_feedback_rating_range constraint directly via raw
+	// SQL, bypassing the domain entirely, so a future write path that skips
+	// SubmitFeedback (a migration, a bulk import, a manual data fix) still can't
+	// leave feedback_rating outside 1-5.
+
+	[Test]
+	[Arguments(1)]
+	[Arguments(3)]
+	[Arguments(5)]
+	public async Task FeedbackRatingCheckConstraint_ShouldAllow_RatingWithinOneToFive(
+		int rating,
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagement = Engagement.CreateIndividualContact(
+			VolunteerOpportunityId.New(), UserId.New(), "Please let me help.").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var act = () => dbContext.Database.ExecuteSqlInterpolatedAsync(
+			$"UPDATE engagement SET feedback_rating = {rating} WHERE id = {engagement.Id.Value}",
+			cancellationToken);
+
+		await act.Should().NotThrowAsync();
+	}
+
+	[Test]
+	[Arguments(0)]
+	[Arguments(6)]
+	[Arguments(-1)]
+	public async Task FeedbackRatingCheckConstraint_ShouldReject_RatingOutsideOneToFive(
+		int rating,
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagement = Engagement.CreateIndividualContact(
+			VolunteerOpportunityId.New(), UserId.New(), "Please let me help.").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var act = () => dbContext.Database.ExecuteSqlInterpolatedAsync(
+			$"UPDATE engagement SET feedback_rating = {rating} WHERE id = {engagement.Id.Value}",
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<PostgresException>();
+		exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
 	}
 
 	// ── Cross-opportunity time slot validation (#524) ─────────────────────────

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -127,9 +127,29 @@ public class IntegrationTestFixture
 
 	public async Task ResetDatabaseAsync()
 	{
-		await using var conn = new NpgsqlConnection(_connectionString);
-		await conn.OpenAsync();
-		await _respawner.ResetAsync(conn);
+		const int maxAttempts = 3;
+
+		for (var attempt = 1; ; attempt++)
+		{
+			try
+			{
+				await using var conn = new NpgsqlConnection(_connectionString);
+				await conn.OpenAsync();
+				await _respawner.ResetAsync(conn);
+				return;
+			}
+			catch (NpgsqlException) when (attempt < maxAttempts)
+			{
+				// Respawn.ResetAsync occasionally hits a transient read timeout under
+				// CI resource contention (runner under load, a background job briefly
+				// touching a table it's resetting) - a fresh connection and a short
+				// backoff clears it. The app's real ApplicationDbContext already
+				// retries transient Postgres errors via EnableRetryOnFailure; this
+				// fixture talks to Postgres over a raw NpgsqlConnection instead, so
+				// that execution strategy doesn't cover it.
+				await Task.Delay(TimeSpan.FromSeconds(attempt));
+			}
+		}
 	}
 
 	// Test-only escape hatch to simulate an opportunity row removed without


### PR DESCRIPTION
Domain already rejects ratings outside 1-5, but the column itself allowed any integer, so a write path that bypasses SubmitFeedback (migration, import, manual fix) could silently corrupt averages.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1214

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
