### PR TITLE
feat: add notification delete and mark-unread

### DIFF
--- a/backend/src/Api/Notifications/DeleteNotification/v1/DeleteNotificationEndpoint.cs
+++ b/backend/src/Api/Notifications/DeleteNotification/v1/DeleteNotificationEndpoint.cs
@@ -1,0 +1,41 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Notifications.DeleteNotification.v1;
+using Domain.Notifications;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Notifications.DeleteNotification.v1;
+
+internal sealed class DeleteNotificationEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapDelete("/notifications/{id:guid}", DeleteNotificationAsync)
+			.WithName("DeleteNotification")
+			.WithTags("Notifications")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> DeleteNotificationAsync(
+		[FromRoute] Guid id,
+		[FromServices] ISender sender,
+		HttpContext httpContext,
+		CancellationToken cancellationToken)
+	{
+		var subClaim = httpContext.User.FindFirst("sub")?.Value;
+		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
+			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
+
+		var command = new DeleteNotificationCommand(NotificationId.Create(id).GetValueOrThrow(), userId);
+		var found = await sender.Send(command, cancellationToken);
+		return found ? Results.NoContent() : Results.NotFound();
+	}
+}

--- a/backend/src/Api/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsEndpoint.cs
+++ b/backend/src/Api/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsEndpoint.cs
@@ -1,0 +1,39 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Notifications.DeleteReadNotifications.v1;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Notifications.DeleteReadNotifications.v1;
+
+internal sealed class DeleteReadNotificationsEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapDelete("/notifications/read", DeleteReadNotificationsAsync)
+			.WithName("DeleteReadNotifications")
+			.WithTags("Notifications")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> DeleteReadNotificationsAsync(
+		[FromServices] ISender sender,
+		HttpContext httpContext,
+		CancellationToken cancellationToken)
+	{
+		var subClaim = httpContext.User.FindFirst("sub")?.Value;
+		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
+			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
+
+		var command = new DeleteReadNotificationsCommand(UserId.Create(userId).GetValueOrThrow());
+		await sender.Send(command, cancellationToken);
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadEndpoint.cs
+++ b/backend/src/Api/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadEndpoint.cs
@@ -1,0 +1,41 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Notifications.MarkNotificationUnread.v1;
+using Domain.Notifications;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Notifications.MarkNotificationUnread.v1;
+
+internal sealed class MarkNotificationUnreadEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapPost("/notifications/{id:guid}/unread", MarkNotificationUnreadAsync)
+			.WithName("MarkNotificationUnread")
+			.WithTags("Notifications")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> MarkNotificationUnreadAsync(
+		[FromRoute] Guid id,
+		[FromServices] ISender sender,
+		HttpContext httpContext,
+		CancellationToken cancellationToken)
+	{
+		var subClaim = httpContext.User.FindFirst("sub")?.Value;
+		if (subClaim is null || !Guid.TryParse(subClaim, out var userId))
+			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
+
+		var command = new MarkNotificationUnreadCommand(NotificationId.Create(id).GetValueOrThrow(), userId);
+		var found = await sender.Send(command, cancellationToken);
+		return found ? Results.NoContent() : Results.NotFound();
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -4627,6 +4627,60 @@
         }
       }
     },
