### PR TITLE
docs: rewrite README with hero, badges, TOC, and architecture link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ einsatzbereit/
 ├── frontend/       Vite SPA + React 19 + Tailwind CSS 4
 ├── keycloak/       Custom Keycloak image + realm config
 ├── docs/           arc42 architecture docs + ADRs
-├── wiki/           Project LLM wiki (informal knowledge)
 └── .github/        CI/CD workflows + issue templates
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,72 +1,178 @@
-# Einsatzbereit
-Einsatzbereit connects engaged volunteers with regional needs.
-Spontaneously, quickly, and effectively.
+<div align="center">
 
-## Motivation
-Volunteering doesn't require a long-term commitment.
-Sometimes an afternoon is enough, sometimes a week.
-But finding out where help is currently needed is often difficult -
-whether at large NGOs or a local sports tournament.
-Existing platforms are too complex, too generic, or barely used.
-Einsatzbereit makes concrete needs visible: what, where, when.
+![Einsatzbereit](frontend/public/og-image.png)
 
-## Local Development
+**Volunteer coordination platform matching helpers with regional needs.**
+
+*Volunteer spontaneously. Find your local cause.*
+
+[Live Demo](https://einsatzbereit.maik-hasler.de) - [Architecture Docs](https://maik-hasler.github.io/einsatzbereit/Architecture.html) - [Report Bug](https://github.com/maik-hasler/einsatzbereit/issues/new/choose) - [Request Feature](https://github.com/maik-hasler/einsatzbereit/issues/new/choose)
+
+[![Backend CI](https://img.shields.io/github/actions/workflow/status/maik-hasler/einsatzbereit/dotnet.yml?label=backend%20CI)](https://github.com/maik-hasler/einsatzbereit/actions/workflows/dotnet.yml)
+[![Frontend CI](https://img.shields.io/github/actions/workflow/status/maik-hasler/einsatzbereit/frontend.yml?label=frontend%20CI)](https://github.com/maik-hasler/einsatzbereit/actions/workflows/frontend.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/maik-hasler/einsatzbereit/docs.yml?label=docs)](https://github.com/maik-hasler/einsatzbereit/actions/workflows/docs.yml)
+[![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
+
+</div>
+
+---
+
+## Table of Contents
+
+- [About](#about)
+- [Features](#features)
+- [Live Demo](#live-demo)
+- [Tech Stack](#tech-stack)
+- [Architecture](#architecture)
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [Security](#security)
+- [Versioning & Releases](#versioning--releases)
+- [License](#license)
+
+---
+
+## About
+
+Volunteering doesn't have to mean a long-term commitment - sometimes an afternoon is enough, sometimes a week. The hard part is usually finding out where help is needed right now, whether that's a large NGO or a local sports tournament. Existing platforms tend to be too complex, too generic, or simply unused.
+
+Einsatzbereit makes concrete needs visible: what, where, when. Organizations post opportunities with real time slots, and volunteers who are ready ("einsatzbereit") sign up for exactly the slot that fits their schedule.
+
+The app itself is served in German by default, since Einsatzbereit's primary audience is German-speaking, with English available as a secondary UI language via a language selector. Code, commits, and documentation for contributors stay in English throughout.
+
+---
+
+## Features
+
+- **Browse and filter opportunities** across a list view, a mini calendar, city/location autocomplete, and a map view built on Leaflet/OpenStreetMap.
+- **Sign up for a specific time slot ("engagement")** - withdraw if plans change, reactivate later within limits, get reminders, and check in on the day.
+- **Rate your engagement afterwards** with a rating and comment, editable for a short window after submission.
+- **Organizations post opportunities** with scheduled time slots (occurrences) and defined participation types.
+- **Organizer dashboard** with a customizable widget layout: upcoming opportunities, calendar, to-do list, quick check-in, and a create-opportunity shortcut.
+- **Organization management** covering membership, roles, a public directory of organizations, and multi-organization support with an org switcher.
+- **Platform administration** to verify organizations, manage users, and toggle admin/enabled status.
+- **Notifications and a language selector** (German by default, English as a secondary language).
+- **Keycloak-backed authentication** via OIDC/PKCE, with Keycloak Organizations powering org membership.
+
+---
+
+## Live Demo
+
+A live staging deployment runs at **[einsatzbereit.maik-hasler.de](https://einsatzbereit.maik-hasler.de)**.
+
+> [!NOTE]
+> This is a disposable staging/QA environment, not a hardened production deployment. It intentionally shares the same Keycloak realm as local dev, including the test-user credentials listed under [Getting Started](#getting-started). That is a deliberate trade-off for demo infrastructure, not an oversight - staging gets wiped and reseeded rather than treated as anything precious.
+
+---
+
+## Tech Stack
+
+| Layer | Tech |
+|---|---|
+| Backend | .NET 10, Clean Architecture (Api -> Application -> Domain, Infrastructure -> Domain), EF Core 10, PostgreSQL 18, CQRS-style command/query handlers, transactional outbox for domain events |
+| Auth | Keycloak 26.7.0 (OIDC, JWT, Keycloak Organizations) |
+| Frontend | Vite SPA, React 19, React Router v8, Tailwind CSS 4, react-oidc-context, Leaflet/react-leaflet |
+| API client | NSwag-generated TypeScript client from the backend OpenAPI spec - never hand-edited |
+| Tests | TUnit + Aspire.Hosting.Testing + Respawn + NetArchTest (Application.UnitTests, IntegrationTests, ArchitectureTests), Vitest (frontend pure-logic units), Playwright + axe-core (E2E and accessibility, `backend/tests/VisualTests`) |
+| CI/CD | GitHub Actions (build and test on every PR, Docker images to GHCR on tag push, auto-deploy to staging) |
+| Dependency updates | Renovate |
+
+---
+
+## Architecture
+
+The full system architecture is documented in arc42 format and published at:
+
+**[maik-hasler.github.io/einsatzbereit/Architecture.html](https://maik-hasler.github.io/einsatzbereit/Architecture.html)**
+
+It is built from the AsciiDoc sources in `docs/Architecture/` via AsciiDoctor and redeployed to GitHub Pages on every push to `main` (`docs.yml`). Individual Architecture Decision Records live alongside it in `docs/ADRs/`.
+
+---
+
+## Getting Started
 
 ### Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download)
-- [Docker](https://docs.docker.com/get-docker/) (Aspire spins up Postgres + Keycloak as containers)
-- [pnpm](https://pnpm.io/installation) (frontend package manager)
+- [.NET 10 SDK](https://dotnet.microsoft.com/) - exact version pinned in `backend/global.json` (10.0.302)
+- [Docker](https://www.docker.com/) - Aspire runs PostgreSQL and Keycloak as containers
+- [pnpm](https://pnpm.io/) - frontend package manager
 
-### Starting Up
+### Run everything with one command
 
 ```bash
 dotnet run --project backend/src/Aspire/AppHost
 ```
 
-The Aspire AppHost provisions PostgreSQL, Keycloak, the backend API, and the Vite frontend. The Aspire dashboard prints service URLs on startup. On first start, databases are created automatically and the Keycloak realm is imported.
+The Aspire AppHost provisions PostgreSQL, Keycloak, the backend API, and the Vite frontend, then prints every service URL in the Aspire dashboard. On first start, databases are created automatically and the Keycloak realm is imported.
 
 ### Services
 
-| Service    | URL                        | Credentials                              |
-|------------|----------------------------|------------------------------------------|
-| Frontend   | http://localhost:4321      | -                                        |
-| Backend    | http://localhost:5000      | -                                        |
-| Keycloak   | http://localhost:8080      | `admin` / `admin`                        |
-| pgAdmin    | http://localhost:5050      | `admin@admin.com` / `admin`              |
-| PostgreSQL | `localhost:5432`           | `postgres` / `postgres`                  |
+| Service | URL | Credentials |
+|---|---|---|
+| Frontend | http://localhost:4321 | - |
+| Backend API | http://localhost:5000 | - |
+| Keycloak | http://localhost:8080 | admin / admin |
+| pgAdmin | http://localhost:5050 | admin@admin.com / admin |
+| PostgreSQL | localhost:5432 | postgres / postgres |
+| Mailpit | http://localhost:1080 | - (no auth, captures outgoing email) |
 
-### Test Users
+### Test users
 
-| Username | Password     | Roles                 | Persona              | Can                                  |
-|----------|--------------|-----------------------|----------------------|--------------------------------------|
-| `vera`   | `vera123`    | `user`                | Volunteer Vera       | Browse volunteer opportunities       |
-| `olaf`   | `olaf123`    | `user`, `organisator` | Organizer Olaf       | Browse and create opportunities      |
-| `admin`  | `admin123`   | `admin`               | Administrator        | Full administration                  |
+| Username | Password | Roles | Persona | Can |
+|---|---|---|---|---|
+| vera | vera123 | user | Volunteer Vera | Browse volunteer opportunities |
+| olaf | olaf123 | user, organisator | Organizer Olaf | Browse and create opportunities |
+| admin | admin123 | admin | Administrator | Full administration |
 
-> **Note:** These same credentials are intentionally also active on the public staging
-> deployment (https://einsatzbereit.maik-hasler.de) - staging runs the same baked-in
-> Keycloak realm as local dev, on purpose. Staging is disposable demo/QA infrastructure,
-> not production: it holds no data worth protecting and can be fully wiped and restarted
-> at any time (see `.github/workflows/reset-staging.yml`). Anyone signing in with `admin`
-> on staging, including to modify or delete other accounts, is operating within the
-> intended threat model - this is a known, accepted trade-off, not a vulnerability to
-> report.
+These same credentials are intentionally also live on the public [staging deployment](#live-demo) - see the note above.
 
-### Databases
+---
 
-| Database        | Purpose                 |
-|-----------------|-------------------------|
-| `einsatzbereit` | Application data        |
-| `keycloak`      | Keycloak internal data  |
+## Project Structure
 
-pgAdmin is pre-connected to the PostgreSQL server on startup.
+```
+einsatzbereit/
+├── backend/        .NET 10 Clean Architecture API
+├── frontend/       Vite SPA + React 19 + Tailwind CSS 4
+├── keycloak/       Custom Keycloak image + realm config
+├── docs/           arc42 architecture docs + ADRs
+├── wiki/           Project LLM wiki (informal knowledge)
+└── .github/        CI/CD workflows + issue templates
+```
+
+---
 
 ## Contributing
-Read the [Contributing Guidelines](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md) to get started.
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for Conventional Commits, branch naming (`feat/`, `fix/`, `docs/`, `chore/`), the PR process, and code style. Please also read the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## Security
+
+Found a vulnerability? Please report it privately via the GitHub Security tab's "Report a vulnerability" option rather than a public issue - see [SECURITY.md](SECURITY.md) for details.
+
+---
+
+## Versioning & Releases
+
+Einsatzbereit uses a single unified SemVer tag across the whole monorepo - see [VERSIONING.md](VERSIONING.md). Stable releases are tagged `vX.Y.Z`; release candidates are `vX.Y.Z-rc.N`. Every tag push builds and publishes Docker images for backend, frontend, and Keycloak to GitHub Container Registry (GHCR). Release notes are auto-generated on [GitHub Releases](https://github.com/maik-hasler/einsatzbereit/releases) - there is no separate changelog file.
+
+---
 
 ## License
+
 Einsatzbereit is intentionally licensed under the [GNU Affero General Public License v3.0](LICENSE).
-It doesn't matter who develops the project further.
-The benefit to society comes first.
-No profit, no closed source, no lost knowledge.
+
+It doesn't matter who develops the project further. The benefit to society comes first. No profit, no closed source, no lost knowledge.
+
+Practically, this means: if you self-host a modified version of Einsatzbereit and let others interact with it over a network, you are obligated to make your modified source available to them too.
+
+---
+
+<div align="center">
+
+Built for the moments when an afternoon of help is exactly enough.
+
+</div>


### PR DESCRIPTION
## What

Rewrites `README.md` from scratch, restructuring it around patterns common to well-regarded open source project READMEs: a centered hero banner (`frontend/public/og-image.png`), a CI/license badge row, a table of contents, and short, scannable sections (About, Features, Live Demo, Tech Stack, Architecture, Getting Started, Project Structure, Contributing, Security, Versioning & Releases, License).

## Why

The previous README was accurate but minimal (motivation blurb + local dev setup only) and didn't link out to the project's arc42 architecture documentation site at all. This rewrite:
- Adds a dedicated **Architecture** section linking `https://maik-hasler.github.io/einsatzbereit/Architecture.html` (the GitHub Pages-hosted arc42 docs built from `docs/Architecture/`), so a visitor can discover it without already knowing it exists.
- Adds a **Features** section (browsing/filtering, sign-up/check-in flow, organizer dashboard, org management, admin) so the README actually explains what the product does, not just how to run it.
- Adds badges (backend/frontend CI status, docs build, AGPL-3.0 license) and a table of contents, both absent before.
- Keeps every existing fact (services table, test-user table, staging trade-off note, AGPL philosophy paragraph) accurate and intact - nothing was invented, only restructured and slightly expanded (e.g. adding the Mailpit row that AGENTS.md documents but the old README omitted).

No application code, config, or behavior changed - `README.md` only.

## Testing

Not applicable - documentation-only change. Verified instead:
- No Unicode en/em dashes anywhere (CI's `lint.yml` dash ban).
- No tabs / no trailing whitespace (`.md` space-indentation convention).
- Every relative link (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `VERSIONING.md`, `LICENSE`, `frontend/public/og-image.png`) resolves to a real file in the repo.
- All 11 table-of-contents anchors verified against GitHub's heading-slug algorithm.
- Credentials/services/test-user tables cross-checked against `AGENTS.md`; SDK version matches `backend/global.json` (10.0.302).

## Live verification

Not applicable - this is a docs-only change (`README.md` text/markdown only, no app behavior affected), so the release-candidate + live-staging verification flow in root `AGENTS.md` doesn't apply here.

## Checklist

- [x] `/self-review` run and findings addressed (one P3 note: the old "Databases" subsection was folded away in favor of a tighter Services table; that info remains discoverable in `docker-compose.yml`)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (this PR *is* the documentation update)


---
_Generated by [Claude Code](https://claude.ai/code/session_015x8pK9RbjHrDSxNpyd6mJw)_