### PR TITLE
fix: resolve live-staging findings from the 1.0 readiness audit

### DIFF
--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -182,7 +182,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 	public async Task ScheduledSlotsSignUpModal_ShowsPerSlotBookingCounts()
 	{
 		// #533: Slot options in the sign-up modal must include availability info,
-		// e.g. "(4 left)" when a slot has 4 remaining spots, or "(Full)" when full.
+		// e.g. "4 spots left" when a slot has 4 remaining spots, or "Full" when full.
 		//
 		// Create the ScheduledSlots opportunity (draft -> add slots -> publish) via the
 		// API rather than hunting for a seed card in the paginated public list.
@@ -218,7 +218,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 
 		// A ScheduledSlots opportunity needs at least one time slot before it can be
 		// published; two slots with spare capacity give the picker options that
-		// each render a "(N left)" availability count.
+		// each render an "N spots left" availability count.
 		var start = DateTimeOffset.UtcNow.AddDays(7);
 		(await http.PostAsJsonAsync($"/v1/volunteer-opportunities/{opportunityId}/time-slots", new
 		{
@@ -267,12 +267,15 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		{
 			options = await optionLocator.EvaluateAllAsync<string[]>(
 				"els => els.map(el => el.textContent ?? '')");
+			// #987: the slot dropdown now reuses the same opportunities.spotsLeft/
+			// full/unlimitedSpots strings the rest of the app uses for remaining
+			// capacity, instead of its own parenthetical signUp.* copies.
 			hasAvailabilityInfo = options.Any(o =>
-				Regex.IsMatch(o, @"\(.*left\)|\(Full\)|\(noch \d+\)|\(Ausgebucht\)", RegexOptions.IgnoreCase));
+				Regex.IsMatch(o, @"\d+ spots? left|\bFull\b|Unlimited spots", RegexOptions.IgnoreCase));
 			return options.Length > 0 && hasAvailabilityInfo;
 		}, () => options.Length == 0
 			? "slot options must be rendered, but none were found"
-			: "each slot option should include booking count info like '(4 left)'. "
+			: "each slot option should include booking count info like '4 spots left'. "
 				+ $"Actual options: [{string.Join(", ", options)}]");
 	}
 
@@ -349,7 +352,9 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 
 		var optionLocator = Page.Locator("[role='option']");
 		await Expect(optionLocator.First).ToBeVisibleAsync();
-		await Expect(optionLocator.First).ToContainTextAsync("(Unlimited)");
+		// #987: the slot dropdown now reuses opportunities.unlimitedSpots ("Unlimited
+		// spots") instead of its own parenthetical signUp.unlimitedSpots ("(Unlimited)").
+		await Expect(optionLocator.First).ToContainTextAsync("Unlimited spots");
 		await Expect(optionLocator.First).Not.ToHaveAttributeAsync("aria-disabled", "true");
 	}
 }

--- a/backend/tests/VisualTests/PageHealthTests.cs
+++ b/backend/tests/VisualTests/PageHealthTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+// einsatzbereit#997: the 2026-07-25 live-staging audit swept 16 page loads
+// across anonymous/vera/olaf/admin sessions and found zero console errors
+// and zero failed (>= 400) network responses - a positive finding worth
+// locking in as a regression guard, since nothing else in this suite watches
+// for either. Scoped to the home page rather than replaying all 16 - that
+// sweep was a one-time manual audit, not a suite this is meant to reproduce
+// wholesale, and every other test in this project already exercises its own
+// page's happy path without a console/network assertion of its own.
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class PageHealthTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task HomePage_HasNoConsoleErrorsOrFailedRequests()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var consoleErrors = new List<string>();
+		var failedResponses = new List<string>();
+
+		Page.Console += (_, msg) =>
+		{
+			if (msg.Type == "error")
+				consoleErrors.Add(msg.Text);
+		};
+		Page.Response += (_, response) =>
+		{
+			// Chromium probes /favicon.ico by default regardless of the SVG
+			// <link rel="icon"> this app actually serves - a browser quirk
+			// unrelated to app correctness, not a real failed request.
+			if (response.Status >= 400 && !response.Url.EndsWith("/favicon.ico"))
+				failedResponses.Add($"{response.Status} {response.Url}");
+		};
+
+		await Page.GotoAsync(frontend.ToString());
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		if (consoleErrors.Count > 0)
+			throw new Exception(
+				$"Home page logged {consoleErrors.Count} console error(s):\n"
+				+ string.Join("\n", consoleErrors));
+
+		if (failedResponses.Count > 0)
+			throw new Exception(
+				$"Home page had {failedResponses.Count} failed request(s):\n"
+				+ string.Join("\n", failedResponses));
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,19 +7,19 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="apple-touch-icon" href="/icons/icon-192.png" />
 		<meta name="theme-color" content="#2d8a5e" />
-		<title>Einsatzbereit - Volunteer spontaneously. Find your local cause.</title>
-		<meta name="description" content="Einsatzbereit connects committed volunteers with regional needs. Find local volunteer opportunities, help spontaneously, and make a difference in your community." />
+		<title>Einsatzbereit - Spontan Freiwilligenarbeit leisten. Finde deinen Einsatz.</title>
+		<meta name="description" content="Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde." />
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://einsatzbereit.maik-hasler.de/" />
-		<meta property="og:title" content="Einsatzbereit - Volunteer spontaneously. Find your local cause." />
-		<meta property="og:description" content="Einsatzbereit connects committed volunteers with regional needs. Find local volunteer opportunities, help spontaneously, and make a difference in your community." />
+		<meta property="og:title" content="Einsatzbereit - Spontan Freiwilligenarbeit leisten. Finde deinen Einsatz." />
+		<meta property="og:description" content="Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde." />
 		<meta property="og:image" content="https://einsatzbereit.maik-hasler.de/og-image.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
 		<meta property="og:image:type" content="image/png" />
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Einsatzbereit - Volunteer spontaneously. Find your local cause." />
-		<meta name="twitter:description" content="Einsatzbereit connects committed volunteers with regional needs. Find local volunteer opportunities, help spontaneously, and make a difference in your community." />
+		<meta name="twitter:title" content="Einsatzbereit - Spontan Freiwilligenarbeit leisten. Finde deinen Einsatz." />
+		<meta name="twitter:description" content="Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde." />
 		<meta name="twitter:image" content="https://einsatzbereit.maik-hasler.de/og-image.png" />
 		<script src="/config.js" defer></script>
 	</head>

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -4,7 +4,7 @@ import type {
 	BadgeCatalogEntry,
 } from "../client/api-client";
 import Skeleton from "./Skeleton";
