### PR TITLE
fix: show draft badge and owner Edit/Publish actions on opportunity detail page

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -123,6 +123,73 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_OwnerDraft_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1027: the draftBadge chip plus owner-only Edit/Publish actions
+		// (isDraft && isOwner) are new interactive elements this page never
+		// rendered before - VolunteerOpportunityDetailPage_HasNoSeriousA11yViolations
+		// above only ever reaches the anonymous/non-owner render path via a
+		// home-page card link, so it can never exercise this state.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Draft Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"A11y Draft Test {suffix}",
+			description = "Seeded draft for the owner-affordances a11y scan.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = true,
+		});
+		draftResponse.EnsureSuccessStatusCode();
+		var draft = await draftResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = draft.GetProperty("id").GetString();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.GetByTestId("opportunity-detail-draft-badge")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var closedResult = await Page.RunAxe();
+		AssertNoViolations(closedResult);
+
+		// The lazy-loaded Edit wizard is a distinct rendered state this page's
+		// own axe coverage has never seen - scan it too, not just the trigger.
+		await Page.GetByTestId("opportunity-detail-edit").ClickAsync();
+		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 10_000 });
+
+		var editModalResult = await Page.RunAxe();
+		AssertNoViolations(editModalResult);
+	}
+
+	[Test]
 	public async Task ProfileOverviewPage_HasNoSeriousA11yViolations()
 	{
 		// #794: /profile was consolidated from a Profile/Activity tab switcher

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -845,4 +845,132 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(Page.Locator("h1").First).ToHaveTextAsync(titleA, new() { Timeout = 15_000 });
 		await Expect(errorBanner).Not.ToBeVisibleAsync();
 	}
+
+	[Test]
+	public async Task DetailPage_OwnerViewingOwnDraft_ShowsDraftBadgeAndCanEditAndPublish()
+	{
+		// Regression for #1027: a lens audit found that isDraft/isOwner were
+		// already computed on this page, and the draftBadge string already
+		// existed, but nothing rendered them here - an organizer opening their
+		// own draft's public detail page saw what looked like a published
+		// listing, with no indication it was a draft and no way to edit or
+		// publish it without navigating away to the Opportunities tab.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Draft Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var draftTitle = $"Detail Draft Test {suffix}";
+		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = draftTitle,
+			description = "Seeded draft for the detail-page owner-affordances regression test.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = true,
+		});
+		draftResponse.EnsureSuccessStatusCode();
+		var draft = await draftResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = draft.GetProperty("id").GetString();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(draftTitle, new() { Timeout = 15_000 });
+
+		var draftBadge = Page.GetByTestId("opportunity-detail-draft-badge");
+		var editBtn = Page.GetByTestId("opportunity-detail-edit");
+		var publishBtn = Page.GetByTestId("opportunity-detail-publish");
+		await Expect(draftBadge).ToBeVisibleAsync();
+		await Expect(draftBadge).ToHaveTextAsync("Draft");
+		await Expect(editBtn).ToBeVisibleAsync();
+		await Expect(publishBtn).ToBeVisibleAsync();
+
+		// Edit opens the (lazy-loaded) create/edit wizard pre-filled with this
+		// draft's own data, not a blank "create" form.
+		await editBtn.ClickAsync();
+		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 10_000 });
+		await Expect(Page.Locator("#opportunity-title")).ToHaveValueAsync(draftTitle);
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync();
+
+		// Publishing directly from the detail page clears every draft-only
+		// affordance once the reload reflects the new status.
+		await publishBtn.ClickAsync();
+		await Expect(draftBadge).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(editBtn).Not.ToBeVisibleAsync();
+		await Expect(publishBtn).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task DetailPage_OwnerViewingOwnPublishedOpportunity_HidesDraftBadgeAndPublishEditActions()
+	{
+		// Edge case for #1027: the new affordances are gated on isDraft &&
+		// isOwner, not isOwner alone - an organizer viewing their own already-
+		// published opportunity must not see the draft badge or the Edit/
+		// Publish actions this fix adds.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Published Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var publishedTitle = $"Detail Published Test {suffix}";
+		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = publishedTitle,
+			description = "Seeded published opportunity for the detail-page owner-affordances edge case.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		response.EnsureSuccessStatusCode();
+		var opportunity = await response.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(publishedTitle, new() { Timeout = 15_000 });
+
+		await Expect(Page.GetByTestId("opportunity-detail-draft-badge")).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("opportunity-detail-edit")).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("opportunity-detail-publish")).Not.ToBeVisibleAsync();
+	}
 }

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -24,6 +24,7 @@ import ConfirmDialog from "../components/ConfirmDialog";
 import Button from "../components/Button";
 import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
