### PR TITLE
feat: allow volunteers to edit or delete submitted engagement feedback

### DIFF
--- a/backend/src/Api/Engagements/DeleteFeedback/v1/DeleteFeedbackEndpoint.cs
+++ b/backend/src/Api/Engagements/DeleteFeedback/v1/DeleteFeedbackEndpoint.cs
@@ -1,0 +1,47 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Engagements.DeleteFeedback.v1;
+using Domain.Engagements;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Engagements.DeleteFeedback.v1;
+
+internal sealed class DeleteFeedbackEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapDelete("/engagements/{engagementId:guid}/feedback", DeleteAsync)
+			.WithName("DeleteFeedback")
+			.WithTags("Engagements")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> DeleteAsync(
+		Guid engagementId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		var command = new DeleteFeedbackCommand(
+			EngagementId.Create(engagementId).GetValueOrThrow(),
+			userId);
+
+		await sender.Send(command, cancellationToken);
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackEndpoint.cs
+++ b/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackEndpoint.cs
@@ -1,0 +1,50 @@
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Engagements.UpdateFeedback.v1;
+using Domain.Engagements;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Api.Engagements.UpdateFeedback.v1;
+
+internal sealed class UpdateFeedbackEndpoint
+	: IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapPut("/engagements/{engagementId:guid}/feedback", UpdateAsync)
+			.WithName("UpdateFeedback")
+			.WithTags("Engagements")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status400BadRequest)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Write)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> UpdateAsync(
+		[FromRoute] Guid engagementId,
+		[FromBody] UpdateFeedbackRequest request,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		var command = new UpdateFeedbackCommand(
+			EngagementId.Create(engagementId).GetValueOrThrow(),
+			userId,
+			request.Rating,
+			request.Comment);
+
+		await sender.Send(command, cancellationToken);
+		return Results.NoContent();
+	}
+}

--- a/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackRequest.cs
+++ b/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackRequest.cs
@@ -1,0 +1,5 @@
+namespace Api.Engagements.UpdateFeedback.v1;
+
+public sealed record UpdateFeedbackRequest(
+	int Rating,
+	string? Comment);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5333,6 +5333,184 @@
         }
       }
     },
+    "/v1/engagements/{engagementId}/feedback": {
+      "put": {
+        "tags": [
+          "Engagements"
+        ],
+        "operationId": "UpdateFeedback",
+        "parameters": [
+          {
+            "name": "engagementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFeedbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Engagements"
+        ],
+        "operationId": "SubmitFeedback",
+        "parameters": [
+          {
+            "name": "engagementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitFeedbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Engagements"
+        ],
+        "operationId": "DeleteFeedback",
+        "parameters": [
+          {
+            "name": "engagementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/engagements/{engagementId}/undo-check-in": {
       "post": {
         "tags": [
@@ -5383,70 +5561,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/engagements/{engagementId}/feedback": {
-      "post": {
-        "tags": [
-          "Engagements"
-        ],
-        "operationId": "SubmitFeedback",
-        "parameters": [
-          {
-            "name": "engagementId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SubmitFeedbackRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7431,6 +7545,28 @@
               "null",
               "string"
             ]
+          },
+          "feedbackRating": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "feedbackComment": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "feedbackSubmittedAt": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
           }
         }
       },
@@ -8999,6 +9135,29 @@
           },
           "city": {
             "type": "string"
+          }
+        }
+      },
+      "UpdateFeedbackRequest": {
+        "required": [
+          "rating",
+          "comment"
+        ],
+        "type": "object",
+        "properties": {
+          "rating": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "comment": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/backend/src/Application/Engagements/DeleteFeedback/v1/DeleteFeedbackCommand.cs
+++ b/backend/src/Application/Engagements/DeleteFeedback/v1/DeleteFeedbackCommand.cs
@@ -1,0 +1,10 @@
+using Application.Common.Messaging;
+using Domain.Engagements;
+using Domain.Users;
+
+namespace Application.Engagements.DeleteFeedback.v1;
+
+public sealed record DeleteFeedbackCommand(
+	EngagementId EngagementId,
+	UserId RequestingUserId)
+	: ICommand<bool>;

--- a/backend/src/Application/Engagements/DeleteFeedback/v1/DeleteFeedbackCommandHandler.cs
+++ b/backend/src/Application/Engagements/DeleteFeedback/v1/DeleteFeedbackCommandHandler.cs
@@ -1,0 +1,29 @@
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+
+namespace Application.Engagements.DeleteFeedback.v1;
+
+internal sealed class DeleteFeedbackCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<DeleteFeedbackCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		DeleteFeedbackCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("Engagement.NotFound", $"Engagement '{request.EngagementId.Value}' not found."));
+
+		if (engagement.IsAnonymized)
+			throw new ResultFailureException(Error.Conflict("Engagement.Anonymized", "This engagement's volunteer account has been deleted."));
+
+		if (engagement.VolunteerId!.Value.Value != request.RequestingUserId.Value)
+			throw new ResultFailureException(Error.Forbidden("Engagement.NotOwner", "You can only delete feedback for your own engagements."));
+
+		engagement.DeleteFeedback(DateTimeOffset.UtcNow).ThrowIfFailure();
+
+		return true;
+	}
+}

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -19,4 +19,7 @@ public sealed record EngagementSummary(
 	string? Location = null,
 	string? VolunteerEmail = null,
 	string? VolunteerPhone = null,
-	string? CancellationReason = null);
+	string? CancellationReason = null,
+	int? FeedbackRating = null,
+	string? FeedbackComment = null,
+	DateTimeOffset? FeedbackSubmittedAt = null);

--- a/backend/src/Application/Engagements/UpdateFeedback/v1/UpdateFeedbackCommand.cs
+++ b/backend/src/Application/Engagements/UpdateFeedback/v1/UpdateFeedbackCommand.cs
@@ -1,0 +1,12 @@
+using Application.Common.Messaging;
+using Domain.Engagements;
+using Domain.Users;
+
+namespace Application.Engagements.UpdateFeedback.v1;
+
+public sealed record UpdateFeedbackCommand(
+	EngagementId EngagementId,
+	UserId RequestingUserId,
+	int Rating,
+	string? Comment)
+	: ICommand<bool>;

--- a/backend/src/Application/Engagements/UpdateFeedback/v1/UpdateFeedbackCommandHandler.cs
+++ b/backend/src/Application/Engagements/UpdateFeedback/v1/UpdateFeedbackCommandHandler.cs
@@ -1,0 +1,29 @@
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+
+namespace Application.Engagements.UpdateFeedback.v1;
+
+internal sealed class UpdateFeedbackCommandHandler(
+	IApplicationDbContext dbContext)
+	: ICommandHandler<UpdateFeedbackCommand, bool>
+{
+	public async ValueTask<bool> Handle(
+		UpdateFeedbackCommand request,
+		CancellationToken cancellationToken = default)
+	{
+		var engagement = await dbContext.Engagements.FindAsync(request.EngagementId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("Engagement.NotFound", $"Engagement '{request.EngagementId.Value}' not found."));
+
+		if (engagement.IsAnonymized)
+			throw new ResultFailureException(Error.Conflict("Engagement.Anonymized", "This engagement's volunteer account has been deleted."));
+
+		if (engagement.VolunteerId!.Value.Value != request.RequestingUserId.Value)
+			throw new ResultFailureException(Error.Forbidden("Engagement.NotOwner", "You can only update feedback for your own engagements."));
+
+		engagement.UpdateFeedback(request.Rating, request.Comment, DateTimeOffset.UtcNow).ThrowIfFailure();
+
+		return true;
+	}
+}

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -58,6 +58,12 @@ public sealed class Engagement
 	// volunteer plus every organizer of the org (einsatzbereit#1174).
 	private const int MaxReactivationCount = 5;
 
+	// Reasonable window (#1069) for a volunteer to reconsider a submitted rating
+	// or comment. Measured from the original FeedbackSubmittedAt rather than
+	// reset by each edit, so editing repeatedly can't keep the window open
+	// indefinitely.
+	public const int FeedbackEditWindowDays = 14;
+
 #pragma warning disable CS8618
 	private Engagement() : base(default) { }
 #pragma warning restore CS8618
@@ -263,6 +269,47 @@ public sealed class Engagement
 		FeedbackComment = comment;
 		FeedbackSubmittedAt = now;
 		AddEvent(new EngagementFeedbackSubmittedDomainEvent(Id, VolunteerId!.Value, OpportunityId, rating));
+		return Result.Success();
+	}
+
+	public Result UpdateFeedback(int rating, string? comment, DateTimeOffset now)
+	{
+		if (IsAnonymized)
+			return Result.Failure(Error.Conflict("Engagement.Anonymized", "This engagement's volunteer has deleted their account and can no longer be acted on."));
+
+		if (!FeedbackSubmittedAt.HasValue)
+			return Result.Failure(Error.Conflict("Engagement.FeedbackNotSubmitted", "Feedback has not been submitted yet."));
+
+		if (now > FeedbackSubmittedAt.Value.AddDays(FeedbackEditWindowDays))
+			return Result.Failure(Error.Conflict("Engagement.FeedbackEditWindowExpired", $"Feedback can no longer be edited more than {FeedbackEditWindowDays} days after it was submitted."));
+
+		if (rating is < 1 or > 5)
+			return Result.Failure(Error.Validation("Engagement.RatingOutOfRange", "Rating must be between 1 and 5."));
+
+		if (comment is not null && comment.Length > 500)
+			return Result.Failure(Error.Validation("Engagement.CommentTooLong", "Comment must not exceed 500 characters."));
+
+		FeedbackRating = rating;
+		FeedbackComment = comment;
+		AddEvent(new EngagementFeedbackUpdatedDomainEvent(Id, VolunteerId!.Value, OpportunityId, rating));
+		return Result.Success();
+	}
+
+	public Result DeleteFeedback(DateTimeOffset now)
+	{
+		if (IsAnonymized)
+			return Result.Failure(Error.Conflict("Engagement.Anonymized", "This engagement's volunteer has deleted their account and can no longer be acted on."));
+
+		if (!FeedbackSubmittedAt.HasValue)
+			return Result.Failure(Error.Conflict("Engagement.FeedbackNotSubmitted", "Feedback has not been submitted yet."));
+
+		if (now > FeedbackSubmittedAt.Value.AddDays(FeedbackEditWindowDays))
+			return Result.Failure(Error.Conflict("Engagement.FeedbackEditWindowExpired", $"Feedback can no longer be edited more than {FeedbackEditWindowDays} days after it was submitted."));
+
+		FeedbackRating = null;
+		FeedbackComment = null;
+		FeedbackSubmittedAt = null;
+		AddEvent(new EngagementFeedbackDeletedDomainEvent(Id, VolunteerId!.Value, OpportunityId));
 		return Result.Success();
 	}
 

--- a/backend/src/Domain/Engagements/EngagementFeedbackDeletedDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementFeedbackDeletedDomainEvent.cs
@@ -1,0 +1,11 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+public sealed record EngagementFeedbackDeletedDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId)
+	: DomainEvent;

