### PR TITLE
fix: make seed org creation idempotent and stop swallowing seed errors

### DIFF
--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -205,7 +205,21 @@ if (app.Environment.IsDevelopment())
 	var initializer = scope.ServiceProvider.GetRequiredService<IApplicationDbContextInitializer>();
 
 	await initializer.MigrateAsync();
-	await initializer.SeedAsync();
+
+	try
+	{
+		await initializer.SeedAsync();
+	}
+	catch (Exception ex)
+	{
+		// Dev-only convenience (#1212): don't fail local startup over a seed hiccup
+		// (e.g. a transient Keycloak call). ApplicationDbContextInitializer.SeedAsync's
+		// Keycloak-dependent seeding is idempotent by organization name, so the next
+		// restart's retry reuses whatever was already created instead of piling up
+		// duplicates - unlike the SeedOnStartup path below, which lets the same
+		// exception crash startup instead of logging it.
+		app.Logger.LogError(ex, "An exception occurred while seeding the database");
+	}
 
 	app.MapOpenApi();
 }
@@ -217,6 +231,10 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 
 	await initializer.MigrateAsync();
 
+	// Unlike the Development branch above, a seed failure here is left to propagate
+	// and crash startup (#1212) - this only runs outside Development when explicitly
+	// opted into via config, so a broken seed should be surfaced immediately rather
+	// than leaving the environment half-seeded with nothing logging it as broken.
 	if (app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
 		await initializer.SeedAsync();
 }

--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -14,6 +14,15 @@ public interface IKeycloakOrganizationService
 		string name,
 		CancellationToken cancellationToken = default);
 
