### PR TITLE
fix: stop admin shadow-delete from 500ing profile loads and opportunity edits

### DIFF
--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -524,7 +524,11 @@ internal sealed class ApplicationDbContext(
 		IReadOnlyCollection<UserId> userIds,
 		CancellationToken cancellationToken = default)
 	{
+		// IgnoreQueryFilters() - a shadow-deleted user's row physically exists
+		// and must count as "existing", or this queues a duplicate-key INSERT
+		// against a row the global !IsDeleted filter merely hid (einsatzbereit#1666).
 		var existing = await Set<User>()
+			.IgnoreQueryFilters()
 			.Where(u => userIds.Contains(u.Id))
 			.ToListAsync(cancellationToken);
 
@@ -542,7 +546,12 @@ internal sealed class ApplicationDbContext(
 		string? preferredLanguage,
 		CancellationToken cancellationToken = default)
 	{
-		var existing = await Users.FindAsync(userId, cancellationToken);
+		// IgnoreQueryFilters() - same reasoning as GetOrCreateUsersAsync above:
+		// a shadow-deleted user's row must be found here, not re-inserted into
+		// (einsatzbereit#1666).
+		var existing = await Set<User>()
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
 		if (existing is not null)
 			return existing;
 
@@ -551,7 +560,9 @@ internal sealed class ApplicationDbContext(
 			VALUES ({userId.Value}, '[]', '[]', {preferredLanguage})
 			ON CONFLICT (id) DO NOTHING", cancellationToken);
 
-		return await Users.FindAsync(userId, cancellationToken)
+		return await Set<User>()
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken)
 			?? throw new InvalidOperationException($"User '{userId.Value}' was not found immediately after being inserted.");
 	}
 

--- a/backend/tests/IntegrationTests/AdminShadowDeleteUserTests.cs
+++ b/backend/tests/IntegrationTests/AdminShadowDeleteUserTests.cs
@@ -1,0 +1,131 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1666: ApplicationDbContext.GetOrCreateUserAsync and
+// GetOrCreateUsersAsync used to query the User set without IgnoreQueryFilters(),
+// so a shadow-deleted user's row (physically present, hidden by the global
+// !IsDeleted query filter) was treated as missing and re-inserted, 500ing both
+// the shadow-deleted user's own profile load and any organizer's edit of an
+// opportunity that user was signed up to.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class AdminShadowDeleteUserTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetUserProfile_ShouldNotFail_WhenCallerWasShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		var (userId, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var volunteerClient = await CreateAuthenticatedClientAsync(username, password);
+
+		// The very first profile load lazily creates the local `user` row -
+		// GetOrCreateUserAsync must run once before the shadow-delete below has
+		// anything to hide.
+		await volunteerClient.GetUserProfileAsync(cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		await adminClient.AdminShadowDeleteUserAsync(userId, cancellationToken);
+
+		var profile = await volunteerClient.GetUserProfileAsync(cancellationToken);
+
+		profile.Id.Should().Be(userId);
+		profile.Username.Should().Be(username);
+	}
+
+	[Test]
+	public async Task UpdateVolunteerOpportunity_ShouldNotFail_WhenSignedUpVolunteerWasShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var (volunteerUserId, volunteerUsername, volunteerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var volunteerClient = await CreateAuthenticatedClientAsync(volunteerUsername, volunteerPassword);
+
+		// AdminShadowDeleteUserCommandHandler looks up the local `user` row via
+		// a filtered Users.FindAsync and 404s if it's missing -
+		// CreateEngagementCommandHandler only does a nullable lookup on it, it
+		// doesn't lazily create it, so force the same first-load path GetUserProfile
+		// uses before the admin shadow-deletes below.
+		await volunteerClient.GetUserProfileAsync(cancellationToken);
+		await volunteerClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		await adminClient.AdminShadowDeleteUserAsync(volunteerUserId, cancellationToken);
+
+		// City change is a material edit (UpdateVolunteerOpportunityCommandHandler's
+		// AddressTextChanged check), which routes through
+		// OpportunityNotificationHelper.NotifyActiveVolunteersAsync ->
+		// dbContext.GetOrCreateUsersAsync for every actively engaged volunteer -
+		// including the now shadow-deleted one.
+		var act = () => olafClient.UpdateVolunteerOpportunityAsync(
+			opportunity.Id,
+			new UpdateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				IsRemote = false,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Hamburg",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			},
+			cancellationToken);
+
+		await act.Should().NotThrowAsync();
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"ShadowDeleteTestOrg_{Guid.NewGuid()}";
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return org.Id.Value;
+	}
+
+	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken)
+	{
+		return await client.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Test Opportunity",
+				Description = "Integration test opportunity",
+				OrganizationId = orgId,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			},
+			cancellationToken);
+	}
+}


