### PR TITLE
fix: consolidate form-label styles onto shared labelClass

### DIFF
--- a/backend/tests/VisualTests/SharedFormClassesTests.cs
+++ b/backend/tests/VisualTests/SharedFormClassesTests.cs
@@ -19,6 +19,19 @@ public class SharedFormClassesTests(AspireFixture fixture) : VisualTestBase(fixt
 	private const string ExpectedInputClass =
 		"mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-400";
 
+	// Regression: ProfileOverviewPage and OrgSettingsPage also used to each
+	// define their own local "Field" helper component, each with its own
+	// hardcoded label style ("text-sm font-medium text-gray-700") that
+	// diverged from lib/formClasses.ts's "labelClass" ("text-xs font-medium
+	// text-gray-600") used by every other field on the very same forms -
+	// e.g. OrgSettingsPage's address block switched size/colour partway
+	// down the form. einsatzbereit#1109 consolidated both local "Field"
+	// components into a single shared components/Field.tsx built on
+	// "labelClass". Assert both pages' field labels still carry that exact
+	// class attribute, so a future edit can't silently reintroduce a
+	// second label style without touching the shared module.
+	private const string ExpectedLabelClass = "block text-xs font-medium text-gray-600";
+
 	[Test]
 	public async Task ProfilePageInput_UsesSharedInputClass()
 	{
@@ -38,6 +51,11 @@ public class SharedFormClassesTests(AspireFixture fixture) : VisualTestBase(fixt
 		var profileInputClass = await profileInput.GetAttributeAsync("class");
 
 		profileInputClass.Should().Be(ExpectedInputClass);
+
+		var profileLabel = Page.Locator("label[for='first-name']");
+		var profileLabelClass = await profileLabel.GetAttributeAsync("class");
+
+		profileLabelClass.Should().Be(ExpectedLabelClass);
 	}
 
 	[Test]
@@ -61,5 +79,19 @@ public class SharedFormClassesTests(AspireFixture fixture) : VisualTestBase(fixt
 		var orgInputClass = await orgInput.GetAttributeAsync("class");
 
 		orgInputClass.Should().Be(ExpectedInputClass);
+
+		var orgLabel = Page.Locator("label[for='org-name']");
+		var orgLabelClass = await orgLabel.GetAttributeAsync("class");
+
+		orgLabelClass.Should().Be(ExpectedLabelClass);
+
+		// einsatzbereit#1109: the address block used to be the only part of
+		// this form already on "labelClass" - assert the upper field (above)
+		// and this lower one now match, so the form doesn't switch label
+		// styles partway down.
+		var orgStreetLabel = Page.Locator("label[for='org-street']");
+		var orgStreetLabelClass = await orgStreetLabel.GetAttributeAsync("class");
+
+		orgStreetLabelClass.Should().Be(ExpectedLabelClass);
 	}
 }

--- a/frontend/src/components/CheckInModal.tsx
+++ b/frontend/src/components/CheckInModal.tsx
@@ -3,6 +3,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunityDetails } from "../client/api-client";
 import { getApiErrorMessage } from "../lib/apiError";
+import { labelClass } from "../lib/formClasses";
 import { useApiClient } from "../hooks/useApiClient";
 import Modal from "./Modal";
 import Spinner from "./Spinner";
