### PR TITLE
feat: add robots.txt and a DB-backed sitemap.xml for search crawlers

### DIFF
--- a/backend/src/Api/Sitemap/GetSitemap/v1/GetSitemapEndpoint.cs
+++ b/backend/src/Api/Sitemap/GetSitemap/v1/GetSitemapEndpoint.cs
@@ -1,0 +1,42 @@
+using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Sitemap.GetSitemap.v1;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace Api.Sitemap.GetSitemap.v1;
+
+// AllowAnonymous is deliberate: search-engine crawlers fetch this directly, with no
+// Bearer token to attach (einsatzbereit#1092). Served under the versioned API prefix
+// like every other endpoint - the frontend's nginx proxies its own /sitemap.xml to
+// this route over the internal Docker network, since a sitemap must be served from
+// the same host as the URLs it lists and the frontend/backend live on different
+// subdomains in production.
+internal sealed class GetSitemapEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/sitemap.xml", GetSitemapAsync)
+			.WithName("GetSitemap")
+			.WithTags("Sitemap")
+			.Produces(StatusCodes.Status200OK, contentType: "application/xml")
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> GetSitemapAsync(
+		[FromServices] ISender sender,
+		[FromServices] IConfiguration configuration,
+		CancellationToken cancellationToken)
+	{
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var baseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+
+		var xml = await sender.Send(new GetSitemapQuery(baseUrl), cancellationToken);
+
+		return Results.Content(xml, "application/xml; charset=utf-8");
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -2600,6 +2600,29 @@
         }
       }
     },
