### PR TITLE
feat: add search and flagged/deleted filters to admin organization list

### DIFF
--- a/backend/src/Api/Organizations/ListOrganizations/v1/ListOrganizationsEndpoint.cs
+++ b/backend/src/Api/Organizations/ListOrganizations/v1/ListOrganizationsEndpoint.cs
@@ -25,10 +25,15 @@ internal sealed class ListOrganizationsEndpoint : IEndpoint
 	private static async Task<IResult> ListOrganizationsAsync(
 		[FromQuery] int pageNumber,
 		[FromQuery] int pageSize,
+		[FromQuery] string? search,
+		[FromQuery] bool? deleted,
+		[FromQuery] bool? flagged,
 		[FromServices] ISender sender,
 		CancellationToken cancellationToken)
 	{
-		var result = await sender.Send(new ListOrganizationsQuery(pageNumber, pageSize), cancellationToken);
+		var result = await sender.Send(
+			new ListOrganizationsQuery(pageNumber, pageSize, search, deleted, flagged),
+			cancellationToken);
 
 		return Results.Ok(result);
 	}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -3910,6 +3910,27 @@
               ],
               "format": "int32"
             }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "flagged",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/backend/src/Application/Organizations/IAdminOrganizationReadRepository.cs
+++ b/backend/src/Application/Organizations/IAdminOrganizationReadRepository.cs
@@ -8,5 +8,8 @@ public interface IAdminOrganizationReadRepository
 	ValueTask<PagedList<AdminOrganizationSummary>> GetPagedAsync(
 		int pageNumber,
 		int pageSize,
+		string? search,
+		bool? deleted,
+		bool? flagged,
 		CancellationToken cancellationToken = default);
 }

--- a/backend/src/Application/Organizations/ListOrganizations/v1/ListOrganizationsQuery.cs
+++ b/backend/src/Application/Organizations/ListOrganizations/v1/ListOrganizationsQuery.cs
@@ -5,5 +5,8 @@ namespace Application.Organizations.ListOrganizations.v1;
 
 public sealed record ListOrganizationsQuery(
 	int PageNumber,
-	int PageSize)
+	int PageSize,
+	string? Search = null,
+	bool? Deleted = null,
+	bool? Flagged = null)
 	: IQuery<PagedList<AdminOrganizationSummary>>;

