### PR TITLE
fix: keep org app shell resilient to Keycloak members-lookup failures

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -8730,7 +8730,9 @@
           "logoUrl",
           "address",
           "createdOn",
-          "members"
+          "members",
+          "requestingUserRole",
+          "membersUnavailable"
         ],
         "type": "object",
         "properties": {
@@ -8790,6 +8792,12 @@
             "items": {
               "$ref": "#/components/schemas/OrganizationMemberDto"
             }
+          },
+          "requestingUserRole": {
+            "type": "string"
+          },
+          "membersUnavailable": {
+            "type": "boolean"
           }
         }
       },

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -72,6 +72,15 @@ public interface IApplicationDbContext
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
 
+	// Every member's role, sourced entirely from organization_membership - unlike
+	// GetOrganizerUserIdsAsync (organizers only), this covers plain Members too.
+	// GetOrganizationDetailsQueryHandler falls back to this when Keycloak's member
+	// lookup fails (#1709), so the org app shell can still render a roster (ids +
+	// roles only, no Keycloak-sourced username/email/name) instead of 500ing.
+	Task<Dictionary<Guid, OrganizationMemberRole>> GetMembershipRolesAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default);
+
 	Task<OrganizationMembership?> GetMembershipAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDetails/v1/GetOrganizationDetailsQueryHandler.cs
@@ -4,12 +4,14 @@ using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Organizations;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Organizations.GetOrganizationDetails.v1;
 
 internal sealed class GetOrganizationDetailsQueryHandler(
 	IApplicationDbContext dbContext,
-	IKeycloakOrganizationService keycloakOrganizationService)
+	IKeycloakOrganizationService keycloakOrganizationService,
+	ILogger<GetOrganizationDetailsQueryHandler> logger)
 	: IQueryHandler<GetOrganizationDetailsQuery, OrganizationDetailsResponse?>
 {
 	public async ValueTask<OrganizationDetailsResponse?> Handle(
@@ -28,8 +30,12 @@ internal sealed class GetOrganizationDetailsQueryHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var members = await keycloakOrganizationService.GetMembersAsync(
-			organization.Id.Value, cancellationToken);
+		// Purely local - answered from organization_membership, so the requesting
+		// user's own role never depends on the Keycloak call below (#1709).
+		var isRequestingUserOrganizer = await dbContext.IsOrganizerAsync(
+			organization.Id, request.RequestingUserId, cancellationToken);
+
+		var (memberDtos, membersUnavailable) = await GetMemberRosterAsync(organization.Id, cancellationToken);
 
 		var address = organization.Address is null
 			? null
@@ -49,15 +55,59 @@ internal sealed class GetOrganizationDetailsQueryHandler(
 			organization.LogoUrl,
 			address,
 			organization.CreatedOn,
-			members
-				.Select(m => new OrganizationMemberDto(
-					m.UserId,
-					m.Username,
-					m.FirstName,
-					m.LastName,
-					m.Email,
-					m.IsOrganisator,
-					(m.IsOrganisator ? OrganizationMemberRole.Organizer : OrganizationMemberRole.Member).ToString()))
-				.ToList());
+			memberDtos,
+			(isRequestingUserOrganizer ? OrganizationMemberRole.Organizer : OrganizationMemberRole.Member).ToString(),
+			membersUnavailable);
+	}
+
+	// The org app shell (navigation, dashboard, every tab besides Members) doesn't
+	// need Keycloak's member roster to render - only the Members tab does. A
+	// transient Keycloak failure here used to throw and 500 the whole shell along
+	// with it (#1709); fall back to what organization_membership already knows
+	// locally (id + role, no Keycloak-sourced username/email/name) instead.
+	private async Task<(List<OrganizationMemberDto> Members, bool Unavailable)> GetMemberRosterAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var members = await keycloakOrganizationService.GetMembersAsync(
+				organizationId.Value, cancellationToken);
+
+			return (
+				members
+					.Select(m => new OrganizationMemberDto(
+						m.UserId,
+						m.Username,
+						m.FirstName,
+						m.LastName,
+						m.Email,
+						m.IsOrganisator,
+						(m.IsOrganisator ? OrganizationMemberRole.Organizer : OrganizationMemberRole.Member).ToString()))
+					.ToList(),
+				false);
+		}
+		catch (HttpRequestException ex)
+		{
+			logger.LogWarning(
+				ex,
+				"Keycloak member lookup failed for organization {OrganizationId}; falling back to a local-only roster.",
+				organizationId.Value);
+
+			var roles = await dbContext.GetMembershipRolesAsync(organizationId, cancellationToken);
+
+			return (
+				roles
+					.Select(kvp => new OrganizationMemberDto(
+						kvp.Key,
+						string.Empty,
+						null,
+						null,
+						string.Empty,
+						kvp.Value == OrganizationMemberRole.Organizer,
+						kvp.Value.ToString()))
+					.ToList(),
+				true);
+		}
 	}
 }

