### PR TITLE
fix: localize everything outside the SPA - email footer, unsubscribe page, CSV export, notification kind, account console

### DIFF
--- a/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
@@ -42,8 +42,13 @@ internal sealed class ExportEngagementsEndpoint : IEndpoint
 			new ExportEngagementsQuery(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), userId),
 			cancellationToken);
 
+		// A UTF-8 BOM (#1675) - without it, Excel on a German Windows install
+		// guesses the ANSI codepage instead of UTF-8 and mangles every umlaut
+		// ("Müller" -> "MÃ¼ller") in a volunteer's name.
+		byte[] bytes = [.. Encoding.UTF8.GetPreamble(), .. Encoding.UTF8.GetBytes(file.Content)];
+
 		return Results.File(
-			Encoding.UTF8.GetBytes(file.Content),
+			bytes,
 			contentType: "text/csv; charset=utf-8",
 			fileDownloadName: file.FileName);
 	}

--- a/backend/src/Api/Users/Unsubscribe/v1/UnsubscribeEndpoint.cs
+++ b/backend/src/Api/Users/Unsubscribe/v1/UnsubscribeEndpoint.cs
@@ -18,7 +18,7 @@ internal sealed class UnsubscribeEndpoint
 		app.MapGet("/users/{userId:guid}/unsubscribe", UnsubscribeAsync)
 			.WithName("Unsubscribe")
 			.WithTags("Users")
-			.Produces(StatusCodes.Status200OK, contentType: "text/html")
+			.Produces(StatusCodes.Status302Found)
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
@@ -26,11 +26,18 @@ internal sealed class UnsubscribeEndpoint
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
+	// Redirects into a branded, localized frontend route rather than returning raw
+	// HTML directly (#1675) - this endpoint has no locale of its own to render in,
+	// so the frontend's own i18n (German-default) takes over from here. Reuses the
+	// same Cors:Origins-derived frontend base URL as GetSitemapEndpoint/
+	// GetEngagementCalendarEndpoint, since there's no dedicated "frontend base URL"
+	// setting in this codebase.
 	private static async Task<IResult> UnsubscribeAsync(
 		[FromRoute] Guid userId,
 		[FromQuery] string type,
 		[FromQuery] Guid token,
 		[FromServices] ISender sender,
+		[FromServices] IConfiguration configuration,
 		CancellationToken cancellationToken)
 	{
 		if (!Enum.TryParse<EmailNotificationType>(type, out var notificationType))
@@ -42,10 +49,9 @@ internal sealed class UnsubscribeEndpoint
 			new UnsubscribeCommand(UserId.Create(userId).GetValueOrThrow(), token, notificationType),
 			cancellationToken);
 
-		return Results.Content(
-			"<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Unsubscribed</title></head>" +
-			"<body><p>You have been unsubscribed from this type of email. You can re-enable it any time " +
-			"from your notification preferences in your profile.</p></body></html>",
-			"text/html");
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var frontendBaseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+
+		return Results.Redirect($"{frontendBaseUrl}/unsubscribed?type={Uri.EscapeDataString(type)}");
 	}
 }

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1999,8 +1999,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "302": {
+            "description": "Found"
           },
           "400": {
             "description": "Bad Request",

--- a/backend/src/Application/Common/Email/EmailFooter.cs
+++ b/backend/src/Application/Common/Email/EmailFooter.cs
@@ -2,6 +2,17 @@ namespace Application.Common.Email;
 
 public static class EmailFooter
 {
-	public static string Append(string body, string unsubscribeUrl) =>
-		$"{body}\n\n---\nDon't want to receive this type of email? Unsubscribe here: {unsubscribeUrl}";
+	public static string Append(
+		IEmailTemplateRenderer emailTemplateRenderer,
+		string language,
+		string body,
+		string unsubscribeUrl)
+	{
+		var footer = emailTemplateRenderer.Render(
+			EmailTemplateKind.EmailFooter,
+			language,
+			new Dictionary<string, string> { ["UnsubscribeUrl"] = unsubscribeUrl }).Body;
+
+		return $"{body}{footer}";
+	}
 }

--- a/backend/src/Application/Common/Email/EmailTemplateKind.cs
+++ b/backend/src/Application/Common/Email/EmailTemplateKind.cs
@@ -19,4 +19,9 @@ public enum EmailTemplateKind
 	InvitationReceived,
 	OpportunityUpdated,
 	SearchAlertNewMatches,
+
+	// Body-only fragment appended to every outgoing notification email via
+	// EmailFooter.Append - same "render separately, splice in" pattern as
+	// EngagementCancelledReasonSuffix above.
+	EmailFooter,
 }

--- a/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledNotificationHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledNotificationHandler.cs
@@ -77,7 +77,7 @@ internal sealed class EngagementCancelledNotificationHandler(
 		await emailService.SendAsync(
 			volunteer.Email,
 			content.Subject,
-			EmailFooter.Append(content.Body, unsubscribeUrl),
+			EmailFooter.Append(emailTemplateRenderer, volunteerLanguage, content.Body, unsubscribeUrl),
 			notification.EngagementId.Value.ToString(),
 			cancellationToken);
 	}

