### PR TITLE
fix: pass missing loadingLabel prop to AdministrationPage's audit log LoadMoreButton

### DIFF
--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -947,6 +947,7 @@ function AuditLogSection() {
 					<LoadMoreButton
 						loading={loadingMore}
 						label={t("administration.auditLog.loadMore")}
+						loadingLabel={t("administration.loadingMore")}
 						onClick={loadMore}
 					/>
 				))}


### PR DESCRIPTION
## What

Passes the required `loadingLabel` prop to the one `LoadMoreButton` call site in `AdministrationPage.tsx` (audit log section) that was missing it.

## Why

`LoadMoreButton`'s `loadingLabel` prop became required when the component was extracted (#1628). Three of the four call sites in this file pass it correctly (`t("administration.loadingMore")`); the audit log one, added around the same time by the admin audit trail work (#1635), never got updated to match. This has been failing `tsc --noEmit` (and therefore `frontend.yml`'s `lint` job / CI's `pnpm check`) on `main` itself since both landed - which in turn fails CI on every branch rebased on top of current `main`.

Found while rebasing several other open PRs onto `main` - five independent rebase passes hit the identical pre-existing `tsc` error in this untouched file.

Closes #

## Testing

- `pnpm exec tsc --noEmit` - passes (was failing before this change)
- `pnpm lint` - clean, zero warnings

## Live verification

Not applicable - one-line type-correctness fix with no behavior change (the translation string it now passes, `administration.loadingMore` / "Loading more...", is already used by the other three `LoadMoreButton` call sites in this same file).

## Checklist

- [x] `/self-review` run and findings addressed (trivial one-line fix matching an established pattern 3x in the same file)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K2eds28vCDNbt3Ed5eqzrS)_