+import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
@@ -44,6 +45,13 @@ import {
 // coordinates, so keep it out of this page's (and thus the shared home page
 // bundle's) initial chunk - #971.
 const SingleMarkerMap = lazy(() => import("../components/SingleMarkerMap"));
+
+// Lazy-loaded: the multi-step create/edit form is only ever needed by the
+// owning organizer editing their own draft, never by the public visitors who
+// make up the vast majority of this page's traffic.
+const CreateVolunteerOpportunityModal = lazy(
+	() => import("../components/CreateVolunteerOpportunityModal"),
+);
 
 export default function VolunteerOpportunityDetailPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
@@ -72,6 +80,8 @@ export default function VolunteerOpportunityDetailPage() {
 	const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
 	const [withdrawing, setWithdrawing] = useState(false);
 	const [withdrawError, setWithdrawError] = useState<string | null>(null);
+	const [showEditModal, setShowEditModal] = useState(false);
+	const [publishing, setPublishing] = useState(false);
 
 	const isAuthenticated = auth.isAuthenticated;
 	const roles = (
@@ -167,6 +177,20 @@ export default function VolunteerOpportunityDetailPage() {
 		dispatchToast("success", t("report.submitSuccess"));
 	}
 
+	async function handlePublish() {
+		if (!opportunity) return;
+		setPublishing(true);
+		try {
+			await api.publishVolunteerOpportunity(opportunity.id);
+			dispatchToast("success", t("opportunities.publishSuccess"));
+			load();
+		} catch (err) {
+			dispatchToast("error", getApiErrorMessage(err, t("error.serverError")));
+		} finally {
+			setPublishing(false);
+		}
+	}
+
 	async function handleWithdrawConfirm() {
 		if (!opportunity?.currentUserEngagement) return;
 		setWithdrawing(true);
@@ -254,12 +278,23 @@ export default function VolunteerOpportunityDetailPage() {
 
 			{/* Org chip + action buttons */}
 			<div className="mb-3 flex items-center justify-between gap-3">
-				<Link
-					to={`/organizations/${opportunity.organizationId}`}
-					className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-100"
-				>
-					{opportunity.organizationName}
-				</Link>
+				<div className="flex min-w-0 items-center gap-2">
+					<Link
+						to={`/organizations/${opportunity.organizationId}`}
+						className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-100"
+					>
+						{opportunity.organizationName}
+					</Link>
+					{isDraft && isOwner && (
+						<Chip
+							tone="warning"
+							size="sm"
+							data-testid="opportunity-detail-draft-badge"
+						>
+							{t("opportunities.draftBadge")}
+						</Chip>
+					)}
+				</div>
 				<div className="flex shrink-0 gap-2">
 					<button
 						onClick={handleShare}
@@ -282,6 +317,28 @@ export default function VolunteerOpportunityDetailPage() {
 								{t("opportunities.report")}
 							</span>
 						</button>
+					)}
+					{isDraft && isOwner && (
+						<>
+							<button
+								onClick={() => setShowEditModal(true)}
+								data-testid="opportunity-detail-edit"
+								className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-50"
+							>
+								{t("opportunities.edit")}
+							</button>
+							<Button
+								type="button"
+								size="sm"
+								onClick={() => void handlePublish()}
+								disabled={publishing}
+								data-testid="opportunity-detail-publish"
+							>
+								{publishing
+									? t("opportunities.publishing")
+									: t("opportunities.publish")}
+							</Button>
+						</>
 					)}
 				</div>
 			</div>
@@ -666,6 +723,24 @@ export default function VolunteerOpportunityDetailPage() {
 					onSubmit={handleReportSubmit}
 					onClose={() => setShowReport(false)}
 				/>
+			)}
+
+			{showEditModal && (
+				<Suspense
+					fallback={
+						<ModalLoadingFallback onClose={() => setShowEditModal(false)} />
+					}
+				>
+					<CreateVolunteerOpportunityModal
+						organizationId={opportunity.organizationId}
+						initialOpportunity={opportunity}
+						onClose={() => setShowEditModal(false)}
+						onSuccess={() => {
+							setShowEditModal(false);
+							load();
+						}}
+					/>
+				</Suspense>
 			)}
 		</div>
 	);


### PR DESCRIPTION
…etail page

isDraft and isOwner were already computed on VolunteerOpportunityDetailPage but never rendered, so an organizer opening their own draft's public detail page saw what looked like a published listing with no way to tell it was a draft or to edit/publish it from there (#1027).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1027

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
