### PR TITLE
fix: make dialogs scroll instead of clipping on short viewports

### DIFF
--- a/backend/tests/VisualTests/CreateOpportunityModalViewportTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityModalViewportTests.cs
@@ -1,0 +1,80 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1663: Modal.tsx's wrapper centered the dialog with
+/// `overflow-hidden` and no scroll container, so a dialog taller than the
+/// viewport lost content off both the top and bottom edges with no way to
+/// recover it via mouse wheel or touch - only a focus()-driven auto-scroll
+/// (keyboard users) could nudge it. iPhone SE 2022 at 375x553 was the worst
+/// measured case in the issue, against the create-opportunity wizard.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class CreateOpportunityModalViewportTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const int ViewportWidth = 375;
+	private const int ViewportHeight = 553;
+
+	[Test]
+	public async Task CreateOpportunityWizard_TallDialogAtIPhoneSeViewport_FooterButtonsReachableByWheelScroll()
+	{
+		// Resize after FastSignInAsync, not before - its own success check
+		// waits on the desktop-only "User menu" button, which is hidden below
+		// the md breakpoint.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+		await Page.SetViewportSizeAsync(ViewportWidth, ViewportHeight);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+
+		// The top edge must already be reachable at rest, with no scrolling at
+		// all: items-start (below the sm: breakpoint) keeps it flush against
+		// the wrapper's own top padding, rather than items-center pushing it
+		// partly above y=0 the way the reported bug did (measured at -30px,
+		// permanently unreachable by any input method).
+		var titleBox = await Page.Locator("#create-opportunity-dialog-title").BoundingBoxAsync();
+		titleBox.Should().NotBeNull();
+		titleBox!.Y.Should().BeGreaterThanOrEqualTo(0,
+			"the dialog title must not be clipped above the top of the viewport at rest");
+
+		// The dialog must actually be taller than the viewport here, or the
+		// wheel-scroll assertions below would pass trivially regardless of
+		// the fix.
+		var scrollHeight = await dialog.EvaluateAsync<int>("el => el.parentElement.scrollHeight");
+		var clientHeight = await dialog.EvaluateAsync<int>("el => el.parentElement.clientHeight");
+		scrollHeight.Should().BeGreaterThan(clientHeight,
+			"the wizard dialog must be taller than the 553px viewport for this regression test to be meaningful");
+
+		// A real user-initiated mouse wheel (not a JS scrollTo()/scrollTop
+		// assignment, and not Locator.HoverAsync/ClickAsync's own
+		// auto-scroll-into-view - both of those are programmatic and, per the
+		// issue's own measurements, still nudge scrollTop even on the broken
+		// overflow-hidden wrapper) is what the bug report showed staying
+		// stuck at scrollTop 0. Hover over the stepper first - already
+		// visible without any scrolling - purely to position the mouse before
+		// dispatching the wheel event at that point.
+		await Page.GetByTestId("wizard-stepper-1").HoverAsync();
+		await Page.Mouse.WheelAsync(0, 2000);
+
+		foreach (var testId in new[] { "modal-cancel", "modal-save-draft", "modal-next" })
+		{
+			var button = Page.GetByTestId(testId);
+			await Expect(button).ToBeVisibleAsync();
+			var box = await button.BoundingBoxAsync();
+			box.Should().NotBeNull();
+			box!.Y.Should().BeGreaterThanOrEqualTo(0,
+				$"{testId} top edge must be within the viewport after scrolling");
+			(box.Y + box.Height).Should().BeLessThanOrEqualTo(ViewportHeight,
+				$"{testId} bottom edge must be within the {ViewportHeight}px-tall viewport after scrolling");
+		}
+	}
+}

--- a/backend/tests/VisualTests/CreateOpportunityModalViewportTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityModalViewportTests.cs
@@ -61,20 +61,37 @@ public class CreateOpportunityModalViewportTests(AspireFixture fixture) : Visual
 		// overflow-hidden wrapper) is what the bug report showed staying
 		// stuck at scrollTop 0. Hover over the stepper first - already
 		// visible without any scrolling - purely to position the mouse before
-		// dispatching the wheel event at that point.
+		// dispatching wheel events at that point.
 		await Page.GetByTestId("wizard-stepper-1").HoverAsync();
-		await Page.Mouse.WheelAsync(0, 2000);
 
