### PR TITLE
fix: stop VisualTests silently skipping on non-waiting CountAsync() gates

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -390,24 +390,23 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	[Test]
 	public async Task OrganizationProfilePage_HasNoSeriousA11yViolations()
 	{
+		// #1708: the old locator (`ul > li .relative.z-10 a`) never matched
+		// anything - OpportunityListItem.tsx's org link carries `relative
+		// z-20` (the stretched card-cover Link is the one at z-10), so this
+		// test always timed out and silently skipped, giving /organizations/{id}
+		// zero axe coverage. Target the org link by data-testid instead of a
+		// brittle Tailwind class combination, and seed data always publishes
+		// opportunities (ApplicationDbContextInitializer.cs), so a missing
+		// link is a genuine failure, not a "not seeded yet" skip.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		// Wait for org links from opportunity cards; skip gracefully if page load times out
-		var orgLinks = Page.Locator("ul > li .relative.z-10 a");
-		try
-		{
-			await orgLinks.First.WaitForAsync(new() { Timeout = 30_000 });
-		}
-		catch (TimeoutException)
-		{
-			Skip.Test("home page did not load in time");
-		}
+		var orgLink = Page.GetByTestId("opportunity-org-link").First;
+		await Expect(orgLink).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		Skip.When(await orgLinks.CountAsync() == 0, "no opportunities seeded");
-
-		var href = await orgLinks.First.GetAttributeAsync("href");
+		var href = await orgLink.GetAttributeAsync("href");
 
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}{href}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -1194,8 +1193,13 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await signUpBtn.ClickAsync();
 		await Page.WaitForSelectorAsync("[role='dialog']");
 
+		// #1708: the SignUpModal is already open and this opportunity was just
+		// filtered above to one with open ScheduledSlots capacity, so the
+		// dropdown is always going to render - a non-waiting CountAsync() here
+		// raced the modal's own mount and could silently skip the axe scan
+		// instead of failing on a genuine regression.
 		var dropdown = Page.Locator("#sign-up-time-slot");
-		Skip.When(await dropdown.CountAsync() == 0, "opportunity has no time slots to pick from");
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		await dropdown.ClickAsync();
 		await Expect(Page.Locator("[role='option']").First).ToBeVisibleAsync();

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -74,8 +74,11 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
+		// #1708: seed data always publishes opportunities - a non-waiting
+		// CountAsync() right after the h1 check above raced the home page's
+		// opportunity fetch and could silently skip this test instead of failing.
 		var orgLink = Page.Locator("a[href*='/organizations/']").First;
-		Skip.When(await orgLink.CountAsync() == 0, "no opportunities/organizations seeded");
+		await Expect(orgLink).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var href = await orgLink.GetAttributeAsync("href");
 		Skip.When(href is null, "organization link had no href");
@@ -130,8 +133,11 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
+		// #1708: seed data always publishes opportunities - a non-waiting
+		// CountAsync() right after the h1 check above raced the home page's
+		// opportunity fetch and could silently skip this test instead of failing.
 		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
-		Skip.When(await firstCard.CountAsync() == 0, "no opportunities seeded");
+		await Expect(firstCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var href = await firstCard.GetAttributeAsync("href");
 		Skip.When(href is null, "opportunity link had no href");
@@ -262,7 +268,13 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
 		await switcherBtn.ClickAsync();
 
-		var rowCount = await Page.GetByTestId("org-switch-row").CountAsync();
+		// #1708: wait for the switcher panel to actually render its rows before
+		// counting them - a bare CountAsync() right after the click raced the
+		// panel's own mount, which could misreport "< 2" and skip this test even
+		// when olaf's seed data has the two orgs it needs.
+		var orgSwitchRows = Page.GetByTestId("org-switch-row");
+		await Expect(orgSwitchRows.First).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		var rowCount = await orgSwitchRows.CountAsync();
 		Skip.When(rowCount < 2, "olaf needs at least two orgs in seed to prove navigation follows selection");
 
 		// The active org's row carries aria-current="page" - pick a different one.

--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -82,9 +82,20 @@ public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase
 		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });
 		await switcherBtn.ClickAsync();
 
+		// #1708: wait for the switcher panel's rows to actually render before
+		// deciding this org is missing - a bare CountAsync() right after the
+		// click above raced the panel's own mount, which could misreport "not
+		// found" even when the seeded org is there, just not painted yet.
 		var animalWelfareRow = Page.GetByTestId("org-switch-row")
 			.Filter(new() { HasText = "Fairview Animal Welfare Association" });
-		Skip.When(await animalWelfareRow.CountAsync() == 0, "seed data changed - nothing to compare against");
+		try
+		{
+			await animalWelfareRow.WaitForAsync(new() { Timeout = 10_000 });
+		}
+		catch (TimeoutException)
+		{
+			Skip.Test("seed data changed - nothing to compare against");
+		}
 
 		await animalWelfareRow.ClickAsync();
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -104,12 +104,17 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Expect(Page.GetByText(new Regex("lend a hand", RegexOptions.IgnoreCase)))
 			.ToBeVisibleAsync();
 
-		// If opportunities are seeded, each card carries the redesigned visuals:
-		// a clickable organisation link and the brand-gradient category banner.
+		// Seed data always publishes opportunities, so a rendered card must
+		// carry the redesigned visuals: a clickable organisation link and the
+		// brand-gradient category banner.
 		var firstCard = Page
 			.Locator("ul li:has(a[href*='/volunteer-opportunities/'])")
 			.First;
