### PR TITLE
refactor: trim bloated and redundant comments repo-wide

### DIFF
--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install .NET 10 SDK if dotnet is not on PATH
 if ! command -v dotnet &>/dev/null; then
 	DOTNET_SDK_VERSION=$(grep -o '"version": *"[^"]*"' backend/global.json | head -1 | sed -E 's/.*"([0-9.]+)".*/\1/')
 	echo "[SessionStart] dotnet not found - installing .NET SDK $DOTNET_SDK_VERSION..."

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -194,23 +194,11 @@ jobs:
         working-directory: backend
         run: dotnet run --project tests/ArchitectureTests --no-restore --no-build --coverage --coverage-output-format cobertura --coverage-output architecturetests.cobertura.xml
 
-      # Report-only (einsatzbereit#1327): every finding in the audit this issue
-      # came from had to be established by hand-diffing handler lists against test
-      # files - this makes a coverage gap visible on the PR itself instead of
-      # requiring someone to go looking for it. No threshold gate - a low or
-      # dropping number never blocks a merge, visibility is the point, not
-      # enforcement.
-      #
-      # Originally posted via 5monkeys/cobertura-action as a PR comment, which
-      # dumped a per-class table (one row per C# class - hundreds of rows for
-      # this codebase) with a mislabeled column and a truncated project title.
-      # That action is also stuck on a Node 20 runtime with no newer release to
-      # pick up (last tagged 2024), which GitHub Actions is deprecating outright -
-      # there's no fix upstream to bump to. Replaced with a plain two-row summary
-      # written straight to the job's own step summary: no third-party action, no
-      # pinned Node runtime, and no per-class noise - just each project's overall
-      # line/branch rate. The now-unused pull-requests/checks permissions that
-      # action needed were dropped from this job too.
+      # Report-only (einsatzbereit#1327): no threshold gate, so a low or
+      # dropping number never blocks a merge - visibility is the point.
+      # Written straight to the job's own step summary rather than via a
+      # third-party action, to avoid per-class noise and a dependency on a
+      # Node 20 runtime GitHub Actions is deprecating.
       - name: Publish coverage summary
         if: github.event_name == 'pull_request'
         working-directory: backend

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -556,7 +556,6 @@ jobs:
           KC_URL="https://login.maik-hasler.de"
           KC_REALM="einsatzbereit"
 
