### PR TITLE
fix: isolate OutputCachingTests' anonymous requests from the shared rate-limit bucket

### DIFF
--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -11,11 +11,24 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	[Before(Test)]
 	public Task ResetAsync() => fixture.ResetAsync();
 
+	// Every anonymous request in this class gets its own X-Forwarded-For, same isolation
+	// technique RateLimitingTests.cs already uses. Without it, all of these share one
+	// anonymous-IP rate-limit bucket (60 req/60s, see IntegrationTestFixture) with the rest
+	// of the ~400-test suite - as the suite grows, cumulative anonymous traffic from
+	// unrelated tests can exhaust that shared bucket mid-run and 429 one of this class's two
+	// requests, which output caching then correctly never caches, so the "Age" header
+	// assertion fails even though caching itself works fine.
+	private static HttpClient WithForwardedFor(HttpClient client, string ip)
+	{
+		client.DefaultRequestHeaders.Add("X-Forwarded-For", ip);
+		return client;
+	}
+
 	[Test]
 	public async Task GetBadgeCatalog_ShouldBeServedFromOutputCache_OnASecondRequest(
 		CancellationToken cancellationToken)
 	{
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.1");
 
 		await httpClient.GetAsync("/v1/badges", cancellationToken);
 		var second = await httpClient.GetAsync("/v1/badges", cancellationToken);
@@ -28,7 +41,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	public async Task GetSitemap_ShouldBeServedFromOutputCache_OnASecondRequest(
 		CancellationToken cancellationToken)
 	{
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.2");
 
 		await httpClient.GetAsync("/v1/sitemap.xml", cancellationToken);
 		var second = await httpClient.GetAsync("/v1/sitemap.xml", cancellationToken);
@@ -41,7 +54,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	public async Task GetVolunteerOpportunities_ShouldBeServedFromOutputCache_OnASecondRequest(
 		CancellationToken cancellationToken)
 	{
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.3");
 		const string route = "/v1/volunteer-opportunities?pageNumber=1&pageSize=10";
 
 		await httpClient.GetAsync(route, cancellationToken);
@@ -61,7 +74,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	{
 		const string route = "/v1/volunteer-opportunities?pageNumber=1&pageSize=10";
 
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.4");
 		var before = await httpClient.GetAsync(route, cancellationToken);
 		var beforeBody = await before.Content.ReadAsStringAsync(cancellationToken);
 		beforeBody.Should().NotContain("Freshly published opportunity");
@@ -98,7 +111,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 	public async Task GetHealth_ShouldBeServedFromOutputCache_OnASecondRequest(
 		CancellationToken cancellationToken)
 	{
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.5");
 
 		await httpClient.GetAsync("/health", cancellationToken);
 		var second = await httpClient.GetAsync("/health", cancellationToken);
@@ -117,7 +130,7 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 		var firstOrgId = await CreateOrganizationAsync(authenticatedClient, "Org One", cancellationToken);
 		var secondOrgId = await CreateOrganizationAsync(authenticatedClient, "Org Two", cancellationToken);
 
-		using var httpClient = fixture.CreateHttpClient();
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.6");
 
 		await httpClient.GetAsync($"/v1/organizations/{firstOrgId}/profile", cancellationToken);
 		var firstResponse = await httpClient.GetAsync($"/v1/organizations/{firstOrgId}/profile", cancellationToken);


### PR DESCRIPTION
## What

Gives each anonymous HTTP request in `OutputCachingTests.cs` its own `X-Forwarded-For` header, isolating it from the rate limiter's shared anonymous-IP bucket - the same technique `RateLimitingTests.cs` already uses for its own tests.

## Why

`IntegrationTestFixture` deliberately overrides `RateLimiting:Read:AnonymousPermitLimit` down to the real production default of 60 req/60s (instead of the 10000 `AppHost.cs` uses elsewhere) so `RateLimitingTests.cs` can prove the limiter actually rejects excess anonymous requests. That bucket is shared by every test in the ~400-test `IntegrationTests` suite that hits an anonymous endpoint through the default `fixture.CreateHttpClient()` - as the suite grows, cumulative anonymous traffic from unrelated tests can exhaust the bucket mid-run and 429 one of `OutputCachingTests`' two requests instead of letting it hit the cache. Output caching never caches a 429 (only 200s), so the "Age" header assertion then fails even though caching itself works correctly.

Observed repeatedly while rebasing several unrelated PRs onto `main`: `GetSitemap_ShouldBeServedFromOutputCache_OnASecondRequest` and `GetHealth_ShouldBeServedFromOutputCache_OnASecondRequest` failing identically (same `65/396` progress checkpoint each time) on branches whose only common factor was slightly more test volume than `main`'s own passing baseline - not a regression in any of those PRs' own changes.

`RateLimitingTests.cs` already solved this exact class of problem for itself (see its own comment: "Unique IP so this test's quota is isolated from other test classes"). This applies the same pattern to `OutputCachingTests.cs`.

Closes #

## Testing

- `dotnet build tests/IntegrationTests` - succeeds
- Full `IntegrationTests` run happens in CI (Testcontainers/Docker not available in this sandbox - see root `AGENTS.md`'s Sandbox Limitations)

## Live verification

Not applicable - test-infrastructure-only change, no runtime/production behavior affected.

## Checklist

- [x] `/self-review` run and findings addressed (mechanical, precedented pattern reuse; verified build)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K2eds28vCDNbt3Ed5eqzrS)_