### PR TITLE
fix: extract shared SectionHeading/PageSectionHeading components

### DIFF
--- a/frontend/src/components/PageSectionHeading.tsx
+++ b/frontend/src/components/PageSectionHeading.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+interface Props {
+	children: ReactNode;
+}
+
+// Shared page-level section heading (dashboard/admin pages carved into
+// several named sections) - was hand-rolled slightly differently per page
+// - see issue #1110.
+const BASE_CLASSES = "mb-4 text-lg font-semibold text-gray-900";
+
+export default function PageSectionHeading({ children }: Props) {
+	return <h2 className={BASE_CLASSES}>{children}</h2>;
+}

--- a/frontend/src/components/SectionHeading.tsx
+++ b/frontend/src/components/SectionHeading.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+interface Props {
+	children: ReactNode;
+}
+
+// Shared small-caps subsection heading - the same "Badges" title rendered
+// with different size/case/color depending on which page it appeared on
+// (own profile overview vs. public profile) - see issue #1110.
+const BASE_CLASSES =
+	"mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase";
+
+export default function SectionHeading({ children }: Props) {
+	return <h2 className={BASE_CLASSES}>{children}</h2>;
+}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -16,6 +16,7 @@ import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import Chip from "../components/Chip";
+import PageSectionHeading from "../components/PageSectionHeading";
 import Skeleton from "../components/Skeleton";
 import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
