### PR TITLE
fix: category label, chip, and map attribution contrast failures

### DIFF
--- a/frontend/src/components/Chip.tsx
+++ b/frontend/src/components/Chip.tsx
@@ -11,7 +11,7 @@ const TONE_CLASSES = {
 	neutral: "bg-gray-100 text-gray-600",
 	success: "bg-green-50 text-green-700",
 	warning: "bg-amber-50 text-amber-700",
-	danger: "bg-red-50 text-red-600",
+	danger: "bg-red-50 text-red-700",
 } as const;
 
 export type ChipTone = keyof typeof TONE_CLASSES;

--- a/frontend/src/components/SingleMarkerMap.css
+++ b/frontend/src/components/SingleMarkerMap.css
@@ -53,3 +53,13 @@ it for ~5 kB gzip. */
 	color: rgb(55 65 81);
 	background: none;
 }
+
+/* ── Leaflet attribution link contrast ───────────────────────────────────── */
+/* Leaflet ships no color for its attribution links, so they render at
+~3.6:1 against the semi-transparent bar over the desaturated tiles above -
+below WCAG AA. Darkened to clear 4.5:1 (measures ~5.1:1) while staying the
+same blue; the ODbL-required attribution text itself stays untouched
+(einsatzbereit#1671). */
+.leaflet-control-attribution a {
+	color: #006086;
+}

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "react-oidc-context";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
 import { formatDate, formatDateTime, formatOccurrence } from "../../lib/format";
-import { getOpportunityCategoryBannerClassName } from "../../lib/opportunityCategoryTheme";
+import {
+	getOpportunityCategoryBannerClassName,
+	OPPORTUNITY_CATEGORY_LABEL_SCRIM_CLASS,
+} from "../../lib/opportunityCategoryTheme";
 import { useApiClient } from "../../hooks/useApiClient";
 import Chip from "../Chip";
 import ReportFlagButton from "../ReportFlagButton";