+    "/v1/sitemap.xml": {
+      "get": {
+        "tags": [
+          "Sitemap"
+        ],
+        "operationId": "GetSitemap",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/reports/targets": {
       "get": {
         "tags": [
@@ -9461,6 +9484,9 @@
     },
     {
       "name": "Users"
+    },
+    {
+      "name": "Sitemap"
     },
     {
       "name": "Organizations"

--- a/backend/src/Application/Common/Sitemap/SitemapEntry.cs
+++ b/backend/src/Application/Common/Sitemap/SitemapEntry.cs
@@ -1,0 +1,3 @@
+namespace Application.Common.Sitemap;
+
+public sealed record SitemapEntry(Guid Id, DateTimeOffset LastModified);

--- a/backend/src/Application/Organizations/IOrganizationReadRepository.cs
+++ b/backend/src/Application/Organizations/IOrganizationReadRepository.cs
@@ -1,4 +1,5 @@
 using Application.Common.Pagination;
+using Application.Common.Sitemap;
 using Application.Organizations.GetPublicOrganizations.v1;
 
 namespace Application.Organizations;
@@ -7,5 +8,8 @@ public interface IOrganizationReadRepository
 {
 	ValueTask<PagedList<PublicOrganizationSummary>> GetPagedPublicSummariesAsync(
 		OrganizationFilter filter,
+		CancellationToken cancellationToken = default);
+
+	ValueTask<IReadOnlyList<SitemapEntry>> GetAllForSitemapAsync(
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Sitemap/GetSitemap/v1/GetSitemapQuery.cs
+++ b/backend/src/Application/Sitemap/GetSitemap/v1/GetSitemapQuery.cs
@@ -1,0 +1,5 @@
+using Application.Common.Messaging;
+
+namespace Application.Sitemap.GetSitemap.v1;
+
+public sealed record GetSitemapQuery(string BaseUrl) : IQuery<string>;

--- a/backend/src/Application/Sitemap/GetSitemap/v1/GetSitemapQueryHandler.cs
+++ b/backend/src/Application/Sitemap/GetSitemap/v1/GetSitemapQueryHandler.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using Application.Common.Messaging;
+using Application.Common.Sitemap;
+using Application.Organizations;
+using Application.VolunteerOpportunities;
+
+namespace Application.Sitemap.GetSitemap.v1;
+
+internal sealed class GetSitemapQueryHandler(
+	IVolunteerOpportunityReadRepository opportunityReadRepository,
+	IOrganizationReadRepository organizationReadRepository)
+	: IQueryHandler<GetSitemapQuery, string>
+{
+	public async ValueTask<string> Handle(
+		GetSitemapQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunities = await opportunityReadRepository.GetPublishedForSitemapAsync(cancellationToken);
+		var organizations = await organizationReadRepository.GetAllForSitemapAsync(cancellationToken);
+
+		var baseUrl = request.BaseUrl.TrimEnd('/');
+
+		var sb = new StringBuilder();
+		sb.AppendLine("""<?xml version="1.0" encoding="UTF-8"?>""");
+		sb.AppendLine("""<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""");
+
+		foreach (var entry in organizations)
+			AppendUrl(sb, $"{baseUrl}/organizations/{entry.Id}", entry.LastModified);
+
+		foreach (var entry in opportunities)
+			AppendUrl(sb, $"{baseUrl}/volunteer-opportunities/{entry.Id}", entry.LastModified);
+
+		sb.AppendLine("</urlset>");
+
+		return sb.ToString();
+	}
+
+	private static void AppendUrl(StringBuilder sb, string loc, DateTimeOffset lastModified)
+	{
+		sb.AppendLine("\t<url>");
+		sb.AppendLine($"\t\t<loc>{loc}</loc>");
+		sb.AppendLine($"\t\t<lastmod>{lastModified.UtcDateTime:yyyy-MM-dd}</lastmod>");
+		sb.AppendLine("\t</url>");
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
+++ b/backend/src/Application/VolunteerOpportunities/IVolunteerOpportunityReadRepository.cs
@@ -1,4 +1,5 @@
 using Application.Common.Pagination;
+using Application.Common.Sitemap;
 using Application.Organizations.GetOrganizationCalendarEvents.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
@@ -8,6 +9,9 @@ namespace Application.VolunteerOpportunities;
 
 public interface IVolunteerOpportunityReadRepository
 {
+	ValueTask<IReadOnlyList<SitemapEntry>> GetPublishedForSitemapAsync(
+		CancellationToken cancellationToken = default);
+
 	ValueTask<PagedList<VolunteerOpportunitySummary>> GetPagedSummariesAsync(
 		VolunteerOpportunityFilter filter,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/OrganizationReadRepository.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Pagination;
+using Application.Common.Sitemap;
 using Application.Organizations;
 using Application.Organizations.GetPublicOrganizations.v1;
 using Domain.Organizations;
@@ -12,6 +13,12 @@ internal sealed class OrganizationReadRepository(
 	ApplicationDbContext dbContext)
 	: IOrganizationReadRepository
 {
+	public async ValueTask<IReadOnlyList<SitemapEntry>> GetAllForSitemapAsync(
+		CancellationToken cancellationToken = default) =>
+		await dbContext.OrganizationsQuery
+			.Select(o => new SitemapEntry(o.Id.Value, o.ModifiedOn ?? o.CreatedOn))
+			.ToListAsync(cancellationToken);
+
 	public async ValueTask<PagedList<PublicOrganizationSummary>> GetPagedPublicSummariesAsync(
 		OrganizationFilter filter,
 		CancellationToken cancellationToken = default)

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Pagination;
+using Application.Common.Sitemap;
 using Application.Organizations.GetOrganizationCalendarEvents.v1;
 using Application.VolunteerOpportunities;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
@@ -17,6 +18,21 @@ internal sealed class VolunteerOpportunityReadRepository(
 	ApplicationDbContext dbContext)
 	: IVolunteerOpportunityReadRepository
 {
+	// Same Published + not-yet-expired filter as GetPagedSummariesAsync below (#1086) -
+	// a sitemap entry for an opportunity that's no longer publicly listed would just be
+	// a dead link to crawlers.
+	public async ValueTask<IReadOnlyList<SitemapEntry>> GetPublishedForSitemapAsync(
+		CancellationToken cancellationToken = default)
+	{
+		var now = DateTimeOffset.UtcNow;
+
+		return await dbContext.VolunteerOpportunitiesQuery
+			.Where(vo => vo.Status == OpportunityStatus.Published)
+			.Where(vo => vo.TimeSlots.Any(ts => ts.EndDateTime >= now) || (!vo.TimeSlots.Any() && vo.ValidUntil != null && vo.ValidUntil >= now))
+			.Select(vo => new SitemapEntry(vo.Id.Value, vo.ModifiedOn ?? vo.CreatedOn))
+			.ToListAsync(cancellationToken);
+	}
+
 	public async ValueTask<PagedList<VolunteerOpportunitySummary>> GetPagedSummariesAsync(
 		VolunteerOpportunityFilter filter,
 		CancellationToken cancellationToken = default)

--- a/backend/tests/Application.UnitTests/Sitemap/GetSitemap/GetSitemapQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Sitemap/GetSitemap/GetSitemapQueryHandlerTests.cs
@@ -1,0 +1,102 @@
+using System.Xml.Linq;
+using Application.Common.Sitemap;
+using Application.Organizations;
+using Application.Sitemap.GetSitemap.v1;
+using Application.VolunteerOpportunities;
+using AwesomeAssertions;
+using NSubstitute;
+
+namespace Application.UnitTests.Sitemap.GetSitemap;
+
+public class GetSitemapQueryHandlerTests
+{
+	private static readonly XNamespace SitemapNs = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+	private readonly IVolunteerOpportunityReadRepository _opportunityReadRepository =
+		Substitute.For<IVolunteerOpportunityReadRepository>();
+	private readonly IOrganizationReadRepository _organizationReadRepository =
+		Substitute.For<IOrganizationReadRepository>();
+	private readonly GetSitemapQueryHandler _sut;
+
+	public GetSitemapQueryHandlerTests()
+	{
+		_opportunityReadRepository
+			.GetPublishedForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([]);
+		_organizationReadRepository
+			.GetAllForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([]);
+		_sut = new GetSitemapQueryHandler(_opportunityReadRepository, _organizationReadRepository);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnEmptyUrlset_WhenNoOpportunitiesOrOrganizationsExist(
+		CancellationToken cancellationToken)
+	{
+		var xml = await _sut.Handle(new GetSitemapQuery("https://einsatzbereit.example"), cancellationToken);
+
+		var document = XDocument.Parse(xml);
+		document.Root!.Name.Should().Be(SitemapNs + "urlset");
+		document.Root!.Elements(SitemapNs + "url").Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task Handle_ShouldIncludeOneUrlEntry_PerOrganizationAndOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var orgId = Guid.NewGuid();
+		var opportunityId = Guid.NewGuid();
+		_organizationReadRepository
+			.GetAllForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([new SitemapEntry(orgId, new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero))]);
+		_opportunityReadRepository
+			.GetPublishedForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([new SitemapEntry(opportunityId, new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero))]);
+
+		var xml = await _sut.Handle(new GetSitemapQuery("https://einsatzbereit.example"), cancellationToken);
+
+		var document = XDocument.Parse(xml);
+		var locs = document.Root!.Elements(SitemapNs + "url")
+			.Select(u => u.Element(SitemapNs + "loc")!.Value)
+			.ToList();
+
+		locs.Should().BeEquivalentTo([
+			$"https://einsatzbereit.example/organizations/{orgId}",
+			$"https://einsatzbereit.example/volunteer-opportunities/{opportunityId}",
+		]);
+	}
+
+	[Test]
+	public async Task Handle_ShouldTrimTrailingSlash_FromBaseUrl(
+		CancellationToken cancellationToken)
+	{
+		var orgId = Guid.NewGuid();
+		_organizationReadRepository
+			.GetAllForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([new SitemapEntry(orgId, DateTimeOffset.UtcNow)]);
+
+		var xml = await _sut.Handle(new GetSitemapQuery("https://einsatzbereit.example/"), cancellationToken);
+
+		var document = XDocument.Parse(xml);
+		var loc = document.Root!.Element(SitemapNs + "url")!.Element(SitemapNs + "loc")!.Value;
+
+		loc.Should().Be($"https://einsatzbereit.example/organizations/{orgId}");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFormatLastModified_AsDateOnly(
+		CancellationToken cancellationToken)
+	{
+		var orgId = Guid.NewGuid();
+		_organizationReadRepository
+			.GetAllForSitemapAsync(Arg.Any<CancellationToken>())
+			.Returns([new SitemapEntry(orgId, new DateTimeOffset(2026, 3, 7, 13, 45, 0, TimeSpan.Zero))]);
+
+		var xml = await _sut.Handle(new GetSitemapQuery("https://einsatzbereit.example"), cancellationToken);
+
+		var document = XDocument.Parse(xml);
+		var lastmod = document.Root!.Element(SitemapNs + "url")!.Element(SitemapNs + "lastmod")!.Value;
+
+		lastmod.Should().Be("2026-03-07");
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -215,6 +215,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task GetSitemapAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<PagedListOfFlaggedTargetSummary> ListFlaggedTargetsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -4577,6 +4582,81 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task GetSitemapAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/sitemap.xml"
+                    urlBuilder_.Append("v1/sitemap.xml");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
                         }
                         else
                         if (status_ == 500)

--- a/backend/tests/IntegrationTests/GetSitemapTests.cs
+++ b/backend/tests/IntegrationTests/GetSitemapTests.cs
@@ -1,0 +1,187 @@
+using System.Net.Http.Headers;
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.VolunteerOpportunities;
+using Infrastructure.Persistence;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetSitemapTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetSitemap_ShouldReturnEmptyUrlset_WhenNothingPublished(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync(SitemapRoute(), cancellationToken);
+		var xml = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		response.EnsureSuccessStatusCode();
+		response.Content.Headers.ContentType!.MediaType.Should().Be("application/xml");
+		xml.Should().Contain("<urlset").And.NotContain("<url>");
+	}
+
+	[Test]
+	public async Task GetSitemap_ShouldIncludeOrganization(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(SitemapRoute(), cancellationToken);
+		var xml = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		xml.Should().Contain($"/organizations/{orgId}</loc>");
+	}
+
+	[Test]
+	public async Task GetSitemap_ShouldIncludePublishedOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		var opportunity = await CreatePublishedOpportunityAsync(authenticatedClient, orgId, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(SitemapRoute(), cancellationToken);
+		var xml = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		xml.Should().Contain($"/volunteer-opportunities/{opportunity.Id}</loc>");
+	}
+
+	[Test]
+	public async Task GetSitemap_ShouldNotIncludeDraftOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		var draft = await CreateDraftOpportunityAsync(authenticatedClient, orgId, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(SitemapRoute(), cancellationToken);
+		var xml = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		xml.Should().NotContain($"/volunteer-opportunities/{draft.Id}</loc>");
+	}
+
+	// CreateTimeSlotAsync's domain validation rejects a past StartDateTime, so there is no
+	// API path to create an already-expired slot - seeded directly through the aggregate,
+	// the same way GetVolunteerOpportunitiesTests.CreateOpportunityWithExpiredTimeSlotAsync
+	// does for the equivalent public-listing expiry filter this method reuses (#1086).
+	[Test]
+	public async Task GetSitemap_ShouldNotIncludeExpiredOpportunity(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		var expired = await CreateOpportunityWithExpiredTimeSlotAsync(authenticatedClient, orgId, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(SitemapRoute(), cancellationToken);
+		var xml = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		xml.Should().NotContain($"/volunteer-opportunities/{expired.Id}</loc>");
+	}
+
+	// The output cache key is method + path + query string, and this route has no eviction
+	// tag wired up (unlike the volunteer-opportunity listing's dedicated policy, #1543) - a
+	// unique, otherwise-unused query string per call keeps every test in this class from
+	// colliding on one shared cached response within ShortPublicReadSeconds.
+	private static string SitemapRoute() => $"/v1/sitemap.xml?_={Guid.NewGuid()}";
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
+	{
+		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"Testorg_{Guid.NewGuid()}";
+		var organization = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return organization.Id.Value;
+	}
+
+	private static Task<CreateVolunteerOpportunityResponse> CreatePublishedOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken) =>
+		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Published opportunity",
+			Description = "IndividualContact - no time slots required to publish",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+			ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+		}, cancellationToken);
+
+	private static Task<CreateVolunteerOpportunityResponse> CreateDraftOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken) =>
+		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Draft opportunity",
+			Description = "Never published",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+			ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			IsDraft = true,
+		}, cancellationToken);
+
+	private async Task<CreateVolunteerOpportunityResponse> CreateOpportunityWithExpiredTimeSlotAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Expired opportunity",
+			Description = "Only has a time slot that already ended",
+			OrganizationId = orgId,
+			Street = "Sample Street",
+			HouseNumber = "1",
+			ZipCode = "12345",
+			City = "Berlin",
+			Occurrence = "OneTime",
+			ParticipationType = "ScheduledSlots",
+			CheckInMethod = "None",
+			IsDraft = true,
+		}, cancellationToken);
+
+		await using (var dbContext = fixture.CreateApplicationDbContext())
+		{
+			var opportunityId = VolunteerOpportunityId.Create(opportunity.Id).GetValueOrThrow();
+			var aggregate = await dbContext.VolunteerOpportunities.FindAsync(opportunityId, cancellationToken)
+				?? throw new InvalidOperationException($"Seeded opportunity '{opportunity.Id}' not found.");
+
+			var start = DateTimeOffset.UtcNow.AddDays(-7);
+			aggregate.AddTimeSlot(start, start.AddHours(2), maxParticipants: 10, now: start.AddDays(-1)).GetValueOrThrow();
+
+			await dbContext.SaveChangesAsync(cancellationToken);
+		}
+
+		await client.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		return opportunity;
+	}
+}

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -25,6 +25,19 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetSitemap_ShouldBeServedFromOutputCache_OnASecondRequest(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		await httpClient.GetAsync("/v1/sitemap.xml", cancellationToken);
+		var second = await httpClient.GetAsync("/v1/sitemap.xml", cancellationToken);
+
+		second.Headers.TryGetValues("Age", out _).Should().BeTrue(
+			"the sitemap is a public, non-personalized endpoint and should be output-cached (einsatzbereit#1092)");
+	}
+
+	[Test]
 	public async Task GetVolunteerOpportunities_ShouldBeServedFromOutputCache_OnASecondRequest(
 		CancellationToken cancellationToken)
 	{

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -66,4 +66,25 @@ server {
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
 	}
+
+	# A sitemap must be served from the same host as the URLs it lists, or crawlers
+	# reject its entries - but the backend (api.maik-hasler.de) and this frontend
+	# (einsatzbereit.maik-hasler.de) are different subdomains in production, and the
+	# sitemap's content is DB-backed (published opportunities/organizations), so it
+	# can't be a static file here either (einsatzbereit#1092). Proxied instead, over
+	# the "proxy" Docker network both containers already share.
+	#
+	# proxy_pass's target is a variable ($backend_upstream), not the literal
+	# "http://backend:8080" - with a literal, nginx resolves "backend" once at
+	# config load and caches that IP for the worker's lifetime, so a backend
+	# container restart (a new IP on the same Compose service name) would leave
+	# this location proxying to a dead address until nginx itself reloads. A
+	# variable forces re-resolution on every request instead, via the `resolver`
+	# below (127.0.0.11 is Docker's embedded DNS server, reachable from any
+	# container on a user-defined network).
+	location = /sitemap.xml {
+		resolver 127.0.0.11 valid=10s;
+		set $backend_upstream http://backend:8080;
+		proxy_pass $backend_upstream/v1/sitemap.xml;
+	}
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://einsatzbereit.maik-hasler.de/sitemap.xml

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -2343,6 +2343,46 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
+    getSitemap(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/sitemap.xml";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetSitemap(_response);
+        });
+    }
+
+    protected processGetSitemap(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return OK
+     */
     listFlaggedTargets(pageNumber: number, pageSize: number, signal?: AbortSignal): Promise<PagedListOfFlaggedTargetSummary> {
         let url_ = this.baseUrl + "/v1/admin/reports/targets?";
         if (pageNumber === undefined || pageNumber === null)


### PR DESCRIPTION
Static robots.txt allows all crawlers and points to /sitemap.xml. The sitemap lists published, not-yet-expired volunteer opportunities and all organizations. Since frontend and backend live on different subdomains in production, the frontend's nginx proxies /sitemap.xml to the backend's /v1/sitemap.xml over the internal Docker network, keeping the sitemap's host matching the URLs it lists.

Closes #1092.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
