### PR TITLE
feat: give org Members read access, gate management to Organizers

### DIFF
--- a/backend/src/Api/Engagements/GetEngagements/v1/GetEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/GetEngagements/v1/GetEngagementsEndpoint.cs
@@ -28,7 +28,7 @@ internal sealed class GetEngagementsEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 

--- a/backend/src/Api/Organizations/GetDashboardLayout/v1/GetDashboardLayoutEndpoint.cs
+++ b/backend/src/Api/Organizations/GetDashboardLayout/v1/GetDashboardLayoutEndpoint.cs
@@ -24,7 +24,7 @@ internal sealed class GetDashboardLayoutEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}

--- a/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsEndpoint.cs
@@ -23,7 +23,7 @@ internal sealed class GetOrganizationCalendarEventsEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}

--- a/backend/src/Api/Organizations/GetOrganizationDashboard/v1/GetOrganizationDashboardEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationDashboard/v1/GetOrganizationDashboardEndpoint.cs
@@ -23,7 +23,7 @@ internal sealed class GetOrganizationDashboardEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}

--- a/backend/src/Api/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsEndpoint.cs
+++ b/backend/src/Api/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsEndpoint.cs
@@ -23,7 +23,7 @@ internal sealed class GetOrganizationDetailsEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 	}

--- a/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
+++ b/backend/src/Api/Organizations/RemoveMember/v1/RemoveMemberEndpoint.cs
@@ -23,7 +23,7 @@ internal sealed class RemoveMemberEndpoint
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 	}

--- a/backend/src/Api/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackEndpoint.cs
@@ -25,7 +25,7 @@ internal sealed class GetOpportunityFeedbackEndpoint : IEndpoint
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 

--- a/backend/src/Api/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesEndpoint.cs
@@ -25,7 +25,7 @@ internal sealed class GetOrganizationOpportunitiesEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
-			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 			.MapToApiVersion(1);
 

--- a/backend/src/Application/Common/Authorization/OwnershipGuard.cs
+++ b/backend/src/Application/Common/Authorization/OwnershipGuard.cs
@@ -22,4 +22,19 @@ public static class OwnershipGuard
 				"Organization.NotOrganizer",
 				"You do not have permission to modify this resource."));
 	}
+
+	public static async Task EnsureIsMemberAsync(
+		IApplicationDbContext dbContext,
+		Guid organizationId,
+		UserId requestingUserId,
+		CancellationToken cancellationToken)
+	{
+		var isMember = await dbContext.IsMemberAsync(
+			OrganizationId.Create(organizationId).GetValueOrThrow(), requestingUserId, cancellationToken);
+
+		if (!isMember)
+			throw new ResultFailureException(Error.Forbidden(
+				"Organization.NotMember",
+				"You do not have permission to view this resource."));
+	}
 }

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -40,6 +40,11 @@ public interface IApplicationDbContext
 		UserId userId,
 		CancellationToken cancellationToken = default);
 
+	Task<bool> IsMemberAsync(
+		OrganizationId organizationId,
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
 	Task<int> CountOrganizersAsync(
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
@@ -84,6 +89,10 @@ public interface IApplicationDbContext
 		CancellationToken cancellationToken = default);
 
 	Task<List<Organization>> GetOrganizerOrganizationsAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default);
+
+	Task<List<Organization>> GetMemberOrganizationsAsync(
 		UserId userId,
 		CancellationToken cancellationToken = default);
 