-import { resolveDateLocale } from "../lib/format";
+import { formatDate } from "../lib/format";
 
 function AchievementTypeIcon({
 	type,
@@ -95,7 +95,6 @@ interface BadgeCardProps {
 
 function BadgeCard({ catalog, earned }: BadgeCardProps) {
 	const { t, i18n } = useTranslation();
-	const locale = resolveDateLocale(i18n.language);
 	const isEarned = !!earned;
 	const isHidden = catalog.isHidden && !isEarned;
 	const typeName = isEarned ? typeLabel(earned.type) : typeLabel(catalog.type);
@@ -145,7 +144,10 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 			{isEarned && (
 				<p className="mt-1 text-xs text-gray-500">
 					{t("achievements.unlockedOn", {
-						date: new Date(earned.unlockedAt).toLocaleDateString(locale),
+						date: formatDate(
+							earned.unlockedAt as unknown as string,
+							i18n.language,
+						),
 					})}
 				</p>
 			)}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 
 export default function Footer({ compact = false }: { compact?: boolean }) {
 	const { t } = useTranslation();
@@ -131,7 +131,27 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 
 				{/* Bottom Bar */}
 				<div className="mt-12 border-t border-brand-700 pt-8 text-center text-xs">
-					<p>{t("footer.copyright", { year: currentYear })}</p>
+					<p>
+						<Trans
+							i18nKey="footer.copyright"
+							values={{ year: currentYear }}
+							components={{
+								// Self-closing, matching the contactLink/privacyLink/imprintLink
+								// convention in TermsOfUsePage.tsx - Trans fills this from
+								// footer.copyright's <licenseLink> tag content in en.json/de.json,
+								// not from children written here, so no fallback text is needed.
+								licenseLink: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a
+										href="https://github.com/maik-hasler/einsatzbereit/blob/main/LICENSE"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="underline hover:text-white"
+									/>
+								),
+							}}
+						/>
+					</p>
 				</div>
 			</div>
 		</footer>

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -81,10 +81,12 @@ export default function SignUpModal({
 			<form onSubmit={handleSubmit} className="space-y-4">
 				{isScheduledSlots && (
 					<div>
-						<label
-							htmlFor="sign-up-time-slot"
-							className="mb-1 block text-sm font-medium text-gray-700"
-						>
+						{/* Visually hidden, not removed - the dialog title just above
+						("Select a slot") already conveys this on screen, so showing it
+						again here read as a duplicated label (#987); the dropdown still
+						needs its own accessible name for screen reader users landing on
+						it directly. */}
+						<label htmlFor="sign-up-time-slot" className="sr-only">
 							{t("signUp.selectTimeSlot")}
 						</label>
 						{timeSlots.length === 0 ? (
@@ -116,10 +118,10 @@ export default function SignUpModal({
 											i18n.language,
 										)} ${
 											spotsLeft === null
-												? t("signUp.unlimitedSpots")
+												? t("opportunities.unlimitedSpots")
 												: slotFull
-													? t("signUp.slotFull")
-													: t("signUp.spotsLeft", { count: spotsLeft })
+													? t("opportunities.full")
+													: t("opportunities.spotsLeft", { count: spotsLeft })
 										}`,
 									};
 								})}

--- a/frontend/src/lib/avatarColor.test.ts
+++ b/frontend/src/lib/avatarColor.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { avatarColorClasses } from "./avatarColor";
+
+describe("avatarColorClasses", () => {
+	it("is deterministic for the same seed", () => {
+		expect(avatarColorClasses("org-1")).toEqual(avatarColorClasses("org-1"));
+	});
+
+	it("picks different pairs for different seeds", () => {
+		// Not a strict guarantee for arbitrary seeds (a fixed-size palette must
+		// collide eventually), but these two are chosen to land on different
+		// palette entries, which is the whole point of #993: two organizations
+		// sharing an initial should not also share a color.
+		expect(
+			avatarColorClasses("11111111-1111-1111-1111-111111111111"),
+		).not.toEqual(avatarColorClasses("22222222-2222-2222-2222-222222222222"));
+	});
+
+	it("always returns a non-empty bg and text class", () => {
+		const { bg, text } = avatarColorClasses("some-org-id");
+		expect(bg).toMatch(/^bg-/);
+		expect(text).toMatch(/^text-/);
+	});
+});

--- a/frontend/src/lib/avatarColor.ts
+++ b/frontend/src/lib/avatarColor.ts
@@ -1,0 +1,29 @@
+// Fixed palette of Tailwind bg/text pairs (same 100/700 shade combo the
+// initial-avatar already used, just varied by hue) - deterministic per seed
+// so the same organization always gets the same color, and same-initial
+// organizations (e.g. two names both starting with "F") are no longer
+// visually indistinguishable in the directory (#993).
+const AVATAR_COLOR_PALETTE = [
+	{ bg: "bg-brand-100", text: "text-brand-700" },
+	{ bg: "bg-blue-100", text: "text-blue-700" },
+	{ bg: "bg-purple-100", text: "text-purple-700" },
+	{ bg: "bg-amber-100", text: "text-amber-700" },
+	{ bg: "bg-teal-100", text: "text-teal-700" },
+	{ bg: "bg-rose-100", text: "text-rose-700" },
+] as const;
+
+export interface AvatarColorClasses {
+	bg: string;
+	text: string;
+}
+
+/** Deterministically picks a color pair from a fixed palette based on `seed`
+ * (e.g. an organization id) - same seed always maps to the same pair. */
+export function avatarColorClasses(seed: string): AvatarColorClasses {
+	let hash = 0;
+	for (let i = 0; i < seed.length; i++) {
+		hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+	}
+	const index = Math.abs(hash) % AVATAR_COLOR_PALETTE.length;
+	return AVATAR_COLOR_PALETTE[index];
+}

--- a/frontend/src/lib/calendarRange.test.ts
+++ b/frontend/src/lib/calendarRange.test.ts
@@ -36,13 +36,6 @@ describe("visibleCalendarRange", () => {
 		expect(day(to)).toBe("2026-03-14");
 	});
 
-	it("returns the same range for work_week as for week", () => {
-		const week = visibleCalendarRange(new Date(2026, 2, 11), "week");
-		const workWeek = visibleCalendarRange(new Date(2026, 2, 11), "work_week");
-
-		expect(workWeek).toEqual(week);
-	});
-
 	it("returns just the single day for day view", () => {
 		const { from, to } = visibleCalendarRange(new Date(2026, 2, 11), "day");
 
@@ -63,7 +56,6 @@ describe("visibleCalendarRange", () => {
 		const views: Array<Parameters<typeof visibleCalendarRange>[1]> = [
 			"month",
 			"week",
-			"work_week",
 			"day",
 			"agenda",
 		];

--- a/frontend/src/lib/calendarRange.ts
+++ b/frontend/src/lib/calendarRange.ts
@@ -32,7 +32,6 @@ export function visibleCalendarRange(
 				to: endOfWeek(endOfMonth(date)),
 			};
 		case "week":
-		case "work_week":
 			return { from: startOfWeek(date), to: endOfWeek(date) };
 		case "agenda":
 			return {

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -5,6 +5,7 @@ import {
 	formatOccurrence,
 	formatParticipationType,
 	formatDate,
+	formatDateLong,
 	formatDateTime,
 	formatPostedAgo,
 	isSlotFull,
@@ -148,6 +149,35 @@ describe("formatDate", () => {
 		expect(formatDate(iso, "en").length).toBeLessThan(
 			formatDateTime(iso, "en").length,
 		);
+	});
+});
+
+describe("formatDateLong", () => {
+	// Compares against the identical Intl call rather than a hardcoded string
+	// so the assertion doesn't depend on the host's local timezone offset.
+	it("formats using en-GB style for en, spelling out the month", () => {
+		const iso = "2026-08-15T23:59:59.999Z";
+		const expected = new Date(iso).toLocaleDateString("en-GB", {
+			day: "2-digit",
+			month: "long",
+			year: "numeric",
+		});
+		expect(formatDateLong(iso, "en")).toBe(expected);
+	});
+
+	it("formats using de-DE style when locale is de", () => {
+		const iso = "2026-08-15T23:59:59.999Z";
+		const expected = new Date(iso).toLocaleDateString("de-DE", {
+			day: "2-digit",
+			month: "long",
+			year: "numeric",
+		});
+		expect(formatDateLong(iso, "de")).toBe(expected);
+	});
+
+	it("differs from the compact formatDate style", () => {
+		const iso = "2026-08-15T23:59:59.999Z";
+		expect(formatDateLong(iso, "de")).not.toBe(formatDate(iso, "de"));
 	});
 });
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -81,6 +81,33 @@ export function formatDate(dt: string, lng: string): string {
 	return getDateFormatter(lng).format(new Date(dt));
 }
 
+const longDateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getLongDateFormatter(lng: string): Intl.DateTimeFormat {
+	const resolvedLocale = resolveDateLocale(lng);
+	let formatter = longDateFormatters.get(resolvedLocale);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(resolvedLocale, {
+			day: "2-digit",
+			month: "long",
+			year: "numeric",
+		});
+		longDateFormatters.set(resolvedLocale, formatter);
+	}
+	return formatter;
+}
+
+/** Long-form date-only formatting (e.g. "25. Juli 2026") - for lower-frequency
+ * "created on"/"sent on" timestamps where a spelled-out month reads better
+ * than the compact numeric style `formatDate` uses. `lng` is i18n.language
+ * ("de"/"en"), not an Intl locale (see formatDateTime). Previously each call
+ * site re-derived this with its own inline `toLocaleDateString(locale, {...})`
+ * options object, which is how it ended up coexisting with two other date
+ * formats across the app (#986) - centralizing it here is the fix. */
+export function formatDateLong(dt: string, lng: string): string {
+	return getLongDateFormatter(lng).format(new Date(dt));
+}
+
 export function formatPostedAgo(dt: string, t: TFunction): string {
 	const days = differenceInCalendarDays(new Date(), new Date(dt));
 	return days <= 0

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -38,9 +38,10 @@
       "privacy": "Datenschutz",
       "contact": "Kontakt",
       "followUs": "Folge uns",
-      "copyright": "© {{year}} Einsatzbereit. Alle Rechte vorbehalten."
+      "copyright": "© {{year}} Einsatzbereit. Lizenziert unter <licenseLink>AGPL-3.0</licenseLink>."
     },
     "landing": {
+      "pageTitle": "Finde Freiwilligenarbeit in deiner Nähe",
       "heroTagline": "Mikro-Ehrenamt · Kostenlos · Open Source",
       "heroTitle": "Ehrenamt muss nicht schwer sein.",
       "heroSubtitle": "Immer weniger Menschen engagieren sich - aus Zeitmangel, Aufwand und Bürokratie. Einsatzbereit macht Mikro-Ehrenamt möglich: ein paar Stunden, echter Impact, null Overhead.",
@@ -318,9 +319,6 @@
       "submit": "Anmelden",
       "cancel": "Abbrechen",
       "unknownError": "Unbekannter Fehler",
-      "spotsLeft": "(noch {{count}})",
-      "slotFull": "(Ausgebucht)",
-      "unlimitedSpots": "(Unbegrenzt)",
       "selectTimeSlotRequired": "Bitte wähle einen Zeitslot aus."
     },
     "organization": {
@@ -365,6 +363,8 @@
       "loading": "Wird geladen…",
       "layoutLoadError": "Dein gespeichertes Dashboard-Layout konnte nicht bestätigt werden. Die Ansicht unten stimmt damit möglicherweise nicht überein - Bearbeiten ist deaktiviert, bis dies erfolgreich geladen wurde.",
       "pendingEngagements": "Ausstehende Anmeldungen",
+      "pendingEngagements_one": "Ausstehende Anmeldung",
+      "pendingEngagements_other": "Ausstehende Anmeldungen",
       "viewOpportunities": "Einsätze anzeigen →",
       "unnamedDraft": "Unbenannter Entwurf",
       "signedUpVolunteers": "Angemeldete Freiwillige",
@@ -827,6 +827,9 @@
     "profile": {
       "title": "Mein Profil",
       "sectionDetails": "Profil-Details",
+      "emptyStateTitle": "Dein Profil ist noch leer",
+      "emptyStateMessage": "Füge eine Bio, Fähigkeiten oder Kontaktpräferenzen hinzu, damit Organisationen etwas über dich wissen.",
+      "emptyStateCta": "Profil vervollständigen",
       "fieldAvatar": "Profilbild",
       "avatarUpload": "Bild hochladen",
       "avatarHint": "JPEG, PNG oder WebP, max. 2 MB.",
@@ -1060,7 +1063,6 @@
       "calendarNext": "Weiter",
       "calendarMonth": "Monat",
       "calendarWeek": "Woche",
-      "calendarWorkWeek": "Arbeitswoche",
       "calendarDay": "Tag",
       "calendarAgenda": "Agenda",
       "eventFillState": "{{booked}} / {{max}} gebucht",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -38,9 +38,10 @@
       "privacy": "Privacy Policy",
       "contact": "Contact",
       "followUs": "Follow us",
-      "copyright": "© {{year}} Einsatzbereit. All rights reserved."
+      "copyright": "© {{year}} Einsatzbereit. Licensed under <licenseLink>AGPL-3.0</licenseLink>."
     },
     "landing": {
+      "pageTitle": "Find volunteer opportunities near you",
       "heroTagline": "Micro-volunteering · Free · Open Source",
       "heroTitle": "Volunteering doesn't have to be hard.",
       "heroSubtitle": "Fewer people volunteer each year - due to time pressure, effort, and bureaucracy. Einsatzbereit makes micro-volunteering possible: a few hours, real impact, zero overhead.",
@@ -318,9 +319,6 @@
       "submit": "Sign up",
       "cancel": "Cancel",
       "unknownError": "Unknown error",
-      "spotsLeft": "({{count}} left)",
-      "slotFull": "(Full)",
-      "unlimitedSpots": "(Unlimited)",
       "selectTimeSlotRequired": "Please select a time slot."
     },
     "organization": {
@@ -365,6 +363,8 @@
       "loading": "Loading…",
       "layoutLoadError": "Couldn't confirm your saved dashboard layout. What's shown below may not match it, and editing is disabled until this loads successfully.",
       "pendingEngagements": "Pending Sign-ups",
+      "pendingEngagements_one": "Pending Sign-up",
+      "pendingEngagements_other": "Pending Sign-ups",
       "viewOpportunities": "View opportunities →",
       "unnamedDraft": "Unnamed Draft",
       "signedUpVolunteers": "Signed-up Volunteers",
@@ -827,6 +827,9 @@
     "profile": {
       "title": "My Profile",
       "sectionDetails": "Profile Details",
+      "emptyStateTitle": "Your profile is still empty",
+      "emptyStateMessage": "Add a bio, skills, or contact preferences so organizations know a bit about you.",
+      "emptyStateCta": "Complete your profile",
       "fieldAvatar": "Profile picture",
       "avatarUpload": "Upload picture",
       "avatarHint": "JPEG, PNG or WebP, max 2 MB.",
@@ -1060,7 +1063,6 @@
       "calendarNext": "Next",
       "calendarMonth": "Month",
       "calendarWeek": "Week",
-      "calendarWorkWeek": "Work week",
       "calendarDay": "Day",
       "calendarAgenda": "Agenda",
       "eventFillState": "{{booked}} / {{max}} booked",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -17,7 +17,7 @@ import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import NotFoundPage from "./NotFoundPage";
-import { formatDateTime, resolveDateLocale } from "../lib/format";
+import { formatDate, formatDateTime, resolveDateLocale } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { useSetOrgBreadcrumbExtra } from "../contexts/OrgBreadcrumbContext";
 import { dispatchToast } from "../lib/toastBus";
@@ -490,7 +490,10 @@ export default function EngagementManagementPage() {
 										})()}
 									<p className="mt-1 text-xs text-gray-500">
 										{t("engagementManagement.receivedOn", {
-											date: new Date(e.createdOn).toLocaleDateString(locale),
+											date: formatDate(
+												e.createdOn as unknown as string,
+												i18n.language,
+											),
 										})}
 									</p>
 									{e.isCheckedIn && (
@@ -695,7 +698,10 @@ export default function EngagementManagementPage() {
 												/>
 											))}
 											<span className="ml-1 text-xs text-gray-500">
-												{new Date(item.submittedAt).toLocaleDateString(locale)}
+												{formatDate(
+													item.submittedAt as unknown as string,
+													i18n.language,
+												)}
 											</span>
 										</div>
 										{item.comment && (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
 	const api = useApiClient();
 	const navigate = useNavigate();
 	const { t } = useTranslation();
-	usePageTitle();
+	usePageTitle(t("landing.pageTitle"));
 
 	const heroTitleId = useId();
 	const howItWorksTitleId = useId();
@@ -249,6 +249,37 @@ export default function HomePage() {
 									{t("landing.heroCtaOrg")}
 								</Button>
 							)}
+						</div>
+
+						{/* Mobile/tablet feature chips - the left rail below is xl+ only,
+						which used to mean these three value props were invisible on
+						every viewport smaller than 1280px, including the phone-sized
+						audience this product's "sign up in seconds" pitch targets
+						(#988). Reflowed here as a compact row instead of duplicating
+						the full bordered cards. */}
+						<div className="animate-fade-up-d3 mt-8 flex flex-wrap items-center justify-center gap-3 xl:hidden">
+							{[
+								{
+									icon: <ClockIcon className="h-4 w-4" />,
+									label: t("landing.heroLeftCard1Label"),
+								},
+								{
+									icon: <MapPinIcon className="h-4 w-4" />,
+									label: t("landing.heroLeftCard2Label"),
+								},
+								{
+									icon: <CheckIcon className="h-4 w-4" />,
+									label: t("landing.heroLeftCard3Label"),
+								},
+							].map(({ icon, label }) => (
+								<span
+									key={label}
+									className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/8 px-3 py-1.5 text-xs font-medium text-white backdrop-blur-sm"
+								>
+									<span aria-hidden="true">{icon}</span>
+									{label}
+								</span>
+							))}
 						</div>
 						<div className="animate-fade-up-d4 mt-8 hidden grid-cols-3 gap-6 border-t border-white/10 pt-8 sm:mt-12 sm:grid sm:pt-10">
 							{stats.map(({ id, value, label }) => (

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -8,6 +8,7 @@ import { useLoadMore } from "../hooks/useLoadMore";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
+import { avatarColorClasses } from "../lib/avatarColor";
 import { inputClass } from "../lib/formClasses";
 import { pageTitleClass } from "../lib/headingClasses";
 import EmptyState from "../components/EmptyState";
@@ -158,68 +159,73 @@ export default function OrganizationsPage() {
 				) : (
 					<>
 						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-							{items.map((org) => (
-								<li
-									key={org.id}
-									className="relative flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white p-4 shadow-resting transition-shadow hover:shadow-raised"
-								>
-									<Link
-										to={`/organizations/${org.id}`}
-										className="absolute inset-0 rounded-card"
-										aria-label={org.name}
-									/>
-									<div className="flex items-center gap-3">
-										{org.logoUrl ? (
-											<img
-												src={org.logoUrl}
-												alt=""
-												width={48}
-												height={48}
-												loading="lazy"
-												className="h-12 w-12 shrink-0 rounded-full object-cover"
-											/>
-										) : (
-											<span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-brand-100 text-lg font-semibold text-brand-700">
-												{org.name.charAt(0).toUpperCase()}
-											</span>
-										)}
-										<div className="flex min-w-0 flex-1 items-center gap-2">
-											<strong className="block truncate text-sm font-semibold text-gray-900">
-												{org.name}
-											</strong>
+							{items.map((org) => {
+								const avatarColor = avatarColorClasses(org.id);
+								return (
+									<li
+										key={org.id}
+										className="relative flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white p-4 shadow-resting transition-shadow hover:shadow-raised"
+									>
+										<Link
+											to={`/organizations/${org.id}`}
+											className="absolute inset-0 rounded-card"
+											aria-label={org.name}
+										/>
+										<div className="flex items-center gap-3">
+											{org.logoUrl ? (
+												<img
+													src={org.logoUrl}
+													alt=""
+													width={48}
+													height={48}
+													loading="lazy"
+													className="h-12 w-12 shrink-0 rounded-full object-cover"
+												/>
+											) : (
+												<span
+													className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-semibold ${avatarColor.bg} ${avatarColor.text}`}
+												>
+													{org.name.charAt(0).toUpperCase()}
+												</span>
+											)}
+											<div className="flex min-w-0 flex-1 items-center gap-2">
+												<strong className="block truncate text-sm font-semibold text-gray-900">
+													{org.name}
+												</strong>
+											</div>
+											{auth.isAuthenticated && (
+												<ReportFlagButton
+													targetLabel={org.name}
+													ariaLabel={t("orgProfile.reportOrganization")}
+													onReport={async (reason, details) => {
+														await api.reportOrganization(org.id, {
+															reason,
+															details: details || undefined,
+														});
+													}}
+												/>
+											)}
 										</div>
-										{auth.isAuthenticated && (
-											<ReportFlagButton
-												targetLabel={org.name}
-												ariaLabel={t("orgProfile.reportOrganization")}
-												onReport={async (reason, details) => {
-													await api.reportOrganization(org.id, {
-														reason,
-														details: details || undefined,
-													});
-												}}
-											/>
-										)}
-									</div>
-									<div className="min-w-0 flex-1">
-										{org.description && (
-											<p className="line-clamp-2 text-sm text-gray-500">
-												{org.description}
-											</p>
-										)}
-										{org.city && (
-											<p className="mt-1 text-xs text-gray-500">{org.city}</p>
-										)}
-										{org.openOpportunityCount > 0 && (
-											<p className="mt-1 text-xs font-medium text-brand-700">
-												{t("organizationsPage.openOpportunities", {
-													count: org.openOpportunityCount,
-												})}
-											</p>
-										)}
-									</div>
-								</li>
-							))}
+										<div className="min-w-0 flex-1">
+											{org.description && (
+												<p className="line-clamp-2 text-sm text-gray-500">
+													{org.description}
+												</p>
+											)}
+											{org.city && (
+												<p className="mt-1 text-xs text-gray-500">{org.city}</p>
+											)}
+											{org.openOpportunityCount > 0 && (
+												<p className="mt-1 text-xs font-medium text-brand-700">
+													{t("organizationsPage.openOpportunities", {
+														count: org.openOpportunityCount,
+													})}
+												</p>
+											)}
+										</div>
+									</li>
+								);
+							})}
 						</ul>
 
 						{hasMore &&

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -9,7 +9,7 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
-import { formatDateTime, resolveDateLocale } from "../../lib/format";
+import { formatDate, formatDateTime } from "../../lib/format";
 import AddToCalendarMenu from "../../components/AddToCalendarMenu";
 import CheckInModal from "../../components/CheckInModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -31,7 +31,6 @@ export default function ActivitySection() {
 	const api = useApiClient();
 	const { t, i18n } = useTranslation();
 	const navigate = useNavigate();
-	const locale = resolveDateLocale(i18n.language);
 
 	const STATUS_LABELS: Record<string, string> = {
 		Pending: t("myEngagements.status.Pending"),
@@ -207,7 +206,10 @@ export default function ActivitySection() {
 									</p>
 									<p className="mt-0.5 text-xs text-gray-500">
 										{t("invitations.invitedOn", {
-											date: new Date(inv.createdOn).toLocaleDateString(locale),
+											date: formatDate(
+												inv.createdOn as unknown as string,
+												i18n.language,
+											),
 										})}
 									</p>
 								</div>
@@ -374,7 +376,10 @@ export default function ActivitySection() {
 									)}
 									<p className="mt-1.5 text-xs text-gray-500">
 										{t("myEngagements.registeredOn", {
-											date: new Date(e.createdOn).toLocaleDateString(locale),
+											date: formatDate(
+												e.createdOn as unknown as string,
+												i18n.language,
+											),
 										})}
 									</p>
 									{e.isCheckedIn && (

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -11,6 +11,7 @@ import { inputClass, textareaClass } from "../../lib/formClasses";
 import { pageTitleClass } from "../../lib/headingClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
+import EmptyState from "../../components/EmptyState";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
 import Skeleton from "../../components/Skeleton";
 import ErrorBanner from "../../components/ErrorBanner";
@@ -301,6 +302,18 @@ export default function ProfileOverviewPage() {
 		onCancel: handleCancel,
 	});
 
+	// ProfileFieldsView renders nothing at all once every field below is
+	// empty (a fresh account has none of them set) - previously that left the
+	// "Profile Details" heading sitting over a blank gap on every new user's
+	// very first view of this page (#985).
+	const isProfileFieldsEmpty =
+		!form.state.bio &&
+		form.state.skills.length === 0 &&
+		form.state.languages.length === 0 &&
+		!form.state.preferredContact &&
+		!form.state.phone &&
+		!form.state.preferredLanguage;
+
 	return (
 		<>
 			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
@@ -411,16 +424,26 @@ export default function ProfileOverviewPage() {
 							{t("profile.sectionDetails")}
 						</h2>
 
-						{!editing && (
-							<ProfileFieldsView
-								bio={form.state.bio}
-								skills={form.state.skills}
-								languages={form.state.languages}
-								preferredContact={form.state.preferredContact || null}
-								phone={form.state.phone || null}
-								preferredLanguage={form.state.preferredLanguage}
-							/>
-						)}
+						{!editing &&
+							(isProfileFieldsEmpty ? (
+								<EmptyState
+									title={t("profile.emptyStateTitle")}
+									message={t("profile.emptyStateMessage")}
+									action={{
+										label: t("profile.emptyStateCta"),
+										onClick: () => setEditing(true),
+									}}
+								/>
+							) : (
+								<ProfileFieldsView
+									bio={form.state.bio}
+									skills={form.state.skills}
+									languages={form.state.languages}
+									preferredContact={form.state.preferredContact || null}
+									phone={form.state.phone || null}
+									preferredLanguage={form.state.preferredLanguage}
+								/>
+							))}
 
 						{editing && (
 							<form ref={formRef} onSubmit={handleSave} className="space-y-6">

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -227,6 +227,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 		() => api.getOrganizationCalendarEvents(organizationId, rangeFrom, rangeTo),
 	);
 	const calLoading = calData === null && !calError;
+
 	const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
 	const [pickerColor, setPickerColor] = useState<string>(() =>
 		brandColor("700"),
@@ -258,6 +259,22 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 		[calData],
 	);
 
+	// #983: opening on the current month whenever the organizer happens to
+	// have no events scheduled in it wastes ~800px on an empty grid and,
+	// since `calDate` also starts on today, defaults to showing exactly
+	// nothing. The one-shot flag is consumed on the *first* load to
+	// complete, regardless of which view that happens to be (medium/compact
+	// widgets default to week/agenda, not month) - gating it behind
+	// `calView === "month"` instead would leave the flag unconsumed for
+	// those sizes and keep re-firing on every later view change, silently
+	// overriding a month view the organizer switched to deliberately.
+	const [hasCheckedInitialView, setHasCheckedInitialView] = useState(false);
+	useEffect(() => {
+		if (hasCheckedInitialView || calLoading) return;
+		setHasCheckedInitialView(true);
+		if (calView === "month" && calEvents.length === 0) setCalView("agenda");
+	}, [calLoading, calView, calEvents, hasCheckedInitialView]);
+
 	const calendarMessages = useMemo(
 		() => ({
 			today: t("orgOverview.calendarToday"),
@@ -265,7 +282,6 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 			next: t("orgOverview.calendarNext"),
 			month: t("orgOverview.calendarMonth"),
 			week: t("orgOverview.calendarWeek"),
-			work_week: t("orgOverview.calendarWorkWeek"),
 			day: t("orgOverview.calendarDay"),
 			agenda: t("orgOverview.calendarAgenda"),
 			noEventsInRange: t("orgOverview.calendarNoEvents"),
@@ -378,7 +394,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 							onView={(v: View) => setCalView(v)}
 							date={calDate}
 							onNavigate={(d: Date) => setCalDate(d)}
-							views={["month", "week", "work_week", "day", "agenda"]}
+							views={["month", "week", "day", "agenda"]}
 							style={{ height: "100%", minHeight: CALENDAR_MIN_HEIGHT_PX }}
 							components={calendarComponents}
 							eventPropGetter={calendarEventPropGetter}

--- a/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../../../client/api-client";
 import WidgetCard from "./WidgetCard";
 import type { WidgetSizeClass } from "./widgetCatalog";
-import { resolveDateLocale } from "../../../lib/format";
+import { formatDateLong } from "../../../lib/format";
 
 interface Props {
 	org: OrganizationDetailsResponse;
@@ -13,7 +13,6 @@ interface Props {
 
 function SettingsWidget({ org, size }: Props) {
 	const { t, i18n } = useTranslation();
-	const locale = resolveDateLocale(i18n.language);
 	const compact = size === "compact";
 
 	const logo = org.logoUrl ? (
@@ -72,11 +71,10 @@ function SettingsWidget({ org, size }: Props) {
 							<>
 								<span className="mx-1.5">&middot;</span>
 								{t("orgSettings.createdOn", {
-									date: new Date(org.createdOn).toLocaleDateString(locale, {
-										day: "2-digit",
-										month: "long",
-										year: "numeric",
-									}),
+									date: formatDateLong(
+										org.createdOn as unknown as string,
+										i18n.language,
+									),
 								})}
 							</>
 						)}

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -82,7 +82,9 @@ function ToDoWidget({ organizationId, size }: Props) {
 							{kpis.pendingEngagements}
 						</p>
 						<p className="text-sm text-gray-500">
-							{t("orgDashboard.pendingEngagements")}
+							{t("orgDashboard.pendingEngagements", {
+								count: kpis.pendingEngagements,
+							})}
 						</p>
 					</div>
 					<div>

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -10,7 +10,7 @@ import CreateVolunteerOpportunityModal from "../../../components/CreateVolunteer
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
-import { resolveDateLocale } from "../../../lib/format";
+import { formatDateTime } from "../../../lib/format";
 
 const MAX_ITEMS = 5;
 const OPPORTUNITY_PAGE_SIZE = 100;
@@ -38,7 +38,6 @@ function UpcomingOpportunitiesWidget({
 }: Props) {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
-	const locale = resolveDateLocale(i18n.language);
 	const [showCreateModal, setShowCreateModal] = useState(false);
 
 	// Shared with QuickCheckInWidget, which fetches the same organization-wide
@@ -145,10 +144,10 @@ function UpcomingOpportunitiesWidget({
 									item.maxParticipants > 0) && (
 									<p className="mt-0.5 text-xs text-gray-500">
 										{item.nextStart &&
-											item.nextStart.toLocaleString(locale, {
-												dateStyle: "medium",
-												timeStyle: "short",
-											})}
+											formatDateTime(
+												item.nextStart as unknown as string,
+												i18n.language,
+											)}
 										{item.nextStart &&
 											(item.maxParticipants === null ||
 												item.maxParticipants > 0) && (

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -15,7 +15,7 @@ import ConfirmDialog from "../../components/ConfirmDialog";
 import Button from "../../components/Button";
 import ErrorBanner from "../../components/ErrorBanner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
-import { resolveDateLocale } from "../../lib/format";
+import { formatDateLong } from "../../lib/format";
 
 export default function OrgMembersPage() {
 	const { org } = useOutletContext<OrgAppContext>();
@@ -23,7 +23,6 @@ export default function OrgMembersPage() {
 	const api = useApiClient();
 	const auth = useAuth();
 	const navigate = useNavigate();
-	const locale = resolveDateLocale(i18n.language);
 	usePageTitle(`${t("orgOverview.tabMembers")} - ${org.name}`);
 	const currentUserId = auth.user?.profile?.sub;
 
@@ -333,13 +332,10 @@ export default function OrgMembersPage() {
 											</p>
 											<p className="truncate text-xs text-gray-500">
 												{t("orgSettings.invitationSentOn", {
-													date: new Date(
-														invitation.createdOn,
-													).toLocaleDateString(locale, {
-														day: "2-digit",
-														month: "long",
-														year: "numeric",
-													}),
+													date: formatDateLong(
+														invitation.createdOn as unknown as string,
+														i18n.language,
+													),
 												})}
 											</p>
 										</div>

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -308,7 +308,17 @@ export default function OrgOpportunitiesPage() {
 		}
 	}
 
-	function renderRow(item: VolunteerOpportunitySummary) {
+	// The Published section's own heading and description already say
+	// "Published" - a per-row badge repeating the same word inside a section
+	// that's already grouped by status carried no information (#984). Draft/
+	// Unpublished/Cancelled keep their badge: those sections' rows can be
+	// the direct result of an action the organizer just took (publish,
+	// unpublish, cancel), so the badge doubles as visible confirmation of
+	// that status change.
+	function renderRow(
+		item: VolunteerOpportunitySummary,
+		showStatusBadge = true,
+	) {
 		const status = item.status;
 		const isHighlighted = item.id === highlightedId;
 		const badgeLabel =
@@ -341,14 +351,16 @@ export default function OrgOpportunitiesPage() {
 						>
 							{item.title || t("orgDashboard.unnamedDraft")}
 						</Link>
-						<Chip
-							data-testid="opportunity-status-badge"
-							tone={STATUS_BADGE_TONE[status] ?? "neutral"}
-							size="sm"
-							className="shrink-0"
-						>
-							{badgeLabel}
-						</Chip>
+						{showStatusBadge && (
+							<Chip
+								data-testid="opportunity-status-badge"
+								tone={STATUS_BADGE_TONE[status] ?? "neutral"}
+								size="sm"
+								className="shrink-0"
+							>
+								{badgeLabel}
+							</Chip>
+						)}
 					</div>
 					{item.description && (
 						<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">
@@ -465,6 +477,7 @@ export default function OrgOpportunitiesPage() {
 		loadingMore: boolean,
 		onLoadMore: () => void,
 		onRetryLoadMore: () => void,
+		showStatusBadge = true,
 	) {
 		if (loading || error || items.length === 0) return null;
 		return (
@@ -472,7 +485,7 @@ export default function OrgOpportunitiesPage() {
 				<h2 className="text-lg font-semibold text-gray-900">{heading}</h2>
 				<p className="mt-1 text-sm text-gray-500">{description}</p>
 				<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-					{items.map(renderRow)}
+					{items.map((item) => renderRow(item, showStatusBadge))}
 				</ul>
 				{hasMore &&
 					(loadMoreError ? (
@@ -586,6 +599,7 @@ export default function OrgOpportunitiesPage() {
 						publishedLoadingMore,
 						loadMorePublished,
 						retryLoadMorePublished,
+						false,
 					)}
 					{renderSection(
 						"unpublished-section",

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -17,7 +17,7 @@ import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
 import FileUploadButton from "../../components/FileUploadButton";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
-import { resolveDateLocale } from "../../lib/format";
+import { formatDateLong } from "../../lib/format";
 
 const MAX_LOGO_BYTES = 2 * 1024 * 1024;
 const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -46,7 +46,6 @@ export default function OrgSettingsPage() {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const navigate = useNavigate();
-	const locale = resolveDateLocale(i18n.language);
 	usePageTitle(`${t("orgOverview.tabSettings")} - ${org.name}`);
 
 	function organizationToFormValues(): OrganizationFormValues {
@@ -219,11 +218,10 @@ export default function OrgSettingsPage() {
 						subtitle={
 							<p className="text-xs text-gray-500">
 								{t("orgSettings.createdOn", {
-									date: new Date(org.createdOn).toLocaleDateString(locale, {
-										day: "2-digit",
-										month: "long",
-										year: "numeric",
-									}),
+									date: formatDateLong(
+										org.createdOn as unknown as string,
+										i18n.language,
+									),
 								})}
 							</p>
 						}

--- a/keycloak/themes/einsatzbereit/login/template.ftl
+++ b/keycloak/themes/einsatzbereit/login/template.ftl
@@ -1,6 +1,6 @@
 <#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false pageTitle="loginTitle">
 <!DOCTYPE html>
-<html lang="${locale.current!'de'}" class="<#if locale.current?? && locale.current == 'de'>lang-de<#else>lang-en</#if>">
+<html lang="${locale.currentLanguageTag!'de'}" class="<#if locale.currentLanguageTag?? && locale.currentLanguageTag == 'de'>lang-de<#else>lang-en</#if>">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## What

Implements the batch of 15 issues labeled `lens:live-staging`, filed from the 2026-07-25 live-staging readiness audit.

## Why

Closes #980
Closes #983
Closes #984
Closes #985
Closes #986
Closes #987
Closes #988
Closes #989
Closes #990
Closes #991
Closes #993
Closes #994
Closes #995
Closes #996
Closes #997

This repo ships fast, and the audit is 9 days old - before implementing anything I re-checked each finding against current `main` (and, for public pages, read-only against live staging) rather than assuming the snapshot was still accurate. Three had already been resolved by unrelated commits that landed after the audit ran; those are closed with no code change and a rationale below instead of a duplicate fix.

**Fixed:**
- **#996** Keycloak login's `<html lang>` used `locale.current` (a display label like "Deutsch"), not a valid BCP-47 tag - switched to `locale.currentLanguageTag`.
- **#995** Footer copyright said "All rights reserved", contradicting the site's own "100% Open Source" positioning - now names the AGPL-3.0 license with a link to `LICENSE`.
- **#993** Organization directory avatars now derive a color from the org id, so same-initial orgs are visually distinguishable. *(The "verified" badge part of this finding is intentionally not implemented - see "Partially out of scope" below.)*
- **#991** Static `index.html` shipped an English title/meta description with `lang="en"` on a German-first site - both localized to German; the homepage's runtime `<title>` also got a descriptive value instead of the bare "Einsatzbereit".
- **#990** Dashboard KPI label used a bare plural noun regardless of count ("1 Ausstehende Anmeldungen") - added i18next `_one`/`_other` forms, matching the existing member-count fix (#959).
- **#988** The hero's three feature chips were hidden entirely below the `xl` breakpoint (1280px) - reflowed as a compact row visible on mobile/tablet too.
- **#987** Unified capacity phrasing: the sign-up modal's slot dropdown now reuses the shared `opportunities.spotsLeft`/`full`/`unlimitedSpots` strings instead of its own `signUp.*` copies, and the redundant visible "Select time slot" label (duplicating the dialog's own title) is now `sr-only` rather than removed outright, keeping the dropdown's accessible name intact.
- **#986** Three coexisting date formats - centralized into `lib/format.ts` (added `formatDateLong`) and routed every ad-hoc `toLocaleDateString`/`toLocaleString` call site through the three shared formatters.
- **#985** A brand-new user's empty "Profile Details" section rendered nothing under its own heading - now shows an `EmptyState` with a CTA into edit mode.
- **#984** Redundant per-row "Published" badge inside the already-status-grouped Published section - hidden there only. Draft/Unpublished/Cancelled keep theirs, since those rows can be the direct result of an action the organizer just took (publish/unpublish/cancel) and the badge doubles as visible confirmation.
- **#983** The calendar widget defaulted to the current month even when empty (~800px of blank grid) and offered a work-week view with little meaning for volunteering - dropped `work_week`, and the widget now falls back to Agenda on first load if the default month has no events.
- **#997** Locked in the audit's positive finding (zero console errors/failed requests across the sweep) as a regression test.

**Closed without a code change** (already resolved on `main`, verified before implementing):
- **#994** Heading skip on `/organizations` and the 404 page - checked live staging directly: it shows a clean h1 → h2 (Platform/Legal/Follow us) structure today, and the organization name in the directory card is already a `<strong>`, not a heading.
- **#989** The one formal-register ("Sie") string on the Administration page was already fixed to informal ("Du") by commit `83df541` (2026-07-27, two days after this audit ran).
- **#980** The detail page's info hierarchy (valueless "Zeitslots" label, meta box ordering) no longer matches the current `VolunteerOpportunityDetailPage` layout, which already orders title → posted-ago → description → a three-row info card → social proof → tags → map → time slots, with no orphaned label.

**Partially out of scope:**
- **#993**'s verified-organization badge is not implemented. `Organization.IsVerified` was removed from the domain/DB entirely after this audit ran (see the `RemoveOrganizationIsVerified` migration) - there is no verification data left to surface. Re-adding a DB column/domain field/admin toggle to satisfy a stale audit finding would reintroduce a feature the team deliberately dropped; flagging this for the repo owner rather than guessing at the reason, and shipping only the avatar-color half of this finding.

## Testing

- `pnpm lint`, `pnpm check`, `pnpm test` (138 passed), `pnpm i18n:check`, `pnpm build` - all green.
- Added unit tests: `lib/avatarColor.test.ts` (new), `lib/format.test.ts` (new `formatDateLong` cases), updated `lib/calendarRange.test.ts` to drop the removed `work_week` case.
- `dotnet build`, `Application.UnitTests` (831 passed), `ArchitectureTests` (368 passed) - all green. `IntegrationTests`/`VisualTests` need Docker/Aspire, which this sandbox can't run (see root `AGENTS.md`'s sandbox limitations) - CI's `dotnet.yml` covers those, including the new `PageHealthTests.HomePage_HasNoConsoleErrorsOrFailedRequests`.
- Ran `/self-review`: fanned out to `a11y-check` (no issues) and `i18n-check` (found the new `footer.copyright` Trans usage diverged from the established self-closing-link convention; fixed). Also caught and fixed a bug in my own first pass of the #983 calendar-view effect (see commit) before it ever left this session.

## Live verification

Per explicit instruction for this batch, no release candidate was cut and no live-staging deploy/verify pass was run for this PR - only monitoring the PR itself was requested. In its place: read-only Playwright checks against live staging (heading structure on `/organizations` and the 404 page, the organization directory's avatar markup, the mobile hero at 375px, the current homepage opportunity list) informed which findings were still current before writing any fix, and grounded the #983/#984/#993 implementations in the actual live DOM rather than the 9-day-old audit snapshot. No staging data was mutated.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs reference the fixed behaviors)


---
_Generated by [Claude Code](https://claude.ai/code/session_017gerwroJiKNJSuLDtWqGcJ)_