@@ -110,10 +111,7 @@ export default function CheckInModal({
 					</p>
 					<form onSubmit={(e) => void handlePinSubmit(e)} className="space-y-3">
 						<div>
-							<label
-								htmlFor="pin-input"
-								className="block text-sm font-medium text-gray-700"
-							>
+							<label htmlFor="pin-input" className={labelClass}>
 								{t("checkIn.pinLabel")}
 							</label>
 							<input

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -181,10 +181,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					</div>
 
 					<div ref={nameFieldRef}>
-						<label
-							htmlFor="create-org-name"
-							className="mb-1 block text-sm font-medium"
-						>
+						<label htmlFor="create-org-name" className={`mb-1 ${labelClass}`}>
 							{t("organization.nameLabel")}
 						</label>
 						<input
@@ -214,7 +211,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					<div>
 						<label
 							htmlFor="create-org-description"
-							className="mb-1 block text-sm font-medium"
+							className={`mb-1 ${labelClass}`}
 						>
 							{t("orgSettings.fieldDescription")}
 						</label>
@@ -243,7 +240,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					<div>
 						<label
 							htmlFor="create-org-contact-email"
-							className="mb-1 block text-sm font-medium"
+							className={`mb-1 ${labelClass}`}
 						>
 							{t("orgSettings.fieldContactEmail")}
 						</label>
@@ -272,10 +269,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					</div>
 
 					<div>
-						<label
-							htmlFor="create-org-phone"
-							className="mb-1 block text-sm font-medium"
-						>
+						<label htmlFor="create-org-phone" className={`mb-1 ${labelClass}`}>
 							{t("orgSettings.fieldPhone")}
 						</label>
 						<input
@@ -303,7 +297,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					<div>
 						<label
 							htmlFor="create-org-website"
-							className="mb-1 block text-sm font-medium"
+							className={`mb-1 ${labelClass}`}
 						>
 							{t("orgSettings.fieldWebsite")}
 						</label>

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -6,6 +6,7 @@ import Dropdown from "../Dropdown";
 import TagsInput from "../TagsInput";
 import ErrorBanner from "../ErrorBanner";
 import { formatDateTime } from "../../lib/format";
+import { labelClass } from "../../lib/formClasses";
 import type { OpportunityFormValues } from "./schema";
 
 export type SeriesEditScope = "Only" | "ThisAndFollowing" | "EntireSeries";
@@ -145,10 +146,7 @@ export default function DetailsStep({
 	return (
 		<div className="space-y-5" data-testid="wizard-step-4">
 			<div>
-				<label
-					htmlFor="create-category"
-					className="mb-1.5 block text-sm font-semibold text-gray-800"
-				>
+				<label htmlFor="create-category" className={`mb-1.5 ${labelClass}`}>
 					{t("createOpportunity.fieldCategory")}
 				</label>
 				<Controller
@@ -594,7 +592,7 @@ export default function DetailsStep({
 				<div className="rounded-card border border-gray-200 bg-gray-50 p-4">
 					<label
 						htmlFor="create-valid-until"
-						className="mb-1.5 block text-sm font-semibold text-gray-800"
+						className={`mb-1.5 ${labelClass}`}
 					>
 						{t("createOpportunity.fieldValidUntil")}
 					</label>

--- a/frontend/src/components/Field.tsx
+++ b/frontend/src/components/Field.tsx
@@ -1,0 +1,20 @@
+import { labelClass } from "../lib/formClasses";
+
+export default function Field({
+	label,
+	id,
+	children,
+}: {
+	label: string;
+	id?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div>
+			<label htmlFor={id} className={labelClass}>
+				{label}
+			</label>
+			{children}
+		</div>
+	);
+}

--- a/frontend/src/components/ReportContentModal.tsx
+++ b/frontend/src/components/ReportContentModal.tsx
@@ -4,6 +4,7 @@ import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
 import { getApiErrorMessage } from "../lib/apiError";
+import { labelClass } from "../lib/formClasses";
 
 const REPORT_REASONS = [
 	"Spam",
@@ -62,10 +63,7 @@ export default function ReportContentModal({
 
 			<form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
 				<div>
-					<label
-						htmlFor="report-reason"
-						className="block text-sm font-medium text-gray-700"
-					>
+					<label htmlFor="report-reason" className={labelClass}>
 						{t("report.reasonLabel")}
 					</label>
 					<select
@@ -83,10 +81,7 @@ export default function ReportContentModal({
 				</div>
 
 				<div>
-					<label
-						htmlFor="report-details"
-						className="block text-sm font-medium text-gray-700"
-					>
+					<label htmlFor="report-details" className={labelClass}>
 						{t("report.detailsLabel")}
 					</label>
 					<textarea

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -4,7 +4,7 @@ import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { computeSpotsLeft, formatDateTime, isSlotFull } from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
-import { textareaClass } from "../lib/formClasses";
+import { labelClass, textareaClass } from "../lib/formClasses";
 import Dropdown from "./Dropdown";
 import Modal from "./Modal";
 import Button from "./Button";
@@ -132,10 +132,7 @@ export default function SignUpModal({
 
 				{!isScheduledSlots && (
 					<div>
-						<label
-							htmlFor="sign-up-message"
-							className="mb-1 block text-sm font-medium text-gray-700"
-						>
+						<label htmlFor="sign-up-message" className={`mb-1 ${labelClass}`}>
 							{t("signUp.message")}
 						</label>
 						<textarea

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -5,6 +5,7 @@ import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
 import { StarIcon } from "./icons";
+import { labelClass } from "../lib/formClasses";
 
 interface SubmitFeedbackModalProps {
 	engagementId: string;
@@ -60,9 +61,7 @@ export default function SubmitFeedbackModal({
 
 			<form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
 				<div>
-					<p className="mb-2 text-sm font-medium text-gray-700">
-						{t("feedback.ratingLabel")}
-					</p>
+					<p className={`mb-2 ${labelClass}`}>{t("feedback.ratingLabel")}</p>
 					<div
 						className="flex gap-1"
 						role="group"
@@ -88,10 +87,7 @@ export default function SubmitFeedbackModal({
 				</div>
 
 				<div>
-					<label
-						htmlFor="feedback-comment"
-						className="block text-sm font-medium text-gray-700"
-					>
+					<label htmlFor="feedback-comment" className={labelClass}>
 						{t("feedback.commentLabel")}
 					</label>
 					<textarea

--- a/frontend/src/components/TagsInput.tsx
+++ b/frontend/src/components/TagsInput.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import Chip from "./Chip";
+import { labelClass } from "../lib/formClasses";
 
 interface Props {
 	id: string;
@@ -63,10 +64,7 @@ export default function TagsInput({
 
 	return (
 		<div>
-			<label
-				htmlFor={id}
-				className="mb-1.5 block text-sm font-semibold text-gray-800"
-			>
+			<label htmlFor={id} className={`mb-1.5 ${labelClass}`}>
 				{label}
 			</label>
 			<div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-sm transition focus-within:border-brand-400">

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -10,7 +10,7 @@ import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
-import { inputClass } from "../lib/formClasses";
+import { inputClass, labelClass } from "../lib/formClasses";
 import { pageTitleClass } from "../lib/headingClasses";
 import { formatDateTime } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -268,10 +268,7 @@ function UsersSection() {
 		<>
 			<form onSubmit={handleSearchSubmit} className="mb-6 flex items-end gap-3">
 				<div className="flex-1">
-					<label
-						htmlFor="admin-user-search"
-						className="block text-xs text-gray-600"
-					>
+					<label htmlFor="admin-user-search" className={labelClass}>
 						{t("administration.users.searchLabel")}
 					</label>
 					<input

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -637,10 +637,7 @@ export default function EngagementManagementPage() {
 					loading={cancelling}
 					error={cancelError}
 				>
-					<label
-						htmlFor="cancel-reason"
-						className="block text-xs font-medium text-gray-700"
-					>
+					<label htmlFor="cancel-reason" className={labelClass}>
 						{t("confirmDialog.cancel.reasonLabel")}
 					</label>
 					<textarea

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -7,7 +7,7 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { usePageToolbar } from "../../contexts/ToolbarContext";
 import { useEditModeQuickActions } from "../../hooks/useEditModeQuickActions";
-import { inputClass, textareaClass } from "../../lib/formClasses";
+import { inputClass, labelClass, textareaClass } from "../../lib/formClasses";
 import { pageTitleClass } from "../../lib/headingClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
@@ -17,6 +17,7 @@ import Skeleton from "../../components/Skeleton";
 import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
 import FileUploadButton from "../../components/FileUploadButton";
+import Field from "../../components/Field";
 import AchievementsSection from "./AchievementsSection";
 import ActivitySection from "./ActivitySection";
 import NotificationPreferencesSection from "./NotificationPreferencesSection";
@@ -75,25 +76,6 @@ function CalendarIcon({ className = "h-5 w-5" }: { className?: string }) {
 				d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
 			/>
 		</svg>
-	);
-}
-
-function Field({
-	label,
-	id,
-	children,
-}: {
-	label: string;
-	id?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div>
-			<label htmlFor={id} className="block text-sm font-medium text-gray-700">
-				{label}
-			</label>
-			{children}
-		</div>
 	);
 }
 
@@ -453,7 +435,7 @@ export default function ProfileOverviewPage() {
 									</h3>
 									<div className="space-y-5">
 										<div>
-											<p className="mb-1 block text-sm font-medium text-gray-700">
+											<p className={`mb-1 ${labelClass}`}>
 												{t("profile.fieldAvatar")}
 											</p>
 											<div className="flex items-center gap-4">

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -25,6 +25,7 @@ import { formatDateTime } from "../../../lib/format";
 import { brandColor } from "../../../lib/brandColor";
 import { readableTextColor } from "../../../lib/colorContrast";
 import { getApiErrorMessage } from "../../../lib/apiError";
+import { labelClass } from "../../../lib/formClasses";
 import type { WidgetSizeClass } from "./widgetCatalog";
 
 // The *default* view a fresh mount opens on - a narrow tile can't usefully
@@ -436,10 +437,7 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 							)
 						)}
 						<div>
-							<label
-								htmlFor="event-color-picker"
-								className="block text-sm font-medium text-gray-700"
-							>
+							<label htmlFor="event-color-picker" className={labelClass}>
 								{t("orgOverview.eventColorLabel")}
 							</label>
 							<div className="mt-1 flex items-center gap-3">

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -9,7 +9,7 @@ import type {
 import { useApiClient } from "../../hooks/useApiClient";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { getApiErrorMessage } from "../../lib/apiError";
-import { inputClass } from "../../lib/formClasses";
+import { inputClass, labelClass } from "../../lib/formClasses";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import Button from "../../components/Button";
@@ -231,10 +231,7 @@ export default function OrgMembersPage() {
 				)}
 
 				<div className="mb-6">
-					<label
-						htmlFor="member-search"
-						className="block text-sm font-medium text-gray-700"
-					>
+					<label htmlFor="member-search" className={labelClass}>
 						{t("orgSettings.inviteLabel")}
 					</label>
 					<input
@@ -245,10 +242,7 @@ export default function OrgMembersPage() {
 						placeholder={t("orgSettings.invitePlaceholder")}
 						className={inputClass}
 					/>
-					<label
-						htmlFor="invite-role"
-						className="mt-2 block text-xs font-medium text-gray-700"
-					>
+					<label htmlFor="invite-role" className={`mt-2 ${labelClass}`}>
 						{t("orgSettings.inviteRoleLabel")}
 					</label>
 					<select

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -10,6 +10,7 @@ import { useLoadMore } from "../../hooks/useLoadMore";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
+import { labelClass } from "../../lib/formClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -689,10 +690,7 @@ export default function OrgOpportunitiesPage() {
 					loading={cancelling}
 					error={cancelError}
 				>
-					<label
-						htmlFor="cancel-opportunity-reason"
-						className="block text-xs font-medium text-gray-700"
-					>
+					<label htmlFor="cancel-opportunity-reason" className={labelClass}>
 						{t("confirmDialog.cancelOpportunity.reasonLabel")}
 					</label>
 					<textarea

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -16,30 +16,12 @@ import OrganizationProfileView from "../../components/OrganizationProfileView";
 import ErrorBanner from "../../components/ErrorBanner";
 import ImageCropModal from "../../components/ImageCropModal";
 import FileUploadButton from "../../components/FileUploadButton";
+import Field from "../../components/Field";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { formatDateLong } from "../../lib/format";
 
 const MAX_LOGO_BYTES = 2 * 1024 * 1024;
 const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
-
-function Field({
-	label,
-	id,
-	children,
-}: {
-	label: string;
-	id?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div>
-			<label htmlFor={id} className="block text-sm font-medium text-gray-700">
-				{label}
-			</label>
-			{children}
-		</div>
-	);
-}
 
 export default function OrgSettingsPage() {
 	const { org, reloadOrg } = useOutletContext<OrgAppContext>();
@@ -261,7 +243,7 @@ export default function OrgSettingsPage() {
 							className="space-y-5"
 						>
 							<div>
-								<p className="mb-1 block text-sm font-medium text-gray-700">
+								<p className={`mb-1 ${labelClass}`}>
 									{t("orgSettings.fieldLogo")}
 								</p>
 								<div className="flex items-center gap-4">


### PR DESCRIPTION
Five competing label styles had accumulated across the app (formClasses.ts's canonical labelClass plus four ad hoc variants), most visibly on OrgSettingsPage where the address block used labelClass while every field above it used a locally duplicated Field component with a different size/colour. Point every form-field caption at lib/formClasses.ts's labelClass, and extract the OrgSettingsPage/ProfileOverviewPage duplicate Field component into a shared components/Field.tsx.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1109

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
