### PR TITLE
fix: unify divergent input/textarea/select recipes across the app

### DIFF
--- a/backend/tests/VisualTests/SharedFormClassesTests.cs
+++ b/backend/tests/VisualTests/SharedFormClassesTests.cs
@@ -16,8 +16,13 @@ public class SharedFormClassesTests(AspireFixture fixture) : VisualTestBase(fixt
 	// pair was dropped - the global :focus-visible ring in global.css
 	// (issue #992) already overrides it, so it was dead weight, same as
 	// Button.tsx's BASE_CLASSES already had it removed.
+	// einsatzbereit#1104: inputClass now composes as `mt-1 block ${inputSurfaceClass}
+	// text-gray-900` - inputSurfaceClass carries the shared surface recipe
+	// (border/radius/background/shadow/focus) without a text color so
+	// Dropdown's trigger button can reuse it, and inputClass appends
+	// text-gray-900 last rather than inline among the surface classes.
 	private const string ExpectedInputClass =
-		"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-400";
+		"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400 text-gray-900";
 
 	// Regression: ProfileOverviewPage and OrgSettingsPage also used to each
 	// define their own local "Field" helper component, each with its own

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -3,7 +3,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunityDetails } from "../client/api-client";
 import { getApiErrorMessage } from "../lib/apiError";