--- a/backend/src/Application/Organizations/GetOrganizationDetails/v1/OrganizationDetailsResponse.cs
+++ b/backend/src/Application/Organizations/GetOrganizationDetails/v1/OrganizationDetailsResponse.cs
@@ -10,7 +10,15 @@ public sealed record OrganizationDetailsResponse(
 	string? LogoUrl,
 	AddressDto? Address,
 	DateTimeOffset CreatedOn,
-	IReadOnlyList<OrganizationMemberDto> Members);
+	IReadOnlyList<OrganizationMemberDto> Members,
+	// Answered from organization_membership, independent of the Keycloak-sourced
+	// Members roster below - so the org app shell can gate Organizer-only nav and
+	// actions without needing Keycloak's member lookup to succeed (#1709).
+	string RequestingUserRole,
+	// True when Keycloak's member lookup failed and Members was filled in from
+	// organization_membership instead (id + role only, no username/email/name -
+	// those live in Keycloak, not locally) rather than left empty (#1709).
+	bool MembersUnavailable);
 
 public sealed record AddressDto(
 	string Street,

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -10,6 +10,7 @@ using Application.Common.Persistence;
 using Domain.Organizations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Polly;
 
 namespace Infrastructure.Keycloak;
 
@@ -147,9 +148,26 @@ internal sealed class KeycloakOrganizationService(
 	{
 		await EnsureAuthenticatedAsync(cancellationToken);
 
-		var membersResponse = await httpClient.GetAsync(
-			$"/admin/realms/{_options.Realm}/organizations/{organizationId}/members",
-			cancellationToken);
+		HttpResponseMessage membersResponse;
+		try
+		{
+			membersResponse = await httpClient.GetAsync(
+				$"/admin/realms/{_options.Realm}/organizations/{organizationId}/members",
+				cancellationToken);
+		}
+		catch (ExecutionRejectedException ex)
+		{
+			// AddStandardResilienceHandler's circuit breaker/timeout/rate limiter can
+			// reject the call outright under sustained failure - exactly the "sustained
+			// concurrent admin-API load" scenario #1709 traces the original 400 back
+			// to - before it ever reaches EnsureSuccessAsync below. Normalize to the
+			// same HttpRequestException that path throws, so
+			// GetOrganizationDetailsQueryHandler has a single exception type to catch
+			// regardless of which stage failed.
+			throw new HttpRequestException(
+				$"Keycloak organization members lookup for {organizationId} was rejected by the resilience pipeline: {ex.Message}",
+				ex);
+		}
 
 		await EnsureSuccessAsync(membersResponse, cancellationToken);
 
@@ -323,15 +341,16 @@ internal sealed class KeycloakOrganizationService(
 		// ever reaches the Error-level exception message that gets logged/exported.
 		var path = response.RequestMessage?.RequestUri?.GetLeftPart(UriPartial.Path);
 
-		if (logger.IsEnabled(LogLevel.Debug))
-		{
-			var body = await response.Content.ReadAsStringAsync(cancellationToken);
-			logger.LogDebug(
-				"Keycloak error response body for {Method} {Path}: {Body}",
-				method,
-				path,
-				body);
-		}
+		// Logged unconditionally rather than gated behind Debug - a non-2xx here is
+		// always unexpected, and Debug logging being off in every environment that
+		// hit it is exactly what made #1709's unexplained 400 undiagnosable.
+		var body = await response.Content.ReadAsStringAsync(cancellationToken);
+		logger.LogWarning(
+			"Keycloak responded with {StatusCode} for {Method} {Path}. Response body: {Body}",
+			(int)response.StatusCode,
+			method,
+			path,
+			body);
 
 		throw new HttpRequestException(
 			$"Keycloak responded with {(int)response.StatusCode} {response.StatusCode} for {method} {path}",

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -181,6 +181,19 @@ internal sealed class ApplicationDbContext(
 		return userIds.Select(id => id.Value).ToHashSet();
 	}
 
+	public async Task<Dictionary<Guid, OrganizationMemberRole>> GetMembershipRolesAsync(
+		OrganizationId organizationId,
+		CancellationToken cancellationToken = default)
+	{
+		var memberships = await Set<OrganizationMembership>()
+			.AsNoTracking()
+			.Where(m => m.OrganizationId == organizationId)
+			.Select(m => new { m.UserId, m.Role })
+			.ToListAsync(cancellationToken);
+
+		return memberships.ToDictionary(m => m.UserId.Value, m => m.Role);
+	}
+
 	public async Task<OrganizationMembership?> GetMembershipAsync(
 		OrganizationId organizationId,
 		UserId userId,

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs
@@ -7,6 +7,7 @@ using Domain.Common;
 using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 
@@ -29,7 +30,8 @@ public class GetOrganizationDetailsQueryHandlerTests
 		_dbContext
 			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_sut = new GetOrganizationDetailsQueryHandler(_dbContext, _keycloakService);
+		_sut = new GetOrganizationDetailsQueryHandler(
+			_dbContext, _keycloakService, NullLogger<GetOrganizationDetailsQueryHandler>.Instance);
 	}
 
 	[Test]
@@ -73,6 +75,73 @@ public class GetOrganizationDetailsQueryHandlerTests
 		result.Members.Should().HaveCount(1);
 		result.Members[0].UserId.Should().Be(userId);
 		result.Members[0].IsOrganisator.Should().BeTrue();
+		result.MembersUnavailable.Should().BeFalse();
+	}
+
+	[Test]
+	[Arguments(true, "Organizer")]
+	[Arguments(false, "Member")]
+	public async Task Handle_ShouldSetRequestingUserRole_FromLocalMembership(
+		bool isOrganizer,
+		string expectedRole,
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the requesting user's own role must come from
+		// organization_membership, not from scanning the Keycloak-sourced Members
+		// roster below - the org app shell needs it even when that roster can't be
+		// loaded (#1709).
+		var orgId = DefaultOrgId;
+		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Org").Value;
+
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(org);
+		_keycloakService.GetMembersAsync(orgId, cancellationToken).Returns([]);
+		_dbContext
+			.IsOrganizerAsync(OrganizationId.Create(orgId).GetValueOrThrow(), DefaultRequestingUserId, cancellationToken)
+			.Returns(isOrganizer);
+
+		// Act
+		var result = await _sut.Handle(new GetOrganizationDetailsQuery(orgId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		result!.RequestingUserRole.Should().Be(expectedRole);
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToLocalRoster_WhenKeycloakMemberLookupFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: any transient Keycloak failure on the members lookup used to
+		// throw and take down the whole org app shell along with it (#1709) - it
+		// should degrade to what organization_membership already knows locally
+		// instead.
+		var orgId = DefaultOrgId;
+		var org = Organization.Create(OrganizationId.Create(orgId).GetValueOrThrow(), "Org").Value;
+		var organizerId = Guid.NewGuid();
+		var memberId = Guid.NewGuid();
+
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(org);
+		_keycloakService.GetMembersAsync(orgId, cancellationToken)
+			.Returns<IReadOnlyList<KeycloakOrganizationMember>>(_ => throw new HttpRequestException(
+				"Keycloak responded with 400 BadRequest for GET /organizations/.../members",
+				inner: null,
+				System.Net.HttpStatusCode.BadRequest));
+		_dbContext
+			.GetMembershipRolesAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken)
+			.Returns(new Dictionary<Guid, OrganizationMemberRole>
+			{
+				[organizerId] = OrganizationMemberRole.Organizer,
+				[memberId] = OrganizationMemberRole.Member,
+			});
+
+		// Act
+		var result = await _sut.Handle(new GetOrganizationDetailsQuery(orgId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		result.Should().NotBeNull();
+		result!.MembersUnavailable.Should().BeTrue();
+		result.Members.Should().HaveCount(2);
+		result.Members.Should().Contain(m => m.UserId == organizerId && m.IsOrganisator);
+		result.Members.Should().Contain(m => m.UserId == memberId && !m.IsOrganisator);
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -13592,6 +13592,13 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<OrganizationMemberDto> Members { get; set; } = new System.Collections.ObjectModel.Collection<OrganizationMemberDto>();
 
+        [System.Text.Json.Serialization.JsonPropertyName("requestingUserRole")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string RequestingUserRole { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("membersUnavailable")]
+        public bool MembersUnavailable { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6819,6 +6819,8 @@ export interface OrganizationDetailsResponse {
     address: AddressDto | undefined;
     createdOn: Date;
     members: OrganizationMemberDto[];
+    requestingUserRole: string;
+    membersUnavailable: boolean;
 
     [key: string]: any;
 }

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -1,7 +1,6 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { Outlet, useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { useAuth } from "react-oidc-context";
 import type { OrganizationDetailsResponse } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
@@ -65,13 +64,13 @@ function OrgAppShell({
 	useAchievementNotifier();
 	const { t } = useTranslation();
 	const location = useLocation();
-	const auth = useAuth();
 	const extra = useOrgBreadcrumbExtra();
 	const quickActions = useQuickActionsList();
-	const currentUserId = auth.user?.profile?.sub;
-	const isOrganizer = Boolean(
-		org.members.find((m) => m.userId === currentUserId)?.isOrganisator,
-	);
+	// Answered from organization_membership (see OrganizationDetailsResponse's
+	// requestingUserRole), not by scanning the Keycloak-sourced org.members roster
+	// below - so the shell's own nav/actions still know the caller's role even
+	// when that roster couldn't be loaded (#1709).
+	const isOrganizer = org.requestingUserRole === "Organizer";
 
 	// Now that the tab bar is gone (dashboard UX redesign), the breadcrumb is
 	// the only thing that shows an organizer where they are relative to the

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -461,6 +461,7 @@
       "saveError": "Speichern fehlgeschlagen.",
       "noMembers": "Noch keine Mitglieder.",
       "noMembersHint": "Mitglieder, die dieser Organisation beitreten, erscheinen hier.",
+      "membersUnavailable": "Mitgliedsprofile konnten gerade nicht geladen werden, daher fehlen unten Namen und E-Mail-Adressen. Die Rollen sind weiterhin korrekt - lade die Seite neu, um die vollständigen Profile zu sehen.",
       "organisator": "Organisator:in",
       "roleMember": "Mitglied",
       "promoteToOrganizer": "Zu Organisator:in befördern",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -461,6 +461,7 @@
       "saveError": "Failed to save.",
       "noMembers": "No members yet.",
       "noMembersHint": "Members who join this organization will appear here.",
+      "membersUnavailable": "Member profiles couldn't be loaded right now, so names and emails are missing below. Roles are still accurate - try reloading to see full profiles.",
       "organisator": "Organizer",
       "roleMember": "Member",
       "promoteToOrganizer": "Promote to Organizer",

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -478,6 +478,13 @@ export default function OrgMembersPage() {
 					</div>
 				)}
 
+				{org.membersUnavailable && (
+					<ErrorBanner
+						message={t("orgSettings.membersUnavailable")}
+						className="mb-4"
+					/>
+				)}
+
 				{members.length === 0 ? (
 					<EmptyState
 						title={t("orgSettings.noMembers")}


### PR DESCRIPTION
## What

A transient Keycloak failure on the organization members lookup no longer takes down the whole org app shell (nav included) with it - `GetOrganizationDetailsQueryHandler` now falls back to a local-only member roster and the requesting user's role is answered locally, independent of Keycloak.

## Why

Closes #1709

Root cause chain per the issue: `GetOrganizationDetailsQueryHandler` called `KeycloakOrganizationService.GetMembersAsync`, which threw on any non-2xx (`EnsureSuccessAsync`), turning into a 500 that put `OrgAppLayout` into its `status === "error"` branch - which renders without `Header`, so the org switcher and all navigation disappear on what should be a roster-only hiccup. `isOrganizer` was also derived by scanning the Keycloak-sourced `org.members` array client-side, even though it's answerable purely from the local `organization_membership` table.

Fix, matching the issue's suggested approach:
- `OrganizationDetailsResponse` gained `RequestingUserRole` (computed via the existing `IApplicationDbContext.IsOrganizerAsync`, local-only) and `MembersUnavailable`.
- `OrgAppLayout` reads `org.requestingUserRole` instead of scanning `org.members` for the current user.
- `GetOrganizationDetailsQueryHandler` now catches a failed Keycloak members lookup and degrades to a roster built from `organization_membership` (id + role only - no Keycloak-sourced username/email/name) instead of letting the failure propagate. `KeycloakOrganizationService.GetMembersAsync` also normalizes `Polly.ExecutionRejectedException` (circuit breaker open / timeout / rate limiter, from `AddStandardResilienceHandler`) to the same `HttpRequestException` the handler catches, so the degrade covers more than just a non-2xx response.
- `OrgMembersPage` shows a banner when the roster is degraded instead of silently rendering blank-named rows.
- `KeycloakOrganizationService.EnsureSuccessAsync` now always logs the Keycloak error response body at Warning (previously gated behind Debug, which is why the original 400 in #1709 went undiagnosed) - addresses the issue's last checklist item.
- No hand-rolled retry was added, per the issue's explicit note that `AddStandardResilienceHandler` already retries + circuit-breaks, and a second retry layer would just feed the breaker faster.

## Testing

- `backend/tests/Application.UnitTests/Organizations/GetOrganizationDetails/GetOrganizationDetailsQueryHandlerTests.cs`: new cases for `RequestingUserRole` being sourced locally (both organizer and plain-member), and for the Keycloak-failure degrade path (roster falls back to `organization_membership`, `MembersUnavailable` is set).
- `dotnet run --project tests/Application.UnitTests` - 1018 passed.
- `dotnet run --project tests/ArchitectureTests` - 426 passed (layer rules unaffected; the new `Polly.ExecutionRejectedException` catch stays inside `Infrastructure`, `Application` only ever sees the BCL `HttpRequestException`).
- `pnpm lint`, `pnpm check`, `pnpm test` (189 passed), `pnpm i18n:check` (1242 keys, in sync) - all clean.
- `/self-review` run, fanning out to `nswag-check`, `ef-migration-check`, `architecture-check`, `a11y-check`, and `i18n-check` - all clean; one German wording nit from `i18n-check` was fixed.

## Live verification

Skipped for this PR at the requester's explicit instruction - no release candidate was cut and no live-staging check was run, since the GitHub Actions runners are currently having problems. This is implementation-only; deploy-and-verify can follow in a separate pass once CI is healthy again.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (inline comments only - no arc42/ADR change needed for this fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JeUJSjEJ4dVpwBLvtmbPGY)_