### PR TITLE
fix: use plain anchor for footer participate link to scroll to opportunities

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -455,6 +455,51 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Footer_ParticipateLink_FromHomePage_ScrollsToOpportunitiesSection()
+	{
+		// #1031: the footer's "Get involved" link used a react-router Link,
+		// which navigates via the history API without triggering native
+		// browser fragment scrolling - clicking it from the home page did
+		// nothing visible. Now a plain <a href="/#opportunities"> like the
+		// hero CTA, so the browser handles the scroll itself.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var participateLink = Page.Locator("footer").GetByRole(
+			AriaRole.Link, new() { Name = "Get involved" });
+		await Expect(participateLink).ToHaveAttributeAsync("href", "/#opportunities");
+
+		await participateLink.ClickAsync();
+
+		await Page.WaitForURLAsync(new Regex(@"/#opportunities$"), new() { Timeout = 10_000 });
+		await Expect(Page.Locator("#opportunities")).ToBeInViewportAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
+	public async Task Footer_ParticipateLink_FromAnotherPage_NavigatesHomeAndScrollsToOpportunitiesSection()
+	{
+		// #1031: from any page other than home, the old Link-based footer
+		// link navigated to "/" but stayed scrolled to the top. A plain
+		// anchor tag forces a full navigation to "/#opportunities", which
+		// the browser scrolls to once the home page has rendered.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend}organizations");
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var participateLink = Page.Locator("footer").GetByRole(
+			AriaRole.Link, new() { Name = "Get involved" });
+		await Expect(participateLink).ToHaveAttributeAsync("href", "/#opportunities");
+
+		await participateLink.ClickAsync();
+
+		await Page.WaitForURLAsync(new Regex(@"/#opportunities$"), new() { Timeout = 10_000 });
+		await Expect(Page.Locator("#opportunities")).ToBeInViewportAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
 	public async Task AccountControls_UserMenu_ClosesOnEscape()
 	{
 		// #884: the account/notification dropdowns (useAccountMenu) only

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -46,12 +46,12 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 								</Link>
 							</li>
 							<li>
-								<Link
-									to="/#opportunities"
+								<a
+									href="/#opportunities"
 									className="transition-colors hover:text-white"
 								>
 									{t("footer.participate")}
-								</Link>
+								</a>
 							</li>
 							<li>
 								<Link

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -72,6 +72,19 @@ export default function HomePage() {
 		}
 	}, [searchParams, auth.isAuthenticated, setSearchParams]);
 
+	// A cross-page "/#opportunities" link (Footer, #1031) triggers a full
+	// browser navigation into this CSR SPA, whose initial HTML has no
+	// #opportunities element yet - it only exists once React has mounted.
+	// The browser's native scroll-to-fragment pass can fire before that
+	// mount completes (a real race, worse under load), silently giving up
+	// rather than retrying. Do it ourselves once mounted, when the element
+	// is guaranteed to be there.
+	useEffect(() => {
+		if (window.location.hash === "#opportunities") {
+			document.getElementById("opportunities")?.scrollIntoView();
+		}
+	}, []);
+
 	function handleOrgCta() {
 		if (auth.isAuthenticated) {
 			setShowCreateOrgModal(true);


### PR DESCRIPTION
Footer used a react-router Link for "/#opportunities", which navigates via the history API without native browser fragment scrolling - clicking it did nothing from the home page and left the scroll position untouched from other pages. Switch to a plain anchor tag, matching the home page's own hero CTA.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1031

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
