### PR TITLE
fix: unblock reset-staging.yml and stop $ in secrets corrupting .env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -490,12 +490,16 @@ jobs:
           ALERT_NOTIFICATION_EMAIL: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
         run: |
           umask 077
-          # Wrap each value in double quotes and escape \ and " so secrets that
-          # contain quotes, hashes, leading apostrophes or other compose .env
-          # metacharacters do not break the parser.
+          # Escape \, " and $ so secrets that contain quotes, hashes, leading
+          # apostrophes, or a literal $ (which Compose's .env parser would
+          # otherwise treat as a self-referential ${VAR} lookup, silently
+          # dropping everything from the $ onward - see docker-compose.yml's
+          # minio-init-script comment on the same Compose behavior) don't
+          # break the parser or corrupt the value.
           escape() {
             local v="$1"
             v="${v//\\/\\\\}"
+            v="${v//\$/\$\$}"
             v="${v//\"/\\\"}"
             printf '%s' "$v"
           }
@@ -844,9 +848,12 @@ jobs:
           ALERT_NOTIFICATION_EMAIL: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
         run: |
           umask 077
+          # Escape \, " and $ - see deploy-staging's "Render .env" step for
+          # why $ needs escaping too (Compose's .env self-interpolation).
           escape() {
             local v="$1"
             v="${v//\\/\\\\}"
+            v="${v//\$/\$\$}"
             v="${v//\"/\\\"}"
             printf '%s' "$v"
           }

--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -60,11 +60,23 @@ jobs:
           SMTP_FROM_NAME: ${{ secrets.SMTP_FROM_NAME }}
           GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          # Where Alertmanager sends alert emails (docker-compose.yml's
+          # alertmanager-config, #1081) - required (":?" guard), so a restart
+          # without it fails rendering the compose config entirely, same as
+          # deploy-staging.
+          ALERT_NOTIFICATION_EMAIL: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
         run: |
           umask 077
+          # Escape \, " and $ so secrets that contain quotes, hashes, leading
+          # apostrophes, or a literal $ (which Compose's .env parser would
+          # otherwise treat as a self-referential ${VAR} lookup, silently
+          # dropping everything from the $ onward - see docker-compose.yml's
+          # minio-init-script comment on the same Compose behavior) don't
+          # break the parser or corrupt the value.
           escape() {
             local v="$1"
             v="${v//\\/\\\\}"
+            v="${v//\$/\$\$}"
             v="${v//\"/\\\"}"
             printf '%s' "$v"
           }
@@ -86,6 +98,12 @@ jobs:
             printf 'SMTP_FROM_NAME="%s"\n' "$(escape "$SMTP_FROM_NAME")"
             printf 'GRAFANA_ADMIN_USER="%s"\n' "$(escape "$GRAFANA_ADMIN_USER")"
             printf 'GRAFANA_ADMIN_PASSWORD="%s"\n' "$(escape "$GRAFANA_ADMIN_PASSWORD")"
+            printf 'ALERT_NOTIFICATION_EMAIL="%s"\n' "$(escape "$ALERT_NOTIFICATION_EMAIL")"
+            # Not a secret - restarting after a reset should come back seeded
+            # with demo organizations/opportunities, same as deploy-staging
+            # (see publish.yml's "Render .env" step and this workflow's
+            # header comment on SeedAsync's idempotency).
+            printf 'DATABASE_SEED_ON_STARTUP="true"\n'
           } > .env
 
       - name: Copy .env


### PR DESCRIPTION
## What

Two bugs found while live-debugging the `v1.0.0-rc.340` publish failure and the follow-up `reset-staging.yml` run:

1. `reset-staging.yml`'s "Render .env" step was missing `ALERT_NOTIFICATION_EMAIL` entirely, despite its own comment claiming it's "kept byte-for-byte in sync with publish.yml's own Render .env step". `docker-compose.yml`'s `alertmanager-config` requires it via a `:?` guard, so every `docker compose down`/`up` on that step failed outright:
   ```
   error while interpolating configs.alertmanager-config.content: required variable ALERT_NOTIFICATION_EMAIL is missing a value: set ALERT_NOTIFICATION_EMAIL in .env
   ```
   It was also missing `DATABASE_SEED_ON_STARTUP="true"`, so a reset silently stopped reseeding staging with demo data on restart - contradicting `.github/AGENTS.md`'s own documented behavior for this workflow ("staging comes back with the standard seeded organizations and published opportunities").

2. All three "Render .env" steps (`deploy-staging`, `deploy-production`, `reset-staging`) escaped `\` and `"` in secret values but not a literal `$`. Compose's `.env` parser performs self-referential `${VAR}` interpolation on values it reads, so any secret containing a `$` (observed live as `The "Wn7P" variable is not set. Defaulting to a blank string.`) had that substring silently dropped before ever reaching the container - a real risk of a deployed credential silently not matching the value stored in GitHub Secrets.

## Why

Closes #

Both bugs were hit live while cutting `v1.0.0-rc.340` and then running a manual staging reset: the reset run failed hard on bug 1, and its logs also showed bug 2's symptom (the `Wn7P` interpolation warnings) even before the hard failure.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` against both modified workflow files - valid YAML.
- Extracted the `escape()` function and round-tripped a string containing `$`, `"`, and `\` through it locally to confirm the escaped form reconstitutes the original value once Compose's `.env` parser (quote-unescape, then `$$` -> `$` interpolation) processes it.

## Live verification

This is deploy-tooling only, not application behavior, so the release-candidate + live-staging Playwright flow in root `AGENTS.md` doesn't apply. Real verification requires actually re-running `reset-staging.yml` (or a fresh RC deploy) against the live host - that's a manually-gated, destructive workflow (`workflow_dispatch` with a required `RESET` confirmation), so it wasn't triggered from this session per the repo's guidance not to run it without the owner's go-ahead. Recommend re-running `reset-staging.yml` after merge to confirm it now completes end-to-end.

## Checklist

- [x] `/self-review` run and findings addressed (manual review - no domain-specific check agent applies to workflow-YAML-only changes)
- [ ] CI is green (pending)
- [ ] Documentation updated if this change affects behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFEJKuXtwykH5rtH39oqcQ)_