-		foreach (var testId in new[] { "modal-cancel", "modal-save-draft", "modal-next" })
+		// Dispatch repeated, modest wheel ticks (closer to real trackpad/wheel
+		// input than one giant delta) and poll rather than reading geometry
+		// once right after a single dispatch - under this suite's own CPU
+		// contention (AssemblyParallelLimit.cs runs many Playwright sessions
+		// concurrently), a single wheel event's resulting scroll is not
+		// guaranteed to already be reflected in the very next BoundingBoxAsync
+		// call. See VisualTestBase.PollUntilAsync's doc comment.
+		var footerTestIds = new[] { "modal-cancel", "modal-save-draft", "modal-next" };
+		var lastObserved = new Dictionary<string, string>();
+		await PollUntilAsync(async () =>
 		{
-			var button = Page.GetByTestId(testId);
-			await Expect(button).ToBeVisibleAsync();
-			var box = await button.BoundingBoxAsync();
-			box.Should().NotBeNull();
-			box!.Y.Should().BeGreaterThanOrEqualTo(0,
-				$"{testId} top edge must be within the viewport after scrolling");
-			(box.Y + box.Height).Should().BeLessThanOrEqualTo(ViewportHeight,
-				$"{testId} bottom edge must be within the {ViewportHeight}px-tall viewport after scrolling");
-		}
+			await Page.Mouse.WheelAsync(0, 400);
+			var allWithinViewport = true;
+			foreach (var testId in footerTestIds)
+			{
+				var box = await Page.GetByTestId(testId).BoundingBoxAsync();
+				var withinViewport = box is not null && box.Y >= 0 && box.Y + box.Height <= ViewportHeight;
+				lastObserved[testId] = box is null
+					? "<no box>"
+					: $"top={box.Y:F0} bottom={box.Y + box.Height:F0}";
+				if (!withinViewport)
+					allWithinViewport = false;
+			}
+			return allWithinViewport;
+		}, () => "footer buttons never became fully visible within the "
+			+ $"{ViewportHeight}px viewport after repeated wheel scrolling (last observed: "
+			+ string.Join(", ", footerTestIds.Select(id => $"{id}: {lastObserved.GetValueOrDefault(id, "<none>")}"))
+			+ ")",
+			timeoutMs: 10_000);
 	}
 }