-          # Attempt to get admin token from the currently-running Keycloak.
           # If Keycloak is not yet running (first deploy), skip - the realm JSON
           # already contains the mapper and it will be imported on first start.
           TOKEN=$(curl -sf -X POST \
@@ -573,7 +572,6 @@ jobs:
             exit 0
           fi
 
-          # Verify the realm exists.
           REALM_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $TOKEN" \
             "$KC_URL/admin/realms/$KC_REALM" 2>/dev/null || echo "000")
@@ -582,7 +580,6 @@ jobs:
             exit 0
           fi
 
-          # Get frontend client UUID.
           FRONTEND_ID=$(curl -sf \
             -H "Authorization: Bearer $TOKEN" \
             "$KC_URL/admin/realms/$KC_REALM/clients?clientId=frontend" \
@@ -592,7 +589,6 @@ jobs:
             exit 1
           fi
 
-          # Add mapper only if not already present (idempotent).
           EXISTING=$(curl -sf \
             -H "Authorization: Bearer $TOKEN" \
             "$KC_URL/admin/realms/$KC_REALM/clients/$FRONTEND_ID/protocol-mappers/models" \
@@ -695,7 +691,6 @@ jobs:
           ssh -i ~/.ssh/id_ed25519 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" bash -s <<'EOF'
             set -euo pipefail
             cd /opt/einsatzbereit
-            # Re-tag staging-previous back to staging so compose uses the old images.
             for svc in backend frontend keycloak; do
               img="ghcr.io/maik-hasler/einsatzbereit-${svc}"
               if docker image inspect "${img}:staging-previous" &>/dev/null; then
@@ -715,7 +710,6 @@ jobs:
           KC_URL="https://login.maik-hasler.de"
           KC_REALM="einsatzbereit"
 
-          # Get admin token from master realm
           TOKEN=$(curl -sf -X POST \
             "$KC_URL/realms/master/protocol/openid-connect/token" \
             -H "Content-Type: application/x-www-form-urlencoded" \
@@ -727,9 +721,9 @@ jobs:
           [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ] && { echo "::error::Keycloak admin auth failed"; exit 1; }
           echo "Admin token acquired."
 
-          # Ensure the single-step flow exists; create it if missing (e.g. first deploy
-          # or realm wipe). Keycloak 26 with organizationsEnabled overrides browserFlow
-          # after every import, so we always re-bind it at the end regardless.
+          # Keycloak 26 with organizationsEnabled overrides browserFlow after
+          # every import, so this always re-binds it below regardless of
+          # whether the flow already existed.
           FLOW_COUNT=$(curl -sf \
             -H "Authorization: Bearer $TOKEN" \
             "$KC_URL/admin/realms/$KC_REALM/authentication/flows" \
@@ -743,7 +737,6 @@ jobs:
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows" \
               -d '{"alias":"einsatzbereit browser","providerId":"basic-flow","topLevel":true,"builtIn":false}'
 
-            # Add auth-cookie (set to ALTERNATIVE)
             curl -sf -X POST \
               -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows/einsatzbereit%20browser/executions/execution" \
@@ -757,7 +750,6 @@ jobs:
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows/einsatzbereit%20browser/executions" \
               -d "$(echo "$COOKIE_EXEC" | jq '.requirement = "ALTERNATIVE"')"
 
-            # Add sub-flow for the form (set to ALTERNATIVE)
             curl -sf -X POST \
               -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows/einsatzbereit%20browser/executions/flow" \
@@ -771,7 +763,6 @@ jobs:
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows/einsatzbereit%20browser/executions" \
               -d "$(echo "$SUBFLOW_EXEC" | jq '.requirement = "ALTERNATIVE"')"
 
-            # Add auth-username-password-form to sub-flow (set to REQUIRED)
             curl -sf -X POST \
               -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
               "$KC_URL/admin/realms/$KC_REALM/authentication/flows/einsatzbereit%20browser%20forms/executions/execution" \
@@ -790,7 +781,6 @@ jobs:
             echo "Flow already exists."
           fi
 
-          # Always re-bind - Keycloak organizations override this after every import
           REALM=$(curl -sf -H "Authorization: Bearer $TOKEN" "$KC_URL/admin/realms/$KC_REALM")
           curl -sf -X PUT \
             -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -55,7 +55,6 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 					"ParticipationType cannot be changed while any engagement exists for this opportunity."));
 		}
 
-		// Snapshot material fields before mutation to detect meaningful changes.
 		var prevIsRemote = opportunity.IsRemote;
 		var prevAddress = opportunity.Address;
 		var prevOccurrence = opportunity.Occurrence;

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -14,14 +14,11 @@ public sealed class Engagement
 
 	public TimeSlotId? TimeSlotId { get; private set; }
 
-	// Snapshotted from the TimeSlot at sign-up/reactivation time (#1203) so a
-	// volunteer's past-engagement history keeps showing when a shift was, even
-	// after the opportunity/time slot it pointed at is later hard-deleted -
-	// which nulls TimeSlotId out via engagement.time_slot_id's ON DELETE SET
-	// NULL and would otherwise erase the date along with it. Read code should
-	// still prefer a live join to TimeSlot when TimeSlotId is present (it may
-	// have been legitimately rescheduled since), falling back to these only
-	// once the slot is gone.
+	// Snapshotted from the TimeSlot at sign-up/reactivation time (#1203): TimeSlotId gets
+	// nulled by engagement.time_slot_id's ON DELETE SET NULL once the slot is hard-deleted,
+	// so this is what keeps a volunteer's past-engagement history showing when a shift was.
+	// Prefer a live join to TimeSlot when TimeSlotId is present (it may have been
+	// rescheduled since) - fall back to these only once the slot is gone.
 	public DateTimeOffset? TimeSlotStartDateTime { get; private set; }
 
 	public DateTimeOffset? TimeSlotEndDateTime { get; private set; }

--- a/backend/src/Domain/Organizations/DashboardGrid.cs
+++ b/backend/src/Domain/Organizations/DashboardGrid.cs
@@ -6,13 +6,10 @@ public static class DashboardGrid
 {
 	public const int Columns = 8;
 
-	// Rows grow downward as organizers place widgets further down, but a
-	// placement still needs *some* ceiling - without one, a widget placed (or
-	// replayed via a crafted request) at an astronomically large Y would make
-	// the frontend's grid-guide-cell backdrop try to render that many rows and
-	// hang the edit-mode UI. Mirrors the frontend's GRID_MAX_ROWS constant
-	// (widgetCatalog.ts), which already used this same number as a "sane
-	// ceiling" for arrow-key cursor movement before this was also enforced as
-	// a real placement bound.
+	// Rows grow downward as organizers place widgets further down, but a placement still
+	// needs *some* ceiling - without one, a widget placed (or replayed via a crafted
+	// request) at an astronomically large Y would make the frontend's grid-guide-cell
+	// backdrop try to render that many rows and hang the edit-mode UI. Mirrors the
+	// frontend's GRID_MAX_ROWS constant (widgetCatalog.ts).
 	public const int MaxRows = 100;
 }

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -276,7 +276,6 @@ internal sealed class KeycloakOrganizationService(
 				continue;
 			}
 
-			// Decompose and strip combining marks for other accented chars
 			var normalized = c.ToString().Normalize(NormalizationForm.FormD);
 			foreach (var nc in normalized)
 			{
@@ -289,7 +288,6 @@ internal sealed class KeycloakOrganizationService(
 
 		var alias = sb.ToString().ToLowerInvariant();
 
-		// Replace non-alphanumeric with hyphens, collapse, and trim
 		sb.Clear();
 		var prevHyphen = true; // treat start as hyphen to trim leading
 		foreach (var c in alias)
@@ -306,7 +304,6 @@ internal sealed class KeycloakOrganizationService(
 			}
 		}
 
-		// Trim trailing hyphen
 		return sb.Length > 0 && sb[^1] == '-'
 			? sb.ToString(0, sb.Length - 1)
 			: sb.ToString();

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -106,7 +106,6 @@ internal sealed class NotificationReadRepository(
 			.Take(limit)
 			.ToList();
 
-		// Collect entity IDs by type
 		var engagementIds = notifications
 			.Where(n => EngagementKinds.Contains(n.Kind))
 			.Select(n => n.RelatedEntityId)
@@ -148,7 +147,6 @@ internal sealed class NotificationReadRepository(
 			invitationOrganizationIds = invitationRows.ToDictionary(x => x.Id.Value, x => x.OrganizationId.Value);
 		}
 
-		// Batch-fetch engagements and compute opportunity IDs from them
 		Dictionary<Guid, Guid> engagementToOpportunity = [];
 		if (engagementIds.Count > 0)
 		{
@@ -163,9 +161,8 @@ internal sealed class NotificationReadRepository(
 		var opportunityIdsFromEngagements = engagementToOpportunity.Values.ToHashSet();
 		var allOpportunityIds = opportunityIdsFromEngagements.Union(directOpportunityIds).ToHashSet();
 
-		// Batch-fetch opportunity titles and their owning organization (the
-		// latter is needed to build the org-app deep link below; both are
-		// null for a since-deleted opportunity).
+		// Organization id is also needed for the org-app deep link below; both
+		// are null once the opportunity is deleted.
 		Dictionary<Guid, string> opportunityTitles = [];
 		Dictionary<Guid, Guid> opportunityOrganizations = [];
 		if (allOpportunityIds.Count > 0)

--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -13,18 +13,12 @@ internal sealed class MinioFileStorageService : IFileStorageService
 	// upload) keeps caching effective without that staleness risk.
 	internal const string CacheControlHeaderValue = "public, max-age=3600";
 
-	// Everything this service stores today (avatars/logos/banners) is meant
-	// to be publicly viewable in an <img> tag, but the bucket policy only
-	// needs to cover this prefix, not the whole bucket - a future object type
-	// that isn't meant to be public (participant lists, ID scans) can then be
-	// stored outside this prefix without any policy change here at all.
-	// Transparent to every caller: GetPublicUrl(key) already returns the full
-	// URL, and nothing outside this class parses or reconstructs an object
-	// key by hand. Changing this prefix moves where new uploads land but does
-	// not relocate objects already stored under the old (whole-bucket-public)
-	// policy - acceptable on this repo's disposable, resettable staging
-	// environment (see reset-staging.yml), not something a one-time
-	// migration script is worth writing for pre-1.0.
+	// Bucket policy only grants public read under this prefix, not the whole bucket, so a
+	// future non-public object type (participant lists, ID scans) can be added outside it
+	// with no policy change. Transparent to callers - GetPublicUrl already returns the
+	// full URL - but changing this value only affects future uploads; existing objects
+	// stay under the old prefix, which is acceptable on this repo's disposable,
+	// resettable staging environment (not worth a migration script pre-1.0).
 	private const string PublicPrefix = "public/";
 
 	private readonly IMinioClient _minio;

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -565,13 +565,12 @@ public class CreateEngagementCommandHandlerTests
 			Arg.Any<IReadOnlyDictionary<string, string>>());
 	}
 
-	// --- Organizer notifications moved off the request path (#1174) ---
+	// --- Organizer notifications (#1174) ---
 	//
-	// The organizer "New sign-up" email (subscription-gated per #1055) is no
-	// longer sent by this handler - it moves onto the outbox, delivered by
-	// EngagementCreatedDomainEventHandler/EngagementReactivatedDomainEventHandler.
-	// See those handlers' tests for the subscription-preference coverage that
-	// used to live here.
+	// The organizer "New sign-up" email (subscription-gated per #1055) is sent
+	// asynchronously via the outbox, by EngagementCreatedDomainEventHandler /
+	// EngagementReactivatedDomainEventHandler - see those handlers' tests for
+	// the subscription-preference coverage.
 
 	[Test]
 	public async Task Handle_ShouldNotEmailOrganizersSynchronously_RegardlessOfHowManyExist(

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
@@ -220,15 +220,13 @@ public class WithdrawEngagementCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*checked-in*");
 	}
 
-	// --- Organizer notifications moved off the request path (#1174) ---
+	// --- Organizer notifications (#1174) ---
 	//
-	// The organizer withdrawal email (subscription-gated per #1055) is no
-	// longer sent by this handler - IEmailService isn't even a dependency of
-	// it any more, so a rapid create/withdraw loop can no longer hold this
-	// request's DB transaction open across one synchronous SMTP send per
-	// organizer. It moves onto the outbox, delivered by
-	// EngagementWithdrawnDomainEventHandler; see that handler's tests for the
-	// subscription-preference/localization coverage that used to live here.
+	// The organizer withdrawal email (subscription-gated per #1055) is sent
+	// asynchronously via the outbox (EngagementWithdrawnDomainEventHandler), not
+	// synchronously here, so a create/withdraw loop never holds this request's
+	// DB transaction open across one SMTP send per organizer - see that
+	// handler's tests for the subscription-preference/localization coverage.
 	// The in-app bell-icon Notification row (unconditional, not
 	// subscription-gated) stays synchronous.
 

--- a/backend/tests/Application.UnitTests/Notifications/DeleteReadNotifications/DeleteReadNotificationsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/DeleteReadNotifications/DeleteReadNotificationsCommandHandlerTests.cs
@@ -54,10 +54,7 @@ public class DeleteReadNotificationsCommandHandlerTests
 	public async Task Handle_ShouldOnlyAffectTheRequestingUsersOwnNotifications(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: the dbContext call itself is scoped to recipientId - this
-		// asserts the handler passes the command's own RecipientId through
-		// rather than some other identity, so a caller can never delete
-		// another user's notifications.
+		// Arrange
 		var recipientId = UserId.New();
 		var otherUsersId = UserId.New();
 		_dbContext.DeleteReadNotificationsForRecipientAsync(otherUsersId, Arg.Any<CancellationToken>())

--- a/backend/tests/Application.UnitTests/Notifications/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandlerTests.cs
@@ -63,10 +63,7 @@ public class MarkAllNotificationsReadCommandHandlerTests
 	public async Task Handle_ShouldOnlyAffectTheRequestingUsersOwnNotifications(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: the repository query itself is scoped to recipientId - this
-		// asserts the handler passes the command's own RecipientId through
-		// rather than some other identity, so a caller can never mark another
-		// user's notifications as read.
+		// Arrange
 		var recipientId = UserId.New();
 		var otherUsersId = UserId.New();
 		_dbContext.GetUnreadNotificationsForRecipientAsync(otherUsersId, Arg.Any<CancellationToken>())

--- a/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
@@ -133,11 +133,9 @@ public class RemoveMemberCommandHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange - the requesting user is the org's sole organizer, removing (leaving)
-		// themselves. This is the previously-unblocked regression: the org may well have
-		// other, non-organizer members (e.g. an accepted-but-never-promoted invitee) - the
-		// old guard only blocked when the org had exactly one member *in total*, so an
-		// organizer with company could still leave and permanently orphan the org. Only
-		// the organizer count - never the total headcount - may gate this.
+		// themselves, even though the org may have other, non-organizer members (e.g. an
+		// accepted-but-never-promoted invitee). Only the organizer count, never the total
+		// headcount, may gate this, or a sole organizer could leave and orphan the org.
 		var orgId = Guid.NewGuid();
 		AllowRequestingUserInOrg(orgId);
 		SetOrganizerCount(orgId, 1);

--- a/backend/tests/Application.UnitTests/Users/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
@@ -61,9 +61,8 @@ public class UpdateUserProfileCommandHandlerTests
 	public async Task Handle_ShouldSetPhone_OnALazilyCreatedUserRow(
 		CancellationToken cancellationToken)
 	{
-		// #1148: the row is fetched-or-created via the idempotent GetOrCreateUserAsync
-		// rather than a check-then-Add the handler used to do itself - the handler
-		// doesn't know or care whether the returned row was just created.
+		// #1148: the row is fetched-or-created via the idempotent GetOrCreateUserAsync -
+		// the handler doesn't know or care whether the returned row was just created.
 		var userId = UserId.New();
 		var user = User.Create(userId);
 		_dbContext.GetOrCreateUserAsync(userId, Arg.Any<string?>(), cancellationToken).Returns(user);

--- a/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UploadUserAvatar/UploadUserAvatarCommandHandlerTests.cs
@@ -54,11 +54,9 @@ public class UploadUserAvatarCommandHandlerTests
 	public async Task Handle_ShouldCreateUserAndSetAvatarUrl_WhenUserDoesNotExistYet(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: RecordActivity/UploadUserAvatar can be the very first write for a
-		// user who has only ever authenticated via Keycloak - there is no
-		// registration step that creates the local User row up front.
-		// #1148: the row is fetched-or-created via the idempotent GetOrCreateUserAsync
-		// rather than a check-then-Add the handler used to do itself.
+		// Arrange: a user who has only ever authenticated via Keycloak has no local
+		// User row yet (no upfront registration step) - GetOrCreateUserAsync creates
+		// it idempotently instead of a racy check-then-add (#1148).
 		var userId = UserId.New();
 		var user = User.Create(userId);
 		_dbContext.GetOrCreateUserAsync(userId, Arg.Any<string?>(), cancellationToken).Returns(user);

--- a/backend/tests/IntegrationTests/AdminEndpointAuthorizationTests.cs
+++ b/backend/tests/IntegrationTests/AdminEndpointAuthorizationTests.cs
@@ -6,8 +6,7 @@ namespace IntegrationTests;
 // Regression coverage for #1323: AuthorizationConventionTests only proved an
 // admin route carries *some* authorization decision, never that it is
 // specifically EinsatzbereitAdminPolicy. These prove the four previously
-// uncovered admin endpoints actually reject a non-admin (organizer) caller,
-// following the VerifyOrganization tests above as the template.
+// uncovered admin endpoints actually reject a non-admin (organizer) caller.
 [ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
 [NotInParallel("IntegrationDb")]
 public class AdminEndpointAuthorizationTests(

--- a/backend/tests/IntegrationTests/AssemblyParallelLimit.cs
+++ b/backend/tests/IntegrationTests/AssemblyParallelLimit.cs
@@ -1,25 +1,18 @@
 using TUnit.Core.Interfaces;
 
-// Mitigates the flaky Respawner/Npgsql "Timeout during reading attempt"
-// failures seen on PR #1597 (2026-08-02, two separate CI runs, four
-// different tests across EngagementTests/CheckInAttemptLimiterTests - same
-// signature both times, always inside IntegrationTestFixture.ResetDatabaseAsync's
-// raw NpgsqlConnection, never in the test body itself). Every test class in
-// this assembly shares one Aspire-hosted stack
+// Every test class in this assembly shares one Aspire-hosted stack
 // (ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)) -
 // Postgres, Keycloak, the backend API, MinIO, Mailpit - all on the same
-// runner. Most DB-touching classes already carry [NotInParallel("IntegrationDb")],
-// which only serializes tests *within* that key; it does nothing to cap how
-// many of the remaining classes (or the "IntegrationDb" group as a whole
-// relative to them) run at once, so with no assembly-wide limit TUnit's
-// default - unbounded concurrency, the .NET thread pool decides - can still
-// pile enough concurrent HTTP calls onto the shared stack to starve Postgres
-// of CPU on a standard CI runner, occasionally tipping a plain connection
-// read over its timeout. This is the same root cause VisualTests hit first
-// (see VisualTests/AssemblyParallelLimit.cs) for the same reason (one shared
-// Aspire stack, no assembly-wide cap) - reusing its fix here rather than
-// starting from Environment.ProcessorCount - 1 and re-discovering
-// empirically that VisualTests already found insufficient.
+// runner. Most DB-touching classes carry [NotInParallel("IntegrationDb")],
+// which only serializes tests *within* that key - it does nothing to cap how
+// many classes (or that group as a whole) run at once, so with no
+// assembly-wide limit, TUnit's default unbounded concurrency can pile enough
+// concurrent HTTP calls onto the shared stack to starve Postgres of CPU,
+// occasionally tipping a raw connection read over its timeout.
+//
+// Same root cause as VisualTests/AssemblyParallelLimit.cs (one shared Aspire
+// stack, no assembly-wide cap) - reuses that file's ProcessorCount - 2 limit,
+// since VisualTests already found ProcessorCount - 1 insufficient.
 [assembly: ParallelLimiter<IntegrationTestsParallelLimit>]
 
 public sealed class IntegrationTestsParallelLimit : IParallelLimit

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -128,8 +128,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task GetEngagements_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their organization's engagements -
-		// this used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
@@ -697,10 +695,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
-		// Simulate the opportunity's row being gone without its engagements
-		// having been cancelled first - e.g. data predating the cancellation
-		// safeguard in DeleteVolunteerOpportunityCommandHandler. The engagement
-		// itself is left Pending, which the normal delete flow never produces.
+		// Leaves the engagement Pending, a state the normal delete flow never produces.
 		await fixture.DeleteOpportunityRowDirectlyAsync(opportunity.Id);
 
 		var upcoming = await veraClient.GetMyEngagementsAsync(1, 20, upcoming: true, cancellationToken);
@@ -1013,7 +1008,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task GetEngagements_ShouldReturn403_WhenOrganisatorAccessesOtherOrgsOpportunity(
 		CancellationToken cancellationToken)
 	{
-		// olaf creates org1 with an opportunity
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
@@ -1060,7 +1054,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task ConfirmEngagement_ShouldReturn403_WhenOrganisatorConfirmsOtherOrgsEngagement(
 		CancellationToken cancellationToken)
 	{
-		// olaf creates org1 with an opportunity
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
@@ -1071,7 +1064,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			new CreateEngagementRequest { Message = "I want to help!" },
 			cancellationToken);
 
-		// vera creates her own org - this grants her the organisator role
 		await CreateOrganizationAsync(veraClient, cancellationToken);
 
 		// vera (organisator of org2, NOT org1) tries to confirm org1's engagement
@@ -1085,7 +1077,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task CheckInEngagement_ShouldReturn403_WhenOrganisatorChecksInOtherOrgsEngagement(
 		CancellationToken cancellationToken)
 	{
-		// olaf creates org1 with an opportunity
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
@@ -1098,7 +1089,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 
-		// vera creates her own org - this grants her the organisator role
 		await CreateOrganizationAsync(veraClient, cancellationToken);
 
 		// the organisator role is a Keycloak realm role baked into the JWT at
@@ -1118,7 +1108,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task CheckInEngagement_ShouldReturn404_WhenOpportunityIsDeleted(
 		CancellationToken cancellationToken)
 	{
-		// olaf creates org1 with an opportunity and confirms vera's engagement
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var org1Id = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, org1Id, cancellationToken);
@@ -1142,10 +1131,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 
 		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 
-		// Simulate the opportunity's row being gone without its engagement having
-		// been cancelled first - e.g. data predating the cancellation safeguard in
-		// DeleteVolunteerOpportunityCommandHandler. The engagement itself is left
-		// Confirmed, which the normal delete flow never produces.
+		// Leaves the engagement Confirmed, a state the normal delete flow never produces.
 		await fixture.DeleteOpportunityRowDirectlyAsync(opportunity.Id);
 
 		// There's no API to observe the opportunity row directly - confirm the
@@ -1386,8 +1372,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	public async Task GetOpportunityFeedback_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their organization's opportunity
-		// feedback - this used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
 		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -139,8 +139,6 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 	public async Task GetOrganizationDashboard_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their organization's dashboard KPIs -
-		// this used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
@@ -158,8 +156,6 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 	public async Task GetDashboardLayout_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their own dashboard widget layout for
-		// the organization - this used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);

--- a/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
@@ -185,8 +185,6 @@ public class OrganizationCalendarEventsTests(IntegrationTestFixture fixture)
 	public async Task GetOrganizationCalendarEvents_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their organization's calendar - this
-		// used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);

--- a/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
@@ -172,8 +172,6 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 	public async Task GetOrganizationOpportunities_ShouldSucceed_WhenRequestingUserIsAPlainMember(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their organization's opportunities -
-		// this used to 403 (only Organizer could).
 		var olafClient = await CreateAuthenticatedClientAsync(cancellationToken);
 		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
 		await CreatePublishedOpportunityAsync(olafClient, orgId, "Published 1", cancellationToken);

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -48,10 +48,9 @@ public class OrganizationSettingsTests(
 	public async Task GetOrganizationDetails_ShouldReturn403_WhenRequestingUserHasNoRelationToTheOrganization(
 		CancellationToken cancellationToken)
 	{
-		// #1024: GetOrganizationDetails is readable by any member (Organizer or
-		// Member), not just organizers - so this proves the true "stranger" case
-		// against a real org, rather than the old role-claim gate (removed) that
-		// used to reject every non-organizer before the handler even ran.
+		// #1024: GetOrganizationDetails is readable by any org member, not just
+		// organizers - vera has no relation to the org at all here, to prove
+		// the true "stranger" 403 case.
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 
@@ -68,9 +67,6 @@ public class OrganizationSettingsTests(
 	public async Task GetOrganizationDetails_ShouldSucceed_WhenRequestingUserIsAPlainMemberOfTheOrganization(
 		CancellationToken cancellationToken)
 	{
-		// #1024: a plain Member can now view their own organization's details -
-		// this used to 403 (only Organizer could), locking Members out of the
-		// org entirely with no way to even see it.
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
@@ -265,11 +261,7 @@ public class OrganizationSettingsTests(
 			new CreateOrganizationRequest { Name = "Escalation Test Org" }, cancellationToken);
 
 		// olaf's org gains vera as a plain member - never promoted to Organizer
-		// of this specific org. (Accepting an invitation now also grants
-		// Organizer capability on the invited org - #826 - so that flow no
-		// longer produces a plain-member-only state and can't be used to set
-		// this scenario up anymore; the admin-only AddMember endpoint that
-		// used to fill this gap was removed as dead code - #810.)
+		// of this specific org.
 		await fixture.AddPlainMemberDirectlyAsync(org.Id.Value, vera.Id, cancellationToken);
 
 		var act = () => veraClient.UpdateOrganizationAsync(
@@ -885,12 +877,7 @@ public class OrganizationSettingsTests(
 		// Organizer. The old guard only blocked removal when the org had
 		// exactly one member in total, so the organizer here could leave and
 		// permanently orphan the org, since no path exists to promote the
-		// remaining member. (Accepting an invitation now also grants
-		// Organizer capability - #826 - so that flow no longer produces a
-		// plain-member-only state; the fixture's direct Keycloak escape hatch
-		// is used here instead to reconstruct it, since the admin-only
-		// AddMember endpoint that used to fill this gap was removed as dead
-		// code - #810.)
+		// remaining member.
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
 		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
 		var vera = await veraClient.GetUserProfileAsync(cancellationToken);

--- a/backend/tests/IntegrationTests/RateLimitingClientIpTests.cs
+++ b/backend/tests/IntegrationTests/RateLimitingClientIpTests.cs
@@ -21,17 +21,15 @@ public class RateLimitingClientIpTests
 	[Test]
 	public void GetClientIp_ShouldIgnoreXForwardedForHeader_AndUseTheRealConnectionAddress()
 	{
-		// Arrange: a caller pretending to be someone else on every request - exactly
+		// A caller pretending to be someone else on every request - exactly
 		// the bypass this issue describes - alongside the real (unspoofable)
 		// connection address a socket-level peer actually has.
 		var context = new DefaultHttpContext();
 		context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.7");
 		context.Request.Headers["X-Forwarded-For"] = "1.2.3.4";
 
-		// Act
 		var clientIp = RateLimitingExtensions.GetClientIp(context);
 
-		// Assert
 		clientIp.Should().Be("203.0.113.7",
 			"the client-supplied header must never be trusted directly - only " +
 			"ForwardedHeadersMiddleware, gated on a known trusted network, may " +

--- a/backend/tests/VisualTests/AssemblyParallelLimit.cs
+++ b/backend/tests/VisualTests/AssemblyParallelLimit.cs
@@ -1,53 +1,19 @@
 using TUnit.Core.Interfaces;
 
-// Root cause of a class of flaky VisualTests failures (e.g. #1339): with no
-// parallelism limit anywhere in this project (AccessibilityTests alone has
-// ~50 test methods, none tagged [NotInParallel]), TUnit's default - "every
-// test is eligible to run concurrently, the .NET thread pool decides how many
-// at once" - let a standard CI runner spin up 16+ concurrent Chromium/
-// Playwright instances, each driving axe-core's CPU-heavy DOM scan, all
-// against one shared Aspire-hosted stack (SharedType.PerTestSession). That
-// sustained contention, not a brief blip, is what made individual tests
-// intermittently time out waiting on UI state - a problem retrying a failed
-// test can't fix, since a retry lands in the same still-contended run.
+// All VisualTests classes share one Aspire-hosted stack (SharedType.PerTestSession);
+// without a cap, TUnit runs every test concurrently and CPU contention among the
+// Playwright/axe-core sessions (not backend slowness) causes intermittent timeouts
+// that retries can't fix. Environment.ProcessorCount - 2 rather than ProcessorCount:
+// the same cores also have to service the stack itself (Postgres, Keycloak, API,
+// frontend dev server) that every concurrent session calls into, so headroom must
+// stay reserved for it. ProcessorCount rather than a hardcoded number so this scales
+// with whatever runner or dev machine it runs on.
 //
-// suite. Capping at exactly Environment.ProcessorCount (as this used to)
-// still starves the Aspire-hosted stack itself: dotnet.yml's visual-tests
-// job runs on ubuntu-latest (4 vCPUs), and those same cores also have to
-// service the stack (Postgres, Keycloak, backend API, frontend dev server)
-// that every one of the N concurrent Playwright sessions is calling into,
-// not just the N browser/axe-core processes - e.g.
-// AccessibilityTests.OrgDashboardPage_PlacingAWidget_AsOlaf and
-// EngagementManagementPage_AsOlaf both timed out waiting on the same
-// GET /v1/organizations round trip in the same CI run (2026-07-28). Reserving
-// one core for the stack itself is a structural fix for that class of flake,
-// as opposed to the timeout bumps this file's sibling comments already flag
-// as running out of headroom. Environment.ProcessorCount rather than a
-// hardcoded number so this scales with whatever runner size CI happens to
-// use, and with a larger local dev machine.
-//
-// Reserving just one core still wasn't enough: on 2026-07-29, three
-// AccessibilityTests methods (OrgDashboardPage_PlacingAWidget_AsOlaf,
-// EngagementManagementPage_AsOlaf, OrganizationSettingsPage_
-// EditModeValidationError_AsOlaf - the single heaviest class in the suite,
-// every method paying for a Page.RunAxe() DOM scan on top of the Chromium
-// work every other test already does) hit this limit's cap of 3 concurrently
-// and all three sat in the runner's "[slow] still running after 1m 00s" log
-// at once; one blew past a 30s Playwright action timeout on a plain input
-// fill (no network call involved), meaning it was CPU-starved, not
-// backend-starved. The obvious-looking fix - give AccessibilityTests its own,
-// tighter [ParallelLimiter<T>] at the class level on top of this assembly-wide
-// one - does NOT work: verified empirically (throwaway TUnit project, two
-// classes, one assembly-level limiter plus one class-level limiter on the
-// second class, tests recording their own peak concurrency) that when both an
-// assembly-level and a class-level ParallelLimiter apply to the same test,
-// TUnit 1.34.5 honors only the assembly-level one - the class-level cap is
-// silently ignored, in both directions (a looser assembly limit lets the
-// class exceed its own tighter one; a tighter assembly limit overrides a
-// looser class one). A class-level-only fix would have shipped as a
-// no-op that still passes the build. Reduce the shared limit itself instead -
-// this does cost the whole suite a slightly lower ceiling, not just the
-// heaviest class, but it's the one lever that's actually proven to work.
+// Do not add a class-level [ParallelLimiter<T>] (e.g. on AccessibilityTests) expecting
+// it to layer a tighter cap on top of this one: TUnit 1.34.5 honors only the
+// assembly-level limiter when both apply to the same test, silently ignoring the
+// class-level one (verified empirically). Lower this shared limit instead if a
+// particular suite needs more headroom.
 [assembly: ParallelLimiter<VisualTestsParallelLimit>]
 
 public sealed class VisualTestsParallelLimit : IParallelLimit

--- a/backend/tests/VisualTests/AuthHelper.cs
+++ b/backend/tests/VisualTests/AuthHelper.cs
@@ -81,10 +81,6 @@ public static class AuthHelper
 	/// on) so the actual login round trip - and that parity - stay under real,
 	/// non-bypassed test coverage.
 	///
-	/// If oidc-client-ts's storage format ever changes (a version bump), this fails
-	/// loudly here rather than as a confusing downstream locator failure in whatever
-	/// the calling test actually checks.
-	///
 	/// Always returns <paramref name="username"/>'s seeded organizer org id
 	/// (per AspireFixture.GetPinnedOrganizerOrganizationId, captured once
 	/// before any test had a chance to create a throwaway org), or null for a
@@ -210,11 +206,9 @@ public static class AuthHelper
 	/// page's "Organization overview" hero CTA. That CTA only renders once
 	/// GET /v1/organizations has resolved *and* produced a non-empty list (see
 	/// resolveOrgAppPath in activeOrg.ts) - a single failed or slow org-list
-	/// request left the hero showing the fallback button with no retry, and
-	/// every caller of the old CTA-clicking helper then burned its full 30s
-	/// timeout waiting for a link that would never appear. Successive timeout
-	/// bumps here (15s -> 25s -> 30s) never fixed that, because the wait was
-	/// not actually short - the link was absent.
+	/// request leaves the hero showing the fallback button with no retry, so a
+	/// caller waiting on that link can time out even though the link itself is
+	/// simply absent.
 	/// </summary>
 	public static async Task GoToOrgAppDashboardAsync(IPage page, Uri frontendUrl, Guid organizationId)
 	{

--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -6,21 +6,16 @@ namespace VisualTests;
 
 /// <summary>
 /// Visual tests for #750: the org app header had no responsive breakpoints at
-/// all, so controls overlapped or got squeezed below the 768px `md`
-/// breakpoint. Per the #755 follow-up review, the org app header is no longer
-/// a bespoke duplicate - it's the same shared <c>Header.tsx</c> component the
-/// public site uses, just grown an optional org-switcher slot, so its mobile
+/// all, so controls overlapped or got squeezed below the 768px `md` breakpoint.
+/// The org app header is the same shared <c>Header.tsx</c> component the public
+/// site uses (grown an optional org-switcher slot per #755), so its mobile
 /// behavior (bell/hamburger always visible, avatar/profile/sign-out/language
 /// collapsed behind the hamburger) is identical to the public site's and
-/// already covered by <c>MobileHeaderTests</c>. What's specific to the org
-/// app here is that the org switcher's own name must not overflow onto the
-/// bell/hamburger. #771 removed the tab bar and the per-page org-name
-/// heading; #775/#777 brought the tab bar back for a time (shared ORG_TABS,
-/// also reused by the burger menu's org submenu), but the dashboard UX
-/// redesign removed it again in favor of the dashboard's own widget links
-/// plus the burger menu's org submenu as the sole way to reach opportunities/
-/// members/settings - see <c>OrganizationDashboardNavLinkTests</c> for that
-/// submenu's own coverage.
+/// already covered by <c>MobileHeaderTests</c>. What's specific to the org app
+/// here is that the org switcher's own name must not overflow onto the
+/// bell/hamburger. There is no tab bar in the current org app UX - opportunities/
+/// members/settings are reached via the dashboard's own widget links and the
+/// burger menu's org submenu (see <c>OrganizationDashboardNavLinkTests</c>).
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -31,10 +26,10 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 	[Test]
 	public async Task MobileHeader_OrgSwitcherDoesNotBlockControls_HamburgerRevealsProfileAndLanguage()
 	{
-		// Log in at the default (desktop) viewport - AuthHelper.LoginAsync looks
-		// for the "Sign in" button that only exists in the public header's
-		// desktop nav (`hidden md:flex`); at mobile width it lives behind that
-		// header's own hamburger instead. Resize only after landing in the app.
+		// Sign in at the default (desktop) viewport - FastSignInAsync's own success
+		// check waits for the "User menu" button, which only exists in the header's
+		// desktop nav (`hidden md:flex`); at mobile width it stays hidden until the
+		// hamburger menu is opened. Resize only after landing in the app.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -5,22 +5,14 @@ using Microsoft.Playwright;
 namespace VisualTests;
 
 /// <summary>
-/// Issue #775: users with >=1 organization had no way to reach the org
-/// dashboard from the mobile burger menu - only the desktop org switcher and
-/// the homepage hero CTA linked to it. Adds an "Organization" entry to the
-/// mobile menu, gated the same way as the admin-only "Administration" entry
-/// (see AdministrationNavLinkTests), resolved via the same
-/// active-org-cookie-then-alphabetical logic HomePage already uses.
-///
-/// Follow-up from PR #777 review: a single link only reached the dashboard
-/// tab, forcing an extra tap to get to opportunities/members/settings. The
-/// entry is now a collapsible submenu (ORG_TABS, shared with OrgAppLayout's
-/// own tab bar) so every org tab is reachable directly from the burger menu.
-///
-/// The entry was originally labeled "Organization Dashboard"; later
-/// consolidated onto the shared nav.organization translation key so mobile
-/// matches the desktop avatar dropdown's own org-submenu toggle, which has
-/// always just read "Organization" (see AccountControls.tsx).
+/// Adds an "Organization" submenu to the mobile burger menu (issue #775) so users
+/// with >=1 organization can reach the org dashboard tabs from mobile, not just via
+/// the desktop org switcher and homepage hero CTA. Gated the same way as the
+/// admin-only "Administration" entry (see AdministrationNavLinkTests) and resolved
+/// via the same active-org-cookie-then-alphabetical logic HomePage uses. Built from
+/// ORG_TABS (shared with OrgAppLayout's own tab bar) so every org tab, not just the
+/// dashboard, is reachable directly from the burger menu. The label matches the
+/// desktop avatar dropdown's own org-submenu toggle (see AccountControls.tsx).
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTestBase(fixture)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,8 +225,8 @@ services:
     networks:
       - proxy
     logging: *default-logging
-    # Bumped from 128m/0.10 now that this handles both the local mirror and
-    # the offsite replication of two datasets in one process.
+    # Higher than a single-purpose mirror needs - this process handles both
+    # the local mirror and the offsite replication of two datasets.
     deploy:
       resources:
         limits:
@@ -601,12 +601,6 @@ configs:
     content: |
       SELECT 'CREATE DATABASE einsatzbereit' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'einsatzbereit')\gexec
       SELECT 'CREATE DATABASE keycloak' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'keycloak')\gexec
-  # Backs up the einsatzbereit bucket to /backups/<YYYY-MM-DD>, once per
-  # BACKUP_INTERVAL_SECONDS, pruning down to BACKUP_KEEP_DAYS snapshots after
-  # each run. `find` is not available in the minio/mc image (RHEL9-UBI-based,
-  # no findutils) - the directory listing/pruning below deliberately uses
-  # only shell globbing plus sort/wc/head/rm, all confirmed present in that
-  # image, instead.
   # Bootstraps the bucket-scoped app service account (#1353) - see the
   # minio-init service above. Idempotent: safe to re-run on every deploy.
   # Same `$$` escaping convention as minio-backup-script below.
@@ -642,6 +636,12 @@ configs:
       mc admin policy attach local einsatzbereit-app --user "$$MINIO_APP_ACCESS_KEY" 2>/dev/null || true
 
       echo "MinIO app service account ready (bucket: $${MINIO_BUCKET_NAME})."
+  # Backs up the einsatzbereit bucket to /backups/<YYYY-MM-DD>, once per
+  # BACKUP_INTERVAL_SECONDS, pruning down to BACKUP_KEEP_DAYS snapshots after
+  # each run. `find` is not available in the minio/mc image (RHEL9-UBI-based,
+  # no findutils) - the directory listing/pruning below deliberately uses
+  # only shell globbing plus sort/wc/head/rm, all confirmed present in that
+  # image, instead.
   # Every `$` below is doubled (`$$`) - compose interpolates `${...}`/`$VAR`
   # in config content the same as anywhere else in this file, so a single `$`
   # here would be silently resolved (usually to blank, since these are

--- a/docs/Architecture/Architecture.adoc
+++ b/docs/Architecture/Architecture.adoc
@@ -1,4 +1,3 @@
-// configure EN settings for asciidoc
 include::src/config.adoc[]
 
 = Einsatzbereit - Architecture Documentation
@@ -7,59 +6,45 @@ include::src/config.adoc[]
 
 include::src/about-arc42.adoc[]
 
-// horizontal line
 ***
 
 
 
 
-// numbering from here on
 :numbered:
 
 <<<<
-// 1. Introduction and Goals
 include::src/01_introduction_and_goals.adoc[]
 
 <<<<
-// 2. Architecture Constraints
 include::src/02_architecture_constraints.adoc[]
 
 <<<<
-// 3. Context and Scope
 include::src/03_context_and_scope.adoc[]
 
 <<<<
-// 4. Solution Strategy
 include::src/04_solution_strategy.adoc[]
 
 <<<<
-// 5. Building Block View
 include::src/05_building_block_view.adoc[]
 
 <<<<
-// 6. Runtime View
 include::src/06_runtime_view.adoc[]
 
 <<<<
-// 7. Deployment View
 include::src/07_deployment_view.adoc[]
 
 <<<<
-// 8. Cross-cutting Concepts
 include::src/08_concepts.adoc[]
 
 <<<<
-// 9. Architecture Decisions
 include::src/09_architecture_decisions.adoc[]
 
 <<<<
-// 10. Quality Requirements
 include::src/10_quality_requirements.adoc[]
 
 <<<<
-// 11. Risks and Technical Debt
 include::src/11_technical_risks.adoc[]
 
 <<<<
-// 12. Glossary
 include::src/12_glossary.adoc[]

--- a/docs/Architecture/src/config.adoc
+++ b/docs/Architecture/src/config.adoc
@@ -1,9 +1,7 @@
 // asciidoc settings for EN (English)
-// =====================================
 // toc-title definition MUST follow document title without blank line!
 :toc-title: Table of Contents
 
-// enable table-of-contents
 :toc:
 
 :caution-caption: Caution
@@ -17,6 +15,5 @@
 :figure-caption: Figure
 :table-caption: Table
 
-// where are images located?
 :imagesdir: {docdir}/images
 :arc42help:

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -978,7 +978,6 @@ export default function CreateVolunteerOpportunityModal({
 					: {stepTitles[step - 1]}
 				</div>
 
-				{/* Scrollable body */}
 				<div
 					ref={bodyRef}
 					className="max-h-[min(70vh,640px)] overflow-y-auto px-6 py-5"
@@ -1060,7 +1059,6 @@ export default function CreateVolunteerOpportunityModal({
 					)}
 				</div>
 
-				{/* Footer navigation */}
 				<div className="flex items-center justify-between gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4">
 					<Button
 						type="button"

--- a/frontend/src/components/QRScannerModal.tsx
+++ b/frontend/src/components/QRScannerModal.tsx
@@ -53,7 +53,6 @@ export default function QRScannerModal({
 		});
 	}, [success]);
 
-	// Check browser support
 	useEffect(() => {
 		const ok =
 			typeof BarcodeDetector !== "undefined" &&
@@ -61,7 +60,6 @@ export default function QRScannerModal({
 		setSupported(ok);
 	}, []);
 
-	// Start camera once support is confirmed
 	useEffect(() => {
 		if (supported !== true) return;
 		let alive = true;
@@ -86,7 +84,6 @@ export default function QRScannerModal({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [supported]);
 
-	// Scan loop
 	useEffect(() => {
 		if (supported !== true) return;
 		let alive = true;

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -39,7 +39,6 @@ export default function OpportunityListItem({
 				aria-label={item.title}
 			/>
 			<div className="flex h-full flex-col">
-				{/* Banner image or category banner */}
 				<div
 					className={`relative flex h-32 w-full shrink-0 items-center justify-center overflow-hidden ${getOpportunityCategoryBannerClassName(item.category)}`}
 				>
@@ -75,7 +74,6 @@ export default function OpportunityListItem({
 					)}
 				</div>
 
-				{/* Content */}
 				<div className="flex min-w-0 flex-1 flex-col p-4 sm:p-5">
 					<div className="mb-2 flex items-center gap-2">
 						<Chip tone="neutral" size="sm" className="shrink-0">

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -1,16 +1,11 @@
 import type { ReactNode } from "react";
 
-// Single source for every icon glyph used across the app (#1115). Before
-// this module existed, the same Heroicons path got hand-copied into up to
-// six different files, each pasted copy free to drift to its own stroke
-// weight or viewBox - a pin icon rendered at stroke 2 on one screen and
-// stroke 1.5 one click later, a 10x10 checkmark rendered ~3.6x heavier than
-// its 24x24 siblings, and so on. All stroke icons here share one 24x24
-// viewBox and one stroke weight via StrokeIcon so that can't happen again;
-// solid (filled) icons and the small drag-handle family are their own
-// natural size since they're a different rendering style, not a stroke
-// weight that can drift. Icons are decorative unless noted otherwise, so
-// they default to aria-hidden.
+// Single source for every icon glyph used across the app (#1115), so all
+// stroke icons share one 24x24 viewBox and stroke weight via StrokeIcon
+// instead of drifting apart across hand-copied paths. Solid (filled) icons
+// and the small drag-handle family keep their own native size since they're
+// a different rendering style, not a stroke weight that can drift. Icons are
+// decorative unless noted otherwise, so they default to aria-hidden.
 
 function StrokeIcon({
 	className = "h-5 w-5",

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -227,15 +227,6 @@ export default function OrgAppLayout() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [organizationId]);
 
-	// einsatzbereit#1308: no page-title effect here anymore - it used to set
-	// the org name unconditionally and never again (its dependency doesn't
-	// change across a tab switch), so every tab under this layout showed the
-	// exact same document title. Each of the four tab pages (plus
-	// EngagementManagementPage for the nested engagements route) now calls
-	// usePageTitle itself with its own tab label, the same fix
-	// EngagementManagementPage already had - this layout no longer needs a
-	// fallback since every route it renders covers its own title.
-
 	// #9: every tab now lives under /dashboard/... (App.tsx's pathless
 	// "dashboard" parent route), so the segment right after "dashboard" -
 	// not the first segment, which is always "dashboard" itself - is what

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -100,10 +100,9 @@ function getLongDateFormatter(lng: string): Intl.DateTimeFormat {
 /** Long-form date-only formatting (e.g. "25. Juli 2026") - for lower-frequency
  * "created on"/"sent on" timestamps where a spelled-out month reads better
  * than the compact numeric style `formatDate` uses. `lng` is i18n.language
- * ("de"/"en"), not an Intl locale (see formatDateTime). Previously each call
- * site re-derived this with its own inline `toLocaleDateString(locale, {...})`
- * options object, which is how it ended up coexisting with two other date
- * formats across the app (#986) - centralizing it here is the fix. */
+ * ("de"/"en"), not an Intl locale (see formatDateTime). Centralized here so
+ * call sites don't each re-derive their own `toLocaleDateString` options and
+ * drift into a third date format alongside formatDate/formatDateTime (#986). */
 export function formatDateLong(dt: string, lng: string): string {
 	return getLongDateFormatter(lng).format(new Date(dt));
 }

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -124,13 +124,11 @@ function UpcomingOpportunitiesWidget({
 			{items !== null && !error && items.length > 0 && (
 				<ul className="space-y-3">
 					{/* Every fetched item always renders - only the metadata line
-					is dropped at compact size, never the items themselves. An
-					earlier version instead truncated the list to fewer items at
-					compact, but size can change from a plain window resize
-					(outside edit mode, so the inert-content guard doesn't apply)
-					and unmounting an item a keyboard user had focus on would
-					silently drop focus to the document body - #771 follow-up
-					review feedback (adaptive layouts per size), a11y follow-up. */}
+					is dropped at compact size, never the items themselves. Size
+					can change from a plain window resize (outside edit mode, so
+					the inert-content guard doesn't apply), and unmounting an item
+					a keyboard user had focus on would silently drop focus to the
+					document body - #771 follow-up, a11y. */}
 					{items.map((item) => (
 						<li
 							key={item.id}

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -374,15 +374,11 @@ export default function OrgDashboardPage() {
 		? Math.min(GRID_MAX_ROWS + 4, rawGuideRows)
 		: GRID_MAX_ROWS + 4;
 
-	// #1402: previously rebuilt with a fresh onClick/onPointerEnter closure
-	// per cell on every render - up to 832 cells at GRID_MAX_ROWS, so up to
-	// 1664 throwaway closures per pointermove while dragging (see
-	// useWidgetPlacement's rAF throttle for the other half of that fix).
-	// Handlers now live once on the grid container (see handleGuideCellClick/
-	// handleGuideCellPointerOver below) and read data-col/data-row off the
-	// event target instead, and the array itself is memoized so an unrelated
-	// re-render (e.g. `saving` toggling) doesn't recompute all 832 cells for
-	// no reason.
+	// #1402: up to 832 cells at GRID_MAX_ROWS, so handlers live once on the
+	// grid container (see handleGuideCellClick/handleGuideCellPointerOver
+	// below) reading data-col/data-row off the event target, rather than a
+	// closure per cell. Memoized so an unrelated re-render (e.g. `saving`
+	// toggling) doesn't recompute all 832 cells for no reason.
 	const guideCells = useMemo(() => {
 		if (!editing || !isLargeViewport) return null;
 		return Array.from({ length: guideRows * GRID_COLUMNS }, (_, i) => {
@@ -464,22 +460,19 @@ export default function OrgDashboardPage() {
 			data-testid="dashboard-widget-grid"
 			// Uniform (not minmax(64px, auto)) row height: CSS Grid auto-rows
 			// apply to the whole row band across every column, not just the cell
-			// whose content demanded the extra height - so a single tall widget
-			// used to stretch its ENTIRE row, including the plain green backdrop
-			// guide cells and any other widget sharing that row, making edit mode
-			// look like an inconsistent, randomly-sized grid instead of the
-			// uniform one it's meant to convey. A widget whose content exceeds
-			// its allotted rows scrolls internally instead (see WidgetCard).
+			// whose content demanded the extra height - a minmax row would let a
+			// single tall widget stretch its entire row, including the backdrop
+			// guide cells and any other widget sharing that row. A widget whose
+			// content exceeds its allotted rows scrolls internally instead (see
+			// WidgetCard).
 			//
 			// The row height itself (see .dashboard-widget-grid in global.css)
 			// tracks the actual rendered column width via a container query,
 			// rather than a flat pixel constant - width already scales with the
-			// viewport (grid-cols-8's 1fr tracks), so a fixed row height meant a
-			// widget's on-screen shape (short-and-wide vs. tall-and-narrow)
-			// warped between a wide monitor and a narrower one even though its
-			// stored cell width/height never changed. Matching the two keeps
-			// every cell roughly square, and a widget's proportions consistent,
-			// on any screen the organizer views it on.
+			// viewport (grid-cols-8's 1fr tracks), and matching row height to it
+			// keeps a widget's on-screen proportions (short-and-wide vs.
+			// tall-and-narrow) consistent across screen sizes instead of warping
+			// while its stored cell width/height stays the same.
 			className="dashboard-widget-grid grid grid-cols-1 gap-4 lg:grid-cols-8"
 			// role="presentation": this delegated onClick/onPointerOver only ever
 			// acts on a bubbled event that actually originated on one of the
@@ -503,8 +496,7 @@ export default function OrgDashboardPage() {
 			{/* Light green cell backdrop behind the whole grid while editing, so
 			an organizer can see the underlying 8-column structure. These cells
 			double as the corner-to-corner placement surface: while a widget is
-			being placed, they become clickable (see handleGuideCellClick above -
-			delegated once at the container instead of a listener per cell, #1402)
+			being placed, they become clickable (see handleGuideCellClick above)
 			and are tinted blue/red to preview whether the current selection is a
 			valid placement. Gated on isLargeViewport since the grid itself
 			collapses to a single stacked column below `lg`, where this wouldn't

--- a/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/useWidgetPlacement.ts
@@ -285,13 +285,11 @@ export function useWidgetPlacement({
 
 		// #1402: a real pointer/mouse can fire pointermove far more often than
 		// the browser actually paints (well past 60-120Hz on a high-polling-
-		// rate mouse or trackpad), and each call used to setDragPreview
-		// synchronously - re-rendering OrgDashboardPage, and with it every one
-		// of the up to 832 grid-guide backdrop cells, once per raw event
-		// instead of once per displayed frame. rafId batches every pointermove
-		// that arrives between two frames into a single state update, so the
-		// preview still tracks the pointer smoothly but the backdrop only
-		// re-renders as often as the screen can actually show it.
+		// rate mouse or trackpad). rafId batches every pointermove that arrives
+		// between two frames into a single state update, so the preview still
+		// tracks the pointer smoothly but OrgDashboardPage - and with it every
+		// one of the up to 832 grid-guide backdrop cells - only re-renders as
+		// often as the screen can actually show it.
 		let rafId: number | null = null;
 		let pendingRect: PlacedWidget | null = null;
 

--- a/keycloak/themes/einsatzbereit/login/login.ftl
+++ b/keycloak/themes/einsatzbereit/login/login.ftl
@@ -10,7 +10,6 @@
 		<#if realm.password>
 			<form id="kc-form-login" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
 
-				<#-- Username / Email -->
 				<div class="form-group">
 					<div class="form-field">
 						<input
@@ -42,7 +41,6 @@
 					</#if>
 				</div>
 
-				<#-- Password -->
 				<div class="form-group">
 					<div class="form-field form-field--with-toggle">
 						<input
@@ -72,7 +70,6 @@
 					</div>
 				</div>
 
-				<#-- Remember me + forgot password -->
 				<div id="kc-form-options" class="form-options">
 					<div class="form-options-wrapper">
 						<#if realm.rememberMe>
@@ -87,7 +84,6 @@
 					</#if>
 				</div>
 
-				<#-- Submit button -->
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
 					<input
 						tabindex="7"

--- a/keycloak/themes/einsatzbereit/login/register-user-profile.ftl
+++ b/keycloak/themes/einsatzbereit/login/register-user-profile.ftl
@@ -11,7 +11,6 @@
 	<#elseif section = "form">
 		<form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
 
-			<#-- Email -->
 			<div class="form-group">
 				<div class="form-field">
 					<input
@@ -33,7 +32,6 @@
 				</#if>
 			</div>
 
-			<#-- Username -->
 			<#if !realm.registrationEmailAsUsername>
 				<div class="form-group">
 					<div class="form-field">
@@ -57,7 +55,6 @@
 				</div>
 			</#if>
 
-			<#-- Password -->
 			<#if passwordRequired??>
 				<div class="form-group">
 					<div class="form-field form-field--with-toggle">
@@ -126,7 +123,6 @@
 				</div>
 			</#if>
 
-			<#-- Terms of Use -->
 			<div class="form-group">
 				<div id="kc-registration-terms-text">
 					${kcSanitize(msg("termsText"))?no_esc}

--- a/keycloak/themes/einsatzbereit/login/register.ftl
+++ b/keycloak/themes/einsatzbereit/login/register.ftl
@@ -11,7 +11,6 @@
 	<#elseif section = "form">
 		<form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
 
-			<#-- Email -->
 			<div class="form-group">
 				<div class="form-field">
 					<input
@@ -33,7 +32,6 @@
 				</#if>
 			</div>
 
-			<#-- Username -->
 			<#if !realm.registrationEmailAsUsername>
 				<div class="form-group">
 					<div class="form-field">
@@ -57,7 +55,6 @@
 				</div>
 			</#if>
 
-			<#-- Password -->
 			<#if passwordRequired??>
 				<div class="form-group">
 					<div class="form-field form-field--with-toggle">
@@ -126,7 +123,6 @@
 				</div>
 			</#if>
 
-			<#-- Terms of Use -->
 			<div class="form-group">
 				<div id="kc-registration-terms-text">
 					${kcSanitize(msg("termsText"))?no_esc}


### PR DESCRIPTION
## What

Repo-wide comment cleanup: 14 parallel passes across backend (Domain, Application, Infrastructure, Api, all four test projects), frontend (components, pages, layouts, lib/hooks), docs, GitHub workflows, Keycloak theme templates, and root configs, trimming or removing comments that were bloated or unnecessary. 43 files changed, comment-only (+145/-365 lines) - no logic, formatting, or behavior changes anywhere.

## Why

The codebase's comments had accumulated bloat in places: restating what the very next line of code already says, over-explaining obvious structure, narrating implementation history ("this used to do X, now it does Y", "fix for issue #NNN") instead of stating the durable rule, and a few stale references to code/tests that no longer exist. Each fix was evidence-based against this repo's own `.claude/skills/lens/references/lens-comment-bloat.md` classification (restates-the-code / over-explains-the-obvious / narrates-process / stale vs. genuinely-load-bearing), not a blanket strip: this codebase already carries a lot of high-quality, issue-cited WHY comments (EF Core/Postgres gotchas, security rationale, cross-file invariants), and those were deliberately left untouched - several agents reported entire feature areas with nothing to fix for exactly that reason.

Representative fixes:
- Deleted comments that purely restated the code directly below them (e.g. `// Collect entity IDs by type` above a self-explanatory LINQ block, `<#-- Password -->` above a `password` form field in Keycloak's login/register templates, `// N. Section Title` above 12 identically-named `include::` directives in the arc42 docs).
- Trimmed comments that narrated removed/changed implementation history down to the current durable invariant (e.g. a dashboard grid test doc that recounted three sequential PRs' worth of history, a CI coverage-summary comment carrying a tool-migration backstory).
- Removed a handful of copy-pasted boilerplate paragraphs repeated near-verbatim across sibling files (integration test "plain Member can now view X" comments, several `publish.yml` deploy-staging steps that restated the line below them and that `deploy-production`'s identical code already omits).
- Fixed one genuinely stale comment (a test referencing a "VerifyOrganization tests" template that no longer exists) and one comment that named the wrong helper method entirely.
- Relocated a misplaced comment block in `docker-compose.yml` that described the `minio-backup` service but sat above `minio-init-script`.

No commented-out dead code was found anywhere in the repo.

## Testing

- Frontend: `pnpm run check` (tsc --noEmit), `pnpm run lint` (ESLint, `--max-warnings 0`), and `pnpm exec prettier --check` on all touched files - all clean.
- Backend: `dotnet build` could not be run in this sandbox (this environment's network policy blocks the .NET SDK download from `builds.dotnet.microsoft.com`); instead every backend diff was manually reviewed line-by-line to confirm comment-only changes with valid C# syntax, plus the `ef-migration-check` subagent confirmed no entity/model changes slipped in anywhere in the diff (including the touched `Domain`/`Infrastructure/Persistence` files). CI's `dotnet.yml` is the authoritative build/test check for this PR - watching it now.
- `a11y-check` subagent confirmed the touched `.tsx` files are comment-only (no JSX/ARIA/markup changes).
- Both edited GitHub Actions workflow files re-parsed as valid YAML.
- Full diff scanned for Unicode en/em dashes - none introduced.
- `/self-review` run - no P1-P4 findings (see below).

## Live verification

Not applicable - this is a comment-only refactor with zero behavior change, so per root `AGENTS.md`'s deploy-and-verify flow this doesn't need a release-candidate/live-staging check. No release candidate was cut for this PR per explicit instruction.

## Checklist

- [x] `/self-review` run and findings addressed (none found - see PR body's Testing section)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3yQNq7GU2j4fh48mjdEva)_