--- a/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
@@ -113,7 +113,7 @@ internal static class EngagementOrganizerNotificationHelper
 			await emailService.SendAsync(
 				organizer.Email,
 				content.Subject,
-				EmailFooter.Append(content.Body, unsubscribeUrl),
+				EmailFooter.Append(emailTemplateRenderer, organizerLanguage, content.Body, unsubscribeUrl),
 				engagementId.Value.ToString(),
 				cancellationToken);
 		}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
@@ -59,7 +59,7 @@ internal sealed class EngagementConfirmedNotificationHandler(
 		await emailService.SendAsync(
 			volunteer.Email,
 			content.Subject,
-			EmailFooter.Append(content.Body, unsubscribeUrl),
+			EmailFooter.Append(emailTemplateRenderer, volunteerLanguage, content.Body, unsubscribeUrl),
 			notification.EngagementId.Value.ToString(),
 			cancellationToken);
 	}

--- a/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
+++ b/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
@@ -79,7 +79,7 @@ internal sealed class EngagementReminderDueHandler(
 			notification.VolunteerId, volunteerUser.UnsubscribeToken, EmailNotificationType.EngagementReminder);
 
 		var subject = content.Subject;
-		var body = EmailFooter.Append(content.Body, unsubscribeUrl);
+		var body = EmailFooter.Append(emailTemplateRenderer, language, content.Body, unsubscribeUrl);
 
 		// SendBatchAsync with a single message (rather than SendAsync) so a failed send
 		// is observable as a bool - SendAsync never throws and never reports outcome,

--- a/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Application.Common.Authorization;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Primitives;
@@ -15,6 +16,8 @@ internal sealed class ExportEngagementsQueryHandler(
 	IKeycloakUserService keycloakUserService)
 	: IQueryHandler<ExportEngagementsQuery, EngagementExportFile>
 {
+	private static readonly TimeZoneInfo BerlinTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+
 	public async ValueTask<EngagementExportFile> Handle(
 		ExportEngagementsQuery request,
 		CancellationToken cancellationToken = default)
@@ -37,71 +40,118 @@ internal sealed class ExportEngagementsQueryHandler(
 			.ToList();
 		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
 
-		var content = BuildCsv(engagements, profileMap);
+		var requestingUser = (await dbContext.GetOrCreateUsersAsync([request.RequestingUserId], cancellationToken))[0];
+		var language = SupportedLanguages.Resolve(requestingUser.PreferredLanguage);
+
+		var content = BuildCsv(engagements, profileMap, language);
 		return new EngagementExportFile($"engagements-{request.OpportunityId.Value}.csv", content);
 	}
 
 	private static string BuildCsv(
 		List<EngagementSummary> engagements,
-		IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap)
+		IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap,
+		string language)
 	{
+		const string delimiter = ";";
+
 		// CRLF line endings explicitly (RFC 4180), not StringBuilder.AppendLine's
 		// Environment.NewLine - a CSV built on Linux CI must byte-for-byte match
 		// one built on a Windows dev machine, and Excel/other spreadsheet tools
 		// expect CRLF regardless of which OS generated the file.
 		var sb = new StringBuilder();
-		sb.Append("Name,Status,Time Slot,Check-in Status,Feedback Rating\r\n");
+
+		// Excel honors this directive line regardless of the running install's own
+		// regional list-separator setting (#1675) - without it, a German Windows
+		// Excel expecting ";" silently collapses a comma-delimited file into a
+		// single column. Emitted unconditionally, with the delimiter itself
+		// switched to ";" to match, so this fixes the German case without
+		// affecting how an English-locale Excel reads the same file.
+		sb.Append("sep=;\r\n");
+		sb.Append(string.Join(delimiter, Header(language))).Append("\r\n");
 
 		foreach (var e in engagements)
 		{
 			var row = new[]
 			{
-				ResolveName(e, profileMap),
-				e.Status,
+				ResolveName(e, profileMap, language),
+				TranslateStatus(e.Status, language),
 				FormatTimeSlot(e.TimeSlotStartDateTime, e.TimeSlotEndDateTime),
-				e.IsCheckedIn ? "Checked in" : "Not checked in",
+				e.IsCheckedIn ? CheckedInLabel(language) : NotCheckedInLabel(language),
 				e.FeedbackRating?.ToString(CultureInfo.InvariantCulture) ?? "",
 			};
-			sb.Append(string.Join(",", row.Select(CsvEscape))).Append("\r\n");
+			sb.Append(string.Join(delimiter, row.Select(v => CsvEscape(v, delimiter)))).Append("\r\n");
 		}
 
 		return sb.ToString();
 	}
 
