### PR TITLE
fix: prune stale notification rows on a retention schedule

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -88,6 +88,11 @@
     "MaxBatchSize": 500,
     "PollIntervalHours": 1
   },
+  "NotificationRetention": {
+    "ReadRetentionDays": 90,
+    "UnreadRetentionDays": 180,
+    "RetentionCheckIntervalHours": 24
+  },
   "RateLimiting": {
     "Read": {
       "AuthenticatedPermitLimit": 200,

--- a/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionJob.cs
@@ -1,0 +1,108 @@
+using Domain.Notifications;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+// Notification.RelatedEntityId is an untyped uuid pointing at an engagement, an
+// opportunity, or an invitation with no FK - a deleted target just leaves the
+// notification pointing at nothing (NotificationReadRepository already
+// tolerates this, falling back to a placeholder). Nothing else ever deletes a
+// notification row (aside from DeleteMyAccountCommandHandler wiping a whole
+// recipient's rows), so the table grew without bound - this periodically
+// prunes read rows past ReadRetentionDays, and unread rows (which could
+// otherwise keep pointing at a long-deleted target indefinitely until the
+// recipient happens to open them) past the longer UnreadRetentionDays (#1209).
+internal sealed class NotificationRetentionJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<NotificationRetentionJob> logger,
+	IOptions<NotificationRetentionOptions> options)
+	: IHostedService, IAsyncDisposable
+{
+	private readonly NotificationRetentionOptions _options = options.Value;
+
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+	private PeriodicTimer? _timer;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_timer = new PeriodicTimer(TimeSpan.FromHours(_options.RetentionCheckIntervalHours));
+		_executeTask = RunLoopAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_timer?.Dispose();
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunLoopAsync(CancellationToken ct)
+	{
+		if (_timer is null) return;
+
+		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+		{
+			try
+			{
+				await TickAsync(ct).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// A row that should have been pruned this tick just gets picked up
+				// again on the next one - no data is lost by skipping a tick.
+				logger.LogError(ex, "Notification retention tick failed; will retry on the next poll interval");
+			}
+		}
+	}
+
+	private async Task TickAsync(CancellationToken ct)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+		var now = DateTimeOffset.UtcNow;
+		var deleted = await DeleteExpiredNotificationsAsync(
+			dbContext,
+			readCutoff: now.AddDays(-_options.ReadRetentionDays),
+			unreadCutoff: now.AddDays(-_options.UnreadRetentionDays),
+			ct);
+
+		if (deleted > 0)
+			logger.LogInformation("Pruned {Count} expired notification(s)", deleted);
+	}
+
+	// Exposed so IntegrationTests can exercise the deletion directly against a real
+	// Postgres without waiting on the real RetentionCheckIntervalHours.
+	internal static async Task<int> DeleteExpiredNotificationsAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset readCutoff,
+		DateTimeOffset unreadCutoff,
+		CancellationToken cancellationToken = default) =>
+		await dbContext.Set<Notification>()
+			.Where(n =>
+				(n.IsRead && n.CreatedOn < readCutoff) ||
+				(!n.IsRead && n.CreatedOn < unreadCutoff))
+			.ExecuteDeleteAsync(cancellationToken);
+}

--- a/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionOptions.cs
@@ -1,0 +1,20 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class NotificationRetentionOptions
+{
+	// How long a read notification is kept before NotificationRetentionJob prunes
+	// it - the table would otherwise grow without bound, since nothing else ever
+	// deletes a notification for reasons other than the recipient's whole account
+	// being deleted. Matches Outbox's ProcessedOnUtc-based retention shape.
+	public int ReadRetentionDays { get; init; } = 90;
+
+	// An unread notification can point (via RelatedEntityId) at an entity that
+	// has since been deleted, showing a stale/broken link indefinitely until the
+	// recipient happens to read it - this longer backstop prunes it regardless of
+	// read status once it's old enough that it's no longer actionable (#1209).
+	public int UnreadRetentionDays { get; init; } = 180;
+
+	// How often NotificationRetentionJob checks for expired rows - a
+	// low-frequency housekeeping concern, unlike a real-time processing job.
+	public int RetentionCheckIntervalHours { get; init; } = 24;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class NotificationRetentionOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<NotificationRetentionOptions>
+{
+	public void Configure(NotificationRetentionOptions options) =>
+		configuration.GetSection("NotificationRetention").Bind(options);
+}

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -47,5 +47,9 @@ internal sealed class NotificationConfiguration
 		builder.HasIndex(n => new { n.RecipientId, n.IsRead });
 
 		builder.HasIndex(n => new { n.RecipientId, n.CreatedOn });
+
+		// Supports NotificationRetentionJob's global prune scan (not scoped to a
+		// single recipient like the indexes above) - see einsatzbereit#1209.
+		builder.HasIndex(n => new { n.IsRead, n.CreatedOn });
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803054805_AddNotificationIsReadCreatedOnIndex.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803054805_AddNotificationIsReadCreatedOnIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260803054805_AddNotificationIsReadCreatedOnIndex")]
+	partial class AddNotificationIsReadCreatedOnIndex
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260803054805_AddNotificationIsReadCreatedOnIndex.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260803054805_AddNotificationIsReadCreatedOnIndex.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddNotificationIsReadCreatedOnIndex : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateIndex(
+				name: "ix_notification_is_read_created_on",
+				table: "notification",
+				columns: new[] { "is_read", "created_on" });
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_notification_is_read_created_on",
+				table: "notification");
+		}
+	}
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -121,6 +121,8 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<InvitationExpiryJob>();
 		services.ConfigureOptions<CheckInAttemptPruneOptionsSetup>();
 		services.AddHostedService<CheckInAttemptPruneJob>();
