### PR TITLE
fix: restore focus to the modal trigger on close

### DIFF
--- a/backend/tests/VisualTests/ModalFocusRestoreTests.cs
+++ b/backend/tests/VisualTests/ModalFocusRestoreTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1670: Modal.tsx's trigger-capture effect was declared
+/// *after* the effect that moves focus into the dialog. React fires mount
+/// effects in declaration order, so the capture read document.activeElement
+/// only once the other effect had already focused something inside the
+/// dialog - it captured that inner element instead of the button that opened
+/// the modal, and the restore-on-close silently no-oped.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class ModalFocusRestoreTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task CreateVolunteerOpportunityModal_Close_RestoresFocusToTriggerButton()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var trigger = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" }).First;
+		await Expect(trigger).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await trigger.ClickAsync();
+
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Step 1's title field is the first focusable element inside the
+		// wizard body (initialFocusRef scopes past the header close button and
+		// the stepper) - a focusable child inside the dialog, the exact
+		// condition #1670 depended on to mis-capture "the trigger".
+		await Expect(Page.Locator("#opportunity-title")).ToBeFocusedAsync();
+
+		// Untouched form, so Escape closes immediately with no discard-changes
+		// confirmation in the way.
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(dialog).Not.ToBeVisibleAsync();
+
+		(await trigger.EvaluateAsync<bool>("el => el === document.activeElement")).Should().BeTrue(
+			"closing the modal must restore focus to the button that opened it, per the WAI-ARIA Dialog pattern");
+	}
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -31,15 +31,17 @@ export default function Modal({
 	const dialogRef = useRef<HTMLDivElement>(null);
 	const hasFocusedRef = useRef(false);
 
-	useEffect(() => {
-		if (hasFocusedRef.current) return;
-		hasFocusedRef.current = true;
-		const scope = initialFocusRef?.current ?? dialogRef.current;
-		scope?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
-	}, [initialFocusRef]);
-
 	// Restore focus to whatever triggered the modal once it unmounts (close),
 	// per the WAI-ARIA Dialog pattern - otherwise focus falls back to <body>.
+	// Declared before the initial-focus effect below so activeElement is
+	// still the trigger when read here (React fires mount effects in
+	// declaration order) - declared second before, this instead captured
+	// whatever the other effect had just focused inside the dialog (#1670).
+	// The hasFocusedRef reset below is for React.StrictMode's dev-only double
+	// mount/cleanup/remount (VisualTests run against the Vite dev server):
+	// its interim cleanup fires this restore early, and clearing the guard
+	// lets the remount's initial-focus effect re-apply instead of leaving
+	// focus stranded on the trigger.
 	useEffect(() => {
 		const trigger =
 			document.activeElement instanceof HTMLElement
@@ -47,8 +49,16 @@ export default function Modal({
 				: null;
 		return () => {
 			if (trigger?.isConnected) trigger.focus();
+			hasFocusedRef.current = false;
 		};
 	}, []);
+
+	useEffect(() => {
+		if (hasFocusedRef.current) return;
+		hasFocusedRef.current = true;
+		const scope = initialFocusRef?.current ?? dialogRef.current;
+		scope?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+	}, [initialFocusRef]);
 
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
## What

`Modal.tsx`'s two focus-management effects were declared in the wrong order, so the "restore focus on close" effect always captured the wrong element and the restore silently no-oped.

## Why

`Modal.tsx` has two effects: one moves focus *into* the dialog on mount, the other captures `document.activeElement` as "the trigger" to restore focus to once the modal unmounts. React fires mount effects in declaration order - the capture effect was declared *second*, so by the time it ran, the other effect had already moved focus into the dialog. It ended up capturing the dialog's own newly focused element instead of the button that opened the modal, so on close the restore was silently skipped (or a no-op) instead of returning focus to the trigger, per the WAI-ARIA Dialog pattern.

The fix reorders the two effects so the trigger is captured before focus moves into the dialog. It also resets the once-only `hasFocusedRef` focus guard in the capture effect's cleanup - needed because this repo's `VisualTests` run the frontend under the Vite dev server, where `React.StrictMode` double-invokes effects (mount -> cleanup -> mount again) purely in development. Without the reset, that interim cleanup would move focus back to the trigger and the guard would then block the second mount's initial-focus effect from re-running, stranding focus outside the dialog instead of landing back inside it.

Closes #1670

## Testing

- `pnpm lint`, `pnpm check` (tsc --noEmit), `pnpm test` (161 tests) all pass locally.
- Added `backend/tests/VisualTests/ModalFocusRestoreTests.cs`, a TUnit.Playwright regression covering `CreateVolunteerOpportunityModal` (one of the two dialogs cited in the issue as evidence): opens the dialog, asserts initial focus lands on the wizard's title field (a focusable child inside the dialog - the exact condition the bug depended on to mis-capture "the trigger"), closes via Escape, then asserts focus is restored to the "Create opportunity" button that opened it.
- Could not run the backend build/`VisualTests` suite locally in this sandbox - this session's egress policy blocks `builds.dotnet.microsoft.com`, so the .NET SDK could not be installed (see root `AGENTS.md`'s Sandbox Limitations; normally `dotnet build` + `Application.UnitTests`/`ArchitectureTests` are runnable without Docker). Relying on `dotnet.yml` CI for the backend build and the new `VisualTests` case.

## Live verification

Skipped per explicit instruction for this task (no release candidate cut). Verification here is CI (`dotnet.yml`'s `visual-tests` job) exercising the new `ModalFocusRestoreTests` case against the real Aspire/Playwright stack, plus the frontend checks above.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - internal bug fix, no user-facing behavior change to document beyond the fix itself)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VLEU6TVNWJfDuNbBoMtqm2)_