@@ -65,7 +68,9 @@ export default function OpportunityListItem({
 								category={item.category}
 								className="h-11 w-11 text-white/90 transition-transform duration-300 group-hover:scale-110"
 							/>
-							<span className="absolute right-0 bottom-2 left-0 px-2 text-center text-xs font-semibold tracking-wider text-white/80 uppercase">
+							<span
+								className={`absolute right-0 bottom-2 left-0 px-2 py-0.5 text-center text-xs font-semibold tracking-wider text-white uppercase ${OPPORTUNITY_CATEGORY_LABEL_SCRIM_CLASS}`}
+							>
 								{item.category
 									? t(`opportunities.category.${item.category}`)
 									: t("opportunities.category.Other")}

--- a/frontend/src/lib/colorContrast.test.ts
+++ b/frontend/src/lib/colorContrast.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { readableTextColor } from "./colorContrast";
+import { readableTextColor, contrastRatio } from "./colorContrast";
 
 describe("readableTextColor", () => {
 	it("picks dark text on a near-white background", () => {
@@ -21,5 +21,30 @@ describe("readableTextColor", () => {
 	it("expands 3-digit shorthand hex", () => {
 		expect(readableTextColor("#000")).toBe("#ffffff");
 		expect(readableTextColor("#fff")).toBe("#111827");
+	});
+});
+
+describe("contrastRatio", () => {
+	it("returns 21:1 for black on white", () => {
+		expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 0);
+	});
+
+	it("returns 1:1 for identical colors", () => {
+		expect(contrastRatio("#3eaf78", "#3eaf78")).toBeCloseTo(1, 5);
+	});
+
+	it("is symmetric regardless of argument order", () => {
+		expect(contrastRatio("#e7000b", "#fef2f2")).toBeCloseTo(
+			contrastRatio("#fef2f2", "#e7000b"),
+			5,
+		);
+	});
+
+	it("flags Chip's pre-fix danger tone (text-red-600 on bg-red-50) as failing WCAG AA", () => {
+		expect(contrastRatio("#e7000b", "#fef2f2")).toBeLessThan(4.5);
+	});
+
+	it("confirms Chip's danger tone clears WCAG AA after the text-red-700 fix (einsatzbereit#1671)", () => {
+		expect(contrastRatio("#c10007", "#fef2f2")).toBeGreaterThanOrEqual(4.5);
 	});
 });

--- a/frontend/src/lib/colorContrast.ts
+++ b/frontend/src/lib/colorContrast.ts
@@ -26,7 +26,10 @@ function relativeLuminance(hex: string): number {
 	return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
 }
 
-function contrastRatio(luminanceA: number, luminanceB: number): number {
+function luminanceContrastRatio(
+	luminanceA: number,
+	luminanceB: number,
+): number {
 	const lighter = Math.max(luminanceA, luminanceB);
 	const darker = Math.min(luminanceA, luminanceB);
 	return (lighter + 0.05) / (darker + 0.05);
@@ -35,7 +38,18 @@ function contrastRatio(luminanceA: number, luminanceB: number): number {
 /** Picks whichever of white/near-black clears more contrast against `backgroundHex`. */
 export function readableTextColor(backgroundHex: string): string {
 	const bgLuminance = relativeLuminance(backgroundHex);
-	const whiteContrast = contrastRatio(1, bgLuminance);
-	const darkContrast = contrastRatio(relativeLuminance(DARK_TEXT), bgLuminance);
+	const whiteContrast = luminanceContrastRatio(1, bgLuminance);
+	const darkContrast = luminanceContrastRatio(
+		relativeLuminance(DARK_TEXT),
+		bgLuminance,
+	);
 	return whiteContrast >= darkContrast ? "#ffffff" : DARK_TEXT;
+}
+
+/** WCAG contrast ratio (1:1 to 21:1) between two colors - the same formula SC 1.4.3 uses. */
+export function contrastRatio(hexA: string, hexB: string): number {
+	return luminanceContrastRatio(
+		relativeLuminance(hexA),
+		relativeLuminance(hexB),
+	);
 }

--- a/frontend/src/lib/opportunityCategoryTheme.test.ts
+++ b/frontend/src/lib/opportunityCategoryTheme.test.ts
@@ -3,8 +3,10 @@ import { describe, it, expect } from "vitest";
 import {
 	OPPORTUNITY_CATEGORY_BANNER_CLASSES,
 	OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
+	OPPORTUNITY_CATEGORY_LABEL_SCRIM_OPACITY,
 	getOpportunityCategoryBannerClassName,
 } from "./opportunityCategoryTheme";
+import { contrastRatio } from "./colorContrast";
 
 describe("getOpportunityCategoryBannerClassName", () => {
 	it("returns the mapped gradient for a known category", () => {
@@ -42,5 +44,70 @@ describe("getOpportunityCategoryBannerClassName", () => {
 		expect(getOpportunityCategoryBannerClassName("")).toBe(
 			OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS,
 		);
+	});
+});
+
+// Tailwind v4's default -500 hex equivalents for each gradient's lightest
+// ("from") stop - the worst case for contrast, since the "to" stop only gets
+// darker. Cross-checked against einsatzbereit#1671's own pixel measurements
+// (e.g. amber-500 there independently measured as the worst offender too).
+const CATEGORY_LIGHTEST_GRADIENT_STOP_HEX: Record<string, string> = {
+	Social: "#ff2056", // rose-500
+	Environment: "#00bc7d", // emerald-500
+	Sport: "#ff6900", // orange-500
+	Education: "#00a6f4", // sky-500
+	DisasterRelief: "#fb2c36", // red-500
+	Health: "#f6339a", // pink-500
+	Animals: "#fe9a00", // amber-500
+	Culture: "#8e51ff", // violet-500
+	Technology: "#615fff", // indigo-500
+};
+const FALLBACK_GRADIENT_LIGHTEST_STOP_HEX = "#3eaf78"; // brand-500, see global.css
+
+// Mirrors CSS alpha compositing of a black scrim over an opaque backdrop:
+// result = alpha*black + (1-alpha)*backdrop = (1-alpha)*backdrop per channel.
+function blendWithBlack(hex: string, alpha: number): string {
+	const int = parseInt(hex.slice(1), 16);
+	const r = Math.round((1 - alpha) * ((int >> 16) & 255));
+	const g = Math.round((1 - alpha) * ((int >> 8) & 255));
+	const b = Math.round((1 - alpha) * (int & 255));
+	return `#${[r, g, b].map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}
+
+describe("opportunity category banner label contrast (einsatzbereit#1671)", () => {
+	it.each(Object.keys(OPPORTUNITY_CATEGORY_BANNER_CLASSES))(
+		"%s: OPPORTUNITY_CATEGORY_BANNER_CLASSES has a matching known -500 hex fixture",
+		(category) => {
+			expect(CATEGORY_LIGHTEST_GRADIENT_STOP_HEX[category]).toBeDefined();
+		},
+	);
+
+	it.each(Object.entries(CATEGORY_LIGHTEST_GRADIENT_STOP_HEX))(
+		"%s: white label text over the scrim clears WCAG AA against the lightest gradient stop",
+		(_category, hex) => {
+			const scrimmedBackground = blendWithBlack(
+				hex,
+				OPPORTUNITY_CATEGORY_LABEL_SCRIM_OPACITY,
+			);
+			expect(
+				contrastRatio("#ffffff", scrimmedBackground),
+			).toBeGreaterThanOrEqual(4.5);
+		},
+	);
+
+	it("fallback brand gradient: white label text over the scrim clears WCAG AA", () => {
+		const scrimmedBackground = blendWithBlack(
+			FALLBACK_GRADIENT_LIGHTEST_STOP_HEX,
+			OPPORTUNITY_CATEGORY_LABEL_SCRIM_OPACITY,
+		);
+		expect(contrastRatio("#ffffff", scrimmedBackground)).toBeGreaterThanOrEqual(
+			4.5,
+		);
+	});
+
+	it("regression guard: white text WITHOUT the scrim fails WCAG AA on the worst category (amber-500)", () => {
+		expect(
+			contrastRatio("#ffffff", CATEGORY_LIGHTEST_GRADIENT_STOP_HEX.Animals),
+		).toBeLessThan(4.5);
 	});
 });

--- a/frontend/src/lib/opportunityCategoryTheme.ts
+++ b/frontend/src/lib/opportunityCategoryTheme.ts
@@ -17,6 +17,16 @@ export const OPPORTUNITY_CATEGORY_BANNER_CLASSES: Record<string, string> = {
 export const OPPORTUNITY_CATEGORY_BANNER_FALLBACK_CLASS =
 	"bg-gradient-to-br from-brand-500 to-brand-800";
 
+// White label text alone fails WCAG AA against several of the gradients above
+// (worst case ~2.1:1 on amber-500, einsatzbereit#1671) - a black/40 scrim
+// strip behind the text clears 4.5:1 against every category's lightest
+// ("from") stop with margin (worst case ~5.4:1 on amber-500), so the fix
+// works for any gradient here without per-category tuning. The class must
+// stay a literal string for Tailwind's content scanner to pick it up; keep
+// the opacity constant below in sync with it by hand.
+export const OPPORTUNITY_CATEGORY_LABEL_SCRIM_CLASS = "bg-black/40";
+export const OPPORTUNITY_CATEGORY_LABEL_SCRIM_OPACITY = 0.4;
+
 export function getOpportunityCategoryBannerClassName(
 	category: string | undefined,
 ): string {


### PR DESCRIPTION
## What

Fixes three WCAG AA color-contrast failures on text over non-flat backgrounds: fallback opportunity banner category labels, the `Chip` danger tone, and the OpenStreetMap attribution link.

## Why

Found by the 1.0 readiness analysis: contrast was never checked where the background is a gradient or a third-party default.

Closes #1671

- **Category labels on fallback opportunity banners** (`OpportunityListItem.tsx`): the label used `text-white/80` directly over each category's gradient background, measuring as low as 3.06:1 for 7 of 9 categories (4.5:1 required at 12px/600-weight). Fixed by switching to solid `text-white` plus a `bg-black/40` scrim strip behind the label - this clears 4.5:1 against every category's lightest gradient stop with margin (worst case ~5.4:1 on Animals/amber), regardless of hue, so it doesn't need per-category color tuning.
- **`Chip tone="danger"`** (the "Full"/"Belegt" badge): `text-red-600` on `bg-red-50` was 4.36:1. Bumped to `text-red-700` (5.87:1).
- **OpenStreetMap attribution link** (`SingleMarkerMap.css`): Leaflet ships no color for its attribution links, which rendered at ~3.64:1 against the semi-transparent bar over the desaturated map tiles. Overrode `.leaflet-control-attribution a` to a darker blue (~5.1:1) while leaving the ODbL-required attribution text itself untouched.

## Testing

- Added `contrastRatio(hexA, hexB)` as a new export on the existing `frontend/src/lib/colorContrast.ts` (WCAG relative-luminance formula, SC 1.4.3).
- `frontend/src/lib/colorContrast.test.ts`: unit tests for the new export, including the exact pre-fix (4.36:1, failing) and post-fix (5.87:1, passing) Chip danger-tone values.
- `frontend/src/lib/opportunityCategoryTheme.test.ts`: regression tests computing the scrimmed background for every category's lightest gradient stop (plus the brand fallback gradient) and asserting white label text clears 4.5:1 against all of them, plus a guard proving the pre-fix (unscrimmed) case fails.
- `pnpm test` (186/186 passing), `pnpm lint`, `pnpm check` (tsc), `pnpm i18n:check` all pass.
- Ran `a11y-check` against the one `.tsx` change (`OpportunityListItem.tsx`) - styling-only change to an existing non-interactive label, no new a11y concerns raised.

## Live verification

No release candidate was cut for this change per explicit instruction, so this was not verified against live staging. All three fixes were verified numerically instead: exact hex/oklch values for every affected Tailwind color were pulled from the installed `tailwindcss@4.3.3` package and run through the same WCAG contrast formula `colorContrast.ts` uses, cross-checked against the pixel-measured values in #1671 itself (several computed values matched the issue's reported numbers to two decimal places, e.g. Chip's pre-fix danger tone at 4.36:1 and the other four Chip tones at 6.19/6.87/4.72/4.85). Those computations are now encoded as the regression tests described above.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (N/A - internal styling fix, no user-facing docs affected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcFe4SWXjM4J4sEnob9V5F)_