-import { labelClass } from "../lib/formClasses";
+import { inputClass, labelClass } from "../lib/formClasses";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
@@ -123,7 +123,7 @@ export default function CheckInModal({
 								value={pin}
 								onChange={(e) => setPin(e.target.value.replace(/\D/g, ""))}
 								placeholder={t("checkIn.pinPlaceholder")}
-								className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+								className={inputClass}
 							/>
 						</div>
 						{error && <ErrorBanner message={error} />}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -6,7 +6,7 @@ import Dropdown from "../Dropdown";
 import TagsInput from "../TagsInput";
 import ErrorBanner from "../ErrorBanner";
 import { formatDateTime } from "../../lib/format";
-import { labelClass } from "../../lib/formClasses";
+import { inputSurfaceClass, labelClass } from "../../lib/formClasses";
 import type { OpportunityFormValues } from "./schema";
 
 export type SeriesEditScope = "Only" | "ThisAndFollowing" | "EntireSeries";
@@ -88,12 +88,6 @@ const CATEGORY_VALUES = [
 	"Other",
 ] as const;
 
-const selectClass =
-	"w-full rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm shadow-sm transition focus:border-brand-400";
-
-const dateInputClass =
-	"w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400";
-
 export default function DetailsStep({
 	control,
 	isScheduledSlots,
@@ -157,7 +151,7 @@ export default function DetailsStep({
 							id="create-category"
 							value={field.value ?? ""}
 							onChange={(v) => field.onChange(v || undefined)}
-							className={selectClass}
+							className={inputSurfaceClass}
 							options={[
 								{
 									value: "",
@@ -266,7 +260,7 @@ export default function DetailsStep({
 																	startDateTime: e.target.value,
 																})
 															}
-															className={dateInputClass}
+															className={inputSurfaceClass}
 														/>
 													</div>
 													<div>
@@ -286,7 +280,7 @@ export default function DetailsStep({
 																	endDateTime: e.target.value,
 																})
 															}
-															className={dateInputClass}
+															className={inputSurfaceClass}
 														/>
 													</div>
 												</div>
@@ -455,7 +449,7 @@ export default function DetailsStep({
 											startDateTime: e.target.value,
 										})
 									}
-									className={dateInputClass}
+									className={inputSurfaceClass}
 								/>
 							</div>
 							<div>
@@ -475,7 +469,7 @@ export default function DetailsStep({
 											endDateTime: e.target.value,
 										})
 									}
-									className={dateInputClass}
+									className={inputSurfaceClass}
 								/>
 							</div>
 						</div>
@@ -534,7 +528,7 @@ export default function DetailsStep({
 										id="slot-recurrence-frequency"
 										value={recurrenceFrequency}
 										onChange={onRecurrenceFrequencyChange}
-										className={selectClass}
+										className={inputSurfaceClass}
 										options={[
 											{
 												value: "Weekly",
@@ -568,7 +562,7 @@ export default function DetailsStep({
 												),
 											)
 										}
-										className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400"
+										className={inputSurfaceClass}
 									/>
 								</div>
 							</div>
@@ -606,7 +600,7 @@ export default function DetailsStep({
 								value={field.value}
 								min={todayDateInputValue}
 								onChange={(e) => field.onChange(e.target.value)}
-								className={dateInputClass}
+								className={inputSurfaceClass}
 							/>
 						)}
 					/>

--- a/frontend/src/components/ReportContentModal.tsx
+++ b/frontend/src/components/ReportContentModal.tsx
@@ -4,7 +4,7 @@ import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
 import { getApiErrorMessage } from "../lib/apiError";
-import { labelClass } from "../lib/formClasses";
+import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 
 const REPORT_REASONS = [
 	"Spam",
@@ -70,7 +70,7 @@ export default function ReportContentModal({
 						id="report-reason"
 						value={reason}
 						onChange={(e) => setReason(e.target.value as ReportReason)}
-						className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+						className={inputClass}
 					>
 						{REPORT_REASONS.map((r) => (
 							<option key={r} value={r}>
@@ -91,7 +91,7 @@ export default function ReportContentModal({
 						value={details}
 						onChange={(e) => setDetails(e.target.value)}
 						placeholder={t("report.detailsPlaceholder")}
-						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+						className={textareaClass}
 					/>
 					<p className="mt-1 text-right text-xs text-gray-500">
 						{details.length}/1000

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
+import { textareaClass } from "../lib/formClasses";
 import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
@@ -97,7 +98,7 @@ export default function SubmitFeedbackModal({
 						value={comment}
 						onChange={(e) => setComment(e.target.value)}
 						placeholder={t("feedback.commentPlaceholder")}
-						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+						className={textareaClass}
 					/>
 					<p className="mt-1 text-right text-xs text-gray-500">
 						{comment.length}/500

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -370,7 +370,7 @@ export default function VolunteerOpportunitiesList() {
 										if (locationSuggestions.length > 0)
 											setShowLocationSuggestions(true);
 									}}
-									className="w-full rounded-lg border border-gray-200 bg-gray-50 py-2 pr-8 pl-9 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-500 focus:bg-white"
+									className="w-full rounded-xl border border-gray-200 bg-gray-50 py-2 pr-8 pl-9 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-400 focus:bg-white"
 								/>
 								{locationCityInput && (
 									<button

--- a/frontend/src/lib/formClasses.test.ts
+++ b/frontend/src/lib/formClasses.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+	inputSurfaceClass,
+	inputClass,
+	textareaClass,
+	labelClass,
+} from "./formClasses";
+
+describe("formClasses", () => {
+	it("gives inputSurfaceClass the shared visual recipe (radius/border/focus)", () => {
+		expect(inputSurfaceClass).toContain("rounded-xl");
+		expect(inputSurfaceClass).toContain("border-gray-200");
+		expect(inputSurfaceClass).toContain("focus:border-brand-400");
+		expect(inputSurfaceClass).toContain("shadow-sm");
+	});
+
+	it("keeps inputSurfaceClass free of block-level layout classes", () => {
+		// Dropdown's trigger button is `flex` - composing inputSurfaceClass
+		// into its className must never add a `block` that contradicts it
+		// (einsatzbereit#1104).
+		expect(inputSurfaceClass.split(" ")).not.toContain("block");
+		expect(inputSurfaceClass.split(" ")).not.toContain("mt-1");
+	});
+
+	it("builds inputClass from inputSurfaceClass plus block-level layout", () => {
+		for (const cls of inputSurfaceClass.split(" ")) {
+			expect(inputClass).toContain(cls);
+		}
+		expect(inputClass).toContain("mt-1");
+		expect(inputClass).toContain("block");
+		expect(inputClass).toContain("text-gray-900");
+	});
+
+	it("extends inputClass with vertical resize for textareaClass", () => {
+		for (const cls of inputClass.split(" ")) {
+			expect(textareaClass).toContain(cls);
+		}
+		expect(textareaClass).toContain("resize-y");
+	});
+
+	it("keeps labelClass a small muted label style", () => {
+		expect(labelClass).toContain("text-xs");
+		expect(labelClass).toContain("text-gray-600");
+	});
+});

--- a/frontend/src/lib/formClasses.ts
+++ b/frontend/src/lib/formClasses.ts
@@ -1,8 +1,16 @@
 // Focus-visible styling comes from the global :focus-visible ring in
 // global.css (issue #992), not from a low-contrast focus:ring-*/outline-none
 // pair here - see Button.tsx's BASE_CLASSES for the same reasoning.
-export const inputClass =
-	"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-400";
+
+// Shared surface recipe (border/radius/background/shadow/focus) for text
+// inputs and select-like triggers alike - kept separate from inputClass's
+// own `block`/`mt-1` layout classes so a flex-based trigger (e.g. Dropdown)
+// can reuse the same look without a block/flex classname contradiction
+// (einsatzbereit#1104).
+export const inputSurfaceClass =
+	"w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400";
+
+export const inputClass = `mt-1 block ${inputSurfaceClass} text-gray-900`;
 
 export const textareaClass = `${inputClass} resize-y`;
 

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -24,7 +24,7 @@ import { useSetOrgBreadcrumbExtra } from "../contexts/OrgBreadcrumbContext";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
-import { inputClass, labelClass } from "../lib/formClasses";
+import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
@@ -644,7 +644,7 @@ export default function EngagementManagementPage() {
 						onChange={(e) => setCancelReason(e.target.value)}
 						placeholder={t("confirmDialog.cancel.reasonPlaceholder")}
 						disabled={cancelling}
-						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+						className={textareaClass}
 					/>
 					<p className="mt-1 text-right text-xs text-gray-500">
 						{cancelReason.length}/500

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../../client/api-client";
 import { useApiClient } from "../../../hooks/useApiClient";
 import { dispatchToast } from "../../../lib/toastBus";
+import { inputSurfaceClass } from "../../../lib/formClasses";
 import Skeleton from "../../../components/Skeleton";
 import Button from "../../../components/Button";
 import Dropdown from "../../../components/Dropdown";
@@ -119,7 +120,7 @@ function QuickCheckInWidget({
 							id="quick-checkin-opportunity"
 							value={selectedId}
 							onChange={setSelectedId}
-							className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-brand-400"
+							className={inputSurfaceClass}
 							options={opportunities.map((o) => ({
 								value: o.id,
 								label: o.title || t("orgDashboard.unnamedDraft"),

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -10,7 +10,7 @@ import { useLoadMore } from "../../hooks/useLoadMore";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
-import { labelClass } from "../../lib/formClasses";
+import { labelClass, textareaClass } from "../../lib/formClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -695,7 +695,7 @@ export default function OrgOpportunitiesPage() {
 						onChange={(e) => setCancelReason(e.target.value)}
 						placeholder={t("confirmDialog.cancelOpportunity.reasonPlaceholder")}
 						disabled={cancelling}
-						className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-500"
+						className={textareaClass}
 					/>
 					<p className="mt-1 text-right text-xs text-gray-500">
 						{cancelReason.length}/500


### PR DESCRIPTION
Six-plus components hand-rolled their own border-radius/color/shadow classNames instead of importing lib/formClasses's canonical inputClass/ textareaClass (rounded-md/gray-300 vs the rounded-xl/gray-200 standard). Found three more offenders (EngagementManagementPage, OrgOpportunitiesPage, ReportContentModal) beyond the two named in the issue via grep.

Extracted inputSurfaceClass (the shared visual recipe minus layout classes) so Dropdown's flex-based trigger can reuse it without a block/flex classname contradiction, and pointed DetailsStep's/QuickCheckInWidget's Dropdown/date/number inputs at it too, removing the local selectClass/ dateInputClass duplicates.

The homepage city search's missing focus outline (the other half of #1104) was already fixed by #1595 the day before - only its radius/focus color token still diverged from the design system, fixed here without touching its bespoke icon-inset padding.

Fixes #1104

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
