### PR TITLE
fix: hide check-in button when method can't process a check-in

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7838,6 +7838,10 @@
               "string"
             ],
             "format": "date-time"
+          },
+          "checkInMethod": {
+            "type": "string",
+            "default": "None"
           }
         }
       },

--- a/backend/src/Application/Engagements/EngagementSummary.cs
+++ b/backend/src/Application/Engagements/EngagementSummary.cs
@@ -22,4 +22,5 @@ public sealed record EngagementSummary(
 	string? CancellationReason = null,
 	int? FeedbackRating = null,
 	string? FeedbackComment = null,
-	DateTimeOffset? FeedbackSubmittedAt = null);
+	DateTimeOffset? FeedbackSubmittedAt = null,
+	string CheckInMethod = "None");

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -21,7 +21,7 @@ internal sealed class EngagementReadRepository(
 		var raw = await dbContext.EngagementsQuery
 			.Where(e => e.OpportunityId == opportunityId)
 			.Join(
-				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId }),
+				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId, o.CheckInMethod }),
 				e => e.OpportunityId,
 				o => o.Id,
 				(e, o) => new
@@ -30,6 +30,7 @@ internal sealed class EngagementReadRepository(
 					e.OpportunityId,
 					OpportunityTitle = o.Title,
 					o.OrganizationId,
+					o.CheckInMethod,
 					e.VolunteerId,
 					e.TimeSlotId,
 					e.Message,
@@ -50,6 +51,7 @@ internal sealed class EngagementReadRepository(
 					x.OpportunityTitle,
 					OrganizationId = org.Id,
 					OrganizationName = org.Name,
+					x.CheckInMethod,
 					x.VolunteerId,
 					x.TimeSlotId,
 					x.Message,
@@ -75,7 +77,8 @@ internal sealed class EngagementReadRepository(
 			x.IsCheckedIn,
 			x.FeedbackSubmittedAt.HasValue,
 			x.CreatedOn,
-			CancellationReason: x.CancellationReason)).ToList();
+			CancellationReason: x.CancellationReason,
+			CheckInMethod: x.CheckInMethod.ToString())).ToList();
 	}
 
 	public async ValueTask<PagedList<EngagementSummary>> GetPagedByOpportunityAsync(
@@ -114,7 +117,7 @@ internal sealed class EngagementReadRepository(
 
 		var raw = await scopedQuery
 			.Join(
-				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId }),
+				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId, o.CheckInMethod }),
 				e => e.OpportunityId,
 				o => o.Id,
 				(e, o) => new
@@ -123,6 +126,7 @@ internal sealed class EngagementReadRepository(
 					e.OpportunityId,
 					OpportunityTitle = o.Title,
 					o.OrganizationId,
+					o.CheckInMethod,
 					e.VolunteerId,
 					e.TimeSlotId,
 					e.Message,
@@ -143,6 +147,7 @@ internal sealed class EngagementReadRepository(
 					x.OpportunityTitle,
 					OrganizationId = org.Id,
 					OrganizationName = org.Name,
+					x.CheckInMethod,
 					x.VolunteerId,
 					x.TimeSlotId,
 					x.Message,
@@ -188,7 +193,8 @@ internal sealed class EngagementReadRepository(
 			VolunteerPhone: x.VolunteerId is not null
 				? phonesByVolunteerId.GetValueOrDefault(x.VolunteerId.Value.Value)
 				: null,
-			CancellationReason: x.CancellationReason)).ToList();
+			CancellationReason: x.CancellationReason,
+			CheckInMethod: x.CheckInMethod.ToString())).ToList();
 
 		return new PagedList<EngagementSummary>(items, totalCount, pageNumber, pageSize);
 	}