--- a/backend/src/Domain/Engagements/EngagementFeedbackUpdatedDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementFeedbackUpdatedDomainEvent.cs
@@ -1,0 +1,12 @@
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Domain.Engagements;
+
+public sealed record EngagementFeedbackUpdatedDomainEvent(
+	EngagementId EngagementId,
+	UserId VolunteerId,
+	VolunteerOpportunityId OpportunityId,
+	int Rating)
+	: DomainEvent;

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -356,7 +356,10 @@ internal sealed class EngagementReadRepository(
 				TimeSlotStartDateTime: timeSlot?.StartDateTime ?? e.TimeSlotStartDateTime,
 				TimeSlotEndDateTime: timeSlot?.EndDateTime ?? e.TimeSlotEndDateTime,
 				Location: location,
-				CancellationReason: e.CancellationReason);
+				CancellationReason: e.CancellationReason,
+				FeedbackRating: e.FeedbackRating,
+				FeedbackComment: e.FeedbackComment,
+				FeedbackSubmittedAt: e.FeedbackSubmittedAt);
 		}).ToList();
 	}
 

--- a/backend/tests/Application.UnitTests/Engagements/DeleteFeedback/DeleteFeedbackCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/DeleteFeedback/DeleteFeedbackCommandHandlerTests.cs
@@ -1,0 +1,186 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Engagements.DeleteFeedback.v1;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.DeleteFeedback;
+
+public class DeleteFeedbackCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
+		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly DeleteFeedbackCommandHandler _sut;
+
+	public DeleteFeedbackCommandHandlerTests()
+	{
+		_dbContext.Engagements.Returns(_engagementRepo);
+		_sut = new DeleteFeedbackCommandHandler(_dbContext);
+	}
+
+	private static (Engagement engagement, UserId volunteerId) CreateEngagementWithFeedback(
+		DateTimeOffset? submittedAt = null)
+	{
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(
+			VolunteerOpportunityId.New(),
+			volunteerId,
+			TimeSlotId.New());
+		engagement.Confirm();
+		engagement.CheckIn();
+		engagement.SubmitFeedback(3, "Okay", submittedAt ?? DateTimeOffset.UtcNow.AddDays(-1));
+		return (engagement, volunteerId);
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteFeedback_WhenCalledByOwner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, volunteerId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		engagement.FeedbackRating.Should().BeNull();
+		engagement.FeedbackComment.Should().BeNull();
+		engagement.FeedbackSubmittedAt.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEngagementNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns((Engagement?)null);
+
+		var command = new DeleteFeedbackCommand(engagementId, UserId.New());
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage($"*{engagementId.Value}*"))
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenCallerIsNotTheEngagementOwner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: a different volunteer attempts to delete someone else's feedback.
+		var (engagement, _) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, UserId.New());
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*You can only delete feedback for your own engagements*"))
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotMutateEngagement_WhenCallerIsNotTheEngagementOwner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, _) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, UserId.New());
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+		await act.Should().ThrowAsync<ResultFailureException>();
+
+		// Assert: the ownership guard fires before the domain method runs.
+		engagement.FeedbackRating.Should().Be(3);
+		engagement.FeedbackSubmittedAt.Should().NotBeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenEngagementIsAnonymized(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, _) = CreateEngagementWithFeedback();
+		engagement.Anonymize();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, UserId.New());
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenFeedbackNotYetSubmitted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: checked in, but never submitted feedback.
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(
+			VolunteerOpportunityId.New(),
+			volunteerId,
+			TimeSlotId.New());
+		engagement.Confirm();
+		engagement.CheckIn();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, volunteerId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*not been submitted*"))
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEditWindowExpired(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-(Engagement.FeedbackEditWindowDays + 1));
+		var (engagement, volunteerId) = CreateEngagementWithFeedback(submittedAt);
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new DeleteFeedbackCommand(engagementId, volunteerId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*no longer be edited*"))
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
@@ -492,4 +492,189 @@ public class EngagementTests
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Match("*deleted their account*");
 	}
