### PR TITLE
fix: mount achievement-unlock notifier in the org app shell

### DIFF
--- a/backend/tests/VisualTests/OrgAppAchievementNotifierTests.cs
+++ b/backend/tests/VisualTests/OrgAppAchievementNotifierTests.cs
@@ -1,0 +1,54 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1034: useAchievementNotifier (the badge-unlock toast poller)
+/// was only ever mounted in AppLayout, the public-site layout - OrgAppLayout/
+/// OrgAppShell (the org app shell at /app/{organizationId}/...) never called it,
+/// so an organizer working inside the org app never polled for newly-unlocked
+/// badges and never saw the unlock toast there, even though the exact same
+/// account would see it on the public site.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgAppAchievementNotifierTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task EnteringOrgAppShell_TriggersItsOwnAchievementsCheck()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		// Registered before FastSignInAsync's own navigation - Page.WaitForResponseAsync
+		// must start listening before the request fires, not after (see
+		// AchievementsTests.cs for the same pattern). This is AppLayout's own
+		// on-mount GET /v1/me/achievements, fired from the home page
+		// FastSignInAsync lands on - not this test's subject, but it must be
+		// allowed to resolve before arming the second wait below, or that
+		// second wait could spuriously match this same, first, request.
+		var homePageAchievementsCheckTask = Page.WaitForResponseAsync(
+			r => r.Url.Contains("/v1/me/achievements") && r.Request.Method == "GET");
+
+		// olaf organizes a seeded org (see AuthHelper.FastSignInAsync's doc
+		// comment on GetPinnedOrganizerOrganizationId).
+		var organizationId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		organizationId.Should().NotBeNull("olaf organizes a seeded org in this test environment");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await homePageAchievementsCheckTask;
+
+		// Armed only after the home page's own initial check (above) has
+		// already resolved, so this can only match the *next* occurrence -
+		// the org app shell's own, independent mount of the same hook, not a
+		// second wait racing that same first request.
+		var orgShellAchievementsCheckTask = Page.WaitForResponseAsync(
+			r => r.Url.Contains("/v1/me/achievements") && r.Request.Method == "GET");
+
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, organizationId!.Value);
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Before the #1034 fix, OrgAppLayout/OrgAppShell never mounted
+		// useAchievementNotifier at all, so entering the org app shell never
+		// fired this GET a second time and this wait timed out.
+		await orgShellAchievementsCheckTask;
+	}
+}

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
 import { setActiveOrgId } from "../lib/activeOrg";
 import { ORG_TABS, orgTabPath } from "../lib/orgTabs";
 import { statusTitleClass } from "../lib/headingClasses";
@@ -51,6 +52,10 @@ function OrgAppShell({
 	activeTabLabel: string;
 	load: () => void;
 }) {
+	// #1034: this hook was previously only mounted in AppLayout (the public
+	// site layout), so users working inside the org app shell never polled
+	// for newly-unlocked badges and never saw the unlock toast.
+	useAchievementNotifier();
 	const { t } = useTranslation();
 	const extra = useOrgBreadcrumbExtra();
 	const quickActions = useQuickActionsList();


### PR DESCRIPTION
useAchievementNotifier() was only invoked from AppLayout (the public site), so users working inside OrgAppLayout/OrgAppShell never polled for new badges and never saw the unlock toast there.

Adds a VisualTests regression case verifying entering the org app shell fires its own /v1/me/achievements check.

Fixes #1034

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