--- a/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/GetEngagements/v1/GetEngagementsQueryHandler.cs
@@ -30,7 +30,7 @@ internal sealed class GetEngagementsQueryHandler(
 		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(request.OpportunityId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId.Value}' not found."));
 
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			opportunity.OrganizationId.Value,
 			request.RequestingUserId,

--- a/backend/src/Application/Organizations/GetDashboardLayout/v1/GetDashboardLayoutQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetDashboardLayout/v1/GetDashboardLayoutQueryHandler.cs
@@ -20,7 +20,7 @@ internal sealed class GetDashboardLayoutQueryHandler(
 		_ = await dbContext.Organizations.FindAsync(organizationId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("Organization.NotFound", $"Organization '{request.OrganizationId}' not found."));
 
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			request.OrganizationId,
 			request.RequestingUserId,

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/GetOrganizationCalendarEventsQueryHandler.cs
@@ -14,7 +14,7 @@ internal sealed class GetOrganizationCalendarEventsQueryHandler(
 		GetOrganizationCalendarEventsQuery request,
 		CancellationToken cancellationToken = default)
 	{
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			request.OrganizationId,
 			request.RequestingUserId,

--- a/backend/src/Application/Organizations/GetOrganizationDashboard/v1/GetOrganizationDashboardQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDashboard/v1/GetOrganizationDashboardQueryHandler.cs
@@ -21,7 +21,7 @@ internal sealed class GetOrganizationDashboardQueryHandler(
 		if (organization is null)
 			return null;
 
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			request.OrganizationId,
 			request.RequestingUserId,

--- a/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
@@ -22,7 +22,7 @@ internal sealed class GetOrganizationDetailsQueryHandler(
 		if (organization is null)
 			return null;
 
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			organization.Id.Value,
 			request.RequestingUserId,

--- a/backend/src/Application/Organizations/GetOrganizations/v1/GetOrganizationsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizations/v1/GetOrganizationsQueryHandler.cs
@@ -13,7 +13,7 @@ internal sealed class GetOrganizationsQueryHandler(
 		GetOrganizationsQuery request,
 		CancellationToken cancellationToken = default)
 	{
-		var organizations = await dbContext.GetOrganizerOrganizationsAsync(
+		var organizations = await dbContext.GetMemberOrganizationsAsync(
 			UserId.Create(request.UserId).GetValueOrThrow(), cancellationToken);
 
 		return organizations

--- a/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
+++ b/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
@@ -18,14 +18,27 @@ internal sealed class RemoveMemberCommandHandler(
 		RemoveMemberCommand request,
 		CancellationToken cancellationToken = default)
 	{
-		await OwnershipGuard.EnsureIsOrganizerAsync(
-			dbContext,
-			request.OrganizationId,
-			request.RequestingUserId,
-			cancellationToken);
-
 		var organizationId = OrganizationId.Create(request.OrganizationId).GetValueOrThrow();
 		var userId = UserId.Create(request.UserId).GetValueOrThrow();
+
+		// Leaving is a self-service action available to any tier, not an
+		// org-management action - only removing someone else requires Organizer.
+		if (userId == request.RequestingUserId)
+		{
+			await OwnershipGuard.EnsureIsMemberAsync(
+				dbContext,
+				request.OrganizationId,
+				request.RequestingUserId,
+				cancellationToken);
+		}
+		else
+		{
+			await OwnershipGuard.EnsureIsOrganizerAsync(
+				dbContext,
+				request.OrganizationId,
+				request.RequestingUserId,
+				cancellationToken);
+		}
 
 		var isOrganizer = await dbContext.IsOrganizerAsync(organizationId, userId, cancellationToken);
 

--- a/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetOpportunityFeedback/v1/GetOpportunityFeedbackQueryHandler.cs
@@ -23,7 +23,7 @@ internal sealed class GetOpportunityFeedbackQueryHandler(
 				"VolunteerOpportunity.NotFound",
 				$"Volunteer opportunity '{request.OpportunityId.Value}' not found."));
 
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			opportunity.OrganizationId.Value,
 			request.RequestingUserId,

--- a/backend/src/Application/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetOrganizationOpportunities/v1/GetOrganizationOpportunitiesQueryHandler.cs
@@ -17,7 +17,7 @@ internal sealed class GetOrganizationOpportunitiesQueryHandler(
 		GetOrganizationOpportunitiesQuery request,
 		CancellationToken cancellationToken = default)
 	{
-		await OwnershipGuard.EnsureIsOrganizerAsync(
+		await OwnershipGuard.EnsureIsMemberAsync(
 			dbContext,
 			request.OrganizationId,
 			request.RequestingUserId,

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -115,6 +115,14 @@ internal sealed class ApplicationDbContext(
 				&& m.UserId == userId
 				&& m.Role == OrganizationMemberRole.Organizer, cancellationToken);
 
+	public async Task<bool> IsMemberAsync(
+		OrganizationId organizationId,
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationMembership>()
+			.AnyAsync(m => m.OrganizationId == organizationId
+				&& m.UserId == userId, cancellationToken);
+
 	public async Task<int> CountOrganizersAsync(
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default) =>
@@ -198,6 +206,20 @@ internal sealed class ApplicationDbContext(
 		await Set<OrganizationMembership>()
 			.AsNoTracking()
 			.Where(m => m.UserId == userId && m.Role == OrganizationMemberRole.Organizer)
+			.Join(
+				Set<Organization>().AsNoTracking(),
+				m => m.OrganizationId,
+				o => o.Id,
+				(m, o) => o)
+			.OrderBy(o => o.Name)
+			.ToListAsync(cancellationToken);
+
+	public async Task<List<Organization>> GetMemberOrganizationsAsync(
+		UserId userId,
+		CancellationToken cancellationToken = default) =>
+		await Set<OrganizationMembership>()
+			.AsNoTracking()
+			.Where(m => m.UserId == userId)
 			.Join(
 				Set<Organization>().AsNoTracking(),
 				m => m.OrganizationId,

--- a/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
@@ -37,7 +37,7 @@ public class GetEngagementsQueryHandlerTests
 			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(CreateDefaultOpportunity());
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_readRepository
 			.GetPagedByOpportunityAsync(
@@ -120,11 +120,11 @@ public class GetEngagementsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
 		var query = new GetEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId, 1, 10);

--- a/backend/tests/Application.UnitTests/Organizations/GetDashboardLayout/GetDashboardLayoutQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetDashboardLayout/GetDashboardLayoutQueryHandlerTests.cs
@@ -25,7 +25,7 @@ public class GetDashboardLayoutQueryHandlerTests
 			.FindAsync(Arg.Any<OrganizationId>(), Arg.Any<CancellationToken>())
 			.Returns(Organization.Create(OrganizationId.Create(DefaultOrgId).GetValueOrThrow(), "Sample Fire Department").Value);
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_sut = new GetDashboardLayoutQueryHandler(_dbContext);
 	}
@@ -43,11 +43,11 @@ public class GetDashboardLayoutQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
 			.Returns(false);
 		var query = new GetDashboardLayoutQuery(DefaultOrgId, DefaultRequestingUserId);
 

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
@@ -24,7 +24,7 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 	public GetOrganizationCalendarEventsQueryHandlerTests()
 	{
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_sut = new GetOrganizationCalendarEventsQueryHandler(_dbContext, _readRepository);
 	}
@@ -75,12 +75,12 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller is not an organizer of the target organization.
+		// Arrange: caller has no membership at all in the target organization.
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
 		var query = new GetOrganizationCalendarEventsQuery(DefaultOrgId, DefaultRequestingUserId, DefaultFrom, DefaultTo);

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationDashboard/GetOrganizationDashboardQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationDashboard/GetOrganizationDashboardQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetOrganizationDashboardQueryHandlerTests
 			.FindAsync(Arg.Any<OrganizationId>(), Arg.Any<CancellationToken>())
 			.Returns(Organization.Create(OrganizationId.Create(DefaultOrgId).GetValueOrThrow(), "Sample Fire Department").Value);
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_sut = new GetOrganizationDashboardQueryHandler(_dbContext, _readRepository);
 	}
@@ -49,12 +49,12 @@ public class GetOrganizationDashboardQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizerOfTheOrganization(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), cancellationToken)
 			.Returns(false);
 		var query = new GetOrganizationDashboardQuery(DefaultOrgId, DefaultRequestingUserId);
 

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetOrganizationDetailsQueryHandlerTests
 	{
 		_dbContext.Organizations.Returns(_orgRepo);
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_sut = new GetOrganizationDetailsQueryHandler(_dbContext, _keycloakService);
 	}
@@ -115,16 +115,17 @@ public class GetOrganizationDetailsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller is not an organizer of the target organization.
+		// Arrange: caller has no membership at all in the target organization (any
+		// member - Organizer or plain Member - may view organization details).
 		var orgId = DefaultOrgId;
 		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Org").Value;
 
 		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(org);
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
 		// Act

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizations/GetOrganizationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizations/GetOrganizationsQueryHandlerTests.cs
@@ -19,7 +19,7 @@ public class GetOrganizationsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnOrganizerOrganizations_WithNameAndLogoUrl(
+	public async Task Handle_ShouldReturnMemberOrganizations_WithNameAndLogoUrl(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
@@ -28,7 +28,7 @@ public class GetOrganizationsQueryHandlerTests
 		org.SetLogoUrl("https://example.com/logo.png");
 
 		_dbContext
-			.GetOrganizerOrganizationsAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken)
+			.GetMemberOrganizationsAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken)
 			.Returns([org]);
 
 		// Act
@@ -42,14 +42,14 @@ public class GetOrganizationsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnEmptyList_WhenUserOrganizesNothing(
+	public async Task Handle_ShouldReturnEmptyList_WhenUserBelongsToNoOrganization(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var userId = Guid.NewGuid();
 
 		_dbContext
-			.GetOrganizerOrganizationsAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken)
+			.GetMemberOrganizationsAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken)
 			.Returns([]);
 
 		// Act

--- a/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
@@ -25,10 +25,19 @@ public class RemoveMemberCommandHandlerTests
 		_sut = new RemoveMemberCommandHandler(_dbContext, _keycloakService);
 	}
 
-	private void AllowRequestingUserInOrg(Guid orgId) =>
-		_dbContext
-			.IsOrganizerAsync(OrganizationId.Create(orgId).GetValueOrThrow(), DefaultRequestingUserId, Arg.Any<CancellationToken>())
-			.Returns(true);
+	private void AllowRequestingUserInOrg(Guid orgId)
+	{
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		_dbContext.IsOrganizerAsync(organizationId, DefaultRequestingUserId, Arg.Any<CancellationToken>()).Returns(true);
+		_dbContext.IsMemberAsync(organizationId, DefaultRequestingUserId, Arg.Any<CancellationToken>()).Returns(true);
+	}
+
+	private void AllowRequestingUserAsPlainMember(Guid orgId)
+	{
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		_dbContext.IsOrganizerAsync(organizationId, DefaultRequestingUserId, Arg.Any<CancellationToken>()).Returns(false);
+		_dbContext.IsMemberAsync(organizationId, DefaultRequestingUserId, Arg.Any<CancellationToken>()).Returns(true);
+	}
 
 	private void SetTargetIsOrganizer(Guid orgId, Guid targetUserId, bool isOrganizer) =>
 		_dbContext
@@ -161,6 +170,44 @@ public class RemoveMemberCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		await _keycloakService.Received(1).RemoveMemberAsync(orgId, otherUserId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldAllowSelfRemoval_WhenRequestingUserIsOnlyAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a plain (non-organizer) Member leaving the organization is a
+		// self-service action, not org management - it must not require Organizer.
+		var orgId = Guid.NewGuid();
+		AllowRequestingUserAsPlainMember(orgId);
+		SetTargetIsOrganizer(orgId, DefaultRequestingUserId.Value, isOrganizer: false);
+		var command = new RemoveMemberCommand(orgId, DefaultRequestingUserId.Value, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _keycloakService.Received(1).RemoveMemberAsync(orgId, DefaultRequestingUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenPlainMemberTriesToRemoveSomeoneElse(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - removing another member is org management and still requires Organizer,
+		// even though the requester is a valid Member of the organization.
+		var orgId = Guid.NewGuid();
+		var otherUserId = Guid.NewGuid();
+		AllowRequestingUserAsPlainMember(orgId);
+		var command = new RemoveMemberCommand(orgId, otherUserId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<ResultFailureException>();
+		await _keycloakService.DidNotReceive().RemoveMemberAsync(orgId, otherUserId, Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
@@ -32,7 +32,7 @@ public class GetOpportunityFeedbackQueryHandlerTests
 			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(CreateOpportunity());
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_engagementReadRepository
 			.GetFeedbackByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -119,14 +119,14 @@ public class GetOpportunityFeedbackQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
 		// Arrange: caller belongs to a different organization than the opportunity's.
 		var opportunity = CreateOpportunity();
 		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
 		var query = new GetOpportunityFeedbackQuery(opportunity.Id, DefaultRequestingUserId, 1, 10);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOrganizationOpportunities/GetOrganizationOpportunitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOrganizationOpportunities/GetOrganizationOpportunitiesQueryHandlerTests.cs
@@ -25,7 +25,7 @@ public class GetOrganizationOpportunitiesQueryHandlerTests
 	public GetOrganizationOpportunitiesQueryHandlerTests()
 	{
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_readRepository
 			.GetPagedSummariesByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<OpportunityStatus>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -96,12 +96,12 @@ public class GetOrganizationOpportunitiesQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller is not an organizer of the target organization.
+		// Arrange: caller has no membership at all in the target organization.
 		_dbContext
-			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
 		var query = new GetOrganizationOpportunitiesQuery(DefaultOrgId, DefaultRequestingUserId, OpportunityStatus.Published, 1, 10);

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -107,15 +107,40 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
-	public async Task GetEngagements_ShouldReturn403_WhenUserLacksOrganisatorRole(
+	public async Task GetEngagements_ShouldReturn403_WhenRequestingUserIsNotAMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{
+		// #1024: GetEngagements is readable by any member (Organizer or Member) of the
+		// opportunity's organization - vera has no relationship to olaf's org at all.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 
-		var act = () => veraClient.GetEngagementsAsync(Guid.NewGuid(), 1, 10, cancellationToken: cancellationToken);
+		var act = () => veraClient.GetEngagementsAsync(opportunity.Id, 1, 10, cancellationToken: cancellationToken);
 
 		var exception = await act.Should().ThrowAsync<ApiException>();
 		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	[Test]
+	public async Task GetEngagements_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their organization's engagements -
+		// this used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var result = await veraClient.GetEngagementsAsync(opportunity.Id, 1, 10, cancellationToken: cancellationToken);
+
+		result.TotalItems.Should().Be(0);
 	}
 
 	[Test]
@@ -1168,6 +1193,26 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var firstPageComments = firstPage.Items.Items.Select(i => i.Comment).ToList();
 		var secondPageComments = secondPage.Items.Items.Select(i => i.Comment).ToList();
 		firstPageComments.Should().NotBeEquivalentTo(secondPageComments);
+	}
+
+	[Test]
+	public async Task GetOpportunityFeedback_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their organization's opportunity
+		// feedback - this used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var summary = await veraClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
+
+		summary.AverageRating.Should().BeNull();
+		summary.FeedbackCount.Should().Be(0);
 	}
 
 	// ── Feedback rating DB check constraint (#1214) ───────────────────────────

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -135,6 +135,43 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 		org1Kpis.ConfirmedEngagementsTotal.Should().Be(1);
 	}
 
+	[Test]
+	public async Task GetOrganizationDashboard_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their organization's dashboard KPIs -
+		// this used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var kpis = await veraClient.GetOrganizationDashboardAsync(orgId, cancellationToken);
+
+		kpis.PendingEngagements.Should().Be(0);
+		kpis.ConfirmedEngagementsTotal.Should().Be(0);
+	}
+
+	[Test]
+	public async Task GetDashboardLayout_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their own dashboard widget layout for
+		// the organization - this used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var layout = await veraClient.GetDashboardLayoutAsync(orgId, cancellationToken);
+
+		layout.HasCustomLayout.Should().BeFalse();
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(

--- a/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
@@ -181,6 +181,28 @@ public class OrganizationCalendarEventsTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(403);
 	}
 
+	[Test]
+	public async Task GetOrganizationCalendarEvents_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their organization's calendar - this
+		// used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var events = await veraClient.GetOrganizationCalendarEventsAsync(
+			orgId,
+			DateTimeOffset.UtcNow,
+			DateTimeOffset.UtcNow.AddDays(30),
+			cancellationToken);
+
+		events.Should().BeEmpty();
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(

--- a/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
@@ -168,6 +168,30 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(403);
 	}
 
+	[Test]
+	public async Task GetOrganizationOpportunities_ShouldSucceed_WhenRequestingUserIsAPlainMember(
+		CancellationToken cancellationToken)
+	{
+		// #1024: a plain Member can now view their organization's opportunities -
+		// this used to 403 (only Organizer could).
+		var olafClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		await CreatePublishedOpportunityAsync(olafClient, orgId, "Published 1", cancellationToken);
+
+		var veraToken = await fixture.GetAccessTokenAsync("vera", "vera123");
+		var veraHttpClient = fixture.CreateHttpClient();
+		veraHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", veraToken);
+		var veraClient = new EinsatzbereitApi(veraHttpClient);
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(orgId, vera.Id, cancellationToken);
+
+		var result = await veraClient.GetOrganizationOpportunitiesAsync(orgId, "Published", 1, 10, cancellationToken);
+
+		result.TotalItems.Should().Be(1);
+		result.Items.Single().Title.Should().Be("Published 1");
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
 	{
 		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -45,52 +45,46 @@ public class OrganizationSettingsTests(
 	}
 
 	[Test]
-	public async Task GetOrganizationDetails_ShouldReturn403_WhenUserHasNoOrganisatorRoleAtAll(
+	public async Task GetOrganizationDetails_ShouldReturn403_WhenRequestingUserHasNoRelationToTheOrganization(
 		CancellationToken cancellationToken)
 	{
-		// This proves only the RequireAuthorization(EinsatzbereitOrganisatorPolicy)
-		// role-claim gate on the endpoint - vera holds no "organisator" realm role
-		// at all, so this 403 fires before the handler (and its OwnershipGuard
-		// membership check) ever runs. See the membership-gate test below for the
-		// case this one used to be mistaken for.
-		var client = await CreateAuthenticatedClientAsync("vera", "vera123");
+		// #1024: GetOrganizationDetails is readable by any member (Organizer or
+		// Member), not just organizers - so this proves the true "stranger" case
+		// against a real org, rather than the old role-claim gate (removed) that
+		// used to reject every non-organizer before the handler even ran.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 
-		var act = () => client.GetOrganizationDetailsAsync(Guid.NewGuid(), cancellationToken);
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Stranger 403 Test Org" }, cancellationToken);
+
+		var act = () => veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
 
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(403);
 	}
 
 	[Test]
-	public async Task GetOrganizationDetails_ShouldReturn403_WhenRequestingUserIsAPlainMemberOfADifferentOrganization(
+	public async Task GetOrganizationDetails_ShouldSucceed_WhenRequestingUserIsAPlainMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{
-		// Regression for #1335: the test above only proves the role-claim gate,
-		// never the handler's OwnershipGuard.EnsureIsOrganizerAsync membership
-		// check. Modelled on the #691 escalation test above - holding the
-		// platform-wide "organisator" role from one org must not grant read
-		// access to a different org the same user is merely a plain member of.
+		// #1024: a plain Member can now view their own organization's details -
+		// this used to 403 (only Organizer could), locking Members out of the
+		// org entirely with no way to even see it.
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
 
-		// vera becomes an organizer of her own, unrelated org - she now holds
-		// the platform-wide "organisator" role.
-		await veraClient.CreateOrganizationAsync(
-			new CreateOrganizationRequest { Name = "Vera's Own Org 6" }, cancellationToken);
-		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
-
 		var org = await olafClient.CreateOrganizationAsync(
 			new CreateOrganizationRequest { Name = "Details Membership Gate Test Org" }, cancellationToken);
 
-		// olaf's org gains vera as a plain member - never promoted to Organizer
-		// of this specific org.
+		// olaf's org gains vera as a plain member - never promoted to Organizer.
 		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
 
-		var act = () => veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		var details = await veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
 
-		var ex = await act.Should().ThrowAsync<ApiException>();
-		ex.Which.StatusCode.Should().Be(403);
+		details.Id.Should().Be(org.Id.Value);
+		details.Members.Should().Contain(m => m.UserId == vera.Id && !m.IsOrganisator && m.Role == "Member");
 	}
 
 	[Test]
@@ -424,12 +418,10 @@ public class OrganizationSettingsTests(
 		var veraOrganizations = await veraClient.GetOrganizationsAsync(cancellationToken);
 		veraOrganizations.Should().Contain(o => o.Id == org.Id.Value);
 
-		// GetOrganizationDetails is gated by the Organisator policy, a role
-		// claim baked into the JWT at mint time - vera's original token
-		// predates the "organisator" role grant that just happened as a side
-		// effect of accepting, so a fresh token is needed here (same pattern
-		// as the #691 escalation test below).
-		veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		// #1024: GetOrganizationDetails is readable by any member now, so a fresh
+		// token isn't required for the read itself - IsOrganisator per member is
+		// answered from the local organization_membership table (#1386), which
+		// Accept already wrote to synchronously, not from a JWT role claim.
 		var details = await veraClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
 		details.Members.Should().Contain(m => m.UserId == vera.Id && m.IsOrganisator);
 	}
@@ -913,6 +905,53 @@ public class OrganizationSettingsTests(
 
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(409);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().Contain(m => m.UserId == olaf.Id);
+	}
+
+	[Test]
+	public async Task RemoveMember_ShouldSucceed_WhenAPlainMemberLeavesTheirOwnMembership(
+		CancellationToken cancellationToken)
+	{
+		// #1024: leaving is a self-service action available to any tier - a plain
+		// Member removing themselves used to 403 (the endpoint required the
+		// platform-wide "organisator" role, which a plain Member never holds).
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Plain Member Leave Test Org" }, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
+
+		await veraClient.RemoveMemberAsync(org.Id.Value, vera.Id, cancellationToken);
+
+		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
+		stillThere.Members.Should().NotContain(m => m.UserId == vera.Id);
+	}
+
+	[Test]
+	public async Task RemoveMember_ShouldReturn403_WhenAPlainMemberTriesToRemoveSomeoneElse(
+		CancellationToken cancellationToken)
+	{
+		// Removing another member is still org management and requires Organizer,
+		// even though the requester is a genuine Member of the organization.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var olaf = await olafClient.GetUserProfileAsync(cancellationToken);
+
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Plain Member Remove Other Test Org" }, cancellationToken);
+
+		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
+
+		var act = () => veraClient.RemoveMemberAsync(org.Id.Value, olaf.Id, cancellationToken);
+
+		var ex = await act.Should().ThrowAsync<ApiException>();
+		ex.Which.StatusCode.Should().Be(403);
 
 		var stillThere = await olafClient.GetOrganizationDetailsAsync(org.Id.Value, cancellationToken);
 		stillThere.Members.Should().Contain(m => m.UserId == olaf.Id);

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -101,14 +101,14 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 	// anything about those tables' contents - AuthHelper's pinned-org
 	// navigation already makes which *org* every test lands on deterministic,
 	// independent of this reset. The only state that's genuinely global,
-	// shared, and something these classes depend on is vera's own Organizer-
-	// role membership/Keycloak role (she must never appear to organize
-	// anything), so that's the only thing restored here - scoped to her user
-	// id specifically, never touching another user's rows or any shared
-	// table at large.
+	// shared, and something these classes depend on is vera's own organization
+	// membership (any role)/Keycloak organisator role (she must never appear
+	// to organize or belong to anything), so that's the only thing restored
+	// here - scoped to her user id specifically, never touching another
+	// user's rows or any shared table at large.
 	public async Task ResetAsync()
 	{
-		await ResetVeraOrganizerMembershipAsync();
+		await ResetVeraOrganizationMembershipAsync();
 		await ResetVeraOrganisatorRoleAsync();
 	}
 
@@ -237,20 +237,25 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 		return pinned;
 	}
 
-	// Vera never organizes anything in seed data (SeedOrg1Async/SeedOrg2Async
-	// only ever assign olaf as Organizer) - remove any Organizer-role
-	// membership row a test granted her, in any organization. Scoped to her
-	// user id only via the WHERE clause, so this can never touch another
-	// user's membership row or race a concurrently running test that isn't
-	// touching vera's own account.
-	private async Task ResetVeraOrganizerMembershipAsync()
+	// Vera never belongs to anything in seed data (SeedOrg1Async/SeedOrg2Async
+	// only ever assign olaf as Organizer) - remove any membership row a test
+	// granted her, in any organization and at any role. Used to be scoped to
+	// role='Organizer' only, back when a plain Member row was invisible to
+	// GetOrganizationsQueryHandler; it now also returns Member-only orgs
+	// (Members gained read access), so a leftover Member row - e.g. from
+	// AccessibilityTests' AddPlainMemberDirectlyAsync call, which never
+	// cleans up - is just as capable of breaking "vera organizes/belongs to
+	// nothing" as an Organizer row was. Scoped to her user id only via the
+	// WHERE clause, so this can never touch another user's membership row or
+	// race a concurrently running test that isn't touching vera's own account.
+	private async Task ResetVeraOrganizationMembershipAsync()
 	{
 		await using var conn = new NpgsqlConnection(_connectionString);
 		await conn.OpenAsync();
 		await using var cmd = new NpgsqlCommand(
 			"""
 			DELETE FROM organization_membership
-			WHERE user_id = @userId AND role = 'Organizer'
+			WHERE user_id = @userId
 			""", conn);
 		cmd.Parameters.AddWithValue("userId", _veraUserId);
 		await cmd.ExecuteNonQueryAsync();

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "react-oidc-context";
 import type { OrganizationDetailsResponse } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
@@ -32,6 +33,11 @@ import NotFoundPage from "../pages/NotFoundPage";
 export interface OrgAppContext {
 	org: OrganizationDetailsResponse;
 	reloadOrg: () => void;
+	// Whether the signed-in user is an Organizer of this specific organization
+	// (as opposed to a plain Member) - gates every management action (invite,
+	// promote/demote, remove, settings edit, opportunity/engagement management)
+	// across every org-app page. A plain Member has read-only access.
+	isOrganizer: boolean;
 }
 
 // Renders the org app shell body inside OrgBreadcrumbProvider so it can read
@@ -59,8 +65,13 @@ function OrgAppShell({
 	useAchievementNotifier();
 	const { t } = useTranslation();
 	const location = useLocation();
+	const auth = useAuth();
 	const extra = useOrgBreadcrumbExtra();
 	const quickActions = useQuickActionsList();
+	const currentUserId = auth.user?.profile?.sub;
+	const isOrganizer = Boolean(
+		org.members.find((m) => m.userId === currentUserId)?.isOrganisator,
+	);
 
 	// Now that the tab bar is gone (dashboard UX redesign), the breadcrumb is
 	// the only thing that shows an organizer where they are relative to the
@@ -150,7 +161,9 @@ function OrgAppShell({
 						}
 					>
 						<Outlet
-							context={{ org, reloadOrg: load } satisfies OrgAppContext}
+							context={
+								{ org, reloadOrg: load, isOrganizer } satisfies OrgAppContext
+							}
 							// Outlet re-mounts children on org identity change so per-tab state resets cleanly
 							key={org.id}
 						/>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -371,6 +371,7 @@
       "loading": "Wird geladen…",
       "layoutLoadError": "Dein gespeichertes Dashboard-Layout konnte nicht bestätigt werden. Die Ansicht unten stimmt damit möglicherweise nicht überein - Bearbeiten ist deaktiviert, bis dies erfolgreich geladen wurde.",
       "widgetError": "Dieses Widget konnte nicht angezeigt werden. Bitte die Seite neu laden.",
+      "layoutEditDisabledNotOrganizerHint": "Nur Organisatoren können das Dashboard-Layout anpassen.",
       "pendingEngagements": "Ausstehende Anmeldungen",
       "pendingEngagements_one": "Ausstehende Anmeldung",
       "pendingEngagements_other": "Ausstehende Anmeldungen",
@@ -483,7 +484,8 @@
       "dangerZone": "Gefahrenzone",
       "deleteOrganization": "Organisation löschen",
       "deleteOrganizationHint": "Nur das letzte verbleibende Mitglied kann die Organisation löschen. Entferne zuerst die anderen Mitglieder.",
-      "deleteOrganizationError": "Organisation konnte nicht gelöscht werden."
+      "deleteOrganizationError": "Organisation konnte nicht gelöscht werden.",
+      "editDisabledNotOrganizerHint": "Nur Organisatoren können die Organisationseinstellungen bearbeiten."
     },
     "account": {
       "title": "Mein Konto",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -371,6 +371,7 @@
       "loading": "Loading…",
       "layoutLoadError": "Couldn't confirm your saved dashboard layout. What's shown below may not match it, and editing is disabled until this loads successfully.",
       "widgetError": "This widget couldn't be displayed. Try reloading the page.",
+      "layoutEditDisabledNotOrganizerHint": "Only organizers can customize the dashboard layout.",
       "pendingEngagements": "Pending Sign-ups",
       "pendingEngagements_one": "Pending Sign-up",
       "pendingEngagements_other": "Pending Sign-ups",
@@ -483,7 +484,8 @@
       "dangerZone": "Danger zone",
       "deleteOrganization": "Delete Organization",
       "deleteOrganizationHint": "Only the organization's sole remaining member can delete it. Remove other members first.",
-      "deleteOrganizationError": "Could not delete organization."
+      "deleteOrganizationError": "Could not delete organization.",
+      "editDisabledNotOrganizerHint": "Only organizers can edit organization settings."
     },
     "account": {
       "title": "My Account",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
 import type {
 	EngagementSummary,
@@ -26,6 +26,7 @@ import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 import { inputClass, labelClass } from "../lib/formClasses";
 import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
+import type { OrgAppContext } from "../layouts/OrgAppLayout";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
 const ENGAGEMENTS_PAGE_SIZE = 10;
@@ -36,6 +37,7 @@ const QRScannerModal = lazy(() => import("../components/QRScannerModal"));
 
 export default function EngagementManagementPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
+	const { isOrganizer } = useOutletContext<OrgAppContext>();
 	const api = useApiClient();
 	const { t, i18n } = useTranslation();
 	const [opportunity, setOpportunity] =
@@ -155,13 +157,20 @@ export default function EngagementManagementPage() {
 	}, [opportunityId]);
 
 	useEffect(() => {
-		if (!opportunityId || opportunity?.checkInMethod !== "PINCode") return;
+		// The check-in PIN is an organizer tool for admitting volunteers - a
+		// plain Member would just get a 403 here, so skip the doomed request.
+		if (
+			!opportunityId ||
+			!isOrganizer ||
+			opportunity?.checkInMethod !== "PINCode"
+		)
+			return;
 		api
 			.getOpportunityCheckInPin(opportunityId)
 			.then(setCheckInPin)
 			.catch(() => undefined);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [opportunityId, opportunity?.checkInMethod]);
+	}, [opportunityId, isOrganizer, opportunity?.checkInMethod]);
 
 	// Confirming/checking a volunteer in swaps the row's button pair for a
 	// different one (Pending's Confirm/Cancel -> Confirmed's Revoke, or
@@ -290,8 +299,8 @@ export default function EngagementManagementPage() {
 	}
 
 	const checkInMethod = opportunity?.checkInMethod;
-	const showManualCheckIn = checkInMethod === "Manual";
-	const showQrScanner = checkInMethod === "QRCode";
+	const showManualCheckIn = isOrganizer && checkInMethod === "Manual";
+	const showQrScanner = isOrganizer && checkInMethod === "QRCode";
 
 	return (
 		<>
@@ -510,7 +519,7 @@ export default function EngagementManagementPage() {
 									>
 										{STATUS_LABELS[e.status] ?? e.status}
 									</span>
-									{e.status === "Pending" && (
+									{isOrganizer && e.status === "Pending" && (
 										<div className="flex gap-2">
 											<button
 												onClick={() => handleConfirm(e.id)}
@@ -537,7 +546,7 @@ export default function EngagementManagementPage() {
 											</Button>
 										</div>
 									)}
-									{e.status === "Confirmed" && (
+									{isOrganizer && e.status === "Confirmed" && (
 										<div className="flex gap-2">
 											{showManualCheckIn && !e.isCheckedIn && (
 												<Button

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -136,6 +136,7 @@ interface Props {
 	organizationId: string;
 	refreshKey: number;
 	size: WidgetSizeClass;
+	isOrganizer: boolean;
 }
 
 // The dashboard grid's row height isn't a flat pixel constant (it tracks
@@ -150,7 +151,12 @@ interface Props {
 // WidgetCard's own overflow-y-auto handles the rest.
 const CALENDAR_MIN_HEIGHT_PX = 400;
 
-function CalendarWidget({ organizationId, refreshKey, size }: Props) {
+function CalendarWidget({
+	organizationId,
+	refreshKey,
+	size,
+	isOrganizer,
+}: Props) {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const calendarContainerRef = useRef<HTMLDivElement | null>(null);
@@ -436,21 +442,23 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 								</p>
 							)
 						)}
-						<div>
-							<label htmlFor="event-color-picker" className={labelClass}>
-								{t("orgOverview.eventColorLabel")}
-							</label>
-							<div className="mt-1 flex items-center gap-3">
-								<input
-									id="event-color-picker"
-									type="color"
-									value={pickerColor}
-									onChange={(e) => handleColorPickerChange(e.target.value)}
-									className="h-9 w-16 cursor-pointer rounded border border-gray-300"
-								/>
-								<span className="text-sm text-gray-500">{pickerColor}</span>
+						{isOrganizer && (
+							<div>
+								<label htmlFor="event-color-picker" className={labelClass}>
+									{t("orgOverview.eventColorLabel")}
+								</label>
+								<div className="mt-1 flex items-center gap-3">
+									<input
+										id="event-color-picker"
+										type="color"
+										value={pickerColor}
+										onChange={(e) => handleColorPickerChange(e.target.value)}
+										className="h-9 w-16 cursor-pointer rounded border border-gray-300"
+									/>
+									<span className="text-sm text-gray-500">{pickerColor}</span>
+								</div>
 							</div>
-						</div>
+						)}
 						{colorSaveError && <ErrorBanner message={colorSaveError} />}
 						<div className="flex flex-col gap-2">
 							<div className="flex gap-4">
@@ -477,16 +485,18 @@ function CalendarWidget({ organizationId, refreshKey, size }: Props) {
 								>
 									{t("createOpportunity.cancel")}
 								</button>
-								<Button
-									type="button"
-									disabled={savingColor}
-									onClick={handleColorSave}
-									size="sm"
-								>
-									{savingColor
-										? t("orgOverview.eventColorSaving")
-										: t("orgOverview.eventColorSave")}
-								</Button>
+								{isOrganizer && (
+									<Button
+										type="button"
+										disabled={savingColor}
+										onClick={handleColorSave}
+										size="sm"
+									>
+										{savingColor
+											? t("orgOverview.eventColorSaving")
+											: t("orgOverview.eventColorSave")}
+									</Button>
+								)}
 							</div>
 						</div>
 					</div>

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -27,6 +27,7 @@ interface Props {
 	organizationId: string;
 	refreshKey: number;
 	size: WidgetSizeClass;
+	isOrganizer: boolean;
 	onOpportunityCreated: (createdDraftId?: string) => void;
 }
 
@@ -34,6 +35,7 @@ function UpcomingOpportunitiesWidget({
 	organizationId,
 	refreshKey,
 	size,
+	isOrganizer,
 	onOpportunityCreated,
 }: Props) {
 	const { t, i18n } = useTranslation();
@@ -109,10 +111,14 @@ function UpcomingOpportunitiesWidget({
 				<EmptyState
 					compact
 					title={t("orgDashboard.upcomingEmpty")}
-					action={{
-						label: t("orgDashboard.emptyStateCreateAction"),
-						onClick: () => setShowCreateModal(true),
-					}}
+					action={
+						isOrganizer
+							? {
+									label: t("orgDashboard.emptyStateCreateAction"),
+									onClick: () => setShowCreateModal(true),
+								}
+							: undefined
+					}
 				/>
 			)}
 			{items !== null && !error && items.length > 0 && (

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -60,8 +60,17 @@ function useIsLargeViewport() {
 	return isLarge;
 }
 
+// Pure action tools with no read-only value for a viewer who can't perform
+// the action they trigger (creating an opportunity, running check-in) -
+// filtered out of a plain Member's rendered layout entirely, unlike the
+// other widgets (ToDo, Calendar, Settings, ...) which stay useful read-only.
+const ORGANIZER_ONLY_WIDGET_KEYS: readonly WidgetKey[] = [
+	"CreateOpportunity",
+	"QuickCheckIn",
+];
+
 export default function OrgDashboardPage() {
-	const { org } = useOutletContext<OrgAppContext>();
+	const { org, isOrganizer } = useOutletContext<OrgAppContext>();
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const api = useApiClient();
@@ -138,7 +147,14 @@ export default function OrgDashboardPage() {
 		void loadLayout().finally(() => setRetryingLayoutLoad(false));
 	}
 
-	const layout = editing ? (draftLayout ?? []) : savedLayout;
+	const rawLayout = editing ? (draftLayout ?? []) : savedLayout;
+	const layout = isOrganizer
+		? rawLayout
+		: compactLayout(
+				rawLayout.filter(
+					(w) => !ORGANIZER_ONLY_WIDGET_KEYS.includes(w.widgetKey),
+				),
+			);
 	const availableToAdd = WIDGET_KEYS.filter(
 		(key) => !layout.some((w) => w.widgetKey === key),
 	);
@@ -196,10 +212,10 @@ export default function OrgDashboardPage() {
 
 	function startEditing() {
 		// Blocked while the true saved layout is unconfirmed (see
-		// layoutLoadFailed above) - the "Edit" quick action is already
-		// disabled for this, but the empty-state CTA below calls this
-		// directly too.
-		if (layoutLoadFailed) return;
+		// layoutLoadFailed above), or for a plain Member (read-only tier) -
+		// the "Edit" quick action is already disabled for both, but the
+		// empty-state CTA below calls this directly too.
+		if (layoutLoadFailed || !isOrganizer) return;
 		setDraftLayout(savedLayout);
 		setEditing(true);
 	}
@@ -234,8 +250,10 @@ export default function OrgDashboardPage() {
 	useEditModeQuickActions({
 		editing,
 		saving,
-		editDisabled: layoutLoadFailed,
-		editDisabledTitle: t("orgDashboard.layoutLoadError"),
+		editDisabled: layoutLoadFailed || !isOrganizer,
+		editDisabledTitle: !isOrganizer
+			? t("orgDashboard.layoutEditDisabledNotOrganizerHint")
+			: t("orgDashboard.layoutLoadError"),
 		onEdit: startEditing,
 		onSave: () => void handleSave(),
 		onCancel: handleCancel,
@@ -287,6 +305,7 @@ export default function OrgDashboardPage() {
 						organizationId={organizationId}
 						refreshKey={refreshKey}
 						size={size}
+						isOrganizer={isOrganizer}
 						onOpportunityCreated={handleOpportunityCreated}
 					/>
 				);
@@ -296,6 +315,7 @@ export default function OrgDashboardPage() {
 						organizationId={organizationId}
 						refreshKey={refreshKey}
 						size={size}
+						isOrganizer={isOrganizer}
 					/>
 				);
 			case "Settings":
@@ -429,10 +449,14 @@ export default function OrgDashboardPage() {
 			<EmptyState
 				title={t("orgDashboard.emptyStateTitle")}
 				message={t("orgDashboard.emptyStateMessage")}
-				action={{
-					label: t("orgDashboard.addWidgetHeading"),
-					onClick: handleStartEditingAndAddWidget,
-				}}
+				action={
+					isOrganizer
+						? {
+								label: t("orgDashboard.addWidgetHeading"),
+								onClick: handleStartEditingAndAddWidget,
+							}
+						: undefined
+				}
 			/>
 		</div>
 	) : (

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -18,7 +18,7 @@ import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { formatDateLong } from "../../lib/format";
 
 export default function OrgMembersPage() {
-	const { org, reloadOrg } = useOutletContext<OrgAppContext>();
+	const { org, reloadOrg, isOrganizer } = useOutletContext<OrgAppContext>();
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const auth = useAuth();
@@ -28,10 +28,8 @@ export default function OrgMembersPage() {
 
 	const [members, setMembers] = useState(org.members);
 	useEffect(() => setMembers(org.members), [org.members]);
-	const currentMember = members.find((m) => m.userId === currentUserId);
 	const organizerCount = members.filter((m) => m.isOrganisator).length;
-	const isLastOrganizer =
-		Boolean(currentMember?.isOrganisator) && organizerCount <= 1;
+	const isLastOrganizer = isOrganizer && organizerCount <= 1;
 
 	const [successMessage, setSuccessMessage] = useState<string | null>(null);
 	const [settingsError, setSettingsError] = useState<string | null>(null);
@@ -112,12 +110,15 @@ export default function OrgMembersPage() {
 	>(null);
 
 	useEffect(() => {
+		// Invitations are an Organizer-only management concern - a plain Member
+		// would just get a 403 here, so skip the doomed request entirely.
+		if (!isOrganizer) return;
 		api
 			.getOrgInvitations(org.id)
 			.then(setInvitations)
 			.catch(() => {});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [org.id]);
+	}, [org.id, isOrganizer]);
 
 	async function handleInviteMember(userId: string) {
 		setInvitingUserId(userId);
@@ -260,77 +261,79 @@ export default function OrgMembersPage() {
 					<ErrorBanner message={settingsError} className="mb-4" />
 				)}
 
-				<div className="mb-6">
-					<label htmlFor="member-search" className={labelClass}>
-						{t("orgSettings.inviteLabel")}
-					</label>
-					<input
-						id="member-search"
-						type="search"
-						value={memberSearch}
-						onChange={(e) => handleMemberSearchChange(e.target.value)}
-						placeholder={t("orgSettings.invitePlaceholder")}
-						className={inputClass}
-					/>
-					<label htmlFor="invite-role" className={`mt-2 ${labelClass}`}>
-						{t("orgSettings.inviteRoleLabel")}
-					</label>
-					<select
-						id="invite-role"
-						value={inviteRole}
-						onChange={(e) =>
-							setInviteRole(e.target.value as "Member" | "Organizer")
-						}
-						className={inputClass}
-					>
-						<option value="Member">{t("orgSettings.roleMember")}</option>
-						<option value="Organizer">{t("orgSettings.organisator")}</option>
-					</select>
-					{memberSearchLoading && (
-						<p role="status" className="mt-1 text-xs text-gray-500">
-							{t("orgSettings.searching")}
-						</p>
-					)}
-					{memberCandidates.length > 0 && (
-						<ul className="mt-1 divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
-							{memberCandidates.map((candidate) => (
-								<li
-									key={candidate.userId}
-									className="flex items-center justify-between px-3 py-2"
-								>
-									<div className="min-w-0">
-										<p className="truncate text-sm font-medium text-gray-900">
-											{candidate.firstName && candidate.lastName
-												? `${candidate.firstName} ${candidate.lastName}`
-												: candidate.username}
-										</p>
-										{candidate.firstName && candidate.lastName && (
-											<p className="truncate text-xs text-gray-500">
-												@{candidate.username}
-											</p>
-										)}
-									</div>
-									<Button
-										type="button"
-										onClick={() => handleInviteMember(candidate.userId)}
-										disabled={invitingUserId === candidate.userId}
-										size="sm"
-										className="ml-3 shrink-0"
-									>
-										{t("orgSettings.invite")}
-									</Button>
-								</li>
-							))}
-						</ul>
-					)}
-					{memberSearch.length >= 4 &&
-						!memberSearchLoading &&
-						memberCandidates.length === 0 && (
+				{isOrganizer && (
+					<div className="mb-6">
+						<label htmlFor="member-search" className={labelClass}>
+							{t("orgSettings.inviteLabel")}
+						</label>
+						<input
+							id="member-search"
+							type="search"
+							value={memberSearch}
+							onChange={(e) => handleMemberSearchChange(e.target.value)}
+							placeholder={t("orgSettings.invitePlaceholder")}
+							className={inputClass}
+						/>
+						<label htmlFor="invite-role" className={`mt-2 ${labelClass}`}>
+							{t("orgSettings.inviteRoleLabel")}
+						</label>
+						<select
+							id="invite-role"
+							value={inviteRole}
+							onChange={(e) =>
+								setInviteRole(e.target.value as "Member" | "Organizer")
+							}
+							className={inputClass}
+						>
+							<option value="Member">{t("orgSettings.roleMember")}</option>
+							<option value="Organizer">{t("orgSettings.organisator")}</option>
+						</select>
+						{memberSearchLoading && (
 							<p role="status" className="mt-1 text-xs text-gray-500">
-								{t("orgSettings.noSearchResults")}
+								{t("orgSettings.searching")}
 							</p>
 						)}
-				</div>
+						{memberCandidates.length > 0 && (
+							<ul className="mt-1 divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
+								{memberCandidates.map((candidate) => (
+									<li
+										key={candidate.userId}
+										className="flex items-center justify-between px-3 py-2"
+									>
+										<div className="min-w-0">
+											<p className="truncate text-sm font-medium text-gray-900">
+												{candidate.firstName && candidate.lastName
+													? `${candidate.firstName} ${candidate.lastName}`
+													: candidate.username}
+											</p>
+											{candidate.firstName && candidate.lastName && (
+												<p className="truncate text-xs text-gray-500">
+													@{candidate.username}
+												</p>
+											)}
+										</div>
+										<Button
+											type="button"
+											onClick={() => handleInviteMember(candidate.userId)}
+											disabled={invitingUserId === candidate.userId}
+											size="sm"
+											className="ml-3 shrink-0"
+										>
+											{t("orgSettings.invite")}
+										</Button>
+									</li>
+								))}
+							</ul>
+						)}
+						{memberSearch.length >= 4 &&
+							!memberSearchLoading &&
+							memberCandidates.length === 0 && (
+								<p role="status" className="mt-1 text-xs text-gray-500">
+									{t("orgSettings.noSearchResults")}
+								</p>
+							)}
+					</div>
+				)}
 
 				{invitations.some((i) => i.status === "Pending") && (
 					<div className="mb-6">
@@ -510,7 +513,7 @@ export default function OrgMembersPage() {
 									>
 										{t("orgSettings.leaveOrganization")}
 									</button>
-								) : (
+								) : isOrganizer ? (
 									<div className="flex shrink-0 items-center gap-3">
 										{(() => {
 											const memberName =
@@ -570,7 +573,7 @@ export default function OrgMembersPage() {
 											);
 										})()}
 									</div>
-								)}
+								) : null}
 							</li>
 						))}
 					</ul>

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -35,7 +35,7 @@ const STATUS_BADGE_TONE: Record<string, ChipTone> = {
 };
 
 export default function OrgOpportunitiesPage() {
-	const { org } = useOutletContext<OrgAppContext>();
+	const { org, isOrganizer } = useOutletContext<OrgAppContext>();
 	const { t } = useTranslation();
 	const api = useApiClient();
 	const organizationId = org.id;
@@ -174,16 +174,19 @@ export default function OrgOpportunitiesPage() {
 	// React's useState setter (referentially stable), so no staleness risk
 	// from not routing it through a ref.
 	const quickActions = useMemo(
-		() => [
-			{
-				key: "create-opportunity",
-				label: t("orgOverview.createOpportunity"),
-				icon: <PlusIcon />,
-				onClick: () => setShowCreate(true),
-				variant: "primary" as const,
-			},
-		],
-		[t],
+		() =>
+			isOrganizer
+				? [
+						{
+							key: "create-opportunity",
+							label: t("orgOverview.createOpportunity"),
+							icon: <PlusIcon />,
+							onClick: () => setShowCreate(true),
+							variant: "primary" as const,
+						},
+					]
+				: [],
+		[t, isOrganizer],
 	);
 	useQuickActions(quickActions);
 
@@ -385,7 +388,7 @@ export default function OrgOpportunitiesPage() {
 					)}
 				</div>
 				<div className="mt-auto flex flex-wrap items-center gap-2">
-					{status !== "Cancelled" && (
+					{isOrganizer && status !== "Cancelled" && (
 						<button
 							type="button"
 							onClick={() => void openEdit(item.id)}
@@ -398,19 +401,21 @@ export default function OrgOpportunitiesPage() {
 								: t("opportunities.edit")}
 						</button>
 					)}
-					<Button
-						type="button"
-						variant="dangerOutline"
-						size="sm"
-						onClick={() => {
-							setDeleteTargetId(item.id);
-							setDeleteError(null);
-						}}
-						data-testid="opportunity-delete"
-					>
-						{t("opportunities.delete")}
-					</Button>
-					{(status === "Draft" || status === "Unpublished") && (
+					{isOrganizer && (
+						<Button
+							type="button"
+							variant="dangerOutline"
+							size="sm"
+							onClick={() => {
+								setDeleteTargetId(item.id);
+								setDeleteError(null);
+							}}
+							data-testid="opportunity-delete"
+						>
+							{t("opportunities.delete")}
+						</Button>
+					)}
+					{isOrganizer && (status === "Draft" || status === "Unpublished") && (
 						<Button
 							type="button"
 							onClick={() => void publish(item.id)}
@@ -423,7 +428,7 @@ export default function OrgOpportunitiesPage() {
 								: t("opportunities.publish")}
 						</Button>
 					)}
-					{status === "Published" && (
+					{isOrganizer && status === "Published" && (
 						<button
 							type="button"
 							onClick={() => {
@@ -436,21 +441,22 @@ export default function OrgOpportunitiesPage() {
 							{t("opportunities.unpublish")}
 						</button>
 					)}
-					{(status === "Published" || status === "Unpublished") && (
-						<Button
-							type="button"
-							variant="dangerOutline"
-							size="sm"
-							onClick={() => {
-								setCancelTargetId(item.id);
-								setCancelReason("");
-								setCancelError(null);
-							}}
-							data-testid="opportunity-cancel"
-						>
-							{t("opportunities.cancel")}
-						</Button>
-					)}
+					{isOrganizer &&
+						(status === "Published" || status === "Unpublished") && (
+							<Button
+								type="button"
+								variant="dangerOutline"
+								size="sm"
+								onClick={() => {
+									setCancelTargetId(item.id);
+									setCancelReason("");
+									setCancelError(null);
+								}}
+								data-testid="opportunity-cancel"
+							>
+								{t("opportunities.cancel")}
+							</Button>
+						)}
 					{status !== "Draft" && (
 						<Link
 							to={`/app/${organizationId}/dashboard/opportunities/${item.id}/engagements`}
@@ -560,10 +566,14 @@ export default function OrgOpportunitiesPage() {
 				<EmptyState
 					title={t("orgOpportunities.emptyTitle")}
 					message={t("orgOpportunities.emptyDesc")}
-					action={{
-						label: t("orgOverview.createOpportunity"),
-						onClick: () => setShowCreate(true),
-					}}
+					action={
+						isOrganizer
+							? {
+									label: t("orgOverview.createOpportunity"),
+									onClick: () => setShowCreate(true),
+								}
+							: undefined
+					}
 				/>
 			)}
 

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -24,7 +24,7 @@ const MAX_LOGO_BYTES = 2 * 1024 * 1024;
 const LOGO_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 export default function OrgSettingsPage() {
-	const { org, reloadOrg } = useOutletContext<OrgAppContext>();
+	const { org, reloadOrg, isOrganizer } = useOutletContext<OrgAppContext>();
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const navigate = useNavigate();
@@ -91,6 +91,10 @@ export default function OrgSettingsPage() {
 	useEditModeQuickActions({
 		editing,
 		saving,
+		editDisabled: !isOrganizer,
+		editDisabledTitle: !isOrganizer
+			? t("orgSettings.editDisabledNotOrganizerHint")
+			: undefined,
 		onEdit: () => setEditing(true),
 		// Goes through the form's native submit (not onSubmit() directly) so
 		// react-hook-form's handleSubmit runs the same zod validation, error
@@ -250,14 +254,16 @@ export default function OrgSettingsPage() {
 							</>
 						}
 					>
-						<DangerZonePanel
-							className="mt-8"
-							title={t("orgSettings.dangerZone")}
-							description={t("orgSettings.deleteOrganizationHint")}
-							actionLabel={t("orgSettings.deleteOrganization")}
-							onAction={() => setShowDeleteConfirm(true)}
-							disabled={!isSoleMember}
-						/>
+						{isOrganizer && (
+							<DangerZonePanel
+								className="mt-8"
+								title={t("orgSettings.dangerZone")}
+								description={t("orgSettings.deleteOrganizationHint")}
+								actionLabel={t("orgSettings.deleteOrganization")}
+								onAction={() => setShowDeleteConfirm(true)}
+								disabled={!isSoleMember}
+							/>
+						)}
 					</OrganizationProfileView>
 				)}
 


### PR DESCRIPTION
Members can now view org details/dashboard/opportunities/engagements/ feedback (previously 403'd on every page, leaving them fully locked out of an org they belong to) while only Organizers can still invite, promote/demote, remove others, edit settings, or manage opportunities and engagements. Leaving an org is a self-service action available to any tier, not gated behind Organizer.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1024

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
