### PR TITLE
fix: complete moderation - 404 shadow-deleted profiles, enrich admin org list, revoke organisator role

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7085,7 +7085,11 @@
         "required": [
           "id",
           "name",
-          "logoUrl"
+          "logoUrl",
+          "isDeleted",
+          "openReportCount",
+          "memberCount",
+          "createdOn"
         ],
         "type": "object",
         "properties": {
@@ -7101,6 +7105,29 @@
               "null",
               "string"
             ]
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "openReportCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "memberCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "createdOn": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
@@ -54,6 +54,21 @@ internal sealed class DeleteOrganizationCommandHandler(
 		await dbContext.RemoveMembershipsForOrganizationAsync(organizationId, cancellationToken);
 		await dbContext.RemoveDashboardLayoutsForOrganizationAsync(organizationId, cancellationToken);
 
+		// The role is realm-wide, not per-organization (see #1386), so it can only
+		// be revoked once the requesting user organizes no other organization
+		// (#1677) - otherwise this deletion would also lock them out of that other
+		// org. The sole-member guard above already confirmed the requesting user is
+		// this organization's only (and therefore only Organizer) member, and
+		// RemoveMembershipsForOrganizationAsync above already deleted that
+		// membership row, so - like RemoveMemberCommandHandler, unlike
+		// ChangeMemberRoleCommandHandler's still-in-memory demotion - no exclusion
+		// filter is needed here.
+		var remainingOrganizerOrgs = await dbContext.GetOrganizerOrganizationsAsync(
+			request.RequestingUserId, cancellationToken);
+
+		if (remainingOrganizerOrgs.Count == 0)
+			await keycloakOrganizationService.RevokeOrganizerRoleAsync(request.RequestingUserId.Value, cancellationToken);
+
 		// Without this, opportunities survive as orphan rows with a dangling
 		// organization_id - there is no FK to cascade the delete at the DB level
 		// (#1153). Only opportunities with no future slots and no active

--- a/backend/src/Application/Organizations/ListOrganizations/v1/AdminOrganizationSummary.cs
+++ b/backend/src/Application/Organizations/ListOrganizations/v1/AdminOrganizationSummary.cs
@@ -3,4 +3,8 @@ namespace Application.Organizations.ListOrganizations.v1;
 public sealed record AdminOrganizationSummary(
 	Guid Id,
 	string Name,
-	string? LogoUrl);
+	string? LogoUrl,
+	bool IsDeleted,
+	int OpenReportCount,
+	int MemberCount,
+	DateTimeOffset CreatedOn);

--- a/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
+++ b/backend/src/Application/Organizations/RemoveMember/v1/RemoveMemberCommandHandler.cs
@@ -60,6 +60,20 @@ internal sealed class RemoveMemberCommandHandler(
 			userId,
 			cancellationToken);
 
+		if (isOrganizer)
+		{
+			// The role is realm-wide, not per-organization (see #1386), so it can
+			// only be revoked once the removed user organizes no other
+			// organization (#1677) - otherwise this removal would also lock them
+			// out of that other org. RemoveMembershipAsync above already deleted
+			// this org's membership row, so unlike ChangeMemberRoleCommandHandler's
+			// still-in-memory demotion, no exclusion filter is needed here.
+			var remainingOrganizerOrgs = await dbContext.GetOrganizerOrganizationsAsync(userId, cancellationToken);
+
+			if (remainingOrganizerOrgs.Count == 0)
+				await keycloakOrganizationService.RevokeOrganizerRoleAsync(userId.Value, cancellationToken);
+		}
+
 		return true;
 	}
 }