@@ -43,21 +44,21 @@ export default function AdministrationPage() {
 				{t("administration.title")}
 			</h1>
 			<section className="mb-10">
-				<h2 className="mb-4 text-lg font-semibold text-gray-900">
+				<PageSectionHeading>
 					{t("administration.organizationsHeading")}
-				</h2>
+				</PageSectionHeading>
 				<OrganizationsSection />
 			</section>
 			<section className="mb-10">
-				<h2 className="mb-4 text-lg font-semibold text-gray-900">
+				<PageSectionHeading>
 					{t("administration.usersHeading")}
-				</h2>
+				</PageSectionHeading>
 				<UsersSection />
 			</section>
 			<section className="mb-10">
-				<h2 className="mb-4 text-lg font-semibold text-gray-900">
+				<PageSectionHeading>
 					{t("administration.reportsHeading")}
-				</h2>
+				</PageSectionHeading>
 				<ReportsSection />
 			</section>
 			<section>

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -17,6 +17,7 @@ import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
 import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
+import PageSectionHeading from "../components/PageSectionHeading";
 import NotFoundPage from "./NotFoundPage";
 import { formatDate, formatDateTime, resolveDateLocale } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -654,9 +655,7 @@ export default function EngagementManagementPage() {
 
 			{feedbackStats !== null && (
 				<section className="mt-8">
-					<h2 className="mb-4 text-lg font-semibold text-gray-900">
-						{t("feedback.organizerTab")}
-					</h2>
+					<PageSectionHeading>{t("feedback.organizerTab")}</PageSectionHeading>
 					{feedbackStats.feedbackCount === 0 ? (
 						<p className="text-sm text-gray-500">{t("feedback.noFeedback")}</p>
 					) : (

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import type { PublicOrganizationProfileResponse } from "../client/api-client";
 import OrganizationProfileView from "../components/OrganizationProfileView";
+import SectionHeading from "../components/SectionHeading";
 import ReportContentModal, {
 	type ReportReason,
 } from "../components/ReportContentModal";
@@ -105,9 +106,7 @@ export default function OrganizationProfilePage() {
 					)
 				}
 			>
-				<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
-					{t("orgProfile.currentNeeds")}
-				</h2>
+				<SectionHeading>{t("orgProfile.currentNeeds")}</SectionHeading>
 
 				{profile.openOpportunities.length === 0 ? (
 					<EmptyState title={t("orgProfile.noOpportunities")} />

--- a/frontend/src/pages/ProfileOverviewPage/AchievementsSection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/AchievementsSection.tsx
@@ -8,6 +8,7 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { getApiErrorMessage } from "../../lib/apiError";
 import BadgeGrid from "../../components/BadgeGrid";
 import ErrorBanner from "../../components/ErrorBanner";
+import SectionHeading from "../../components/SectionHeading";
 
 export default function AchievementsSection() {
 	const api = useApiClient();
@@ -31,9 +32,7 @@ export default function AchievementsSection() {
 
 	return (
 		<section id="achievements" className="mb-6">
-			<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
-				{t("achievements.badgesTitle")}
-			</h2>
+			<SectionHeading>{t("achievements.badgesTitle")}</SectionHeading>
 			{error ? (
 				<ErrorBanner message={t("achievements.error", { message: error })} />
 			) : (

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -14,6 +14,7 @@ import AddToCalendarMenu from "../../components/AddToCalendarMenu";
 import CheckInModal from "../../components/CheckInModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
+import SectionHeading from "../../components/SectionHeading";
 import SubmitFeedbackModal from "../../components/SubmitFeedbackModal";
 import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
@@ -192,9 +193,9 @@ export default function ActivitySection() {
 			)}
 			{!invitationsLoading && invitations.length > 0 && (
 				<div className="mb-6">
-					<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
+					<SectionHeading>
 						{t("profileOverview.invitationsHeading")}
-					</h2>
+					</SectionHeading>
 					<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
 						{invitations.map((inv) => (
 							<li
@@ -242,9 +243,7 @@ export default function ActivitySection() {
 				</div>
 			)}
 
-			<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
-				{t("myEngagements.title")}
-			</h2>
+			<SectionHeading>{t("myEngagements.title")}</SectionHeading>
 
 			<div className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
 				<button

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -13,6 +13,7 @@ import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
 import EmptyState from "../../components/EmptyState";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
+import SectionHeading from "../../components/SectionHeading";
 import Skeleton from "../../components/Skeleton";
 import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
@@ -407,9 +408,7 @@ export default function ProfileOverviewPage() {
 
 					{/* Profile details */}
 					<section className="mb-6">
-						<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
-							{t("profile.sectionDetails")}
-						</h2>
+						<SectionHeading>{t("profile.sectionDetails")}</SectionHeading>
 
 						{!editing &&
 							(isProfileFieldsEmpty ? (

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -9,6 +9,7 @@ import type {
 import BadgeGrid from "../components/BadgeGrid";
 import ProfileFieldsView from "../components/ProfileFieldsView";
 import ReportFlagButton from "../components/ReportFlagButton";
+import SectionHeading from "../components/SectionHeading";
 import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
 import { useApiClient } from "../hooks/useApiClient";
@@ -123,9 +124,7 @@ export default function UserProfilePage() {
 			)}
 
 			<section>
-				<h2 className="mb-4 text-base font-semibold text-gray-700">
-					{t("achievements.badgesTitle")}
-				</h2>
+				<SectionHeading>{t("achievements.badgesTitle")}</SectionHeading>
 				<BadgeGrid earned={profile.badges} catalog={catalog} loading={false} />
 			</section>
 		</>

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "../lib/format";
 import { pageTitleClass } from "../lib/headingClasses";
 import Chip from "../components/Chip";
+import SectionHeading from "../components/SectionHeading";
 import SignUpModal from "../components/SignUpModal";
 import ReportContentModal, {
 	type ReportReason,
@@ -449,9 +450,9 @@ export default function VolunteerOpportunityDetailPage() {
 			{opportunity.participationType === "ScheduledSlots" &&
 				opportunity.timeSlots.length > 0 && (
 					<div className="mb-6">
-						<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
+						<SectionHeading>
 							{t("opportunities.availableTimeSlots")}
-						</h2>
+						</SectionHeading>
 						<ul className="space-y-2">
 							{opportunity.timeSlots.map((ts) => (
 								<li
@@ -595,9 +596,9 @@ export default function VolunteerOpportunityDetailPage() {
 					orgProfile.website ||
 					orgProfile.address) && (
 					<div className="mb-6" data-testid="about-organization">
-						<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
+						<SectionHeading>
 							{t("opportunities.aboutOrganization")}
-						</h2>
+						</SectionHeading>
 						{orgProfile.description && (
 							<p className="mb-3 leading-relaxed text-gray-600">
 								{orgProfile.description}
@@ -661,9 +662,9 @@ export default function VolunteerOpportunityDetailPage() {
 			{/* More from this organization */}
 			{otherOrgOpportunities.length > 0 && (
 				<div className="mb-6" data-testid="more-from-organization">
-					<h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase">
+					<SectionHeading>
 						{t("opportunities.moreFromOrganization")}
-					</h2>
+					</SectionHeading>
 					<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
 						{otherOrgOpportunities.map((opp) => (
 							<li

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -20,6 +20,7 @@ import Button from "../../components/Button";
 import ErrorBanner from "../../components/ErrorBanner";
 import LoadMoreError from "../../components/LoadMoreError";
 import LoadMoreButton from "../../components/LoadMoreButton";
+import PageSectionHeading from "../../components/PageSectionHeading";
 import { PlusIcon } from "../../components/QuickActionIcons";
 import { ArrowRightIcon } from "../../components/icons";
 import { useQuickActions } from "../../contexts/QuickActionsContext";
@@ -482,7 +483,7 @@ export default function OrgOpportunitiesPage() {
 		if (loading || error || items.length === 0) return null;
 		return (
 			<section data-testid={testId}>
-				<h2 className="text-lg font-semibold text-gray-900">{heading}</h2>
+				<PageSectionHeading>{heading}</PageSectionHeading>
 				<p className="mt-1 text-sm text-gray-500">{description}</p>
 				<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{items.map((item) => renderRow(item, showStatusBadge))}


### PR DESCRIPTION
h2 section headings used four unrelated size/color/case treatments across pages, including the same "Badges" title rendering differently on the public profile page vs. the profile overview page for the same user. Consolidate into two shared components and apply consistently.

Closes #1110

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1110

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