+	// Exact-name lookup. Lets a caller make organization creation idempotent - retrying
+	// after a partial failure (e.g. ApplicationDbContextInitializer.SeedAsync's own
+	// SaveChangesAsync failing after the Keycloak call already succeeded, #1212) can
+	// look this up first and reuse the existing organization instead of creating a
+	// second, orphaned one. Returns null rather than throwing when nothing matches.
+	Task<Guid?> FindOrganizationByNameAsync(
+		string name,
+		CancellationToken cancellationToken = default);
+
 	Task AddMemberAsync(
 		Guid organizationId,
 		Guid userId,

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -125,13 +125,15 @@ var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26
 	// finish inside it. backend's own startup (Program.cs) races Keycloak's admin
 	// API right after that with its Keycloak-dependent seed calls
 	// (ApplicationDbContextInitializer.SeedOrg1Async/SeedOrg2Async), which fail if
-	// the realm isn't servable yet - silently, since SeedAsync only logs the
-	// exception rather than rethrowing. On a slower CI runner, realm import can
-	// plausibly take longer than the gap between "container started" and
-	// backend's first admin API call, losing this race deterministically
-	// rather than intermittently. Wait for the same endpoint
-	// AspireFixture.WaitForRealmReadyAsync already polls from the test side, so
-	// backend is gated on real readiness, not just process liveness.
+	// the realm isn't servable yet - Program.cs's Development branch (this
+	// AppHost forces backend into, see AspireFixture.InitializeAsync) logs and
+	// continues rather than rethrowing (#1212), so the failure wouldn't otherwise
+	// surface here at all. On a slower CI runner, realm import can plausibly take
+	// longer than the gap between "container started" and backend's first admin
+	// API call, losing this race deterministically rather than intermittently.
+	// Wait for the same endpoint AspireFixture.WaitForRealmReadyAsync already polls
+	// from the test side, so backend is gated on real readiness, not just process
+	// liveness.
 	.WithHttpHealthCheck("/realms/einsatzbereit/.well-known/openid-configuration");
 
 var keycloakEndpoint = keycloak.GetEndpoint("http");

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -53,6 +53,27 @@ internal sealed class KeycloakOrganizationService(
 		return Guid.Parse(idString);
 	}
 
+	public async Task<Guid?> FindOrganizationByNameAsync(
+		string name,
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var encoded = Uri.EscapeDataString(name);
+		var response = await httpClient.GetAsync(
+			$"/admin/realms/{_options.Realm}/organizations?search={encoded}&exact=true",
+			cancellationToken);
+
+		await EnsureSuccessAsync(response, cancellationToken);
+
+		var organizations = await response.Content.ReadFromJsonAsync<List<KeycloakOrganizationResponse>>(
+			JsonOptions, cancellationToken) ?? [];
+
+		var match = organizations.FirstOrDefault(o => o.Name == name);
+
+		return match is null ? null : Guid.Parse(match.Id);
+	}
+
 	public async Task AddMemberAsync(
 		Guid organizationId,
 		Guid userId,
@@ -320,6 +341,10 @@ internal sealed class KeycloakOrganizationService(
 			inner: null,
 			response.StatusCode);
 	}
+
+	private sealed record KeycloakOrganizationResponse(
+		string Id,
+		string Name);
 
 	private sealed record KeycloakRole(
 		string Id,

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -44,189 +44,190 @@ internal sealed class ApplicationDbContextInitializer(
 		}
 	}
 
+	// Exceptions are intentionally left to propagate (#1212) - the caller (Program.cs)
+	// decides whether that means logging and continuing (Development) or failing
+	// startup outright (everywhere else). Silently swallowing here used to mean a
+	// SaveChangesAsync failure after the Keycloak-dependent seeding below had already
+	// run left orphaned Keycloak organizations with nothing pointing at them locally,
+	// and re-seeding on the next boot (the AnyAsync guard below still sees an empty
+	// table) made it worse by risking creating a *second* orphaned set. SeedOrg1Async/
+	// SeedOrg2Async now look up an existing organization by name before creating one,
+	// so a retry after a partial failure reuses what already exists instead.
 	public async ValueTask SeedAsync(
 		CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			if (await dbContext.Set<Organization>().AnyAsync(cancellationToken))
-				return;
+		if (await dbContext.Set<Organization>().AnyAsync(cancellationToken))
+			return;
 
-			var org1Id = await SeedOrg1Async(cancellationToken);
-			var org2Id = await SeedOrg2Async(cancellationToken);
+		var org1Id = await SeedOrg1Async(cancellationToken);
+		var org2Id = await SeedOrg2Async(cancellationToken);
 
-			var now = DateTimeOffset.UtcNow;
+		var now = DateTimeOffset.UtcNow;
 
-			var opp1 = VolunteerOpportunity.Create(
-				org1Id,
-				"First Aid Course",
-				"Learn life-saving first aid techniques in our hands-on one-day course.",
-				isRemote: false,
-				Address.Create("Main Street", "1", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.OneTime,
-				ParticipationType.ScheduledSlots,
-				CheckInMethod.Manual,
-				pinGenerator,
-				category: Category.Health,
-				status: OpportunityStatus.Draft).GetValueOrThrow();
-			opp1.AddTimeSlot(now.AddDays(14), now.AddDays(14).AddHours(8), 20, now).GetValueOrThrow();
-			opp1.Publish().ThrowIfFailure();
+		var opp1 = VolunteerOpportunity.Create(
+			org1Id,
+			"First Aid Course",
+			"Learn life-saving first aid techniques in our hands-on one-day course.",
+			isRemote: false,
+			Address.Create("Main Street", "1", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.Manual,
+			pinGenerator,
+			category: Category.Health,
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		opp1.AddTimeSlot(now.AddDays(14), now.AddDays(14).AddHours(8), 20, now).GetValueOrThrow();
+		opp1.Publish().ThrowIfFailure();
 
-			var opp2 = VolunteerOpportunity.Create(
-				org1Id,
-				"Blood Donation Drive",
-				"Support our regular blood donation drive and help save lives.",
-				isRemote: false,
-				Address.Create("Town Hall Square", "1", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.Recurring,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Health,
-				validUntil: now.AddDays(60)).GetValueOrThrow();
+		var opp2 = VolunteerOpportunity.Create(
+			org1Id,
+			"Blood Donation Drive",
+			"Support our regular blood donation drive and help save lives.",
+			isRemote: false,
+			Address.Create("Town Hall Square", "1", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.Recurring,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Health,
+			validUntil: now.AddDays(60)).GetValueOrThrow();
 
-			var opp2b = VolunteerOpportunity.Create(
-				org1Id,
-				"Paramedic Service at the Town Festival",
-				"Join our paramedic team at the annual town festival and provide first aid on site.",
-				isRemote: false,
-				Address.Create("Market Square", "2", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.OneTime,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Health,
-				validUntil: now.AddDays(30)).GetValueOrThrow();
+		var opp2b = VolunteerOpportunity.Create(
+			org1Id,
+			"Paramedic Service at the Town Festival",
+			"Join our paramedic team at the annual town festival and provide first aid on site.",
+			isRemote: false,
+			Address.Create("Market Square", "2", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Health,
+			validUntil: now.AddDays(30)).GetValueOrThrow();
 
-			var opp2c = VolunteerOpportunity.Create(
-				org1Id,
-				"Clothing Collection for People in Need",
-				"Help sort and distribute donated clothing to people in need in the region.",
-				isRemote: false,
-				Address.Create("Warehouse Street", "10", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.Recurring,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Social,
-				validUntil: now.AddDays(90)).GetValueOrThrow();
+		var opp2c = VolunteerOpportunity.Create(
+			org1Id,
+			"Clothing Collection for People in Need",
+			"Help sort and distribute donated clothing to people in need in the region.",
+			isRemote: false,
+			Address.Create("Warehouse Street", "10", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.Recurring,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Social,
+			validUntil: now.AddDays(90)).GetValueOrThrow();
 
-			var opp2d = VolunteerOpportunity.Create(
-				org1Id,
-				"First Aid Training for Clubs and Associations",
-				"Teach clubs and volunteer groups the basics of first aid in online training sessions.",
-				isRemote: true,
-				address: null,
-				Occurrence.Recurring,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Education,
-				validUntil: now.AddDays(45)).GetValueOrThrow();
+		var opp2d = VolunteerOpportunity.Create(
+			org1Id,
+			"First Aid Training for Clubs and Associations",
+			"Teach clubs and volunteer groups the basics of first aid in online training sessions.",
+			isRemote: true,
+			address: null,
+			Occurrence.Recurring,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Education,
+			validUntil: now.AddDays(45)).GetValueOrThrow();
 
-			var opp3 = VolunteerOpportunity.Create(
-				org2Id,
-				"Animal Shelter Helpers Wanted",
-				"Help us care for and look after the animals in our shelter.",
-				isRemote: false,
-				Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.Recurring,
-				ParticipationType.ScheduledSlots,
-				CheckInMethod.QRCode,
-				pinGenerator,
-				category: Category.Animals,
-				status: OpportunityStatus.Draft).GetValueOrThrow();
-			opp3.AddTimeSlot(now.AddDays(7), now.AddDays(7).AddHours(4), 5, now).GetValueOrThrow();
-			// Unlimited capacity - demonstrates the "no cap" option locally (#1066).
-			opp3.AddTimeSlot(now.AddDays(21), now.AddDays(21).AddHours(4), null, now).GetValueOrThrow();
-			opp3.Publish().ThrowIfFailure();
+		var opp3 = VolunteerOpportunity.Create(
+			org2Id,
+			"Animal Shelter Helpers Wanted",
+			"Help us care for and look after the animals in our shelter.",
+			isRemote: false,
+			Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.Recurring,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.QRCode,
+			pinGenerator,
+			category: Category.Animals,
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		opp3.AddTimeSlot(now.AddDays(7), now.AddDays(7).AddHours(4), 5, now).GetValueOrThrow();
+		// Unlimited capacity - demonstrates the "no cap" option locally (#1066).
+		opp3.AddTimeSlot(now.AddDays(21), now.AddDays(21).AddHours(4), null, now).GetValueOrThrow();
+		opp3.Publish().ThrowIfFailure();
 
-			var opp4 = VolunteerOpportunity.Create(
-				org2Id,
-				"Online Fundraising Support",
-				"Support our online fundraising team from the comfort of your own home.",
-				isRemote: true,
-				address: null,
-				Occurrence.OneTime,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Social,
-				validUntil: now.AddDays(30)).GetValueOrThrow();
+		var opp4 = VolunteerOpportunity.Create(
+			org2Id,
+			"Online Fundraising Support",
+			"Support our online fundraising team from the comfort of your own home.",
+			isRemote: true,
+			address: null,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Social,
+			validUntil: now.AddDays(30)).GetValueOrThrow();
 
-			var opp4b = VolunteerOpportunity.Create(
-				org2Id,
-				"Dog Walking Service for Shelter Dogs",
-				"Take our shelter dogs for regular walks and give them the exercise they need.",
-				isRemote: false,
-				Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.Recurring,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Animals,
-				validUntil: now.AddDays(60)).GetValueOrThrow();
+		var opp4b = VolunteerOpportunity.Create(
+			org2Id,
+			"Dog Walking Service for Shelter Dogs",
+			"Take our shelter dogs for regular walks and give them the exercise they need.",
+			isRemote: false,
+			Address.Create("Animal Park Lane", "5", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.Recurring,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Animals,
+			validUntil: now.AddDays(60)).GetValueOrThrow();
 
-			var opp4c = VolunteerOpportunity.Create(
-				org2Id,
-				"Pet Food Donation Drive",
-				"Collect food and supply donations for our animals at a local drive.",
-				isRemote: false,
-				Address.Create("Field Lane", "3", "12345", "Fairview").GetValueOrThrow(),
-				Occurrence.OneTime,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Animals,
-				validUntil: now.AddDays(30)).GetValueOrThrow();
+		var opp4c = VolunteerOpportunity.Create(
+			org2Id,
+			"Pet Food Donation Drive",
+			"Collect food and supply donations for our animals at a local drive.",
+			isRemote: false,
+			Address.Create("Field Lane", "3", "12345", "Fairview").GetValueOrThrow(),
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Animals,
+			validUntil: now.AddDays(30)).GetValueOrThrow();
 
-			var opp4d = VolunteerOpportunity.Create(
-				org2Id,
-				"Foster Animal Sponsorships",
-				"Take on a sponsorship for a foster animal and support them through their placement.",
-				isRemote: true,
-				address: null,
-				Occurrence.Recurring,
-				ParticipationType.IndividualContact,
-				CheckInMethod.None,
-				pinGenerator,
-				category: Category.Animals,
-				validUntil: now.AddDays(90)).GetValueOrThrow();
+		var opp4d = VolunteerOpportunity.Create(
+			org2Id,
+			"Foster Animal Sponsorships",
+			"Take on a sponsorship for a foster animal and support them through their placement.",
+			isRemote: true,
+			address: null,
+			Occurrence.Recurring,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			pinGenerator,
+			category: Category.Animals,
+			validUntil: now.AddDays(90)).GetValueOrThrow();
 
-			dbContext.Set<VolunteerOpportunity>().AddRange(
-				opp1, opp2, opp2b, opp2c, opp2d, opp3, opp4, opp4b, opp4c, opp4d);
+		dbContext.Set<VolunteerOpportunity>().AddRange(
+			opp1, opp2, opp2b, opp2c, opp2d, opp3, opp4, opp4b, opp4c, opp4d);
 
-			var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
+		var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
 
-			dbContext.Set<Engagement>().AddRange(
-				Engagement.CreateSlotSignUp(opp1.Id, veraUserId, opp1.TimeSlots.First().Id),
-				Engagement.CreateIndividualContact(
-					opp2.Id,
-					veraUserId,
-					"I would love to help out as a volunteer at the next blood donation drive.").GetValueOrThrow(),
-				Engagement.CreateSlotSignUp(opp3.Id, veraUserId, opp3.TimeSlots.First().Id));
+		dbContext.Set<Engagement>().AddRange(
+			Engagement.CreateSlotSignUp(opp1.Id, veraUserId, opp1.TimeSlots.First().Id),
+			Engagement.CreateIndividualContact(
+				opp2.Id,
+				veraUserId,
+				"I would love to help out as a volunteer at the next blood donation drive.").GetValueOrThrow(),
+			Engagement.CreateSlotSignUp(opp3.Id, veraUserId, opp3.TimeSlots.First().Id));
 
-			await dbContext.SaveChangesAsync(cancellationToken);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(
-				ex,
-				"An exception occurred while seeding the database");
-		}
+		await dbContext.SaveChangesAsync(cancellationToken);
 	}
 
 	private async Task<OrganizationId> SeedOrg1Async(CancellationToken cancellationToken)
 	{
-		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(
-			"Fairview Red Cross",
-			cancellationToken);
+		const string name = "Fairview Red Cross";
 
-		await keycloakOrganizationService.AddMemberAsync(keycloakId, OlafId, cancellationToken);
-		await keycloakOrganizationService.AssignOrganizerRoleAsync(OlafId, cancellationToken);
-		await keycloakOrganizationService.AddMemberAsync(keycloakId, VeraId, cancellationToken);
+		var keycloakId = await keycloakOrganizationService.FindOrganizationByNameAsync(name, cancellationToken)
+			?? await keycloakOrganizationService.CreateOrganizationAsync(name, cancellationToken);
 
-		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Fairview Red Cross")
+		await EnsureMemberAsync(keycloakId, OlafId, cancellationToken);
+		await EnsureOrganizerRoleAsync(OlafId, cancellationToken);
+		await EnsureMemberAsync(keycloakId, VeraId, cancellationToken);
+
+		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), name)
 			.GetValueOrThrow();
 		org.ChangeDescription("Your local Red Cross chapter - we help people in need.");
 		org.ChangeContactInfo("info@fairview-redcross.org", "+1 555 0100", "https://www.fairview-redcross.example");
@@ -242,14 +243,15 @@ internal sealed class ApplicationDbContextInitializer(
 
 	private async Task<OrganizationId> SeedOrg2Async(CancellationToken cancellationToken)
 	{
-		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(
-			"Fairview Animal Welfare Association",
-			cancellationToken);
+		const string name = "Fairview Animal Welfare Association";
 
-		await keycloakOrganizationService.AddMemberAsync(keycloakId, OlafId, cancellationToken);
-		await keycloakOrganizationService.AssignOrganizerRoleAsync(OlafId, cancellationToken);
+		var keycloakId = await keycloakOrganizationService.FindOrganizationByNameAsync(name, cancellationToken)
+			?? await keycloakOrganizationService.CreateOrganizationAsync(name, cancellationToken);
 
-		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), "Fairview Animal Welfare Association")
+		await EnsureMemberAsync(keycloakId, OlafId, cancellationToken);
+		await EnsureOrganizerRoleAsync(OlafId, cancellationToken);
+
+		var org = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), name)
 			.GetValueOrThrow();
 		org.ChangeDescription("We are committed to the wellbeing of animals in Fairview and the surrounding area.");
 		org.ChangeContactInfo("info@fairview-animalwelfare.org", "+1 555 0101", null);
@@ -261,5 +263,29 @@ internal sealed class ApplicationDbContextInitializer(
 			OrganizationMembership.Create(org.Id, UserId.Create(OlafId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
 
 		return org.Id;
+	}
+
+	// Checked-before-added rather than a bare AddMemberAsync call, so re-running
+	// seeding after a partial failure (the organization was already reused via
+	// FindOrganizationByNameAsync, but a prior attempt had already added this member
+	// too) doesn't depend on Keycloak's add-member endpoint tolerating a duplicate
+	// add - we just never call it a second time for the same member.
+	private async Task EnsureMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken)
+	{
+		var members = await keycloakOrganizationService.GetMembersAsync(organizationId, cancellationToken);
+		if (members.Any(m => m.UserId == userId))
+			return;
+
+		await keycloakOrganizationService.AddMemberAsync(organizationId, userId, cancellationToken);
+	}
+
+	// Same reasoning as EnsureMemberAsync above, for the realm-wide organisator role.
+	private async Task EnsureOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken)
+	{
+		var organisatorIds = await keycloakOrganizationService.GetRealmOrganisatorUserIdsAsync(cancellationToken);
+		if (organisatorIds.Contains(userId))
+			return;
+
+		await keycloakOrganizationService.AssignOrganizerRoleAsync(userId, cancellationToken);
 	}
 }

--- a/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
+++ b/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
@@ -1,0 +1,196 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using AwesomeAssertions;
+using Infrastructure.Persistence;
+using Infrastructure.VolunteerOpportunities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Core.Interfaces;
+// ApiClient.cs (generated, same "IntegrationTests" namespace) also declares an
+// "Organization"/"OrganizationId" DTO, which would otherwise shadow the domain types.
+using DomainOrganization = Domain.Organizations.Organization;
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Exercises ApplicationDbContextInitializer.SeedAsync directly (InternalsVisibleTo, see
+// Infrastructure.csproj) against the real integration Postgres, standing a hand-written
+// fake in for the real KeycloakOrganizationService. The real "backend" Aspire resource
+// already ran its own one-shot SeedAsync at boot and had it wiped by IntegrationTestFixture's
+// own reset before any test runs, so this is the only way to reproduce "Keycloak already
+// has this organization/membership/role from a prior, partially-failed seed attempt" and
+// prove the fix for #1212: organization creation is idempotent by name, and a Keycloak
+// failure now propagates instead of being silently swallowed.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixture fixture)
+{
+	// Duplicated from ApplicationDbContextInitializer's own private constants - same
+	// reasoning as AspireFixture.OlafId (VisualTests): a fixed literal, not worth
+	// exposing cross-assembly just for this.
+	private static readonly Guid OlafId = new("00000000-0000-0000-0000-000000000001");
+	private static readonly Guid VeraId = new("00000000-0000-0000-0000-000000000002");
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task SeedAsync_OrganizationAlreadyExistsInKeycloakFromPriorPartialFailure_ReusesItInsteadOfCreatingDuplicate(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var keycloak = new FakeKeycloakOrganizationService();
+
+		// Simulates the exact failure mode from #1212: a prior seed attempt got far
+		// enough to create the Red Cross organization in Keycloak, then failed before
+		// the trailing SaveChangesAsync - so the local database is still empty, but
+		// re-seeding must not create a second, orphaned "Fairview Red Cross" org.
+		var existingOrgId = keycloak.SeedExistingOrganization("Fairview Red Cross");
+
+		var initializer = new ApplicationDbContextInitializer(
+			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+
+		await initializer.SeedAsync(cancellationToken);
+
+		keycloak.FindOrganizationByNameCallCount.Should().Be(2, "both seed organizations are looked up by name before creating one");
+		keycloak.CreateOrganizationCallCount.Should().Be(
+			1, "the Red Cross organization already existed in Keycloak and must not be created a second time");
+
+		var organizations = await dbContext.Set<DomainOrganization>().ToListAsync(cancellationToken);
+		organizations.Should().HaveCount(2);
+		organizations.Should().Contain(o => o.Id == DomainOrganizationId.Create(existingOrgId).GetValueOrThrow());
+	}
+
+	[Test]
+	public async Task SeedAsync_MembersAndOrganizerRoleAlreadyPresentFromPriorPartialFailure_DoesNotReapplyThem(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var keycloak = new FakeKeycloakOrganizationService();
+
+		// Simulates a prior attempt that got further still: both organizations, all
+		// their members, and olaf's organizer role were already provisioned in
+		// Keycloak before the trailing SaveChangesAsync failed.
+		keycloak.SeedExistingOrganization("Fairview Red Cross", OlafId, VeraId);
+		keycloak.SeedExistingOrganization("Fairview Animal Welfare Association", OlafId);
+		keycloak.SeedExistingOrganizerRole(OlafId);
+
+		var initializer = new ApplicationDbContextInitializer(
+			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+
+		await initializer.SeedAsync(cancellationToken);
+
+		keycloak.CreateOrganizationCallCount.Should().Be(0, "both organizations already existed in Keycloak");
+		keycloak.AddMemberCallCount.Should().Be(0, "every member had already been added in the prior attempt");
+		keycloak.AssignOrganizerRoleCallCount.Should().Be(0, "olaf already held the organizer role from the prior attempt");
+
+		var organizations = await dbContext.Set<DomainOrganization>().ToListAsync(cancellationToken);
+		organizations.Should().HaveCount(2, "seeding must still complete and persist locally even though nothing needed to change in Keycloak");
+	}
+
+	[Test]
+	public async Task SeedAsync_KeycloakCallFails_PropagatesExceptionInsteadOfSwallowingIt(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var keycloak = new FakeKeycloakOrganizationService
+		{
+			ThrowOnCreateOrganizationFor = _ => true,
+		};
+
+		var initializer = new ApplicationDbContextInitializer(
+			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+
+		Func<Task> act = async () => await initializer.SeedAsync(cancellationToken);
+
+		await act.Should().ThrowAsync<InvalidOperationException>(
+			"a Keycloak failure must surface instead of being silently logged and swallowed (#1212)");
+
+		(await dbContext.Set<DomainOrganization>().AnyAsync(cancellationToken)).Should().BeFalse(
+			"nothing should have been persisted - SaveChangesAsync never had a chance to run");
+	}
+
+	private sealed class FakeKeycloakOrganizationService : IKeycloakOrganizationService
+	{
+		private readonly Dictionary<string, Guid> _organizationsByName = [];
+		private readonly Dictionary<Guid, HashSet<Guid>> _membersByOrganization = [];
+		private readonly HashSet<Guid> _organisatorUserIds = [];
+
+		public int CreateOrganizationCallCount { get; private set; }
+
+		public int FindOrganizationByNameCallCount { get; private set; }
+
+		public int AddMemberCallCount { get; private set; }
+
+		public int AssignOrganizerRoleCallCount { get; private set; }
+
+		public Func<string, bool>? ThrowOnCreateOrganizationFor { get; set; }
+
+		public Guid SeedExistingOrganization(string name, params Guid[] existingMemberIds)
+		{
+			var id = Guid.NewGuid();
+			_organizationsByName[name] = id;
+			_membersByOrganization[id] = [.. existingMemberIds];
+			return id;
+		}
+
+		public void SeedExistingOrganizerRole(Guid userId) => _organisatorUserIds.Add(userId);
+
+		public Task<Guid> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default)
+		{
+			CreateOrganizationCallCount++;
+
+			if (ThrowOnCreateOrganizationFor?.Invoke(name) == true)
+				throw new InvalidOperationException($"Simulated Keycloak failure creating '{name}'.");
+
+			var id = Guid.NewGuid();
+			_organizationsByName[name] = id;
+			_membersByOrganization[id] = [];
+			return Task.FromResult(id);
+		}
+
+		public Task<Guid?> FindOrganizationByNameAsync(string name, CancellationToken cancellationToken = default)
+		{
+			FindOrganizationByNameCallCount++;
+			return Task.FromResult(_organizationsByName.TryGetValue(name, out var id) ? id : (Guid?)null);
+		}
+
+		public Task AddMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default)
+		{
+			AddMemberCallCount++;
+			_membersByOrganization[organizationId].Add(userId);
+			return Task.CompletedTask;
+		}
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> GetMembersAsync(
+			Guid organizationId, CancellationToken cancellationToken = default) =>
+			Task.FromResult<IReadOnlyList<KeycloakOrganizationMember>>(
+				_membersByOrganization[organizationId]
+					.Select(userId => new KeycloakOrganizationMember(
+						userId, "user", null, null, "user@example.com", _organisatorUserIds.Contains(userId)))
+					.ToList());
+
+		public Task AssignOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default)
+		{
+			AssignOrganizerRoleCallCount++;
+			_organisatorUserIds.Add(userId);
+			return Task.CompletedTask;
+		}
+
+		public Task<IReadOnlySet<Guid>> GetRealmOrganisatorUserIdsAsync(CancellationToken cancellationToken = default) =>
+			Task.FromResult<IReadOnlySet<Guid>>(_organisatorUserIds.ToHashSet());
+
+		public Task RemoveMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task DeleteOrganizationAsync(Guid organizationId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task RevokeOrganizerRoleAsync(Guid userId, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
+			string search, int max = 20, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+	}
+}

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -224,6 +224,9 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 		public Task<Guid> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();
 
+		public Task<Guid?> FindOrganizationByNameAsync(string name, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
 		public Task AddMemberAsync(Guid organizationId, Guid userId, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();
 

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -194,22 +194,22 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 
 		_pinnedOrganizerOrgByUserId = await ReadPinnedOrganizerOrgsAsync(conn);
 
-		// ApplicationDbContextInitializer.SeedAsync wraps its Keycloak-dependent
-		// org/membership seeding in a catch-and-log-only block with no retry
-		// (a transient Keycloak hiccup during backend startup silently leaves
-		// olaf's Organizer memberships un-seeded, no exception surfaced anywhere)
-		// - if that happened, every downstream test that dereferences
-		// FastSignInAsync's pinned-org id for olaf would fail with a nullref
-		// deep into the run, minutes later, with no obvious connection back to
-		// this. Fail loudly here instead, at fixture boot, with a message that
+		// Program.cs's Development branch (this AppHost forces backend into, see
+		// InitializeAsync above) catches and logs a SeedAsync failure rather than
+		// rethrowing (#1212) - a transient Keycloak hiccup during backend startup
+		// can still silently leave olaf's Organizer memberships un-seeded with no
+		// exception surfaced anywhere. If that happened, every downstream test that
+		// dereferences FastSignInAsync's pinned-org id for olaf would fail with a
+		// nullref deep into the run, minutes later, with no obvious connection back
+		// to this. Fail loudly here instead, at fixture boot, with a message that
 		// actually points at the cause.
 		if (!_pinnedOrganizerOrgByUserId.ContainsKey(OlafId))
 			throw new InvalidOperationException(
 				"Seed data has no Organizer-role organization membership for olaf "
 				+ $"(user id {OlafId}). ApplicationDbContextInitializer.SeedAsync likely "
-				+ "failed partway through (it swallows exceptions from its Keycloak-dependent "
-				+ "seed calls and logs rather than rethrowing) - check the backend resource's "
-				+ "startup logs for \"An exception occurred while seeding the database\".");
+				+ "failed partway through and Program.cs's Development branch logged "
+				+ "rather than rethrowing - check the backend resource's startup logs "
+				+ "for \"An exception occurred while seeding the database\".");
 	}
 
 	// Ordered by name so the first row seen per user is exactly the org


### PR DESCRIPTION
SeedOrg1Async/SeedOrg2Async created Keycloak organizations before the single trailing SaveChangesAsync, with no compensation on failure - a save failure left orphaned Keycloak orgs, and since the DB write never happened, the next boot's AnyAsync guard re-ran seeding and could create a second orphaned set. SeedAsync also caught and silently logged every exception, hiding the failure entirely.

Look up an existing organization by exact name (new IKeycloakOrganizationService.FindOrganizationByNameAsync) before creating one, and skip member/role calls that were already applied in a prior attempt, so retrying after a partial failure reuses what already exists instead of duplicating it. SeedAsync no longer swallows exceptions itself; Program.cs now decides per environment - log and continue in Development, propagate (crash startup) everywhere else.

Fixes #1212.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
