### PR TITLE
feat: add /help page with volunteer/organizer FAQs and contact info

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -889,6 +889,18 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task HelpPage_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/help");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task NotFoundPage_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
 const ImprintPage = lazy(() => import("./pages/ImprintPage"));
 const TermsOfUsePage = lazy(() => import("./pages/TermsOfUsePage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));
+const HelpPage = lazy(() => import("./pages/HelpPage"));
 const VolunteerOpportunityDetailPage = lazy(
 	() => import("./pages/VolunteerOpportunityDetailPage"),
 );
@@ -127,6 +128,7 @@ export default function App() {
 				<Route path="/imprint" element={<ImprintPage />} />
 				<Route path="/terms-of-use" element={<TermsOfUsePage />} />
 				<Route path="/contact" element={<ContactPage />} />
+				<Route path="/help" element={<HelpPage />} />
 				<Route
 					path="/volunteer-opportunities/:opportunityId"
 					element={<VolunteerOpportunityDetailPage />}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -11,6 +11,10 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 	if (compact) {
 		return (
 			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">
+				<Link to="/help" className="hover:text-gray-600">
+					{t("footer.help")}
+				</Link>
+				<span className="mx-2">&middot;</span>
 				<Link to="/imprint" className="hover:text-gray-600">
 					{t("footer.imprint")}
 				</Link>
@@ -97,6 +101,11 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 									className="transition-colors hover:text-white"
 								>
 									{t("footer.contact")}
+								</Link>
+							</li>
+							<li>
+								<Link to="/help" className="transition-colors hover:text-white">
+									{t("footer.help")}
 								</Link>
 							</li>
 						</ul>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -37,6 +37,7 @@
       "terms": "Nutzungsbedingungen",
       "privacy": "Datenschutz",
       "contact": "Kontakt",
+      "help": "Hilfe",
       "followUs": "Folge uns",
       "copyright": "© {{year}} Einsatzbereit. Lizenziert unter <licenseLink>AGPL-3.0</licenseLink>."
     },
@@ -654,6 +655,26 @@
       "reportSectionBody": "Wenn dir ein Einsatz oder eine Organisation auffällt, die wie Spam, Betrug oder anderweitig illegale Inhalte aussieht, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Einsatz-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Unsere Administratoren prüfen jede Meldung und können die Inhalte entfernen.",
       "otherSectionTitle": "Andere Fragen oder Anliegen",
       "otherSectionBody": "Bei allen anderen Anliegen wende dich bitte direkt an die Organisation, bei der du dich engagierst, oder an den im Impressum genannten Betreiber der Plattform."
+    },
+    "help": {
+      "title": "Hilfe",
+      "intro": "Antworten auf häufige Fragen für Freiwillige und Organisationen auf Einsatzbereit. Nicht gefunden, was du suchst? Siehe „Noch Hilfe nötig?“ unten.",
+      "volunteersTitle": "Für Freiwillige",
+      "volunteersQ1": "Wie melde ich mich für einen Einsatz an?",
+      "volunteersA1": "Durchsuche die Einsätze auf der Startseite, öffne den gewünschten Einsatz und klicke auf „Anmelden“. Je nach Einsatz wählst du einen konkreten Zeitslot oder sendest eine kurze Nachricht mit deinem Interesse.",
+      "volunteersQ2": "Wie checke ich vor Ort ein?",
+      "volunteersA2": "Bei Einsätzen mit Check-in erscheint eine Schaltfläche „Einchecken“, sobald dein Zeitslot beginnt. Die Organisation kann dich vor Ort auch per QR-Code oder Namen einchecken.",
+      "volunteersQ3": "Wo sehe ich meine Anmeldungen?",
+      "volunteersA3": "Öffne dein Profil und wechsle zum Tab „Meine Anmeldungen“, um alle vergangenen und kommenden Anmeldungen zu sehen.",
+      "organizersTitle": "Für Organisationen",
+      "organizersQ1": "Wie starte ich als Organisation?",
+      "organizersA1": "Erstelle eine Organisation auf der Startseite und veröffentliche anschließend deinen ersten Einsatz über das Dashboard deiner Organisation.",
+      "organizersQ2": "Wie veröffentliche ich einen Einsatz?",
+      "organizersA2": "Gehe im Dashboard deiner Organisation zu „Einsätze“ und klicke auf „Einsatz erstellen“. Fülle die Details und Zeitslots aus und veröffentliche den Einsatz, damit sich Freiwillige anmelden können.",
+      "organizersQ3": "Wie verwalte ich Anmeldungen von Freiwilligen?",
+      "organizersA3": "Öffne einen Einsatz im Dashboard deiner Organisation, um alle Angemeldeten zu sehen, ihnen zu schreiben oder sie einzuchecken.",
+      "contactTitle": "Noch Hilfe nötig?",
+      "contactBody": "Wenn dir etwas wie Spam, Betrug oder anderweitig illegale Inhalte auffällt, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Einsatz-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Für alles andere besuche unsere <contactLink>Kontaktseite</contactLink> oder schreibe uns direkt an maikhslr@gmail.com - wir antworten in der Regel innerhalb von 24 Stunden."
     },
     "termsOfUse": {
       "title": "Nutzungsbedingungen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -37,6 +37,7 @@
       "terms": "Terms of Use",
       "privacy": "Privacy Policy",
       "contact": "Contact",
+      "help": "Help",
       "followUs": "Follow us",
       "copyright": "© {{year}} Einsatzbereit. Licensed under <licenseLink>AGPL-3.0</licenseLink>."
     },
@@ -654,6 +655,26 @@
       "reportSectionBody": "If you come across an opportunity or organization that looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on its <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. Our administrators review every report and can remove the content.",
       "otherSectionTitle": "Other questions or concerns",
       "otherSectionBody": "For anything else, please reach out to the organization you are volunteering with directly, or contact the platform operator listed in the imprint."
+    },
+    "help": {
+      "title": "Help",
+      "intro": "Answers to common questions for volunteers and organizations using Einsatzbereit. Can't find what you're looking for? See \"Still need help?\" below.",
+      "volunteersTitle": "For volunteers",
+      "volunteersQ1": "How do I sign up for a volunteer opportunity?",
+      "volunteersA1": "Browse opportunities on the home page, open the one you're interested in, and click \"Sign up\". Depending on the opportunity, you'll either pick a specific time slot or send a short message expressing your interest.",
+      "volunteersQ2": "How do I check in when I arrive?",
+      "volunteersA2": "Opportunities that require check-in show a \"Check in\" button once your time slot starts. The organization may also check you in on-site using a QR code or your name.",
+      "volunteersQ3": "Where can I see my sign-ups?",
+      "volunteersA3": "Open your profile and go to the \"My Engagements\" tab to see every opportunity you've signed up for, past and upcoming.",
+      "organizersTitle": "For organizations",
+      "organizersQ1": "How do I get started as an organization?",
+      "organizersA1": "Create an organization from the home page, then publish your first volunteer opportunity from your organization's dashboard.",
+      "organizersQ2": "How do I publish a volunteer opportunity?",
+      "organizersA2": "From your organization's dashboard, go to \"Opportunities\" and click \"Create opportunity\". Fill in the details and time slots, then publish it so volunteers can sign up.",
+      "organizersQ3": "How do I manage volunteer sign-ups?",
+      "organizersA3": "Open an opportunity from your organization's dashboard to see everyone who signed up, message them, or check them in.",
+      "contactTitle": "Still need help?",
+      "contactBody": "If something looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on the relevant <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. For anything else, visit our <contactLink>Contact page</contactLink>, or email us directly at maikhslr@gmail.com - we usually reply within 24 hours."
     },
     "termsOfUse": {
       "title": "Terms of Use",

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -1,0 +1,79 @@
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { usePageToolbar } from "../contexts/ToolbarContext";
+import { pageTitleClass } from "../lib/headingClasses";
+
+export default function HelpPage() {
+	const { t } = useTranslation();
+	usePageTitle(t("help.title"));
+	usePageToolbar([{ label: t("help.title") }]);
+
+	return (
+		<div data-content-wrapper className="max-w-2xl">
+			<h1 className={`mb-2 text-gray-900 ${pageTitleClass}`}>
+				{t("help.title")}
+			</h1>
+			<p className="mb-8 leading-relaxed text-gray-700">{t("help.intro")}</p>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("help.volunteersTitle")}
+				</h2>
+				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ1")}</h3>
+				<p className="mb-4 leading-relaxed text-gray-700">
+					{t("help.volunteersA1")}
+				</p>
+				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ2")}</h3>
+				<p className="mb-4 leading-relaxed text-gray-700">
+					{t("help.volunteersA2")}
+				</p>
+				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ3")}</h3>
+				<p className="leading-relaxed text-gray-700">
+					{t("help.volunteersA3")}
+				</p>
+			</section>
+
+			<section className="mb-8">
+				<h2 className="mb-2 text-xl font-semibold">
+					{t("help.organizersTitle")}
+				</h2>
+				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ1")}</h3>
+				<p className="mb-4 leading-relaxed text-gray-700">
+					{t("help.organizersA1")}
+				</p>
+				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ2")}</h3>
+				<p className="mb-4 leading-relaxed text-gray-700">
+					{t("help.organizersA2")}
+				</p>
+				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ3")}</h3>
+				<p className="leading-relaxed text-gray-700">
+					{t("help.organizersA3")}
+				</p>
+			</section>
+
+			<section>
+				<h2 className="mb-2 text-xl font-semibold">{t("help.contactTitle")}</h2>
+				<p className="leading-relaxed text-gray-700">
+					<Trans
+						i18nKey="help.contactBody"
+						components={{
+							opportunitiesLink: (
+								<Link to="/" className="text-brand-700 underline" />
+							),
+							organizationsLink: (
+								<Link
+									to="/organizations"
+									className="text-brand-700 underline"
+								/>
+							),
+							contactLink: (
+								<Link to="/contact" className="text-brand-700 underline" />
+							),
+						}}
+					/>
+				</p>
+			</section>
+		</div>
+	);
+}


### PR DESCRIPTION
Closes #1094 - the platform had no in-product support path for users unfamiliar with technology, only a contact email buried in the imprint. Linked from the footer (including the compact org-app variant) alongside the legal pages.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