+
+	// --- UpdateFeedback (#1069) ---
+
+	private static Engagement CreateCheckedInEngagementWithFeedback(int rating, string? comment, DateTimeOffset submittedAt)
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Confirm();
+		engagement.CheckIn();
+		engagement.SubmitFeedback(rating, comment, submittedAt);
+		return engagement;
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldUpdateRatingAndComment_WhenWithinEditWindow()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.UpdateFeedback(5, "Actually, great!", submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeFalse();
+		engagement.FeedbackRating.Should().Be(5);
+		engagement.FeedbackComment.Should().Be("Actually, great!");
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldNotChangeFeedbackSubmittedAt()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		engagement.UpdateFeedback(5, "Actually, great!", submittedAt.AddHours(1));
+
+		// The edit window is anchored to the original submission (#1069) - editing
+		// must not reset it, or repeated edits could keep feedback editable forever.
+		engagement.FeedbackSubmittedAt.Should().Be(submittedAt);
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldFail_WhenFeedbackNotYetSubmitted()
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Confirm();
+		engagement.CheckIn();
+
+		var result = engagement.UpdateFeedback(5, "Great!", DateTimeOffset.UtcNow);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*not been submitted*");
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldSucceed_AtExactEditWindowBoundary()
+	{
+		var submittedAt = DateTimeOffset.UtcNow;
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.UpdateFeedback(5, "Better!", submittedAt.AddDays(Engagement.FeedbackEditWindowDays));
+
+		result.IsFailure.Should().BeFalse();
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldFail_WhenEditWindowExpired()
+	{
+		var submittedAt = DateTimeOffset.UtcNow;
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.UpdateFeedback(
+			5,
+			"Better!",
+			submittedAt.AddDays(Engagement.FeedbackEditWindowDays).AddSeconds(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*no longer be edited*");
+	}
+
+	[Test]
+	[Arguments(0)]
+	[Arguments(-1)]
+	[Arguments(6)]
+	public void UpdateFeedback_ShouldFail_WhenRatingIsOutOfRange(int invalidRating)
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.UpdateFeedback(invalidRating, null, submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*Rating must be between 1 and 5*");
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldFail_WhenCommentExceedsMaxLength()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+		var tooLongComment = new string('a', 501);
+
+		var result = engagement.UpdateFeedback(4, tooLongComment, submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*must not exceed 500 characters*");
+	}
+
+	[Test]
+	public void UpdateFeedback_ShouldFail_WhenAnonymized()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+		engagement.Anonymize();
+
+		var result = engagement.UpdateFeedback(5, "Great!", submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*deleted their account*");
+	}
+
+	// --- DeleteFeedback (#1069) ---
+
+	[Test]
+	public void DeleteFeedback_ShouldClearFeedbackFields_WhenWithinEditWindow()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.DeleteFeedback(submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeFalse();
+		engagement.FeedbackRating.Should().BeNull();
+		engagement.FeedbackComment.Should().BeNull();
+		engagement.FeedbackSubmittedAt.Should().BeNull();
+	}
+
+	[Test]
+	public void DeleteFeedback_ShouldAllowResubmission_Afterward()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+		engagement.DeleteFeedback(submittedAt.AddHours(1));
+
+		var result = engagement.SubmitFeedback(4, "Second try", submittedAt.AddHours(2));
+
+		result.IsFailure.Should().BeFalse();
+		engagement.FeedbackRating.Should().Be(4);
+	}
+
+	[Test]
+	public void DeleteFeedback_ShouldFail_WhenFeedbackNotYetSubmitted()
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Confirm();
+		engagement.CheckIn();
+
+		var result = engagement.DeleteFeedback(DateTimeOffset.UtcNow);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*not been submitted*");
+	}
+
+	[Test]
+	public void DeleteFeedback_ShouldFail_WhenEditWindowExpired()
+	{
+		var submittedAt = DateTimeOffset.UtcNow;
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+
+		var result = engagement.DeleteFeedback(
+			submittedAt.AddDays(Engagement.FeedbackEditWindowDays).AddSeconds(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*no longer be edited*");
+	}
+
+	[Test]
+	public void DeleteFeedback_ShouldFail_WhenAnonymized()
+	{
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-1);
+		var engagement = CreateCheckedInEngagementWithFeedback(3, "Okay", submittedAt);
+		engagement.Anonymize();
+
+		var result = engagement.DeleteFeedback(submittedAt.AddHours(1));
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Match("*deleted their account*");
+	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/UpdateFeedback/UpdateFeedbackCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/UpdateFeedback/UpdateFeedbackCommandHandlerTests.cs
@@ -1,0 +1,251 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Engagements.UpdateFeedback.v1;
+using AwesomeAssertions;
+using Domain.Engagements;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.UpdateFeedback;
+
+public class UpdateFeedbackCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
+		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly UpdateFeedbackCommandHandler _sut;
+
+	public UpdateFeedbackCommandHandlerTests()
+	{
+		_dbContext.Engagements.Returns(_engagementRepo);
+		_sut = new UpdateFeedbackCommandHandler(_dbContext);
+	}
+
+	private static (Engagement engagement, UserId volunteerId) CreateEngagementWithFeedback(
+		int rating = 3, string? comment = "Okay", DateTimeOffset? submittedAt = null)
+	{
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(
+			VolunteerOpportunityId.New(),
+			volunteerId,
+			TimeSlotId.New());
+		engagement.Confirm();
+		engagement.CheckIn();
+		engagement.SubmitFeedback(rating, comment, submittedAt ?? DateTimeOffset.UtcNow.AddDays(-1));
+		return (engagement, volunteerId);
+	}
+
+	[Test]
+	public async Task Handle_ShouldUpdateFeedback_WhenCalledByOwnerWithValidRating(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, 5, "Actually, great!");
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		engagement.FeedbackRating.Should().Be(5);
+		engagement.FeedbackComment.Should().Be("Actually, great!");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEngagementNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns((Engagement?)null);
+
+		var command = new UpdateFeedbackCommand(engagementId, UserId.New(), 4, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage($"*{engagementId.Value}*"))
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenCallerIsNotTheEngagementOwner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: a different volunteer attempts to update someone else's feedback.
+		var (engagement, _) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, UserId.New(), 5, "Hijacked");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*You can only update feedback for your own engagements*"))
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotMutateEngagement_WhenCallerIsNotTheEngagementOwner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, _) = CreateEngagementWithFeedback(rating: 3, comment: "Okay");
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, UserId.New(), 5, "Hijacked");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+		await act.Should().ThrowAsync<ResultFailureException>();
+
+		// Assert: the ownership guard fires before the domain method runs.
+		engagement.FeedbackRating.Should().Be(3);
+		engagement.FeedbackComment.Should().Be("Okay");
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrowConflict_WhenEngagementIsAnonymized(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, _) = CreateEngagementWithFeedback();
+		engagement.Anonymize();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, UserId.New(), 5, "Great!");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenFeedbackNotYetSubmitted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: checked in, but never submitted feedback.
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(
+			VolunteerOpportunityId.New(),
+			volunteerId,
+			TimeSlotId.New());
+		engagement.Confirm();
+		engagement.CheckIn();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, 5, "Great!");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*not been submitted*"))
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenEditWindowExpired(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var submittedAt = DateTimeOffset.UtcNow.AddDays(-(Engagement.FeedbackEditWindowDays + 1));
+		var (engagement, volunteerId) = CreateEngagementWithFeedback(submittedAt: submittedAt);
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, 5, "Too late");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*no longer be edited*"))
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+	}
+
+	[Test]
+	[Arguments(0)]
+	[Arguments(-1)]
+	[Arguments(6)]
+	[Arguments(100)]
+	public async Task Handle_ShouldThrow_WhenRatingIsOutOfRange(
+		int invalidRating, CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, invalidRating, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*Rating must be between 1 and 5*"))
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+
+	[Test]
+	[Arguments(1)]
+	[Arguments(5)]
+	public async Task Handle_ShouldSucceed_WhenRatingIsAtBoundary(
+		int boundaryRating, CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, boundaryRating, null);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		engagement.FeedbackRating.Should().Be(boundaryRating);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenCommentExceedsMaxLength(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (engagement, volunteerId) = CreateEngagementWithFeedback();
+		var engagementId = EngagementId.New();
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+
+		var tooLongComment = new string('a', 501);
+		var command = new UpdateFeedbackCommand(engagementId, volunteerId, 4, tooLongComment);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>()
+			.WithMessage("*must not exceed 500 characters*"))
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+	}
+}

