### PR TITLE
feat: create a GitHub Release with notes on every tag push

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -8,7 +8,7 @@
 ├── frontend.yml                Frontend: lint → build
 ├── docs.yml                    Docs: AsciiDoc build (push + PR) → GitHub Pages deploy (push only)
 ├── keycloak-realm-import.yml   Verifies the committed realm still imports on the production Keycloak version
-├── publish.yml                 Tag-triggered: build + push backend/frontend/keycloak to GHCR, then deploy-staging (RC tags) or deploy-production (stable tags)
+├── publish.yml                 Tag-triggered: build + push backend/frontend/keycloak to GHCR, create a GitHub Release, then deploy-staging (RC tags) or deploy-production (stable tags)
 ├── release-rc.yml              Promotes a release/v* branch into a real tag (used by Claude Code on the web)
 ├── reset-staging.yml           Manual (workflow_dispatch): wipes staging Postgres + MinIO data, restarts with same images
 ├── lint.yml                    Ban em/en dashes + EditorConfig check
@@ -68,7 +68,8 @@ All images pushed to **GitHub Container Registry (GHCR)**.
 3. Extract version from tag (strips leading `v`)
 4. Build and push Docker image
 5. Tag with version + `latest` (if not RC) or `staging` (if RC)
-6. `deploy-staging` (RC tags) or `deploy-production` (stable tags) deploys - see below
+6. `github-release` job (`needs: [publish-backend, publish-frontend, publish-keycloak]`, so it runs for both stable and RC tags - unlike `deploy-staging`/`deploy-production`, which are gated on `prerelease`) creates a GitHub Release for the tag via `gh release create`, using the default `GITHUB_TOKEN` (job-scoped `permissions: contents: write`, no `RELEASE_TOKEN` needed - creating a release doesn't push a ref, so it doesn't hit the "tags pushed with `GITHUB_TOKEN` don't trigger workflows" restriction that `release-rc.yml` works around). Notes are generated from commit subjects since the previous tag (found by semver sort across both stable and RC tags, via `git tag --sort=-v:refname`), grouped by Conventional Commit type - a `!` after the type/scope (e.g. `feat!:`) surfaces under a "Breaking Changes" section. See [VERSIONING.md](../VERSIONING.md)'s "Release Notes" section - GitHub Releases is the canonical record, there is no `CHANGELOG.md` file.
+7. `deploy-staging` (RC tags) or `deploy-production` (stable tags) deploys - see below
 
 ### `deploy-staging` vs `deploy-production` (#1344)
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1100,3 +1100,108 @@ jobs:
             -d "$(echo "$REALM" | jq '.browserFlow = "einsatzbereit browser"')"
 
           echo "browserFlow bound to 'einsatzbereit browser'."
+
+  github-release:
+    name: GitHub Release
+    # Depends on the three publish-* jobs directly (not deploy-staging, which
+    # only runs for -rc.N tags) so a GitHub Release is created for stable
+    # tags too, and only after the images they describe actually published.
+    needs: [publish-backend, publish-frontend, publish-keycloak]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history + tags needed to find the previous tag and diff
+          # commit messages against it below.
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "$TAG" == *-rc.* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Groups commit subjects since the previous tag by Conventional Commit
+      # type (enforced PR-title-side by pr-title.yml, so main's history is
+      # squash-merged commits in that format already) instead of relying on
+      # GitHub's own auto-generated notes, which group by PR label - a label
+      # this repo's PRs don't consistently set.
+      - name: Generate release notes from Conventional Commits
+        id: notes
+        run: |
+          CURRENT_TAG="${{ steps.version.outputs.tag }}"
+
+          # Previous tag = the one immediately before this one in semver
+          # order across both stable and rc tags - not the previous tag
+          # chronologically, since an rc for an already-released line could
+          # in principle be re-cut later.
+          PREV_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --list 'v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*' --sort=-v:refname \
+            | grep -A1 -x -F "$CURRENT_TAG" | tail -n1)
+          if [ "$PREV_TAG" = "$CURRENT_TAG" ]; then
+            PREV_TAG=""
+          fi
+
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="$CURRENT_TAG"
+          else
+            RANGE="$PREV_TAG..$CURRENT_TAG"
+          fi
+
+          {
+            echo "## What's Changed"
+            echo
+
+            breaking=$(git log "$RANGE" --pretty=format:'%s' | grep -E '^[a-z]+(\(.+\))?!:' || true)
+            if [ -n "$breaking" ]; then
+              echo "### Breaking Changes"
+              echo "$breaking" | sed 's/^/- /'
+              echo
+            fi
+
+            declare -A LABELS=( [feat]="Features" [fix]="Bug Fixes" [perf]="Performance" [refactor]="Refactoring" [docs]="Documentation" [revert]="Reverts" )
+            for type in feat fix perf refactor docs revert; do
+              commits=$(git log "$RANGE" --pretty=format:'%s' | grep -E "^${type}(\(.+\))?!?:" || true)
+              if [ -n "$commits" ]; then
+                echo "### ${LABELS[$type]}"
+                echo "$commits" | sed 's/^/- /'
+                echo
+              fi
+            done
+
+            if [ -z "$PREV_TAG" ]; then
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/${CURRENT_TAG}"
+            else
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}"
+            fi
+          } > release-notes.md
+
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          FLAGS=()
+          if [ "${{ steps.version.outputs.prerelease }}" = "true" ]; then
+            FLAGS+=(--prerelease)
+          fi
+
+          # Idempotent: a re-run of this job (e.g. after an unrelated failure
+          # elsewhere in the workflow, retried via "Re-run failed jobs") would
+          # otherwise fail with "release already exists" - edit notes in place
+          # instead, mirroring the tag-idempotency check in release-rc.yml.
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $TAG already exists - updating notes instead."
+            gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file release-notes.md "${FLAGS[@]}"
+          else
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --notes-file release-notes.md "${FLAGS[@]}"
+          fi

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -62,3 +62,12 @@ Prerelease tags produce Docker images that are **not** tagged as `latest`.
 2. Set tag: `git tag v1.0.0`
 3. Push tag: `git push origin v1.0.0`
 4. GitHub Actions builds and pushes all three Docker images automatically
+
+## Release Notes
+
+Every tag (stable and `-rc.N`) gets a [GitHub Release](https://github.com/maik-hasler/einsatzbereit/releases)
+with auto-generated notes grouped by Conventional Commit type (Features, Bug
+Fixes, Performance, Refactoring, Documentation, Reverts, and any `!`-marked
+Breaking Changes) since the previous tag. Release candidates are marked as
+prereleases. This is the canonical human-readable record of what shipped in
+each version - there is no separate `CHANGELOG.md` file to keep in sync.


### PR DESCRIPTION
publish.yml gets a new github-release job (needs: publish-backend/ frontend/keycloak, runs for both stable and -rc.N tags) that groups commit subjects since the previous tag by Conventional Commit type and creates/updates a GitHub Release via gh CLI, using the default GITHUB_TOKEN (job-scoped contents: write, no RELEASE_TOKEN needed). RCs are marked as prereleases; a `!` after the type surfaces under Breaking Changes. VERSIONING.md and .github/AGENTS.md document GitHub Releases as the canonical record - no separate CHANGELOG.md.

Closes #1355.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