--- a/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
+++ b/backend/src/Application/Users/GetPublicUserProfile/v1/GetPublicUserProfileQueryHandler.cs
@@ -15,6 +15,18 @@ internal sealed class GetPublicUserProfileQueryHandler(
 		GetPublicUserProfileQuery request,
 		CancellationToken cancellationToken = default)
 	{
+		// #1677: look up the local row (including shadow-deleted ones) first and
+		// bail out before ever calling Keycloak or any other repo - a
+		// shadow-deleted user's public profile must 404, not fall back to
+		// default field values while still exposing display name/engagement
+		// count/badges. A user with no local row yet (never touched their own
+		// profile/settings, so User.Create was never called for them - see
+		// GetOrCreateUserAsync's callers) is not shadow-deleted and keeps the
+		// existing default-field behavior below.
+		var user = await dbContext.FindUserIncludingDeletedAsync(request.UserId, cancellationToken);
+		if (user is { IsDeleted: true })
+			return null;
+
 		KeycloakUserProfile keycloakUser;
 		try
 		{
@@ -38,8 +50,6 @@ internal sealed class GetPublicUserProfileQueryHandler(
 		var badges = await achievementReadRepository.GetByUserAsync(
 			request.UserId,
 			cancellationToken);
-
-		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
 
 		// PreferredContact/Phone are deliberately not surfaced here (#1028) - this
 		// endpoint is AllowAnonymous(), so contact info only ever reaches an

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -85,6 +85,8 @@ internal sealed class ApplicationDbContext(
 			Set<OrganizationMembership>(),
 			m => m.Id);
 
+	internal IQueryable<OrganizationMembership> OrganizationMembershipsQuery => Set<OrganizationMembership>().AsNoTracking();
+
 	public IAggregateRepository<OrganizationDashboardLayout, OrganizationDashboardLayoutId> OrganizationDashboardLayouts
 		=> new AggregateRepository<OrganizationDashboardLayout, OrganizationDashboardLayoutId>(
 			Set<OrganizationDashboardLayout>(),

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminOrganizationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminOrganizationReadRepository.cs
@@ -51,6 +51,30 @@ internal sealed class AdminOrganizationReadRepository(
 			.ThenBy(o => o.Id)
 			.ToPagedListAsync(pageNumber, pageSize, cancellationToken);
 
-		return paged.Map(o => new AdminOrganizationSummary(o.Id.Value, o.Name, o.LogoUrl));
+		var organizationIds = paged.Items.Select(o => o.Id).ToList();
+		var organizationGuidIds = organizationIds.Select(id => id.Value).ToList();
+
+		var openReportCounts = await dbContext.ReportsQuery
+			.Where(r => r.TargetType == ReportTargetType.Organization
+				&& r.Status == ReportStatus.Open
+				&& organizationGuidIds.Contains(r.TargetId))
+			.GroupBy(r => r.TargetId)
+			.Select(g => new { OrganizationId = g.Key, Count = g.Count() })
+			.ToDictionaryAsync(x => x.OrganizationId, x => x.Count, cancellationToken);
+
+		var memberCounts = await dbContext.OrganizationMembershipsQuery
+			.Where(m => organizationIds.Contains(m.OrganizationId))
+			.GroupBy(m => m.OrganizationId)
+			.Select(g => new { OrganizationId = g.Key, Count = g.Count() })
+			.ToDictionaryAsync(x => x.OrganizationId, x => x.Count, cancellationToken);
+
+		return paged.Map(o => new AdminOrganizationSummary(
+			o.Id.Value,
+			o.Name,
+			o.LogoUrl,
+			o.IsDeleted,
+			openReportCounts.GetValueOrDefault(o.Id.Value, 0),
+			memberCounts.GetValueOrDefault(o.Id, 0),
+			o.CreatedOn));
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
@@ -43,6 +43,12 @@ public class DeleteOrganizationCommandHandlerTests
 		_dbContext
 			.GetActiveEngagementsForOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Domain.Engagements.Engagement>());
+		// Default: the requesting user organizes nothing else, matching the common
+		// case (a fresh test user whose only org is the one being deleted) - tests
+		// for the #1677 fix override this via SetRemainingOrganizerOrganizations.
+		_dbContext
+			.GetOrganizerOrganizationsAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Organization>());
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Guid>());
@@ -60,6 +66,11 @@ public class DeleteOrganizationCommandHandlerTests
 			.Returns((IReadOnlyList<KeycloakOrganizationMember>)memberIds
 				.Select(id => new KeycloakOrganizationMember(id, "user", "First", "Last", "user@example.com", false))
 				.ToList());
+
+	private void SetRemainingOrganizerOrganizations(params Organization[] organizations) =>
+		_dbContext
+			.GetOrganizerOrganizationsAsync(DefaultRequestingUserId, Arg.Any<CancellationToken>())
+			.Returns(organizations.ToList());
 
 	private static Organization CreateOrganization(Guid id) =>
 		Organization.Create(OrganizationId.Create(id).GetValueOrThrow(), "Test Org").Value;
@@ -239,5 +250,51 @@ public class DeleteOrganizationCommandHandlerTests
 			.WithMessage("*Titel*");
 		_organizationRepo.DidNotReceive().Delete(Arg.Any<Organization>());
 		await _keycloakService.DidNotReceive().DeleteOrganizationAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRevokeKeycloakRole_WhenRequestingUserHasNoRemainingOrganizations(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the sole-member guard above already forces the requesting user
+		// to be this organization's only (and therefore only Organizer) member, so
+		// deleting it and organizing nothing else must revoke the realm-wide role
+		// (#1677).
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		SetRemainingOrganizerOrganizations();
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _keycloakService.Received(1).RevokeOrganizerRoleAsync(DefaultRequestingUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotRevokeKeycloakRole_WhenRequestingUserStillOrganizesAnotherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the requesting user still organizes a different organization,
+		// so the realm-wide role (shared across every org they organize, #1386)
+		// must stay assigned.
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		var otherOrg = Organization.Create(OrganizationId.New(), "Other Org").GetValueOrThrow();
+		SetRemainingOrganizerOrganizations(otherOrg);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/ListOrganizations/ListOrganizationsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ListOrganizations/ListOrganizationsQueryHandlerTests.cs
@@ -31,7 +31,8 @@ public class ListOrganizationsQueryHandlerTests
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var item = new AdminOrganizationSummary(Guid.NewGuid(), "Fire Department", null);
+		var item = new AdminOrganizationSummary(
+			Guid.NewGuid(), "Fire Department", null, false, 0, 3, DateTimeOffset.UtcNow);
 
 		_readRepo
 			.GetPagedAsync(1, 10, null, null, null, cancellationToken)

--- a/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/RemoveMember/RemoveMemberCommandHandlerTests.cs
@@ -22,6 +22,12 @@ public class RemoveMemberCommandHandlerTests
 
 	public RemoveMemberCommandHandlerTests()
 	{
+		// Default: the removed user organizes nothing else, matching the common
+		// case in tests that don't care about role revocation - tests for the
+		// #1677 fix override this via SetRemainingOrganizerOrganizations.
+		_dbContext
+			.GetOrganizerOrganizationsAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(new List<Organization>());
 		_sut = new RemoveMemberCommandHandler(_dbContext, _keycloakService);
 	}
 
@@ -48,6 +54,11 @@ public class RemoveMemberCommandHandlerTests
 		_dbContext
 			.CountOrganizersAsync(OrganizationId.Create(orgId).GetValueOrThrow(), Arg.Any<CancellationToken>())
 			.Returns(count);
+
+	private void SetRemainingOrganizerOrganizations(Guid userId, params Organization[] organizations) =>
+		_dbContext
+			.GetOrganizerOrganizationsAsync(UserId.Create(userId).GetValueOrThrow(), Arg.Any<CancellationToken>())
+			.Returns(organizations.ToList());
 
 	[Test]
 	public async Task Handle_ShouldCallRemoveMemberOnKeycloak(
@@ -225,5 +236,70 @@ public class RemoveMemberCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		await _keycloakService.Received(1).RemoveMemberAsync(orgId, DefaultRequestingUserId.Value, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRevokeKeycloakRole_WhenRemovedOrganizerHasNoRemainingOrganizations(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the removed user was an Organizer here and organizes nothing
+		// else once this org's membership row is gone, so the realm-wide role
+		// must come off (#1677).
+		var orgId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		SetTargetIsOrganizer(orgId, userId, isOrganizer: true);
+		SetOrganizerCount(orgId, 2);
+		SetRemainingOrganizerOrganizations(userId);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _keycloakService.Received(1).RevokeOrganizerRoleAsync(userId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotRevokeKeycloakRole_WhenRemovedOrganizerStillOrganizesAnotherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - the removed user is still Organizer of a different
+		// organization, so the realm-wide role (shared across every org they
+		// organize, #1386) must stay assigned.
+		var orgId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		SetTargetIsOrganizer(orgId, userId, isOrganizer: true);
+		SetOrganizerCount(orgId, 2);
+		var otherOrg = Organization.Create(OrganizationId.New(), "Other Org").GetValueOrThrow();
+		SetRemainingOrganizerOrganizations(userId, otherOrg);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotRevokeKeycloakRole_WhenRemovedMemberWasNotAnOrganizer(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - removing a plain Member never touches the realm-wide
+		// organisator role, regardless of what other organizations exist.
+		var orgId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		AllowRequestingUserInOrg(orgId);
+		SetTargetIsOrganizer(orgId, userId, isOrganizer: false);
+		var command = new RemoveMemberCommand(orgId, userId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.DidNotReceive().GetOrganizerOrganizationsAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>());
+		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Users/GetPublicUserProfile/GetPublicUserProfileQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/GetPublicUserProfile/GetPublicUserProfileQueryHandlerTests.cs
@@ -13,12 +13,10 @@ public class GetPublicUserProfileQueryHandlerTests
 	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAchievementReadRepository _achievementReadRepository = Substitute.For<IAchievementReadRepository>();
-	private readonly IAggregateRepository<User, UserId> _userRepo = Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly GetPublicUserProfileQueryHandler _sut;
 
 	public GetPublicUserProfileQueryHandlerTests()
 	{
-		_dbContext.Users.Returns(_userRepo);
 		_achievementReadRepository
 			.GetByUserAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns([]);
@@ -39,7 +37,7 @@ public class GetPublicUserProfileQueryHandlerTests
 		user.ChangeBio("Loves helping out");
 		user.UpdateSkills(["First aid"]);
 		user.UpdateLanguages(["German", "English"]);
-		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(userId, cancellationToken).Returns(user);
 
 		// Act
 		var result = await _sut.Handle(new GetPublicUserProfileQuery(userId), cancellationToken);
@@ -67,7 +65,7 @@ public class GetPublicUserProfileQueryHandlerTests
 		var user = User.Create(userId);
 		user.SetPreferredContact(PreferredContact.Phone);
 		user.SetPhone("+49 555 1234567");
-		_userRepo.FindAsync(userId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(userId, cancellationToken).Returns(user);
 
 		// Act
 		var result = await _sut.Handle(new GetPublicUserProfileQuery(userId), cancellationToken);
@@ -82,21 +80,46 @@ public class GetPublicUserProfileQueryHandlerTests
 	public async Task Handle_ShouldReturnEmptyProfileFields_WhenNoUserRowExists(
 		CancellationToken cancellationToken)
 	{
-		// Arrange
+		// A missing local row (never lazily created - see GetOrCreateUserAsync's
+		// callers) is not the same as a shadow-deleted user: it just means this
+		// person never touched their own profile/settings yet. The profile still
+		// resolves via Keycloak, with Bio/Skills/Languages/AvatarUrl defaulted.
 		var userId = UserId.New();
 		_keycloakUserService
 			.GetUserAsync(userId.Value, cancellationToken)
 			.Returns(new KeycloakUserProfile(userId.Value, "vera", "Vera", "Volunteer", "vera@test.de"));
-
-		_userRepo.FindAsync(userId, cancellationToken).Returns((User?)null);
+		_dbContext.FindUserIncludingDeletedAsync(userId, cancellationToken).Returns((User?)null);
 
 		// Act
 		var result = await _sut.Handle(new GetPublicUserProfileQuery(userId), cancellationToken);
 
 		// Assert
 		result.Should().NotBeNull();
-		result!.Bio.Should().BeNull();
+		result!.AvatarUrl.Should().BeNull();
+		result.Bio.Should().BeNull();
 		result.Skills.Should().BeEmpty();
 		result.Languages.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnNull_AndNotCallKeycloak_WhenUserIsShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		// #1677 bug #1: a shadow-deleted user's public profile must 404 outright,
+		// not fall back to default Bio/Skills/Languages while still calling
+		// Keycloak and returning a fully populated response.
+		var userId = UserId.New();
+		var user = User.Create(userId);
+		user.MarkDeleted(DateTimeOffset.UtcNow);
+		_dbContext.FindUserIncludingDeletedAsync(userId, cancellationToken).Returns(user);
+
+		// Act
+		var result = await _sut.Handle(new GetPublicUserProfileQuery(userId), cancellationToken);
+
+		// Assert
+		result.Should().BeNull();
+		await _keycloakUserService
+			.DidNotReceive()
+			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12097,6 +12097,23 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("logoUrl")]
         public string? LogoUrl { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("isDeleted")]
+        public bool IsDeleted { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("openReportCount")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int OpenReportCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("memberCount")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^-?(?:0|[1-9]\d*)$")]
+        public int MemberCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("createdOn")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.DateTimeOffset CreatedOn { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/GetPublicUserProfileShadowDeleteTests.cs
+++ b/backend/tests/IntegrationTests/GetPublicUserProfileShadowDeleteTests.cs
@@ -1,0 +1,51 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Regression coverage for #1677 bug #1: GetPublicUserProfileQueryHandler used
+// to only consult the filtered dbContext.Users.FindAsync for AvatarUrl/Bio/etc
+// (falling back to defaults for a shadow-deleted target) while still calling
+// Keycloak and still returning a fully populated PublicUserProfileResponse -
+// so a shadow-deleted user's public profile stayed fully browsable instead of
+// 404ing like the rest of their public presence.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class GetPublicUserProfileShadowDeleteTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task GetPublicUserProfile_ShouldReturn404_WhenTargetWasShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		var (userId, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var targetClient = await CreateAuthenticatedClientAsync(username, password);
+
+		// The very first profile load lazily creates the local `user` row -
+		// AdminShadowDeleteUserCommandHandler looks it up via a filtered
+		// Users.FindAsync and 404s if it's missing, so this must run before the
+		// shadow-delete below has anything to hide.
+		await targetClient.GetUserProfileAsync(cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		await adminClient.AdminShadowDeleteUserAsync(userId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var act = () => veraClient.GetPublicUserProfileAsync(userId, cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(404);
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+}

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -264,6 +264,17 @@ public class IntegrationTestFixture
 	// organizations - so it leaks into later tests in the shared session and
 	// breaks assumptions that, for example, vera is not an organisator. Revoke it
 	// from every non-baseline user between tests to restore the imported baseline.
+	//
+	// #1677 made the role revocable mid-test too (RemoveMember/DeleteOrganization
+	// now call RevokeOrganizerRoleAsync once a user organizes nothing else). The
+	// local Postgres test DB - reset to empty by ResetDatabaseAsync before every
+	// test - carries no persistent baseline OrganizationMembership row for olaf
+	// the way the real seeded app database does, so any test that has olaf
+	// create-then-delete a throwaway sole organization now legitimately strips
+	// his Keycloak role via that same production code path. Nothing used to need
+	// to restore it, since revocation never happened before #1677. Re-grant it
+	// here if missing, so the baseline invariant "olaf is always an organisator"
+	// holds at the start of every test regardless of what the previous test did.
 	public async Task ResetKeycloakOrganisatorRolesAsync()
 	{
 		var adminToken = await GetAdminTokenAsync();
@@ -286,11 +297,15 @@ public class IntegrationTestFixture
 		await EnsureSuccessAsync(usersResponse);
 
 		var users = await usersResponse.Content.ReadFromJsonAsync<List<KeycloakUser>>() ?? [];
+		var hasBaselineOrganisator = false;
 
 		foreach (var user in users)
 		{
 			if (string.Equals(user.Username, BaselineOrganisator, StringComparison.OrdinalIgnoreCase))
+			{
+				hasBaselineOrganisator = true;
 				continue;
+			}
 
 			using var deleteRequest = new HttpRequestMessage(
 				HttpMethod.Delete, $"/admin/realms/{Realm}/users/{user.Id}/role-mappings/realm")
@@ -301,6 +316,30 @@ public class IntegrationTestFixture
 
 			var deleteResponse = await _keycloakClient.SendAsync(deleteRequest);
 			await EnsureSuccessAsync(deleteResponse);
+		}
+
+		if (!hasBaselineOrganisator)
+		{
+			using var lookupRequest = new HttpRequestMessage(
+				HttpMethod.Get, $"/admin/realms/{Realm}/users?username={BaselineOrganisator}&exact=true");
+			lookupRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+			var lookupResponse = await _keycloakClient.SendAsync(lookupRequest);
+			await EnsureSuccessAsync(lookupResponse);
+
+			var matches = await lookupResponse.Content.ReadFromJsonAsync<List<KeycloakUser>>() ?? [];
+			var baselineUser = matches.SingleOrDefault(u => string.Equals(u.Username, BaselineOrganisator, StringComparison.OrdinalIgnoreCase))
+				?? throw new InvalidOperationException($"Keycloak user '{BaselineOrganisator}' not found.");
+
+			using var assignRequest = new HttpRequestMessage(
+				HttpMethod.Post, $"/admin/realms/{Realm}/users/{baselineUser.Id}/role-mappings/realm")
+			{
+				Content = JsonContent.Create(new[] { new { id = organisatorRole.Id, name = organisatorRole.Name } }),
+			};
+			assignRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+			var assignResponse = await _keycloakClient.SendAsync(assignRequest);
+			await EnsureSuccessAsync(assignResponse);
 		}
 	}
 

--- a/backend/tests/IntegrationTests/IntegrationTestFixture.cs
+++ b/backend/tests/IntegrationTests/IntegrationTestFixture.cs
@@ -304,6 +304,26 @@ public class IntegrationTestFixture
 		}
 	}
 
+	// Test-only escape hatch for asserting a user's realm-level role state
+	// directly against Keycloak (#1677): there's no EinsatzbereitApi surface that
+	// exposes another user's realm roles, so this mirrors
+	// ResetKeycloakOrganisatorRolesAsync's own GET call above.
+	public async Task<bool> UserHasOrganisatorRoleAsync(Guid userId, CancellationToken cancellationToken = default)
+	{
+		var adminToken = await GetAdminTokenAsync();
+
+		using var usersRequest = new HttpRequestMessage(
+			HttpMethod.Get, $"/admin/realms/{Realm}/roles/{OrganisatorRole}/users?max=1000");
+		usersRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var usersResponse = await _keycloakClient.SendAsync(usersRequest, cancellationToken);
+		await EnsureSuccessAsync(usersResponse);
+
+		var users = await usersResponse.Content.ReadFromJsonAsync<List<KeycloakUser>>(cancellationToken) ?? [];
+
+		return users.Any(u => Guid.Parse(u.Id) == userId);
+	}
+
 	// Test-only escape hatch replicating what the now-removed admin-only
 	// AddMember endpoint did (#810): add a user to a Keycloak organization as a
 	// plain member, without granting the Organizer role. Accepting an

--- a/backend/tests/IntegrationTests/ListOrganizationsFilterTests.cs
+++ b/backend/tests/IntegrationTests/ListOrganizationsFilterTests.cs
@@ -64,7 +64,8 @@ public class ListOrganizationsFilterTests(IntegrationTestFixture fixture)
 		var result = await adminClient.ListOrganizationsAsync(
 			1, 50, deleted: true, cancellationToken: cancellationToken);
 
-		result.Items.Should().ContainSingle(o => o.Id == deletedId);
+		var deletedOrg = result.Items.Should().ContainSingle(o => o.Id == deletedId).Which;
+		deletedOrg.IsDeleted.Should().BeTrue();
 	}
 
 	[Test]
@@ -88,7 +89,59 @@ public class ListOrganizationsFilterTests(IntegrationTestFixture fixture)
 		var result = await adminClient.ListOrganizationsAsync(
 			1, 50, flagged: true, cancellationToken: cancellationToken);
 
-		result.Items.Should().ContainSingle(o => o.Id == flaggedId);
+		var flaggedOrg = result.Items.Should().ContainSingle(o => o.Id == flaggedId).Which;
+		flaggedOrg.OpenReportCount.Should().BeGreaterThan(0);
+	}
+
+	[Test]
+	public async Task ListOrganizations_ShouldPopulateMemberCount_ForOrganizationWithMultipleMembers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - creating the org makes the creator its first (Organizer)
+		// member; inviting two more ephemeral users in as Members and having
+		// them accept brings the total membership count to 3.
+		var (_, organizerUsername, organizerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var (memberOneId, memberOneUsername, memberOnePassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var (memberTwoId, memberTwoUsername, memberTwoPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+
+		var organizerClient = await CreateAuthenticatedClientAsync(organizerUsername, organizerPassword);
+		var orgName = $"Multi Member Org {Guid.NewGuid()}";
+		var org = await organizerClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = orgName }, cancellationToken);
+
+		// A fresh token is needed to invite: CreateInvitation is gated by the
+		// Organisator policy, a role claim baked into the JWT at mint time -
+		// organizerClient's original token predates the "organisator" role
+		// grant that just happened as a side effect of creating the
+		// organization (same reasoning as OrganizerRoleRevocationTests).
+		organizerClient = await CreateAuthenticatedClientAsync(organizerUsername, organizerPassword);
+
+		var invitationOne = await organizerClient.CreateInvitationAsync(
+			org.Id.Value,
+			new CreateInvitationRequest { InviteeId = memberOneId, Role = "Member" },
+			cancellationToken);
+		var memberOneClient = await CreateAuthenticatedClientAsync(memberOneUsername, memberOnePassword);
+		await memberOneClient.AcceptInvitationAsync(invitationOne.InvitationId, cancellationToken);
+
+		var invitationTwo = await organizerClient.CreateInvitationAsync(
+			org.Id.Value,
+			new CreateInvitationRequest { InviteeId = memberTwoId, Role = "Member" },
+			cancellationToken);
+		var memberTwoClient = await CreateAuthenticatedClientAsync(memberTwoUsername, memberTwoPassword);
+		await memberTwoClient.AcceptInvitationAsync(invitationTwo.InvitationId, cancellationToken);
+
+		// Act
+		var result = await adminClient.ListOrganizationsAsync(
+			1, 50, search: orgName, cancellationToken: cancellationToken);
+
+		// Assert
+		var summary = result.Items.Should().ContainSingle(o => o.Id == org.Id.Value).Which;
+		summary.MemberCount.Should().Be(3);
+		summary.CreatedOn.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(5));
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────────

--- a/backend/tests/IntegrationTests/OrganizerRoleRevocationTests.cs
+++ b/backend/tests/IntegrationTests/OrganizerRoleRevocationTests.cs
@@ -1,0 +1,142 @@
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace IntegrationTests;
+
+// Coverage for #1677 bug 3: the realm-wide "organisator" Keycloak role was
+// never revoked when a user left their only organization (RemoveMember) or
+// deleted their only organization (DeleteOrganization) - only
+// ChangeMemberRole's demotion path did this correctly. See
+// ChangeMemberRoleCommandHandler's own comment for why the role is realm-wide
+// rather than per-organization (#1386).
+//
+// All three tests use ephemeral users (never olaf/vera/admin): revoking the
+// shared BaselineOrganisator's role would not be restored by
+// ResetKeycloakOrganisatorRolesAsync between tests (it only ever *skips
+// deleting* olaf's role, never re-grants it), so it would leak into every
+// later test in this shared session that assumes olaf already organizes
+// something - the same reasoning documented on
+// IntegrationTestFixture.CreateEphemeralUserAsync.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class OrganizerRoleRevocationTests(IntegrationTestFixture fixture)
+{
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task RemoveMember_ShouldRevokeOrganisatorRole_WhenRemovedOrganizerHasNoOtherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - soleOrganizer creates the org (becoming its Organizer);
+		// coOrganizer is invited in as a second Organizer purely so someone else
+		// is allowed to remove soleOrganizer - RemoveMemberCommandHandler rejects
+		// removing an organization's last remaining organizer, self-removal or
+		// not.
+		var (soleOrganizerId, soleOrganizerUsername, soleOrganizerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var (coOrganizerId, coOrganizerUsername, coOrganizerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+
+		var soleOrganizerClient = await CreateAuthenticatedClientAsync(soleOrganizerUsername, soleOrganizerPassword);
+		var org = await soleOrganizerClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"Sole Organizer Removal {Guid.NewGuid()}" }, cancellationToken);
+
+		// A fresh token is needed to invite: CreateInvitation is gated by the
+		// Organisator policy, a role claim baked into the JWT at mint time -
+		// soleOrganizerClient's original token predates the "organisator" role
+		// grant that just happened as a side effect of creating the
+		// organization (same reasoning as AccountDeletionTests).
+		soleOrganizerClient = await CreateAuthenticatedClientAsync(soleOrganizerUsername, soleOrganizerPassword);
+		var invitation = await soleOrganizerClient.CreateInvitationAsync(
+			org.Id.Value,
+			new CreateInvitationRequest { InviteeId = coOrganizerId, Role = "Organizer" },
+			cancellationToken);
+
+		var coOrganizerClient = await CreateAuthenticatedClientAsync(coOrganizerUsername, coOrganizerPassword);
+		await coOrganizerClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		// Act - the co-organizer removes the sole organizer from their only org.
+		// RemoveMember only requires the DefaultUser policy at the HTTP layer (the
+		// Organizer check happens against the DB inside the handler), so
+		// coOrganizerClient's original token is fine here.
+		await coOrganizerClient.RemoveMemberAsync(org.Id.Value, soleOrganizerId, cancellationToken);
+
+		// Assert
+		(await fixture.UserHasOrganisatorRoleAsync(soleOrganizerId, cancellationToken))
+			.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task DeleteOrganization_ShouldRevokeOrganisatorRole_WhenSoleOrganizerDeletesTheirOnlyOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var (userId, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var client = await CreateAuthenticatedClientAsync(username, password);
+
+		var org = await client.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"Sole Organizer Deletion {Guid.NewGuid()}" }, cancellationToken);
+
+		// A fresh token is needed: DeleteOrganization is gated by the
+		// Organisator policy, a role claim baked into the JWT at mint time.
+		client = await CreateAuthenticatedClientAsync(username, password);
+
+		// Act
+		await client.DeleteOrganizationAsync(org.Id.Value, cancellationToken);
+
+		// Assert
+		(await fixture.UserHasOrganisatorRoleAsync(userId, cancellationToken))
+			.Should().BeFalse();
+	}
+
+	[Test]
+	public async Task RemoveMember_ShouldKeepOrganisatorRole_WhenRemovedOrganizerStillOrganizesAnotherOrganization(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - twoOrgOrganizer organizes both orgA and orgB; coOrganizer is
+		// invited into orgA only, purely so twoOrgOrganizer can be removed from
+		// orgA without tripping the sole-organizer guard.
+		var (twoOrgOrganizerId, twoOrgOrganizerUsername, twoOrgOrganizerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var (coOrganizerId, coOrganizerUsername, coOrganizerPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+
+		var twoOrgOrganizerClient = await CreateAuthenticatedClientAsync(twoOrgOrganizerUsername, twoOrgOrganizerPassword);
+		var orgA = await twoOrgOrganizerClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"Two Org Organizer A {Guid.NewGuid()}" }, cancellationToken);
+		var orgB = await twoOrgOrganizerClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"Two Org Organizer B {Guid.NewGuid()}" }, cancellationToken);
+
+		// A fresh token is needed to invite (see above).
+		twoOrgOrganizerClient = await CreateAuthenticatedClientAsync(twoOrgOrganizerUsername, twoOrgOrganizerPassword);
+		var invitation = await twoOrgOrganizerClient.CreateInvitationAsync(
+			orgA.Id.Value,
+			new CreateInvitationRequest { InviteeId = coOrganizerId, Role = "Organizer" },
+			cancellationToken);
+
+		var coOrganizerClient = await CreateAuthenticatedClientAsync(coOrganizerUsername, coOrganizerPassword);
+		await coOrganizerClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		// Act - remove twoOrgOrganizer from orgA only; orgB is left untouched.
+		await coOrganizerClient.RemoveMemberAsync(orgA.Id.Value, twoOrgOrganizerId, cancellationToken);
+
+		// Assert - still Organizer of orgB, so the realm-wide role must stay.
+		(await fixture.UserHasOrganisatorRoleAsync(twoOrgOrganizerId, cancellationToken))
+			.Should().BeTrue();
+
+		// Sanity check that orgB itself was untouched by the orgA removal.
+		var orgBDetails = await twoOrgOrganizerClient.GetOrganizationDetailsAsync(orgB.Id.Value, cancellationToken);
+		orgBDetails.Members.Should().ContainSingle(m => m.UserId == twoOrgOrganizerId);
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6374,6 +6374,10 @@ export interface AdminOrganizationSummary {
     id: string;
     name: string;
     logoUrl: string | undefined;
+    isDeleted: boolean;
+    openReportCount: number;
+    memberCount: number;
+    createdOn: Date;
 
     [key: string]: any;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1116,7 +1116,12 @@
         "searchPlaceholder": "Nach Name suchen",
         "searchButton": "Suchen",
         "flaggedOnlyLabel": "Nur gemeldete",
-        "deletedOnlyLabel": "Nur gelöschte"
+        "deletedOnlyLabel": "Nur gelöschte",
+        "memberCount": "{{count}} Mitglieder",
+        "memberCount_one": "{{count}} Mitglied",
+        "memberCount_other": "{{count}} Mitglieder",
+        "createdOn": "Erstellt am {{date}}",
+        "flaggedBadge": "Gemeldet"
       },
       "users": {
         "loading": "Nutzer:innen werden geladen…",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1117,7 +1117,6 @@
         "searchButton": "Suchen",
         "flaggedOnlyLabel": "Nur gemeldete",
         "deletedOnlyLabel": "Nur gelöschte",
-        "memberCount": "{{count}} Mitglieder",
         "memberCount_one": "{{count}} Mitglied",
         "memberCount_other": "{{count}} Mitglieder",
         "createdOn": "Erstellt am {{date}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1117,7 +1117,6 @@
         "searchButton": "Search",
         "flaggedOnlyLabel": "Flagged only",
         "deletedOnlyLabel": "Deleted only",
-        "memberCount": "{{count}} members",
         "memberCount_one": "{{count}} member",
         "memberCount_other": "{{count}} members",
         "createdOn": "Created on {{date}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1116,7 +1116,12 @@
         "searchPlaceholder": "Search by name",
         "searchButton": "Search",
         "flaggedOnlyLabel": "Flagged only",
-        "deletedOnlyLabel": "Deleted only"
+        "deletedOnlyLabel": "Deleted only",
+        "memberCount": "{{count}} members",
+        "memberCount_one": "{{count}} member",
+        "memberCount_other": "{{count}} members",
+        "createdOn": "Created on {{date}}",
+        "flaggedBadge": "Flagged"
       },
       "users": {
         "loading": "Loading users…",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -13,7 +13,8 @@ import { dispatchToast } from "../lib/toastBus";
 import { inputClass, labelClass } from "../lib/formClasses";
 import { pageTitleClass } from "../lib/headingClasses";
 import { cardSubtleClass } from "../lib/surfaceClasses";
-import { formatDateTime } from "../lib/format";
+import { formatDateLong, formatDateTime } from "../lib/format";
+import { avatarColorClasses } from "../lib/avatarColor";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { usePageToolbar } from "../contexts/ToolbarContext";
 import Chip from "../components/Chip";
@@ -32,6 +33,11 @@ const PAGE_SIZE = 10;
 interface OrgRow {
 	id: string;
 	name: string;
+	logoUrl: string | undefined;
+	isDeleted: boolean;
+	openReportCount: number;
+	memberCount: number;
+	createdOn: string;
 }
 
 export default function AdministrationPage() {
@@ -73,16 +79,23 @@ export default function AdministrationPage() {
 }
 
 function OrganizationsSection() {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 
 	const [search, setSearch] = useState("");
 	const [appliedSearch, setAppliedSearch] = useState("");
 	const [flaggedOnly, setFlaggedOnly] = useState(false);
 	const [deletedOnly, setDeletedOnly] = useState(false);
+	const [confirmAction, setConfirmAction] = useState<{
+		row: OrgRow;
+		kind: "delete" | "restore";
+	} | null>(null);
+	const [actioning, setActioning] = useState(false);
+	const [actionError, setActionError] = useState<string | null>(null);
 
 	const {
 		items: rows,
+		setItems: setRows,
 		loading,
 		loadingMore,
 		error,
@@ -105,6 +118,11 @@ function OrganizationsSection() {
 					items: result.items.map((o) => ({
 						id: o.id,
 						name: o.name,
+						logoUrl: o.logoUrl,
+						isDeleted: o.isDeleted,
+						openReportCount: o.openReportCount,
+						memberCount: o.memberCount,
+						createdOn: o.createdOn as unknown as string,
 					})),
 					pageCount: result.pageCount,
 				})),
@@ -118,6 +136,39 @@ function OrganizationsSection() {
 		e.preventDefault();
 		setAppliedSearch(search);
 		reset();
+	}
+
+	async function confirmActionSubmit() {
+		if (!confirmAction) return;
+		const { row, kind } = confirmAction;
+		setActioning(true);
+		setActionError(null);
+		try {
+			if (kind === "delete") {
+				await api.adminShadowDeleteOrganization(row.id);
+				dispatchToast("success", t("administration.reports.deleteSuccess"));
+			} else {
+				await api.adminRestoreOrganization(row.id);
+				dispatchToast("success", t("administration.reports.restoreSuccess"));
+			}
+			setRows((prev) =>
+				prev.map((r) =>
+					r.id === row.id ? { ...r, isDeleted: kind === "delete" } : r,
+				),
+			);
+			setConfirmAction(null);
+		} catch (err) {
+			setActionError(
+				getApiErrorMessage(
+					err,
+					kind === "delete"
+						? t("administration.reports.deleteError")
+						: t("administration.reports.restoreError"),
+				),
+			);
+		} finally {
+			setActioning(false);
+		}
 	}
 
 	return (
@@ -195,15 +246,98 @@ function OrganizationsSection() {
 			) : (
 				<>
 					<ul className="divide-y divide-gray-100 overflow-hidden rounded-card border border-gray-200">
-						{rows.map((row) => (
-							<li key={row.id} className="flex items-center gap-4 px-4 py-3">
-								<div className="min-w-0 flex-1">
-									<p className="truncate font-medium text-gray-900">
-										{row.name}
-									</p>
-								</div>
-							</li>
-						))}
+						{rows.map((row) => {
+							const avatarColor = avatarColorClasses(row.id);
+							return (
+								<li
+									key={row.id}
+									className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+								>
+									<div className="flex min-w-0 flex-1 items-center gap-3">
+										{row.logoUrl ? (
+											<img
+												src={row.logoUrl}
+												alt=""
+												width={40}
+												height={40}
+												loading="lazy"
+												className="h-10 w-10 shrink-0 rounded-full object-cover"
+											/>
+										) : (
+											<span
+												aria-hidden="true"
+												className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold ${avatarColor.bg} ${avatarColor.text}`}
+											>
+												{row.name.charAt(0).toUpperCase()}
+											</span>
+										)}
+										<div className="min-w-0 flex-1">
+											<div className="flex flex-wrap items-center gap-2">
+												<Link
+													to={`/organizations/${row.id}`}
+													className="truncate font-medium text-brand-700 hover:underline"
+												>
+													{row.name}
+												</Link>
+												<Chip
+													tone={row.isDeleted ? "danger" : "success"}
+													size="sm"
+												>
+													{row.isDeleted
+														? t("administration.reports.statusDeleted")
+														: t("administration.reports.statusActive")}
+												</Chip>
+												{row.openReportCount > 0 && (
+													<Chip tone="warning" size="sm">
+														{t("administration.organizations.flaggedBadge")}
+													</Chip>
+												)}
+											</div>
+											<p className="mt-1 truncate text-xs text-gray-500">
+												{t("administration.organizations.memberCount", {
+													count: row.memberCount,
+												})}
+												{" · "}
+												{t("administration.organizations.createdOn", {
+													date: formatDateLong(row.createdOn, i18n.language),
+												})}
+											</p>
+										</div>
+									</div>
+									<div className="flex shrink-0 items-center gap-2 sm:justify-end">
+										{row.isDeleted ? (
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												onClick={() =>
+													setConfirmAction({ row, kind: "restore" })
+												}
+												aria-label={t("administration.reports.restoreNamed", {
+													name: row.name,
+												})}
+											>
+												{t("administration.reports.restore")}
+											</Button>
+										) : (
+											<button
+												type="button"
+												onClick={() =>
+													setConfirmAction({ row, kind: "delete" })
+												}
+												aria-label={t(
+													"administration.reports.shadowDeleteNamed",
+													{ name: row.name },
+												)}
+												className="rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50"
+											>
+												{t("administration.reports.shadowDelete")}
+											</button>
+										)}
+									</div>
+								</li>
+							);
+						})}
 					</ul>
 					{hasMore &&
 						(loadMoreError ? (
@@ -220,6 +354,34 @@ function OrganizationsSection() {
 								onClick={loadMore}
 							/>
 						))}
+					{confirmAction && (
+						<ConfirmDialog
+							title={t(
+								confirmAction.kind === "delete"
+									? "confirmDialog.adminShadowDelete.title"
+									: "confirmDialog.adminRestore.title",
+							)}
+							message={t(
+								confirmAction.kind === "delete"
+									? "confirmDialog.adminShadowDelete.message"
+									: "confirmDialog.adminRestore.message",
+								{ name: confirmAction.row.name },
+							)}
+							confirmLabel={t(
+								confirmAction.kind === "delete"
+									? "confirmDialog.adminShadowDelete.confirm"
+									: "confirmDialog.adminRestore.confirm",
+							)}
+							onConfirm={() => void confirmActionSubmit()}
+							onClose={() => {
+								if (actioning) return;
+								setConfirmAction(null);
+								setActionError(null);
+							}}
+							loading={actioning}
+							error={actionError}
+						/>
+					)}
 				</>
 			)}
 		</>


### PR DESCRIPTION
## What

Fixes the three moderation gaps described in #1677: shadow-deleted users' public profiles were still fully served, the admin organization list was a name-only stub that couldn't act on its own flagged/deleted filters, and the realm-wide `organisator` Keycloak role was never revoked when a user left or deleted their only organization.

## Why

Closes #1677

1. `GetPublicUserProfileQueryHandler` only consulted the filtered `dbContext.Users.FindAsync` for `AvatarUrl`/`Bio`/etc, but still called Keycloak and other repos and returned a fully populated profile regardless - a shadow-deleted user's public profile page (real name, badge count) stayed live. It now looks the user up via `FindUserIncludingDeletedAsync` and returns `null` (404) as soon as it finds `IsDeleted == true`, before ever calling Keycloak. A user with no local row yet (never touched their own profile/settings) is *not* treated as deleted - that's a different case and keeps the existing default-field behavior.
2. `AdminOrganizationSummary` only carried `Id`/`Name`/`LogoUrl`, so the admin org list's existing "Nur gemeldete"/"Nur gelöschte" filters had nothing to display once applied. The DTO now also carries `IsDeleted`, `OpenReportCount`, `MemberCount`, `CreatedOn`, and `AdministrationPage`'s organization list links each row to the org profile, shows its logo (or an initials fallback), a flagged/active/deleted badge, member count + created date, and inline shadow-delete/restore actions - mirroring the pattern already used in the reports section.
3. `RemoveMemberCommandHandler` and `DeleteOrganizationCommandHandler` removed a user's organization membership but never revoked their realm-wide `organisator` role, unlike `ChangeMemberRoleCommandHandler`'s demotion path. Both now call `GetOrganizerOrganizationsAsync` after the membership removal and revoke the Keycloak role once the user organizes no other organization.

## Testing

- New/updated unit tests in `Application.UnitTests` for all three handlers/queries (shadow-delete 404 + "no row yet" fallback, org-summary field mapping, role-revocation revoke/keep/not-an-organizer cases for both `RemoveMember` and `DeleteOrganization`).
- New integration tests: `GetPublicUserProfileShadowDeleteTests.cs` (404 after shadow-delete), `OrganizerRoleRevocationTests.cs` (role revoked on last-org removal/deletion, kept when another org remains), and extended `ListOrganizationsFilterTests.cs` (new DTO fields populated correctly for flagged/deleted/multi-member orgs).
- Ran locally: `Application.UnitTests` (1006/1006 passed), `ArchitectureTests` (426/426 passed), frontend `pnpm check`/`pnpm lint`/`pnpm test` (186/186 passed)/`pnpm format:check`/`pnpm i18n:check` - all clean. `IntegrationTests`/`VisualTests` need Docker/Aspire, which this sandbox can't run; CI's `dotnet.yml` covers them (all green - see below).
- `/self-review` run: fanned out to `nswag-check`, `architecture-check`, `a11y-check`, `i18n-check`, `ef-migration-check` - all clean except one minor dead locale key (`memberCount` unsuffixed, unreachable since i18next always resolves to `_one`/`_other`), fixed in a follow-up commit.
- CI caught a real regression the local sandbox couldn't: `integration-tests` failed because the new revoke-on-last-org-removal behavior, when exercised by a pre-existing test using the shared baseline `olaf` account, legitimately stripped his Keycloak `organisator` role (the local test Postgres DB has no persistent baseline membership row for him, unlike the real seeded app database) with nothing to restore it afterward, breaking later tests that assume he's always an organizer. Fixed by making `IntegrationTestFixture`'s between-test reset self-healing (re-grants the role if a prior test's correct revocation removed it). All CI checks are now green.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. Verified locally instead (see Testing above); CI's full suite (`IntegrationTests`/`VisualTests` against real Postgres/Keycloak containers) is green.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior (none needed - no arc42/ADR docs describe this endpoint/handler behavior)