### PR DESCRIPTION
## What

`ApplicationDbContext.GetOrCreateUserAsync` and `GetOrCreateUsersAsync` now use `IgnoreQueryFilters()` before concluding a user row is missing, so a shadow-deleted user's row (hidden by `UserConfiguration`'s global `!IsDeleted` query filter) is found instead of being treated as missing and re-inserted.

## Why

`UserConfiguration.cs` applies `builder.HasQueryFilter(u => !u.IsDeleted)`. Both lazy-seed helpers in `ApplicationDbContext` ignored this: after an admin shadow-deletes a user, the row still physically exists but is filtered out, so both helpers tried to re-insert a row that already has that primary key, causing a duplicate-key crash surfaced as an unhandled 500.

This broke two things after any admin shadow-delete:
- the shadow-deleted user's own `GET /v1/users/me` (via `GetOrCreateUserAsync`)
- any organizer's `PUT` on an opportunity that shadow-deleted user had signed up for, once a material change (address/occurrence/remote) triggers the volunteer-notification path (via `GetOrCreateUsersAsync` in `OpportunityNotificationHelper`)

Both helpers now mirror the existing `Find*IncludingDeletedAsync` pattern already used elsewhere in the same file (`FindUserIncludingDeletedAsync`, `FindOrganizationIncludingDeletedAsync`, `FindVolunteerOpportunityIncludingDeletedAsync`).

Whether shadow-delete should also cancel the user's active engagements is a separate, deliberately deferred decision per the issue - out of scope here.

Closes #1666

## Testing

Added `backend/tests/IntegrationTests/AdminShadowDeleteUserTests.cs`:
- `GetUserProfile_ShouldNotFail_WhenCallerWasShadowDeleted` - a volunteer loads their profile (lazily creating the local row), an admin shadow-deletes them, then the same profile load must still succeed instead of 500ing.
- `UpdateVolunteerOpportunity_ShouldNotFail_WhenSignedUpVolunteerWasShadowDeleted` - a volunteer signs up for an opportunity, an admin shadow-deletes them, then the organizer's material update to that opportunity (which notifies active volunteers) must still succeed instead of 500ing.

`/self-review` was run: no migration needed (confirmed via `ef-migration-check` - the change is query-shape only, no model/Fluent-API change), no API/DTO change (no `nswag-check` needed). One issue found and fixed during review: the second test initially shadow-deleted the volunteer right after they signed up, but `CreateEngagementCommandHandler` doesn't lazily create the local `user` row (only `GetUserProfile` does), so `AdminShadowDeleteUserCommandHandler` would 404 first - fixed by having the volunteer load their profile before the shadow-delete.

Could not run `dotnet build`/the test suite locally in this sandbox - the .NET SDK install is blocked by this session's network egress policy (`builds.dotnet.microsoft.com` returns 403 through the proxy). CI's `dotnet.yml` runs the full suite (`Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, `VisualTests`) on a real runner; this PR is being monitored for those results and any failures will be fixed.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). The fix is covered by the new integration test above, which CI runs against the real Aspire stack (Postgres + Keycloak).

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no user-facing behavior/doc change beyond the bug fix itself)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RSfNsnnQDTU7yLYZwzBrkh)_