### PR TITLE
test: cover ReportUserCommandHandler and bulk-confirm partial failure

### DIFF
--- a/backend/tests/Application.UnitTests/Users/ReportUser/ReportUserCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/ReportUser/ReportUserCommandHandlerTests.cs
@@ -1,0 +1,147 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Users.ReportUser.v1;
+using AwesomeAssertions;
+using Domain.Primitives;
+using Domain.Reports;
+using Domain.Users;
+using NSubstitute;
+
+namespace Application.UnitTests.Users.ReportUser;
+
+public class ReportUserCommandHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<User, UserId> _userRepo =
+		Substitute.For<IAggregateRepository<User, UserId>>();
+	private readonly IAggregateRepository<Report, ReportId> _reportRepo =
+		Substitute.For<IAggregateRepository<Report, ReportId>>();
+	private readonly ReportUserCommandHandler _sut;
+
+	private static readonly UserId DefaultReporterId = UserId.New();
+
+	public ReportUserCommandHandlerTests()
+	{
+		_dbContext.Users.Returns(_userRepo);
+		_dbContext.Reports.Returns(_reportRepo);
+		_dbContext
+			.HasOpenReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+		_sut = new ReportUserCommandHandler(_dbContext);
+	}
+
+	private static User CreateUser(Guid id) => User.Create(UserId.Create(id).GetValueOrThrow());
+
+	[Test]
+	public async Task Handle_ShouldAddReport_WhenUserExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var targetUserGuid = Guid.CreateVersion7();
+		var targetUser = CreateUser(targetUserGuid);
+		_userRepo
+			.FindAsync(UserId.Create(targetUserGuid).GetValueOrThrow(), cancellationToken)
+			.Returns(targetUser);
+
+		var command = new ReportUserCommand(targetUserGuid, DefaultReporterId, ReportReason.Harassment, "rude messages");
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _reportRepo.Received(1).AddAsync(
+			Arg.Is<Report>(r => r!.TargetType == ReportTargetType.User
+				&& r.TargetId == targetUserGuid
+				&& r.ReporterId == DefaultReporterId
+				&& r.Reason == ReportReason.Harassment
+				&& r.Details == "rude messages"),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenReportingSelf(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new ReportUserCommand(DefaultReporterId.Value, DefaultReporterId, ReportReason.Spam, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+		await _userRepo.DidNotReceive().FindAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+		await _reportRepo.DidNotReceive().AddAsync(Arg.Any<Report>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenUserNotFound(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var targetUserGuid = Guid.CreateVersion7();
+		_userRepo
+			.FindAsync(UserId.Create(targetUserGuid).GetValueOrThrow(), cancellationToken)
+			.Returns((User?)null);
+
+		var command = new ReportUserCommand(targetUserGuid, DefaultReporterId, ReportReason.Spam, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+		await _reportRepo.DidNotReceive().AddAsync(Arg.Any<Report>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenReporterAlreadyHasOpenReport(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var targetUserGuid = Guid.CreateVersion7();
+		var targetUser = CreateUser(targetUserGuid);
+		_userRepo
+			.FindAsync(UserId.Create(targetUserGuid).GetValueOrThrow(), cancellationToken)
+			.Returns(targetUser);
+		_dbContext
+			.HasOpenReportAsync(ReportTargetType.User, targetUserGuid, DefaultReporterId, cancellationToken)
+			.Returns(true);
+
+		var command = new ReportUserCommand(targetUserGuid, DefaultReporterId, ReportReason.Spam, null);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _reportRepo.DidNotReceive().AddAsync(Arg.Any<Report>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenDetailsTooLong(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var targetUserGuid = Guid.CreateVersion7();
+		var targetUser = CreateUser(targetUserGuid);
+		_userRepo
+			.FindAsync(UserId.Create(targetUserGuid).GetValueOrThrow(), cancellationToken)
+			.Returns(targetUser);
+
+		var tooLong = new string('a', Report.MaxDetailsLength + 1);
+		var command = new ReportUserCommand(targetUserGuid, DefaultReporterId, ReportReason.Other, tooLong);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Validation);
+		await _reportRepo.DidNotReceive().AddAsync(Arg.Any<Report>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/VisualTests/EngagementBulkActionsTests.cs
+++ b/backend/tests/VisualTests/EngagementBulkActionsTests.cs
@@ -1,0 +1,156 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Coverage for #1682: c3f9ada1 shipped bulk confirm/cancel (#1044) - selection
+/// state, partial-failure handling, the bulk action bars - with no test at any
+/// level. This drives a real bulk-confirm through the browser where one of the
+/// two selected engagements has already been confirmed out of band by the time
+/// the click lands (a stale checkbox against a since-changed server state), and
+/// asserts both the partial-failure toast and that only the row the backend
+/// actually confirmed flips to Confirmed in the UI - EngagementManagementPage.tsx's
+/// handleBulkConfirm only patches local state for ids in the response's
+/// succeeded list, leaving a failed id both visibly Pending and still selected.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task EngagementManagementPage_BulkConfirm_ReportsPartialFailure_WhenOneEngagementWasAlreadyConfirmed()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = await GetTokenAsync(keycloak, "olaf", "olaf123");
+		var (opportunityId, organizationId, firstSlotId, secondSlotId) =
+			await CreateScheduledSlotsOpportunityWithTwoSlotsAsync(keycloak, backend, olafToken, "BulkConfirmPartial");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		var firstEngagementId = await ApplyForSlotAsync(veraHttp, opportunityId, firstSlotId);
+		var secondEngagementId = await ApplyForSlotAsync(veraHttp, opportunityId, secondSlotId);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(Page.Locator("#select-all-pending")).ToBeVisibleAsync();
+
+		// Simulate a concurrent action: by the time the bulk-confirm click below
+		// lands, the second engagement has already been confirmed out of band
+		// (e.g. from a second organizer's tab) - the page's own engagement list
+		// was fetched before this and still shows it as Pending and selectable.
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+		var preemptResponse = await olafHttp.PostAsync($"/v1/engagements/{secondEngagementId}/confirm", content: null);
+		preemptResponse.EnsureSuccessStatusCode();
+
+		await Page.Locator("#select-all-pending").CheckAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Confirm selected" }).ClickAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Alert).GetByText("1 confirmed, 1 failed."))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The engagement the backend actually confirmed flips to Confirmed (and
+		// gains its Revoke control) in the UI...
+		await Expect(Page.Locator($"[data-testid='engagement-revoke-{firstEngagementId}']"))
+			.ToBeVisibleAsync();
+
+		// ...the one that failed server-side (Engagement.NotPending) never does.
+		await Expect(Page.Locator($"[data-testid='engagement-revoke-{secondEngagementId}']"))
+			.Not.ToBeVisibleAsync();
+
+		// Only succeeded ids are dropped from the selection - the failed row
+		// stays checked, the per-item signal a partial failure leaves behind.
+		await Expect(Page.Locator("li input[type='checkbox']:checked")).ToHaveCountAsync(1);
+	}
+
+	private static async Task<string> ApplyForSlotAsync(HttpClient http, string opportunityId, string timeSlotId)
+	{
+		var response = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { timeSlotId });
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("id").GetString()!;
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<(string OpportunityId, string OrganizationId, string FirstSlotId, string SecondSlotId)>
+		CreateScheduledSlotsOpportunityWithTwoSlotsAsync(Uri keycloak, Uri backend, string olafToken, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		// Fresh organization rather than olaf's shared seed org - see the
+		// identical note in EngagementManagementFiltersTests.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"{label} Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		// Created as a draft: a ScheduledSlots opportunity can't be published
+		// until it has at least one time slot.
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"{label} {suffix}",
+			description = "Created by EngagementBulkActionsTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString()!;
+
+		// One recurring call creates both slots at once.
+		var slotsResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new
+			{
+				startDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				endDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				maxParticipants = 10,
+				recurrenceFrequency = "Weekly",
+				recurrenceCount = 2,
+			});
+		slotsResponse.EnsureSuccessStatusCode();
+		var slots = (await slotsResponse.Content.ReadFromJsonAsync<JsonElement>()).EnumerateArray().ToList();
+		var firstSlotId = slots[0].GetProperty("id").GetString()!;
+		var secondSlotId = slots[1].GetProperty("id").GetString()!;
+
+		var publishResponse = await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null);
+		publishResponse.EnsureSuccessStatusCode();
+
+		return (opportunityId, organizationId, firstSlotId, secondSlotId);
+	}
+}

--- a/backend/tests/VisualTests/EngagementBulkActionsTests.cs
+++ b/backend/tests/VisualTests/EngagementBulkActionsTests.cs
@@ -115,7 +115,9 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
 
 		// Created as a draft: a ScheduledSlots opportunity can't be published
-		// until it has at least one time slot.
+		// until it has at least one time slot. ValidUntil is omitted - it is
+		// only allowed for IndividualContact opportunities (VolunteerOpportunity.
+		// Create rejects a non-null ValidUntil for any other participation type).
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
 			title = $"{label} {suffix}",
@@ -125,7 +127,6 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 			occurrence = "OneTime",
 			participationType = "ScheduledSlots",
 			checkInMethod = "None",
-			validUntil = DateTimeOffset.UtcNow.AddDays(30),
 			isDraft = true,
 		});
 		oppResponse.EnsureSuccessStatusCode();

--- a/wiki/bundle/decisions/frontend-component-tests-not-adopted.md
+++ b/wiki/bundle/decisions/frontend-component-tests-not-adopted.md
@@ -1,0 +1,78 @@
+---
+type: "decision-note"
+title: "Frontend component-level tests are not adopted - VisualTests covers that layer instead"
+description: "Vitest stays scoped to src/lib/ pure functions; component/page rendering and interaction behavior is tested exclusively through the Playwright suite in backend/tests/VisualTests/."
+tags:
+  - testing
+  - frontend
+  - vitest
+  - playwright
+  - visualtests
+timestamp: 2026-08-06
+---
+
+# What was decided
+
+Component- and page-level frontend behavior is not tested with Vitest plus a
+DOM-rendering library. `frontend/package.json` has no `@testing-library/react`
+dependency, no `*.test.tsx` file exists anywhere in `src/`, and
+`vitest.config.ts`'s coverage `include` is hard-scoped to `src/lib/**/*.ts` -
+none of this is missing tooling, it is the intended boundary.
+`src/lib/*.test.ts` keeps covering pure logic, colocated next to the module it
+tests. Coverage of how a component or page actually renders and behaves is
+carried entirely by the Playwright suite in `backend/tests/VisualTests/`.
+
+# Why
+
+Issue #1682, a 1.0-readiness test-coverage audit, flagged that commit
+`c3f9ada1` shipped roughly 528 lines of stateful selection and
+partial-failure-rendering logic in `EngagementManagementPage.tsx` (bulk
+confirm/cancel, #1044) with no test at any level, and asked to "decide
+explicitly whether component-level frontend tests are wanted, and record the
+decision." The decision already existed implicitly - `frontend/AGENTS.md`'s
+Unit Tests section states "Component/page-level behavior is covered by the
+Playwright suite in `backend/tests/VisualTests/` instead - see root
+`AGENTS.md`" - but had never been written down as a deliberate trade-off, so
+a contributor who only notices the absence of `@testing-library/react` could
+read it as an oversight rather than a choice.
+
+The trade-off, made explicit here: a Vitest-plus-Testing-Library component
+test would give a faster, more isolated feedback loop for pure
+rendering/interaction logic than an E2E test ever can. This repo chooses one
+E2E suite (Playwright driving a real browser against the full Aspire stack,
+already around 50 test classes) as the single source of UI-behavior coverage
+instead of splitting it across two frameworks with two different
+rendering/mocking models. The issue names the resulting cost directly: "a
+change to a component's rendering logic has no fast local signal" -
+VisualTests is CI-only, it needs Aspire/DCP container orchestration a web/
+cloud Claude Code session cannot provide (see sandbox-limitations), so a
+regression surfaces on the PR's CI run rather than while the change is being
+written.
+
+# What this does not change
+
+`src/lib/*.test.ts` continues testing pure functions with Vitest; that
+boundary is unaffected. `AccessibilityTests.cs` in VisualTests still needs a
+matching case for any new page, unrelated to this decision and already
+enforced by the `a11y-check` agent. This does not rule out revisiting the
+split later if VisualTests' runtime becomes a bigger bottleneck than it is
+now - `backend/AGENTS.md` already calls it out as the "Largest and slowest
+suite (~50 test classes)" among the four backend test projects.
+
+# Related
+
+- [frontend-conventions](/reference/frontend-conventions.md) - the frontend
+  stack and directory layout this testing boundary applies to
+- [backend-conventions](/reference/backend-conventions.md) - VisualTests'
+  place among the four TUnit test projects
+- [sandbox-limitations](/gotchas/sandbox-limitations.md) - why VisualTests
+  never gives the fast local signal a component test would
+
+# Citations
+
+- #1682
+- frontend/AGENTS.md ("Unit Tests" section)
+- frontend/vitest.config.ts
+- frontend/package.json
+- backend/AGENTS.md ("Visual tests" section)
+- frontend/src/pages/EngagementManagementPage.tsx@c3f9ada1

--- a/wiki/bundle/decisions/index.md
+++ b/wiki/bundle/decisions/index.md
@@ -1,7 +1,8 @@
 # Decisions
 
-Why the repo's tooling and autonomous routines are set up the way they are.
+Why the repo's tooling, autonomous routines, and testing boundaries are set up the way they are.
 
 - [The autonomous routines and their guardrails](autonomous-routines.md) - issue-triage, its persona-simulation fallback, and deep-lens-review - plus the boundaries the owner keeps for themselves.
 - [The report-only self-review machinery in .claude](claude-check-setup.md) - Five check agents each scoped to a gap CI cannot catch, a self-review skill that fans out to them, and the hooks that enforce the rest.
 - [The root scripts/ folder and root package.json were removed](scripts-folder-removed.md) - 106 tracked .mjs/.sh files and the Playwright pin they depended on are gone; live-verification scripts are now scratch-only and never committed.
+- [Frontend component-level tests are not adopted](frontend-component-tests-not-adopted.md) - VisualTests covers component/page behavior instead; Vitest stays scoped to `src/lib/` pure functions.

--- a/wiki/bundle/gotchas/sandbox-limitations.md
+++ b/wiki/bundle/gotchas/sandbox-limitations.md
@@ -42,6 +42,7 @@ The proxy blocks two push targets: `main` and any tag. Both blocks hold even whe
 - [release-workflow](/process/release-workflow.md) - the tag-push block is the reason releases go through a release/* branch
 - [live-playwright-scripts](/process/live-playwright-scripts.md) - the egress-proxy TLS trap the launch args work around is a sandbox effect
 - [backend-conventions](/reference/backend-conventions.md) - the IntegrationTests/VisualTests that need DCP orchestration are the ones that cannot run here
+- [frontend-component-tests-not-adopted](/decisions/frontend-component-tests-not-adopted.md) - names this page as the reason VisualTests gives no fast local signal for a frontend change
 
 # Citations
 - AGENTS.md (root, 'Sandbox Limitations')

--- a/wiki/bundle/index.md
+++ b/wiki/bundle/index.md
@@ -6,7 +6,7 @@ okf_version: "0.1"
 
 Root index of this OKF bundle (`wiki/bundle/`). Informal knowledge about Einsatzbereit -
 traps, decisions, process, and reference - that complements the formal `docs/` and the
-`CLAUDE.md`/`AGENTS.md` convention files. 20 concept pages, grouped below; each
+`CLAUDE.md`/`AGENTS.md` convention files. 21 concept pages, grouped below; each
 section has its own index. This file is a routing table, not meant to be read cover to
 cover. See `../AGENTS.md` for when to split a section further.
 
@@ -16,5 +16,5 @@ cover. See `../AGENTS.md` for when to split a section further.
 - [Process](process/index.md) (5) - Workflows and procedures - releasing, the mandatory deploy-and-verify flow, live Playwright scripts, EF migrations, and keeping this wiki self-building.
 - [Gotchas](gotchas/index.md) (5) - Traps and non-obvious constraints, each learned from fixing a real bug or hitting a real wall.
 - [Reference](reference/index.md) (4) - Stable reference material - the conventions the architecture tests enforce, the frontend stack and its lint gaps, the Keycloak realm, and a pointer to the formal ADRs/TDRs.
-- [Decisions](decisions/index.md) (3) - Why the repo's tooling and autonomous routines are set up the way they are.
+- [Decisions](decisions/index.md) (4) - Why the repo's tooling, autonomous routines, and testing boundaries are set up the way they are.
 - [CI](ci/index.md) (1) - Recurring CI failure modes and their causes.

--- a/wiki/bundle/log.md
+++ b/wiki/bundle/log.md
@@ -10,6 +10,10 @@ dates and a bold action-word prefix, e.g. `**Added**`, `**Updated**`,
 - **Added** - <one-line description of what changed and why>
 ```
 
+## 2026-08-06
+
+- **Added** - `decisions/frontend-component-tests-not-adopted.md`: #1682 (a 1.0-readiness test-coverage audit) asked to make explicit the already-implicit choice not to test frontend components with Vitest/Testing Library, since `frontend/AGENTS.md` only said VisualTests covers that layer without spelling out the trade-off. Backlinked from `reference/frontend-conventions.md`, `reference/backend-conventions.md`, and `gotchas/sandbox-limitations.md`.
+
 ## 2026-08-02
 
 - **Fixed** - `reference/keycloak-realm-config.md`: `frontend-test`'s ROPC access was documented as always-on, but #1167 found it shipping enabled in the same realm baked into the staging/production image, letting anyone mint a real `backend`-audience access token via a single `grant_type=password` HTTP call with no browser or PKCE. Fixed by shipping the client `enabled: false` in the committed realm and having `AppHost.cs` flip it back to `enabled: true` only in the dev-only realm copy it writes before import for local Aspire runs and the IntegrationTests/VisualTests fixtures, which both boot Keycloak through the AppHost rather than the baked image.

--- a/wiki/bundle/reference/backend-conventions.md
+++ b/wiki/bundle/reference/backend-conventions.md
@@ -85,6 +85,7 @@ Never `.Result` or `.Wait()`. Await instead.
 - [adr-tdr-index](/reference/adr-tdr-index.md) - rate limiting is TDR-1 and the layering choices trace to the ADRs
 - [keycloak-realm-config](/reference/keycloak-realm-config.md) - auth policies depend on the realm claim and backend audience in the token
 - [domain-events-noop](/gotchas/domain-events-noop.md) - the transaction pipeline behavior governs domain-event handler timing
+- [frontend-component-tests-not-adopted](/decisions/frontend-component-tests-not-adopted.md) - the frontend's mirror-image decision: VisualTests, not a frontend unit-test layer, covers component/page behavior
 
 # Citations
 

--- a/wiki/bundle/reference/frontend-conventions.md
+++ b/wiki/bundle/reference/frontend-conventions.md
@@ -47,6 +47,7 @@ The Register button must not call `auth.signinRedirect()` - that hits Keycloak's
 - [nswag-generated-clients](/gotchas/nswag-generated-clients.md) - api-client.ts is consumed via useApiClient() and must not be hand-edited
 - [claude-check-setup](/decisions/claude-check-setup.md) - the a11y-check and i18n-check agents exist precisely to cover these lint gaps
 - [pre-launch-testing-event](/project/pre-launch-testing-event.md) - the 'unfamiliar with technology' role card exercises exactly these a11y patterns
+- [frontend-component-tests-not-adopted](/decisions/frontend-component-tests-not-adopted.md) - why this stack has no `*.test.tsx`/Testing Library layer and never will by default
 
 # Citations
 


### PR DESCRIPTION
## What

Adds the two concrete test-coverage gaps issue #1682 identified, plus records a decision the issue asked for explicitly.

## Why

Issue #1682 is a targeted follow-up from the 1.0-readiness analysis, not a general "add more tests" request - it names two specific, recently shipped behaviours that landed without matching coverage:

1. **Bulk confirm/cancel** - commit `c3f9ada1` shipped ~528 lines of stateful frontend logic in `EngagementManagementPage.tsx` (selection state, partial-failure handling, the bulk action bars) with no test at any level. The backend handlers themselves already had `Application.UnitTests` coverage from that same commit; the gap was specifically the frontend's partial-failure rendering path.
2. **`ReportUserCommandHandler`** - zero coverage of any kind, the only `Report*` handler without a unit test, on the abuse-reporting path.

Closes #1682

## Testing

- `backend/tests/Application.UnitTests/Users/ReportUser/ReportUserCommandHandlerTests.cs` (new) - mirrors the existing `ReportOrganizationCommandHandlerTests`/`ReportVolunteerOpportunityCommandHandlerTests` pattern (NSubstitute mocks, AwesomeAssertions). Covers the happy path, the self-report guard (`ReportUserCommandHandler`'s one behaviour with no sibling to copy - `targetUserId == request.ReporterId`), user-not-found, an already-open-report conflict, and details-too-long validation.
- `backend/tests/VisualTests/EngagementBulkActionsTests.cs` (new) - drives a real bulk-confirm through the browser: an organizer selects two Pending engagements via "Select all pending," but one has already been confirmed out of band (a stale checkbox against a since-changed server state) by the time the click lands. Asserts the "1 confirmed, 1 failed." toast, that only the engagement the backend actually confirmed gains its Revoke control (flips to Confirmed in the UI), and that the failed engagement's checkbox stays checked - the per-item signal a partial failure leaves behind, since `handleBulkConfirm` only patches local state for ids in the response's `succeeded` list.
- Both new test files build on existing, already-passing conventions in their respective suites (raw-HTTP test-data setup via Keycloak ROPC + `FastSignInAsync`, `ScheduledSlots` participation with two time slots so the single seeded `vera` account can hold two independent Pending engagements on one opportunity).
- Ran locally: `python scripts/validate.py` (wiki/) passed. `dotnet build`/`Application.UnitTests`/`ArchitectureTests` could not be run locally in this sandbox - the SDK auto-install (`dotnet-install.sh`) is blocked by this session's egress policy (`builds.dotnet.microsoft.com` returns 403 from the proxy). CI's `dotnet.yml` ran the full suite including these new tests - `visual-tests` initially failed (`EngagementBulkActionsTests`'s own setup passed an invalid `ValidUntil` on a `ScheduledSlots` opportunity, which `VolunteerOpportunity.Create` rejects for any participation type other than `IndividualContact`); fixed in a follow-up commit and all checks are now green.

## Live verification

Not applicable - this PR is test-only (no `backend/src/` or `frontend/src/` changes), so there is no user-visible behaviour to verify on staging. Per explicit instruction for this task, no release candidate was cut.

## Also included

- `wiki/bundle/decisions/frontend-component-tests-not-adopted.md` (new) - the issue's third checklist item ("decide explicitly whether component-level frontend tests are wanted, and record the decision") was already answered implicitly by `frontend/AGENTS.md` ("Component/page-level behavior is covered by the Playwright suite... instead"), but never written down as a deliberate trade-off. This records it explicitly, with backlinks from `reference/frontend-conventions.md`, `reference/backend-conventions.md`, and `gotchas/sandbox-limitations.md`.

## Checklist

- [x] `/self-review` run and findings addressed (no issues found - diff is test files + wiki docs only, no domain-specific check agents applied)
- [x] CI is green
- [x] Documentation updated (wiki decision note)
