### PR TITLE
fix: add CHECK constraints for enum-backed columns

### DIFF
--- a/backend/src/Infrastructure/Persistence/Configurations/AchievementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/AchievementConfiguration.cs
@@ -14,6 +14,10 @@ internal sealed class AchievementConfiguration
 	{
 		builder.HasKey(a => a.Id);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"ck_achievement_type_valid",
+			"type IN ('Milestone', 'Streak', 'Hidden')"));
+
 		builder.Property(a => a.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -15,6 +15,10 @@ internal sealed class EngagementConfiguration
 	{
 		builder.HasKey(e => e.Id);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"ck_engagement_status_valid",
+			"status IN ('Pending', 'Confirmed', 'Cancelled', 'Withdrawn')"));
+
 		builder.Property(e => e.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -14,6 +14,11 @@ internal sealed class NotificationConfiguration
 	{
 		builder.HasKey(n => n.Id);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"ck_notification_kind_valid",
+			"kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', " +
+			"'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived')"));
+
 		builder.Property(n => n.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationInvitationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationInvitationConfiguration.cs
@@ -12,6 +12,16 @@ internal sealed class OrganizationInvitationConfiguration : IEntityTypeConfigura
 	{
 		builder.HasKey(i => i.Id);
 
+		builder.ToTable(t =>
+		{
+			t.HasCheckConstraint(
+				"ck_organization_invitation_intended_role_valid",
+				"intended_role IN ('Member', 'Organizer')");
+			t.HasCheckConstraint(
+				"ck_organization_invitation_status_valid",
+				"status IN ('Pending', 'Accepted', 'Declined', 'Expired')");
+		});
+
 		builder.Property(i => i.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OrganizationMembershipConfiguration.cs
@@ -12,6 +12,10 @@ internal sealed class OrganizationMembershipConfiguration : IEntityTypeConfigura
 	{
 		builder.HasKey(m => m.Id);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"ck_organization_membership_role_valid",
+			"role IN ('Member', 'Organizer')"));
+
 		builder.Property(m => m.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/ReportConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/ReportConfiguration.cs
@@ -15,6 +15,19 @@ internal sealed class ReportConfiguration
 	{
 		builder.HasKey(r => r.Id);
 
+		builder.ToTable(t =>
+		{
+			t.HasCheckConstraint(
+				"ck_report_target_type_valid",
+				"target_type IN ('VolunteerOpportunity', 'Organization', 'User')");
+			t.HasCheckConstraint(
+				"ck_report_reason_valid",
+				"reason IN ('Spam', 'IllegalContent', 'Fraud', 'Harassment', 'Other')");
+			t.HasCheckConstraint(
+				"ck_report_status_valid",
+				"status IN ('Open', 'Dismissed', 'Actioned')");
+		});
+
 		builder.Property(r => r.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -15,6 +15,10 @@ internal sealed class UserConfiguration
 	{
 		builder.HasKey(u => u.Id);
 
+		builder.ToTable(t => t.HasCheckConstraint(
+			"ck_user_preferred_contact_valid",
+			"preferred_contact IN ('Email', 'Phone')"));
+
 		builder.Property(u => u.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
@@ -14,6 +14,25 @@ internal sealed class VolunteerOpportunityConfiguration
 	{
 		builder.HasKey(vo => vo.Id);
 
+		builder.ToTable(t =>
+		{
+			t.HasCheckConstraint(
+				"ck_volunteer_opportunity_occurrence_valid",
+				"occurrence IN ('OneTime', 'Recurring')");
+			t.HasCheckConstraint(
+				"ck_volunteer_opportunity_participation_type_valid",
+				"participation_type IN ('ScheduledSlots', 'IndividualContact')");
+			t.HasCheckConstraint(
+				"ck_volunteer_opportunity_check_in_method_valid",
+				"check_in_method IN ('None', 'QRCode', 'PINCode', 'Manual')");
+			t.HasCheckConstraint(
+				"ck_volunteer_opportunity_category_valid",
+				"category IN ('Social', 'Environment', 'Sport', 'Education', 'DisasterRelief', 'Health', 'Animals', 'Culture', 'Technology', 'Other')");
+			t.HasCheckConstraint(
+				"ck_volunteer_opportunity_status_valid",
+				"status IN ('Draft', 'Published', 'Unpublished', 'Cancelled')");
+		});
+
 		builder.Property(vo => vo.Id)
 			.HasConversion(
 				id => id.Value,

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803052537_AddEnumCheckConstraints.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803052537_AddEnumCheckConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260803052537_AddEnumCheckConstraints")]
+	partial class AddEnumCheckConstraints
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803052537_AddEnumCheckConstraints.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803052537_AddEnumCheckConstraints.cs
@@ -1,0 +1,153 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddEnumCheckConstraints : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_volunteer_opportunity_category_valid",
+				table: "volunteer_opportunity",
+				sql: "category IN ('Social', 'Environment', 'Sport', 'Education', 'DisasterRelief', 'Health', 'Animals', 'Culture', 'Technology', 'Other')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_volunteer_opportunity_check_in_method_valid",
+				table: "volunteer_opportunity",
+				sql: "check_in_method IN ('None', 'QRCode', 'PINCode', 'Manual')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_volunteer_opportunity_occurrence_valid",
+				table: "volunteer_opportunity",
+				sql: "occurrence IN ('OneTime', 'Recurring')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_volunteer_opportunity_participation_type_valid",
+				table: "volunteer_opportunity",
+				sql: "participation_type IN ('ScheduledSlots', 'IndividualContact')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_volunteer_opportunity_status_valid",
+				table: "volunteer_opportunity",
+				sql: "status IN ('Draft', 'Published', 'Unpublished', 'Cancelled')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_user_preferred_contact_valid",
+				table: "user",
+				sql: "preferred_contact IN ('Email', 'Phone')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_report_reason_valid",
+				table: "report",
+				sql: "reason IN ('Spam', 'IllegalContent', 'Fraud', 'Harassment', 'Other')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_report_status_valid",
+				table: "report",
+				sql: "status IN ('Open', 'Dismissed', 'Actioned')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_report_target_type_valid",
+				table: "report",
+				sql: "target_type IN ('VolunteerOpportunity', 'Organization', 'User')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_organization_membership_role_valid",
+				table: "organization_membership",
+				sql: "role IN ('Member', 'Organizer')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_organization_invitation_intended_role_valid",
+				table: "organization_invitation",
+				sql: "intended_role IN ('Member', 'Organizer')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_organization_invitation_status_valid",
+				table: "organization_invitation",
+				sql: "status IN ('Pending', 'Accepted', 'Declined', 'Expired')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification",
+				sql: "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_engagement_status_valid",
+				table: "engagement",
+				sql: "status IN ('Pending', 'Confirmed', 'Cancelled', 'Withdrawn')");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_achievement_type_valid",
+				table: "achievement",
+				sql: "type IN ('Milestone', 'Streak', 'Hidden')");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_volunteer_opportunity_category_valid",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_volunteer_opportunity_check_in_method_valid",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_volunteer_opportunity_occurrence_valid",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_volunteer_opportunity_participation_type_valid",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_volunteer_opportunity_status_valid",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_user_preferred_contact_valid",
+				table: "user");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_report_reason_valid",
+				table: "report");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_report_status_valid",
+				table: "report");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_report_target_type_valid",
+				table: "report");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_organization_membership_role_valid",
+				table: "organization_membership");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_organization_invitation_intended_role_valid",
+				table: "organization_invitation");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_organization_invitation_status_valid",
+				table: "organization_invitation");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_engagement_status_valid",
+				table: "engagement");
+
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_achievement_type_valid",
+				table: "achievement");
+		}
+	}
+}