--- a/backend/tests/ArchitectureTests/OwnershipConventionTests.cs
+++ b/backend/tests/ArchitectureTests/OwnershipConventionTests.cs
@@ -24,6 +24,8 @@ public sealed class OwnershipConventionTests
 		// Ownership is checked against engagement.VolunteerId - a per-user
 		// resource, not an organization.
 		"Application.Engagements.SubmitFeedback.v1.SubmitFeedbackCommandHandler",
+		"Application.Engagements.UpdateFeedback.v1.UpdateFeedbackCommandHandler",
+		"Application.Engagements.DeleteFeedback.v1.DeleteFeedbackCommandHandler",
 		"Application.Engagements.CheckInWithPin.v1.CheckInWithPinCommandHandler",
 	};
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -423,14 +423,24 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<EngagementStatusResponse> WithdrawEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
+        /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<EngagementStatusResponse> UndoCheckInEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task UpdateFeedbackAsync(System.Guid engagementId, UpdateFeedbackRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task SubmitFeedbackAsync(System.Guid engagementId, SubmitFeedbackRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DeleteFeedbackAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<EngagementStatusResponse> UndoCheckInEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -9218,12 +9228,15 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
+        /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<EngagementStatusResponse> UndoCheckInEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task UpdateFeedbackAsync(System.Guid engagementId, UpdateFeedbackRequest body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (engagementId == null)
                 throw new System.ArgumentNullException("engagementId");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -9231,16 +9244,18 @@ namespace IntegrationTests
             {
                 using (var request_ = new System.Net.Http.HttpRequestMessage())
                 {
-                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
-                    request_.Method = new System.Net.Http.HttpMethod("POST");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                 
-                    // Operation Path: "v1/engagements/{engagementId}/undo-check-in"
+                    // Operation Path: "v1/engagements/{engagementId}/feedback"
                     urlBuilder_.Append("v1/engagements/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(engagementId, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append("/undo-check-in");
+                    urlBuilder_.Append("/feedback");
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -9265,14 +9280,9 @@ namespace IntegrationTests
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
+                        if (status_ == 204)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<EngagementStatusResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
+                            return;
                         }
                         else
                         if (status_ == 400)
@@ -9293,16 +9303,6 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 403)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 404)
@@ -9410,6 +9410,223 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DeleteFeedbackAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (engagementId == null)
+                throw new System.ArgumentNullException("engagementId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/engagements/{engagementId}/feedback"
+                    urlBuilder_.Append("v1/engagements/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(engagementId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/feedback");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<EngagementStatusResponse> UndoCheckInEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (engagementId == null)
+                throw new System.ArgumentNullException("engagementId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/engagements/{engagementId}/undo-check-in"
+                    urlBuilder_.Append("v1/engagements/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(engagementId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/undo-check-in");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<EngagementStatusResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 404)
@@ -11845,6 +12062,16 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("cancellationReason")]
         public string? CancellationReason { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("feedbackRating")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int? FeedbackRating { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("feedbackComment")]
+        public string? FeedbackComment { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("feedbackSubmittedAt")]
+        public System.DateTimeOffset? FeedbackSubmittedAt { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -13259,6 +13486,29 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("city")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string City { get; set; } = default!;
+
+        private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateFeedbackRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("rating")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int Rating { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("comment")]
+        public string? Comment { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1215,6 +1215,232 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		summary.FeedbackCount.Should().Be(0);
 	}
 
+	// ── UpdateFeedback / DeleteFeedback (#1069) ───────────────────────────────
+
+	[Test]
+	public async Task UpdateFeedback_ShouldUpdateRatingAndComment_WhenCalledByOwnerWithinWindow(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		await veraClient.UpdateFeedbackAsync(
+			engagement.Id, new UpdateFeedbackRequest { Rating = 5, Comment = "Actually, great!" }, cancellationToken);
+
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
+		summary.Items.Items.Should().ContainSingle(i => i.Rating == 5 && i.Comment == "Actually, great!");
+	}
+
+	[Test]
+	public async Task UpdateFeedback_ShouldReturn404_WhenEngagementNotFound(
+		CancellationToken cancellationToken)
+	{
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => veraClient.UpdateFeedbackAsync(
+			Guid.NewGuid(), new UpdateFeedbackRequest { Rating = 5, Comment = null }, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task UpdateFeedback_ShouldReturn403_WhenCallerIsNotTheOwner(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		var act = () => olafClient.UpdateFeedbackAsync(
+			engagement.Id, new UpdateFeedbackRequest { Rating = 5, Comment = "Hijacked" }, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	[Test]
+	public async Task UpdateFeedback_ShouldReturn409_WhenFeedbackNotYetSubmitted(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+
+		var act = () => veraClient.UpdateFeedbackAsync(
+			engagement.Id, new UpdateFeedbackRequest { Rating = 5, Comment = null }, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
+	[Test]
+	public async Task UpdateFeedback_ShouldReturn409_WhenEditWindowExpired(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		// Backdate the submission directly in the DB - there's no API path to
+		// simulate the passage of time, so this mirrors the raw-SQL approach the
+		// check-constraint tests below already use to bypass the domain.
+		await using (var dbContext = fixture.CreateApplicationDbContext())
+		{
+			var expiredSubmittedAt = DateTimeOffset.UtcNow.AddDays(-(Engagement.FeedbackEditWindowDays + 1));
+			await dbContext.Database.ExecuteSqlInterpolatedAsync(
+				$"UPDATE engagement SET feedback_submitted_at = {expiredSubmittedAt} WHERE id = {engagement.Id}",
+				cancellationToken);
+		}
+
+		var act = () => veraClient.UpdateFeedbackAsync(
+			engagement.Id, new UpdateFeedbackRequest { Rating = 5, Comment = "Too late" }, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
+	[Test]
+	public async Task DeleteFeedback_ShouldClearFeedback_WhenCalledByOwnerWithinWindow(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		await veraClient.DeleteFeedbackAsync(engagement.Id, cancellationToken);
+
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
+		summary.FeedbackCount.Should().Be(0);
+	}
+
+	[Test]
+	public async Task DeleteFeedback_ShouldAllowResubmission_Afterward(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+		await veraClient.DeleteFeedbackAsync(engagement.Id, cancellationToken);
+
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 5, Comment = "Second try" }, cancellationToken);
+
+		var summary = await olafClient.GetOpportunityFeedbackAsync(opportunity.Id, 1, 10, cancellationToken);
+		summary.Items.Items.Should().ContainSingle(i => i.Rating == 5 && i.Comment == "Second try");
+	}
+
+	[Test]
+	public async Task DeleteFeedback_ShouldReturn404_WhenEngagementNotFound(
+		CancellationToken cancellationToken)
+	{
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => veraClient.DeleteFeedbackAsync(Guid.NewGuid(), cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+	}
+
+	[Test]
+	public async Task DeleteFeedback_ShouldReturn403_WhenCallerIsNotTheOwner(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		var act = () => olafClient.DeleteFeedbackAsync(engagement.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(403);
+	}
+
+	[Test]
+	public async Task DeleteFeedback_ShouldReturn409_WhenEditWindowExpired(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 3, Comment = "Okay" }, cancellationToken);
+
+		await using (var dbContext = fixture.CreateApplicationDbContext())
+		{
+			var expiredSubmittedAt = DateTimeOffset.UtcNow.AddDays(-(Engagement.FeedbackEditWindowDays + 1));
+			await dbContext.Database.ExecuteSqlInterpolatedAsync(
+				$"UPDATE engagement SET feedback_submitted_at = {expiredSubmittedAt} WHERE id = {engagement.Id}",
+				cancellationToken);
+		}
+
+		var act = () => veraClient.DeleteFeedbackAsync(engagement.Id, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
 	// ── Feedback rating DB check constraint (#1214) ───────────────────────────
 	// SubmitFeedback already rejects an out-of-range rating (Application.UnitTests
 	// covers that), but that only guards the one write path through the API. These

--- a/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
+++ b/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
@@ -67,7 +67,11 @@ public class OutboxMessageSerializationTests
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		yield return new EngagementConfirmedDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		yield return new EngagementFeedbackDeletedDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		yield return new EngagementFeedbackSubmittedDomainEvent(
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), 5);
+		yield return new EngagementFeedbackUpdatedDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), 5);
 		yield return new EngagementReactivatedDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1420,6 +1420,56 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task ProfileOverviewPage_EditableFeedback_AsVera_HasNoSeriousA11yViolations()
+	{
+		// einsatzbereit#1069: the axe gate above only ever renders the
+		// create-mode "Leave feedback" state - it never opens the edit-mode
+		// SubmitFeedbackModal, the badge+Edit+Delete buttons state, or the
+		// delete-feedback ConfirmDialog. Seed feedback that's already been
+		// submitted so this scan actually reaches all three.
+		var (_, _, engagementId) = await SeedConfirmedEngagementAsync("Manual", "FeedbackEditA11y");
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/check-in", null)).EnsureSuccessStatusCode();
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		(await veraHttp.PostAsJsonAsync($"/v1/engagements/{engagementId}/feedback", new { rating = 4, comment = "Great!" }))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/profile");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByTestId("engagements-scope-past").ClickAsync();
+
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(card.GetByRole(AriaRole.Button, new() { Name = "Edit" })).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var badgeAndButtonsResult = await Page.RunAxe();
+		AssertNoViolations(badgeAndButtonsResult);
+
+		await card.GetByRole(AriaRole.Button, new() { Name = "Edit" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+
+		var editModalResult = await Page.RunAxe();
+		AssertNoViolations(editModalResult);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Cancel" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).Not.ToBeVisibleAsync();
+
+		await card.GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+
+		var deleteDialogResult = await Page.RunAxe();
+		AssertNoViolations(deleteDialogResult);
+	}
+
+	[Test]
 	public async Task ProfileOverviewPage_CheckInModalPinCode_AsVera_HasNoSeriousA11yViolations()
 	{
 		// einsatzbereit#1297: CheckInModal's PIN-entry state (and its

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Playwright;
 
@@ -387,5 +389,140 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 
 		await Expect(Page.Locator("#bio")).ToHaveValueAsync(draftBio);
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true })).ToBeVisibleAsync();
+	}
+
+	// einsatzbereit#1069: seeds a checked-in engagement with feedback already
+	// submitted (via raw HTTP, same pattern as AccessibilityTests's
+	// SeedConfirmedEngagementAsync) so the Edit/Delete tests below don't have to
+	// drive the initial "Leave feedback" submission through the UI first.
+	private async Task<string> SeedCheckedInEngagementWithFeedbackAsync(int rating, string comment)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"FeedbackEdit Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()
+			?? throw new InvalidOperationException("Created organization had no id.");
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"FeedbackEdit Opportunity {suffix}",
+			description = "Created by ProfileOverviewTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "Manual",
+			isDraft = false,
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString()
+			?? throw new InvalidOperationException("Created opportunity had no id.");
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		var applyResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "FeedbackEdit application." });
+		applyResponse.EnsureSuccessStatusCode();
+		var engagement = await applyResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString()
+			?? throw new InvalidOperationException("Created engagement had no id.");
+
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", null)).EnsureSuccessStatusCode();
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/check-in", null)).EnsureSuccessStatusCode();
+		(await veraHttp.PostAsJsonAsync($"/v1/engagements/{engagementId}/feedback", new { rating, comment }))
+			.EnsureSuccessStatusCode();
+
+		return engagementId;
+	}
+
+	[Test]
+	public async Task ActivitySection_EditFeedback_PersistsUpdatedRatingAndComment()
+	{
+		var originalComment = $"Original comment {Guid.NewGuid():N}";
+		var engagementId = await SeedCheckedInEngagementWithFeedbackAsync(3, originalComment);
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// einsatzbereit#675: a checked-in Confirmed engagement is classified as
+		// Past, not "Current & Upcoming".
+		await Page.GetByTestId("engagements-scope-past").ClickAsync();
+
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(card.GetByText("Feedback given")).ToBeVisibleAsync();
+
+		await card.GetByRole(AriaRole.Button, new() { Name = "Edit" }).ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await Expect(dialog.GetByRole(AriaRole.Heading, new() { Name = "Edit your feedback" })).ToBeVisibleAsync();
+		await Expect(dialog.Locator("#feedback-comment")).ToHaveValueAsync(originalComment);
+
+		var updatedComment = $"Updated comment {Guid.NewGuid():N}";
+		await dialog.Locator("#feedback-comment").FillAsync(updatedComment);
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "5 stars" }).ClickAsync();
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Save changes" }).ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
+
+		// Reload so the page re-fetches from the server, proving the edit
+		// actually persisted rather than only updating local UI state.
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByTestId("engagements-scope-past").ClickAsync();
+
+		var reloadedCard = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(reloadedCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await reloadedCard.GetByRole(AriaRole.Button, new() { Name = "Edit" }).ClickAsync();
+		await Expect(Page.Locator("#feedback-comment")).ToHaveValueAsync(updatedComment);
+	}
+
+	[Test]
+	public async Task ActivitySection_DeleteFeedback_ReturnsEngagementToLeaveFeedbackState()
+	{
+		var engagementId = await SeedCheckedInEngagementWithFeedbackAsync(4, "To be deleted");
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByTestId("engagements-scope-past").ClickAsync();
+
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await card.GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+		var confirmDialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(confirmDialog).ToBeVisibleAsync();
+		await Expect(confirmDialog.GetByRole(AriaRole.Heading, new() { Name = "Delete feedback?" })).ToBeVisibleAsync();
+		await confirmDialog.GetByRole(AriaRole.Button, new() { Name = "Yes, delete" }).ClickAsync();
+		await Expect(confirmDialog).Not.ToBeVisibleAsync();
+
+		await Expect(card.GetByText("Feedback given")).Not.ToBeVisibleAsync();
+		await Expect(card.GetByRole(AriaRole.Button, new() { Name = "Leave feedback" })).ToBeVisibleAsync();
+
+		// Reload to prove the delete persisted server-side, not just locally.
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.GetByTestId("engagements-scope-past").ClickAsync();
+
+		var reloadedCard = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await Expect(reloadedCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(reloadedCard.GetByRole(AriaRole.Button, new() { Name = "Leave feedback" })).ToBeVisibleAsync();
 	}
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -4879,6 +4879,179 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @return No Content
+     */
+    updateFeedback(engagementId: string, body: UpdateFeedbackRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/engagements/{engagementId}/feedback";
+        if (engagementId === undefined || engagementId === null)
+            throw new globalThis.Error("The parameter 'engagementId' must be defined.");
+        url_ = url_.replace("{engagementId}", encodeURIComponent("" + engagementId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            signal,
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateFeedback(_response);
+        });
+    }
+
+    protected processUpdateFeedback(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
+    submitFeedback(engagementId: string, body: SubmitFeedbackRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/engagements/{engagementId}/feedback";
+        if (engagementId === undefined || engagementId === null)
+            throw new globalThis.Error("The parameter 'engagementId' must be defined.");
+        url_ = url_.replace("{engagementId}", encodeURIComponent("" + engagementId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            signal,
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSubmitFeedback(_response);
+        });
+    }
+
+    protected processSubmitFeedback(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return No Content
+     */
+    deleteFeedback(engagementId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/engagements/{engagementId}/feedback";
+        if (engagementId === undefined || engagementId === null)
+            throw new globalThis.Error("The parameter 'engagementId' must be defined.");
+        url_ = url_.replace("{engagementId}", encodeURIComponent("" + engagementId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteFeedback(_response);
+        });
+    }
+
+    protected processDeleteFeedback(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * @return OK
      */
     undoCheckInEngagement(engagementId: string, signal?: AbortSignal): Promise<EngagementStatusResponse> {
@@ -4940,65 +5113,6 @@ export class EinsatzbereitApi {
             });
         }
         return Promise.resolve<EngagementStatusResponse>(null as any);
-    }
-
-    /**
-     * @return No Content
-     */
-    submitFeedback(engagementId: string, body: SubmitFeedbackRequest, signal?: AbortSignal): Promise<void> {
-        let url_ = this.baseUrl + "/v1/engagements/{engagementId}/feedback";
-        if (engagementId === undefined || engagementId === null)
-            throw new globalThis.Error("The parameter 'engagementId' must be defined.");
-        url_ = url_.replace("{engagementId}", encodeURIComponent("" + engagementId));
-        url_ = url_.replace(/[?&]$/, "");
-
-        const content_ = JSON.stringify(body);
-
-        let options_: RequestInit = {
-            body: content_,
-            method: "POST",
-            signal,
-            headers: {
-                "Content-Type": "application/json",
-            }
-        };
-
-        return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processSubmitFeedback(_response);
-        });
-    }
-
-    protected processSubmitFeedback(response: Response): Promise<void> {
-        const status = response.status;
-        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 204) {
-            return response.text().then((_responseText) => {
-            return;
-            });
-        } else if (status === 400) {
-            return response.text().then((_responseText) => {
-            let result400: any = null;
-            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
-            return throwException("Bad Request", status, _responseText, _headers, result400);
-            });
-        } else if (status === 401) {
-            return response.text().then((_responseText) => {
-            let result401: any = null;
-            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
-            return throwException("Unauthorized", status, _responseText, _headers, result401);
-            });
-        } else if (status === 404) {
-            return response.text().then((_responseText) => {
-            let result404: any = null;
-            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
-            return throwException("Not Found", status, _responseText, _headers, result404);
-            });
-        } else if (status !== 200 && status !== 204) {
-            return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-            });
-        }
-        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -6012,6 +6126,9 @@ export interface EngagementSummary {
     volunteerEmail?: string | undefined;
     volunteerPhone?: string | undefined;
     cancellationReason?: string | undefined;
+    feedbackRating?: number | undefined;
+    feedbackComment?: string | undefined;
+    feedbackSubmittedAt?: Date | undefined;
 
     [key: string]: any;
 }
@@ -6435,6 +6552,13 @@ export interface UpdateAddressRequest {
     houseNumber: string;
     zipCode: string;
     city: string;
+
+    [key: string]: any;
+}
+
+export interface UpdateFeedbackRequest {
+    rating: number;
+    comment: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "../hooks/useApiClient";
 import { textareaClass } from "../lib/formClasses";
+import { getApiErrorMessage } from "../lib/apiError";
 import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
@@ -11,8 +12,12 @@ import { labelClass } from "../lib/formClasses";
 interface SubmitFeedbackModalProps {
 	engagementId: string;
 	opportunityTitle: string;
-	onSubmitted: () => void;
+	onSubmitted: (rating: number, comment: string | null) => void;
 	onClose: () => void;
+	/** Pre-fills the form and switches submit/cancel wording to editing an
+	 * existing rating (PUT) instead of creating a new one (POST). */
+	initialRating?: number;
+	initialComment?: string | null;
 }
 
 export default function SubmitFeedbackModal({
@@ -20,12 +25,15 @@ export default function SubmitFeedbackModal({
 	opportunityTitle,
 	onSubmitted,
 	onClose,
+	initialRating,
+	initialComment,
 }: SubmitFeedbackModalProps) {
 	const api = useApiClient();
 	const { t } = useTranslation();
-	const [rating, setRating] = useState(0);
+	const isEditing = initialRating !== undefined;
+	const [rating, setRating] = useState(initialRating ?? 0);
 	const [hovered, setHovered] = useState(0);
-	const [comment, setComment] = useState("");
+	const [comment, setComment] = useState(initialComment ?? "");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -34,15 +42,23 @@ export default function SubmitFeedbackModal({
 		if (rating === 0) return;
 		setSubmitting(true);
 		setError(null);
+		const trimmedComment = comment.trim() || null;
 		try {
-			await api.submitFeedback(engagementId, {
-				rating,
-				comment: comment.trim() || undefined,
-			});
-			onSubmitted();
+			if (isEditing) {
+				await api.updateFeedback(engagementId, {
+					rating,
+					comment: trimmedComment ?? undefined,
+				});
+			} else {
+				await api.submitFeedback(engagementId, {
+					rating,
+					comment: trimmedComment ?? undefined,
+				});
+			}
+			onSubmitted(rating, trimmedComment);
 			onClose();
-		} catch {
-			setError(t("feedback.submitError"));
+		} catch (err) {
+			setError(getApiErrorMessage(err, t("feedback.submitError")));
 		} finally {
 			setSubmitting(false);
 		}
@@ -56,7 +72,7 @@ export default function SubmitFeedbackModal({
 				id="feedback-title"
 				className="mb-1 text-lg font-semibold text-gray-900"
 			>
-				{t("feedback.title")}
+				{isEditing ? t("feedback.editTitle") : t("feedback.title")}
 			</h2>
 			<p className="mb-5 text-sm text-gray-500">{opportunityTitle}</p>
 
@@ -121,7 +137,11 @@ export default function SubmitFeedbackModal({
 						disabled={submitting || rating === 0}
 						className="flex-1"
 					>
-						{submitting ? t("feedback.submitting") : t("feedback.submit")}
+						{submitting
+							? t("feedback.submitting")
+							: isEditing
+								? t("feedback.saveChanges")
+								: t("feedback.submit")}
 					</Button>
 				</div>
 			</form>

--- a/frontend/src/lib/feedback.test.ts
+++ b/frontend/src/lib/feedback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isFeedbackEditable, FEEDBACK_EDIT_WINDOW_DAYS } from "./feedback";
+
+describe("isFeedbackEditable", () => {
+	const now = new Date("2026-01-15T12:00:00Z");
+
+	it("returns false when feedback was never submitted", () => {
+		expect(isFeedbackEditable(null, now)).toBe(false);
+		expect(isFeedbackEditable(undefined, now)).toBe(false);
+	});
+
+	it("returns true right after submission", () => {
+		expect(isFeedbackEditable(now, now)).toBe(true);
+	});
+
+	it("returns true just before the window closes", () => {
+		const submittedAt = new Date(now);
+		submittedAt.setDate(submittedAt.getDate() - FEEDBACK_EDIT_WINDOW_DAYS);
+		submittedAt.setMilliseconds(submittedAt.getMilliseconds() + 1);
+		expect(isFeedbackEditable(submittedAt, now)).toBe(true);
+	});
+
+	it("returns false once the window has passed", () => {
+		const submittedAt = new Date(now);
+		submittedAt.setDate(submittedAt.getDate() - FEEDBACK_EDIT_WINDOW_DAYS - 1);
+		expect(isFeedbackEditable(submittedAt, now)).toBe(false);
+	});
+
+	it("accepts an ISO date string as returned by the API client", () => {
+		expect(isFeedbackEditable(now.toISOString(), now)).toBe(true);
+	});
+});

--- a/frontend/src/lib/feedback.ts
+++ b/frontend/src/lib/feedback.ts
@@ -1,0 +1,17 @@
+import { addDays } from "date-fns";
+
+// Mirrors Engagement.FeedbackEditWindowDays on the backend (#1069) - only
+// used here to decide whether to show the Edit/Delete affordances at all.
+// The backend re-checks this independently on every request, so a stale or
+// skewed client clock can only ever hide the buttons a little early/late,
+// never bypass the real guard.
+export const FEEDBACK_EDIT_WINDOW_DAYS = 14;
+
+export function isFeedbackEditable(
+	feedbackSubmittedAt: Date | string | null | undefined,
+	now: Date = new Date(),
+): boolean {
+	if (!feedbackSubmittedAt) return false;
+	const submittedAt = new Date(feedbackSubmittedAt);
+	return now <= addDays(submittedAt, FEEDBACK_EDIT_WINDOW_DAYS);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -525,7 +525,12 @@
       "loadMore": "Mehr laden",
       "starLabel_one": "{{count}} Stern",
       "starLabel_other": "{{count}} Sterne",
-      "averageRating_one": "{{rating}} von 5 ({{count}} Bewertung)"
+      "averageRating_one": "{{rating}} von 5 ({{count}} Bewertung)",
+      "editTitle": "Feedback bearbeiten",
+      "saveChanges": "Änderungen speichern",
+      "editButtonLabel": "Bearbeiten",
+      "deleteButtonLabel": "Löschen",
+      "deleteError": "Feedback konnte nicht gelöscht werden. Bitte versuche es erneut."
     },
     "checkIn": {
       "buttonLabel": "Einchecken",
@@ -831,6 +836,11 @@
       "clearReadNotifications": {
         "title": "Gelesene Benachrichtigungen löschen?",
         "message": "Dadurch werden alle gelesenen Benachrichtigungen dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, löschen"
+      },
+      "deleteFeedback": {
+        "title": "Feedback löschen?",
+        "message": "Dies entfernt deine Bewertung und deinen Kommentar von diesem Engagement. Du kannst danach neues Feedback abgeben.",
         "confirm": "Ja, löschen"
       }
     },
@@ -1269,6 +1279,8 @@
         "NotCheckedIn": "Feedback kann nur für eingecheckte Engagements abgegeben werden.",
         "CheckInNotActive": "Der Check-in kann nur für eingecheckte Engagements rückgängig gemacht werden.",
         "FeedbackAlreadySubmitted": "Für dieses Engagement wurde bereits Feedback abgegeben.",
+        "FeedbackNotSubmitted": "Es wurde noch kein Feedback abgegeben.",
+        "FeedbackEditWindowExpired": "Feedback kann nicht mehr bearbeitet werden, wenn es vor mehr als 14 Tagen abgegeben wurde.",
         "RatingOutOfRange": "Die Bewertung muss zwischen 1 und 5 liegen.",
         "CommentTooLong": "Der Kommentar darf 500 Zeichen nicht überschreiten.",
         "NotFound": "Engagement nicht gefunden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -525,7 +525,12 @@
       "loadMore": "Load more",
       "starLabel_one": "{{count}} star",
       "starLabel_other": "{{count}} stars",
-      "averageRating_one": "{{rating}} out of 5 ({{count}} rating)"
+      "averageRating_one": "{{rating}} out of 5 ({{count}} rating)",
+      "editTitle": "Edit your feedback",
+      "saveChanges": "Save changes",
+      "editButtonLabel": "Edit",
+      "deleteButtonLabel": "Delete",
+      "deleteError": "Could not delete feedback. Please try again."
     },
     "checkIn": {
       "buttonLabel": "Check in",
@@ -832,6 +837,11 @@
         "title": "Clear read notifications?",
         "message": "This permanently deletes all read notifications. This cannot be undone.",
         "confirm": "Yes, clear"
+      },
+      "deleteFeedback": {
+        "title": "Delete feedback?",
+        "message": "This removes your rating and comment from this engagement. You can leave new feedback afterwards.",
+        "confirm": "Yes, delete"
       }
     },
     "imageCrop": {
@@ -1269,6 +1279,8 @@
         "NotCheckedIn": "Feedback can only be submitted for checked-in engagements.",
         "CheckInNotActive": "Only checked-in engagements can have their check-in undone.",
         "FeedbackAlreadySubmitted": "Feedback has already been submitted for this engagement.",
+        "FeedbackNotSubmitted": "Feedback has not been submitted yet.",
+        "FeedbackEditWindowExpired": "Feedback can no longer be edited more than 14 days after it was submitted.",
         "RatingOutOfRange": "Rating must be between 1 and 5.",
         "CommentTooLong": "Comment must not exceed 500 characters.",
         "NotFound": "Engagement not found.",

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -9,6 +9,7 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
+import { isFeedbackEditable } from "../../lib/feedback";
 import { formatDate, formatDateTime } from "../../lib/format";
 import AddToCalendarMenu from "../../components/AddToCalendarMenu";
 import CheckInModal from "../../components/CheckInModal";
@@ -75,6 +76,13 @@ export default function ActivitySection() {
 		useState<EngagementSummary | null>(null);
 	const [feedbackEngagement, setFeedbackEngagement] =
 		useState<EngagementSummary | null>(null);
+	const [confirmDeleteFeedbackId, setConfirmDeleteFeedbackId] = useState<
+		string | null
+	>(null);
+	const [deletingFeedback, setDeletingFeedback] = useState(false);
+	const [deleteFeedbackError, setDeleteFeedbackError] = useState<string | null>(
+		null,
+	);
 
 	// --- Invitations ---
 	const [invitations, setInvitations] = useState<MyInvitationDto[]>([]);
@@ -148,13 +156,74 @@ export default function ActivitySection() {
 		);
 	}
 
-	function handleFeedbackSubmitted() {
+	function handleFeedbackSubmitted(rating: number, comment: string | null) {
 		if (!feedbackEngagement) return;
 		setEngagements((prev) =>
 			prev.map((e) =>
-				e.id === feedbackEngagement.id ? { ...e, hasFeedback: true } : e,
+				e.id === feedbackEngagement.id
+					? {
+							...e,
+							hasFeedback: true,
+							feedbackRating: rating,
+							feedbackComment: comment ?? undefined,
+							feedbackSubmittedAt: e.feedbackSubmittedAt ?? new Date(),
+						}
+					: e,
 			),
 		);
+	}
+
+	async function handleDeleteFeedbackConfirm() {
+		if (!confirmDeleteFeedbackId) return;
+		const engagementId = confirmDeleteFeedbackId;
+		setDeletingFeedback(true);
+		setDeleteFeedbackError(null);
+		try {
+			await api.deleteFeedback(engagementId);
+			setEngagements((prev) =>
+				prev.map((e) =>
+					e.id === engagementId
+						? {
+								...e,
+								hasFeedback: false,
+								feedbackRating: undefined,
+								feedbackComment: undefined,
+								feedbackSubmittedAt: undefined,
+							}
+						: e,
+				),
+			);
+			setConfirmDeleteFeedbackId(null);
+			// Deleting swaps this card from the badge+Edit+Delete branch to the
+			// "Leave feedback" branch in the same commit that unmounts the confirm
+			// dialog, so the Delete button Modal's focus-restore effect is looking
+			// for is already gone from the DOM by the time that cleanup runs -
+			// focus would otherwise fall back to <body>. Move it to the button
+			// that replaces it instead, once the new branch has painted.
+			requestAnimationFrame(() => {
+				const card = document.querySelector(
+					`[data-engagement-id="${engagementId}"]`,
+				);
+				const leaveFeedbackButton = Array.from(
+					card?.querySelectorAll("button") ?? [],
+				).find(
+					(button) => button.textContent?.trim() === t("feedback.buttonLabel"),
+				);
+				leaveFeedbackButton?.focus();
+			});
+		} catch (err) {
+			setDeleteFeedbackError(
+				getApiErrorMessage(err, t("feedback.deleteError")),
+			);
+		} finally {
+			setDeletingFeedback(false);
+		}
+	}
+
+	function handleDeleteFeedbackClose() {
+		if (deletingFeedback) return;
+		setConfirmDeleteFeedbackId(null);
+		setDeleteFeedbackError(null);
 	}
 
 	async function handleAcceptInvitation(invitationId: string) {
@@ -412,9 +481,29 @@ export default function ActivitySection() {
 									</button>
 								)}
 								{e.isCheckedIn && e.hasFeedback && (
-									<span className="rounded-full bg-yellow-50 px-2.5 py-0.5 text-xs text-yellow-700">
-										{t("feedback.submitted")}
-									</span>
+									<>
+										<span className="rounded-full bg-yellow-50 px-2.5 py-0.5 text-xs text-yellow-700">
+											{t("feedback.submitted")}
+										</span>
+										{isFeedbackEditable(e.feedbackSubmittedAt) && (
+											<>
+												<button
+													type="button"
+													onClick={() => setFeedbackEngagement(e)}
+													className="rounded-lg border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+												>
+													{t("feedback.editButtonLabel")}
+												</button>
+												<button
+													type="button"
+													onClick={() => setConfirmDeleteFeedbackId(e.id)}
+													className="rounded-lg border border-red-200 px-3 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-50"
+												>
+													{t("feedback.deleteButtonLabel")}
+												</button>
+											</>
+										)}
+									</>
 								)}
 								{e.status === "Confirmed" &&
 									e.timeSlotId &&
@@ -497,8 +586,30 @@ export default function ActivitySection() {
 						feedbackEngagement.opportunityTitle ??
 						t("myEngagements.deletedOpportunityTitle")
 					}
+					initialRating={
+						feedbackEngagement.hasFeedback
+							? feedbackEngagement.feedbackRating
+							: undefined
+					}
+					initialComment={
+						feedbackEngagement.hasFeedback
+							? (feedbackEngagement.feedbackComment ?? null)
+							: undefined
+					}
 					onSubmitted={handleFeedbackSubmitted}
 					onClose={() => setFeedbackEngagement(null)}
+				/>
+			)}
+
+			{confirmDeleteFeedbackId && (
+				<ConfirmDialog
+					title={t("confirmDialog.deleteFeedback.title")}
+					message={t("confirmDialog.deleteFeedback.message")}
+					confirmLabel={t("confirmDialog.deleteFeedback.confirm")}
+					onConfirm={handleDeleteFeedbackConfirm}
+					onClose={handleDeleteFeedbackClose}
+					loading={deletingFeedback}
+					error={deleteFeedbackError}
 				/>
 			)}
 		</section>


### PR DESCRIPTION
Feedback was previously write-once: SubmitFeedback rejected any change once FeedbackSubmittedAt was set. Adds Engagement.UpdateFeedback/DeleteFeedback, each bounded by a 14-day edit window anchored to the original submission, plus PUT/DELETE /engagements/{id}/feedback endpoints and an edit affordance on the volunteer's own activity list. Organizer reply is a separate, larger feature and stays out of scope.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1069

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