-	private static string ResolveName(EngagementSummary e, IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap)
+	// The time slot column names its zone explicitly rather than per-row (see
+	// FormatBerlinTime) - simpler than a per-row MEZ/MESZ abbreviation and just
+	// as unambiguous.
+	private static string[] Header(string language) => language == "de"
+		? ["Name", "Status", "Zeitslot (Europe/Berlin)", "Check-in-Status", "Feedback-Bewertung"]
+		: ["Name", "Status", "Time Slot (Europe/Berlin)", "Check-in Status", "Feedback Rating"];
+
+	private static string TranslateStatus(string status, string language) => language == "de"
+		? status switch
+		{
+			"Pending" => "Ausstehend",
+			"Confirmed" => "Bestätigt",
+			"Cancelled" => "Abgesagt",
+			"Withdrawn" => "Zurückgezogen",
+			_ => status,
+		}
+		: status;
+
+	private static string CheckedInLabel(string language) => language == "de" ? "Eingecheckt" : "Checked in";
+
+	private static string NotCheckedInLabel(string language) => language == "de" ? "Nicht eingecheckt" : "Not checked in";
+
+	private static string ResolveName(
+		EngagementSummary e, IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap, string language)
 	{
 		if (e.VolunteerId is not Guid volunteerId)
-			return "Anonymized volunteer";
+			return language == "de" ? "Anonymisierte:r Freiwillige:r" : "Anonymized volunteer";
 
 		if (!profileMap.TryGetValue(volunteerId, out var profile))
-			return $"Volunteer {volunteerId}";
+			return FallbackVolunteerLabel(volunteerId, language);
 
 		var name = profile.FirstName is not null || profile.LastName is not null
 			? $"{profile.FirstName} {profile.LastName}".Trim()
 			: profile.Username;
 
-		return string.IsNullOrWhiteSpace(name) ? $"Volunteer {volunteerId}" : name;
+		return string.IsNullOrWhiteSpace(name) ? FallbackVolunteerLabel(volunteerId, language) : name;
 	}
+
+	private static string FallbackVolunteerLabel(Guid volunteerId, string language) =>
+		language == "de" ? $"Freiwillige:r {volunteerId}" : $"Volunteer {volunteerId}";
 
 	private static string FormatTimeSlot(DateTimeOffset? start, DateTimeOffset? end)
 	{
 		if (start is null)
 			return "";
 
-		var startText = start.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+		var startText = FormatBerlinTime(start.Value);
 		if (end is null)
-			return $"{startText} UTC";
+			return startText;
 
-		var endText = end.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
-		return $"{startText} - {endText} UTC";
+		return $"{startText} - {FormatBerlinTime(end.Value)}";
 	}
 
+	// No per-opportunity timezone is stored (same Europe/Berlin fallback used
+	// throughout this codebase - see EngagementReminderDueHandler.FormatStart's
+	// own comment) - converts from UTC rather than leaving it raw, since that's
+	// what an organizer's own browser (defaulting to its local timezone, almost
+	// always this one for this product's userbase) already shows them on screen.
+	private static string FormatBerlinTime(DateTimeOffset instant) =>
+		TimeZoneInfo.ConvertTime(instant, BerlinTimeZone).ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+
 	// RFC 4180: only quote (and escape embedded quotes in) a field that actually
-	// needs it - a volunteer's name or comment field could contain a comma,
-	// quote, or newline that would otherwise break the CSV's column boundaries.
-	private static string CsvEscape(string value)
+	// needs it - a volunteer's name could contain the delimiter, a quote, or a
+	// newline that would otherwise break the CSV's column boundaries.
+	private static string CsvEscape(string value, string delimiter)
 	{
-		if (value.IndexOfAny([',', '"', '\n', '\r']) < 0)
+		if (value.IndexOfAny(['"', '\n', '\r']) < 0 && !value.Contains(delimiter))
 			return value;
 
 		return $"\"{value.Replace("\"", "\"\"")}\"";

--- a/backend/src/Infrastructure/Email/Templates/de.json
+++ b/backend/src/Infrastructure/Email/Templates/de.json
@@ -42,5 +42,9 @@
   "SearchAlertNewMatches": {
     "subject": "{Count} neue Einsätze passen zu deiner gespeicherten Suche",
     "body": "Hallo {DisplayName},\n\nwir haben {Count} neue Einsätze gefunden, die zu deiner gespeicherten Suche passen:\n\n{OpportunitiesList}\n\nMelde dich bei Einsatzbereit an, um die Details zu sehen und dich anzumelden. Du kannst diese Benachrichtigung jederzeit auf der Suchseite deaktivieren.\n\nEinsatzbereit"
+  },
+  "EmailFooter": {
+    "subject": "",
+    "body": "\n\n---\nMöchtest du diese Art von E-Mail nicht mehr erhalten? Hier abmelden: {UnsubscribeUrl}"
   }
 }

--- a/backend/src/Infrastructure/Email/Templates/en.json
+++ b/backend/src/Infrastructure/Email/Templates/en.json
@@ -42,5 +42,9 @@
   "SearchAlertNewMatches": {
     "subject": "{Count} new opportunities match your saved search",
     "body": "Hi {DisplayName},\n\nWe found {Count} new opportunities matching your saved search:\n\n{OpportunitiesList}\n\nLog in to Einsatzbereit to see the details and sign up. You can turn this alert off any time from the search page.\n\nEinsatzbereit"
+  },
+  "EmailFooter": {
+    "subject": "",
+    "body": "\n\n---\nDon't want to receive this type of email? Unsubscribe here: {UnsubscribeUrl}"
   }
 }

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledNotificationHandlerTests.cs
@@ -41,6 +41,11 @@ public class EngagementCancelledNotificationHandlerTests
 		_emailTemplateRenderer
 			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
 			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_emailTemplateRenderer
