### PR TITLE
fix: exclude pending-invitation users from member search results

### DIFF
--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
@@ -1,7 +1,9 @@
 using Application.Common.Authorization;
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Domain.Organizations;
 
 namespace Application.Organizations.SearchMemberCandidates.v1;
 
@@ -30,8 +32,20 @@ internal sealed class SearchMemberCandidatesQueryHandler(
 
 		var memberIds = currentMembers.Select(m => m.UserId).ToHashSet();
 
+		// Excluded alongside existing members (#1062) - a candidate with a
+		// pending invitation would otherwise still show up in search, and
+		// selecting them fails with a 409 the search results gave no hint of.
+		var invitations = await dbContext.GetInvitationsForOrganizationAsync(
+			OrganizationId.Create(query.OrganizationId).GetValueOrThrow(),
+			cancellationToken);
+
+		var pendingInviteeIds = invitations
+			.Where(i => i.Status == InvitationStatus.Pending)
+			.Select(i => i.InviteeId.Value)
+			.ToHashSet();
+
 		return allResults
-			.Where(u => !memberIds.Contains(u.UserId))
+			.Where(u => !memberIds.Contains(u.UserId) && !pendingInviteeIds.Contains(u.UserId))
 			.Select(u => new MemberCandidateDto(
 				u.UserId,
 				u.Username,

--- a/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
@@ -30,6 +30,9 @@ public class SearchMemberCandidatesQueryHandlerTests
 		_keycloakService
 			.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns([]);
+		_dbContext
+			.GetInvitationsForOrganizationAsync(Arg.Any<OrganizationId>(), Arg.Any<CancellationToken>())
+			.Returns([]);
 		_sut = new SearchMemberCandidatesQueryHandler(_dbContext, _keycloakService);
 	}
 
@@ -61,6 +64,76 @@ public class SearchMemberCandidatesQueryHandlerTests
 
 		// Assert
 		result.Should().ContainSingle(c => c.UserId == candidate);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCandidates_ExcludingUsersWithPendingInvitation(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var pendingInvitee = Guid.NewGuid();
+		var candidate = Guid.NewGuid();
+		_keycloakService
+			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
+			[
+				new KeycloakOrganizationMember(pendingInvitee, "olaf", "Olaf", "Miller", "olaf@test.de", false),
+				new KeycloakOrganizationMember(candidate, "vera", "Vera", "Smith", "vera@test.de", false),
+			]);
+
+		var organizationId = OrganizationId.Create(DefaultOrgId).GetValueOrThrow();
+		var pendingInvitation = OrganizationInvitation.Create(
+			organizationId,
+			UserId.Create(pendingInvitee).GetValueOrThrow(),
+			DefaultRequestingUserId,
+			OrganizationMemberRole.Member,
+			DateTimeOffset.UtcNow);
+		_dbContext
+			.GetInvitationsForOrganizationAsync(organizationId, cancellationToken)
+			.Returns([pendingInvitation]);
+
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().ContainSingle(c => c.UserId == candidate);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnCandidate_WhenInvitationIsNotPending(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: a Declined invitation shouldn't block the invitee from
+		// being re-invited via search.
+		var declinedInvitee = Guid.NewGuid();
+		_keycloakService
+			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
+			[
+				new KeycloakOrganizationMember(declinedInvitee, "olaf", "Olaf", "Miller", "olaf@test.de", false),
+			]);
+
+		var organizationId = OrganizationId.Create(DefaultOrgId).GetValueOrThrow();
+		var declinedInvitation = OrganizationInvitation.Create(
+			organizationId,
+			UserId.Create(declinedInvitee).GetValueOrThrow(),
+			DefaultRequestingUserId,
+			OrganizationMemberRole.Member,
+			DateTimeOffset.UtcNow);
+		declinedInvitation.Decline();
+		_dbContext
+			.GetInvitationsForOrganizationAsync(organizationId, cancellationToken)
+			.Returns([declinedInvitation]);
+
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().ContainSingle(c => c.UserId == declinedInvitee);
 	}
 
 	[Test]

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -120,9 +120,9 @@ export default function OrgMembersPage() {
 			setMemberSearch("");
 			setSettingsError(null);
 			setSuccessMessage(t("orgSettings.inviteSent"));
-		} catch {
+		} catch (err) {
 			setSuccessMessage(null);
-			setSettingsError(t("orgSettings.inviteError"));
+			setSettingsError(getApiErrorMessage(err, t("orgSettings.inviteError")));
 		} finally {
 			setInvitingUserId(null);
 		}


### PR DESCRIPTION
SearchMemberCandidatesQueryHandler filtered out existing members but not users with a pending invitation, so search could still offer a candidate whose invite would immediately 409. Also surface the specific errorCode-backed message on invite failure instead of the generic fallback, so a race (or direct API use) still gets an actionable message.

Fixes #1062

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