@@ -295,7 +301,7 @@ internal sealed class EngagementReadRepository(
 		var opportunityIds = engagements.Select(e => e.OpportunityId).Distinct().ToList();
 		var opportunities = await dbContext.VolunteerOpportunitiesQuery
 			.Where(o => opportunityIds.Contains(o.Id))
-			.Select(o => new { o.Id, o.Title, o.IsRemote, o.Address, o.OrganizationId })
+			.Select(o => new { o.Id, o.Title, o.IsRemote, o.Address, o.OrganizationId, o.CheckInMethod })
 			.ToDictionaryAsync(o => o.Id, cancellationToken);
 
 		var organizationIds = opportunities.Values.Select(o => o.OrganizationId).Distinct().ToList();
@@ -359,7 +365,8 @@ internal sealed class EngagementReadRepository(
 				CancellationReason: e.CancellationReason,
 				FeedbackRating: e.FeedbackRating,
 				FeedbackComment: e.FeedbackComment,
-				FeedbackSubmittedAt: e.FeedbackSubmittedAt);
+				FeedbackSubmittedAt: e.FeedbackSubmittedAt,
+				CheckInMethod: (opportunity?.CheckInMethod ?? CheckInMethod.None).ToString());
 		}).ToList();
 	}
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12433,6 +12433,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("feedbackSubmittedAt")]
         public System.DateTimeOffset? FeedbackSubmittedAt { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("checkInMethod")]
+        public string CheckInMethod { get; set; } = "None";
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -392,6 +392,92 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 			.Which.CancellationReason.Should().Be("Position filled");
 	}
 
+	// Regression for #1016: EngagementSummary never carried CheckInMethod, so the
+	// frontend couldn't tell a QRCode/PINCode opportunity (where a "Check in" button
+	// makes sense) apart from a Manual or None one (where it doesn't) and always
+	// rendered the button.
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldIncludeCheckInMethod_FromOpportunity(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"CheckInMethodOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.QRCode, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, volunteerId, "Please let me help.").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetByVolunteerAsync(volunteerId, upcoming: true, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CheckInMethod.Should().Be("QRCode");
+	}
+
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldDefaultCheckInMethodToNone_WhenOpportunityWasDeleted(
+		CancellationToken cancellationToken)
+	{
+		// Same no-inner-join scenario as the CancellationReason regression above
+		// (#667): a hard-deleted opportunity leaves no row to join CheckInMethod
+		// from, so the mapping must fall back to a safe default rather than throw.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+		var opportunityId = VolunteerOpportunityId.New();
+
+		var engagement = Engagement.CreateIndividualContact(opportunityId, volunteerId, "Please let me help.").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		// A Pending engagement whose opportunity no longer exists moves to the Past
+		// bucket (#703) - see GetByVolunteerAsync's opportunityExists handling.
+		var page = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CheckInMethod.Should().Be("None");
+	}
+
+	[Test]
+	public async Task GetPagedByOpportunityAsync_ShouldIncludeCheckInMethod_FromOpportunity(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"CheckInMethodOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.PINCode, new RandomPinGenerator(),
+			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, UserId.New(), "Please let me help.").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var page = await repository.GetPagedByOpportunityAsync(opportunity.Id, pageNumber: 1, pageSize: 10, cancellationToken: cancellationToken);
+
+		page.Items.Should().ContainSingle()
+			.Which.CheckInMethod.Should().Be("PINCode");
+	}
+
 	// --- Current & Upcoming never expiring (#1163) ---
 
 	[Test]

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -14,12 +14,16 @@ namespace VisualTests;
 public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	/// <summary>
-	/// Regression for #671: the "Check in" modal rendered no branch for
-	/// checkInMethod == "None", so clicking "Check in" on such an engagement
-	/// opened a blank modal with only a title and a "Done" button.
+	/// Regression for #1016: the "Check in" button used to render for every
+	/// Confirmed engagement regardless of the opportunity's CheckInMethod, so a
+	/// None-method opportunity (the wizard default) showed a button that only ever
+	/// led to a modal saying no check-in was needed. It must not render at all now.
+	/// Supersedes the #671 regression test that used to click this same button to
+	/// assert the modal's None-method instruction text - that click-through is no
+	/// longer reachable from the UI once the button itself is gone for this method.
 	/// </summary>
 	[Test]
