### PR TITLE
feat: add CSV engagement export for organizers

### DIFF
--- a/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using System.Text;
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Engagements.ExportEngagements.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Engagements.ExportEngagements.v1;
+
+internal sealed class ExportEngagementsEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/volunteer-opportunities/{opportunityId:guid}/engagements/export", ExportEngagementsAsync)
+			.WithName("ExportEngagements")
+			.WithTags("Engagements")
+			.Produces(StatusCodes.Status200OK, contentType: "text/csv")
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> ExportEngagementsAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		var file = await sender.Send(
+			new ExportEngagementsQuery(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), userId),
+			cancellationToken);
+
+		return Results.File(
+			Encoding.UTF8.GetBytes(file.Content),
+			contentType: "text/csv; charset=utf-8",
+			fileDownloadName: file.FileName);
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5910,6 +5910,70 @@
         }
       }
     },
+    "/v1/volunteer-opportunities/{opportunityId}/engagements/export": {
+      "get": {
+        "tags": [
+          "Engagements"
+        ],
+        "operationId": "ExportEngagements",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/engagements/{engagementId}/confirm": {
       "post": {
         "tags": [

--- a/backend/src/Application/Engagements/EngagementExportFile.cs
+++ b/backend/src/Application/Engagements/EngagementExportFile.cs
@@ -1,0 +1,3 @@
+namespace Application.Engagements;
+
+public sealed record EngagementExportFile(string FileName, string Content);

--- a/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQuery.cs
+++ b/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQuery.cs
@@ -1,0 +1,8 @@
+using Application.Common.Messaging;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Application.Engagements.ExportEngagements.v1;
+
+public sealed record ExportEngagementsQuery(VolunteerOpportunityId OpportunityId, UserId RequestingUserId)
+	: IQuery<EngagementExportFile>;

--- a/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using System.Text;
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+
+namespace Application.Engagements.ExportEngagements.v1;
+
+internal sealed class ExportEngagementsQueryHandler(
+	IEngagementReadRepository readRepository,
+	IApplicationDbContext dbContext,
+	IKeycloakUserService keycloakUserService)
+	: IQueryHandler<ExportEngagementsQuery, EngagementExportFile>
+{
+	public async ValueTask<EngagementExportFile> Handle(
+		ExportEngagementsQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(request.OpportunityId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId.Value}' not found."));
+
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		var engagements = await readRepository.GetForExportAsync(request.OpportunityId, cancellationToken);
+
+		var volunteerIds = engagements
+			.Where(e => e.VolunteerId is not null)
+			.Select(e => e.VolunteerId!.Value)
+			.Distinct()
+			.ToList();
+		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
+
+		var content = BuildCsv(engagements, profileMap);
+		return new EngagementExportFile($"engagements-{request.OpportunityId.Value}.csv", content);
+	}
+
+	private static string BuildCsv(
+		List<EngagementSummary> engagements,
+		IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap)
+	{
+		// CRLF line endings explicitly (RFC 4180), not StringBuilder.AppendLine's
+		// Environment.NewLine - a CSV built on Linux CI must byte-for-byte match
+		// one built on a Windows dev machine, and Excel/other spreadsheet tools
+		// expect CRLF regardless of which OS generated the file.
+		var sb = new StringBuilder();
+		sb.Append("Name,Status,Time Slot,Check-in Status,Feedback Rating\r\n");
+
+		foreach (var e in engagements)
+		{
+			var row = new[]
+			{
+				ResolveName(e, profileMap),
+				e.Status,
+				FormatTimeSlot(e.TimeSlotStartDateTime, e.TimeSlotEndDateTime),
+				e.IsCheckedIn ? "Checked in" : "Not checked in",
+				e.FeedbackRating?.ToString(CultureInfo.InvariantCulture) ?? "",
+			};
+			sb.Append(string.Join(",", row.Select(CsvEscape))).Append("\r\n");
+		}
+
+		return sb.ToString();
+	}
+
+	private static string ResolveName(EngagementSummary e, IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap)
+	{
+		if (e.VolunteerId is not Guid volunteerId)
+			return "Anonymized volunteer";
+
+		if (!profileMap.TryGetValue(volunteerId, out var profile))
+			return $"Volunteer {volunteerId}";
+
+		var name = profile.FirstName is not null || profile.LastName is not null
+			? $"{profile.FirstName} {profile.LastName}".Trim()
+			: profile.Username;
+
+		return string.IsNullOrWhiteSpace(name) ? $"Volunteer {volunteerId}" : name;
+	}
+
+	private static string FormatTimeSlot(DateTimeOffset? start, DateTimeOffset? end)
+	{
+		if (start is null)
+			return "";
+
+		var startText = start.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+		if (end is null)
+			return $"{startText} UTC";
+
+		var endText = end.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+		return $"{startText} - {endText} UTC";
+	}
+
+	// RFC 4180: only quote (and escape embedded quotes in) a field that actually
+	// needs it - a volunteer's name or comment field could contain a comma,
+	// quote, or newline that would otherwise break the CSV's column boundaries.
+	private static string CsvEscape(string value)
+	{
+		if (value.IndexOfAny([',', '"', '\n', '\r']) < 0)
+			return value;
+
+		return $"\"{value.Replace("\"", "\"\"")}\"";
+	}
+}

--- a/backend/src/Application/Engagements/IEngagementReadRepository.cs
+++ b/backend/src/Application/Engagements/IEngagementReadRepository.cs
@@ -53,6 +53,16 @@ public interface IEngagementReadRepository
 		int pageSize,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Every engagement for the opportunity, unpaginated, with the live TimeSlot join
+	/// (falling back to the engagement's own snapshot, same rule as <see cref="GetByVolunteerAsync"/>)
+	/// and <see cref="EngagementSummary.FeedbackRating"/> populated - fields the paginated
+	/// organizer list doesn't need but the CSV roster export does.
+	/// </summary>
+	ValueTask<List<EngagementSummary>> GetForExportAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default);
+
 	ValueTask<EngagementCalendarInfo?> GetCalendarInfoAsync(
 		EngagementId engagementId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -378,6 +378,59 @@ internal sealed class EngagementReadRepository(
 		return string.Join(", ", parts);
 	}
 
+	public async ValueTask<List<EngagementSummary>> GetForExportAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default)
+	{
+		var raw = await (
+			from e in dbContext.EngagementsQuery
+			where e.OpportunityId == opportunityId
+			join o in dbContext.VolunteerOpportunitiesQuery on e.OpportunityId equals o.Id
+			join org in dbContext.OrganizationsQuery on o.OrganizationId equals org.Id
+			join ts in dbContext.TimeSlotsQuery on e.TimeSlotId equals ts.Id into tsGroup
+			from ts in tsGroup.DefaultIfEmpty()
+			select new
+			{
+				e.Id,
+				e.OpportunityId,
+				o.Title,
+				OrganizationId = org.Id,
+				OrganizationName = org.Name,
+				e.VolunteerId,
+				e.TimeSlotId,
+				e.Message,
+				e.Status,
+				e.IsCheckedIn,
+				e.FeedbackRating,
+				e.FeedbackSubmittedAt,
+				e.CreatedOn,
+				e.CancellationReason,
+				TimeSlotStart = (DateTimeOffset?)ts.StartDateTime ?? e.TimeSlotStartDateTime,
+				TimeSlotEnd = (DateTimeOffset?)ts.EndDateTime ?? e.TimeSlotEndDateTime,
+			})
+			.OrderBy(x => x.TimeSlotStart ?? DateTimeOffset.MaxValue)
+			.ThenBy(x => x.CreatedOn)
+			.ToListAsync(cancellationToken);
+
+		return raw.Select(x => new EngagementSummary(
+			x.Id.Value,
+			x.OpportunityId.Value,
+			x.Title,
+			x.OrganizationId.Value,
+			x.OrganizationName,
+			x.VolunteerId?.Value,
+			x.TimeSlotId?.Value,
+			x.Message,
+			x.Status.ToString(),
+			x.IsCheckedIn,
+			x.FeedbackSubmittedAt.HasValue,
+			x.CreatedOn,
+			TimeSlotStartDateTime: x.TimeSlotStart,
+			TimeSlotEndDateTime: x.TimeSlotEnd,
+			CancellationReason: x.CancellationReason,
+			FeedbackRating: x.FeedbackRating)).ToList();
+	}
+
 	public async ValueTask<EngagementCalendarInfo?> GetCalendarInfoAsync(
 		EngagementId engagementId,
 		CancellationToken cancellationToken = default)

--- a/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
@@ -1,0 +1,305 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.Engagements.ExportEngagements.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.ExportEngagements;
+
+public class ExportEngagementsQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IEngagementReadRepository _readRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly ExportEngagementsQueryHandler _sut;
+
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
+	private static readonly VolunteerOpportunityId DefaultOpportunityId = VolunteerOpportunityId.New();
+
+	public ExportEngagementsQueryHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
+		_sut = new ExportEngagementsQueryHandler(_readRepository, _dbContext, _keycloakUserService);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns((VolunteerOpportunity?)null);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNameFileAfterOpportunityId(
+		CancellationToken cancellationToken)
+	{
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.FileName.Should().Be($"engagements-{DefaultOpportunityId.Value}.csv");
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnHeaderOnly_WhenNoEngagements(
+		CancellationToken cancellationToken)
+	{
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Be("Name,Status,Time Slot,Check-in Status,Feedback Rating\r\n");
+	}
+
+	[Test]
+	public async Task Handle_ShouldIncludeResolvedName_TimeSlot_CheckIn_AndFeedbackRating_ForACompleteRow(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var start = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero);
+		var end = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.Zero);
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			Guid.NewGuid(),
+			null,
+			"Confirmed",
+			IsCheckedIn: true,
+			HasFeedback: true,
+			DateTimeOffset.UtcNow,
+			TimeSlotStartDateTime: start,
+			TimeSlotEndDateTime: end,
+			FeedbackRating: 5);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera", "Volunteer", "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Vera Volunteer,Confirmed,2026-08-10 09:00 - 2026-08-10 12:00 UTC,Checked in,5");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToUsername_WhenKeycloakProfileHasNoName(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", null, null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("vera,Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToVolunteerId_WhenKeycloakLookupFailsForVolunteer(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain($"Volunteer {volunteerId}");
+	}
+
+	[Test]
+	public async Task Handle_ShouldUseAnonymizedVolunteerLabel_WhenVolunteerIdIsNull(
+		CancellationToken cancellationToken)
+	{
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			null,
+			null,
+			"Cancelled",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Anonymized volunteer,Cancelled");
+	}
+
+	[Test]
+	public async Task Handle_ShouldLeaveTimeSlotBlank_AndNotCheckedIn_AndBlankFeedbackRating_ForIndividualContactWithNoFeedback(
+		CancellationToken cancellationToken)
+	{
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			TimeSlotId: null,
+			Message: "Please let me help",
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Anonymized volunteer,Pending,,Not checked in,\r\n");
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsACommaAndQuote(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera \"The Helper\"", "Doe, Jr.", "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("\"Vera \"\"The Helper\"\" Doe, Jr.\",Pending");
+	}
+
+	private static VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -465,6 +465,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ExportEngagementsAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<EngagementStatusResponse> ConfirmEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -10113,6 +10118,116 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ExportEngagementsAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/engagements/export"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/engagements/export");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -499,4 +499,86 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 
 		upcoming.Items.Select(e => e.Id).Should().ContainInOrder(soonerEngagement.Id.Value, laterEngagement.Id.Value);
 	}
