### PR TITLE
refactor: extract shared LoadMoreButton component

### DIFF
--- a/frontend/src/components/LoadMoreButton.tsx
+++ b/frontend/src/components/LoadMoreButton.tsx
@@ -1,0 +1,32 @@
+interface Props {
+	loading: boolean;
+	label: string;
+	loadingLabel: string;
+	onClick: () => void;
+}
+
+// Shared "load more" trigger - see einsatzbereit#1108: this markup had
+// drifted into four hand-rolled copies (one with divergent padding, all with
+// divergent wrapper margins) across OrganizationsPage, AdministrationPage,
+// OpportunityResultsList, and ActivitySection. Margin matches LoadMoreError's
+// wrapper so swapping between the two states (button vs. inline retry) on
+// the same list doesn't shift layout.
+export default function LoadMoreButton({
+	loading,
+	label,
+	loadingLabel,
+	onClick,
+}: Props) {
+	return (
+		<div className="mt-6 flex justify-center">
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={loading}
+				className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
+			>
+				{loading ? loadingLabel : label}
+			</button>
+		</div>
+	);
+}

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -4,6 +4,7 @@ import EmptyState from "../EmptyState";
 import Skeleton from "../Skeleton";
 import ErrorBanner from "../ErrorBanner";
 import LoadMoreError from "../LoadMoreError";
+import LoadMoreButton from "../LoadMoreButton";
 import OpportunityListItem from "./OpportunityListItem";
 
 export default function OpportunityResultsList({
@@ -109,17 +110,12 @@ export default function OpportunityResultsList({
 								onRetry={onRetryLoadMore}
 							/>
 						) : (
-							<div className="mt-8 flex justify-center">
-								<button
-									onClick={onLoadMore}
-									disabled={loadingMore}
-									className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-								>
-									{loadingMore
-										? t("opportunities.loading")
-										: t("opportunities.loadMore")}
-								</button>
-							</div>
+							<LoadMoreButton
+								loading={loadingMore}
+								label={t("opportunities.loadMore")}
+								loadingLabel={t("opportunities.loading")}
+								onClick={onLoadMore}
+							/>
 						))}
 				</>
 			)}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -21,6 +21,7 @@ import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
+import LoadMoreButton from "../components/LoadMoreButton";
 import ConfirmDialog from "../components/ConfirmDialog";
 import Modal from "../components/Modal";
 
@@ -60,30 +61,6 @@ export default function AdministrationPage() {
 				<ReportsSection />
 			</section>
 		</>
-	);
-}
-
-function LoadMoreButton({
-	loading,
-	label,
-	onClick,
-}: {
-	loading: boolean;
-	label: string;
-	onClick: () => void;
-}) {
-	const { t } = useTranslation();
-	return (
-		<div className="mt-4 flex justify-center">
-			<button
-				type="button"
-				onClick={onClick}
-				disabled={loading}
-				className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-			>
-				{loading ? t("administration.loadingMore") : label}
-			</button>
-		</div>
 	);
 }
 
@@ -159,6 +136,7 @@ function OrganizationsSection() {
 					<LoadMoreButton
 						loading={loadingMore}
 						label={t("administration.organizations.loadMore")}
+						loadingLabel={t("administration.loadingMore")}
 						onClick={loadMore}
 					/>
 				))}
@@ -424,6 +402,7 @@ function UsersSection() {
 							<LoadMoreButton
 								loading={loadingMore}
 								label={t("administration.users.loadMore")}
+								loadingLabel={t("administration.loadingMore")}
 								onClick={loadMore}
 							/>
 						))}
@@ -676,6 +655,7 @@ function ReportsSection() {
 					<LoadMoreButton
 						loading={loadingMore}
 						label={t("administration.reports.loadMore")}
+						loadingLabel={t("administration.loadingMore")}
 						onClick={loadMore}
 					/>
 				))}

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -15,6 +15,7 @@ import Skeleton from "../components/Skeleton";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
+import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import NotFoundPage from "./NotFoundPage";
 import { formatDateTime, resolveDateLocale } from "../lib/format";
