### PR TITLE
fix: batch-fix 20 lens:frontend-states frontend state/UX bugs

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -563,7 +563,13 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// Blocked client-side - the dialog is still open, nothing was created.
 		await Expect(createDialog).ToBeVisibleAsync();
 
+		// Name/street were filled in above, so Cancel must ask for confirmation
+		// instead of silently discarding them (#1238).
 		await createDialog.GetByTestId("modal-cancel").ClickAsync();
+		var discardBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Discard changes" });
+		await Expect(discardBtn).ToBeVisibleAsync();
+		await discardBtn.ClickAsync();
+		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync();
 	}
 
 	[Test]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,9 @@ import {
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useSessionExpiryHandler } from "./hooks/useSessionExpiryHandler";
+import { signinLocaleArgs } from "./lib/authLocale";
 import ErrorBanner from "./components/ErrorBanner";
+import Button from "./components/Button";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
@@ -79,6 +81,15 @@ function CallbackPage() {
 				<ErrorBanner
 					message={t("auth.authError", { message: auth.error.message })}
 				/>
+				<div className="flex gap-3">
+					<Button
+						variant="secondary"
+						onClick={() => void auth.signinRedirect(signinLocaleArgs())}
+					>
+						{t("orgApp.retry")}
+					</Button>
+					<Button to="/">{t("orgApp.backToSite")}</Button>
+				</div>
 			</main>
 		);
 	}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -66,6 +66,7 @@ export default function ConfirmDialog({
 					variant="danger"
 					onClick={onConfirm}
 					disabled={loading}
+					aria-busy={loading}
 				>
 					{loading ? t("common.saving") : confirmLabel}
 				</Button>

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -13,6 +13,7 @@ import {
 import type { OrganizationFormValues } from "../lib/organizationFormSchema";
 import Modal from "./Modal";
 import Button from "./Button";
+import ConfirmDialog from "./ConfirmDialog";
 import ErrorBanner from "./ErrorBanner";
 import ImageCropModal from "./ImageCropModal";
 import FileUploadButton from "./FileUploadButton";
@@ -33,7 +34,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 		register,
 		handleSubmit,
 		watch,
-		formState: { errors },
+		formState: { errors, isDirty },
 	} = useForm<OrganizationFormValues>({
 		resolver: zodResolver(schema),
 		mode: "onBlur",
@@ -49,12 +50,21 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 	const nameFieldRef = useRef<HTMLDivElement>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
 	useEffect(() => {
 		return () => {
 			if (logoPreview) URL.revokeObjectURL(logoPreview);
 		};
 	}, [logoPreview]);
+
+	// react-hook-form's isDirty alone would miss a picked (but not yet
+	// uploaded) logo - without this, a fully filled form was discarded with no
+	// prompt on Escape, a backdrop click, or Cancel (#1238).
+	function requestClose() {
+		if (isDirty || logoFile !== null) setShowDiscardConfirm(true);
+		else onClose();
+	}
 
 	function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
@@ -127,12 +137,12 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 
 	return (
 		<Modal
-			onClose={onClose}
+			onClose={requestClose}
 			labelledBy="create-org-dialog-title"
 			maxWidth="max-w-md"
 			className="flex max-h-[min(85vh,720px)] flex-col overflow-hidden rounded-card bg-white shadow-modal"
 			initialFocusRef={nameFieldRef}
-			suspended={croppingLogoFile !== null}
+			suspended={croppingLogoFile !== null || showDiscardConfirm}
 		>
 			<h2
 				id="create-org-dialog-title"
@@ -443,7 +453,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					<Button
 						type="button"
 						variant="secondary"
-						onClick={onClose}
+						onClick={requestClose}
 						data-testid="modal-cancel"
 					>
 						{t("organization.cancel")}
@@ -464,6 +474,19 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					title={t("orgSettings.logoUpload")}
 					onCancel={() => setCroppingLogoFile(null)}
 					onCropped={handleLogoCropped}
+				/>
+			)}
+
+			{showDiscardConfirm && (
+				<ConfirmDialog
+					title={t("organization.unsavedChangesTitle")}
+					message={t("organization.unsavedChangesMessage")}
+					confirmLabel={t("organization.discardChanges")}
+					onConfirm={() => {
+						setShowDiscardConfirm(false);
+						onClose();
+					}}
+					onClose={() => setShowDiscardConfirm(false)}
 				/>
 			)}
 		</Modal>

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -342,7 +342,17 @@ export default function CreateVolunteerOpportunityModal({
 	}, [bannerPreview]);
 
 	function requestClose() {
-		if (isDirty) setShowDiscardConfirm(true);
+		// isDirty only tracks react-hook-form's own fields - time slots, the
+		// banner file and its removal all live in separate useState outside the
+		// form, so a wizard that only touched those (e.g. added slots on step 4
+		// without editing a text field) needs its own check too, or the discard
+		// guard fails to guard the very thing it exists for (#1233).
+		const hasUnsavedChanges =
+			isDirty ||
+			pendingSlots.length > 0 ||
+			bannerFile !== null ||
+			bannerRemoved;
+		if (hasUnsavedChanges) setShowDiscardConfirm(true);
 		else onClose();
 	}
 
@@ -452,6 +462,10 @@ export default function CreateVolunteerOpportunityModal({
 						recurrenceCount: r.recurrenceCount,
 					})),
 				]);
+				// Only cleared on success (#1241) - on failure the organizer would
+				// otherwise have to re-enter the whole slot, recurrence included,
+				// to retry.
+				setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });
 			} catch {
 				setSlotError(t("timeSlots.addError"));
 			} finally {
@@ -481,8 +495,8 @@ export default function CreateVolunteerOpportunityModal({
 				},
 			);
 			setPendingSlots((prev) => [...prev, ...newSlots]);
+			setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });
 		}