--- a/backend/src/Application/Organizations/ListOrganizations/v1/ListOrganizationsQueryHandler.cs
+++ b/backend/src/Application/Organizations/ListOrganizations/v1/ListOrganizationsQueryHandler.cs
@@ -16,6 +16,12 @@ internal sealed class ListOrganizationsQueryHandler(
 		var pageNumber = Math.Max(1, request.PageNumber);
 		var pageSize = Math.Clamp(request.PageSize, 1, MaxPageSize);
 
-		return await readRepository.GetPagedAsync(pageNumber, pageSize, cancellationToken);
+		return await readRepository.GetPagedAsync(
+			pageNumber,
+			pageSize,
+			request.Search,
+			request.Deleted,
+			request.Flagged,
+			cancellationToken);
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminOrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminOrganizationReadRepository.cs
@@ -1,7 +1,11 @@
+using Application.Common.Exceptions;
 using Application.Common.Pagination;
 using Application.Organizations;
 using Application.Organizations.ListOrganizations.v1;
+using Domain.Organizations;
+using Domain.Reports;
 using Infrastructure.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
 
@@ -12,9 +16,37 @@ internal sealed class AdminOrganizationReadRepository(
 	public async ValueTask<PagedList<AdminOrganizationSummary>> GetPagedAsync(
 		int pageNumber,
 		int pageSize,
+		string? search,
+		bool? deleted,
+		bool? flagged,
 		CancellationToken cancellationToken = default)
 	{
-		var paged = await dbContext.OrganizationsQuery
+		var query = deleted == true
+			? dbContext.OrganizationsQuery.IgnoreQueryFilters().Where(o => o.IsDeleted)
+			: dbContext.OrganizationsQuery;
+
+		if (!string.IsNullOrWhiteSpace(search))
+		{
+			var normalizedSearch = search.ToLower();
+			query = query.Where(o => o.Name.ToLower().Contains(normalizedSearch));
+		}
+
+		if (flagged == true)
+		{
+			var flaggedOrganizationIds = await dbContext.ReportsQuery
+				.Where(r => r.TargetType == ReportTargetType.Organization && r.Status == ReportStatus.Open)
+				.Select(r => r.TargetId)
+				.Distinct()
+				.ToListAsync(cancellationToken);
+
+			var flaggedOrganizationIdVOs = flaggedOrganizationIds
+				.Select(id => OrganizationId.Create(id).GetValueOrThrow())
+				.ToList();
+
+			query = query.Where(o => flaggedOrganizationIdVOs.Contains(o.Id));
+		}
+
+		var paged = await query
 			.OrderBy(o => o.Name)
 			.ThenBy(o => o.Id)
 			.ToPagedListAsync(pageNumber, pageSize, cancellationToken);

--- a/backend/tests/Application.UnitTests/Organizations/ListOrganizations/ListOrganizationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ListOrganizations/ListOrganizationsQueryHandlerTests.cs
@@ -15,7 +15,13 @@ public class ListOrganizationsQueryHandlerTests
 	public ListOrganizationsQueryHandlerTests()
 	{
 		_readRepo
-			.GetPagedAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.GetPagedAsync(
+				Arg.Any<int>(),
+				Arg.Any<int>(),
+				Arg.Any<string?>(),
+				Arg.Any<bool?>(),
+				Arg.Any<bool?>(),
+				Arg.Any<CancellationToken>())
 			.Returns(new PagedList<AdminOrganizationSummary>([], 0, 1, 10));
 		_sut = new ListOrganizationsQueryHandler(_readRepo);
 	}
@@ -28,7 +34,7 @@ public class ListOrganizationsQueryHandlerTests
 		var item = new AdminOrganizationSummary(Guid.NewGuid(), "Fire Department", null);
 
 		_readRepo
-			.GetPagedAsync(1, 10, cancellationToken)
+			.GetPagedAsync(1, 10, null, null, null, cancellationToken)
 			.Returns(new PagedList<AdminOrganizationSummary>([item], 1, 1, 10));
 
 		// Act
@@ -44,7 +50,7 @@ public class ListOrganizationsQueryHandlerTests
 	{
 		await _sut.Handle(new ListOrganizationsQuery(0, 10), cancellationToken);
 
-		await _readRepo.Received(1).GetPagedAsync(1, 10, cancellationToken);
+		await _readRepo.Received(1).GetPagedAsync(1, 10, null, null, null, cancellationToken);
 	}
 
 	[Test]
@@ -53,7 +59,7 @@ public class ListOrganizationsQueryHandlerTests
 	{
 		await _sut.Handle(new ListOrganizationsQuery(-5, 10), cancellationToken);
 
-		await _readRepo.Received(1).GetPagedAsync(1, 10, cancellationToken);
+		await _readRepo.Received(1).GetPagedAsync(1, 10, null, null, null, cancellationToken);
 	}
 
 	[Test]
@@ -62,7 +68,7 @@ public class ListOrganizationsQueryHandlerTests
 	{
 		await _sut.Handle(new ListOrganizationsQuery(1, 0), cancellationToken);
 
-		await _readRepo.Received(1).GetPagedAsync(1, 1, cancellationToken);
+		await _readRepo.Received(1).GetPagedAsync(1, 1, null, null, null, cancellationToken);
 	}
 
 	[Test]
@@ -71,6 +77,17 @@ public class ListOrganizationsQueryHandlerTests
 	{
 		await _sut.Handle(new ListOrganizationsQuery(1, 5000), cancellationToken);
 
-		await _readRepo.Received(1).GetPagedAsync(1, 100, cancellationToken);
+		await _readRepo.Received(1).GetPagedAsync(1, 100, null, null, null, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldPassSearchDeletedAndFlagged_ToReadRepository(
+		CancellationToken cancellationToken)
+	{
+		await _sut.Handle(
+			new ListOrganizationsQuery(1, 10, "Fire", true, true),
+			cancellationToken);
+
+		await _readRepo.Received(1).GetPagedAsync(1, 10, "Fire", true, true, cancellationToken);
 	}
 }

--- a/backend/tests/IntegrationTests/AdminEndpointAuthorizationTests.cs
+++ b/backend/tests/IntegrationTests/AdminEndpointAuthorizationTests.cs
@@ -22,7 +22,7 @@ public class AdminEndpointAuthorizationTests(
 	{
 		var client = new EinsatzbereitApi(fixture.CreateHttpClient());
 
-		var act = () => client.ListOrganizationsAsync(1, 20, cancellationToken);
+		var act = () => client.ListOrganizationsAsync(1, 20, cancellationToken: cancellationToken);
 
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(401);
@@ -34,7 +34,7 @@ public class AdminEndpointAuthorizationTests(
 	{
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 
-		var act = () => olafClient.ListOrganizationsAsync(1, 20, cancellationToken);
+		var act = () => olafClient.ListOrganizationsAsync(1, 20, cancellationToken: cancellationToken);
 
 		var ex = await act.Should().ThrowAsync<ApiException>();
 		ex.Which.StatusCode.Should().Be(403);

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -315,7 +315,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, string? search = null, bool? deleted = null, bool? flagged = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
@@ -6880,7 +6880,7 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<PagedListOfAdminOrganizationSummary> ListOrganizationsAsync(int pageNumber, int pageSize, string? search = null, bool? deleted = null, bool? flagged = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (pageNumber == null)
                 throw new System.ArgumentNullException("pageNumber");
@@ -6904,6 +6904,18 @@ namespace IntegrationTests
                     urlBuilder_.Append('?');
                     urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    if (search != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("search")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(search, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (deleted != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("deleted")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(deleted, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (flagged != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("flagged")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(flagged, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
                     urlBuilder_.Length--;
 
                     PrepareRequest(client_, request_, urlBuilder_);

--- a/backend/tests/IntegrationTests/ListOrganizationsFilterTests.cs
+++ b/backend/tests/IntegrationTests/ListOrganizationsFilterTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Coverage for #1054: the admin organization list gained Search, Deleted, and
+// Flagged query params so admins can find a pending organization without
+// paging through the whole table.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class ListOrganizationsFilterTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task ListOrganizations_ShouldFilterByCaseInsensitiveNameSearch(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var matchName = $"Feuerwehr Alpha {Guid.NewGuid()}";
+		var otherName = $"Wasserwacht Beta {Guid.NewGuid()}";
+		await CreateOrganizationAsync(olafClient, matchName, cancellationToken);
+		await CreateOrganizationAsync(olafClient, otherName, cancellationToken);
+
+		var result = await adminClient.ListOrganizationsAsync(
+			1, 50, search: "alpha", cancellationToken: cancellationToken);
+
+		result.Items.Should().ContainSingle(o => o.Name == matchName);
+	}
+
+	[Test]
+	public async Task ListOrganizations_ShouldExcludeDeletedOrganizations_ByDefault(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var name = $"ToDelete {Guid.NewGuid()}";
+		var orgId = await CreateOrganizationAsync(olafClient, name, cancellationToken);
+		await adminClient.AdminShadowDeleteOrganizationAsync(orgId, cancellationToken);
+
+		var result = await adminClient.ListOrganizationsAsync(
+			1, 50, search: name, cancellationToken: cancellationToken);
+
+		result.Items.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task ListOrganizations_ShouldReturnOnlyDeletedOrganizations_WhenDeletedFilterIsTrue(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var deletedName = $"Deleted {Guid.NewGuid()}";
+		var activeName = $"Active {Guid.NewGuid()}";
+		var deletedId = await CreateOrganizationAsync(olafClient, deletedName, cancellationToken);
+		await CreateOrganizationAsync(olafClient, activeName, cancellationToken);
+		await adminClient.AdminShadowDeleteOrganizationAsync(deletedId, cancellationToken);
+
+		var result = await adminClient.ListOrganizationsAsync(
+			1, 50, deleted: true, cancellationToken: cancellationToken);
+
+		result.Items.Should().ContainSingle(o => o.Id == deletedId);
+	}
+
+	[Test]
+	public async Task ListOrganizations_ShouldReturnOnlyFlaggedOrganizations_WhenFlaggedFilterIsTrue(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var flaggedName = $"Flagged {Guid.NewGuid()}";
+		var unflaggedName = $"Unflagged {Guid.NewGuid()}";
+		var flaggedId = await CreateOrganizationAsync(olafClient, flaggedName, cancellationToken);
+		await CreateOrganizationAsync(olafClient, unflaggedName, cancellationToken);
+
+		await veraClient.ReportOrganizationAsync(
+			flaggedId,
+			new ReportOrganizationRequest { Reason = "Other", Details = "Integration test report" },
+			cancellationToken);
+
+		var result = await adminClient.ListOrganizationsAsync(
+			1, 50, flagged: true, cancellationToken: cancellationToken);
+
+		result.Items.Should().ContainSingle(o => o.Id == flaggedId);
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, string name, CancellationToken cancellationToken)
+	{
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = name }, cancellationToken);
+		return org.Id.Value;
+	}
+}

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -34,7 +34,13 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 			await Page.Locator("#admin-user-search").FillAsync(username);
-			await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
+			// einsatzbereit#1054 added a second "Search" button (organization
+			// list), so the unscoped role lookup now matches two elements -
+			// scope to the form containing the user-search input.
+			await Page.Locator("form")
+				.Filter(new() { Has = Page.Locator("#admin-user-search") })
+				.GetByRole(AriaRole.Button, new() { Name = "Search" })
+				.ClickAsync();
 
 			// einsatzbereit#1294: Block/Promote carry a per-row aria-label (the
 			// user's name interpolated into the middle of the phrase, e.g.
@@ -78,7 +84,13 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 			await Page.Locator("#admin-user-search").FillAsync(username);
-			await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
+			// einsatzbereit#1054 added a second "Search" button (organization
+			// list), so the unscoped role lookup now matches two elements -
+			// scope to the form containing the user-search input.
+			await Page.Locator("form")
+				.Filter(new() { Has = Page.Locator("#admin-user-search") })
+				.GetByRole(AriaRole.Button, new() { Name = "Search" })
+				.ClickAsync();
 
 			var row = Page.Locator("li").Filter(new() { HasTextString = username });
 			await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
@@ -132,7 +144,13 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Page.Locator("#admin-user-search").FillAsync("admin");
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Search" }).ClickAsync();
+		// einsatzbereit#1054 added a second "Search" button (organization
+		// list), so the unscoped role lookup now matches two elements -
+		// scope to the form containing the user-search input.
+		await Page.Locator("form")
+			.Filter(new() { Has = Page.Locator("#admin-user-search") })
+			.GetByRole(AriaRole.Button, new() { Name = "Search" })
+			.ClickAsync();
 
 		var ownRow = Page.Locator("li").Filter(new() { HasTextString = "admin@example.com" });
 		await Expect(ownRow).ToBeVisibleAsync(new() { Timeout = 15_000 });

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -3552,9 +3552,12 @@ export class EinsatzbereitApi {
     }
 
     /**
+     * @param search (optional) 
+     * @param deleted (optional) 
+     * @param flagged (optional) 
      * @return OK
      */
-    listOrganizations(pageNumber: number, pageSize: number, signal?: AbortSignal): Promise<PagedListOfAdminOrganizationSummary> {
+    listOrganizations(pageNumber: number, pageSize: number, search: string | undefined, deleted: boolean | undefined, flagged: boolean | undefined, signal?: AbortSignal): Promise<PagedListOfAdminOrganizationSummary> {
         let url_ = this.baseUrl + "/v1/admin/organizations?";
         if (pageNumber === undefined || pageNumber === null)
             throw new globalThis.Error("The parameter 'pageNumber' must be defined and cannot be null.");
@@ -3564,6 +3567,18 @@ export class EinsatzbereitApi {
             throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
         else
             url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (search === null)
+            throw new globalThis.Error("The parameter 'search' cannot be null.");
+        else if (search !== undefined)
+            url_ += "search=" + encodeURIComponent("" + search) + "&";
+        if (deleted === null)
+            throw new globalThis.Error("The parameter 'deleted' cannot be null.");
+        else if (deleted !== undefined)
+            url_ += "deleted=" + encodeURIComponent("" + deleted) + "&";
+        if (flagged === null)
+            throw new globalThis.Error("The parameter 'flagged' cannot be null.");
+        else if (flagged !== undefined)
+            url_ += "flagged=" + encodeURIComponent("" + flagged) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1092,7 +1092,12 @@
         "loading": "Organisationen werden geladen…",
         "error": "Organisationen konnten nicht geladen werden.",
         "noOrganizations": "Keine Organisationen gefunden.",
-        "loadMore": "Mehr laden"
+        "loadMore": "Mehr laden",
+        "searchLabel": "Organisationen durchsuchen",
+        "searchPlaceholder": "Nach Name suchen",
+        "searchButton": "Suchen",
+        "flaggedOnlyLabel": "Nur gemeldete",
+        "deletedOnlyLabel": "Nur gelöschte"
       },
       "users": {
         "loading": "Nutzer:innen werden geladen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1092,7 +1092,12 @@
         "loading": "Loading organizations…",
         "error": "Failed to load organizations.",
         "noOrganizations": "No organizations found.",
-        "loadMore": "Load more"
+        "loadMore": "Load more",
+        "searchLabel": "Search organizations",
+        "searchPlaceholder": "Search by name",
+        "searchButton": "Search",
+        "flaggedOnlyLabel": "Flagged only",
+        "deletedOnlyLabel": "Deleted only"
       },
       "users": {
         "loading": "Loading users…",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -75,6 +75,11 @@ function OrganizationsSection() {
 	const { t } = useTranslation();
 	const api = useApiClient();
 
+	const [search, setSearch] = useState("");
+	const [appliedSearch, setAppliedSearch] = useState("");
+	const [flaggedOnly, setFlaggedOnly] = useState(false);
+	const [deletedOnly, setDeletedOnly] = useState(false);
+
 	const {
 		items: rows,
 		loading,
@@ -84,69 +89,138 @@ function OrganizationsSection() {
 		hasMore,
 		loadMore,
 		retryLoadMore,
+		reset,
 	} = useLoadMore<OrgRow>(
 		(pageNumber) =>
-			api.listOrganizations(pageNumber, PAGE_SIZE).then((result) => ({
-				items: result.items.map((o) => ({
-					id: o.id,
-					name: o.name,
+			api
+				.listOrganizations(
+					pageNumber,
+					PAGE_SIZE,
+					appliedSearch.trim() || undefined,
+					deletedOnly || undefined,
+					flaggedOnly || undefined,
+				)
+				.then((result) => ({
+					items: result.items.map((o) => ({
+						id: o.id,
+						name: o.name,
+					})),
+					pageCount: result.pageCount,
 				})),
-				pageCount: result.pageCount,
-			})),
-		{ getErrorMessage: () => t("administration.organizations.error") },
+		{
+			deps: [flaggedOnly, deletedOnly],
+			getErrorMessage: () => t("administration.organizations.error"),
+		},
 	);
 
-	if (loading) {
-		return (
-			<div
-				role="status"
-				className="overflow-hidden rounded-card border border-gray-200"
-			>
-				<span className="sr-only">
-					{t("administration.organizations.loading")}
-				</span>
-				<div className="divide-y divide-gray-100">
-					{Array.from({ length: 5 }).map((_, i) => (
-						<div key={i} aria-hidden="true" className="px-4 py-3">
-							<Skeleton className="h-4 w-1/3" />
-						</div>
-					))}
-				</div>
-			</div>
-		);
+	function handleSearchSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setAppliedSearch(search);
+		reset();
 	}
-	if (error) return <ErrorBanner message={error} />;
-	if (rows.length === 0)
-		return (
-			<EmptyState title={t("administration.organizations.noOrganizations")} />
-		);
 
 	return (
 		<>
-			<ul className="divide-y divide-gray-100 overflow-hidden rounded-card border border-gray-200">
-				{rows.map((row) => (
-					<li key={row.id} className="flex items-center gap-4 px-4 py-3">
-						<div className="min-w-0 flex-1">
-							<p className="truncate font-medium text-gray-900">{row.name}</p>
-						</div>
-					</li>
-				))}
-			</ul>
-			{hasMore &&
-				(loadMoreError ? (
-					<LoadMoreError
-						message={loadMoreError}
-						retrying={loadingMore}
-						onRetry={retryLoadMore}
+			<form onSubmit={handleSearchSubmit} className="mb-4 flex items-end gap-3">
+				<div className="flex-1">
+					<label htmlFor="admin-org-search" className={labelClass}>
+						{t("administration.organizations.searchLabel")}
+					</label>
+					<input
+						id="admin-org-search"
+						type="search"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder={t("administration.organizations.searchPlaceholder")}
+						className={inputClass}
 					/>
-				) : (
-					<LoadMoreButton
-						loading={loadingMore}
-						label={t("administration.organizations.loadMore")}
-						loadingLabel={t("administration.loadingMore")}
-						onClick={loadMore}
+				</div>
+				<Button type="submit">
+					{t("administration.organizations.searchButton")}
+				</Button>
+			</form>
+			<div className="mb-6 flex flex-wrap items-center gap-4">
+				<label
+					htmlFor="admin-org-flagged-only"
+					className="flex cursor-pointer items-center gap-2"
+				>
+					<input
+						type="checkbox"
+						id="admin-org-flagged-only"
+						checked={flaggedOnly}
+						onChange={(e) => setFlaggedOnly(e.target.checked)}
+						className="h-4 w-4 accent-brand-600"
 					/>
-				))}
+					<span className="text-sm text-gray-800">
+						{t("administration.organizations.flaggedOnlyLabel")}
+					</span>
+				</label>
+				<label
+					htmlFor="admin-org-deleted-only"
+					className="flex cursor-pointer items-center gap-2"
+				>
+					<input
+						type="checkbox"
+						id="admin-org-deleted-only"
+						checked={deletedOnly}
+						onChange={(e) => setDeletedOnly(e.target.checked)}
+						className="h-4 w-4 accent-brand-600"
+					/>
+					<span className="text-sm text-gray-800">
+						{t("administration.organizations.deletedOnlyLabel")}
+					</span>
+				</label>
+			</div>
+			{loading ? (
+				<div
+					role="status"
+					className="overflow-hidden rounded-card border border-gray-200"
+				>
+					<span className="sr-only">
+						{t("administration.organizations.loading")}
+					</span>
+					<div className="divide-y divide-gray-100">
+						{Array.from({ length: 5 }).map((_, i) => (
+							<div key={i} aria-hidden="true" className="px-4 py-3">
+								<Skeleton className="h-4 w-1/3" />
+							</div>
+						))}
+					</div>
+				</div>
+			) : error ? (
+				<ErrorBanner message={error} />
+			) : rows.length === 0 ? (
+				<EmptyState title={t("administration.organizations.noOrganizations")} />
+			) : (
+				<>
+					<ul className="divide-y divide-gray-100 overflow-hidden rounded-card border border-gray-200">
+						{rows.map((row) => (
+							<li key={row.id} className="flex items-center gap-4 px-4 py-3">
+								<div className="min-w-0 flex-1">
+									<p className="truncate font-medium text-gray-900">
+										{row.name}
+									</p>
+								</div>
+							</li>
+						))}
+					</ul>
+					{hasMore &&
+						(loadMoreError ? (
+							<LoadMoreError
+								message={loadMoreError}
+								retrying={loadingMore}
+								onRetry={retryLoadMore}
+							/>
+						) : (
+							<LoadMoreButton
+								loading={loadingMore}
+								label={t("administration.organizations.loadMore")}
+								loadingLabel={t("administration.loadingMore")}
+								onClick={loadMore}
+							/>
+						))}
+				</>
+			)}
 		</>
 	);
 }


### PR DESCRIPTION
Admins could search and filter the user list but not the organization list, forcing them to page through the whole table to find a pending org. Adds Search (name, case-insensitive), Deleted (shadow-deleted orgs, off by default), and Flagged (open-report orgs) query params to GET /admin/organizations, plus matching search input and checkboxes on the admin page.

Organization.IsVerified was fully removed in #1080 as an unused badge, so this reuses the existing soft-delete and report-moderation signals instead of resurrecting it.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1054

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
