### PR TITLE
fix: mobile layout gaps - invisible menu, clipped rows, sub-24px touch targets

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1269,6 +1269,44 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task MobileMenu_Open_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1672: MobileMenu gained a scrim, role="dialog"/aria-modal, a Tab
+		// focus trap, and a body scroll lock - none of that markup existed
+		// when this suite's other scans ran, and every other scan here runs
+		// at the default desktop viewport (the panel is md:hidden), so
+		// nothing has ever axe-scanned it. Olaf, not Vera, so the org
+		// submenu (issue #775) is also present and gets expanded below -
+		// the whole panel's markup exercised in one scan, not just the
+		// anonymous/no-org subset.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		// FastSignInAsync verifies auth via the desktop "User menu" button,
+		// which is CSS-hidden below the md breakpoint (see
+		// OrganizationDashboardNavLinkTests) - sign in before shrinking to a
+		// mobile viewport, not after.
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(375, 812);
+
+		var banner = Page.GetByRole(AriaRole.Banner);
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+
+		var dialog = Page.GetByRole(AriaRole.Dialog, new() { Name = "Menu" });
+		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Organization", Exact = true })
+			.ClickAsync();
+		await Expect(dialog.GetByRole(AriaRole.Link, new() { Name = "Dashboard", Exact = true }))
+			.ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task AdministrationPage_HasNoSeriousA11yViolations()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type {
 	AchievementSummary,
@@ -6,6 +7,15 @@ import type {
 import Skeleton from "./Skeleton";
 import { formatDate } from "../lib/format";
 import { achievementTypeLabel } from "../lib/achievementType";
+
+// Mirrors FilterDropdown.tsx's edge margin - keeps a clamped tooltip from
+// touching the viewport edge exactly, not just staying inside it.
+const EDGE_MARGIN = 8;
+// Matches the tooltip's own w-48 - fixed, so unlike FilterDropdown's
+// dynamically-sized panel this doesn't need to be measured (and can't be:
+// the tooltip is display:none via the `hidden` class until hovered/focused,
+// so getBoundingClientRect/offsetWidth would read 0 anyway).
+const TOOLTIP_WIDTH = 192;
 
 function AchievementTypeIcon({
 	type,
@@ -81,9 +91,36 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 		: achievementTypeLabel(catalog.type);
 	const tooltipId = `badge-tooltip-${catalog.key}`;
 	const nameId = `badge-name-${catalog.key}`;
+	const cardRef = useRef<HTMLDivElement>(null);
+	// Centered on the badge by default (see the tooltip's left-1/2 below) -
+	// shifted only far enough to keep it on-screen for badges near the edge
+	// of the grid's outer columns (#1672). Recomputed on resize since which
+	// columns are "outer" depends on the grid's current column count.
+	const [tooltipShift, setTooltipShift] = useState(0);
+
+	useLayoutEffect(() => {
+		function updatePosition() {
+			const card = cardRef.current;
+			if (!card) return;
+			const cardRect = card.getBoundingClientRect();
+			const cardCenter = cardRect.left + cardRect.width / 2;
+			const halfTooltipWidth = TOOLTIP_WIDTH / 2;
+			const minCenter = EDGE_MARGIN + halfTooltipWidth;
+			const maxCenter = window.innerWidth - EDGE_MARGIN - halfTooltipWidth;
+			const clampedCenter = Math.min(
+				Math.max(cardCenter, minCenter),
+				maxCenter,
+			);
+			setTooltipShift(clampedCenter - cardCenter);
+		}
+		updatePosition();
+		window.addEventListener("resize", updatePosition);
+		return () => window.removeEventListener("resize", updatePosition);
+	}, []);
 
 	return (
 		<div
+			ref={cardRef}
 			className={`group relative flex flex-col items-center rounded-card border p-4 text-center transition-all ${
 				isEarned
 					? "border-brand-200 bg-white shadow-resting hover:shadow-raised"
@@ -143,7 +180,8 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 				<div
 					id={tooltipId}
 					role="tooltip"
-					className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block group-focus:block"
+					style={{ transform: `translateX(calc(-50% + ${tooltipShift}px))` }}
+					className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg group-hover:block group-focus:block"
 				>
 					<p className="font-semibold">
 						{t(`achievements.badges.${catalog.key}.name`, {

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -11,15 +11,18 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 	if (compact) {
 		return (
 			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">
-				<Link to="/help" className="hover:text-gray-600">
+				<Link to="/help" className="inline-block py-1 hover:text-gray-600">
 					{t("footer.help")}
 				</Link>
 				<span className="mx-2">&middot;</span>
-				<Link to="/imprint" className="hover:text-gray-600">
+				<Link to="/imprint" className="inline-block py-1 hover:text-gray-600">
 					{t("footer.imprint")}
 				</Link>
 				<span className="mx-2">&middot;</span>
-				<Link to="/privacy-policy" className="hover:text-gray-600">
+				<Link
+					to="/privacy-policy"
+					className="inline-block py-1 hover:text-gray-600"
+				>
 					{t("footer.privacy")}
 				</Link>
 			</footer>
@@ -45,14 +48,17 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 						</h2>
 						<ul className="space-y-2 text-sm">
 							<li>
-								<Link to="/" className="transition-colors hover:text-white">
+								<Link
+									to="/"
+									className="inline-block py-0.5 transition-colors hover:text-white"
+								>
 									{t("footer.findOpportunities")}
 								</Link>
 							</li>
 							<li>
 								<a
 									href="/#opportunities"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.participate")}
 								</a>
@@ -60,7 +66,7 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							<li>
 								<Link
 									to="/organizations"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.browseOrganizations")}
 								</Link>
@@ -74,7 +80,7 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							<li>
 								<Link
 									to="/imprint"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.imprint")}
 								</Link>
@@ -82,7 +88,7 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							<li>
 								<Link
 									to="/terms-of-use"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.terms")}
 								</Link>
@@ -90,7 +96,7 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							<li>
 								<Link
 									to="/privacy-policy"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.privacy")}
 								</Link>
@@ -98,13 +104,16 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							<li>
 								<Link
 									to="/contact"
-									className="transition-colors hover:text-white"
+									className="inline-block py-0.5 transition-colors hover:text-white"
 								>
 									{t("footer.contact")}
 								</Link>
 							</li>
 							<li>
-								<Link to="/help" className="transition-colors hover:text-white">
+								<Link
+									to="/help"
+									className="inline-block py-0.5 transition-colors hover:text-white"
+								>
 									{t("footer.help")}
 								</Link>
 							</li>
@@ -155,7 +164,7 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 										href="https://github.com/maik-hasler/einsatzbereit/blob/main/LICENSE"
 										target="_blank"
 										rel="noopener noreferrer"
-										className="underline hover:text-white"
+										className="inline-block py-1 underline hover:text-white"
 									/>
 								),
 							}}

--- a/frontend/src/components/Header/BreadcrumbBar.tsx
+++ b/frontend/src/components/Header/BreadcrumbBar.tsx
@@ -38,7 +38,7 @@ export default function BreadcrumbBar({
 					<Link
 						to={homeHref}
 						aria-label={t("breadcrumb.home")}
-						className="flex shrink-0 items-center text-gray-600 transition-colors hover:text-brand-700"
+						className="-m-1 flex shrink-0 items-center p-1 text-gray-600 transition-colors hover:text-brand-700"
 					>
 						<HomeIcon className="h-4 w-4" />
 					</Link>
@@ -59,12 +59,12 @@ export default function BreadcrumbBar({
 								) : item.href !== undefined ? (
 									<Link
 										to={item.href}
-										className="shrink-0 truncate font-medium text-gray-500 transition-colors hover:text-brand-700"
+										className="truncate py-0.5 font-medium text-gray-500 transition-colors hover:text-brand-700"
 									>
 										{item.label}
 									</Link>
 								) : (
-									<span className="shrink-0 truncate font-medium text-gray-500">
+									<span className="truncate font-medium text-gray-500">
 										{item.label}
 									</span>
 								)}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
@@ -59,144 +59,203 @@ export default function MobileMenu({
 	const rootRef = useDismissableOverlay<HTMLDivElement>(true, onClose, [
 		triggerRef,
 	]);
+	// Scoped to the panel itself (not the scrim below) - both the initial
+	// focus and the Tab trap need to search only the real dialog content.
+	const panelRef = useRef<HTMLDivElement>(null);
 
 	// Move focus into the panel on open, mirroring Modal.tsx's initial-focus
 	// behavior - without this, a keyboard user who opens the menu stays
 	// focused on the (now expanded) hamburger button and has to Tab past it
 	// again to reach the first item.
 	useEffect(() => {
-		rootRef.current
+		panelRef.current
 			?.querySelector<HTMLElement>("a[href], button:not([disabled])")
 			?.focus();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// Body scroll lock - without this, the page behind the scrim (#1672) keeps
+	// scrolling under a touch drag, which both feels broken and can scroll the
+	// open menu itself out of view since it's positioned in flow, not fixed.
+	useEffect(() => {
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previousOverflow;
+		};
+	}, []);
+
+	// Tab focus trap, mirroring Modal.tsx's - Escape is already handled by
+	// useDismissableOverlay above, so this only needs to own Tab. Without it,
+	// Tab/Shift+Tab walks straight past the panel into whatever's behind the
+	// scrim (#1672 - "71 focusables remain reachable behind the open menu").
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key !== "Tab" || !panelRef.current) return;
+			const focusables = Array.from(
+				panelRef.current.querySelectorAll<HTMLElement>(
+					'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+				),
+			).filter((el) => el.offsetParent !== null);
+			if (focusables.length === 0) return;
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, []);
 
 	return (
-		<div
-			ref={rootRef}
-			className={`absolute top-full right-0 left-0 border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-800" : "border-gray-100 bg-white"}`}
-		>
-			{isTransparent && (
-				<div
-					className="pointer-events-none absolute inset-0 overflow-hidden"
-					aria-hidden="true"
-				>
-					<div className="absolute -top-10 -left-20 h-64 w-64 rounded-full bg-brand-700 opacity-60 blur-3xl" />
-					<div className="absolute -top-8 -right-16 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl" />
-				</div>
-			)}
-			<div className="relative space-y-2 px-4 py-4">
-				<div className="pb-2">
-					<LanguageSelector transparent={isTransparent} />
-				</div>
-				{isLoggedIn ? (
-					<div className="space-y-1">
-						<div className="flex items-center gap-3 px-3 py-2">
-							{avatarUrl ? (
-								<img
-									src={avatarUrl}
-									alt=""
-									width={36}
-									height={36}
-									loading="lazy"
-									className="h-9 w-9 rounded-full object-cover"
-								/>
-							) : (
-								<div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-700 text-sm font-semibold text-white">
-									{initials}
-								</div>
-							)}
-							<span
-								className={`text-sm font-medium ${isTransparent ? "text-white/90" : "text-gray-700"}`}
-							>
-								{displayName}
-							</span>
-						</div>
-						<Link
-							to="/profile"
-							onClick={onClose}
-							className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
-						>
-							{t("nav.myProfile")}
-						</Link>
-						<a
-							href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={onClose}
-							className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
-						>
-							{t("nav.accountSettings")}
-						</a>
-						{isAdmin && (
+		<div ref={rootRef}>
+			{/* Scrim: dims and blocks interaction with whatever's behind the panel
+			(the hero on the homepage, in particular) - separates the backdrop-
+			button from the dialog container per the repo's modal a11y convention
+			(see Modal.tsx), even though this dialog isn't portaled like Modal is.
+			Starts below --header-height rather than the full viewport, so the
+			header bar itself (its burger/bell buttons included) stays undimmed
+			and directly clickable instead of hiding under the scrim. */}
+			<button
+				type="button"
+				onClick={onClose}
+				tabIndex={-1}
+				aria-hidden="true"
+				className="fixed top-[var(--header-height)] right-0 bottom-0 left-0 z-30 bg-black/50 md:hidden"
+			/>
+			<div
+				ref={panelRef}
+				role="dialog"
+				aria-modal="true"
+				aria-label={t("nav.menu")}
+				className={`absolute top-full right-0 left-0 z-30 border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
+			>
+				{isTransparent && (
+					<div
+						className="pointer-events-none absolute inset-0 overflow-hidden"
+						aria-hidden="true"
+					>
+						<div className="absolute -top-10 -left-20 h-64 w-64 rounded-full bg-brand-700 opacity-60 blur-3xl" />
+						<div className="absolute -top-8 -right-16 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl" />
+					</div>
+				)}
+				<div className="relative space-y-2 px-4 py-4">
+					<div className="pb-2">
+						<LanguageSelector transparent={isTransparent} />
+					</div>
+					{isLoggedIn ? (
+						<div className="space-y-1">
+							<div className="flex items-center gap-3 px-3 py-2">
+								{avatarUrl ? (
+									<img
+										src={avatarUrl}
+										alt=""
+										width={36}
+										height={36}
+										loading="lazy"
+										className="h-9 w-9 rounded-full object-cover"
+									/>
+								) : (
+									<div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-700 text-sm font-semibold text-white">
+										{initials}
+									</div>
+								)}
+								<span
+									className={`text-sm font-medium ${isTransparent ? "text-white/90" : "text-gray-700"}`}
+								>
+									{displayName}
+								</span>
+							</div>
 							<Link
-								to="/administration"
+								to="/profile"
 								onClick={onClose}
 								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
 							>
-								{t("nav.administration")}
+								{t("nav.myProfile")}
 							</Link>
-						)}
-						{activeOrg && (
-							<div>
-								<button
-									type="button"
-									onClick={() => setOrgMenuOpen((o) => !o)}
-									aria-expanded={orgMenuOpen}
-									className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+							<a
+								href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={onClose}
+								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+							>
+								{t("nav.accountSettings")}
+							</a>
+							{isAdmin && (
+								<Link
+									to="/administration"
+									onClick={onClose}
+									className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
 								>
-									{t("nav.organization")}
-									<ChevronDownIcon
-										open={orgMenuOpen}
-										className="h-4 w-4 shrink-0"
-									/>
-								</button>
-								{orgMenuOpen && (
-									<div
-										className={`ml-3 space-y-1 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
+									{t("nav.administration")}
+								</Link>
+							)}
+							{activeOrg && (
+								<div>
+									<button
+										type="button"
+										onClick={() => setOrgMenuOpen((o) => !o)}
+										aria-expanded={orgMenuOpen}
+										className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
 									>
-										{ORG_TABS.map((tab) => (
-											<Link
-												key={tab.key}
-												to={orgTabPath(activeOrg.id, tab.key)}
-												onClick={onClose}
-												className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-600"}`}
-											>
-												{t(tab.labelKey)}
-											</Link>
-										))}
-									</div>
-								)}
-							</div>
-						)}
-						<button
-							type="button"
-							onClick={onSignOut}
-							className={`block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${isTransparent ? "text-red-400 hover:bg-white/10 hover:text-red-300" : "text-red-600 hover:bg-red-50 hover:text-red-700"}`}
-						>
-							{t("nav.signOut")}
-						</button>
-					</div>
-				) : (
-					<div className="space-y-2">
-						<Button
-							type="button"
-							onClick={onSignIn}
-							variant={isTransparent ? "onDark" : "primary"}
-							fullWidth
-						>
-							{t("nav.signIn")}
-						</Button>
-						<Button
-							type="button"
-							onClick={onRegister}
-							variant={isTransparent ? "outlineOnDark" : "outline"}
-							fullWidth
-						>
-							{t("nav.register")}
-						</Button>
-					</div>
-				)}
+										{t("nav.organization")}
+										<ChevronDownIcon
+											open={orgMenuOpen}
+											className="h-4 w-4 shrink-0"
+										/>
+									</button>
+									{orgMenuOpen && (
+										<div
+											className={`ml-3 space-y-1 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
+										>
+											{ORG_TABS.map((tab) => (
+												<Link
+													key={tab.key}
+													to={orgTabPath(activeOrg.id, tab.key)}
+													onClick={onClose}
+													className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-600"}`}
+												>
+													{t(tab.labelKey)}
+												</Link>
+											))}
+										</div>
+									)}
+								</div>
+							)}
+							<button
+								type="button"
+								onClick={onSignOut}
+								className={`block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${isTransparent ? "text-red-400 hover:bg-white/10 hover:text-red-300" : "text-red-600 hover:bg-red-50 hover:text-red-700"}`}
+							>
+								{t("nav.signOut")}
+							</button>
+						</div>
+					) : (
+						<div className="space-y-2">
+							<Button
+								type="button"
+								onClick={onSignIn}
+								variant={isTransparent ? "onDark" : "primary"}
+								fullWidth
+							>
+								{t("nav.signIn")}
+							</Button>
+							<Button
+								type="button"
+								onClick={onRegister}
+								variant={isTransparent ? "outlineOnDark" : "outline"}
+								fullWidth
+							>
+								{t("nav.register")}
+							</Button>
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -3,6 +3,7 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import Button from "../Button";
+import { FOCUSABLE_SELECTOR } from "../Modal";
 import LanguageSelector from "./LanguageSelector";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
@@ -68,9 +69,7 @@ export default function MobileMenu({
 	// focused on the (now expanded) hamburger button and has to Tab past it
 	// again to reach the first item.
 	useEffect(() => {
-		panelRef.current
-			?.querySelector<HTMLElement>("a[href], button:not([disabled])")
-			?.focus();
+		panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
 	}, []);
 
 	// Body scroll lock - without this, the page behind the scrim (#1672) keeps
@@ -92,9 +91,7 @@ export default function MobileMenu({
 		function handleKeyDown(e: KeyboardEvent) {
 			if (e.key !== "Tab" || !panelRef.current) return;
 			const focusables = Array.from(
-				panelRef.current.querySelectorAll<HTMLElement>(
-					'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-				),
+				panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
 			).filter((el) => el.offsetParent !== null);
 			if (focusables.length === 0) return;
 			const first = focusables[0];
@@ -132,7 +129,13 @@ export default function MobileMenu({
 				role="dialog"
 				aria-modal="true"
 				aria-label={t("nav.menu")}
-				className={`absolute top-full right-0 left-0 z-30 border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
+				// max-h + overflow-y-auto so the body scroll lock above doesn't
+				// strand content taller than the viewport with no way to reach it
+				// (e.g. an organizer with the org submenu expanded on a short
+				// landscape-phone viewport) - overscroll-contain keeps a drag past
+				// this panel's own scroll bounds from rubber-banding the (locked)
+				// body underneath.
+				className={`absolute top-full right-0 left-0 z-30 max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
 			>
 				{isTransparent && (
 					<div

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { ReactNode, RefObject } from "react";
 
-const FOCUSABLE_SELECTOR =
+// Exported so other hand-rolled dialogs (e.g. MobileMenu.tsx, which can't use
+// this component itself since it's anchored under the header instead of
+// centered/portaled) can share the same focus-trap boundary instead of
+// hand-rolling a narrower copy that silently drifts out of sync.
+export const FOCUSABLE_SELECTOR =
 	'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
 interface ModalProps {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -25,7 +25,8 @@
       "signOut": "Abmelden",
       "signIn": "Anmelden",
       "register": "Registrieren",
-      "openMenu": "Menü öffnen"
+      "openMenu": "Menü öffnen",
+      "menu": "Menü"
     },
     "footer": {
       "platform": "Plattform",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -25,7 +25,8 @@
       "signOut": "Sign out",
       "signIn": "Sign in",
       "register": "Register",
-      "openMenu": "Open menu"
+      "openMenu": "Open menu",
+      "menu": "Menu"
     },
     "footer": {
       "platform": "Platform",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -142,7 +142,7 @@ function OrganizationsSection() {
 			<div className="mb-6 flex flex-wrap items-center gap-4">
 				<label
 					htmlFor="admin-org-flagged-only"
-					className="flex cursor-pointer items-center gap-2"
+					className="flex cursor-pointer items-center gap-2 py-1"
 				>
 					<input
 						type="checkbox"
@@ -157,7 +157,7 @@ function OrganizationsSection() {
 				</label>
 				<label
 					htmlFor="admin-org-deleted-only"
-					className="flex cursor-pointer items-center gap-2"
+					className="flex cursor-pointer items-center gap-2 py-1"
 				>
 					<input
 						type="checkbox"
@@ -409,7 +409,7 @@ function UsersSection() {
 												? t("administration.users.statusActive")
 												: t("administration.users.statusBlocked")}
 										</Chip>
-										<div className="flex shrink-0 items-center gap-2">
+										<div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
 											{isSelf ? (
 												<span
 													className="text-xs text-gray-500"

--- a/frontend/src/pages/ProfileOverviewPage/NotificationPreferencesSection.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/NotificationPreferencesSection.tsx
@@ -132,7 +132,7 @@ export default function NotificationPreferencesSection() {
 							<label
 								key={row.key}
 								htmlFor={row.key}
-								className="flex cursor-pointer items-start gap-3"
+								className="flex cursor-pointer items-start gap-3 py-1"
 							>
 								<input
 									type="checkbox"

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -485,13 +485,15 @@ export default function OrgMembersPage() {
 								key={member.userId}
 								className="flex items-center justify-between py-3"
 							>
-								<div>
-									<p className="text-sm font-medium text-gray-900">
+								<div className="min-w-0">
+									<p className="truncate text-sm font-medium text-gray-900">
 										{member.firstName && member.lastName
 											? `${member.firstName} ${member.lastName}`
 											: member.username}
 									</p>
-									<p className="text-xs text-gray-500">{member.email}</p>
+									<p className="truncate text-xs text-gray-500">
+										{member.email}
+									</p>
 									{member.isOrganisator && (
 										<span className="mt-0.5 inline-block rounded-full bg-brand-50 px-2 py-0.5 text-xs text-brand-700">
 											{t("orgSettings.organisator")}


### PR DESCRIPTION
## What

Fixes the bundle of narrow-viewport defects from issue #1672, all in `frontend/`:

1. **Invisible mobile menu on the homepage** (`MobileMenu.tsx`) - the panel and the hero underneath it shared the exact same `bg-brand-800`, with no scrim and an imperceptible shadow, so the menu visually merged into the hero. Added a scrim (dims/blocks the content behind the panel), switched the panel's transparent-mode surface to `bg-brand-900` (distinct from the hero), and gave it `role="dialog"`/`aria-modal="true"`, a Tab focus trap, and a body scroll lock. A follow-up commit fixes a regression the scroll lock introduced: without an internal `overflow-y-auto`/`max-height`, panel content taller than the viewport (e.g. an organizer with the org submenu expanded on a short viewport) became completely unreachable - the panel now scrolls internally instead.
2. **Rows clipped beyond reach** - `AdministrationPage.tsx`'s action-button group now wraps instead of overflowing at 320px; `OrgMembersPage.tsx`'s member row gets the same `min-w-0`/`truncate` treatment its sibling lists already use, so a long email no longer clips the remove/leave action off-screen.
3. **Touch targets below 24px** - padded (not resized) the footer links (compact and full footer, including the license link), the breadcrumb home icon link, and the profile/administration checkbox labels so every tap target reaches >=24px.
4. **Smaller ones in the same layer** - `BadgeGrid.tsx`'s tooltip is now clamped to the viewport (mirroring `FilterDropdown.tsx`'s edge-clamp pattern) instead of statically centered and able to overflow the screen edge on the outer columns of the mobile grid; `BreadcrumbBar.tsx` drops `shrink-0` from intermediate crumbs so `truncate` can actually engage on a long crumb.

## Why

Closes #1672

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest), `pnpm i18n:check` - all pass.
- `/self-review` run, fanning out to `a11y-check` and `i18n-check`. `i18n-check` came back clean. `a11y-check` caught a real regression (body-scroll-lock stranding overflowing menu content unreachable) and a selector-drift risk (a hand-rolled focus-trap selector instead of reusing `Modal.tsx`'s) - both fixed in a follow-up commit, plus a new `MobileMenu_Open_AsOlaf_HasNoSeriousA11yViolations` axe-core test in `AccessibilityTests.cs`, since none of that suite's existing scans run at a mobile viewport.
- Couldn't run the backend `VisualTests`/`Application.UnitTests` suites locally - this sandbox has no Docker (Aspire/Testcontainers) and this session's outbound network policy blocks `dot.net`'s SDK installer, so the new C# test is unverified until CI runs it.

## Live verification

Not performed - no release candidate was cut for this change (explicit instruction for this task). CI (`dotnet.yml`/`frontend.yml`) is the verification for this PR.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no docs reference this behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TxMau9z3uBn1T28hPzuuPy)_