### PR TITLE
fix: stop exposing PreferredContact on the anonymous public profile

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -8412,8 +8412,7 @@
           "avatarUrl",
           "bio",
           "skills",
-          "languages",
-          "preferredContact"
+          "languages"
         ],
         "type": "object",
         "properties": {
@@ -8457,12 +8456,6 @@
             "items": {
               "type": "string"
             }
-          },
-          "preferredContact": {
-            "type": [
-              "null",
-              "string"
-            ]
           }
         }
       },

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
@@ -41,6 +41,10 @@ internal sealed class GetPublicUserProfileQueryHandler(
 
 		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 
+		// PreferredContact/Phone are deliberately not surfaced here (#1028) - this
+		// endpoint is AllowAnonymous(), so contact info only ever reaches an
+		// organizer through an actual engagement (EngagementSummary), never a
+		// cold-view of the public profile by an anonymous visitor.
 		return new PublicUserProfileResponse(
 			displayName,
 			engagementCount,
@@ -48,7 +52,6 @@ internal sealed class GetPublicUserProfileQueryHandler(
 			user?.AvatarUrl,
 			user?.Bio,
 			user?.Skills ?? [],
-			user?.Languages ?? [],
-			user?.PreferredContact?.ToString());
+			user?.Languages ?? []);
 	}
 }

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/PublicUserProfileResponse.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/PublicUserProfileResponse.cs
@@ -9,5 +9,4 @@ public sealed record PublicUserProfileResponse(
 	string? AvatarUrl,
 	string? Bio,
 	IReadOnlyList<string> Skills,
-	IReadOnlyList<string> Languages,
-	string? PreferredContact);
+	IReadOnlyList<string> Languages);

--- a/backend/tests/Application.UnitTests/Users/GetPublicUserProfile/GetPublicUserProfileQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/GetPublicUserProfile/GetPublicUserProfileQueryHandlerTests.cs
@@ -26,7 +26,7 @@ public class GetPublicUserProfileQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnBioSkillsLanguagesAndPreferredContact_WhenUserRowExists(
+	public async Task Handle_ShouldReturnBioSkillsAndLanguages_WhenUserRowExists(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
@@ -39,7 +39,6 @@ public class GetPublicUserProfileQueryHandlerTests
 		user.ChangeBio("Loves helping out");
 		user.UpdateSkills(["First aid"]);
 		user.UpdateLanguages(["German", "English"]);
-		user.SetPreferredContact(PreferredContact.Phone);
 		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
 
 		// Act
@@ -50,7 +49,33 @@ public class GetPublicUserProfileQueryHandlerTests
 		result!.Bio.Should().Be("Loves helping out");
 		result.Skills.Should().ContainSingle().Which.Should().Be("First aid");
 		result.Languages.Should().BeEquivalentTo(["German", "English"]);
-		result.PreferredContact.Should().Be("Phone");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotExposePreferredContactOrPhone_EvenWhenSet(
+		CancellationToken cancellationToken)
+	{
+		// #1028: this endpoint is AllowAnonymous() - PreferredContact/Phone must
+		// never leak to an anonymous visitor, regardless of what the volunteer
+		// has set on their own profile. Contact info only ever reaches an
+		// organizer through an actual engagement (EngagementSummary).
+		var userId = UserId.New();
+		_keycloakUserService
+			.GetUserAsync(userId.Value, cancellationToken)
+			.Returns(new KeycloakUserProfile(userId.Value, "vera", "Vera", "Volunteer", "vera@test.de"));
+
+		var user = User.Create(userId);
+		user.SetPreferredContact(PreferredContact.Phone);
+		user.SetPhone("+49 555 1234567");
+		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+
+		// Act
+		var result = await _sut.Handle(new GetPublicUserProfileQuery(userId), cancellationToken);
+
+		// Assert
+		result.Should().NotBeNull();
+		result!.GetType().GetProperty("PreferredContact").Should().BeNull();
+		result!.GetType().GetProperty("Phone").Should().BeNull();
 	}
 
 	[Test]
@@ -73,6 +98,5 @@ public class GetPublicUserProfileQueryHandlerTests
 		result!.Bio.Should().BeNull();
 		result.Skills.Should().BeEmpty();
 		result.Languages.Should().BeEmpty();
-		result.PreferredContact.Should().BeNull();
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12409,9 +12409,6 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<string> Languages { get; set; } = new System.Collections.ObjectModel.Collection<string>();
 
-        [System.Text.Json.Serialization.JsonPropertyName("preferredContact")]
-        public string? PreferredContact { get; set; } = default!;
-
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -196,7 +196,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	{
 		// #576: the public /users/{userId} page previously showed only avatar,
 		// name, engagement count, and badges - it now also renders bio/skills/
-		// languages/preferredContact via the shared ProfileFieldsView component.
+		// languages via the shared ProfileFieldsView component (preferredContact
+		// is deliberately excluded from this page, see #1028).
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -157,11 +157,18 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 	}
 
 	[Test]
-	public async Task PublicUserProfile_ShowsBioSkillsLanguagesAndPreferredContact()
+	public async Task PublicUserProfile_ShowsBioSkillsAndLanguagesButNotPreferredContact()
 	{
-		// #576: bio/skills/languages/preferredContact were captured on the owner's
-		// own profile but never exposed on the public /users/{userId} page. Set
-		// them on vera's own profile, then verify they appear on her public page.
+		// #576: bio/skills/languages were captured on the owner's own profile but
+		// never exposed on the public /users/{userId} page. Set them on vera's own
+		// profile, then verify they appear on her public page.
+		//
+		// #1028: PreferredContact (and Phone) are deliberately excluded from this
+		// page - it's reachable by anonymous visitors, and showing a contact
+		// preference with no way to actually reach the volunteer was decorative/
+		// misleading. Contact info only ever reaches an organizer through an
+		// actual engagement, not a cold view of the public profile - so this test
+		// now asserts the opposite of what #576 asserted.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -209,7 +216,7 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		// this specific fetch fans out further than most.
 		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 30_000 });
 		await Expect(Page.GetByText(skill)).ToBeVisibleAsync();
-		await Expect(Page.GetByText("Preferred contact channel")).ToBeVisibleAsync();
+		await Expect(Page.GetByText("Preferred contact channel")).Not.ToBeVisibleAsync();
 
 		// Regression for #766: this bio/skills/contact wrapper had `mx-auto`,
 		// centering it independently of the left-aligned avatar/name row

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6091,7 +6091,6 @@ export interface PublicUserProfileResponse {
     bio: string | undefined;
     skills: string[];
     languages: string[];
-    preferredContact: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -112,14 +112,12 @@ export default function UserProfilePage() {
 
 			{(profile.bio ||
 				profile.skills.length > 0 ||
-				profile.languages.length > 0 ||
-				profile.preferredContact) && (
+				profile.languages.length > 0) && (
 				<div data-content-wrapper className="mb-8 max-w-2xl space-y-5">
 					<ProfileFieldsView
 						bio={profile.bio}
 						skills={profile.skills}
 						languages={profile.languages}
-						preferredContact={profile.preferredContact}
 					/>
 				</div>
 			)}


### PR DESCRIPTION
The public /users/{userId} page (AllowAnonymous) told visitors a volunteer prefers phone/email contact but never surfaced a phone number or address - decorative and privacy-inconsistent, since real contact info only ever reaches an organizer through an engagement.

Drop PreferredContact from PublicUserProfileResponse instead of wiring Phone into it; self-profile editing and organizer-facing engagement views are unaffected.

Closes #1028

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