--- a/backend/tests/IntegrationTests/EnumCheckConstraintTests.cs
+++ b/backend/tests/IntegrationTests/EnumCheckConstraintTests.cs
@@ -1,0 +1,463 @@
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Achievements;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Reports;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Infrastructure.VolunteerOpportunities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using TUnit.Core.Interfaces;
+// OrganizationId collides with the generated ApiClient.cs DTO of the same name in this
+// same "IntegrationTests" namespace (see the same workaround in EngagementReadRepositoryTests.cs).
+using DomainOrganizationId = Domain.Organizations.OrganizationId;
+
+namespace IntegrationTests;
+
+// Regression coverage for einsatzbereit#1210 - enum-to-string columns had no DB-level
+// constraint, so a typo'd or partially-migrated string value could sit in the DB and
+// throw when EF tries to parse it back into the CLR enum on read (a 500, not a 400 at
+// write time). These tests assert both that valid values still round-trip through the
+// full write+read path, and that Postgres now rejects an invalid string outright via the
+// CHECK constraints added in the AddEnumCheckConstraints migration - bypassing the
+// value converter with a raw UPDATE, since the converter itself would reject a bad
+// C# enum value before it ever reached the DB.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class EnumCheckConstraintTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task Achievement_ShouldPersistAndReload_ValidType(
+		CancellationToken cancellationToken)
+	{
+		var achievement = Achievement.Create(UserId.New(), AchievementType.Milestone, "key", "Name", "Description", DateTimeOffset.UtcNow);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Achievements.AddAsync(achievement, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.Achievements.FindAsync(achievement.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Type.Should().Be(AchievementType.Milestone);
+	}
+
+	[Test]
+	public async Task Achievement_Type_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var achievement = Achievement.Create(UserId.New(), AchievementType.Milestone, "key", "Name", "Description", DateTimeOffset.UtcNow);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Achievements.AddAsync(achievement, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"achievement", "type", achievement.Id.Value, "ck_achievement_type_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task Engagement_ShouldPersistAndReload_ValidStatus(
+		CancellationToken cancellationToken)
+	{
+		var engagement = Engagement.CreateIndividualContact(VolunteerOpportunityId.New(), UserId.New(), "Message").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Engagements.AddAsync(engagement, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.Engagements.FindAsync(engagement.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Status.Should().Be(EngagementStatus.Pending);
+	}
+
+	[Test]
+	public async Task Engagement_Status_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var engagement = Engagement.CreateIndividualContact(VolunteerOpportunityId.New(), UserId.New(), "Message").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Engagements.AddAsync(engagement, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"engagement", "status", engagement.Id.Value, "ck_engagement_status_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task Notification_ShouldPersistAndReload_ValidKind(
+		CancellationToken cancellationToken)
+	{
+		var notification = Notification.Create(UserId.New(), NotificationKind.EngagementCreated, Guid.NewGuid());
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Notifications.AddAsync(notification, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.Notifications.FindAsync(notification.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Kind.Should().Be(NotificationKind.EngagementCreated);
+	}
+
+	[Test]
+	public async Task Notification_Kind_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var notification = Notification.Create(UserId.New(), NotificationKind.EngagementCreated, Guid.NewGuid());
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Notifications.AddAsync(notification, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"notification", "kind", notification.Id.Value, "ck_notification_kind_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task OrganizationInvitation_ShouldPersistAndReload_ValidIntendedRoleAndStatus(
+		CancellationToken cancellationToken)
+	{
+		var invitation = OrganizationInvitation.Create(
+			DomainOrganizationId.New(), "Org", UserId.New(), "Invitee", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.OrganizationInvitations.AddAsync(invitation, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.OrganizationInvitations.FindAsync(invitation.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.IntendedRole.Should().Be(OrganizationMemberRole.Organizer);
+		reloaded.Status.Should().Be(InvitationStatus.Pending);
+	}
+
+	[Test]
+	public async Task OrganizationInvitation_IntendedRole_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var invitation = OrganizationInvitation.Create(
+			DomainOrganizationId.New(), "Org", UserId.New(), "Invitee", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.OrganizationInvitations.AddAsync(invitation, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"organization_invitation", "intended_role", invitation.Id.Value, "ck_organization_invitation_intended_role_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task OrganizationInvitation_Status_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var invitation = OrganizationInvitation.Create(
+			DomainOrganizationId.New(), "Org", UserId.New(), "Invitee", UserId.New(), OrganizationMemberRole.Organizer, DateTimeOffset.UtcNow);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.OrganizationInvitations.AddAsync(invitation, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"organization_invitation", "status", invitation.Id.Value, "ck_organization_invitation_status_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task OrganizationMembership_ShouldPersistAndReload_ValidRole(
+		CancellationToken cancellationToken)
+	{
+		var membership = OrganizationMembership.Create(DomainOrganizationId.New(), UserId.New(), OrganizationMemberRole.Member);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.OrganizationMemberships.FindAsync(membership.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Role.Should().Be(OrganizationMemberRole.Member);
+	}
+
+	[Test]
+	public async Task OrganizationMembership_Role_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var membership = OrganizationMembership.Create(DomainOrganizationId.New(), UserId.New(), OrganizationMemberRole.Member);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"organization_membership", "role", membership.Id.Value, "ck_organization_membership_role_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task Report_ShouldPersistAndReload_ValidTargetTypeReasonAndStatus(
+		CancellationToken cancellationToken)
+	{
+		var report = Report.Create(ReportTargetType.User, Guid.NewGuid(), UserId.New(), ReportReason.Spam, "Details").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Reports.AddAsync(report, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.Reports.FindAsync(report.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.TargetType.Should().Be(ReportTargetType.User);
+		reloaded.Reason.Should().Be(ReportReason.Spam);
+		reloaded.Status.Should().Be(ReportStatus.Open);
+	}
+
+	[Test]
+	public async Task Report_TargetType_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var report = Report.Create(ReportTargetType.User, Guid.NewGuid(), UserId.New(), ReportReason.Spam, "Details").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Reports.AddAsync(report, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"report", "target_type", report.Id.Value, "ck_report_target_type_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task Report_Reason_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var report = Report.Create(ReportTargetType.User, Guid.NewGuid(), UserId.New(), ReportReason.Spam, "Details").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Reports.AddAsync(report, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"report", "reason", report.Id.Value, "ck_report_reason_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task Report_Status_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var report = Report.Create(ReportTargetType.User, Guid.NewGuid(), UserId.New(), ReportReason.Spam, "Details").GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Reports.AddAsync(report, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"report", "status", report.Id.Value, "ck_report_status_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task User_ShouldPersistAndReload_ValidPreferredContact(
+		CancellationToken cancellationToken)
+	{
+		var user = User.Create(UserId.New());
+		user.SetPreferredContact(PreferredContact.Phone);
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Users.AddAsync(user, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.Users.FindAsync(user.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.PreferredContact.Should().Be(PreferredContact.Phone);
+	}
+
+	[Test]
+	public async Task User_PreferredContact_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var user = User.Create(UserId.New());
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.Users.AddAsync(user, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"user", "preferred_contact", user.Id.Value, "ck_user_preferred_contact_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_ShouldPersistAndReload_ValidEnumValues(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.VolunteerOpportunities.FindAsync(opportunity.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Occurrence.Should().Be(Occurrence.OneTime);
+		reloaded.ParticipationType.Should().Be(ParticipationType.IndividualContact);
+		reloaded.CheckInMethod.Should().Be(CheckInMethod.None);
+		reloaded.Category.Should().Be(Category.Social);
+		reloaded.Status.Should().Be(OpportunityStatus.Draft);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_Category_ShouldAllowNull(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = VolunteerOpportunity.Create(
+			DomainOrganizationId.New(),
+			"Title",
+			"Description",
+			isRemote: true,
+			address: null,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			new RandomPinGenerator(),
+			category: null,
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await using var readContext = fixture.CreateApplicationDbContext();
+		var reloaded = await readContext.VolunteerOpportunities.FindAsync(opportunity.Id, cancellationToken);
+
+		reloaded.Should().NotBeNull();
+		reloaded!.Category.Should().BeNull();
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_Occurrence_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"volunteer_opportunity", "occurrence", opportunity.Id.Value, "ck_volunteer_opportunity_occurrence_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_ParticipationType_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"volunteer_opportunity", "participation_type", opportunity.Id.Value, "ck_volunteer_opportunity_participation_type_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_CheckInMethod_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"volunteer_opportunity", "check_in_method", opportunity.Id.Value, "ck_volunteer_opportunity_check_in_method_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_Category_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"volunteer_opportunity", "category", opportunity.Id.Value, "ck_volunteer_opportunity_category_valid", cancellationToken);
+	}
+
+	[Test]
+	public async Task VolunteerOpportunity_Status_ShouldReject_InvalidValue(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateDraftOpportunity();
+
+		await using var writeContext = fixture.CreateApplicationDbContext();
+		await writeContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await writeContext.SaveChangesAsync(cancellationToken);
+
+		await AssertRejectsInvalidValueAsync(
+			"volunteer_opportunity", "status", opportunity.Id.Value, "ck_volunteer_opportunity_status_valid", cancellationToken);
+	}
+
+	// Draft sidesteps Create's Published-only validation (a deadline, at least one time
+	// slot for ScheduledSlots, etc.) - these tests only care about the enum columns.
+	private static VolunteerOpportunity CreateDraftOpportunity() =>
+		VolunteerOpportunity.Create(
+			DomainOrganizationId.New(),
+			"Title",
+			"Description",
+			isRemote: true,
+			address: null,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			new RandomPinGenerator(),
+			category: Category.Social,
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+
+	// Bypasses the HasConversion<string>() value converter (which would reject an invalid
+	// C# enum value before it ever reached the DB) with a raw UPDATE, to prove the
+	// CHECK constraint itself - not just the converter - is what's guarding the column.
+	private async Task AssertRejectsInvalidValueAsync(
+		string table,
+		string column,
+		Guid id,
+		string constraintName,
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		await using var connection = (NpgsqlConnection)dbContext.Database.GetDbConnection();
+		await connection.OpenAsync(cancellationToken);
+
+		// Identifiers are double-quoted since "user" is a reserved Postgres keyword and
+		// would otherwise fail with a syntax error (42601), not the check violation (23514)
+		// this test is actually after.
+		await using var cmd = new NpgsqlCommand(
+			$"UPDATE \"{table}\" SET \"{column}\" = 'NotARealValue' WHERE id = @id", connection);
+		cmd.Parameters.AddWithValue("id", id);
+
+		var act = async () => await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<PostgresException>();
+		exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+		exception.Which.ConstraintName.Should().Be(constraintName);
+	}
+}


### PR DESCRIPTION
Prevents an invalid string in an enum-to-string column (typo, partial migration) from ever being written, so EF's value converter can no longer throw on read (einsatzbereit#1210).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1210 

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