@@ -592,17 +593,12 @@ export default function EngagementManagementPage() {
 						onRetry={retryLoadMoreEngagements}
 					/>
 				) : (
-					<div className="mt-6 flex justify-center">
-						<button
-							onClick={loadMoreEngagements}
-							disabled={engagementsLoadingMore}
-							className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-						>
-							{engagementsLoadingMore
-								? t("engagementManagement.loading")
-								: t("engagementManagement.loadMore")}
-						</button>
-					</div>
+					<LoadMoreButton
+						loading={engagementsLoadingMore}
+						label={t("engagementManagement.loadMore")}
+						loadingLabel={t("engagementManagement.loading")}
+						onClick={loadMoreEngagements}
+					/>
 				))}
 
 			{qrScannerOpen && (
@@ -710,17 +706,12 @@ export default function EngagementManagementPage() {
 								!feedbackError &&
 								feedbackItems.length > 0 &&
 								hasMoreFeedback && (
-									<div className="mt-6 flex justify-center">
-										<button
-											onClick={loadMoreFeedback}
-											disabled={feedbackLoadingMore}
-											className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-										>
-											{feedbackLoadingMore
-												? t("engagementManagement.loading")
-												: t("feedback.loadMore")}
-										</button>
-									</div>
+									<LoadMoreButton
+										loading={feedbackLoadingMore}
+										label={t("feedback.loadMore")}
+										loadingLabel={t("engagementManagement.loading")}
+										onClick={loadMoreFeedback}
+									/>
 								)}
 						</>
 					)}

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -14,6 +14,7 @@ import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
+import LoadMoreButton from "../components/LoadMoreButton";
 import ReportFlagButton from "../components/ReportFlagButton";
 
 const PAGE_SIZE = 10;
@@ -232,17 +233,12 @@ export default function OrganizationsPage() {
 									onRetry={retryLoadMore}
 								/>
 							) : (
-								<div className="mt-8 flex justify-center">
-									<button
-										onClick={loadMore}
-										disabled={loadingMore}
-										className="rounded-xl border border-brand-200 bg-brand-50 px-8 py-3 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-									>
-										{loadingMore
-											? t("organizationsPage.loading")
-											: t("organizationsPage.loadMore")}
-									</button>
-								</div>
+								<LoadMoreButton
+									loading={loadingMore}
+									label={t("organizationsPage.loadMore")}
+									loadingLabel={t("organizationsPage.loading")}
+									onClick={loadMore}
+								/>
 							))}
 					</>
 				)}

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -19,6 +19,7 @@ import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
 import ErrorBanner from "../../components/ErrorBanner";
 import LoadMoreError from "../../components/LoadMoreError";
+import LoadMoreButton from "../../components/LoadMoreButton";
 import { CheckIconSolid } from "../../components/icons";
 
 const ENGAGEMENTS_PAGE_SIZE = 10;
@@ -456,17 +457,12 @@ export default function ActivitySection() {
 						onRetry={retryLoadMoreEngagements}
 					/>
 				) : (
-					<div className="mt-6 flex justify-center">
-						<button
-							onClick={loadMoreEngagements}
-							disabled={engagementsLoadingMore}
-							className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-						>
-							{engagementsLoadingMore
-								? t("myEngagements.loading")
-								: t("myEngagements.loadMore")}
-						</button>
-					</div>
+					<LoadMoreButton
+						loading={engagementsLoadingMore}
+						label={t("myEngagements.loadMore")}
+						loadingLabel={t("myEngagements.loading")}
+						onClick={loadMoreEngagements}
+					/>
 				))}
 
 			{confirmWithdrawId && (

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -18,6 +18,7 @@ import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
 import ErrorBanner from "../../components/ErrorBanner";
 import LoadMoreError from "../../components/LoadMoreError";
+import LoadMoreButton from "../../components/LoadMoreButton";
 import { PlusIcon } from "../../components/QuickActionIcons";
 import { ArrowRightIcon } from "../../components/icons";
 import { useQuickActions } from "../../contexts/QuickActionsContext";
@@ -482,17 +483,12 @@ export default function OrgOpportunitiesPage() {
 							onRetry={onRetryLoadMore}
 						/>
 					) : (
-						<div className="mt-4 flex justify-center">
-							<button
-								onClick={onLoadMore}
-								disabled={loadingMore}
-								className="rounded-xl border border-brand-200 bg-brand-50 px-6 py-2.5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 disabled:opacity-40"
-							>
-								{loadingMore
-									? t("orgOpportunities.loading")
-									: t("orgOpportunities.loadMore")}
-							</button>
-						</div>
+						<LoadMoreButton
+							loading={loadingMore}
+							label={t("orgOpportunities.loadMore")}
+							loadingLabel={t("orgOpportunities.loading")}
+							onClick={onLoadMore}
+						/>
 					))}
 			</section>
 		);


### PR DESCRIPTION
Dedup four (plus three more found live) hand-rolled "Load more" button copies across OrganizationsPage, AdministrationPage, OpportunityResultsList, ActivitySection, OrgOpportunitiesPage, and EngagementManagementPage into components/LoadMoreButton.tsx, and standardize wrapper margin (mt-6, matching LoadMoreError) and padding (px-8 py-3) across all of them.

Closes #1108

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