-		setNewSlot({ startDateTime: "", endDateTime: "", maxParticipants: 1 });
 	}
 
 	function handleRemovePendingSlot(id: string) {

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -5,6 +5,10 @@ import Button from "./Button";
 
 interface Props {
 	children: ReactNode;
+	/** Renders in place of the default full-page fallback - for a boundary
+	 * scoped to a smaller region (e.g. a single dashboard widget) where the
+	 * full-page "Something went wrong" UI would break the surrounding layout. */
+	fallback?: ReactNode;
 }
 
 interface State {
@@ -37,6 +41,7 @@ export default class ErrorBoundary extends Component<Props, State> {
 
 	render() {
 		if (this.state.hasError) {
+			if (this.props.fallback) return this.props.fallback;
 			const t = i18next.t.bind(i18next);
 			return (
 				<div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -112,6 +112,8 @@ export default function QRScannerModal({
 						alive = false;
 						try {
 							await api.checkInEngagement(raw);
+							streamRef.current?.getTracks().forEach((tr) => tr.stop());
+							streamRef.current = null;
 							setSuccess(true);
 							onCheckedIn(raw);
 						} catch (err) {

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -74,7 +74,20 @@ export default function VolunteerOpportunitiesList() {
 		show: showLocationSuggestions,
 		setShow: setShowLocationSuggestions,
 		reset: resetLocationSuggestions,
+		loading: locationSuggestionsLoading,
+		error: locationSuggestionsError,
 	} = useCitySuggestions(locationCityInput);
+
+	// Without this, a rate-limited/unreachable Nominatim just left the
+	// dropdown never appearing - indistinguishable from "this city doesn't
+	// exist" (#1240).
+	const cityStatusMessage = locationSuggestionsLoading
+		? t("opportunities.citySearching")
+		: locationSuggestionsError
+			? locationSuggestionsError
+			: locationCityInput.length >= 2 && locationSuggestions.length === 0
+				? t("opportunities.cityNoMatch")
+				: "";
 
 	// Keeps the roving highlight in bounds (and cleared) whenever the
 	// suggestion list itself changes - a stale index from the previous
@@ -411,6 +424,15 @@ export default function VolunteerOpportunitiesList() {
 									</ul>
 								)}
 							</div>
+
+							<p
+								role="status"
+								className={
+									cityStatusMessage ? "mb-3 text-xs text-gray-500" : "sr-only"
+								}
+							>
+								{cityStatusMessage}
+							</p>
 
 							<button
 								type="button"

--- a/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
+++ b/frontend/src/components/VolunteerOpportunitiesList/useCitySuggestions.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../hooks/useApiClient";
 
 export interface CitySuggestion {
@@ -27,14 +28,19 @@ function cacheKeyFor(query: string) {
 // docs/ADRs/5_map_and_geocoding_request_proxying.adoc.
 export function useCitySuggestions(query: string) {
 	const api = useApiClient();
+	const { t } = useTranslation();
 	const [suggestions, setSuggestions] = useState<CitySuggestion[]>([]);
 	const [show, setShow] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	useEffect(() => {
 		if (query.length < 2) {
 			setSuggestions([]);
 			setShow(false);
+			setLoading(false);
+			setError(null);
 			return;
 		}
 
@@ -42,13 +48,17 @@ export function useCitySuggestions(query: string) {
 		if (cached) {
 			setSuggestions(cached);
 			setShow(cached.length > 0);
+			setLoading(false);
+			setError(null);
 			return;
 		}
 
 		abortRef.current?.abort();
 		const controller = new AbortController();
 		abortRef.current = controller;
+		setError(null);
 		const timer = setTimeout(async () => {
+			setLoading(true);
 			try {
 				const places = await api.searchCities(query, controller.signal);
 				const results: CitySuggestion[] = places.map((place) => ({
@@ -62,7 +72,15 @@ export function useCitySuggestions(query: string) {
 				setSuggestions(results);
 				setShow(results.length > 0);
 			} catch {
-				// AbortError or network - ignore
+				// A stale request's own abort (superseded by a newer keystroke, or
+				// the component unmounting) isn't a real failure - only a genuine
+				// rate-limit/network failure from Nominatim should surface (#1240).
+				if (controller.signal.aborted) return;
+				setSuggestions([]);
+				setShow(false);
+				setError(t("opportunities.cityError"));
+			} finally {
+				if (!controller.signal.aborted) setLoading(false);
 			}
 		}, 350);
 		return () => {
@@ -75,7 +93,9 @@ export function useCitySuggestions(query: string) {
 	function reset() {
 		setSuggestions([]);
 		setShow(false);
+		setLoading(false);
+		setError(null);
 	}
 
-	return { suggestions, show, setShow, reset };
+	return { suggestions, show, setShow, reset, loading, error };
 }

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -6,6 +6,7 @@ import { useApiClient } from "./useApiClient";
 import { useDismissableOverlay } from "./useDismissableOverlay";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
+import { subscribeAvatarChanged } from "../lib/avatarBus";
 import type { NotificationSummary } from "../client/api-client";
 
 export interface AccountMenuState {
@@ -121,6 +122,20 @@ export function useAccountMenu(
 			}
 		})();
 		return () => controller.abort();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isLoggedIn]);
+
+	// ProfileOverviewPage's avatar upload has no direct reference to this
+	// hook's own copy of avatarUrl, fetched independently above - without this,
+	// the header kept showing the pre-upload image until a full reload (#1245).
+	useEffect(() => {
+		if (!isLoggedIn) return;
+		return subscribeAvatarChanged(() => {
+			void api
+				.getUserProfile()
+				.then((profile) => setAvatarUrl(profile.avatarUrl ?? null))
+				.catch(() => {});
+		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isLoggedIn]);
 

--- a/frontend/src/hooks/useAchievementNotifier.ts
+++ b/frontend/src/hooks/useAchievementNotifier.ts
@@ -4,22 +4,32 @@ import { useTranslation } from "react-i18next";
 import { useApiClient } from "./useApiClient";
 import { dispatchToast } from "../lib/toastBus";
 
-const SEEN_KEY = "einsatzbereit:seen-achievements";
+const SEEN_KEY_PREFIX = "einsatzbereit:seen-achievements";
+// Stored inside the same per-user seen-set rather than a second localStorage
+// key - marks that the first-poll seeding below has already run for this
+// user, so it can be told apart from "seen.size === 0 because this account
+// genuinely has zero achievements yet" (which used to re-seed - and thus
+// silently swallow - every poll until the user's first badge existed, #1236).
+const SEEDED_MARKER = "__seeded__";
 
-function getSeenIds(): Set<string> {
+function seenKeyFor(userId: string | undefined): string {
+	return `${SEEN_KEY_PREFIX}:${userId ?? "anonymous"}`;
+}
+
+function getSeenIds(key: string): Set<string> {
 	try {
-		const raw = localStorage.getItem(SEEN_KEY);
+		const raw = localStorage.getItem(key);
 		return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
 	} catch {
 		return new Set();
 	}
 }
 
-function markSeen(ids: string[]): void {
+function markSeen(key: string, ids: string[]): void {
 	try {
-		const seen = getSeenIds();
+		const seen = getSeenIds(key);
 		ids.forEach((id) => seen.add(id));
-		localStorage.setItem(SEEN_KEY, JSON.stringify([...seen]));
+		localStorage.setItem(key, JSON.stringify([...seen]));
 	} catch {
 		// ignore storage errors
 	}
@@ -30,26 +40,32 @@ export function useAchievementNotifier() {
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	// Scoped per user id (#1236) - a global key leaked between accounts on any
+	// shared browser (a kiosk, or the seeded vera/olaf/admin staging accounts).
+	const userId = auth.user?.profile?.sub;
 
 	useEffect(() => {
 		if (!auth.isAuthenticated) return;
+		const key = seenKeyFor(userId);
 
 		const check = async () => {
 			try {
 				const achievements = await api.getMyAchievements();
-				const seen = getSeenIds();
-				// Fresh browser/device/profile with no seen-tracking yet: seed the
-				// account's existing achievements as already-seen instead of
-				// announcing all of them as newly unlocked.
-				if (seen.size === 0) {
-					if (achievements.length > 0) {
-						markSeen(achievements.map((a) => a.id));
-					}
+				const seen = getSeenIds(key);
+				// First successful poll for this user/device: seed their existing
+				// achievements as already-seen (writing the marker unconditionally,
+				// even with zero achievements) instead of announcing all of them as
+				// newly unlocked.
+				if (!seen.has(SEEDED_MARKER)) {
+					markSeen(key, [...achievements.map((a) => a.id), SEEDED_MARKER]);
 					return;
 				}
 				const newOnes = achievements.filter((a) => !seen.has(a.id));
 				if (newOnes.length > 0) {
-					markSeen(newOnes.map((a) => a.id));
+					markSeen(
+						key,
+						newOnes.map((a) => a.id),
+					);
 					newOnes.forEach((a) =>
 						dispatchToast(
 							"success",
@@ -63,8 +79,8 @@ export function useAchievementNotifier() {
 						),
 					);
 				}
-			} catch {
-				// never fail silently
+			} catch (err) {
+				console.error("[useAchievementNotifier] poll failed:", err);
 			}
 		};
 
@@ -74,5 +90,5 @@ export function useAchievementNotifier() {
 			if (intervalRef.current) clearInterval(intervalRef.current);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [auth.isAuthenticated]);
+	}, [auth.isAuthenticated, userId]);
 }

--- a/frontend/src/hooks/useSharedOrgFetch.ts
+++ b/frontend/src/hooks/useSharedOrgFetch.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import i18n from "../i18n";
+import { getApiErrorMessage } from "../lib/apiError";
 
 // Module-level registry of in-flight requests, keyed by a caller-supplied
 // string (typically `${resource}:${organizationId}:${refreshKey}`, or just
@@ -42,7 +44,7 @@ export function useSharedOrgFetch<T>(
 				if (alive) setData(result);
 			})
 			.catch((e: unknown) => {
-				if (alive) setError(e instanceof Error ? e.message : String(e));
+				if (alive) setError(getApiErrorMessage(e, i18n.t("error.serverError")));
 			});
 
 		return () => {

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import Header from "../components/Header/Header";
 import Footer from "../components/Footer";
 import Spinner from "../components/Spinner";
 import SkipLink from "../components/SkipLink";
+import ErrorBoundary from "../components/ErrorBoundary";
 import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
 import { ToolbarProvider, useToolbarConfig } from "../contexts/ToolbarContext";
 import {
@@ -15,6 +16,7 @@ import {
 function AppLayoutInner() {
 	useAchievementNotifier();
 	const { t } = useTranslation();
+	const location = useLocation();
 	const toolbarConfig = useToolbarConfig();
 	const quickActions = useQuickActionsList();
 	const breadcrumb =
@@ -34,15 +36,22 @@ function AppLayoutInner() {
 				tabIndex={-1}
 				className="mx-auto w-full max-w-7xl flex-1 scroll-mt-24 px-4 pt-[var(--main-top-padding)] pb-16 focus:outline-none sm:px-6 lg:px-8"
 			>
-				<Suspense
-					fallback={
-						<div className="flex justify-center py-16">
-							<Spinner label={t("common.pageLoading")} size="lg" />
-						</div>
-					}
-				>
-					<Outlet />
-				</Suspense>
+				{/* Scoped to this route (remounts, clearing any caught error, whenever
+				the location changes) so a render crash in a single page replaces
+				just the content below Header/Footer instead of the whole app - see
+				the top-level ErrorBoundary in main.tsx for the last-resort fallback
+				this can't catch (e.g. a crash in Header itself). */}
+				<ErrorBoundary key={location.pathname}>
+					<Suspense
+						fallback={
+							<div className="flex justify-center py-16">
+								<Spinner label={t("common.pageLoading")} size="lg" />
+							</div>
+						}
+					>
+						<Outlet />
+					</Suspense>
+				</ErrorBoundary>
 			</main>
 			<Footer />
 		</div>

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -26,6 +26,7 @@ import Spinner from "../components/Spinner";
 import SkipLink from "../components/SkipLink";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
+import ErrorBoundary from "../components/ErrorBoundary";
 import NotFoundPage from "../pages/NotFoundPage";
 
 export interface OrgAppContext {
@@ -57,6 +58,7 @@ function OrgAppShell({
 	// for newly-unlocked badges and never saw the unlock toast.
 	useAchievementNotifier();
 	const { t } = useTranslation();
+	const location = useLocation();
 	const extra = useOrgBreadcrumbExtra();
 	const quickActions = useQuickActionsList();
 
@@ -110,19 +112,50 @@ function OrgAppShell({
 				className="mx-auto w-full max-w-7xl flex-1 scroll-mt-24 px-4 py-8 focus:outline-none sm:px-6 lg:px-8"
 			>
 				<h1 className="mb-6 text-2xl font-bold text-gray-900">{pageTitle}</h1>
-				<Suspense
+				{/* Scoped to this route (remounts, clearing any caught error, whenever
+				the location changes) so a render crash in a single tab replaces just
+				the content below Header/Footer instead of the whole app - see the
+				top-level ErrorBoundary in main.tsx for the last-resort fallback this
+				can't catch (e.g. a crash in Header itself). A custom `fallback` is
+				required here (unlike AppLayout's equivalent boundary) - the default
+				one renders its own <h1>, which would collide with `pageTitle` above,
+				and its min-h-screen centering would break out of this Header/Footer
+				shell it's nested in. */}
+				<ErrorBoundary
+					key={location.pathname}
 					fallback={
-						<div className="flex justify-center py-16">
-							<Spinner label={t("common.pageLoading")} size="lg" />
+						<div className="flex flex-col items-center justify-center gap-4 px-4 py-16 text-center">
+							<p className="max-w-md text-gray-500">
+								{t("error.boundaryMessage")}
+							</p>
+							<div className="flex gap-3">
+								<Button
+									variant="secondary"
+									onClick={() => window.history.back()}
+								>
+									{t("error.goBack")}
+								</Button>
+								<Button onClick={() => window.location.reload()}>
+									{t("error.reload")}
+								</Button>
+							</div>
 						</div>
 					}
 				>
-					<Outlet
-						context={{ org, reloadOrg: load } satisfies OrgAppContext}
-						// Outlet re-mounts children on org identity change so per-tab state resets cleanly
-						key={org.id}
-					/>
-				</Suspense>
+					<Suspense
+						fallback={
+							<div className="flex justify-center py-16">
+								<Spinner label={t("common.pageLoading")} size="lg" />
+							</div>
+						}
+					>
+						<Outlet
+							context={{ org, reloadOrg: load } satisfies OrgAppContext}
+							// Outlet re-mounts children on org identity change so per-tab state resets cleanly
+							key={org.id}
+						/>
+					</Suspense>
+				</ErrorBoundary>
 			</main>
 
 			<Footer compact />

--- a/frontend/src/layouts/ProtectedRoute.tsx
+++ b/frontend/src/layouts/ProtectedRoute.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { Navigate, useLocation } from "react-router";
 import type { ReactNode } from "react";
 import { signinLocaleArgs } from "../lib/authLocale";
 import Spinner from "../components/Spinner";
+import ErrorBanner from "../components/ErrorBanner";
+import Button from "../components/Button";
 
 interface Props {
 	children: ReactNode;
@@ -17,21 +20,51 @@ export default function ProtectedRoute({ children, requiredRole }: Props) {
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const location = useLocation();
+	// Rendering must stay side-effect free - calling signinRedirect() directly
+	// in the render body (as this used to) fires a fresh redirect on every
+	// re-render before the browser actually navigates away, and leaves its
+	// promise neither awaited nor caught (#1235). `attemptedRef` guards against
+	// re-firing while one is already in flight (including React's dev-only
+	// double effect invocation); `retryToken` is the only way to intentionally
+	// retry after a failure.
+	const attemptedRef = useRef(false);
+	const [retryToken, setRetryToken] = useState(0);
+	const [redirectError, setRedirectError] = useState<string | null>(null);
 
-	if (auth.isLoading) {
+	useEffect(() => {
+		if (auth.isLoading || auth.isAuthenticated || attemptedRef.current) return;
+		attemptedRef.current = true;
+		setRedirectError(null);
+		auth
+			.signinRedirect({
+				...signinLocaleArgs(),
+				state: { returnTo: location.pathname + location.search },
+			})
+			.catch((err: unknown) => {
+				attemptedRef.current = false;
+				console.error("[ProtectedRoute] signinRedirect failed:", err);
+				setRedirectError(t("error.serverError"));
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [auth.isLoading, auth.isAuthenticated, retryToken]);
+
+	if (redirectError) {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+				<ErrorBanner message={redirectError} className="max-w-md" />
+				<Button onClick={() => setRetryToken((n) => n + 1)}>
+					{t("common.retry")}
+				</Button>
+			</div>
+		);
+	}
+
+	if (auth.isLoading || !auth.isAuthenticated) {
 		return (
 			<div className="flex min-h-screen items-center justify-center">
 				<Spinner label={t("auth.loading")} size="lg" />
 			</div>
 		);
-	}
-
-	if (!auth.isAuthenticated) {
-		auth.signinRedirect({
-			...signinLocaleArgs(),
-			state: { returnTo: location.pathname + location.search },
-		});
-		return null;
 	}
 
 	if (requiredRole) {

--- a/frontend/src/lib/avatarBus.test.ts
+++ b/frontend/src/lib/avatarBus.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { subscribeAvatarChanged, notifyAvatarChanged } from "./avatarBus";
+
+describe("avatarBus", () => {
+	it("does not throw when notifying with no listeners", () => {
+		expect(() => notifyAvatarChanged()).not.toThrow();
+	});
+
+	it("calls a subscribed listener when notified", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeAvatarChanged(listener);
+		notifyAvatarChanged();
+		expect(listener).toHaveBeenCalledTimes(1);
+		unsubscribe();
+	});
+
+	it("stops calling a listener after it unsubscribes", () => {
+		const listener = vi.fn();
+		const unsubscribe = subscribeAvatarChanged(listener);
+		unsubscribe();
+		notifyAvatarChanged();
+		expect(listener).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/avatarBus.ts
+++ b/frontend/src/lib/avatarBus.ts
@@ -1,0 +1,20 @@
+// Notifies listeners that the signed-in user's avatar changed (uploaded via
+// ProfileOverviewPage) so the header's independently-fetched copy
+// (useAccountMenu) can refresh itself instead of showing the pre-upload
+// image until the next full reload (#1245). Same minimal pub/sub shape as
+// sessionExpiryBus.ts.
+type Listener = () => void;
+
+const listeners: Listener[] = [];
+
+export function subscribeAvatarChanged(listener: Listener): () => void {
+	listeners.push(listener);
+	return () => {
+		const idx = listeners.indexOf(listener);
+		if (idx !== -1) listeners.splice(idx, 1);
+	};
+}
+
+export function notifyAvatarChanged(): void {
+	listeners.forEach((l) => l());
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -125,6 +125,9 @@
       "radiusKmValue": "{{count}} km",
       "nearMe": "In meiner Nähe",
       "nearMeDenied": "Standortzugriff verweigert - bitte manuell suchen.",
+      "citySearching": "Wird gesucht…",
+      "cityNoMatch": "Keine passende Stadt gefunden.",
+      "cityError": "Suche nach dieser Stadt fehlgeschlagen. Bitte erneut versuchen.",
       "category": {
         "Social": "Soziales",
         "Environment": "Umwelt",
@@ -330,7 +333,10 @@
       "creating": "Wird erstellt…",
       "submit": "Erstellen",
       "cancel": "Abbrechen",
-      "unknownError": "Unbekannter Fehler"
+      "unknownError": "Unbekannter Fehler",
+      "unsavedChangesTitle": "Nicht gespeicherte Änderungen verwerfen?",
+      "unsavedChangesMessage": "Du hast nicht gespeicherte Änderungen an dieser Organisation. Wenn du jetzt schließt, gehen sie verloren.",
+      "discardChanges": "Änderungen verwerfen"
     },
     "orgApp": {
       "backToSite": "Zurück zu Einsatzbereit",
@@ -362,6 +368,7 @@
     "orgDashboard": {
       "loading": "Wird geladen…",
       "layoutLoadError": "Dein gespeichertes Dashboard-Layout konnte nicht bestätigt werden. Die Ansicht unten stimmt damit möglicherweise nicht überein - Bearbeiten ist deaktiviert, bis dies erfolgreich geladen wurde.",
+      "widgetError": "Dieses Widget konnte nicht angezeigt werden. Bitte die Seite neu laden.",
       "pendingEngagements": "Ausstehende Anmeldungen",
       "pendingEngagements_one": "Ausstehende Anmeldung",
       "pendingEngagements_other": "Ausstehende Anmeldungen",
@@ -525,7 +532,7 @@
       "pinLabel": "PIN",
       "pinPlaceholder": "4-stellige PIN",
       "submitPin": "Bestätigen",
-      "submitting": "…",
+      "submitting": "Wird gesendet…",
       "success": "Erfolgreich eingecheckt!",
       "invalidPin": "Falsche PIN. Bitte erneut versuchen.",
       "manualInstruction": "Der:die Organisator:in wird dich manuell einchecken.",
@@ -536,9 +543,10 @@
       "organizerPinHint": "Teile diese PIN mit deinen Freiwilligen, damit sie einchecken können.",
       "markCheckedIn": "Als eingecheckt markieren",
       "markCheckedInSuccess": "Freiwilliger als eingecheckt markiert.",
-      "markingCheckedIn": "…",
+      "markingCheckedIn": "Wird als eingecheckt markiert…",
+      "manualCheckInError": "Dieser Freiwillige konnte nicht als eingecheckt markiert werden. Bitte erneut versuchen.",
       "undoCheckIn": "Check-in rückgängig machen",
-      "undoingCheckIn": "…",
+      "undoingCheckIn": "Wird rückgängig gemacht…",
       "undoCheckInError": "Fehler beim Rückgängigmachen des Check-ins",
       "qrScanButton": "QR-Code scannen",
       "qrScanTitle": "Freiwilligen-QR-Code scannen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -125,6 +125,9 @@
       "radiusKmValue": "{{count}} km",
       "nearMe": "Near me",
       "nearMeDenied": "Location access denied - please search manually.",
+      "citySearching": "Searching…",
+      "cityNoMatch": "No matching city found.",
+      "cityError": "Couldn't search for that city. Please try again.",
       "category": {
         "Social": "Social",
         "Environment": "Environment",
@@ -330,7 +333,10 @@
       "creating": "Creating…",
       "submit": "Create",
       "cancel": "Cancel",
-      "unknownError": "Unknown error"
+      "unknownError": "Unknown error",
+      "unsavedChangesTitle": "Discard unsaved changes?",
+      "unsavedChangesMessage": "You have unsaved changes to this organization. If you close now, they will be lost.",
+      "discardChanges": "Discard changes"
     },
     "orgApp": {
       "backToSite": "Back to Einsatzbereit",
@@ -362,6 +368,7 @@
     "orgDashboard": {
       "loading": "Loading…",
       "layoutLoadError": "Couldn't confirm your saved dashboard layout. What's shown below may not match it, and editing is disabled until this loads successfully.",
+      "widgetError": "This widget couldn't be displayed. Try reloading the page.",
       "pendingEngagements": "Pending Sign-ups",
       "pendingEngagements_one": "Pending Sign-up",
       "pendingEngagements_other": "Pending Sign-ups",
@@ -525,7 +532,7 @@
       "pinLabel": "PIN",
       "pinPlaceholder": "4-digit PIN",
       "submitPin": "Submit",
-      "submitting": "…",
+      "submitting": "Submitting…",
       "success": "Checked in successfully!",
       "invalidPin": "Invalid PIN. Please try again.",
       "manualInstruction": "The organizer will check you in manually.",
@@ -536,9 +543,10 @@
       "organizerPinHint": "Share this PIN with your volunteers so they can check in.",
       "markCheckedIn": "Mark as checked in",
       "markCheckedInSuccess": "Volunteer marked as checked in.",
-      "markingCheckedIn": "…",
+      "markingCheckedIn": "Marking as checked in…",
+      "manualCheckInError": "Could not mark this volunteer as checked in. Please try again.",
       "undoCheckIn": "Undo check-in",
-      "undoingCheckIn": "…",
+      "undoingCheckIn": "Undoing…",
       "undoCheckInError": "Error undoing check-in",
       "qrScanButton": "Scan QR code",
       "qrScanTitle": "Scan volunteer QR code",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import App from "./App";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ToastProvider } from "./contexts/ToastContext";
 import { runtimeConfig } from "./lib/runtimeConfig";
+import { dispatchToast } from "./lib/toastBus";
 // Imported before global.css (not from CalendarWidget, which only lives on
 // the lazy-loaded OrgDashboardPage chunk) so react-big-calendar's default,
 // low-contrast stylesheet always ends up earlier than global.css's brand
@@ -58,6 +59,15 @@ const oidcConfig = {
 		window.location.replace(returnTo);
 	},
 };
+
+// Every floating promise in this codebase (signinRedirect/signoutRedirect
+// calls, ProtectedRoute's redirect, etc.) previously failed completely
+// invisibly to the user on rejection - this is the single, app-wide net that
+// makes an otherwise-silent failure at least visible as a toast (#1243).
+window.addEventListener("unhandledrejection", (event) => {
+	console.error("[unhandledrejection]", event.reason);
+	dispatchToast("error", i18n.t("error.serverError"));
+});
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -224,7 +224,7 @@ export default function EngagementManagementPage() {
 		} catch (err) {
 			dispatchToast(
 				"error",
-				err instanceof Error ? err.message : t("checkIn.markCheckedIn"),
+				getApiErrorMessage(err, t("checkIn.manualCheckInError")),
 			);
 		} finally {
 			setCheckingIn(null);

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "react-oidc-context";
@@ -29,6 +29,16 @@ export default function OrganizationsPage() {
 	const search = searchParams.get("search") ?? "";
 	const [searchInput, setSearchInput] = useState(search);
 	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Without this, typing then navigating away within the debounce window
+	// (SEARCH_DEBOUNCE_MS) still fires commitSearch after the route change,
+	// rewriting whatever page the user navigated to with a stray ?search=
+	// param (#1239).
+	useEffect(() => {
+		return () => {
+			if (searchTimer.current) clearTimeout(searchTimer.current);
+		};
+	}, []);
 
 	const {
 		items,

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -265,17 +265,22 @@ export default function ProfileOverviewPage() {
 		setSaving(true);
 		setProfileError(null);
 		setSuccessMessage(null);
+		const savedValues = {
+			firstName: form.state.firstName || undefined,
+			lastName: form.state.lastName || undefined,
+			bio: form.state.bio || undefined,
+			phone: form.state.phone || undefined,
+			skills: form.state.skills,
+			languages: form.state.languages,
+			preferredContact: form.state.preferredContact || undefined,
+			preferredLanguage: form.state.preferredLanguage,
+		};
 		try {
-			await api.updateUserProfile({
-				firstName: form.state.firstName || undefined,
-				lastName: form.state.lastName || undefined,
-				bio: form.state.bio || undefined,
-				phone: form.state.phone || undefined,
-				skills: form.state.skills,
-				languages: form.state.languages,
-				preferredContact: form.state.preferredContact || undefined,
-				preferredLanguage: form.state.preferredLanguage,
-			});
+			await api.updateUserProfile(savedValues);
+			// Keeps `profile` (the source handleCancel's form.reset(profile) reads
+			// from) in sync with what was just saved - otherwise re-entering edit
+			// mode and cancelling would silently restore the pre-save values (#1247).
+			setProfile((prev) => (prev ? { ...prev, ...savedValues } : prev));
 			setSuccessMessage(t("profile.savedSuccess"));
 			setEditing(false);
 		} catch {

--- a/frontend/src/pages/ProfileOverviewPage/useAvatarUpload.ts
+++ b/frontend/src/pages/ProfileOverviewPage/useAvatarUpload.ts
@@ -1,6 +1,7 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../../hooks/useApiClient";
+import { notifyAvatarChanged } from "../../lib/avatarBus";
 
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 const AVATAR_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -15,6 +16,16 @@ export function useAvatarUpload(onUploaded: (url: string) => void) {
 	const [error, setError] = useState<string | null>(null);
 	const [croppingFile, setCroppingFile] = useState<File | null>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
+	// Tracks the blob: URL handed to `onUploaded` so a later upload (or
+	// unmount) can revoke it - unrevoked, each upload pinned the whole
+	// previewed image file in memory for the rest of the tab's life (#1245).
+	const objectUrlRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+		};
+	}, []);
 
 	function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
@@ -40,7 +51,13 @@ export function useAvatarUpload(onUploaded: (url: string) => void) {
 				data: croppedFile,
 				fileName: croppedFile.name,
 			});
-			onUploaded(URL.createObjectURL(croppedFile));
+			if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+			const url = URL.createObjectURL(croppedFile);
+			objectUrlRef.current = url;
+			onUploaded(url);
+			// The header fetched its own copy of avatarUrl independently and has
+			// no other way to learn it just changed (#1245).
+			notifyAvatarChanged();
 		} catch {
 			setError(t("profile.avatarUploadError"));
 		} finally {

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -127,8 +127,13 @@ export default function VolunteerOpportunityDetailPage() {
 		// organizationId effect below notices it changed.
 		setOrgProfile(null);
 		load();
+		// `api` is deliberately excluded (matches every other effect in this
+		// codebase, e.g. ProfileOverviewPage) - useApiClient() memoizes on
+		// user.access_token, which automaticSilentRenew replaces every ~4
+		// minutes, so listing it here reran this effect (and its setLoading(true)
+		// skeleton swap) on every silent token renewal (#1237).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [opportunityId, api]);
+	}, [opportunityId]);
 
 	function load() {
 		if (!opportunityId) return;

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -127,13 +127,18 @@ export default function VolunteerOpportunityDetailPage() {
 		// organizationId effect below notices it changed.
 		setOrgProfile(null);
 		load();
-		// `api` is deliberately excluded (matches every other effect in this
-		// codebase, e.g. ProfileOverviewPage) - useApiClient() memoizes on
-		// user.access_token, which automaticSilentRenew replaces every ~4
-		// minutes, so listing it here reran this effect (and its setLoading(true)
-		// skeleton swap) on every silent token renewal (#1237).
+		// `auth.isAuthenticated`, not `api` itself (#1237): useApiClient() memoizes
+		// on user.access_token, which automaticSilentRenew replaces every ~4
+		// minutes even though the user's actual auth status hasn't changed -
+		// depending on `api` directly reran this effect (and its setLoading(true)
+		// skeleton swap) on every one of those renewals. Unlike ProfileOverviewPage
+		// (behind ProtectedRoute, so always already-authenticated on mount), this
+		// page is public and can mount before auth has finished resolving - the
+		// anonymous-vs-authenticated fetch genuinely differs (draft visibility,
+		// currentUserEngagement), so a real `isAuthenticated` flip (once auth
+		// settles, or on sign-in/out) still needs to trigger a refetch.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [opportunityId]);
+	}, [opportunityId, isAuthenticated]);
 
 	function load() {
 		if (!opportunityId) return;

--- a/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
@@ -10,6 +10,8 @@ import {
 	ResizeHandleIcon,
 	TrashIcon,
 } from "../../../components/icons";
+import ErrorBoundary from "../../../components/ErrorBoundary";
+import ErrorBanner from "../../../components/ErrorBanner";
 import { WIDGET_CATALOG, type WidgetKey } from "./widgetCatalog";
 
 export default function EditableWidgetTile({
@@ -103,7 +105,33 @@ export default function EditableWidgetTile({
 			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
 		>
 			<div inert={editing} className={`h-full ${editing ? "opacity-60" : ""}`}>
-				{children}
+				{/* A crash inside a single widget shouldn't blank the whole dashboard
+				(#1243) - the default full-page ErrorBoundary fallback would break
+				this tile's grid layout, so a small inline one is used instead. It
+				keeps the same landmark-region-plus-heading shape WidgetCard renders
+				in the non-error case (see WidgetCard.tsx) so a screen-reader user
+				navigating by region/heading still finds this widget - by name - and
+				isn't left with just an anonymous error paragraph. */}
+				<ErrorBoundary
+					fallback={
+						<section
+							aria-labelledby={`widget-error-title-${widgetKey}`}
+							className="flex h-full flex-col rounded-card border border-gray-100 bg-white p-5 shadow-resting"
+						>
+							<h2
+								id={`widget-error-title-${widgetKey}`}
+								className="mb-4 text-base font-semibold text-gray-900"
+							>
+								{title}
+							</h2>
+							<div className="flex flex-1 items-center justify-center">
+								<ErrorBanner message={t("orgDashboard.widgetError")} />
+							</div>
+						</section>
+					}
+				>
+					{children}
+				</ErrorBoundary>
 			</div>
 			{editing && (
 				<>

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -18,7 +18,7 @@ import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { formatDateLong } from "../../lib/format";
 
 export default function OrgMembersPage() {
-	const { org } = useOutletContext<OrgAppContext>();
+	const { org, reloadOrg } = useOutletContext<OrgAppContext>();
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const auth = useAuth();
@@ -59,24 +59,49 @@ export default function OrgMembersPage() {
 	const [changingRoleUserId, setChangingRoleUserId] = useState<string | null>(
 		null,
 	);
-	const memberSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const memberSearchAbortRef = useRef<AbortController | null>(null);
 
 	function handleMemberSearchChange(value: string) {
 		setMemberSearch(value);
-		if (memberSearchTimer.current) clearTimeout(memberSearchTimer.current);
-		if (value.length < 4) {
+	}
+
+	// Debounce moved into an effect (mirrors useCitySuggestions.ts) so cleanup
+	// runs on every keystroke and on unmount - the previous setTimeout-in-a-
+	// handler version had no cleanup at all, so a request could still land
+	// after the component unmounted, and had no way to tell a stale response
+	// apart from the latest one (#1232).
+	useEffect(() => {
+		if (memberSearch.length < 4) {
 			setMemberCandidates([]);
+			setMemberSearchLoading(false);
 			return;
 		}
-		memberSearchTimer.current = setTimeout(() => {
+		memberSearchAbortRef.current?.abort();
+		const controller = new AbortController();
+		memberSearchAbortRef.current = controller;
+		const timer = setTimeout(() => {
 			setMemberSearchLoading(true);
 			api
-				.searchMemberCandidates(org.id, value)
-				.then(setMemberCandidates)
-				.catch(() => setMemberCandidates([]))
-				.finally(() => setMemberSearchLoading(false));
+				.searchMemberCandidates(org.id, memberSearch, controller.signal)
+				.then((results) => {
+					if (controller.signal.aborted) return;
+					setMemberCandidates(results);
+				})
+				.catch(() => {
+					if (controller.signal.aborted) return;
+					setMemberCandidates([]);
+				})
+				.finally(() => {
+					if (controller.signal.aborted) return;
+					setMemberSearchLoading(false);
+				});
 		}, 300);
-	}
+		return () => {
+			clearTimeout(timer);
+			controller.abort();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [memberSearch]);
 
 	const [invitations, setInvitations] = useState<OrgInvitationDto[]>([]);
 	const [dismissingInvitationId, setDismissingInvitationId] = useState<
@@ -191,7 +216,12 @@ export default function OrgMembersPage() {
 		setRemoveMemberError(null);
 		try {
 			await api.removeMember(org.id, userId);
+			// Optimistic update for immediate feedback, plus a real refetch (#1230)
+			// - `org` (and thus `members`, synced from it above) only otherwise
+			// refreshes when `organizationId` changes, so navigating away and back
+			// without this would show the removed member again.
 			setMembers((prev) => prev.filter((m) => m.userId !== userId));
+			reloadOrg();
 			setRemoveTarget(null);
 		} catch (err) {
 			setRemoveMemberError(

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -257,9 +257,7 @@ export default function OrgOpportunitiesPage() {
 			setDeleteTargetId(null);
 			reloadAll();
 		} catch (err) {
-			setDeleteError(
-				err instanceof Error ? err.message : t("opportunities.deleteError"),
-			);
+			setDeleteError(getApiErrorMessage(err, t("opportunities.deleteError")));
 		} finally {
 			setDeleting(false);
 		}

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -81,6 +81,22 @@ export default function OrgSettingsPage() {
 	const [croppingLogoFile, setCroppingLogoFile] = useState<File | null>(null);
 	const logoInputRef = useRef<HTMLInputElement>(null);
 	const formRef = useRef<HTMLFormElement>(null);
+	// Tracks the blob: URL handed to setLogoUrl so it can be revoked once
+	// replaced - unrevoked, each upload pinned the previewed file in memory
+	// for the rest of the tab's life (#1245).
+	const logoObjectUrlRef = useRef<string | null>(null);
+
+	// Reconciles the local preview with the server once reloadOrg's refetch
+	// resolves (see handleLogoCropped/handleRemoveLogo below) - without this,
+	// `logoUrl` stayed on whatever blob: preview or null the upload/removal
+	// set locally, permanently out of sync with `org` (#1230).
+	useEffect(() => {
+		if (logoObjectUrlRef.current) {
+			URL.revokeObjectURL(logoObjectUrlRef.current);
+			logoObjectUrlRef.current = null;
+		}
+		setLogoUrl(org.logoUrl ?? null);
+	}, [org.logoUrl]);
 
 	const [editing, setEditing] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -129,7 +145,16 @@ export default function OrgSettingsPage() {
 				data: croppedFile,
 				fileName: croppedFile.name,
 			});
-			setLogoUrl(URL.createObjectURL(croppedFile));
+			if (logoObjectUrlRef.current)
+				URL.revokeObjectURL(logoObjectUrlRef.current);
+			const url = URL.createObjectURL(croppedFile);
+			logoObjectUrlRef.current = url;
+			setLogoUrl(url);
+			// Refreshes `org` (and thus the effect above, once it resolves) so
+			// the preview is reconciled with the real server URL - without this,
+			// the org logo shown elsewhere (e.g. the org switcher) stayed stale
+			// until a full reload (#1230).
+			reloadOrg();
 		} catch {
 			setLogoError(t("orgSettings.logoUploadError"));
 		} finally {
@@ -143,7 +168,12 @@ export default function OrgSettingsPage() {
 		setLogoError(null);
 		try {
 			await api.deleteOrganizationLogo(org.id);
+			if (logoObjectUrlRef.current) {
+				URL.revokeObjectURL(logoObjectUrlRef.current);
+				logoObjectUrlRef.current = null;
+			}
 			setLogoUrl(null);
+			reloadOrg();
 		} catch {
 			setLogoError(t("orgSettings.logoRemoveError"));
 		} finally {


### PR DESCRIPTION
## What

Fixes all 20 open issues labeled `lens:frontend-states` in a single batch: dead-end error screens, stale state after mutations, missing cleanup on unmount/navigation, `"[object Object]"` error banners, a global-blast-radius `ErrorBoundary` with no unhandled-rejection handler, and unsaved-changes guards that missed non-form state.

## Why

These were all filed by the 2026-07-25 1.0 readiness audit under the `lens:frontend-states` label. Several of the original repro locations had already shifted or been partially resolved by unrelated commits since the audit ran (notably `UserAchievementsPage.tsx` no longer exists post-#1619, and `OrgOpportunitiesPage`'s specific `String(e)` repro was already gone) - those are closed as already-resolved rather than re-fixed. The rest are fixed here, each scoped to its own file(s):

- **#1249** - OIDC callback error screen now has retry + back-to-site actions instead of being a dead end.
- **#1248** - QR scanner stops the camera stream immediately on a successful check-in instead of leaving it live with no preview.
- **#1247** - Profile save now updates the `profile` source-of-truth, so re-entering edit mode and cancelling no longer resurrects pre-save values.
- **#1246** - Normalized the one remaining raw `err.message` fallback in `OrgOpportunitiesPage` to `getApiErrorMessage`, matching the rest of the file.
- **#1245** - Avatar/org-logo blob: URLs are now revoked on replacement/unmount; the header's independently-fetched avatar now refreshes via a small pub/sub bus, and the org logo reconciles via `reloadOrg()`.
- **#1244** - `ConfirmDialog`'s pending button now sets `aria-busy`; `checkIn.submitting`/`markingCheckedIn`/`undoingCheckIn` no longer render as a bare `"…"`.
- **#1243** - Added a per-route `ErrorBoundary` (in `AppLayout`/`OrgAppLayout`, remounting on navigation) and a per-widget one in the dashboard grid, plus a `window.addEventListener("unhandledrejection", ...)` net in `main.tsx`.
- **#1242** - Already resolved: the whole page/route/endpoint was removed in #1619.
- **#1241** - Time-slot inputs are now only cleared after a successful add, not on failure.
- **#1240** - City autocomplete now surfaces loading/no-match/error states instead of silently doing nothing on a Nominatim failure.
- **#1239** - Organizations search debounce timer is now cleared on unmount.
- **#1238** - `CreateOrganizationModal` now prompts before discarding a dirty form (Escape/backdrop/Cancel), matching the volunteer-opportunity wizard's existing pattern.
- **#1237** - Opportunity detail page no longer refetches (and flashes its skeleton) on every silent token renewal.
- **#1236** - Achievement "seen" tracking is now scoped per user id, with an explicit seeded-marker so a zero-achievement account isn't silently re-seeded forever.
- **#1235** - `ProtectedRoute`'s `signinRedirect()` moved out of the render body into a guarded effect, with error handling and a visible pending state.
- **#1233** - The wizard's discard guard now also considers pending time slots, the picked banner, and its removal - not just react-hook-form's own dirty flag.
- **#1232** - Member-candidate search debounce now has unmount cleanup, an `AbortController`, and sequencing so a stale response can't clobber a newer one.
- **#1230** - Removing a member (and uploading/removing an org logo) now calls `reloadOrg()` so the change survives a tab switch instead of only living in local state.
- **#1229** - The manual check-in failure toast now uses a dedicated error key instead of reusing the button's own label as its error text.
- **#1225** - `useSharedOrgFetch`'s shared error path now uses `getApiErrorMessage`, fixing `"[object Object]"` across every dashboard widget that shares it.

Closes #1249
Closes #1248
Closes #1247
Closes #1246
Closes #1245
Closes #1244
Closes #1243
Closes #1242
Closes #1241
Closes #1240
Closes #1239
Closes #1238
Closes #1237
Closes #1236
Closes #1235
Closes #1233
Closes #1232
Closes #1230
Closes #1229
Closes #1225

## Testing

- `pnpm format:write && pnpm lint && pnpm check && pnpm test && pnpm build` - all green.
- `pnpm i18n:check` - all locale keys in sync.
- One existing Playwright test (`OrganizationTests.CreateOrganizationModal_PartialAddress_ShowsInlineErrorsForMissingFields`) updated to click through the new discard-confirmation dialog it now triggers.
- `/self-review` run, including `a11y-check` and `i18n-check` subagents; both flagged findings (a duplicate `<h1>` from the new `OrgAppLayout` error boundary, and a missing heading/landmark in the per-widget error fallback) were fixed before this PR was opened.

## Live verification

Not run for this batch per explicit instruction - no release candidate was cut and no live-staging verification was performed. Verification here is local: type-check, lint, unit tests, and production build all pass; VisualTests (Docker/Aspire-dependent) could not be run in this sandbox per this repo's documented sandbox limitations.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs affected beyond in-app copy)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uc84Pk8CnKY18M7udHkBdo)_