+		services.ConfigureOptions<NotificationRetentionOptionsSetup>();
+		services.AddHostedService<NotificationRetentionJob>();
 
 
 		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see

--- a/backend/tests/IntegrationTests/NotificationRetentionJobTests.cs
+++ b/backend/tests/IntegrationTests/NotificationRetentionJobTests.cs
@@ -1,0 +1,132 @@
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Users;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.NotificationRetentionJob.DeleteExpiredNotificationsAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres, rather than waiting a real 24-hour tick for the pruning behavior (#1209) to
+// become observable.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
+{
+	private static readonly DateTimeOffset ReadCutoff = DateTimeOffset.UtcNow.AddDays(-90);
+	private static readonly DateTimeOffset UnreadCutoff = DateTimeOffset.UtcNow.AddDays(-180);
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task DeleteExpiredNotificationsAsync_ReadNotificationPastReadRetention_IsRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var notificationId = await SeedNotificationAsync(
+			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(-1), cancellationToken);
+
+		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
+			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
+
+		deleted.Should().Be(1);
+		await NotificationShouldNotExistAsync(dbContext, notificationId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredNotificationsAsync_ReadNotificationWithinReadRetention_IsNotRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var notificationId = await SeedNotificationAsync(
+			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(1), cancellationToken);
+
+		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
+			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await NotificationShouldExistAsync(dbContext, notificationId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredNotificationsAsync_UnreadNotificationPastUnreadRetention_IsRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var notificationId = await SeedNotificationAsync(
+			dbContext, isRead: false, createdOn: UnreadCutoff.AddDays(-1), cancellationToken);
+
+		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
+			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
+
+		deleted.Should().Be(1);
+		await NotificationShouldNotExistAsync(dbContext, notificationId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredNotificationsAsync_UnreadNotificationPastReadButWithinUnreadRetention_IsNotRemoved(
+		CancellationToken cancellationToken)
+	{
+		// Regression guard for the read/unread split itself: an unread
+		// notification older than the (shorter) read retention window must
+		// survive until it also crosses the longer unread retention window.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var notificationId = await SeedNotificationAsync(
+			dbContext, isRead: false, createdOn: ReadCutoff.AddDays(-1), cancellationToken);
+
+		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
+			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await NotificationShouldExistAsync(dbContext, notificationId, cancellationToken);
+	}
+
+	private static async Task<NotificationId> SeedNotificationAsync(
+		ApplicationDbContext dbContext,
+		bool isRead,
+		DateTimeOffset createdOn,
+		CancellationToken cancellationToken)
+	{
+		var notification = Notification.Create(
+			UserId.Create(Guid.NewGuid()).GetValueOrThrow(),
+			NotificationKind.EngagementCreated,
+			Guid.NewGuid());
+
+		if (isRead)
+			notification.MarkRead();
+
+		dbContext.Set<Notification>().Add(notification);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		// CreatedOn is stamped by AuditableEntityInterceptor on save - overwrite
+		// it directly afterward so seeded rows can simulate an arbitrary age.
+		await dbContext.Set<Notification>()
+			.Where(n => n.Id == notification.Id)
+			.ExecuteUpdateAsync(s => s.SetProperty(n => n.CreatedOn, createdOn), cancellationToken);
+
+		return notification.Id;
+	}
+
+	private static async Task NotificationShouldExistAsync(
+		ApplicationDbContext dbContext, NotificationId id, CancellationToken cancellationToken)
+	{
+		var exists = await dbContext.Set<Notification>()
+			.AsNoTracking()
+			.AnyAsync(n => n.Id == id, cancellationToken);
+		exists.Should().BeTrue();
+	}
+
+	private static async Task NotificationShouldNotExistAsync(
+		ApplicationDbContext dbContext, NotificationId id, CancellationToken cancellationToken)
+	{
+		var exists = await dbContext.Set<Notification>()
+			.AsNoTracking()
+			.AnyAsync(n => n.Id == id, cancellationToken);
+		exists.Should().BeFalse();
+	}
+}


### PR DESCRIPTION
Notification.RelatedEntityId is an untyped uuid with no FK, so notifications outlive their target entity indefinitely once it's deleted, and the table grows without bound (#1209). Adds NotificationRetentionJob, mirroring the existing OutboxRetentionJob pattern: deletes read notifications after 90 days, and unread ones (which could otherwise show a broken link forever) after 180 days.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1209

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