--- a/frontend/src/components/ImageCropModal.tsx
+++ b/frontend/src/components/ImageCropModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	blobToFile,
@@ -41,8 +41,13 @@ export default function ImageCropModal({
 	onCropped,
 }: ImageCropModalProps) {
 	const { t } = useTranslation();
-	const frameWidth = FRAME_MAX_WIDTH;
-	const frameHeight = FRAME_MAX_WIDTH / aspectRatio;
+	const frameRef = useRef<HTMLButtonElement>(null);
+	// FRAME_MAX_WIDTH is only the upper bound now - the frame's actual CSS box
+	// (`w-full max-w-80`) shrinks to whatever the dialog has room for on narrow
+	// viewports, and this state tracks the real measured size so the drag/zoom
+	// math below stays pixel-accurate to what's rendered (#1663).
+	const [frameWidth, setFrameWidth] = useState(FRAME_MAX_WIDTH);
+	const frameHeight = frameWidth / aspectRatio;
 
 	const [image, setImage] = useState<HTMLImageElement | null>(null);
 	const [loadError, setLoadError] = useState(false);
@@ -54,6 +59,51 @@ export default function ImageCropModal({
 		start: { x: number; y: number };
 		offset: Offset;
 	} | null>(null);
+
+	// Layout effect (not a regular one) so the measurement is committed before
+	// the image-load effect below ever reads `frameWidth` - that effect only
+	// depends on `[file]`, so whatever `frameWidth` is by the time it runs
+	// becomes the crop's initial centering. `[image]` re-runs this once the
+	// frame button actually mounts (it doesn't exist yet during the loading
+	// state) and again for a freshly picked file.
+	useLayoutEffect(() => {
+		const el = frameRef.current;
+		if (!el) return;
+		const measure = () => {
+			const width = el.getBoundingClientRect().width;
+			if (width > 0) setFrameWidth(Math.min(FRAME_MAX_WIDTH, width));
+		};
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [image]);
+
+	// Re-clamps (without recentering) whenever the measured frame size itself
+	// changes after the image has already loaded - e.g. a viewport
+	// resize/orientation change while the modal is open. Drag/zoom already
+	// clamp on every change of their own, so this intentionally doesn't
+	// depend on `image`/`zoom` too - it would otherwise fight them.
+	useEffect(() => {
+		if (!image) return;
+		setOffset((prev) => {
+			const scale =
+				coverScale(
+					image.naturalWidth,
+					image.naturalHeight,
+					frameWidth,
+					frameHeight,
+				) * zoom;
+			return clampOffset(
+				prev,
+				image.naturalWidth * scale,
+				image.naturalHeight * scale,
+				frameWidth,
+				frameHeight,
+			);
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [frameWidth, frameHeight]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -238,10 +288,11 @@ export default function ImageCropModal({
 			<p className="mt-1 text-xs text-gray-500">{t("imageCrop.dragHint")}</p>
 
 			<button
+				ref={frameRef}
 				type="button"
 				aria-label={t("imageCrop.frameLabel")}
-				className="relative mt-4 block touch-none overflow-hidden rounded-card border-0 bg-gray-100 p-0"
-				style={{ width: frameWidth, height: frameHeight }}
+				className="relative mt-4 block w-full max-w-80 touch-none overflow-hidden rounded-card border-0 bg-gray-100 p-0"
+				style={{ aspectRatio }}
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -83,11 +83,21 @@ export default function Modal({
 	// mode is entered while the modal is open. `inert` only reaches real DOM
 	// descendants, so portaling out from under it keeps the modal interactive
 	// regardless of the widget's own edit-mode state.
+	// items-start (rather than items-center) plus overflow-y-auto keeps the
+	// dialog's top edge inside the scrollable range - centering vertically
+	// with overflow-hidden clips whatever doesn't fit at *both* edges, and
+	// scrollTop can never go negative to recover the top half (#1663).
+	// items-center only kicks back in from sm: up, where dialogs reliably fit.
 	return createPortal(
-		<div className="fixed inset-0 z-2000 flex items-center justify-center overflow-hidden p-3 sm:p-4">
+		<div className="fixed inset-0 z-2000 flex max-h-dvh items-start justify-center overflow-y-auto p-3 sm:items-center sm:p-4">
 			<button
 				type="button"
-				className={`absolute inset-0 ${backdropClassName}`}
+				// fixed (not absolute) so it keeps covering the full viewport as the
+				// wrapper scrolls - an absolutely positioned inset-0 only matches the
+				// wrapper's own (viewport-sized) box at scrollTop 0 and would scroll
+				// away with the rest of the content otherwise, uncovering whatever's
+				// behind the dialog once scrolled.
+				className={`fixed inset-0 ${backdropClassName}`}
 				onClick={onClose}
 				tabIndex={-1}
 				aria-hidden="true"


### PR DESCRIPTION
## What

`Modal.tsx`'s wrapper centered every dialog with `overflow-hidden` and no scroll fallback, so a dialog taller than the viewport lost content off both the top and bottom edges with no way to recover it by touch or mouse wheel.

## Why

Closes #1663

On an iPhone SE (375x553), the create-opportunity wizard's footer buttons (Cancel/Save as draft/Next) were unreachable by touch - `scrollTop` could never go negative to recover the clipped top ~30px, and the `overflow-hidden` wrapper ignored real wheel/touch scroll input entirely (only a `.focus()`-driven auto-scroll for keyboard users nudged it). Since `Modal` is used in 17 files, this was a shared-primitive problem affecting every dialog in the app, worst on the German locale (default served locale, longer strings).

## Changes

- **`Modal.tsx`**: wrapper now scrolls (`overflow-y-auto` + `max-h-dvh`) and anchors to the top on narrow viewports (`items-start`, `sm:items-center` from 640px up) so the top edge stays inside the scrollable range instead of being split unreachably across both edges.
- **Backdrop button**: switched from `absolute inset-0` to `fixed inset-0`. Caught in self-review: once the wrapper became scrollable, an absolutely-positioned backdrop only matched the viewport-sized box at `scrollTop=0` and would scroll away with the rest of the content on a tall dialog, uncovering whatever's behind it.
- **`ImageCropModal.tsx`**: the crop frame's hardcoded `FRAME_MAX_WIDTH = 320` inline pixel width compounded the overflow on narrow dialogs (avatar/logo crop flow). It's now a responsive CSS box (`w-full max-w-80` + `aspect-ratio`), with the real rendered pixel size tracked via a `ResizeObserver`-backed `useLayoutEffect` so the drag/zoom/crop math stays accurate to what's actually rendered. A `useLayoutEffect` (not a regular effect) guarantees the measurement is committed before the image-load effect first computes the initial centered offset.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (161 unit tests) all pass.
- Added `backend/tests/VisualTests/CreateOpportunityModalViewportTests.cs`: opens the create-opportunity wizard at 375x553 (the worst case measured in the issue), asserts the dialog title isn't clipped above the viewport at rest, confirms the dialog is genuinely taller than the viewport (so the test is meaningful), then dispatches a real synthetic mouse-wheel event (not `scrollTo()`/`.focus()`, which per the issue's own measurements still nudge `scrollTop` even on the broken `overflow-hidden` wrapper) and asserts the footer buttons end up fully within the viewport.
- `/self-review` run - one finding (the backdrop positioning issue above) was surfaced and fixed before opening this PR. `a11y-check` subagent run against both changed components - clean (backdrop-button pattern, focus trap, and Escape handling all intact; no new route needing an `AccessibilityTests.cs` entry).

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. `dotnet.yml`'s `visual-tests` job will run the new regression test above against the local Aspire stack as part of this PR's CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no docs changes needed - this is a shared-component bug fix, no behavior/API documented elsewhere)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXRTuaCoYNjNMhXh8mgf1y)_