### PR TITLE
fix: run engagement reminder tick immediately on job start

### DIFF
--- a/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/EngagementReminderJob.cs
@@ -62,20 +62,34 @@ internal sealed class EngagementReminderJob(
 	{
 		if (_timer is null) return;
 
+		// PeriodicTimer.WaitForNextTickAsync only completes after a full
+		// PollIntervalHours - without an eager first run, every restart (deploy,
+		// crash, rolling update) opens an hourly window where no engagement is
+		// ever checked for a due reminder (#1097). Ticking once up front closes
+		// that gap; the 23-25h scan window still covers a single missed hour, but
+		// not several restarts in quick succession.
+		if (!ct.IsCancellationRequested)
+			await RunTickWithErrorHandlingAsync(ct).ConfigureAwait(false);
+
 		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
 		{
-			try
-			{
-				await TickAsync(ct).ConfigureAwait(false);
-			}
-			catch (Exception ex) when (ex is not OperationCanceledException)
-			{
-				// Mirrors OutboxProcessorJob's tick-level catch: a failure here (e.g. a
-				// transient DB error) must not stop the PeriodicTimer from ever being
-				// awaited again. Any due engagement still has ReminderSentAt == null,
-				// so it is simply picked up again on the next tick.
-				logger.LogError(ex, "Engagement reminder tick failed; will retry on the next poll interval");
-			}
+			await RunTickWithErrorHandlingAsync(ct).ConfigureAwait(false);
+		}
+	}
+
+	private async Task RunTickWithErrorHandlingAsync(CancellationToken ct)
+	{
+		try
+		{
+			await TickAsync(ct).ConfigureAwait(false);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			// Mirrors OutboxProcessorJob's tick-level catch: a failure here (e.g. a
+			// transient DB error) must not stop the PeriodicTimer from ever being
+			// awaited again. Any due engagement still has ReminderSentAt == null,
+			// so it is simply picked up again on the next tick.
+			logger.LogError(ex, "Engagement reminder tick failed; will retry on the next poll interval");
 		}
 	}
 

--- a/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
@@ -6,6 +6,9 @@ using Domain.VolunteerOpportunities;
 using Infrastructure.BackgroundJobs;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using TUnit.Core.Interfaces;
 // ApiClient.cs (generated, same "IntegrationTests" namespace) also declares
 // "Organization"/"OrganizationId" DTO types, which would otherwise shadow the domain
@@ -125,6 +128,52 @@ public class EngagementReminderJobTests(IntegrationTestFixture fixture)
 			1, "the losing replica must not have queued a second reminder for the same engagement");
 	}
 
+	[Test]
+	public async Task StartAsync_EngagementDueForReminder_QueuesItWithoutWaitingForFirstHourlyTick(
+		CancellationToken cancellationToken)
+	{
+		// Regression test for #1097: RunLoopAsync used to only ever tick after
+		// PeriodicTimer.WaitForNextTickAsync completed, i.e. a full
+		// PollIntervalHours after StartAsync - leaving an hour-long gap right
+		// after every restart where a due engagement's reminder went unqueued.
+		// PollIntervalHours is set far longer than this test's timeout below, so
+		// this only passes if the eager tick on StartAsync actually runs.
+		await using var seedContext = fixture.CreateApplicationDbContext();
+		var now = DateTimeOffset.UtcNow;
+		var (engagementId, _, _) = await SeedConfirmedEngagementAsync(
+			seedContext, timeSlotStart: now.AddHours(24), reminderSentAt: null, cancellationToken);
+
+		using var scopeFactory = new SingleContextScopeFactory(fixture.CreateApplicationDbContext);
+		var job = new EngagementReminderJob(
+			scopeFactory,
+			NullLogger<EngagementReminderJob>.Instance,
+			Options.Create(new EngagementReminderOptions { MaxBatchSize = 500, PollIntervalHours = 24 }));
+
+		await job.StartAsync(cancellationToken);
+		try
+		{
+			var deadline = DateTime.UtcNow.AddSeconds(10);
+			int remindedCount;
+			do
+			{
+				await Task.Delay(200, cancellationToken);
+				remindedCount = await seedContext.Set<Engagement>()
+					.AsNoTracking()
+					.Where(e => e.Id == engagementId && e.ReminderSentAt != null)
+					.CountAsync(cancellationToken);
+			}
+			while (remindedCount == 0 && DateTime.UtcNow < deadline);
+
+			remindedCount.Should().Be(
+				1, "starting the job should tick immediately instead of waiting a full PollIntervalHours");
+			(await fixture.CountOutboxMessagesOfTypeAsync(ReminderDueDomainEventType)).Should().Be(1);
+		}
+		finally
+		{
+			await job.StopAsync(cancellationToken);
+		}
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
 	private static async Task<(EngagementId EngagementId, VolunteerOpportunityId OpportunityId, TimeSlotId TimeSlotId)> SeedConfirmedEngagementAsync(
@@ -167,5 +216,44 @@ public class EngagementReminderJobTests(IntegrationTestFixture fixture)
 	private sealed class NoOpPinGenerator : IPinGenerator
 	{
 		public string GeneratePin() => "0000";
+	}
+
+	// Minimal IServiceScopeFactory so EngagementReminderJob's real StartAsync/
+	// RunLoopAsync lifecycle can be exercised directly against a real
+	// ApplicationDbContext, without pulling in the full Aspire-hosted DI
+	// container (which already has its own EngagementReminderJob running on an
+	// hourly timer against the same database).
+	private sealed class SingleContextScopeFactory(Func<ApplicationDbContext> contextFactory)
+		: IServiceScopeFactory, IDisposable
+	{
+		private readonly List<ApplicationDbContext> _createdContexts = [];
+
+		public IServiceScope CreateScope()
+		{
+			var dbContext = contextFactory();
+			_createdContexts.Add(dbContext);
+			return new Scope(dbContext);
+		}
+
+		public void Dispose()
+		{
+			foreach (var dbContext in _createdContexts)
+				dbContext.Dispose();
+		}
+
+		private sealed class Scope(ApplicationDbContext dbContext) : IServiceScope
+		{
+			public IServiceProvider ServiceProvider { get; } = new Provider(dbContext);
+
+			public void Dispose()
+			{
+			}
+		}
+
+		private sealed class Provider(ApplicationDbContext dbContext) : IServiceProvider
+		{
+			public object? GetService(Type serviceType) =>
+				serviceType == typeof(ApplicationDbContext) ? dbContext : null;
+		}
 	}
 }


### PR DESCRIPTION
RunLoopAsync only ticked after PeriodicTimer.WaitForNextTickAsync completed, opening an hour-long window after every restart where a due 24h reminder went unqueued (#1097).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1097

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
