### PR TITLE
fix: add engagements to org nav, give shared links their own preview

### DIFF
--- a/backend/src/Api/Meta/GetOrganizationMeta/v1/GetOrganizationMetaEndpoint.cs
+++ b/backend/src/Api/Meta/GetOrganizationMeta/v1/GetOrganizationMetaEndpoint.cs
@@ -1,0 +1,43 @@
+using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Meta.GetOrganizationMeta.v1;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace Api.Meta.GetOrganizationMeta.v1;
+
+// AllowAnonymous is deliberate: only reached via frontend/nginx.conf.template's
+// bot-User-Agent rewrite for /organizations/{id} (einsatzbereit#1680), which carries no
+// Bearer token to attach - same rationale as GetSitemapEndpoint / the sibling
+// GetVolunteerOpportunityMetaEndpoint.
+internal sealed class GetOrganizationMetaEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/meta/organizations/{organizationId:guid}", GetOrganizationMetaAsync)
+			.WithName("GetOrganizationMeta")
+			.WithTags("Meta")
+			.Produces(StatusCodes.Status200OK, contentType: "text/html")
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> GetOrganizationMetaAsync(
+		[FromRoute] Guid organizationId,
+		[FromServices] ISender sender,
+		[FromServices] IConfiguration configuration,
+		CancellationToken cancellationToken)
+	{
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var baseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+
+		var html = await sender.Send(
+			new GetOrganizationMetaQuery(organizationId, baseUrl), cancellationToken);
+
+		return html is null ? Results.NotFound() : Results.Content(html, "text/html; charset=utf-8");
+	}
+}

--- a/backend/src/Api/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaEndpoint.cs
+++ b/backend/src/Api/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaEndpoint.cs
@@ -1,0 +1,45 @@
+using Api.Common.Endpoints;
+using Api.Common.OutputCaching;
+using Api.Common.RateLimiting;
+using Application.Common.Messaging;
+using Application.Meta.GetVolunteerOpportunityMeta.v1;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace Api.Meta.GetVolunteerOpportunityMeta.v1;
+
+// AllowAnonymous is deliberate: only reached via frontend/nginx.conf.template's
+// bot-User-Agent rewrite for /volunteer-opportunities/{id} (einsatzbereit#1680), which
+// carries no Bearer token to attach - same rationale as GetSitemapEndpoint. Served under
+// the versioned API prefix like every other endpoint; the frontend's nginx proxies its
+// own internal /__meta/volunteer-opportunities/{id} rewrite target to this route over
+// the internal Docker network.
+internal sealed class GetVolunteerOpportunityMetaEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/meta/volunteer-opportunities/{opportunityId:guid}", GetVolunteerOpportunityMetaAsync)
+			.WithName("GetVolunteerOpportunityMeta")
+			.WithTags("Meta")
+			.Produces(StatusCodes.Status200OK, contentType: "text/html")
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.AllowAnonymous()
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.CacheOutput(OutputCachingPolicies.ShortPublicRead)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> GetVolunteerOpportunityMetaAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		[FromServices] IConfiguration configuration,
+		CancellationToken cancellationToken)
+	{
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var baseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+
+		var html = await sender.Send(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, baseUrl), cancellationToken);
+
+		return html is null ? Results.NotFound() : Results.Content(html, "text/html; charset=utf-8");
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5300,6 +5300,94 @@
         }
       }
     },
