### PR TITLE
fix: require admin role to reach /administration

### DIFF
--- a/backend/tests/VisualTests/AdministrationNavLinkTests.cs
+++ b/backend/tests/VisualTests/AdministrationNavLinkTests.cs
@@ -44,4 +44,41 @@ public class AdministrationNavLinkTests(AspireFixture fixture) : VisualTestBase(
 		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Administration" }))
 			.Not.ToBeVisibleAsync();
 	}
+
+	// Regression for #1026: the nav link was already hidden for non-admins
+	// (see the test above), but /administration itself had no role check -
+	// a non-admin who typed the URL directly still got the page shell (the
+	// "Administration" heading) with every section immediately failing its
+	// API call and rendering an error banner, instead of being kept off the
+	// page entirely. ProtectedRoute's requiredRole="admin" now redirects
+	// such visitors to "/" before AdministrationPage ever mounts.
+	[Test]
+	public async Task Administration_DirectNavigationAsNonAdmin_RedirectsToHome()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync($"{origin}/administration");
+
+		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 15_000 });
+		await Expect(Page.Locator("h1")).Not.ToHaveTextAsync("Administration");
+	}
+
+	[Test]
+	public async Task Administration_DirectNavigationAsAdmin_ShowsAdministrationPage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "admin", "admin123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync($"{origin}/administration");
+
+		await Page.WaitForURLAsync($"{origin}/administration", new() { Timeout = 15_000 });
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Administration");
+	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -156,7 +156,7 @@ export default function App() {
 				<Route
 					path="/administration"
 					element={
-						<ProtectedRoute>
+						<ProtectedRoute requiredRole="admin">
 							<AdministrationPage />
 						</ProtectedRoute>
 					}

--- a/frontend/src/layouts/ProtectedRoute.tsx
+++ b/frontend/src/layouts/ProtectedRoute.tsx
@@ -1,15 +1,19 @@
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router";
+import { Navigate, useLocation } from "react-router";
 import type { ReactNode } from "react";
 import { signinLocaleArgs } from "../lib/authLocale";
 import Spinner from "../components/Spinner";
 
 interface Props {
 	children: ReactNode;
+	// Role a signed-in user must have to render `children` (see the flat
+	// roles array shape documented in frontend/AGENTS.md's Role Checks
+	// section). Omit for routes that only require being signed in.
+	requiredRole?: string;
 }
 
-export default function ProtectedRoute({ children }: Props) {
+export default function ProtectedRoute({ children, requiredRole }: Props) {
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const location = useLocation();
@@ -28,6 +32,15 @@ export default function ProtectedRoute({ children }: Props) {
 			state: { returnTo: location.pathname + location.search },
 		});
 		return null;
+	}
+
+	if (requiredRole) {
+		const roles = (
+			Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
+		) as string[];
+		if (!roles.includes(requiredRole)) {
+			return <Navigate to="/" replace />;
+		}
 	}
 
 	return <>{children}</>;


### PR DESCRIPTION
ProtectedRoute only checked authentication, not role, so a signed-in non-admin who typed /administration directly got the page shell with every section's API call immediately 403'ing into an error banner. Add an optional requiredRole prop and redirect non-matching users to "/" instead.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1026

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