+			.Render(EmailTemplateKind.EmailFooter, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(call => new EmailContent(
+				string.Empty,
+				$"\n\n---\n{((IReadOnlyDictionary<string, string>)call[2]!)["UnsubscribeUrl"]}"));
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new EngagementCancelledNotificationHandler(

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
@@ -41,6 +41,11 @@ public class EngagementConfirmedNotificationHandlerTests
 		_emailTemplateRenderer
 			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
 			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_emailTemplateRenderer
+			.Render(EmailTemplateKind.EmailFooter, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(call => new EmailContent(
+				string.Empty,
+				$"\n\n---\n{((IReadOnlyDictionary<string, string>)call[2]!)["UnsubscribeUrl"]}"));
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new EngagementConfirmedNotificationHandler(

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
@@ -38,6 +38,11 @@ public class EngagementCreatedDomainEventHandlerTests
 		_emailTemplateRenderer
 			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
 			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_emailTemplateRenderer
+			.Render(EmailTemplateKind.EmailFooter, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(call => new EmailContent(
+				string.Empty,
+				$"\n\n---\n{((IReadOnlyDictionary<string, string>)call[2]!)["UnsubscribeUrl"]}"));
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new EngagementCreatedDomainEventHandler(

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
@@ -38,6 +38,11 @@ public class EngagementReactivatedDomainEventHandlerTests
 		_emailTemplateRenderer
 			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
 			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_emailTemplateRenderer
+			.Render(EmailTemplateKind.EmailFooter, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(call => new EmailContent(
+				string.Empty,
+				$"\n\n---\n{((IReadOnlyDictionary<string, string>)call[2]!)["UnsubscribeUrl"]}"));
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new EngagementReactivatedDomainEventHandler(

--- a/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
@@ -42,6 +42,17 @@ public class ExportEngagementsQueryHandlerTests
 		_keycloakUserService
 			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
 			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
+		// Defaults the requesting organizer to English so every test not
+		// specifically about localization keeps asserting the English labels
+		// below - Handle_ShouldLocalizeHeaderStatusAndLabels_... below is the
+		// one exercising the German branch.
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call =>
+			{
+				var requestingUser = User.Create(((IReadOnlyCollection<UserId>)call[0]!).First());
+				requestingUser.SetPreferredLanguage("en");
+				return new List<User> { requestingUser };
+			});
 		_sut = new ExportEngagementsQueryHandler(_readRepository, _dbContext, _keycloakUserService);
 	}
 
@@ -89,14 +100,17 @@ public class ExportEngagementsQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnHeaderOnly_WhenNoEngagements(
+	public async Task Handle_ShouldReturnSepDirectiveAndHeaderOnly_WhenNoEngagements(
 		CancellationToken cancellationToken)
 	{
 		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Be("Name,Status,Time Slot,Check-in Status,Feedback Rating\r\n");
+		// The leading "sep=;" line (#1675) tells Excel to use ";" as the column
+		// delimiter regardless of the running install's own regional settings.
+		file.Content.Should().Be(
+			"sep=;\r\nName;Status;Time Slot (Europe/Berlin);Check-in Status;Feedback Rating\r\n");
 	}
 
 	[Test]
@@ -137,7 +151,43 @@ public class ExportEngagementsQueryHandlerTests
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Contain("Vera Volunteer,Confirmed,2026-08-10 09:00 - 2026-08-10 12:00 UTC,Checked in,5");
+		// 09:00-12:00 UTC on an August date is 11:00-14:00 in Europe/Berlin (CEST, UTC+2).
+		file.Content.Should().Contain("Vera Volunteer;Confirmed;2026-08-10 11:00 - 2026-08-10 14:00;Checked in;5");
+	}
+
+	[Test]
+	public async Task Handle_ShouldConvertTimeSlotStart_FromUtcToEuropeBerlin_NotLeaveItRawUtc(
+		CancellationToken cancellationToken)
+	{
+		// A winter instant makes Europe/Berlin deterministically UTC+1 (CET, no
+		// DST) regardless of when this test runs - mirrors
+		// EngagementReminderDueHandlerTests' own approach to the same fallback.
+		var start = new DateTimeOffset(2027, 1, 15, 12, 0, 0, TimeSpan.Zero);
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			TimeSlotId: null,
+			Message: null,
+			"Confirmed",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow,
+			TimeSlotStartDateTime: start,
+			TimeSlotEndDateTime: null);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("2027-01-15 13:00").And.NotContain("12:00");
 	}
 
 	[Test]
@@ -173,7 +223,7 @@ public class ExportEngagementsQueryHandlerTests
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Contain("vera,Pending");
+		file.Content.Should().Contain("vera;Pending");
 	}
 
 	[Test]
@@ -232,7 +282,7 @@ public class ExportEngagementsQueryHandlerTests
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Contain("Anonymized volunteer,Cancelled");
+		file.Content.Should().Contain("Anonymized volunteer;Cancelled");
 	}
 
 	[Test]
@@ -261,11 +311,11 @@ public class ExportEngagementsQueryHandlerTests
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Contain("Anonymized volunteer,Pending,,Not checked in,\r\n");
+		file.Content.Should().Contain("Anonymized volunteer;Pending;;Not checked in;\r\n");
 	}
 
 	[Test]
-	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsACommaAndQuote(
+	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsAQuote(
 		CancellationToken cancellationToken)
 	{
 		var volunteerId = Guid.NewGuid();
@@ -297,7 +347,118 @@ public class ExportEngagementsQueryHandlerTests
 
 		var file = await _sut.Handle(query, cancellationToken);
 
-		file.Content.Should().Contain("\"Vera \"\"The Helper\"\" Doe, Jr.\",Pending");
+		// The embedded quote still forces quoting/escaping - the embedded comma
+		// rides along inside those quotes but, unlike before #1675, no longer
+		// needs escaping on its own since ";" (not ",") is now the delimiter.
+		file.Content.Should().Contain("\"Vera \"\"The Helper\"\" Doe, Jr.\";Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEscapeAPlainComma_SinceSemicolonIsTheDelimiterNow(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Doe, Jane", null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Doe, Jane;Pending").And.NotContain("\"Doe, Jane\"");
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsTheSemicolonDelimiter(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera; The Helper", null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("\"Vera; The Helper\";Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldLocalizeHeaderStatusAndLabels_InRequestingOrganizersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		var organizer = User.Create(DefaultRequestingUserId);
+		organizer.SetPreferredLanguage("de");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([organizer]);
+
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			null,
+			null,
+			"Confirmed",
+			IsCheckedIn: true,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().StartWith(
+			"sep=;\r\nName;Status;Zeitslot (Europe/Berlin);Check-in-Status;Feedback-Bewertung\r\n");
+		file.Content.Should().Contain("Anonymisierte:r Freiwillige:r;Bestätigt;;Eingecheckt;\r\n");
 	}
 
 	private static VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
@@ -38,6 +38,11 @@ public class EngagementWithdrawnDomainEventHandlerTests
 		_emailTemplateRenderer
 			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
 			.Returns(new EmailContent("Test Subject", "Test Body"));
+		_emailTemplateRenderer
+			.Render(EmailTemplateKind.EmailFooter, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(call => new EmailContent(
+				string.Empty,
+				$"\n\n---\n{((IReadOnlyDictionary<string, string>)call[2]!)["UnsubscribeUrl"]}"));
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
 		_sut = new EngagementWithdrawnDomainEventHandler(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -168,7 +168,6 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<NotificationPreferencesResponse> GetNotificationPreferencesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task UnsubscribeAsync(System.Guid userId, string type, System.Guid token, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -3670,7 +3669,6 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task UnsubscribeAsync(System.Guid userId, string type, System.Guid token, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -3725,9 +3723,10 @@ namespace IntegrationTests
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
+                        if (status_ == 302)
                         {
-                            return;
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("Found", status_, responseText_, headers_, null);
                         }
                         else
                         if (status_ == 400)
@@ -3758,6 +3757,13 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+
+                        if (status_ == 200 || status_ == 204)
+                        {
+
+                            return;
                         }
                         else
                         {

--- a/backend/tests/IntegrationTests/Email/EmailTemplateRendererTests.cs
+++ b/backend/tests/IntegrationTests/Email/EmailTemplateRendererTests.cs
@@ -32,6 +32,7 @@ public class EmailTemplateRendererTests
 				["OrganizationName"] = "Beach Cleanup Crew",
 				["Count"] = "2",
 				["OpportunitiesList"] = "- Beach Cleanup\n- Park Cleanup",
+				["UnsubscribeUrl"] = "https://example.com/unsubscribe",
 			};
 
 			var content = _sut.Render(kind, language, placeholders);

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1093,6 +1093,18 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task UnsubscribePage_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/unsubscribed?type=EngagementReminder");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations()
 	{
 		// #573: the native time slot <select> was replaced with a custom

--- a/backend/tests/VisualTests/AccountConsoleLinkTests.cs
+++ b/backend/tests/VisualTests/AccountConsoleLinkTests.cs
@@ -3,39 +3,37 @@ using Microsoft.Playwright;
 namespace VisualTests;
 
 /// <summary>
-/// #1098: users had no in-app way to change their password or email - the
-/// account dropdown (desktop) and mobile burger menu only ever linked to
-/// /profile and (admins only) /administration. This adds an "Account
-/// Settings" entry in both menus pointing at Keycloak's own account console
-/// (`${authority}/account`), which already supports password/email changes,
-/// rather than building that functionality natively.
+/// #1675: the "Account Settings" entry (added by #1098) linked out to
+/// Keycloak's own, unbranded account console (`${authority}/account`), which
+/// the realm never actually provisions a client for and which currently
+/// errors on staging. Everything it uniquely offered is either already
+/// reachable branded (password reset, profile editing at /profile) or not
+/// configured in the realm at all (2FA, session management) - so the entry
+/// point itself is removed rather than themed. This guards against it
+/// reappearing in either menu.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class AccountConsoleLinkTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task AccountDropdown_AuthenticatedUser_LinksToKeycloakAccountConsole()
+	public async Task AccountDropdown_AuthenticatedUser_HasNoKeycloakAccountConsoleLink()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
-		var authority = $"{Fixture.GetEndpoint("keycloak").ToString().TrimEnd('/')}/realms/einsatzbereit";
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await Page.GetByRole(AriaRole.Button, new() { Name = "User menu" }).ClickAsync();
 
-		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" });
-		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await Expect(link).ToHaveAttributeAsync("href", $"{authority}/account");
-		await Expect(link).ToHaveAttributeAsync("target", "_blank");
-		await Expect(link).ToHaveAttributeAsync("rel", "noopener noreferrer");
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "My Profile" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" })).Not.ToBeVisibleAsync();
 	}
 
 	[Test]
-	public async Task MobileMenu_AuthenticatedUser_LinksToKeycloakAccountConsole()
+	public async Task MobileMenu_AuthenticatedUser_HasNoKeycloakAccountConsoleLink()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
-		var authority = $"{Fixture.GetEndpoint("keycloak").ToString().TrimEnd('/')}/realms/einsatzbereit";
 
 		// FastSignInAsync's own "User menu" wait needs the desktop-width nav
 		// visible (DesktopHeader.tsx's "hidden md:flex") - sign in at the
@@ -48,10 +46,8 @@ public class AccountConsoleLinkTests(AspireFixture fixture) : VisualTestBase(fix
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
 			.ClickAsync(new() { Timeout = 10_000 });
 
-		var link = Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" });
-		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
-		await Expect(link).ToHaveAttributeAsync("href", $"{authority}/account");
-		await Expect(link).ToHaveAttributeAsync("target", "_blank");
-		await Expect(link).ToHaveAttributeAsync("rel", "noopener noreferrer");
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "My Profile" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Account Settings" })).Not.ToBeVisibleAsync();
 	}
 }

--- a/frontend/scripts/check-i18n-keys.js
+++ b/frontend/scripts/check-i18n-keys.js
@@ -104,6 +104,9 @@ const EMAIL_TEMPLATE_ALLOWED_IDENTICAL_KEYS = new Set([
 	// A reason suffix appended into another template's body - it has no
 	// subject line of its own, so both languages leave it empty.
 	"EngagementCancelledReasonSuffix.subject",
+	// Same as above - a body-only fragment (the unsubscribe line) spliced into
+	// every other outgoing template, with no subject line of its own.
+	"EmailFooter.subject",
 ]);
 
 // Keys that interpolate {{count}} but never need a plural form: the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const ImprintPage = lazy(() => import("./pages/ImprintPage"));
 const TermsOfUsePage = lazy(() => import("./pages/TermsOfUsePage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));
 const HelpPage = lazy(() => import("./pages/HelpPage"));
+const UnsubscribePage = lazy(() => import("./pages/UnsubscribePage"));
 const VolunteerOpportunityDetailPage = lazy(
 	() => import("./pages/VolunteerOpportunityDetailPage"),
 );
@@ -153,6 +154,7 @@ export default function App() {
 				<Route path="/terms-of-use" element={<TermsOfUsePage />} />
 				<Route path="/contact" element={<ContactPage />} />
 				<Route path="/help" element={<HelpPage />} />
+				<Route path="/unsubscribed" element={<UnsubscribePage />} />
 				<Route
 					path="/volunteer-opportunities/:opportunityId"
 					element={<VolunteerOpportunityDetailPage />}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1770,9 +1770,6 @@ export class EinsatzbereitApi {
         return Promise.resolve<NotificationPreferencesResponse>(null as any);
     }
 
-    /**
-     * @return OK
-     */
     unsubscribe(userId: string, type: string, token: string, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/users/{userId}/unsubscribe?";
         if (userId === undefined || userId === null)
@@ -1803,9 +1800,9 @@ export class EinsatzbereitApi {
     protected processUnsubscribe(response: Response): Promise<void> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 200) {
+        if (status === 302) {
             return response.text().then((_responseText) => {
-            return;
+            return throwException("Found", status, _responseText, _headers);
             });
         } else if (status === 400) {
             return response.text().then((_responseText) => {

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -4,14 +4,12 @@ import { useTranslation } from "react-i18next";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
-import { runtimeConfig } from "../../lib/runtimeConfig";
 import NotificationDropdown from "./NotificationDropdown";
 import {
 	ArrowRightOnRectangleIcon,
 	ChevronDownIcon,
 	ChevronRightIcon,
 	Cog6ToothIcon,
-	KeyIcon,
 	Squares2x2Icon,
 	UserCircleIcon,
 } from "../icons";
@@ -96,15 +94,6 @@ export default function AccountControls({
 								<UserCircleIcon className="h-4 w-4" />
 								{t("nav.myProfile")}
 							</Link>
-							<a
-								href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
-							>
-								<KeyIcon className="h-4 w-4" />
-								{t("nav.accountSettings")}
-							</a>
 							{isAdmin && (
 								<Link
 									to="/administration"

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -7,7 +7,6 @@ import { FOCUSABLE_SELECTOR } from "../Modal";
 import LanguageSelector from "./LanguageSelector";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
-import { runtimeConfig } from "../../lib/runtimeConfig";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 import { ChevronDownIcon } from "../icons";
 
@@ -180,15 +179,6 @@ export default function MobileMenu({
 							>
 								{t("nav.myProfile")}
 							</Link>
-							<a
-								href={`${runtimeConfig.keycloakAuthorityUrl}/account`}
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={onClose}
-								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
-							>
-								{t("nav.accountSettings")}
-							</a>
 							{isAdmin && (
 								<Link
 									to="/administration"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -19,7 +19,6 @@
       "primaryLabel": "Hauptnavigation",
       "userMenu": "Benutzermenü",
       "myProfile": "Mein Profil",
-      "accountSettings": "Kontoeinstellungen",
       "administration": "Administration",
       "organization": "Organisation",
       "signOut": "Abmelden",
@@ -817,7 +816,8 @@
         "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten",
         "InvitationAccepted": "Deine Einladung, {{title}} beizutreten, wurde angenommen",
         "InvitationDeclined": "Deine Einladung, {{title}} beizutreten, wurde abgelehnt",
-        "FeedbackSubmitted": "Neues Feedback erhalten für {{title}}"
+        "FeedbackSubmitted": "Neues Feedback erhalten für {{title}}",
+        "NewMatchingOpportunity": "Ein neuer Einsatz passt zu deiner gespeicherten Suche: {{title}}"
       }
     },
     "language": {
@@ -834,6 +834,11 @@
       "title": "Seite nicht gefunden",
       "description": "Die Seite existiert nicht oder wurde verschoben. Vielleicht hat der Hund sie gefressen…",
       "backHome": "Zur Startseite"
+    },
+    "unsubscribe": {
+      "title": "Du wurdest abgemeldet",
+      "description": "Du hast diese Art von E-Mail abbestellt. Du kannst sie jederzeit in deinen Benachrichtigungseinstellungen im Profil wieder aktivieren.",
+      "manageInProfile": "Benachrichtigungseinstellungen verwalten"
     },
     "report": {
       "title": "Inhalt melden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -19,7 +19,6 @@
       "primaryLabel": "Main navigation",
       "userMenu": "User menu",
       "myProfile": "My Profile",
-      "accountSettings": "Account Settings",
       "administration": "Administration",
       "organization": "Organization",
       "signOut": "Sign out",
@@ -817,7 +816,8 @@
         "InvitationReceived": "You've been invited to join {{title}}",
         "InvitationAccepted": "Your invitation to join {{title}} was accepted",
         "InvitationDeclined": "Your invitation to join {{title}} was declined",
-        "FeedbackSubmitted": "New feedback received for {{title}}"
+        "FeedbackSubmitted": "New feedback received for {{title}}",
+        "NewMatchingOpportunity": "A new opportunity matches your saved search: {{title}}"
       }
     },
     "language": {
@@ -834,6 +834,11 @@
       "title": "Page not found",
       "description": "This page doesn't exist or has been moved. Maybe the dog ate it…",
       "backHome": "Back to home"
+    },
+    "unsubscribe": {
+      "title": "You've been unsubscribed",
+      "description": "You have been unsubscribed from this type of email. You can re-enable it any time from your notification preferences in your profile.",
+      "manageInProfile": "Manage notification preferences"
     },
     "report": {
       "title": "Report content",

--- a/frontend/src/pages/UnsubscribePage.tsx
+++ b/frontend/src/pages/UnsubscribePage.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { usePageTitle } from "../hooks/usePageTitle";
+import Button from "../components/Button";
+import { statusTitleClass } from "../lib/headingClasses";
+
+// Landing page the one-click unsubscribe link in transactional emails
+// redirects to after UnsubscribeEndpoint records the opt-out server-side
+// (#1675) - replaces a bare, unbranded HTML response with a page that
+// actually renders in the reader's language and gives them a way back
+// into the app instead of a dead end.
+export default function UnsubscribePage() {
+	const { t } = useTranslation();
+	usePageTitle(t("unsubscribe.title"));
+
+	return (
+		<div className="flex min-h-[70vh] items-center justify-center px-4 text-center">
+			<div className="max-w-md">
+				<h1 className={`mb-4 text-brand-700 ${statusTitleClass}`}>
+					{t("unsubscribe.title")}
+				</h1>
+				<p className="mb-8 text-black">{t("unsubscribe.description")}</p>
+				<Button to="/profile" size="lg">
+					{t("unsubscribe.manageInProfile")}
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -1,6 +1,8 @@
 {
   "realm": "einsatzbereit",
   "enabled": true,
+  "displayName": "Einsatzbereit",
+  "displayNameHtml": "<b>Einsatzbereit</b>",
   "organizationsEnabled": true,
   "sslRequired": "external",
   "loginTheme": "einsatzbereit",


### PR DESCRIPTION
## What

Localizes (or removes) every user-facing surface that lives outside the SPA and was still hardcoded English/unbranded, even though German is the default served locale.

## Why

Closes #1675

Found by the 1.0 readiness analysis: the SPA itself is fully localized via `en.json`/`de.json`, but everything *outside* it wasn't:

1. **Email footer** - `EmailFooter.Append` hardcoded an English "Unsubscribe here" line and appended it verbatim to every otherwise-localized notification email (confirmation, cancellation, reminder, organizer notifications). Now `EmailFooter` is a proper `EmailTemplateKind` (de/en templates in `Infrastructure/Email/Templates/`), rendered in the recipient's already-resolved language via `IEmailTemplateRenderer` - the same "render separately, splice in" pattern the existing `EngagementCancelledReasonSuffix` fragment already used.
2. **Unsubscribe landing page** - `UnsubscribeEndpoint` returned hardcoded, unstyled English HTML with no branding and no way back into the app. It now redirects (302) into a new branded, localized frontend route (`/unsubscribed`), reusing the same `Cors:Origins`-derived frontend-base-URL pattern already used by `GetSitemapEndpoint`/`GetEngagementCalendarEndpoint`.
3. **Missing notification translation key** - `NotificationKind.NewMatchingOpportunity` had no `notifications.kinds.NewMatchingOpportunity` key in either locale, so a volunteer's saved-search alert notification rendered as the literal string `NewMatchingOpportunity` in the German bell dropdown. Added to both `en.json`/`de.json`.
4. **CSV export** - `ExportEngagementsQueryHandler` always wrote an English header with no BOM, raw `;`-hostile commas, and raw UTC timestamps. It now: prepends a UTF-8 BOM (via `Encoding.UTF8.GetPreamble()` in the endpoint), emits a `sep=;` directive with `;` as the actual delimiter (so a German Windows Excel install - which expects `;` - no longer collapses the file into one column), translates the header/status values/labels into the *requesting organizer's* preferred language, and renders time slot timestamps converted to Europe/Berlin instead of raw UTC (the same fallback timezone convention already used throughout this codebase, e.g. `EngagementReminderDueHandler`).
5. **"Kontoeinstellungen" entry point** - per the issue's own analysis, theming Keycloak's account console isn't worth it: the realm never provisions an `account`/`account-console` client, `accountTheme`/`displayName` are null, and the link currently errors on staging ("Unerwarteter Fehler"). Everything it uniquely offered is either already reachable branded (password reset via the themed login flow, profile editing at `/profile`) or not configured in the realm at all (2FA, session management). Removed the link from both the desktop dropdown (`AccountControls.tsx`) and mobile menu (`MobileMenu.tsx`). Independently, set `displayName`/`displayNameHtml` on the realm so Keycloak's own verification email (`verifyEmail: true`) carries "Einsatzbereit" instead of interpolating the lowercase realm id.

## Testing

- `Application.UnitTests` (1004 tests) and `ArchitectureTests` (426 tests) run locally - all passing.
- Updated the 5 notification-handler test files (`EngagementConfirmed`/`EngagementCancelled`/`EngagementCreated`/`EngagementReactivated`/`EngagementWithdrawn`) to stub the new `EmailTemplateKind.EmailFooter` render call so the existing "unsubscribe link appears in the body" assertions keep working against the new template-based footer.
- Added `["UnsubscribeUrl"]` to `EmailTemplateRendererTests`' shared placeholder dict so its "every template kind renders a non-empty body with no unresolved placeholders, in both languages" test covers the new `EmailFooter` kind.
- Rewrote `ExportEngagementsQueryHandlerTests` for the new `;`-delimited, `sep=;`-prefixed, Europe/Berlin-converted, language-aware CSV output, including new cases for: no-longer-needing-escaped commas, still-needing-escaped semicolons, the Europe/Berlin conversion (winter instant, deterministic UTC+1), and full German-language header/status/label translation.
- Rewrote `AccountConsoleLinkTests` (VisualTests) to assert the "Account Settings" link is now absent from both the desktop dropdown and mobile menu, instead of asserting it links to Keycloak.
- Added `UnsubscribePage_HasNoSeriousA11yViolations` to `AccessibilityTests` for the new `/unsubscribed` route.
- Frontend: `pnpm lint`, `pnpm check`, `pnpm format:check`, `pnpm i18n:check`, `pnpm test` (186 tests), `pnpm build`, and the nginx/PWA CI check scripts all pass locally. Added `EmailFooter.subject` to `check-i18n-keys.js`'s identical-value allowlist (both languages legitimately leave it empty, same as the existing `EngagementCancelledReasonSuffix.subject` entry).
- `/self-review` run: fanned out to `nswag-check` (caught that `UnsubscribeEndpoint`'s response contract change - 200 text/html to 302 redirect - needed NSwag client regeneration; regenerated `openapi-v1.json`/`api-client.ts`/`ApiClient.cs` and confirmed nothing in the frontend actually calls the generated `unsubscribe()` client method, since the real flow is a direct browser navigation from the email link, not a `fetch()` call), `architecture-check` (no layer/naming/rate-limiting violations), `a11y-check` (no issues, new page and test correctly placed), and `i18n-check` (key parity confirmed, no dead keys left behind). No findings outstanding.

## Live verification

Not performed - the task explicitly asked not to cut a release candidate for this change. CI (`dotnet.yml`/`frontend.yml`) is the verification gate for this PR; happy to cut an RC and run `/live-verify` in a follow-up if wanted.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs reference the removed account-console link or the old unsubscribe HTML response)


---
_Generated by [Claude Code](https://claude.ai/code/session_016m5DkY5aqidaiMFfLtPPEq)_