### PR TITLE
chore: ignore transient Claude Code agent worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .claude/settings.local.json
 
+# Claude Code agent worktrees (transient, per-session)
+.claude/worktrees/
+
 # Deployment secrets (server-side only, see .env.example)
 .env


### PR DESCRIPTION
## What

Adds `.claude/worktrees/` to `.gitignore`.

## Why

Background rebase/CI-fix agents (spawned via the Agent tool's `isolation: worktree` option) create `.claude/worktrees/agent-*/` directories while working. These are session-local scratch state, not repo content, but without a `.gitignore` entry they show up as untracked files and trip the repo's `pre-stop-verify`/git-check hooks.

Closes #

## Testing

N/A - `.gitignore`-only change, nothing to build or test.

## Live verification

Not applicable - this is a repo/tooling hygiene change with no runtime behavior, no deploy needed.

## Checklist

- [x] `/self-review` run and findings addressed (trivial `.gitignore`-only change)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K2eds28vCDNbt3Ed5eqzrS)_