-	public async Task CheckInModal_ShowsInstruction_ForNoneCheckInMethod()
+	public async Task CheckInButton_IsHidden_ForNoneCheckInMethod()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var backend = Fixture.GetEndpoint("backend");
@@ -69,12 +73,71 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var row = Page.Locator("li", new() { HasText = oppTitle });
 		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await row.GetByRole(AriaRole.Button, new() { Name = "Check in" }).ClickAsync();
-		var dialog = Page.Locator("[role='dialog']");
-		await Expect(dialog).ToBeVisibleAsync();
+		// Give the card a moment to finish rendering its action row before
+		// asserting a negative - there's no positive signal to wait on here.
+		await Page.WaitForTimeoutAsync(500);
+		await Expect(row.GetByRole(AriaRole.Button, new() { Name = "Check in" })).Not.ToBeVisibleAsync();
+	}
 
-		await Expect(dialog.GetByText("This opportunity doesn't require an explicit check-in step."))
+	/// <summary>
+	/// Regression for #1016: a Manual-method opportunity must show inline
+	/// instructional text instead of a "Check in" button, since clicking it can't
+	/// actually check the volunteer in - only the organizer can do that.
+	/// </summary>
+	[Test]
+	public async Task CheckInButton_ShowsInlineText_ForManualCheckInMethod()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInManual Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"CheckInManual Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by CheckInAndSlotTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "Manual",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var engagementResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Applying via CheckInAndSlotTests regression check." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await http.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/profile?tab=engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var row = Page.Locator("li", new() { HasText = oppTitle });
+		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(row.GetByText("The organizer will check you in manually."))
 			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(row.GetByRole(AriaRole.Button, new() { Name = "Check in" })).Not.ToBeVisibleAsync();
 	}
 
 	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)

--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -40,7 +40,10 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 			isRemote = true,
 			occurrence = "OneTime",
 			participationType = "IndividualContact",
-			checkInMethod = "None",
+			// einsatzbereit#1016: the "Check in" button only renders for QRCode/PINCode
+			// opportunities now, so this race (organizer deletes the opportunity between
+			// list load and button click) needs a method that still shows the button.
+			checkInMethod = "QRCode",
 			validUntil = DateTimeOffset.UtcNow.AddDays(30),
 			isDraft = false,
 		});

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6307,6 +6307,7 @@ export interface EngagementSummary {
     feedbackRating?: number | undefined;
     feedbackComment?: string | undefined;
     feedbackSubmittedAt?: Date | undefined;
+    checkInMethod?: string;
 
     [key: string]: any;
 }

--- a/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/ActivitySection.tsx
@@ -464,10 +464,20 @@ export default function ActivitySection() {
 							<div className="mt-auto flex flex-wrap items-center gap-2">
 								{e.status === "Confirmed" &&
 									!e.isCheckedIn &&
-									e.opportunityTitle && (
+									e.opportunityTitle &&
+									(e.checkInMethod === "QRCode" ||
+										e.checkInMethod === "PINCode") && (
 										<Button onClick={() => setCheckInEngagement(e)} size="sm">
 											{t("checkIn.buttonLabel")}
 										</Button>
+									)}
+								{e.status === "Confirmed" &&
+									!e.isCheckedIn &&
+									e.opportunityTitle &&
+									e.checkInMethod === "Manual" && (
+										<span className="text-xs text-gray-500">
+											{t("checkIn.manualInstruction")}
+										</span>
 									)}
 								{e.isCheckedIn && !e.hasFeedback && (
 									<button


### PR DESCRIPTION
EngagementSummary lacked checkInMethod, so the volunteer's engagement card always showed a "Check in" button regardless of the opportunity's CheckInMethod - CheckInMethod.None (the wizard default) led to a modal that just said no check-in was needed.

Add checkInMethod to EngagementSummary and gate the button on it: render for QRCode/PINCode, show inline text for Manual, nothing for None.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1016

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
