### PR TITLE
fix: unify card/panel surface styling into shared cardClass/cardSubtleClass

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -173,8 +173,9 @@ Shared UI primitives live in `src/components/` and `src/lib/` (no separate desig
 | `EmptyState`  | `components/EmptyState.tsx`  | "Nothing here yet" placeholder with an optional CTA button                                                                           |
 | `Skeleton`    | `components/Skeleton.tsx`    | Loading placeholders (`animate-pulse` block)                                                                                         |
 | `Modal`       | `components/Modal.tsx`       | Every dialog - backdrop-button a11y pattern (see Accessibility below), focus trap, Escape-to-close, portals out of `inert` ancestors |
+| `surfaceClasses` | `lib/surfaceClasses.ts`   | `cardClass`, `cardSubtleClass` for every bordered content panel (list items, result cards, widget panels, info panels) - not media cards whose padding lives on an inner wrapper around an edge-to-edge image/map |
 
-**Tokens:** the brand color scale (`brand-50`...`brand-900`) and `accent-400` are defined once in `src/styles/global.css`'s `@theme` block - use them instead of ad hoc hex values or arbitrary colors. `rounded-xl` is the default corner radius for interactive surfaces (buttons, inputs, cards, modals); `rounded-md` is reserved for `Skeleton` loading blocks.
+**Tokens:** the brand color scale (`brand-50`...`brand-900`) and `accent-400` are defined once in `src/styles/global.css`'s `@theme` block - use them instead of ad hoc hex values or arbitrary colors. `rounded-xl` is the default corner radius for interactive surfaces (buttons, inputs); cards, panels and modals use the separate `rounded-card` (16px) token instead - see `surfaceClasses.ts` and `Modal.tsx`. `rounded-md` is reserved for `Skeleton` loading blocks.
 
 ## Accessibility (a11y)
 

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { EnvelopeIcon, GlobeIcon, MapPinIcon, PhoneIcon } from "./icons";
+import { cardSubtleClass } from "../lib/surfaceClasses";
 
 interface OrganizationAddress {
 	street: string;
@@ -81,7 +82,9 @@ export default function OrganizationProfileView({
 				)}
 
 				{hasContactInfo && (
-					<div className="mb-6 space-y-2.5 rounded-card border border-gray-100 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+					<div
+						className={`mb-6 space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
+					>
 						{contactEmail && (
 							<div className="flex items-center gap-3">
 								<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />

--- a/frontend/src/lib/surfaceClasses.ts
+++ b/frontend/src/lib/surfaceClasses.ts
@@ -1,0 +1,15 @@
+// Shared card/panel recipe so every bordered content surface picks the same
+// radius, border, background and shadow instead of its own slightly
+// different hand-rolled combination (see issue #1106: eight incompatible
+// card recipes, five of them on a single page). Card-like surfaces whose
+// padding lives on an inner content wrapper instead of the outer frame
+// (media cards with an edge-to-edge banner image or map) aren't covered
+// here - the drift that mattered was the text/panel role, not those.
+
+/** Standard elevated card surface - list items, result cards, widget panels. */
+export const cardClass =
+	"rounded-card border border-gray-100 bg-white p-4 shadow-resting";
+
+/** Flat "info panel" variant - no shadow, tinted background, same radius/border. */
+export const cardSubtleClass =
+	"rounded-card border border-gray-100 bg-gray-50 p-4";

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -26,6 +26,7 @@ import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
+import { cardClass } from "../lib/surfaceClasses";
 import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
 import type { OrgAppContext } from "../layouts/OrgAppLayout";
 
@@ -405,7 +406,7 @@ export default function EngagementManagementPage() {
 						<div
 							key={i}
 							aria-hidden="true"
-							className="space-y-2 rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting"
+							className={`space-y-2 ${cardClass}`}
 						>
 							<Skeleton className="h-4 w-1/3" />
 							<Skeleton className="h-3 w-1/2" />
@@ -437,10 +438,7 @@ export default function EngagementManagementPage() {
 			{!loading && !error && engagements.length > 0 && (
 				<ul className="space-y-3">
 					{engagements.map((e) => (
-						<li
-							key={e.id}
-							className="rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting"
-						>
+						<li key={e.id} className={cardClass}>
 							<div className="flex items-start justify-between gap-2">
 								<div className="min-w-0">
 									<p className="text-sm font-medium text-gray-800">
@@ -681,10 +679,7 @@ export default function EngagementManagementPage() {
 							</p>
 							<ul className="space-y-3">
 								{feedbackItems.map((item, idx) => (
-									<li
-										key={idx}
-										className="rounded-card border border-gray-100 bg-white px-4 py-3 shadow-resting"
-									>
+									<li key={idx} className={cardClass}>
 										<div
 											className="flex items-center gap-1"
 											role="img"

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -17,6 +17,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
+import { cardClass } from "../lib/surfaceClasses";
 import { FlagIcon } from "../components/icons";
 
 export default function OrganizationProfilePage() {
@@ -115,7 +116,7 @@ export default function OrganizationProfilePage() {
 						{profile.openOpportunities.map((opp) => (
 							<li
 								key={opp.id}
-								className="relative rounded-card border border-gray-100 bg-white p-4 shadow-resting transition-shadow hover:shadow-raised"
+								className={`relative ${cardClass} transition-shadow hover:shadow-raised`}
 							>
 								<Link
 									to={`/volunteer-opportunities/${opp.id}`}

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -11,6 +11,7 @@ import { getApiErrorMessage } from "../lib/apiError";
 import { avatarColorClasses } from "../lib/avatarColor";
 import { inputClass } from "../lib/formClasses";
 import { pageTitleClass } from "../lib/headingClasses";
+import { cardClass } from "../lib/surfaceClasses";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
 import ErrorBanner from "../components/ErrorBanner";
@@ -135,7 +136,7 @@ export default function OrganizationsPage() {
 							<div
 								key={i}
 								aria-hidden="true"
-								className="flex flex-col gap-3 rounded-card border border-gray-100 bg-white p-4 shadow-resting"
+								className={`flex flex-col gap-3 ${cardClass}`}
 							>
 								<div className="flex items-center gap-3">
 									<Skeleton className="h-12 w-12 shrink-0 rounded-full" />
@@ -175,7 +176,7 @@ export default function OrganizationsPage() {
 								return (
 									<li
 										key={org.id}
-										className="relative flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white p-4 shadow-resting transition-shadow hover:shadow-raised"
+										className={`relative flex h-full flex-col gap-3 ${cardClass} transition-shadow hover:shadow-raised`}
 									>
 										<Link
 											to={`/organizations/${org.id}`}

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -10,6 +10,7 @@ import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
 import { formatDate, formatDateTime } from "../../lib/format";
+import { cardClass } from "../../lib/surfaceClasses";
 import AddToCalendarMenu from "../../components/AddToCalendarMenu";
 import CheckInModal from "../../components/CheckInModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -200,7 +201,7 @@ export default function ActivitySection() {
 						{invitations.map((inv) => (
 							<li
 								key={inv.id}
-								className="flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting"
+								className={`flex h-full flex-col gap-3 ${cardClass}`}
 							>
 								<div>
 									<p className="text-sm font-semibold text-gray-900">
@@ -283,11 +284,7 @@ export default function ActivitySection() {
 				>
 					<span className="sr-only">{t("myEngagements.loading")}</span>
 					{Array.from({ length: 3 }).map((_, i) => (
-						<div
-							key={i}
-							aria-hidden="true"
-							className="rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting"
-						>
+						<div key={i} aria-hidden="true" className={cardClass}>
 							<div className="flex items-start justify-between gap-3">
 								<div className="min-w-0 flex-1 space-y-2">
 									<Skeleton className="h-4 w-2/3" />
@@ -329,7 +326,7 @@ export default function ActivitySection() {
 							key={e.id}
 							data-testid="engagement-card"
 							data-engagement-id={e.id}
-							className="flex h-full flex-col gap-3 rounded-card border border-gray-100 bg-white px-4 py-4 shadow-resting transition-shadow hover:shadow-raised"
+							className={`flex h-full flex-col gap-3 ${cardClass} transition-shadow hover:shadow-raised`}
 						>
 							<div className="flex items-start justify-between gap-3">
 								<div className="min-w-0">

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -9,6 +9,7 @@ import { usePageToolbar } from "../../contexts/ToolbarContext";
 import { useEditModeQuickActions } from "../../hooks/useEditModeQuickActions";
 import { inputClass, labelClass, textareaClass } from "../../lib/formClasses";
 import { pageTitleClass } from "../../lib/headingClasses";
+import { cardSubtleClass } from "../../lib/surfaceClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
 import EmptyState from "../../components/EmptyState";
@@ -311,7 +312,7 @@ export default function ProfileOverviewPage() {
 
 			{profileLoading && (
 				<div
-					className="mb-6 flex items-center gap-4 rounded-card border border-gray-100 bg-gray-50 px-4 py-4"
+					className={`mb-6 flex items-center gap-4 ${cardSubtleClass}`}
 					role="status"
 				>
 					<span className="sr-only">{t("profile.loading")}</span>
@@ -337,7 +338,9 @@ export default function ProfileOverviewPage() {
 
 					{/* Identity + momentum hero */}
 					{!editing && (
-						<div className="mb-6 flex flex-col gap-4 rounded-card border border-gray-100 bg-gray-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+						<div
+							className={`mb-6 flex flex-col gap-4 ${cardSubtleClass} sm:flex-row sm:items-center sm:justify-between`}
+						>
 							<div className="flex items-center gap-4">
 								{avatarUrl ? (
 									<img

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -31,6 +31,7 @@ import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
 import { signinLocaleArgs } from "../lib/authLocale";
+import { cardClass, cardSubtleClass } from "../lib/surfaceClasses";
 import {
 	CalendarIcon,
 	EnvelopeIcon,
@@ -370,7 +371,7 @@ export default function VolunteerOpportunityDetailPage() {
 			)}
 
 			{/* Info card */}
-			<div className="mb-6 space-y-3 rounded-card border border-gray-100 bg-gray-50 px-4 py-4">
+			<div className={`mb-6 space-y-3 ${cardSubtleClass}`}>
 				<div className="flex items-center gap-3 text-sm text-gray-700">
 					<CalendarIcon className="h-4 w-4 shrink-0 text-gray-400" />
 					<span>{formatOccurrence(opportunity.occurrence, t)}</span>
@@ -457,7 +458,7 @@ export default function VolunteerOpportunityDetailPage() {
 							{opportunity.timeSlots.map((ts) => (
 								<li
 									key={ts.id}
-									className="flex items-center justify-between rounded-card border border-gray-100 bg-white px-4 py-3 text-sm text-gray-700 shadow-resting"
+									className={`flex items-center justify-between ${cardClass} text-sm text-gray-700`}
 								>
 									<span>
 										{formatDateTime(
@@ -500,10 +501,7 @@ export default function VolunteerOpportunityDetailPage() {
 
 			{/* Your application status */}
 			{isAuthenticated && !isOwner && cue && !isDraft && (
-				<div
-					data-testid="application-status"
-					className="mb-6 rounded-card border border-gray-100 bg-white px-4 py-3 shadow-resting"
-				>
+				<div data-testid="application-status" className={`mb-6 ${cardClass}`}>
 					<div className="flex items-center justify-between gap-4">
 						<div>
 							<p className="mb-1 text-xs text-gray-500">
@@ -608,7 +606,9 @@ export default function VolunteerOpportunityDetailPage() {
 							orgProfile.contactPhone ||
 							orgProfile.website ||
 							orgProfile.address) && (
-							<div className="space-y-2.5 rounded-card border border-gray-100 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+							<div
+								className={`space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
+							>
 								{orgProfile.contactEmail && (
 									<div className="flex items-center gap-3">
 										<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />
@@ -669,7 +669,7 @@ export default function VolunteerOpportunityDetailPage() {
 						{otherOrgOpportunities.map((opp) => (
 							<li
 								key={opp.id}
-								className="relative flex h-full flex-col rounded-card border border-gray-100 bg-white p-4 shadow-resting transition-shadow hover:shadow-raised"
+								className={`relative flex h-full flex-col ${cardClass} transition-shadow hover:shadow-raised`}
 							>
 								<Link
 									to={`/volunteer-opportunities/${opp.id}`}

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -98,7 +98,7 @@ function UpcomingOpportunitiesWidget({
 						<div
 							key={i}
 							aria-hidden="true"
-							className="rounded-xl border border-gray-100 p-3"
+							className="rounded-card border border-gray-100 p-3"
 						>
 							<Skeleton className="h-4 w-2/3" />
 							{size !== "compact" && <Skeleton className="mt-2 h-3 w-1/2" />}
@@ -134,7 +134,7 @@ function UpcomingOpportunitiesWidget({
 					{items.map((item) => (
 						<li
 							key={item.id}
-							className="relative rounded-xl border border-gray-100 bg-white p-3 shadow-resting transition-shadow hover:shadow-raised"
+							className="relative rounded-card border border-gray-100 bg-white p-3 shadow-resting transition-shadow hover:shadow-raised"
 						>
 							<Link
 								to={`/app/${organizationId}/dashboard/opportunities/${item.id}/engagements`}

--- a/frontend/src/pages/app/OrgDashboardPage/WidgetCard.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/WidgetCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cardClass } from "../../../lib/surfaceClasses";
 
 interface Props {
 	titleId: string;
@@ -18,7 +19,7 @@ export default function WidgetCard({
 	return (
 		<section
 			aria-labelledby={titleId}
-			className={`flex h-full flex-col rounded-card border border-gray-100 bg-white p-5 shadow-resting ${className ?? ""}`}
+			className={`flex h-full flex-col ${cardClass} ${className ?? ""}`}
 		>
 			<div className="mb-4 flex shrink-0 items-center justify-between gap-3">
 				<h2 id={titleId} className="text-base font-semibold text-gray-900">

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -11,6 +11,7 @@ import { usePageTitle } from "../../hooks/usePageTitle";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { labelClass, textareaClass } from "../../lib/formClasses";
+import { cardClass } from "../../lib/surfaceClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -532,7 +533,7 @@ export default function OrgOpportunitiesPage() {
 						<div
 							key={i}
 							aria-hidden="true"
-							className="space-y-2 rounded-card border border-gray-100 bg-white p-4 shadow-resting"
+							className={`space-y-2 ${cardClass}`}
 						>
 							<Skeleton className="h-4 w-2/3" />
 							<Skeleton className="h-3 w-1/2" />


### PR DESCRIPTION
Radius/shadow had already been tokenized (rounded-card, shadow-resting) by earlier work, but padding still drifted across p-3/p-4/p-5/px-4 py-3/ px-4 py-4 with no single source of truth, so it could (and did) drift again - see issue #1106.

Adds lib/surfaceClasses.ts (cardClass, cardSubtleClass) and migrates the ~20 call sites where the drift was real (same structural role, different padding/shadow), leaving alone the media-card frames (image/map bleed to the edge, padding lives on an inner wrapper) and the HomePage hero panel (deliberately larger by design).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1106

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
