### PR TITLE
fix: remove dead Social achievement-type mapping and off-by-one bug

### DIFF
--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -5,6 +5,7 @@ import type {
 } from "../client/api-client";
 import Skeleton from "./Skeleton";
 import { formatDate } from "../lib/format";
+import { achievementTypeLabel } from "../lib/achievementType";
 
 function AchievementTypeIcon({
 	type,
@@ -43,16 +44,6 @@ function AchievementTypeIcon({
 					/>
 				</svg>
 			);
-		case "Social":
-			return (
-				<svg {...svgProps}>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
-					/>
-				</svg>
-			);
 		case "Hidden":
 			return (
 				<svg {...svgProps}>
@@ -76,18 +67,6 @@ function AchievementTypeIcon({
 	}
 }
 
-const TYPE_NUM_MAP: Record<number, string> = {
-	0: "Milestone",
-	1: "Streak",
-	2: "Social",
-	3: "Hidden",
-};
-
-function typeLabel(type: string | number): string {
-	if (typeof type === "number") return TYPE_NUM_MAP[type] ?? "Milestone";
-	return type;
-}
-
 interface BadgeCardProps {
 	catalog: BadgeCatalogEntry;
 	earned?: AchievementSummary;
@@ -97,7 +76,9 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 	const { t, i18n } = useTranslation();
 	const isEarned = !!earned;
 	const isHidden = catalog.isHidden && !isEarned;
-	const typeName = isEarned ? typeLabel(earned.type) : typeLabel(catalog.type);
+	const typeName = isEarned
+		? achievementTypeLabel(earned.type)
+		: achievementTypeLabel(catalog.type);
 	const tooltipId = `badge-tooltip-${catalog.key}`;
 	const nameId = `badge-name-${catalog.key}`;
 

--- a/frontend/src/lib/achievementType.test.ts
+++ b/frontend/src/lib/achievementType.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	ACHIEVEMENT_TYPE_NUM_MAP,
+	achievementTypeLabel,
+} from "./achievementType";
+
+describe("achievementTypeLabel", () => {
+	it("maps the Milestone ordinal to its name", () => {
+		expect(achievementTypeLabel(0)).toBe("Milestone");
+	});
+
+	it("maps the Streak ordinal to its name", () => {
+		expect(achievementTypeLabel(1)).toBe("Streak");
+	});
+
+	it("maps the Hidden ordinal to its name", () => {
+		expect(achievementTypeLabel(2)).toBe("Hidden");
+	});
+
+	it("passes an already-stringified type through unchanged", () => {
+		expect(achievementTypeLabel("Hidden")).toBe("Hidden");
+		expect(achievementTypeLabel("Milestone")).toBe("Milestone");
+	});
+
+	it("falls back to Milestone for an unknown ordinal", () => {
+		expect(achievementTypeLabel(99)).toBe("Milestone");
+	});
+
+	it("has no leftover mapping for the removed Social type", () => {
+		expect(Object.values(ACHIEVEMENT_TYPE_NUM_MAP)).not.toContain("Social");
+	});
+});

--- a/frontend/src/lib/achievementType.ts
+++ b/frontend/src/lib/achievementType.ts
@@ -1,0 +1,16 @@
+// BadgeCatalogEntry.type serializes as the raw AchievementType enum ordinal (no
+// JsonStringEnumConverter on the backend), while AchievementSummary.type is already
+// stringified server-side (AchievementReadRepository projects a.Type.ToString()). This
+// map has to mirror Domain.Achievements.AchievementType's declaration order exactly -
+// Milestone, Streak, Hidden - or a numeric type resolves to the wrong name.
+export const ACHIEVEMENT_TYPE_NUM_MAP: Record<number, string> = {
+	0: "Milestone",
+	1: "Streak",
+	2: "Hidden",
+};
+
+export function achievementTypeLabel(type: string | number): string {
+	if (typeof type === "number")
+		return ACHIEVEMENT_TYPE_NUM_MAP[type] ?? "Milestone";
+	return type;
+}


### PR DESCRIPTION
BadgeGrid.tsx mapped numeric AchievementType 2 to "Social", a type no badge in the catalog uses and the backend enum no longer even declares (Milestone=0, Streak=1, Hidden=2). Extract the ordinal-to-name mapping into a tested lib module so it stays in sync with the backend enum.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1029

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
