### PR TITLE
feat: notify organizers on invitation accept/decline and feedback submitted

### DIFF
--- a/backend/src/Application/Engagements/SubmitFeedback/v1/EngagementFeedbackSubmittedDomainEventHandler.cs
+++ b/backend/src/Application/Engagements/SubmitFeedback/v1/EngagementFeedbackSubmittedDomainEventHandler.cs
@@ -1,0 +1,48 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.SubmitFeedback.v1;
+
+// Consumer of EngagementFeedbackSubmittedDomainEvent (#1047): SubmitFeedbackCommandHandler only
+// records the rating/comment on the engagement and raises the event; letting the opportunity's
+// organizers know feedback came in happens here, dispatched by OutboxProcessorJob like every
+// other domain event.
+internal sealed class EngagementFeedbackSubmittedDomainEventHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	IKeycloakOrganizationService keycloakOrganizationService,
+	ILogger<EngagementFeedbackSubmittedDomainEventHandler> logger)
+	: INotificationHandler<EngagementFeedbackSubmittedDomainEvent>
+{
+	public async Task Handle(
+		EngagementFeedbackSubmittedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken);
+		if (opportunity is null)
+		{
+			logger.LogWarning(
+				"Skipping feedback notification for opportunity {OpportunityId}: it no longer exists",
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var members = await keycloakOrganizationService.GetMembersAsync(opportunity.OrganizationId.Value, cancellationToken);
+		foreach (var organizer in members.Where(m => m.IsOrganisator))
+		{
+			var inAppNotification = Notification.Create(
+				UserId.Create(organizer.UserId).GetValueOrThrow(),
+				NotificationKind.FeedbackSubmitted,
+				notification.EngagementId.Value);
+			await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Invitations/AcceptInvitation/v1/OrganizationInvitationAcceptedDomainEventHandler.cs
+++ b/backend/src/Application/Invitations/AcceptInvitation/v1/OrganizationInvitationAcceptedDomainEventHandler.cs
@@ -1,0 +1,40 @@
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Notifications;
+using Domain.Organizations;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Invitations.AcceptInvitation.v1;
+
+// Consumer of OrganizationInvitationAcceptedDomainEvent (#1047): AcceptInvitationCommandHandler
+// only flips the invitation's Status and raises the event; letting the inviting organizer know
+// their invite was accepted happens here, dispatched by OutboxProcessorJob like every other
+// domain event.
+internal sealed class OrganizationInvitationAcceptedDomainEventHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	ILogger<OrganizationInvitationAcceptedDomainEventHandler> logger)
+	: INotificationHandler<OrganizationInvitationAcceptedDomainEvent>
+{
+	public async Task Handle(
+		OrganizationInvitationAcceptedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var invitation = await dbContext.OrganizationInvitations.FindAsync(notification.InvitationId, cancellationToken);
+		if (invitation is null)
+		{
+			logger.LogWarning(
+				"Skipping acceptance notification for invitation {InvitationId}: it no longer exists",
+				notification.InvitationId.Value);
+			return;
+		}
+
+		var inAppNotification = Notification.Create(
+			invitation.InvitedById,
+			NotificationKind.InvitationAccepted,
+			notification.InvitationId.Value);
+		await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/Invitations/DeclineInvitation/v1/OrganizationInvitationDeclinedDomainEventHandler.cs
+++ b/backend/src/Application/Invitations/DeclineInvitation/v1/OrganizationInvitationDeclinedDomainEventHandler.cs
@@ -1,0 +1,40 @@
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Notifications;
+using Domain.Organizations;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Invitations.DeclineInvitation.v1;
+
+// Consumer of OrganizationInvitationDeclinedDomainEvent (#1047): DeclineInvitationCommandHandler
+// only flips the invitation's Status and raises the event; letting the inviting organizer know
+// their invite was declined happens here, dispatched by OutboxProcessorJob like every other
+// domain event.
+internal sealed class OrganizationInvitationDeclinedDomainEventHandler(
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	ILogger<OrganizationInvitationDeclinedDomainEventHandler> logger)
+	: INotificationHandler<OrganizationInvitationDeclinedDomainEvent>
+{
+	public async Task Handle(
+		OrganizationInvitationDeclinedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var invitation = await dbContext.OrganizationInvitations.FindAsync(notification.InvitationId, cancellationToken);
+		if (invitation is null)
+		{
+			logger.LogWarning(
+				"Skipping decline notification for invitation {InvitationId}: it no longer exists",
+				notification.InvitationId.Value);
+			return;
+		}
+
+		var inAppNotification = Notification.Create(
+			invitation.InvitedById,
+			NotificationKind.InvitationDeclined,
+			notification.InvitationId.Value);
+		await dbContext.Notifications.AddAsync(inAppNotification, cancellationToken);
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
@@ -2,7 +2,7 @@ using Application.Common.Authorization;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
-using Domain.Notifications;
+using Application.Engagements.Common;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
 
@@ -76,13 +76,12 @@ internal sealed class DeleteTimeSlotCommandHandler(
 		var engagementsToCancel = await dbContext.GetActiveEngagementsForTimeSlotsAsync(affectedIds, cancellationToken);
 		foreach (var engagement in engagementsToCancel)
 		{
-			engagement.Cancel("The recurring time slot series was cancelled.", opportunity.Title).ThrowIfFailure();
-
-			var notification = Notification.Create(
-				engagement.VolunteerId!.Value,
-				NotificationKind.EngagementCancelled,
-				engagement.Id.Value);
-			await dbContext.Notifications.AddAsync(notification, cancellationToken);
+			await EngagementCancellationHelper.CancelAndNotifyAsync(
+				dbContext,
+				engagement,
+				"The recurring time slot series was cancelled.",
+				opportunity.Title,
+				cancellationToken);
 		}
 
 		foreach (var slot in affectedSlots)

--- a/backend/src/Domain/Notifications/NotificationKind.cs
+++ b/backend/src/Domain/Notifications/NotificationKind.cs
@@ -11,5 +11,8 @@ public enum NotificationKind
 	OpportunityUnpublished,
 	OpportunityCancelled,
 	InvitationReceived,
-	NewMatchingOpportunity
+	NewMatchingOpportunity,
+	InvitationAccepted,
+	InvitationDeclined,
+	FeedbackSubmitted
 }

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -18,7 +18,7 @@ internal sealed class NotificationConfiguration
 			"ck_notification_kind_valid",
 			"kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', " +
 			"'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived', " +
-			"'NewMatchingOpportunity')"));
+			"'NewMatchingOpportunity', 'InvitationAccepted', 'InvitationDeclined', 'FeedbackSubmitted')"));
 
 		builder.Property(n => n.Id)
 			.HasConversion(

--- a/backend/src/Infrastructure/Persistence/Migrations/20260804175705_AddInvitationAndFeedbackNotificationKinds.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260804175705_AddInvitationAndFeedbackNotificationKinds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260804175705_AddInvitationAndFeedbackNotificationKinds")]
+	partial class AddInvitationAndFeedbackNotificationKinds
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
@@ -299,7 +302,7 @@ namespace Infrastructure.Persistence.Migrations
 
 					b.ToTable("notification", null, t =>
 						{
-							t.HasCheckConstraint("ck_notification_kind_valid", "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived', 'NewMatchingOpportunity', 'InvitationAccepted', 'InvitationDeclined', 'FeedbackSubmitted')");
+							t.HasCheckConstraint("ck_notification_kind_valid", "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived', 'InvitationAccepted', 'InvitationDeclined', 'FeedbackSubmitted')");
 						});
 				});
 
@@ -583,79 +586,6 @@ namespace Infrastructure.Persistence.Migrations
 							t.HasCheckConstraint("ck_report_status_valid", "status IN ('Open', 'Dismissed', 'Actioned')");
 
 							t.HasCheckConstraint("ck_report_target_type_valid", "target_type IN ('VolunteerOpportunity', 'Organization', 'User')");
-						});
-				});
-
-			modelBuilder.Entity("Domain.SearchAlerts.SearchAlert", b =>
-				{
-					b.Property<Guid>("Id")
-						.HasColumnType("uuid")
-						.HasColumnName("id");
-
-					b.PrimitiveCollection<string[]>("Categories")
-						.IsRequired()
-						.HasColumnType("text[]")
-						.HasColumnName("categories");
-
-					b.Property<double?>("CenterLatitude")
-						.HasColumnType("double precision")
-						.HasColumnName("center_latitude");
-
-					b.Property<double?>("CenterLongitude")
-						.HasColumnType("double precision")
-						.HasColumnName("center_longitude");
-
-					b.Property<DateTimeOffset>("CreatedOn")
-						.HasColumnType("timestamp with time zone")
-						.HasColumnName("created_on");
-
-					b.Property<bool?>("IsRemote")
-						.HasColumnType("boolean")
-						.HasColumnName("is_remote");
-
-					b.Property<DateTimeOffset>("LastNotifiedAt")
-						.HasColumnType("timestamp with time zone")
-						.HasColumnName("last_notified_at");
-
-					b.Property<DateTimeOffset?>("ModifiedOn")
-						.HasColumnType("timestamp with time zone")
-						.HasColumnName("modified_on");
-
-					b.Property<string>("Occurrence")
-						.HasColumnType("text")
-						.HasColumnName("occurrence");
-
-					b.Property<string>("ParticipationType")
-						.HasColumnType("text")
-						.HasColumnName("participation_type");
-
-					b.Property<double?>("RadiusKm")
-						.HasColumnType("double precision")
-						.HasColumnName("radius_km");
-
-					b.Property<string>("Tag")
-						.HasColumnType("text")
-						.HasColumnName("tag");
-
-					b.Property<Guid>("UserId")
-						.HasColumnType("uuid")
-						.HasColumnName("user_id");
-
-					b.HasKey("Id")
-						.HasName("pk_search_alert");
-
-					b.HasIndex("LastNotifiedAt")
-						.HasDatabaseName("ix_search_alert_last_notified_at");
-
-					b.HasIndex("UserId")
-						.IsUnique()
-						.HasDatabaseName("ix_search_alert_user_id");
-
-					b.ToTable("search_alert", null, t =>
-						{
-							t.HasCheckConstraint("ck_search_alert_occurrence_valid", "occurrence IS NULL OR occurrence IN ('OneTime', 'Recurring')");
-
-							t.HasCheckConstraint("ck_search_alert_participation_type_valid", "participation_type IS NULL OR participation_type IN ('ScheduledSlots', 'IndividualContact')");
 						});
 				});
 
