### PR TITLE
fix: give ProfileFieldsView its own block spacing

### DIFF
--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -206,6 +206,16 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
 		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
+		// Regression for #1112: ProfileFieldsView rendered sibling field blocks
+		// with no spacing of its own, relying on the caller to supply a
+		// `space-y-*` wrapper - ProfileOverviewPage's non-editing view didn't,
+		// so Bio/Skills/Languages/Preferred contact stacked flush against each
+		// other. The component now owns its own spacing.
+		await AssertVerticalGapBetweenAsync(
+			Page.GetByText("Bio", new() { Exact = true }),
+			Page.GetByText("Skills & Interests", new() { Exact = true }),
+			"Profile overview page (#1112)");
+
 		await Page.GotoAsync($"{origin}/users/{userId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -217,6 +227,14 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Expect(Page.GetByText(bioText)).ToBeVisibleAsync(new() { Timeout = 30_000 });
 		await Expect(Page.GetByText(skill)).ToBeVisibleAsync();
 		await Expect(Page.GetByText("Preferred contact channel")).Not.ToBeVisibleAsync();
+
+		// Regression for #1112: this page's wrapper already supplied `space-y-5`
+		// before the fix, so it never showed the bug - kept here as a guard that
+		// moving spacing into ProfileFieldsView didn't remove it from this page.
+		await AssertVerticalGapBetweenAsync(
+			Page.GetByText("Bio", new() { Exact = true }),
+			Page.GetByText("Skills & Interests", new() { Exact = true }),
+			"Public user profile page (#1112)");
 
 		// Regression for #766: this bio/skills/contact wrapper had `mx-auto`,
 		// centering it independently of the left-aligned avatar/name row

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -218,4 +218,35 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 		}, () => $"{label}: content wrapper should sit flush against <main>'s left padding edge, "
 			+ $"not be centered (last observed gap = {leftGap}px, must be <2px)");
 	}
+
+	/// <summary>
+	/// Asserts <paramref name="lower"/> sits visibly below <paramref name="upper"/>
+	/// with a non-trivial gap, not flush against it - i.e. the two locators are
+	/// separated by real spacing rather than stacked with 0px between them.
+	/// </summary>
+	protected async Task AssertVerticalGapBetweenAsync(ILocator upper, ILocator lower, string label)
+	{
+		await Expect(upper).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(lower).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Both boxes read via PollUntilAsync (not a single read) - see
+		// AdminUserManagementTests' Name-cell/Block-button assertion for the same
+		// rationale: layout can still be mid-reflow the instant elements become
+		// visible, which a single read can catch under CI resource contention.
+		var upperBottom = 0f;
+		var lowerTop = 0f;
+		await PollUntilAsync(async () =>
+		{
+			var upperBox = await upper.BoundingBoxAsync();
+			var lowerBox = await lower.BoundingBoxAsync();
+			if (upperBox is null || lowerBox is null)
+				return false;
+
+			upperBottom = upperBox.Y + upperBox.Height;
+			lowerTop = lowerBox.Y;
+			return lowerTop - upperBottom >= 8f;
+		}, () => $"{label}: expected a visible gap (>=8px) between blocks, "
+			+ $"(last observed: upper bottom {upperBottom:F0}px, lower top {lowerTop:F0}px, "
+			+ $"gap {lowerTop - upperBottom:F0}px)");
+	}
 }

--- a/frontend/src/components/ProfileFieldsView.tsx
+++ b/frontend/src/components/ProfileFieldsView.tsx
@@ -21,7 +21,7 @@ export default function ProfileFieldsView({
 	const { t } = useTranslation();
 
 	return (
-		<>
+		<div className="space-y-5">
 			{bio && (
 				<div>
 					<p className="mb-1 text-sm font-medium text-gray-700">
@@ -95,6 +95,6 @@ export default function ProfileFieldsView({
 					</p>
 				</div>
 			)}
-		</>
+		</div>
 	);
 }

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -113,7 +113,7 @@ export default function UserProfilePage() {
 			{(profile.bio ||
 				profile.skills.length > 0 ||
 				profile.languages.length > 0) && (
-				<div data-content-wrapper className="mb-8 max-w-2xl space-y-5">
+				<div data-content-wrapper className="mb-8 max-w-2xl">
 					<ProfileFieldsView
 						bio={profile.bio}
 						skills={profile.skills}


### PR DESCRIPTION
ProfileFieldsView rendered sibling field blocks (bio/skills/languages/ preferred contact) with no spacing of its own, relying on the caller to wrap it in a space-y-* div. UserProfilePage did; ProfileOverviewPage didn't, so fields stacked flush with 0px between them there.

Move space-y-5 into the component and drop the now-redundant class from UserProfilePage's wrapper.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1112

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