+
+	// --- GetForExportAsync (#1045) ---
+
+	[Test]
+	public async Task GetForExportAsync_ShouldIncludeTimeSlotTimesAndFeedbackRating(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"ExportOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var slot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), slot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		engagement.CheckIn().ThrowIfFailure();
+		engagement.SubmitFeedback(4, "Great shift", DateTimeOffset.UtcNow).ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var items = await repository.GetForExportAsync(opportunity.Id, cancellationToken);
+
+		var item = items.Should().ContainSingle().Which;
+		item.Should().BeEquivalentTo(new
+		{
+			OpportunityTitle = "Titel",
+			OrganizationName = organization.Name,
+			IsCheckedIn = true,
+			FeedbackRating = 4,
+		}, options => options.ExcludingMissingMembers());
+		// Postgres timestamptz has microsecond precision vs. DateTimeOffset's
+		// 100ns ticks, so a round-tripped value can differ by a sub-microsecond
+		// rounding error - the same reason other tests in this file compare
+		// timestamps loosely rather than for exact equality.
+		item.TimeSlotStartDateTime.Should().BeCloseTo(slot.StartDateTime, TimeSpan.FromMilliseconds(1));
+		item.TimeSlotEndDateTime.Should().BeCloseTo(slot.EndDateTime, TimeSpan.FromMilliseconds(1));
+	}
+
+	[Test]
+	public async Task GetForExportAsync_ShouldLeaveTimeSlotAndFeedbackNull_ForIndividualContactEngagement(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var opportunityId = VolunteerOpportunityId.New();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"ExportOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, UserId.New(), "Please let me help").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var items = await repository.GetForExportAsync(opportunity.Id, cancellationToken);
+
+		items.Should().ContainSingle()
+			.Which.Should().BeEquivalentTo(new
+			{
+				TimeSlotStartDateTime = (DateTimeOffset?)null,
+				TimeSlotEndDateTime = (DateTimeOffset?)null,
+				FeedbackRating = (int?)null,
+				IsCheckedIn = false,
+			}, options => options.ExcludingMissingMembers());
+	}
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5389,6 +5389,67 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
+    exportEngagements(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/engagements/export";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processExportEngagements(_response);
+        });
+    }
+
+    protected processExportEngagements(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return OK
+     */
     confirmEngagement(engagementId: string, signal?: AbortSignal): Promise<EngagementStatusResponse> {
         let url_ = this.baseUrl + "/v1/engagements/{engagementId}/confirm";
         if (engagementId === undefined || engagementId === null)

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -390,6 +390,18 @@ export function CalendarIcon({ className = "h-3.5 w-3.5" }: IconProps) {
 	);
 }
 
+export function ArrowDownTrayIcon({ className = "h-4 w-4" }: IconProps) {
+	return (
+		<StrokeIcon className={className}>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 12m0 0 4.5-4.5M12 12V3"
+			/>
+		</StrokeIcon>
+	);
+}
+
 export function QrCodeIcon({ className = "h-4 w-4" }: IconProps) {
 	return (
 		<StrokeIcon className={className}>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -643,6 +643,9 @@
       "bulkCancelSuccess_other": "{{count}} abgesagt.",
       "bulkCancelPartial": "{{succeeded}} abgesagt, {{failed}} fehlgeschlagen.",
       "bulkCancelError": "Fehler beim Absagen der Auswahl",
+      "exportButton": "Exportieren",
+      "exportButtonLoading": "Wird exportiert…",
+      "exportError": "Fehler beim Exportieren der Anmeldungen",
       "status": {
         "Pending": "Ausstehend",
         "Confirmed": "Bestätigt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -643,6 +643,9 @@
       "bulkCancelSuccess_other": "{{count}} cancelled.",
       "bulkCancelPartial": "{{succeeded}} cancelled, {{failed}} failed.",
       "bulkCancelError": "Error cancelling selected applications",
+      "exportButton": "Export",
+      "exportButtonLoading": "Exporting…",
+      "exportError": "Error exporting sign-ups",
       "status": {
         "Pending": "Pending",
         "Confirmed": "Confirmed",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "react-oidc-context";
 import type {
 	EngagementSummary,
 	FeedbackItemDto,
@@ -9,6 +10,7 @@ import type {
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
+import { runtimeConfig } from "../lib/runtimeConfig";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
@@ -27,7 +29,12 @@ import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
 import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
-import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
+import {
+	ArrowDownTrayIcon,
+	CheckIconSolid,
+	QrCodeIcon,
+	StarIcon,
+} from "../components/icons";
 import type { OrgAppContext } from "../layouts/OrgAppLayout";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
@@ -41,6 +48,7 @@ export default function EngagementManagementPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
 	const { isOrganizer } = useOutletContext<OrgAppContext>();
 	const api = useApiClient();
+	const auth = useAuth();
 	const { t, i18n } = useTranslation();
 	const [opportunity, setOpportunity] =
 		useState<VolunteerOpportunityDetails | null>(null);
@@ -82,6 +90,8 @@ export default function EngagementManagementPage() {
 	const [checkingIn, setCheckingIn] = useState<string | null>(null);
 	const [undoingCheckIn, setUndoingCheckIn] = useState<string | null>(null);
 	const [qrScannerOpen, setQrScannerOpen] = useState(false);
+	const [exporting, setExporting] = useState(false);
+	const [exportError, setExportError] = useState<string | null>(null);
 
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 	const [bulkConfirming, setBulkConfirming] = useState(false);
@@ -454,6 +464,47 @@ export default function EngagementManagementPage() {
 		setCancelError(null);
 	}
 
+	// Not routed through useApiClient()/EinsatzbereitApi: NSwag has no typed
+	// response for a file-returning endpoint (see GetEngagementCalendar's
+	// generated client method, which discards the body and returns void), so
+	// this needs a raw authenticated fetch + blob download instead - the same
+	// pattern DangerZoneCard uses for the GDPR data export download.
+	async function handleExport() {
+		if (!opportunityId) return;
+		setExporting(true);
+		setExportError(null);
+		try {
+			const response = await fetch(
+				`${runtimeConfig.apiUrl}/v1/volunteer-opportunities/${opportunityId}/engagements/export`,
+				{
+					headers: {
+						Authorization: `Bearer ${auth.user?.access_token ?? ""}`,
+					},
+				},
+			);
+			if (!response.ok) {
+				throw new Error(t("engagementManagement.exportError"));
+			}
+			const blob = await response.blob();
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `engagements-${opportunityId}.csv`;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			setExportError(
+				err instanceof Error
+					? err.message
+					: t("engagementManagement.exportError"),
+			);
+		} finally {
+			setExporting(false);
+		}
+	}
+
 	if (notFound) {
 		return <NotFoundPage />;
 	}
@@ -486,6 +537,22 @@ export default function EngagementManagementPage() {
 					</Button>
 				</div>
 			)}
+
+			<div className="mb-4 flex justify-end">
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={handleExport}
+					disabled={exporting}
+				>
+					<ArrowDownTrayIcon className="h-4 w-4" />
+					{exporting
+						? t("engagementManagement.exportButtonLoading")
+						: t("engagementManagement.exportButton")}
+				</Button>
+			</div>
+			{exportError && <ErrorBanner message={exportError} className="mb-4" />}
 
 			<div className="mb-4 flex flex-wrap items-end gap-3">
 				<div>


### PR DESCRIPTION
Add GET /volunteer-opportunities/{id}/engagements/export returning a CSV roster (name, status, time slot, check-in status, feedback rating) so organizers can produce a sign-in sheet without transcribing from the browser. Add an Export button to EngagementManagementPage.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1045

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