-		Skip.When(await firstCard.CountAsync() == 0, "no opportunities seeded - skip card-specific checks");
+		// #1708: seed data always publishes opportunities, and the list only
+		// mounts <ul>/<li> once its loading skeleton clears - a non-waiting
+		// CountAsync() right after the heading check above raced that fetch
+		// and could silently skip these card-specific assertions.
+		await Expect(firstCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await Expect(firstCard.Locator("a[href*='/organizations/']"))
 			.ToBeVisibleAsync();
@@ -206,8 +211,12 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
 
+		// #1708: seed data always publishes opportunities - a non-waiting
+		// CountAsync() right after the h1 check above raced the home page's
+		// opportunity fetch (h1 paints before the list leaves its loading
+		// skeleton) and could silently skip this test instead of failing.
 		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
-		Skip.When(await firstCard.CountAsync() == 0, "no opportunities seeded, skip");
+		await Expect(firstCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var href = await firstCard.GetAttributeAsync("href");
 		Skip.When(href is null, "opportunity card link had no href");
@@ -238,8 +247,12 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
 
+		// #1708: seed data always publishes opportunities - a non-waiting
+		// CountAsync() right after the h1 check above raced the home page's
+		// opportunity fetch (h1 paints before the list leaves its loading
+		// skeleton) and could silently skip this test instead of failing.
 		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
-		Skip.When(await firstCard.CountAsync() == 0, "no opportunities seeded, skip");
+		await Expect(firstCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var href = await firstCard.GetAttributeAsync("href");
 		Skip.When(href is null, "opportunity card link had no href");
@@ -268,8 +281,12 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GotoAsync(frontend.ToString());
 		await Expect(Page.Locator("h1")).ToBeVisibleAsync();
 
+		// #1708: seed data always publishes opportunities - a non-waiting
+		// CountAsync() right after the h1 check above raced the home page's
+		// opportunity fetch (h1 paints before the list leaves its loading
+		// skeleton) and could silently skip this test instead of failing.
 		var firstCard = Page.Locator("a[href*='/volunteer-opportunities/']").First;
-		Skip.When(await firstCard.CountAsync() == 0, "no opportunities seeded, skip");
+		await Expect(firstCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		var href = await firstCard.GetAttributeAsync("href");
 		Skip.When(href is null, "opportunity card link had no href");

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -176,6 +176,7 @@ export default function OpportunityListItem({
 					<div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-gray-100 pt-3">
 						<Link
 							to={`/organizations/${item.organizationId}`}
+							data-testid="opportunity-org-link"
 							className="group/org relative z-20 inline-flex items-center gap-2"
 						>
 							{item.organizationLogoUrl ? (


### PR DESCRIPTION
## What

Fixes two provable bugs in `backend/tests/VisualTests/` that let tests silently skip instead of failing:

1. `OrganizationProfilePage_HasNoSeriousA11yViolations`'s locator (`ul > li .relative.z-10 a`) never matched anything, so it always timed out and skipped, giving `/organizations/{id}` zero axe coverage.
2. Several tests gated a skip on a non-waiting `Locator.CountAsync()` right after a static heading became visible, racing the opportunity/organization list's own data fetch (it renders a loading skeleton until the request resolves) and silently skipping instead of running real assertions.

## Why

Closes #1708

`OpportunityListItem.tsx`'s org link carries `relative z-20` (the stretched full-card link is the one at `z-10`), so the old test locator could never resolve. Fixed by adding a stable `data-testid="opportunity-org-link"` to the org link and pointing the test at it instead of a brittle Tailwind class combination.

Seed data always publishes opportunities (`ApplicationDbContextInitializer.cs`), so a `Skip.When("no opportunities seeded", ...)` right after `Expect(h1).ToBeVisibleAsync()` was never a genuine precondition check - it was masking a race against `OpportunityResultsList.tsx`'s loading skeleton. Those gates are replaced with an awaited `Expect(...).ToBeVisibleAsync()`, so a genuinely broken/empty list now fails loudly instead of skipping.

Skips that depend on real, variable seed data (a specific named org for one org, needing two orgs seeded for another) are legitimate "this scenario doesn't apply" checks, not bugs - those keep their `Skip.Test`/`Skip.When`, but now wait for the relevant panel to actually render before deciding, closing the same underlying race without changing their semantics.

As the issue itself calls out: fixing the dead `OrganizationProfilePage` selector may surface real axe violations on `/organizations/{id}` that have never been checked before - that would be a genuine finding to triage, not a regression from this PR.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest, 189 tests), and `pnpm format:write` all pass on the frontend change.
- `dotnet build` could not be run in this sandbox - the .NET SDK download is blocked by this session's network egress policy (confirmed via the proxy status endpoint: a 403 policy denial on `builds.dotnet.microsoft.com`, not a transient failure). Every edited region was reviewed manually for correctness (braces, existing `using` directives, tab indentation, no leftover references to renamed locals) instead.
- Ran `/self-review` plus the `a11y-check` subagent (triggered by the `.tsx` change) - no accessibility concerns with the added `data-testid`, and no new page/route test needed since this is an existing link on an already-covered page.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed - the GitHub Actions runners are currently having problems, and this PR is implementation-only. The updated assertions are the automated VisualTests changes themselves (`AccessibilityTests.cs`, `NavigationTests.cs`, `OrgAppMobileResponsiveTests.cs`, `VolunteerOpportunityTests.cs`); they'll get their first real execution in CI's `visual-tests` job once runners are healthy again.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green (not verified - GitHub Actions runners reported as having problems for this task; PR is implementation-only per instruction)
- [ ] Documentation updated if this change affects behavior (not applicable - test-only fix plus one `data-testid` addition, no user-facing behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_016dgZ14YCcbCeLVBdPuZL7V)_