+    "/v1/notifications/{id}/unread": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "MarkNotificationUnread",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/notifications/{id}/read": {
       "post": {
         "tags": [
@@ -4800,6 +4854,93 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/read": {
+      "delete": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "DeleteReadNotifications",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/{id}": {
+      "delete": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "DeleteNotification",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -166,6 +166,10 @@ public interface IApplicationDbContext
 		UserId recipientId,
 		CancellationToken cancellationToken = default);
 
+	Task<int> DeleteReadNotificationsForRecipientAsync(
+		UserId recipientId,
+		CancellationToken cancellationToken = default);
+
 	Task<List<Engagement>> GetEngagementsForVolunteerTrackingAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Notifications/DeleteNotification/v1/DeleteNotificationCommand.cs
+++ b/backend/src/Application/Notifications/DeleteNotification/v1/DeleteNotificationCommand.cs
@@ -1,0 +1,7 @@
+using Application.Common.Messaging;
+using Domain.Notifications;
+
+namespace Application.Notifications.DeleteNotification.v1;
+
+public sealed record DeleteNotificationCommand(NotificationId NotificationId, Guid RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/Notifications/DeleteNotification/v1/DeleteNotificationCommandHandler.cs
+++ b/backend/src/Application/Notifications/DeleteNotification/v1/DeleteNotificationCommandHandler.cs
@@ -1,0 +1,23 @@
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+
+namespace Application.Notifications.DeleteNotification.v1;
+
+internal sealed class DeleteNotificationCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<DeleteNotificationCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		DeleteNotificationCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var notification = await dbContext.Notifications.FindAsync(
+			request.NotificationId, cancellationToken);
+
+		if (notification is null || notification.RecipientId.Value != request.RequestingUserId)
+			return false;
+
+		dbContext.Notifications.Delete(notification);
+		return true;
+	}
+}

--- a/backend/src/Application/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsCommand.cs
+++ b/backend/src/Application/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsCommand.cs
@@ -1,0 +1,7 @@
+using Application.Common.Messaging;
+using Domain.Users;
+
+namespace Application.Notifications.DeleteReadNotifications.v1;
+
+public sealed record DeleteReadNotificationsCommand(UserId RecipientId)
+	: ICommand<int>;

--- a/backend/src/Application/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsCommandHandler.cs
+++ b/backend/src/Application/Notifications/DeleteReadNotifications/v1/DeleteReadNotificationsCommandHandler.cs
@@ -1,0 +1,14 @@
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+
+namespace Application.Notifications.DeleteReadNotifications.v1;
+
+internal sealed class DeleteReadNotificationsCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<DeleteReadNotificationsCommand, int>
+{
+	public async ValueTask<int> Handle(
+		DeleteReadNotificationsCommand request,
+		CancellationToken cancellationToken = default) =>
+		await dbContext.DeleteReadNotificationsForRecipientAsync(request.RecipientId, cancellationToken);
+}

--- a/backend/src/Application/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadCommand.cs
+++ b/backend/src/Application/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadCommand.cs
@@ -1,0 +1,7 @@
+using Application.Common.Messaging;
+using Domain.Notifications;
+
+namespace Application.Notifications.MarkNotificationUnread.v1;
+
+public sealed record MarkNotificationUnreadCommand(NotificationId NotificationId, Guid RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadCommandHandler.cs
+++ b/backend/src/Application/Notifications/MarkNotificationUnread/v1/MarkNotificationUnreadCommandHandler.cs
@@ -1,0 +1,23 @@
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+
+namespace Application.Notifications.MarkNotificationUnread.v1;
+
+internal sealed class MarkNotificationUnreadCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<MarkNotificationUnreadCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		MarkNotificationUnreadCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var notification = await dbContext.Notifications.FindAsync(
+			request.NotificationId, cancellationToken);
+
+		if (notification is null || notification.RecipientId.Value != request.RequestingUserId)
+			return false;
+
+		notification.MarkUnread();
+		return true;
+	}
+}

--- a/backend/src/Domain/Notifications/Notification.cs
+++ b/backend/src/Domain/Notifications/Notification.cs
@@ -50,4 +50,9 @@ public sealed class Notification
 	{
 		IsRead = true;
 	}
+
+	public void MarkUnread()
+	{
+		IsRead = false;
+	}
 }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -325,6 +325,13 @@ internal sealed class ApplicationDbContext(
 			.Where(n => n.RecipientId == recipientId)
 			.ExecuteDeleteAsync(cancellationToken);
 
+	public async Task<int> DeleteReadNotificationsForRecipientAsync(
+		UserId recipientId,
+		CancellationToken cancellationToken = default) =>
+		await Set<Notification>()
+			.Where(n => n.RecipientId == recipientId && n.IsRead)
+			.ExecuteDeleteAsync(cancellationToken);
+
 	public async Task<List<Engagement>> GetEngagementsForVolunteerTrackingAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default) =>