+    "/v1/meta/volunteer-opportunities/{opportunityId}": {
+      "get": {
+        "tags": [
+          "Meta"
+        ],
+        "operationId": "GetVolunteerOpportunityMeta",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/meta/organizations/{organizationId}": {
+      "get": {
+        "tags": [
+          "Meta"
+        ],
+        "operationId": "GetOrganizationMeta",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/maps/cities": {
       "get": {
         "tags": [
@@ -10862,6 +10950,9 @@
     },
     {
       "name": "Notifications"
+    },
+    {
+      "name": "Meta"
     },
     {
       "name": "SearchCitiesEndpoint"

--- a/backend/src/Application/Common/Meta/MetaHtmlBuilder.cs
+++ b/backend/src/Application/Common/Meta/MetaHtmlBuilder.cs
@@ -1,0 +1,87 @@
+namespace Application.Common.Meta;
+
+// Builds a standalone HTML document carrying one entity's own title/description/image
+// in its OG and Twitter card tags, instead of the site-wide metadata frontend/index.html
+// hardcodes (einsatzbereit#1680). Only ever reaches a social-preview crawler or search
+// engine - frontend/nginx.conf.template only proxies here for User-Agents it recognizes
+// as a bot, so this never needs to match the SPA's own hashed asset filenames or ship a
+// working app shell, just correct tags plus a plain fallback link for anything that does
+// render the body.
+public static class MetaHtmlBuilder
+{
+	// OG/Twitter cards truncate long descriptions anyway; capping here keeps the
+	// preview's own wording intact instead of an engine-chosen cut mid-sentence.
+	private const int MaxDescriptionLength = 200;
+
+	public static string Build(
+		string title,
+		string? description,
+		string canonicalUrl,
+		string imageUrl)
+	{
+		var fallbackDescription =
+			"Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten.";
+		var encodedTitle = HtmlEscape(title);
+		var encodedDescription = HtmlEscape(
+			Truncate(string.IsNullOrWhiteSpace(description) ? fallbackDescription : description));
+		var encodedCanonicalUrl = HtmlEscape(canonicalUrl);
+		var encodedImageUrl = HtmlEscape(imageUrl);
+
+		return $"""
+			<!doctype html>
+			<html lang="de">
+				<head>
+					<meta charset="UTF-8" />
+					<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+					<meta name="color-scheme" content="light" />
+					<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+					<link rel="apple-touch-icon" href="/icons/icon-192.png" />
+					<meta name="theme-color" content="#2d8a5e" />
+					<title>{encodedTitle}</title>
+					<meta name="description" content="{encodedDescription}" />
+					<link rel="canonical" href="{encodedCanonicalUrl}" />
+					<meta property="og:type" content="website" />
+					<meta property="og:url" content="{encodedCanonicalUrl}" />
+					<meta property="og:title" content="{encodedTitle}" />
+					<meta property="og:description" content="{encodedDescription}" />
+					<meta property="og:image" content="{encodedImageUrl}" />
+					<meta name="twitter:card" content="summary_large_image" />
+					<meta name="twitter:title" content="{encodedTitle}" />
+					<meta name="twitter:description" content="{encodedDescription}" />
+					<meta name="twitter:image" content="{encodedImageUrl}" />
+				</head>
+				<body>
+					<p><a href="{encodedCanonicalUrl}">{encodedTitle}</a></p>
+					<p>{encodedDescription}</p>
+				</body>
+			</html>
+			""";
+	}
+
+	private static string Truncate(string value)
+	{
+		if (value.Length <= MaxDescriptionLength)
+			return value;
+
+		// Back off one code unit when the cut would land inside a UTF-16 surrogate
+		// pair (e.g. an emoji in a user-entered description) - otherwise the
+		// trailing half-character renders as U+FFFD in any client that validates it.
+		var cutIndex = char.IsLowSurrogate(value[MaxDescriptionLength])
+			? MaxDescriptionLength - 1
+			: MaxDescriptionLength;
+
+		return string.Concat(value.AsSpan(0, cutIndex).TrimEnd(), "...");
+	}
+
+	// Escapes only what HTML text/double-quoted-attribute content actually needs -
+	// unlike WebUtility.HtmlEncode, this leaves non-ASCII characters (e.g. umlauts in
+	// organization/opportunity names) as literal UTF-8 rather than numeric character
+	// references, which the document's own <meta charset="UTF-8" /> already covers.
+	private static string HtmlEscape(string value) =>
+		value
+			.Replace("&", "&amp;")
+			.Replace("<", "&lt;")
+			.Replace(">", "&gt;")
+			.Replace("\"", "&quot;")
+			.Replace("'", "&#39;");
+}

--- a/backend/src/Application/Meta/GetOrganizationMeta/v1/GetOrganizationMetaQuery.cs
+++ b/backend/src/Application/Meta/GetOrganizationMeta/v1/GetOrganizationMetaQuery.cs
@@ -1,0 +1,6 @@
+using Application.Common.Messaging;
+
+namespace Application.Meta.GetOrganizationMeta.v1;
+
+public sealed record GetOrganizationMetaQuery(Guid OrganizationId, string BaseUrl)
+	: IQuery<string?>;

--- a/backend/src/Application/Meta/GetOrganizationMeta/v1/GetOrganizationMetaQueryHandler.cs
+++ b/backend/src/Application/Meta/GetOrganizationMeta/v1/GetOrganizationMetaQueryHandler.cs
@@ -1,0 +1,30 @@
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Common.Meta;
+using Application.Common.Persistence;
+using Domain.Organizations;
+
+namespace Application.Meta.GetOrganizationMeta.v1;
+
+internal sealed class GetOrganizationMetaQueryHandler(IApplicationDbContext dbContext)
+	: IQueryHandler<GetOrganizationMetaQuery, string?>
+{
+	public async ValueTask<string?> Handle(
+		GetOrganizationMetaQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var organization = await dbContext.Organizations.FindAsync(
+			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(), cancellationToken);
+
+		if (organization is null)
+			return null;
+
+		var baseUrl = request.BaseUrl.TrimEnd('/');
+
+		return MetaHtmlBuilder.Build(
+			$"{organization.Name} - Einsatzbereit",
+			organization.Description,
+			$"{baseUrl}/organizations/{organization.Id.Value}",
+			organization.LogoUrl ?? $"{baseUrl}/og-image.png");
+	}
+}

--- a/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQuery.cs
+++ b/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQuery.cs
@@ -1,0 +1,6 @@
+using Application.Common.Messaging;
+
+namespace Application.Meta.GetVolunteerOpportunityMeta.v1;
+
+public sealed record GetVolunteerOpportunityMetaQuery(Guid OpportunityId, string BaseUrl)
+	: IQuery<string?>;

--- a/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQueryHandler.cs
+++ b/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQueryHandler.cs
@@ -1,0 +1,29 @@
+using Application.Common.Messaging;
+using Application.Common.Meta;
+using Application.VolunteerOpportunities;
+
+namespace Application.Meta.GetVolunteerOpportunityMeta.v1;
+
+internal sealed class GetVolunteerOpportunityMetaQueryHandler(
+	IVolunteerOpportunityReadRepository readRepository)
+	: IQueryHandler<GetVolunteerOpportunityMetaQuery, string?>
+{
+	public async ValueTask<string?> Handle(
+		GetVolunteerOpportunityMetaQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await readRepository.GetDetailsAsync(
+			request.OpportunityId, requestingUserId: null, cancellationToken);
+
+		if (opportunity is null)
+			return null;
+
+		var baseUrl = request.BaseUrl.TrimEnd('/');
+
+		return MetaHtmlBuilder.Build(
+			$"{opportunity.Title} - Einsatzbereit",
+			opportunity.Description,
+			$"{baseUrl}/volunteer-opportunities/{opportunity.Id}",
+			opportunity.BannerImageUrl ?? $"{baseUrl}/og-image.png");
+	}
+}

--- a/backend/tests/Application.UnitTests/Meta/GetOrganizationMeta/GetOrganizationMetaQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Meta/GetOrganizationMeta/GetOrganizationMetaQueryHandlerTests.cs
@@ -1,0 +1,123 @@
+using Application.Common.Exceptions;
+using Application.Common.Persistence;
+using Application.Meta.GetOrganizationMeta.v1;
+using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Primitives;
+using NSubstitute;
+
+namespace Application.UnitTests.Meta.GetOrganizationMeta;
+
+public class GetOrganizationMetaQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<Organization, OrganizationId> _organizationRepo =
+		Substitute.For<IAggregateRepository<Organization, OrganizationId>>();
+	private readonly GetOrganizationMetaQueryHandler _sut;
+
+	public GetOrganizationMetaQueryHandlerTests()
+	{
+		_dbContext.Organizations.Returns(_organizationRepo);
+		_sut = new GetOrganizationMetaQueryHandler(_dbContext);
+	}
+
+	private static Organization CreateOrganization(
+		OrganizationId id,
+		string name = "Küstenschutz e.V.",
+		string? description = "Wir schützen die Küste.",
+		string? logoUrl = null)
+	{
+		var organization = Organization.Create(id, name).Value;
+		organization.ChangeDescription(description);
+		organization.SetLogoUrl(logoUrl);
+		return organization;
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnNull_WhenOrganizationNotFound(CancellationToken cancellationToken)
+	{
+		var organizationId = Guid.NewGuid();
+		_organizationRepo
+			.FindAsync(OrganizationId.Create(organizationId).GetValueOrThrow(), cancellationToken)
+			.Returns((Organization?)null);
+
+		var result = await _sut.Handle(
+			new GetOrganizationMetaQuery(organizationId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		result.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldIncludeNameDescriptionAndCanonicalUrl_WhenOrganizationFound(
+		CancellationToken cancellationToken)
+	{
+		var organizationId = Guid.NewGuid();
+		var domainId = OrganizationId.Create(organizationId).GetValueOrThrow();
+		_organizationRepo
+			.FindAsync(domainId, cancellationToken)
+			.Returns(CreateOrganization(domainId));
+
+		var html = await _sut.Handle(
+			new GetOrganizationMetaQuery(organizationId, "https://einsatzbereit.example/"),
+			cancellationToken);
+
+		html.Should().NotBeNull();
+		html.Should().Contain("Küstenschutz e.V. - Einsatzbereit");
+		html.Should().Contain("Wir schützen die Küste.");
+		html.Should().Contain($"https://einsatzbereit.example/organizations/{organizationId}");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToSiteOgImage_WhenOrganizationHasNoLogo(
+		CancellationToken cancellationToken)
+	{
+		var organizationId = Guid.NewGuid();
+		var domainId = OrganizationId.Create(organizationId).GetValueOrThrow();
+		_organizationRepo
+			.FindAsync(domainId, cancellationToken)
+			.Returns(CreateOrganization(domainId, logoUrl: null));
+
+		var html = await _sut.Handle(
+			new GetOrganizationMetaQuery(organizationId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().Contain("https://einsatzbereit.example/og-image.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldUseOrganizationLogo_WhenSet(CancellationToken cancellationToken)
+	{
+		var organizationId = Guid.NewGuid();
+		var domainId = OrganizationId.Create(organizationId).GetValueOrThrow();
+		_organizationRepo
+			.FindAsync(domainId, cancellationToken)
+			.Returns(CreateOrganization(domainId, logoUrl: "https://storage.example/logos/abc.png"));
+
+		var html = await _sut.Handle(
+			new GetOrganizationMetaQuery(organizationId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().Contain("https://storage.example/logos/abc.png");
+		html.Should().NotContain("og-image.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldHtmlEncodeOrganizationName_ToPreventMarkupInjection(
+		CancellationToken cancellationToken)
+	{
+		var organizationId = Guid.NewGuid();
+		var domainId = OrganizationId.Create(organizationId).GetValueOrThrow();
+		_organizationRepo
+			.FindAsync(domainId, cancellationToken)
+			.Returns(CreateOrganization(domainId, name: "<script>alert(1)</script> & Friends"));
+
+		var html = await _sut.Handle(
+			new GetOrganizationMetaQuery(organizationId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().NotContain("<script>");
+		html.Should().Contain("&lt;script&gt;");
+		html.Should().Contain("&amp; Friends");
+	}
+}

--- a/backend/tests/Application.UnitTests/Meta/GetVolunteerOpportunityMeta/GetVolunteerOpportunityMetaQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Meta/GetVolunteerOpportunityMeta/GetVolunteerOpportunityMetaQueryHandlerTests.cs
@@ -1,0 +1,155 @@
+using Application.Meta.GetVolunteerOpportunityMeta.v1;
+using Application.VolunteerOpportunities;
+using Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
+using AwesomeAssertions;
+using NSubstitute;
+
+namespace Application.UnitTests.Meta.GetVolunteerOpportunityMeta;
+
+public class GetVolunteerOpportunityMetaQueryHandlerTests
+{
+	private readonly IVolunteerOpportunityReadRepository _readRepository =
+		Substitute.For<IVolunteerOpportunityReadRepository>();
+	private readonly GetVolunteerOpportunityMetaQueryHandler _sut;
+
+	public GetVolunteerOpportunityMetaQueryHandlerTests()
+	{
+		_sut = new GetVolunteerOpportunityMetaQueryHandler(_readRepository);
+	}
+
+	private static VolunteerOpportunityDetails CreateDetails(
+		Guid? id = null,
+		string title = "Strandreinigung",
+		string? description = "Wir sammeln gemeinsam Müll am Strand.",
+		string? bannerImageUrl = null) =>
+		new(
+			id ?? Guid.NewGuid(),
+			title,
+			description,
+			Guid.NewGuid(),
+			"Küstenschutz e.V.",
+			"Strandweg",
+			"1",
+			"12345",
+			"Musterstadt",
+			null,
+			null,
+			false,
+			"OneTime",
+			"ScheduledSlots",
+			"None",
+			null,
+			[],
+			[],
+			DateTimeOffset.UtcNow,
+			null,
+			0,
+			"Published",
+			bannerImageUrl);
+
+	[Test]
+	public async Task Handle_ShouldReturnNull_WhenOpportunityNotFound(CancellationToken cancellationToken)
+	{
+		_readRepository
+			.GetDetailsAsync(Arg.Any<Guid>(), null, Arg.Any<CancellationToken>())
+			.Returns((VolunteerOpportunityDetails?)null);
+
+		var result = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(Guid.NewGuid(), "https://einsatzbereit.example"),
+			cancellationToken);
+
+		result.Should().BeNull();
+	}
+
+	[Test]
+	public async Task Handle_ShouldIncludeTitleDescriptionAndCanonicalUrl_WhenOpportunityFound(
+		CancellationToken cancellationToken)
+	{
+		var opportunityId = Guid.NewGuid();
+		var details = CreateDetails(id: opportunityId);
+		_readRepository
+			.GetDetailsAsync(opportunityId, null, Arg.Any<CancellationToken>())
+			.Returns(details);
+
+		var html = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, "https://einsatzbereit.example/"),
+			cancellationToken);
+
+		html.Should().NotBeNull();
+		html.Should().Contain("Strandreinigung - Einsatzbereit");
+		html.Should().Contain("Wir sammeln gemeinsam Müll am Strand.");
+		html.Should().Contain($"https://einsatzbereit.example/volunteer-opportunities/{opportunityId}");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToSiteOgImage_WhenOpportunityHasNoBanner(
+		CancellationToken cancellationToken)
+	{
+		var opportunityId = Guid.NewGuid();
+		_readRepository
+			.GetDetailsAsync(opportunityId, null, Arg.Any<CancellationToken>())
+			.Returns(CreateDetails(bannerImageUrl: null));
+
+		var html = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().Contain("https://einsatzbereit.example/og-image.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldUseOpportunityBanner_WhenSet(CancellationToken cancellationToken)
+	{
+		var opportunityId = Guid.NewGuid();
+		_readRepository
+			.GetDetailsAsync(opportunityId, null, Arg.Any<CancellationToken>())
+			.Returns(CreateDetails(bannerImageUrl: "https://storage.example/banners/abc.png"));
+
+		var html = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().Contain("https://storage.example/banners/abc.png");
+		html.Should().NotContain("og-image.png");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotSplitSurrogatePair_WhenTruncatingLongDescription(
+		CancellationToken cancellationToken)
+	{
+		// The 😀 emoji sits at UTF-16 indices 199-200 (a surrogate pair) - a
+		// naive cut at the 200-char limit would land mid-pair and produce an
+		// unpaired surrogate in the output.
+		var longDescription = new string('a', 199) + "\U0001F600" + new string('b', 50);
+		var opportunityId = Guid.NewGuid();
+		_readRepository
+			.GetDetailsAsync(opportunityId, null, Arg.Any<CancellationToken>())
+			.Returns(CreateDetails(description: longDescription));
+
+		var html = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().Contain(new string('a', 199) + "...");
+		html.Should().NotContain("\U0001F600");
+		html.Should().NotContain("\uD83D").And.NotContain("\uDE00");
+	}
+
+	[Test]
+	public async Task Handle_ShouldHtmlEncodeOpportunityTitle_ToPreventMarkupInjection(
+		CancellationToken cancellationToken)
+	{
+		var opportunityId = Guid.NewGuid();
+		_readRepository
+			.GetDetailsAsync(opportunityId, null, Arg.Any<CancellationToken>())
+			.Returns(CreateDetails(title: "<script>alert(1)</script> & Friends"));
+
+		var html = await _sut.Handle(
+			new GetVolunteerOpportunityMetaQuery(opportunityId, "https://einsatzbereit.example"),
+			cancellationToken);
+
+		html.Should().NotContain("<script>");
+		html.Should().Contain("&lt;script&gt;");
+		html.Should().Contain("&amp; Friends");
+	}
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -420,6 +420,16 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task GetVolunteerOpportunityMetaAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task GetOrganizationMetaAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<CitySuggestion>> SearchCitiesAsync(string q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -9144,6 +9154,184 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task GetVolunteerOpportunityMetaAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/meta/volunteer-opportunities/{opportunityId}"
+                    urlBuilder_.Append("v1/meta/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task GetOrganizationMetaAsync(System.Guid organizationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (organizationId == null)
+                throw new System.ArgumentNullException("organizationId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/meta/organizations/{organizationId}"
+                    urlBuilder_.Append("v1/meta/organizations/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(organizationId, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
                         }
                         else
                         if (status_ == 404)

--- a/backend/tests/IntegrationTests/GetOrganizationMetaTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationMetaTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Regression coverage for einsatzbereit#1680: a shared or crawled deep link to a
+// specific organization previously got the site-wide metadata baked into
+// frontend/index.html - GetOrganizationMetaEndpoint (proxied to by
+// frontend/nginx.conf.template for recognized bot User-Agents) must return that
+// organization's own name/description/logo instead. Hits the versioned API route
+// directly, the same way GetSitemapTests does for its own nginx-proxied endpoint -
+// the bot-User-Agent rewrite itself lives in nginx, which this suite doesn't run.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetOrganizationMetaTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetOrganizationMeta_ShouldReturnNotFound_WhenOrganizationDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync(
+			$"/v1/meta/organizations/{Guid.NewGuid()}", cancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task GetOrganizationMeta_ShouldReturnHtml_WithOrganizationNameAndDescription(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var uniqueName = $"Küstenschutz {Guid.NewGuid():N}";
+		var organization = await authenticatedClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest
+			{
+				Name = uniqueName,
+				Description = "Wir schützen die Küste vor Müll und Erosion.",
+			},
+			cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(
+			$"/v1/meta/organizations/{organization.Id.Value}", cancellationToken);
+		var html = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		response.EnsureSuccessStatusCode();
+		response.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
+		html.Should().Contain(uniqueName);
+		html.Should().Contain("Wir schützen die Küste vor Müll und Erosion.");
+		html.Should().Contain($"/organizations/{organization.Id.Value}");
+		// No logo uploaded - falls back to the site's own share image rather
+		// than omitting og:image entirely.
+		html.Should().Contain("/og-image.png");
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
+	{
+		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+}

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityMetaTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityMetaTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Regression coverage for einsatzbereit#1680: a shared or crawled deep link to a
+// specific opportunity previously got the site-wide metadata baked into
+// frontend/index.html - GetVolunteerOpportunityMetaEndpoint (proxied to by
+// frontend/nginx.conf.template for recognized bot User-Agents) must return that
+// opportunity's own title/description/image instead. Hits the versioned API route
+// directly, the same way GetSitemapTests does for its own nginx-proxied endpoint -
+// the bot-User-Agent rewrite itself lives in nginx, which this suite doesn't run.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetVolunteerOpportunityMetaTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetVolunteerOpportunityMeta_ShouldReturnNotFound_WhenOpportunityDoesNotExist(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = fixture.CreateHttpClient();
+
+		var response = await httpClient.GetAsync(
+			$"/v1/meta/volunteer-opportunities/{Guid.NewGuid()}", cancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunityMeta_ShouldReturnNotFound_WhenOpportunityIsDraft(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		var draft = await CreateOpportunityAsync(authenticatedClient, orgId, isDraft: true, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(
+			$"/v1/meta/volunteer-opportunities/{draft.Id}", cancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task GetVolunteerOpportunityMeta_ShouldReturnHtml_WithOpportunityTitleAndDescription(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(authenticatedClient, orgId, isDraft: false, cancellationToken);
+
+		using var httpClient = fixture.CreateHttpClient();
+		var response = await httpClient.GetAsync(
+			$"/v1/meta/volunteer-opportunities/{opportunity.Id}", cancellationToken);
+		var html = await response.Content.ReadAsStringAsync(cancellationToken);
+
+		response.EnsureSuccessStatusCode();
+		response.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
+		html.Should().Contain("Strandreinigung Musterstadt");
+		html.Should().Contain("Gemeinsam sammeln wir Müll am Strand ein.");
+		html.Should().Contain($"/volunteer-opportunities/{opportunity.Id}");
+		// No banner uploaded - falls back to the site's own share image rather
+		// than omitting og:image entirely.
+		html.Should().Contain("/og-image.png");
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
+	{
+		var token = await fixture.GetAccessTokenAsync("olaf", "olaf123");
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+
+	private static async Task<Guid> CreateOrganizationAsync(
+		EinsatzbereitApi client, CancellationToken cancellationToken)
+	{
+		var uniqueName = $"Testorg_{Guid.NewGuid()}";
+		var organization = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = uniqueName }, cancellationToken);
+		return organization.Id.Value;
+	}
+
+	private static Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
+		EinsatzbereitApi client, Guid orgId, bool isDraft, CancellationToken cancellationToken) =>
+		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
+		{
+			Title = "Strandreinigung Musterstadt",
+			Description = "Gemeinsam sammeln wir Müll am Strand ein.",
+			OrganizationId = orgId,
+			IsRemote = true,
+			Occurrence = "OneTime",
+			ParticipationType = "IndividualContact",
+			CheckInMethod = "None",
+			ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			IsDraft = isDraft,
+		}, cancellationToken);
+}

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -996,11 +996,10 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/engagements?status=Pending");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// "engagements" isn't a tab in ORG_TABS, so the h1 depends on
-		// useSetOrgBreadcrumbExtra rather than the parent tab's own label -
-		// the same #973 pageTitle mechanism EngagementManagementPage_AsOlaf_...
-		// above guards for its own nested route.
-		await Expect(Page.Locator("h1")).ToHaveTextAsync("Sign-up queue");
+		// einsatzbereit#1680: "engagements" became a real ORG_TABS entry, so the
+		// h1 now comes from OrgAppLayout's own tab-label lookup (orgOverview.tabEngagements)
+		// like every other tab, rather than from a page-local useSetOrgBreadcrumbExtra call.
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Sign-ups");
 
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Confirm" })).ToBeVisibleAsync();
 

--- a/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
+++ b/backend/tests/VisualTests/OrganizationDashboardNavLinkTests.cs
@@ -121,6 +121,19 @@ public class OrganizationDashboardNavLinkTests(AspireFixture fixture) : VisualTe
 		await banner.GetByRole(AriaRole.Button, new() { Name = "Organization", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 
+		// Regression coverage for #1680: the org-wide engagement queue
+		// ("Sign-ups") previously had exactly one entry point (the dashboard's
+		// To-Do widget) - it must now be reachable from ORG_TABS like every
+		// other tab, the same way this test already exercises Members/Settings.
+		await banner.GetByRole(AriaRole.Link, new() { Name = "Sign-ups", Exact = true })
+			.ClickAsync(new() { Timeout = 10_000 });
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/engagements"), new() { Timeout = 15_000 });
+
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).First
+			.ClickAsync(new() { Timeout = 10_000 });
+		await banner.GetByRole(AriaRole.Button, new() { Name = "Organization", Exact = true })
+			.ClickAsync(new() { Timeout = 10_000 });
+
 		await banner.GetByRole(AriaRole.Link, new() { Name = "Settings", Exact = true })
 			.ClickAsync(new() { Timeout = 10_000 });
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/settings"), new() { Timeout = 15_000 });

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -15,6 +15,16 @@ map $host $csp_header {
 	default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: ${CSP_API_ORIGIN} ${CSP_STORAGE_ORIGIN}; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN}; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
 }
 
+# Recognizes social-preview and search-engine crawlers by User-Agent so a shared or
+# crawled deep link to a specific opportunity/organization gets that entity's own
+# title/description/image instead of the site-wide metadata frontend/index.html
+# hardcodes (einsatzbereit#1680) - real browsers never match this and are served the
+# unmodified SPA shell below, same as today.
+map $http_user_agent $is_social_bot {
+	default 0;
+	"~*(facebookexternalhit|Twitterbot|Slackbot|LinkedInBot|TelegramBot|Discordbot|WhatsApp|SkypeUriPreview|Googlebot|bingbot|Applebot|redditbot|Pinterest|Baiduspider|YandexBot)" 1;
+}
+
 server {
 	listen 80;
 	server_name _;
@@ -65,6 +75,32 @@ server {
 		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
+	}
+
+	# Shared/crawled deep links to a specific opportunity or organization
+	# (einsatzbereit#1680) - a social-preview crawler or search engine (see
+	# $is_social_bot above) gets rewritten to the internal /__meta/... location
+	# below instead, which proxies to the backend's per-entity HTML. Everyone
+	# else (i.e. every real browser) falls through to try_files exactly as
+	# before, so the SPA experience here is unchanged.
+	location ~ ^/(volunteer-opportunities|organizations)/[0-9a-fA-F-]+$ {
+		if ($is_social_bot) {
+			rewrite ^ /__meta$uri last;
+		}
+		try_files $uri $uri/ /index.html;
+	}
+
+	# Internal-only rewrite target for the bot branch above - proxied rather than
+	# served as a static file since it needs the opportunity/organization's
+	# current title/description/banner from the database. Same cross-subdomain
+	# proxy rationale as /sitemap.xml below (einsatzbereit#1092).
+	location ~ ^/__meta/(volunteer-opportunities|organizations)/([0-9a-fA-F-]+)$ {
+		internal;
+		resolver 127.0.0.11 valid=10s;
+		set $backend_upstream http://backend:8080;
+		set $meta_entity_type $1;
+		set $meta_entity_id $2;
+		proxy_pass $backend_upstream/v1/meta/$meta_entity_type/$meta_entity_id;
 	}
 
 	# A sitemap must be served from the same host as the URLs it lists, or crawlers

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -4853,6 +4853,104 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
+    getVolunteerOpportunityMeta(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/meta/volunteer-opportunities/{opportunityId}";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetVolunteerOpportunityMeta(_response);
+        });
+    }
+
+    protected processGetVolunteerOpportunityMeta(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return OK
+     */
+    getOrganizationMeta(organizationId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/meta/organizations/{organizationId}";
+        if (organizationId === undefined || organizationId === null)
+            throw new globalThis.Error("The parameter 'organizationId' must be defined.");
+        url_ = url_.replace("{organizationId}", encodeURIComponent("" + organizationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetOrganizationMeta(_response);
+        });
+    }
+
+    protected processGetOrganizationMeta(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return OK
+     */
     searchCities(q: string, signal?: AbortSignal): Promise<CitySuggestion[]> {
         let url_ = this.baseUrl + "/v1/maps/cities?";
         if (q === undefined || q === null)

--- a/frontend/src/lib/orgTabs.test.ts
+++ b/frontend/src/lib/orgTabs.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect } from "vitest";
 import { ORG_TABS, orgTabPath } from "./orgTabs";
 
 describe("ORG_TABS", () => {
-	it("declares the dashboard, opportunities, settings and members tabs in order", () => {
+	it("declares the dashboard, opportunities, engagements, settings and members tabs in order", () => {
 		expect(ORG_TABS.map((tab) => tab.key)).toEqual([
 			"dashboard",
 			"opportunities",
+			"engagements",
 			"settings",
 			"members",
 		]);
@@ -27,6 +28,9 @@ describe("orgTabPath", () => {
 		expect(orgTabPath("org-1", "members")).toBe("/app/org-1/dashboard/members");
 		expect(orgTabPath("org-1", "opportunities")).toBe(
 			"/app/org-1/dashboard/opportunities",
+		);
+		expect(orgTabPath("org-1", "engagements")).toBe(
+			"/app/org-1/dashboard/engagements",
 		);
 		expect(orgTabPath("org-1", "settings")).toBe(
 			"/app/org-1/dashboard/settings",

--- a/frontend/src/lib/orgTabs.ts
+++ b/frontend/src/lib/orgTabs.ts
@@ -4,6 +4,7 @@
 export const ORG_TABS = [
 	{ key: "dashboard", labelKey: "orgOverview.tabDashboard" },
 	{ key: "opportunities", labelKey: "orgOverview.tabOpportunities" },
+	{ key: "engagements", labelKey: "orgOverview.tabEngagements" },
 	{ key: "settings", labelKey: "orgOverview.tabSettings" },
 	{ key: "members", labelKey: "orgOverview.tabMembers" },
 ] as const;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -665,7 +665,6 @@
       }
     },
     "orgEngagements": {
-      "title": "Anmeldewarteschlange",
       "pageDescription": "Ausstehende und bearbeitete Anmeldungen über alle Einsätze deiner Organisation hinweg, an einem Ort.",
       "loading": "Wird geladen…",
       "error": "{{message}}",
@@ -1240,6 +1239,7 @@
     "orgOverview": {
       "tabDashboard": "Dashboard",
       "tabOpportunities": "Einsätze",
+      "tabEngagements": "Anmeldungen",
       "tabMembers": "Mitglieder",
       "tabSettings": "Einstellungen",
       "calendarLoading": "Kalender wird geladen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -665,7 +665,6 @@
       }
     },
     "orgEngagements": {
-      "title": "Sign-up queue",
       "pageDescription": "Pending and processed sign-ups across every one of your organization's opportunities, in one place.",
       "loading": "Loading…",
       "error": "Error: {{message}}",
@@ -1240,6 +1239,7 @@
     "orgOverview": {
       "tabDashboard": "Dashboard",
       "tabOpportunities": "Opportunities",
+      "tabEngagements": "Sign-ups",
       "tabMembers": "Members",
       "tabSettings": "Settings",
       "calendarLoading": "Loading calendar…",

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -5,7 +5,6 @@ import type { EngagementSummary } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import { useLoadMore } from "../../hooks/useLoadMore";
 import { usePageTitle } from "../../hooks/usePageTitle";
-import { useSetOrgBreadcrumbExtra } from "../../contexts/OrgBreadcrumbContext";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { formatDate } from "../../lib/format";
@@ -32,13 +31,7 @@ export default function OrgEngagementsPage() {
 	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const organizationId = org.id;
-	usePageTitle(`${t("orgEngagements.title")} - ${org.name}`);
-	// "engagements" isn't a tab in ORG_TABS (it's a dashboard-widget-linked
-	// page, not a persistent nav destination, mirroring how
-	// EngagementManagementPage nests under "opportunities" rather than
-	// getting its own tab) - OrgAppLayout's h1/breadcrumb would otherwise
-	// fall back to "Dashboard" for an unrecognized tab segment.
-	useSetOrgBreadcrumbExtra(t("orgEngagements.title"));
+	usePageTitle(`${t("orgOverview.tabEngagements")} - ${org.name}`);
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	const statusFilter = searchParams.get("status") ?? "";


### PR DESCRIPTION
## What

Two shipped features that stopped just short of doing their job:

1. Adds `engagements` (the org-wide sign-up queue, #1048) to `ORG_TABS`, giving it a proper nav entry point via the account-menu submenu and mobile burger menu (both already built from that array) instead of its only entry point being the dashboard's removable To-Do widget.
2. Adds a backend `Meta` feature (`GET /v1/meta/volunteer-opportunities/{id}`, `GET /v1/meta/organizations/{id}`) that renders a standalone HTML document carrying that entity's own title/description/image in its OG and Twitter card tags, and an nginx User-Agent map that routes recognized social-preview/search crawlers to it for `/volunteer-opportunities/:id` and `/organizations/:id`. Real browsers are unaffected and keep getting today's SPA shell.

## Why

Closes #1680

Grouped by the 1.0 readiness analysis: each is "a small addition, not a rework." The engagement queue's only entry point was a removable dashboard widget - removing it left organizers with no UI access to a queue they need. Shared/crawled deep links got the generic homepage preview instead of the specific opportunity/organization, and crawlers got an empty `<div id="root">` since JS execution isn't guaranteed.

The issue's fix note also raised "reconsider whether the organizer app should have a persistent nav" as an open question, not a directive (only "add engagements to ORG_TABS" was under **Fix:**) - deliberately scoped out of this PR since it's a bigger UX-redesign discussion, not a bug fix.

## Testing

- Backend: `Application.UnitTests` (1011/1011, including new `GetVolunteerOpportunityMetaQueryHandlerTests`/`GetOrganizationMetaQueryHandlerTests` - not-found, HTML injection/XSS escaping, banner/logo fallback, and a UTF-16 surrogate-pair-safe truncation case) and `ArchitectureTests` (434/434) run locally.
- New `IntegrationTests` (`GetVolunteerOpportunityMetaTests`, `GetOrganizationMetaTests`) hit the new endpoints directly, mirroring `GetSitemapTests`'s pattern for its own nginx-proxied endpoint - not run locally (Testcontainers need real container networking this sandbox doesn't have), but compiled clean; CI's `dotnet.yml` runs them.
- `frontend`: `pnpm lint` / `pnpm check` / `pnpm test` (186/186) / `pnpm i18n:check` / `pnpm build` all pass locally.
- nginx: validated the rendered config against a real `nginx -t` plus live request testing (not just syntax-checking) - confirmed real-browser UAs fall through to the unmodified SPA shell, recognized bot UAs get proxied to the new meta endpoint, direct external requests to the internal `/__meta/...` rewrite target 404, and a malformed id falls through safely.
- Updated `OrganizationDashboardNavLinkTests` (VisualTests) to click through the new "Sign-ups" mobile-burger entry, and fixed `AccessibilityTests`'s `OrgEngagementsPage` test, whose `h1` assertion was written for the old fallback-to-dashboard heading mechanism and would have failed once "engagements" became a real tab. Not run locally (Playwright browser install is blocked by this sandbox's egress policy), but compiled clean; CI's `dotnet.yml` runs them.

## Live verification

Skipped per explicit instruction for this task - no release candidate was cut. CI (`dotnet.yml`/`frontend.yml`) is the verification gate for this PR; will monitor and fix any failures.

## Checklist

- [x] `/self-review` run and findings addressed (caught and fixed: a stale `AccessibilityTests` assertion that would have failed CI, an `OrganizationId` interpolation bug producing a malformed canonical URL, over-eager `WebUtility.HtmlEncode` numeric-escaping non-ASCII characters, and a title/heading wording inconsistency vs. sibling `ORG_TABS` pages)
- [ ] CI is green (monitoring)
- [x] Documentation updated if this change affects behavior (N/A - no user-facing docs describe org nav tabs or share-preview behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTL4HcbjJSprucPjmh88iA)_