@@ -963,10 +893,6 @@ namespace Infrastructure.Persistence.Migrations
 						.HasColumnType("text")
 						.HasColumnName("participation_type");
 
-					b.Property<DateTimeOffset?>("PublishedOn")
-						.HasColumnType("timestamp with time zone")
-						.HasColumnName("published_on");
-
 					b.Property<string>("Status")
 						.IsRequired()
 						.HasColumnType("text")
@@ -1006,9 +932,6 @@ namespace Infrastructure.Persistence.Migrations
 
 					b.HasIndex("Status", "CreatedOn")
 						.HasDatabaseName("ix_volunteer_opportunity_status_created_on");
-
-					b.HasIndex("Status", "PublishedOn")
-						.HasDatabaseName("ix_volunteer_opportunity_status_published_on");
 
 					b.ToTable("volunteer_opportunity", null, t =>
 						{

--- a/backend/src/Infrastructure/Persistence/Migrations/20260804175705_AddInvitationAndFeedbackNotificationKinds.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260804175705_AddInvitationAndFeedbackNotificationKinds.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddInvitationAndFeedbackNotificationKinds : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification",
+				sql: "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived', 'NewMatchingOpportunity', 'InvitationAccepted', 'InvitationDeclined', 'FeedbackSubmitted')");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification");
+
+			migrationBuilder.AddCheckConstraint(
+				name: "ck_notification_kind_valid",
+				table: "notification",
+				sql: "kind IN ('EngagementCreated', 'EngagementConfirmed', 'EngagementCancelled', 'EngagementWithdrawn', 'OpportunityUpdated', 'OpportunityDeleted', 'OpportunityUnpublished', 'OpportunityCancelled', 'InvitationReceived', 'NewMatchingOpportunity')");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -19,6 +19,14 @@ internal sealed class NotificationReadRepository(
 		NotificationKind.EngagementConfirmed,
 		NotificationKind.EngagementCancelled,
 		NotificationKind.EngagementWithdrawn,
+		NotificationKind.FeedbackSubmitted,
+	];
+
+	private static readonly NotificationKind[] InvitationKinds =
+	[
+		NotificationKind.InvitationReceived,
+		NotificationKind.InvitationAccepted,
+		NotificationKind.InvitationDeclined,
 	];
 
 	public async ValueTask<List<NotificationSummary>> GetByRecipientAsync(
@@ -105,33 +113,39 @@ internal sealed class NotificationReadRepository(
 			.ToHashSet();
 
 		var directOpportunityIds = notifications
-			.Where(n => !EngagementKinds.Contains(n.Kind) && n.Kind != NotificationKind.InvitationReceived)
+			.Where(n => !EngagementKinds.Contains(n.Kind) && !InvitationKinds.Contains(n.Kind))
 			.Select(n => n.RelatedEntityId)
 			.ToHashSet();
 
-		// An InvitationReceived notification's RelatedEntityId is the
-		// invitation's own id, not an opportunity id (there is no opportunity
-		// involved at all) - looking it up in opportunityTitles below always
-		// missed, silently falling back to the frontend's "deleted opportunity"
-		// placeholder for something that was never an opportunity to begin
-		// with. Resolve it against the invitation itself instead.
+		// An invitation notification's RelatedEntityId is the invitation's own
+		// id, not an opportunity id (there is no opportunity involved at all) -
+		// looking it up in opportunityTitles below always missed, silently
+		// falling back to the frontend's "deleted opportunity" placeholder for
+		// something that was never an opportunity to begin with. Resolve it
+		// against the invitation itself instead. InvitationAccepted/Declined
+		// share this same shape (RelatedEntityId = invitation id) - the
+		// invitation row is never deleted after being accepted/declined, only
+		// its Status changes, so the lookup is just as safe for those.
 		var invitationIds = notifications
-			.Where(n => n.Kind == NotificationKind.InvitationReceived)
+			.Where(n => InvitationKinds.Contains(n.Kind))
 			.Select(n => n.RelatedEntityId)
 			.ToHashSet();
 
 		Dictionary<Guid, string> invitationOrganizationNames = [];
+		Dictionary<Guid, Guid> invitationOrganizationIds = [];
 		if (invitationIds.Count > 0)
 		{
 			var invitationIdVOs = invitationIds.Select(id => OrganizationInvitationId.Create(id).GetValueOrThrow()).ToList();
-			invitationOrganizationNames = await dbContext.OrganizationInvitationsQuery
+			var invitationRows = await dbContext.OrganizationInvitationsQuery
 				.Where(i => invitationIdVOs.Contains(i.Id))
 				.Join(
 					dbContext.OrganizationsQuery,
 					i => i.OrganizationId,
 					org => org.Id,
-					(i, org) => new { i.Id, org.Name })
-				.ToDictionaryAsync(x => x.Id.Value, x => x.Name, cancellationToken);
+					(i, org) => new { i.Id, OrganizationId = org.Id, org.Name })
+				.ToListAsync(cancellationToken);
+			invitationOrganizationNames = invitationRows.ToDictionary(x => x.Id.Value, x => x.Name);
+			invitationOrganizationIds = invitationRows.ToDictionary(x => x.Id.Value, x => x.OrganizationId.Value);
 		}
 
 		// Batch-fetch engagements and compute opportunity IDs from them
@@ -175,16 +189,20 @@ internal sealed class NotificationReadRepository(
 			{
 				opportunityTitles.TryGetValue(opportunityId, out relatedTitle);
 
-				actionUrl = n.Kind is NotificationKind.EngagementCreated or NotificationKind.EngagementWithdrawn
+				actionUrl = n.Kind is NotificationKind.EngagementCreated or NotificationKind.EngagementWithdrawn or NotificationKind.FeedbackSubmitted
 					? (opportunityOrganizations.TryGetValue(opportunityId, out var organizationId)
 						? $"/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements"
 						: null)
 					: "/my-engagements";
 			}
-			else if (n.Kind == NotificationKind.InvitationReceived)
+			else if (InvitationKinds.Contains(n.Kind))
 			{
 				invitationOrganizationNames.TryGetValue(n.RelatedEntityId, out relatedTitle);
-				actionUrl = "/profile?tab=invitations";
+				actionUrl = n.Kind == NotificationKind.InvitationReceived
+					? "/profile?tab=invitations"
+					: (invitationOrganizationIds.TryGetValue(n.RelatedEntityId, out var invitationOrganizationId)
+						? $"/app/{invitationOrganizationId}/dashboard/members"
+						: null);
 			}
 			else if (!EngagementKinds.Contains(n.Kind))
 			{

--- a/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/EngagementFeedbackSubmittedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/EngagementFeedbackSubmittedDomainEventHandlerTests.cs
@@ -1,0 +1,133 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements.SubmitFeedback.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.SubmitFeedback;
+
+public class EngagementFeedbackSubmittedDomainEventHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly EngagementFeedbackSubmittedDomainEventHandler _sut;
+
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+
+	public EngagementFeedbackSubmittedDomainEventHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_sut = new EngagementFeedbackSubmittedDomainEventHandler(
+			_dbContext, _unitOfWork, _keycloakService, NullLogger<EngagementFeedbackSubmittedDomainEventHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateOpportunity(OrganizationId organizationId) =>
+		VolunteerOpportunity.Create(
+			organizationId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Published,
+			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForEachOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var organizerId1 = Guid.NewGuid();
+		var organizerId2 = Guid.NewGuid();
+		_keycloakService.GetMembersAsync(organizationId.Value, cancellationToken)
+			.Returns([
+				new KeycloakOrganizationMember(organizerId1, "olaf", "Olaf", "Organizer", "olaf@example.com", true),
+				new KeycloakOrganizationMember(organizerId2, "petra", "Petra", "Organizer", "petra@example.com", true),
+			]);
+		var engagementId = EngagementId.New();
+		var domainEvent = new EngagementFeedbackSubmittedDomainEvent(engagementId, UserId.New(), opportunity.Id, 5);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == UserId.Create(organizerId1).GetValueOrThrow()
+				&& n.Kind == NotificationKind.FeedbackSubmitted
+				&& n.RelatedEntityId == engagementId.Value),
+			Arg.Any<CancellationToken>());
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == UserId.Create(organizerId2).GetValueOrThrow()
+				&& n.Kind == NotificationKind.FeedbackSubmitted
+				&& n.RelatedEntityId == engagementId.Value),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotNotifyNonOrganizerMembers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var memberId = Guid.NewGuid();
+		_keycloakService.GetMembersAsync(organizationId.Value, cancellationToken)
+			.Returns([new KeycloakOrganizationMember(memberId, "vera", "Vera", "Volunteer", "vera@example.com", false)]);
+		var domainEvent = new EngagementFeedbackSubmittedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, 5);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new EngagementFeedbackSubmittedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, 5);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
+		var domainEvent = new EngagementFeedbackSubmittedDomainEvent(EngagementId.New(), UserId.New(), opportunityId, 5);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/OrganizationInvitationAcceptedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/OrganizationInvitationAcceptedDomainEventHandlerTests.cs
@@ -1,0 +1,95 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Invitations.AcceptInvitation.v1;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Invitations.AcceptInvitation;
+
+public class OrganizationInvitationAcceptedDomainEventHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
+		Substitute.For<IAggregateRepository<OrganizationInvitation, OrganizationInvitationId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly OrganizationInvitationAcceptedDomainEventHandler _sut;
+
+	private static readonly OrganizationId OrgId = OrganizationId.New();
+	private static readonly UserId InviteeId = UserId.New();
+	private static readonly UserId InviterId = UserId.New();
+
+	public OrganizationInvitationAcceptedDomainEventHandlerTests()
+	{
+		_dbContext.OrganizationInvitations.Returns(_invitationRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_sut = new OrganizationInvitationAcceptedDomainEventHandler(
+			_dbContext, _unitOfWork, NullLogger<OrganizationInvitationAcceptedDomainEventHandler>.Instance);
+	}
+
+	private static OrganizationInvitation CreateAcceptedInvitation()
+	{
+		var invitation = OrganizationInvitation.Create(OrgId, InviteeId, InviterId, OrganizationMemberRole.Member, DateTimeOffset.UtcNow);
+		invitation.Accept().ThrowIfFailure();
+		return invitation;
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForTheInvitingOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateAcceptedInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var domainEvent = new OrganizationInvitationAcceptedDomainEvent(invitation.Id, OrgId, InviteeId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == InviterId
+				&& n.Kind == NotificationKind.InvitationAccepted
+				&& n.RelatedEntityId == invitation.Id.Value),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateAcceptedInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var domainEvent = new OrganizationInvitationAcceptedDomainEvent(invitation.Id, OrgId, InviteeId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenInvitationNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitationId = OrganizationInvitationId.New();
+		_invitationRepo.FindAsync(invitationId, cancellationToken).Returns((OrganizationInvitation?)null);
+		var domainEvent = new OrganizationInvitationAcceptedDomainEvent(invitationId, OrgId, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/OrganizationInvitationDeclinedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/OrganizationInvitationDeclinedDomainEventHandlerTests.cs
@@ -1,0 +1,95 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Invitations.DeclineInvitation.v1;
+using AwesomeAssertions;
+using Domain.Notifications;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.Invitations.DeclineInvitation;
+
+public class OrganizationInvitationDeclinedDomainEventHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+	private readonly IAggregateRepository<OrganizationInvitation, OrganizationInvitationId> _invitationRepo =
+		Substitute.For<IAggregateRepository<OrganizationInvitation, OrganizationInvitationId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
+	private readonly OrganizationInvitationDeclinedDomainEventHandler _sut;
+
+	private static readonly OrganizationId OrgId = OrganizationId.New();
+	private static readonly UserId InviteeId = UserId.New();
+	private static readonly UserId InviterId = UserId.New();
+
+	public OrganizationInvitationDeclinedDomainEventHandlerTests()
+	{
+		_dbContext.OrganizationInvitations.Returns(_invitationRepo);
+		_dbContext.Notifications.Returns(_notifRepo);
+		_sut = new OrganizationInvitationDeclinedDomainEventHandler(
+			_dbContext, _unitOfWork, NullLogger<OrganizationInvitationDeclinedDomainEventHandler>.Instance);
+	}
+
+	private static OrganizationInvitation CreateDeclinedInvitation()
+	{
+		var invitation = OrganizationInvitation.Create(OrgId, InviteeId, InviterId, OrganizationMemberRole.Member, DateTimeOffset.UtcNow);
+		invitation.Decline().ThrowIfFailure();
+		return invitation;
+	}
+
+	[Test]
+	public async Task Handle_ShouldCreateInAppNotification_ForTheInvitingOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateDeclinedInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var domainEvent = new OrganizationInvitationDeclinedDomainEvent(invitation.Id, OrgId, InviteeId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == InviterId
+				&& n.Kind == NotificationKind.InvitationDeclined
+				&& n.RelatedEntityId == invitation.Id.Value),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSaveChanges_AfterNotifying(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateDeclinedInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var domainEvent = new OrganizationInvitationDeclinedDomainEvent(invitation.Id, OrgId, InviteeId);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenInvitationNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitationId = OrganizationInvitationId.New();
+		_invitationRepo.FindAsync(invitationId, cancellationToken).Returns((OrganizationInvitation?)null);
+		var domainEvent = new OrganizationInvitationDeclinedDomainEvent(invitationId, OrgId, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -139,6 +139,104 @@ public class NotificationTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetMyNotifications_InvitationAccepted_HasOrganizationNameAsRelatedTitleAndMembersUrl(
+		CancellationToken cancellationToken)
+	{
+		// einsatzbereit#1047: the inviting organizer previously heard nothing
+		// back when an invite was accepted - they had to re-open the members
+		// page and diff the list to find out.
+		const string organizationName = "Invitation Accepted Notification Test Org";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		// Unlike the inline InvitationReceived notification above, InvitationAccepted
+		// is created by OrganizationInvitationAcceptedDomainEventHandler, dispatched
+		// async by OutboxProcessorJob (which polls every 5s) - give it several cycles
+		// before asserting, same budget as OutboxTests.cs.
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			"Domain.Organizations.OrganizationInvitationAcceptedDomainEvent", TimeSpan.FromSeconds(45));
+		processed.Should().BeTrue("OutboxProcessorJob should dispatch the accepted event within a few poll cycles");
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+
+		var notification = olafNotifications.Items.Single(n => n.Kind == "InvitationAccepted");
+		notification.RelatedTitle.Should().Be(organizationName);
+		notification.ActionUrl.Should().Be($"/app/{org.Id.Value}/dashboard/members");
+	}
+
+	[Test]
+	public async Task GetMyNotifications_InvitationDeclined_HasOrganizationNameAsRelatedTitleAndMembersUrl(
+		CancellationToken cancellationToken)
+	{
+		const string organizationName = "Invitation Declined Notification Test Org";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			"Domain.Organizations.OrganizationInvitationDeclinedDomainEvent", TimeSpan.FromSeconds(45));
+		processed.Should().BeTrue("OutboxProcessorJob should dispatch the declined event within a few poll cycles");
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+
+		var notification = olafNotifications.Items.Single(n => n.Kind == "InvitationDeclined");
+		notification.RelatedTitle.Should().Be(organizationName);
+		notification.ActionUrl.Should().Be($"/app/{org.Id.Value}/dashboard/members");
+	}
+
+	[Test]
+	public async Task GetMyNotifications_FeedbackSubmitted_HasRelatedTitleAndOrganizerDashboardUrl(
+		CancellationToken cancellationToken)
+	{
+		// einsatzbereit#1047: a volunteer submitting feedback previously
+		// notified nobody - the organizer had no signal that feedback had come in.
+		const string opportunityTitle = "Notification Feedback Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+		await veraClient.SubmitFeedbackAsync(
+			engagement.Id, new SubmitFeedbackRequest { Rating = 5, Comment = "Great experience" }, cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			"Domain.Engagements.EngagementFeedbackSubmittedDomainEvent", TimeSpan.FromSeconds(45));
+		processed.Should().BeTrue("OutboxProcessorJob should dispatch the feedback event within a few poll cycles");
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+
+		var notification = olafNotifications.Items.Single(n => n.Kind == "FeedbackSubmitted");
+		notification.RelatedTitle.Should().Be(opportunityTitle);
+		notification.ActionUrl.Should()
+			.Be($"/app/{orgId}/dashboard/opportunities/{opportunity.Id}/engagements");
+	}
+
+	[Test]
 	public async Task GetMyNotifications_BeforeCursor_ReturnsOnlyOlderNotifications(
 		CancellationToken cancellationToken)
 	{

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -798,7 +798,10 @@
         "OpportunityDeleted": "Ein Einsatz, für den du dich angemeldet hast, wurde entfernt",
         "OpportunityUnpublished": "{{title}} wurde zurückgezogen und deine Anmeldung wurde abgesagt",
         "OpportunityCancelled": "{{title}} wurde abgesagt und deine Anmeldung wurde abgesagt",
-        "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten"
+        "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten",
+        "InvitationAccepted": "Deine Einladung, {{title}} beizutreten, wurde angenommen",
+        "InvitationDeclined": "Deine Einladung, {{title}} beizutreten, wurde abgelehnt",
+        "FeedbackSubmitted": "Neues Feedback erhalten für {{title}}"
       }
     },
     "language": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -798,7 +798,10 @@
         "OpportunityDeleted": "An opportunity you signed up for was removed",
         "OpportunityUnpublished": "{{title}} was taken down and your sign-up was cancelled",
         "OpportunityCancelled": "{{title}} was cancelled and your sign-up was cancelled",
-        "InvitationReceived": "You've been invited to join {{title}}"
+        "InvitationReceived": "You've been invited to join {{title}}",
+        "InvitationAccepted": "Your invitation to join {{title}} was accepted",
+        "InvitationDeclined": "Your invitation to join {{title}} was declined",
+        "FeedbackSubmitted": "New feedback received for {{title}}"
       }
     },
     "language": {


### PR DESCRIPTION
Adds domain-event handlers for the three orphaned events with a clear recipient and value: OrganizationInvitationAccepted/DeclinedDomainEvent (notify the inviting organizer) and EngagementFeedbackSubmittedDomainEvent (notify the opportunity's organizers). Also dedupes DeleteTimeSlotCommandHandler's inline engagement-cancel notification onto the existing EngagementCancellationHelper.

Closes #1047

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