--- a/backend/tests/Application.UnitTests/Notifications/DeleteNotification/DeleteNotificationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/DeleteNotification/DeleteNotificationCommandHandlerTests.cs
@@ -1,0 +1,80 @@
+using Application.Common.Persistence;
+using Application.Notifications.DeleteNotification.v1;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.DeleteNotification;
+
+public class DeleteNotificationCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notificationRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly DeleteNotificationCommandHandler _sut;
+
+	public DeleteNotificationCommandHandlerTests()
+	{
+		_dbContext.Notifications.Returns(_notificationRepo);
+		_sut = new DeleteNotificationCommandHandler(_dbContext);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteNotificationAndReturnTrue_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new DeleteNotificationCommand(notification.Id, recipientUserId.Value);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		_notificationRepo.Received(1).Delete(notification);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalse_WhenNotificationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var notificationId = NotificationId.New();
+		_notificationRepo.FindAsync(notificationId, cancellationToken).Returns((Notification?)null);
+		var command = new DeleteNotificationCommand(notificationId, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeFalse();
+		_notificationRepo.DidNotReceiveWithAnyArgs().Delete(default!);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalseAndNotDelete_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new DeleteNotificationCommand(notification.Id, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		// Same ownership-check shape as MarkNotificationRead/MarkNotificationUnread
+		// (einsatzbereit#829): a cross-user attempt collapses into the same
+		// "false" result as a nonexistent id, and never touches the row.
+		result.Should().BeFalse();
+		_notificationRepo.DidNotReceiveWithAnyArgs().Delete(default!);
+	}
+}

--- a/backend/tests/Application.UnitTests/Notifications/DeleteReadNotifications/DeleteReadNotificationsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/DeleteReadNotifications/DeleteReadNotificationsCommandHandlerTests.cs
@@ -1,0 +1,77 @@
+using Application.Common.Persistence;
+using Application.Notifications.DeleteReadNotifications.v1;
+using AwesomeAssertions;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.DeleteReadNotifications;
+
+public class DeleteReadNotificationsCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly DeleteReadNotificationsCommandHandler _sut;
+
+	public DeleteReadNotificationsCommandHandlerTests()
+	{
+		_sut = new DeleteReadNotificationsCommandHandler(_dbContext);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnTheDeletedCount_FromTheDbContext(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		_dbContext.DeleteReadNotificationsForRecipientAsync(recipientId, cancellationToken).Returns(3);
+
+		var command = new DeleteReadNotificationsCommand(recipientId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().Be(3);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnZero_WhenCallerHasNoReadNotifications(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientId = UserId.New();
+		_dbContext.DeleteReadNotificationsForRecipientAsync(recipientId, cancellationToken).Returns(0);
+
+		var command = new DeleteReadNotificationsCommand(recipientId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().Be(0);
+	}
+
+	[Test]
+	public async Task Handle_ShouldOnlyAffectTheRequestingUsersOwnNotifications(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the dbContext call itself is scoped to recipientId - this
+		// asserts the handler passes the command's own RecipientId through
+		// rather than some other identity, so a caller can never delete
+		// another user's notifications.
+		var recipientId = UserId.New();
+		var otherUsersId = UserId.New();
+		_dbContext.DeleteReadNotificationsForRecipientAsync(otherUsersId, Arg.Any<CancellationToken>())
+			.Returns(5);
+		_dbContext.DeleteReadNotificationsForRecipientAsync(recipientId, cancellationToken)
+			.Returns(0);
+
+		var command = new DeleteReadNotificationsCommand(recipientId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().Be(0);
+		await _dbContext.DidNotReceive().DeleteReadNotificationsForRecipientAsync(otherUsersId, Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Notifications/MarkNotificationUnread/MarkNotificationUnreadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkNotificationUnread/MarkNotificationUnreadCommandHandlerTests.cs
@@ -1,0 +1,100 @@
+using Application.Common.Persistence;
+using Application.Notifications.MarkNotificationUnread.v1;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Notifications.MarkNotificationUnread;
+
+public class MarkNotificationUnreadCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notificationRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly MarkNotificationUnreadCommandHandler _sut;
+
+	public MarkNotificationUnreadCommandHandlerTests()
+	{
+		_dbContext.Notifications.Returns(_notificationRepo);
+		_sut = new MarkNotificationUnreadCommandHandler(_dbContext);
+	}
+
+	[Test]
+	public async Task Handle_ShouldMarkNotificationUnreadAndReturnTrue_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		notification.MarkRead();
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationUnreadCommand(notification.Id, recipientUserId.Value);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		notification.IsRead.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalse_WhenNotificationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var notificationId = NotificationId.New();
+		_notificationRepo.FindAsync(notificationId, cancellationToken).Returns((Notification?)null);
+		var command = new MarkNotificationUnreadCommand(notificationId, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFalseAndNotMarkUnread_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		notification.MarkRead();
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationUnreadCommand(notification.Id, Guid.NewGuid());
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		// Mirrors MarkNotificationRead's ownership check (einsatzbereit#829): a
+		// cross-user attempt collapses into the same "false" result as a
+		// nonexistent id rather than leaking whether the id belongs to someone else.
+		result.Should().BeFalse();
+		notification.IsRead.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnTrue_WhenNotificationIsAlreadyUnread(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var recipientUserId = UserId.New();
+		var notification = Notification.Create(
+			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
+		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
+		var command = new MarkNotificationUnreadCommand(notification.Id, recipientUserId.Value);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		notification.IsRead.Should().BeFalse();
+	}
+}

--- a/backend/tests/ArchitectureTests/OwnershipConventionTests.cs
+++ b/backend/tests/ArchitectureTests/OwnershipConventionTests.cs
@@ -19,6 +19,8 @@ public sealed class OwnershipConventionTests
 		// Ownership is checked against notification.RecipientId - a per-user
 		// resource, not an organization.
 		"Application.Notifications.MarkNotificationRead.v1.MarkNotificationReadCommandHandler",
+		"Application.Notifications.MarkNotificationUnread.v1.MarkNotificationUnreadCommandHandler",
+		"Application.Notifications.DeleteNotification.v1.DeleteNotificationCommandHandler",
 		// Ownership is checked against engagement.VolunteerId - a per-user
 		// resource, not an organization.
 		"Application.Engagements.SubmitFeedback.v1.SubmitFeedbackCommandHandler",

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -355,6 +355,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task MarkNotificationUnreadAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task MarkNotificationReadAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -371,6 +376,16 @@ namespace IntegrationTests
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<NotificationsPage> GetMyNotificationsAsync(long? beforeUnixMs = null, System.Guid? beforeId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteReadNotificationsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteNotificationAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -7844,6 +7859,107 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task MarkNotificationUnreadAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/notifications/{id}/unread"
+                    urlBuilder_.Append("v1/notifications/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/unread");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task MarkNotificationReadAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
@@ -8189,6 +8305,190 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteReadNotificationsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/notifications/read"
+                    urlBuilder_.Append("v1/notifications/read");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteNotificationAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/notifications/{id}"
+                    urlBuilder_.Append("v1/notifications/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -244,6 +244,167 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		unchangedNotifications.Items.Single(n => n.Id == notification.Id).IsRead.Should().BeFalse();
 	}
 
+	[Test]
+	public async Task MarkNotificationUnread_ShouldReturn204AndFlagAsUnread_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Mark Unread Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+
+		await olafClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
+		await olafClient.MarkNotificationUnreadAsync(notification.Id, cancellationToken);
+
+		var updatedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		updatedNotifications.Items.Single(n => n.Id == notification.Id).IsRead.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task MarkNotificationUnread_ShouldReturn404AndLeaveItRead_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Cross-User Mark Unread Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+		await olafClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
+
+		var act = () => veraClient.MarkNotificationUnreadAsync(notification.Id, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+
+		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		unchangedNotifications.Items.Single(n => n.Id == notification.Id).IsRead.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task DeleteNotification_ShouldReturn204AndRemoveIt_WhenRequestingUserIsTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Delete Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+
+		await olafClient.DeleteNotificationAsync(notification.Id, cancellationToken);
+
+		var updatedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		updatedNotifications.Items.Should().NotContain(n => n.Id == notification.Id);
+	}
+
+	[Test]
+	public async Task DeleteNotification_ShouldReturn404AndLeaveIt_WhenRequestingUserIsNotTheRecipient(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Notification Cross-User Delete Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+
+		var act = () => veraClient.DeleteNotificationAsync(notification.Id, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(404);
+
+		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		unchangedNotifications.Items.Should().Contain(n => n.Id == notification.Id);
+	}
+
+	[Test]
+	public async Task DeleteReadNotifications_ShouldRemoveOnlyReadNotifications_ForTheRequestingUser(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunityOne = await CreateOpportunityAsync(olafClient, orgId, "Delete Read Test One", cancellationToken);
+		var opportunityTwo = await CreateOpportunityAsync(olafClient, orgId, "Delete Read Test Two", cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunityOne.Id, new CreateEngagementRequest { Message = "First" }, cancellationToken);
+		await veraClient.CreateEngagementAsync(
+			opportunityTwo.Id, new CreateEngagementRequest { Message = "Second" }, cancellationToken);
+
+		var notifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var toMarkRead = notifications.Items.First(n => n.Kind == "EngagementCreated");
+		var toLeaveUnread = notifications.Items.Last(n => n.Kind == "EngagementCreated" && n.Id != toMarkRead.Id);
+		await olafClient.MarkNotificationReadAsync(toMarkRead.Id, cancellationToken);
+
+		await olafClient.DeleteReadNotificationsAsync(cancellationToken);
+
+		var remaining = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		remaining.Items.Should().NotContain(n => n.Id == toMarkRead.Id);
+		remaining.Items.Should().Contain(n => n.Id == toLeaveUnread.Id);
+	}
+
+	[Test]
+	public async Task DeleteReadNotifications_ShouldNotAffectAnotherUsersReadNotifications(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitle = "Delete Read Cross-User Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+		await olafClient.MarkNotificationReadAsync(notification.Id, cancellationToken);
+
+		await veraClient.DeleteReadNotificationsAsync(cancellationToken);
+
+		var unchangedNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		unchangedNotifications.Items.Should().Contain(n => n.Id == notification.Id);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
 		string username, string password)
 	{

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -94,7 +94,10 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var notificationItem = panel.Locator("li", new() { HasText = oppTitle }).First;
 		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await notificationItem.GetByRole(AriaRole.Button).ClickAsync();
+		// .First: the row's own select button is always the first interactive
+		// element (before the conditional mark-unread/delete action buttons
+		// added by #1061), but it has no aria-label of its own to filter by.
+		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
 
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements",
@@ -180,7 +183,10 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var notificationItem = panel.Locator("li", new() { HasText = oppTitle }).First;
 		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await notificationItem.GetByRole(AriaRole.Button).ClickAsync();
+		// .First: the row's own select button is always the first interactive
+		// element (before the conditional mark-unread/delete action buttons
+		// added by #1061), but it has no aria-label of its own to filter by.
+		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
 
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements",

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -4139,6 +4139,61 @@ export class EinsatzbereitApi {
     /**
      * @return No Content
      */
+    markNotificationUnread(id: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/notifications/{id}/unread";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "POST",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarkNotificationUnread(_response);
+        });
+    }
+
+    protected processMarkNotificationUnread(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
     markNotificationRead(id: string, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/notifications/{id}/read";
         if (id === undefined || id === null)
@@ -4343,6 +4398,107 @@ export class EinsatzbereitApi {
             });
         }
         return Promise.resolve<NotificationsPage>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
+    deleteReadNotifications(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/notifications/read";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteReadNotifications(_response);
+        });
+    }
+
+    protected processDeleteReadNotifications(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
+    deleteNotification(id: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/notifications/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteNotification(_response);
+        });
+    }
+
+    protected processDeleteNotification(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -1,8 +1,9 @@
-import type { RefObject } from "react";
+import { useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
 import type { NotificationSummary } from "../../client/api-client";
 import EmptyState from "../EmptyState";
+import ConfirmDialog from "../ConfirmDialog";
 import NotificationItem from "./NotificationItem";
 import { BellIcon } from "../icons";
 
@@ -40,12 +41,22 @@ export default function NotificationDropdown({
 		setNotifOpen,
 		markAllRead,
 		markOneRead,
+		markOneUnread,
+		deleteOne,
+		deleteAllRead,
+		deletingAllRead,
 	} = menu;
+	const [showClearReadConfirm, setShowClearReadConfirm] = useState(false);
 	const panelId = mobile ? "notification-panel-mobile" : "notification-panel";
 	const bellLabel =
 		unreadCount > 0
 			? t("notifications.bellLabelWithCount", { count: unreadCount })
 			: t("notifications.bellLabel");
+
+	async function handleConfirmClearRead() {
+		await deleteAllRead();
+		setShowClearReadConfirm(false);
+	}
 
 	async function handleSelect(n: NotificationSummary) {
 		// Marking as read is a side effect, not a prerequisite for navigation -
@@ -99,15 +110,26 @@ export default function NotificationDropdown({
 						<p className="text-sm font-medium text-gray-900">
 							{t("notifications.bellLabel")}
 						</p>
-						{notifications.some((n) => !n.isRead) && (
-							<button
-								type="button"
-								className="cursor-pointer text-xs text-brand-700 hover:underline"
-								onClick={() => void markAllRead()}
-							>
-								{t("notifications.markAllRead")}
-							</button>
-						)}
+						<div className="flex items-center gap-3">
+							{notifications.some((n) => !n.isRead) && (
+								<button
+									type="button"
+									className="cursor-pointer text-xs text-brand-700 hover:underline"
+									onClick={() => void markAllRead()}
+								>
+									{t("notifications.markAllRead")}
+								</button>
+							)}
+							{notifications.some((n) => n.isRead) && (
+								<button
+									type="button"
+									className="cursor-pointer text-xs text-brand-700 hover:underline"
+									onClick={() => setShowClearReadConfirm(true)}
+								>
+									{t("notifications.clearRead")}
+								</button>
+							)}
+						</div>
 					</div>
 					<ul className="max-h-80 divide-y divide-gray-50 overflow-y-auto">
 						{notifications.length === 0 ? (
@@ -121,6 +143,8 @@ export default function NotificationDropdown({
 										key={n.id}
 										notification={n}
 										onSelect={handleSelect}
+										onMarkUnread={markOneUnread}
+										onDelete={deleteOne}
 									/>
 								))}
 								{notifHasMore && (
@@ -146,6 +170,16 @@ export default function NotificationDropdown({
 						)}
 					</ul>
 				</div>
+			)}
+			{showClearReadConfirm && (
+				<ConfirmDialog
+					title={t("confirmDialog.clearReadNotifications.title")}
+					message={t("confirmDialog.clearReadNotifications.message")}
+					confirmLabel={t("confirmDialog.clearReadNotifications.confirm")}
+					onConfirm={() => void handleConfirmClearRead()}
+					onClose={() => setShowClearReadConfirm(false)}
+					loading={deletingAllRead}
+				/>
 			)}
 		</div>
 	);

--- a/frontend/src/components/Header/NotificationItem.tsx
+++ b/frontend/src/components/Header/NotificationItem.tsx
@@ -1,22 +1,31 @@
 import { useTranslation } from "react-i18next";
 import type { NotificationSummary } from "../../client/api-client";
 import { formatDateTime } from "../../lib/format";
+import { EyeSlashIcon, TrashIcon } from "../icons";
 
 export default function NotificationItem({
 	notification,
 	onSelect,
+	onMarkUnread,
+	onDelete,
 }: {
 	notification: NotificationSummary;
 	onSelect: (notification: NotificationSummary) => Promise<void>;
+	onMarkUnread: (id: string) => Promise<void>;
+	onDelete: (id: string) => Promise<void>;
 }) {
 	const { t, i18n } = useTranslation();
 	const n = notification;
+	const text = t(`notifications.kinds.${n.kind}` as Parameters<typeof t>[0], {
+		title: n.relatedTitle ?? t("notifications.deletedOpportunityPlaceholder"),
+		defaultValue: n.kind,
+	});
 
 	return (
-		<li>
+		<li className="relative">
 			<button
 				type="button"
-				className={`w-full cursor-pointer px-4 py-3 text-left text-sm transition-colors hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
+				className={`w-full cursor-pointer px-4 py-3 pr-16 text-left text-sm transition-colors hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
 				onClick={() => void onSelect(n)}
 			>
 				<span className="flex items-start gap-2">
@@ -24,12 +33,7 @@ export default function NotificationItem({
 						<span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-500" />
 					)}
 					<span className={!n.isRead ? "" : "pl-4"}>
-						{t(`notifications.kinds.${n.kind}` as Parameters<typeof t>[0], {
-							title:
-								n.relatedTitle ??
-								t("notifications.deletedOpportunityPlaceholder"),
-							defaultValue: n.kind,
-						})}
+						{text}
 						<br />
 						<span className="text-xs text-gray-500">
 							{formatDateTime(n.createdOn as unknown as string, i18n.language)}
@@ -37,6 +41,28 @@ export default function NotificationItem({
 					</span>
 				</span>
 			</button>
+			<span className="absolute top-2 right-2 z-10 flex gap-1">
+				{n.isRead && (
+					<button
+						type="button"
+						aria-label={t("notifications.markUnreadNamed", {
+							notification: text,
+						})}
+						onClick={() => void onMarkUnread(n.id)}
+						className="cursor-pointer rounded p-1.5 text-gray-500 hover:bg-brand-50 hover:text-brand-600"
+					>
+						<EyeSlashIcon className="h-3.5 w-3.5" />
+					</button>
+				)}
+				<button
+					type="button"
+					aria-label={t("notifications.deleteNamed", { notification: text })}
+					onClick={() => void onDelete(n.id)}
+					className="cursor-pointer rounded p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600"
+				>
+					<TrashIcon className="h-3.5 w-3.5" />
+				</button>
+			</span>
 		</li>
 	);
 }

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -491,6 +491,18 @@ export function TrashIcon({ className = "h-4 w-4" }: IconProps) {
 	);
 }
 
+export function EyeSlashIcon({ className = "h-4 w-4" }: IconProps) {
+	return (
+		<StrokeIcon className={className}>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"
+			/>
+		</StrokeIcon>
+	);
+}
+
 export function ShareIcon({ className = "h-4 w-4" }: IconProps) {
 	return (
 		<StrokeIcon className={className}>

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -24,6 +24,10 @@ export interface AccountMenuState {
 	dropdownRef: RefObject<HTMLDivElement | null>;
 	markAllRead: () => Promise<void>;
 	markOneRead: (id: string) => Promise<void>;
+	markOneUnread: (id: string) => Promise<void>;
+	deleteOne: (id: string) => Promise<void>;
+	deleteAllRead: () => Promise<void>;
+	deletingAllRead: boolean;
 }
 
 /**
@@ -48,6 +52,7 @@ export function useAccountMenu(
 	const [notifHasMore, setNotifHasMore] = useState(false);
 	const [notifLoadingMore, setNotifLoadingMore] = useState(false);
 	const [unreadCount, setUnreadCount] = useState(0);
+	const [deletingAllRead, setDeletingAllRead] = useState(false);
 	const dropdownRef = useDismissableOverlay<HTMLDivElement>(dropdownOpen, () =>
 		setDropdownOpen(false),
 	);
@@ -205,6 +210,52 @@ export function useAccountMenu(
 		}
 	}
 
+	async function markOneUnread(id: string) {
+		try {
+			await api.markNotificationUnread(id);
+			setNotifications((prev) =>
+				prev.map((n) => (n.id === id ? { ...n, isRead: false } : n)),
+			);
+			setUnreadCount((prev) => prev + 1);
+		} catch (err) {
+			dispatchToast(
+				"error",
+				getApiErrorMessage(err, t("notifications.markUnreadError")),
+			);
+		}
+	}
+
+	async function deleteOne(id: string) {
+		const target = notifications.find((n) => n.id === id);
+		try {
+			await api.deleteNotification(id);
+			setNotifications((prev) => prev.filter((n) => n.id !== id));
+			if (target && !target.isRead) {
+				setUnreadCount((prev) => Math.max(0, prev - 1));
+			}
+		} catch (err) {
+			dispatchToast(
+				"error",
+				getApiErrorMessage(err, t("notifications.deleteError")),
+			);
+		}
+	}
+
+	async function deleteAllRead() {
+		setDeletingAllRead(true);
+		try {
+			await api.deleteReadNotifications();
+			setNotifications((prev) => prev.filter((n) => !n.isRead));
+		} catch (err) {
+			dispatchToast(
+				"error",
+				getApiErrorMessage(err, t("notifications.clearReadError")),
+			);
+		} finally {
+			setDeletingAllRead(false);
+		}
+	}
+
 	return {
 		avatarUrl,
 		notifications,
@@ -220,5 +271,9 @@ export function useAccountMenu(
 		dropdownRef,
 		markAllRead,
 		markOneRead,
+		markOneUnread,
+		deleteOne,
+		deleteAllRead,
+		deletingAllRead,
 	};
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -707,10 +707,16 @@
       "bellLabelWithCount_one": "Benachrichtigungen, {{count}} ungelesen",
       "bellLabelWithCount_other": "Benachrichtigungen, {{count}} ungelesen",
       "markAllRead": "Alle als gelesen markieren",
+      "clearRead": "Gelesene löschen",
+      "clearReadError": "Gelesene Benachrichtigungen konnten nicht gelöscht werden.",
       "empty": "Keine Benachrichtigungen.",
       "loadMore": "Mehr laden",
       "loadingMore": "Lädt…",
       "markReadError": "Benachrichtigung konnte nicht als gelesen markiert werden.",
+      "markUnreadNamed": "Als ungelesen markieren: {{notification}}",
+      "markUnreadError": "Benachrichtigung konnte nicht als ungelesen markiert werden.",
+      "deleteNamed": "Löschen: {{notification}}",
+      "deleteError": "Benachrichtigung konnte nicht gelöscht werden.",
       "deletedOpportunityPlaceholder": "einen gelöschten Einsatz",
       "kinds": {
         "EngagementCreated": "Neue Anmeldung eingegangen für {{title}}",
@@ -819,6 +825,11 @@
         "title": "Inhalt wiederherstellen?",
         "message": "Möchtest du \"{{name}}\" wirklich wiederherstellen? Der Inhalt wird wieder sichtbar.",
         "confirm": "Ja, wiederherstellen"
+      },
+      "clearReadNotifications": {
+        "title": "Gelesene Benachrichtigungen löschen?",
+        "message": "Dadurch werden alle gelesenen Benachrichtigungen dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, löschen"
       }
     },
     "imageCrop": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -707,10 +707,16 @@
       "bellLabelWithCount_one": "Notifications, {{count}} unread notification",
       "bellLabelWithCount_other": "Notifications, {{count}} unread notifications",
       "markAllRead": "Mark all as read",
+      "clearRead": "Clear read",
+      "clearReadError": "Failed to clear read notifications.",
       "empty": "No notifications.",
       "loadMore": "Load more",
       "loadingMore": "Loading…",
       "markReadError": "Failed to mark notification as read.",
+      "markUnreadNamed": "Mark as unread: {{notification}}",
+      "markUnreadError": "Failed to mark notification as unread.",
+      "deleteNamed": "Delete: {{notification}}",
+      "deleteError": "Failed to delete notification.",
       "deletedOpportunityPlaceholder": "a deleted opportunity",
       "kinds": {
         "EngagementCreated": "New sign-up received for {{title}}",
@@ -819,6 +825,11 @@
         "title": "Restore this content?",
         "message": "Are you sure you want to restore \"{{name}}\"? It will become visible again.",
         "confirm": "Yes, restore"
+      },
+      "clearReadNotifications": {
+        "title": "Clear read notifications?",
+        "message": "This permanently deletes all read notifications. This cannot be undone.",
+        "confirm": "Yes, clear"
       }
     },
     "imageCrop": {


### PR DESCRIPTION
Pagination and unread polling already shipped via #1453; this fills the remaining gaps from #1061 - a per-user MarkUnread() domain method, DELETE endpoints for a single notification and for all read notifications, and matching UI actions in the notification dropdown.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1061

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
