### PR TITLE
refactor: trim process-narration bloat from dashboard and engagement-notify comments

### DIFF
--- a/backend/src/Application/Engagements/CreateEngagement/v1/EngagementCreatedDomainEventHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/EngagementCreatedDomainEventHandler.cs
@@ -9,12 +9,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.CreateEngagement.v1;
 
-// Consumer of EngagementCreatedDomainEvent (#1174): the organizer "New sign-up"
-// email used to be sent inline inside CreateEngagementCommandHandler's DB
-// transaction, once per organizer. Delivery now happens here, dispatched by
-// OutboxProcessorJob like every other domain event, well after the triggering
-// command's transaction has committed - see EngagementOrganizerNotificationHelper
-// for the full rationale.
+// Consumer of EngagementCreatedDomainEvent (#1174) - sends the organizer
+// "New sign-up" email. See EngagementOrganizerNotificationHelper for the
+// full rationale.
 internal sealed class EngagementCreatedDomainEventHandler(
 	IApplicationDbContext dbContext,
 	IUnitOfWork unitOfWork,

--- a/backend/src/Application/Engagements/WithdrawEngagement/v1/EngagementWithdrawnDomainEventHandler.cs
+++ b/backend/src/Application/Engagements/WithdrawEngagement/v1/EngagementWithdrawnDomainEventHandler.cs
@@ -9,11 +9,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.WithdrawEngagement.v1;
 
-// Consumer of EngagementWithdrawnDomainEvent (#1174): the organizer withdrawal
-// email used to be sent inline inside WithdrawEngagementCommandHandler's DB
-// transaction, once per organizer. Mirrors
-// EngagementCreatedDomainEventHandler/EngagementReactivatedDomainEventHandler -
-// see EngagementOrganizerNotificationHelper for the full rationale.
+// Consumer of EngagementWithdrawnDomainEvent (#1174) - sends the organizer
+// withdrawal email. See EngagementOrganizerNotificationHelper for the full
+// rationale.
 internal sealed class EngagementWithdrawnDomainEventHandler(
 	IApplicationDbContext dbContext,
 	IUnitOfWork unitOfWork,

--- a/backend/src/Domain/Organizations/DashboardWidgetPlacement.cs
+++ b/backend/src/Domain/Organizations/DashboardWidgetPlacement.cs
@@ -2,10 +2,8 @@ namespace Domain.Organizations;
 
 // One widget's slot in a customized dashboard: its catalog key plus its
 // organizer-drawn bounding box on the dashboard's grid. X/Y are 1-based
-// grid-cell coordinates and Width/Height are cell spans - the organizer sets
-// all four explicitly by marking two corners on the grid (#782), replacing
-// the automatic packing algorithm that used to derive column/row spans from
-// display order alone.
+// grid-cell coordinates and Width/Height are cell spans, set explicitly by
+// the organizer marking two corners on the grid (#782).
 public sealed record DashboardWidgetPlacement(
 	DashboardWidgetKey WidgetKey,
 	int X,

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
@@ -100,8 +100,7 @@ export const GRID_MAX_ROWS = 100;
 
 // A widget's explicit, organizer-drawn bounding box on the grid - 1-based
 // grid-cell coordinates and cell spans, exactly as stored by the backend
-// (#782). Replaces the automatic skyline packer that used to derive
-// col/colSpan/row/rowSpan purely from display order.
+// (#782).
 export interface PlacedWidget {
 	widgetKey: WidgetKey;
 	x: number;
@@ -110,14 +109,10 @@ export interface PlacedWidget {
 	height: number;
 }
 
-// Layout applied when an organizer hasn't customized their dashboard yet -
-// matches the arrangement the former auto-fit packer used to produce for
-// this same widget order (ToDo+CreateOpportunity side by side, then Upcoming
-// Opportunities, Calendar and Settings each full-width below), now stored as
-// explicit coordinates instead of being recomputed at render time. Heights
-// match each widget's own defaultHeight above (#982 - these used to be taller
-// than any of these widgets actually render, leaving 110-170px of dead space
-// per card on a fresh dashboard).
+// Layout applied when an organizer hasn't customized their dashboard yet:
+// ToDo+CreateOpportunity side by side, then UpcomingOpportunities, Calendar
+// and Settings each full-width below. Heights match each widget's own
+// defaultHeight above so no card leaves dead space.
 export const DEFAULT_LAYOUT: PlacedWidget[] = [
 	{ widgetKey: "CreateOpportunity", x: 1, y: 1, width: 4, height: 1 },
 	{ widgetKey: "ToDo", x: 5, y: 1, width: 4, height: 1 },


### PR DESCRIPTION
Drop repeated "used to work like X" history from the engagement organizer-notification handlers and the #782 dashboard-grid placement comments; the durable WHY already lives in the referenced helper/PR.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
