### PR TITLE
fix(test): stop LoadMoreUntilVisibleAsync racing the load-more unmount

### DIFF
--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -74,15 +74,14 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		// shared session where other concurrently-running tests have already
 		// given vera their own time-slotted upcoming engagements, this row can
 		// land past the first (10-item) page instead of being visible
-		// immediately. Click "Load more" until it shows up or there is nothing
-		// left to load - see MyEngagementsTests.cs for the same pattern.
-		var loadMoreButton = Page.Locator("#activity").GetByRole(AriaRole.Button, new() { Name = "Load more" });
-		var loadMoreDeadline = DateTimeOffset.UtcNow.AddSeconds(60);
-		while (!await row.IsVisibleAsync() && await loadMoreButton.IsVisibleAsync() && DateTimeOffset.UtcNow < loadMoreDeadline)
-		{
-			await loadMoreButton.ClickAsync();
-			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-		}
+		// immediately, so page through to it.
+		//
+		// Wait for the first page before starting: the WaitForLoadStateAsync
+		// above can settle before the engagements fetch is even issued, since
+		// useLoadMore only requests from an effect after React commits.
+		await Expect(Page.Locator("#activity [data-testid='engagement-card']").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await LoadMoreUntilVisibleAsync(row);
 
 		await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
 		var checkInButton = row.GetByRole(AriaRole.Button, new() { Name = "Check in" });

--- a/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
+++ b/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
@@ -76,15 +76,14 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 		// Upcoming" scope by time-slot start (entries with none sort last) - so on
 		// a shared session where other concurrently-running tests have already
 		// given vera their own time-slotted upcoming engagements, this card can
-		// land past the first (10-item) page. Click "Load more" until it shows up
-		// or there is nothing left to load - see MyEngagementsTests.cs.
-		var loadMoreButton = Page.Locator("#activity").GetByRole(AriaRole.Button, new() { Name = "Load more" });
-		var loadMoreDeadline = DateTimeOffset.UtcNow.AddSeconds(60);
-		while (!await card.IsVisibleAsync() && await loadMoreButton.IsVisibleAsync() && DateTimeOffset.UtcNow < loadMoreDeadline)
-		{
-			await loadMoreButton.ClickAsync();
-			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-		}
+		// land past the first (10-item) page, so page through to it.
+		//
+		// Wait for the first page before starting: the WaitForLoadStateAsync
+		// above can settle before the engagements fetch is even issued, since
+		// useLoadMore only requests from an effect after React commits.
+		await Expect(Page.Locator("#activity [data-testid='engagement-card']").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await LoadMoreUntilVisibleAsync(card);
 
 		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
 

--- a/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
+++ b/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
@@ -81,16 +81,15 @@ public class LocalizedCheckInPinErrorTests(AspireFixture fixture) : VisualTestBa
 		// Upcoming" scope by time-slot start (entries with none sort last) - so on
 		// a shared session where other concurrently-running tests have already
 		// given vera their own time-slotted upcoming engagements, this row can
-		// land past the first (10-item) page. Click "Load more" until it shows up
-		// or there is nothing left to load, before switching language below (the
-		// load state doesn't depend on locale) - see MyEngagementsTests.cs.
-		var loadMoreButton = Page.Locator("#activity").GetByRole(AriaRole.Button, new() { Name = "Load more" });
-		var loadMoreDeadline = DateTimeOffset.UtcNow.AddSeconds(60);
-		while (!await row.IsVisibleAsync() && await loadMoreButton.IsVisibleAsync() && DateTimeOffset.UtcNow < loadMoreDeadline)
-		{
-			await loadMoreButton.ClickAsync();
-			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-		}
+		// land past the first (10-item) page, so page through to it before
+		// switching language below (the load state doesn't depend on locale).
+		//
+		// Wait for the first page before starting: the WaitForLoadStateAsync
+		// above can settle before the engagements fetch is even issued, since
+		// useLoadMore only requests from an effect after React commits.
+		await Expect(Page.Locator("#activity [data-testid='engagement-card']").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await LoadMoreUntilVisibleAsync(row);
 
 		// Switch to German only after signing in - FastSignInAsync itself waits on
 		// the English "User menu" aria-label (see OrgDashboardWidgetsTests).

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -475,6 +475,22 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.GetByTestId("modal-submit").ClickAsync();
 
+		// Wait for the create itself to finish before asserting anything about
+		// where it navigated. CreateOrganizationModal only closes on success
+		// (onSuccess then onClose, after the POST resolves); a failed create
+		// keeps the dialog open with an inline error instead.
+		//
+		// This is a diagnostic split, not a fix for a known race: this test
+		// failed once in CI (run 31158818536) with the switcher still showing
+		// the previous org, and the single assertion below could not tell
+		// "create failed", "create was still in flight" and "create succeeded
+		// but navigation didn't happen" apart - all three render identically.
+		// Splitting the wait means the next occurrence says which one it was.
+		// The root cause is still unknown; four separate analyses failed to
+		// find a mechanism that survived scrutiny, so nothing here claims to
+		// remove it.
+		await Expect(createDialog).Not.ToBeVisibleAsync(new() { Timeout = 30_000 });
+
 		// Creating an org makes it the active org and navigates into its new
 		// /app dashboard. Wait for the switcher to reflect the NEW org before
 		// opening Settings: a bare WaitForURLAsync(/app/.../dashboard) is already

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -248,18 +248,30 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				return;
 
 			clickedAtElementCount = elementCount;
-			commitDeadline = DateTimeOffset.UtcNow.AddSeconds(2);
 			try
 			{
 				await loadMoreButton.ClickAsync(new() { Timeout = (float)remainingMs });
 			}
-			catch (PlaywrightException)
+			// Fully qualified because a bare TimeoutException here resolves to
+			// Playwright's only by virtue of this file's using shadowing the
+			// implicit global System one - too subtle to rely on silently.
+			// Deliberately narrower than PlaywrightException: a strict-mode
+			// violation or a protocol error is a real defect that should surface
+			// with its own message, not vanish into a silent return that fails
+			// confusingly further down.
+			catch (Microsoft.Playwright.TimeoutException)
 			{
 				// The button was unmounted between the read above and the click,
 				// or the budget ran out mid-click. Either way there is nothing
 				// more to page through - same as Gone above.
 				return;
 			}
+
+			// Started only once the click has actually been dispatched. ClickAsync
+			// can block for a while first (waiting out actionability on a list
+			// that is still settling), and a grace period started before that
+			// wait could be spent before React has had a single tick to commit.
+			commitDeadline = DateTimeOffset.UtcNow.AddSeconds(2);
 		}
 	}
 

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -195,6 +195,7 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 		var loadMoreButton = Page.Locator($"{listSelector} [data-testid='load-more']");
 		var deadline = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
 		var clickedAtElementCount = -1;
+		var commitDeadline = DateTimeOffset.MinValue;
 
 		while (DateTimeOffset.UtcNow < deadline)
 		{
@@ -210,17 +211,30 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 			if (state == LoadMoreState.Gone)
 				return;
 
-			// Either a page is in flight (button still mounted, but
-			// disabled={loadingMore}), or our own last click hasn't been
-			// committed by React yet - it re-renders a tick after ClickAsync
-			// returns, so an enabled button over an unchanged list means "not
-			// yet", not "click again". Both windows have to be waited out rather
-			// than clicked through: a second click during the *final* load waits
-			// on a button useLoadMore is about to unmount instead of re-enable
-			// (see this method's doc), and a second click before React commits
-			// double-advances `page`, whose cancelled fetch silently drops a
-			// whole page of rows - possibly the one holding the target.
-			if (state == LoadMoreState.Loading || elementCount == clickedAtElementCount)
+			// A page is in flight - the button is still mounted but
+			// disabled={loadingMore}. Waiting this out instead of clicking
+			// through it is the actual fix: a second click during the *final*
+			// load waits on a button useLoadMore is about to unmount rather
+			// than re-enable (see this method's doc).
+			if (state == LoadMoreState.Loading)
+			{
+				await Task.Delay(100);
+				continue;
+			}
+
+			// Enabled, but nothing has changed since our last click - React
+			// re-renders a tick after ClickAsync returns, so this is most likely
+			// "your click hasn't been committed yet" rather than "the page
+			// landed". Clicking again here would double-advance `page`, and the
+			// superseded fetch's cleanup drops a whole page of rows silently -
+			// possibly the one holding the target.
+			//
+			// Bounded rather than waited out indefinitely, because an unchanged
+			// list is not proof of an uncommitted click: a page that legitimately
+			// lands with no new rows (this suite pages over live data that
+			// sibling tests concurrently withdraw from) looks identical. After
+			// the grace period, click again and make progress.
+			if (elementCount == clickedAtElementCount && DateTimeOffset.UtcNow < commitDeadline)
 			{
 				await Task.Delay(100);
 				continue;
@@ -234,6 +248,7 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				return;
 
 			clickedAtElementCount = elementCount;
+			commitDeadline = DateTimeOffset.UtcNow.AddSeconds(2);
 			try
 			{
 				await loadMoreButton.ClickAsync(new() { Timeout = (float)remainingMs });

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -252,14 +252,15 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 			{
 				await loadMoreButton.ClickAsync(new() { Timeout = (float)remainingMs });
 			}
-			// Fully qualified because a bare TimeoutException here resolves to
-			// Playwright's only by virtue of this file's using shadowing the
-			// implicit global System one - too subtle to rely on silently.
-			// Deliberately narrower than PlaywrightException: a strict-mode
-			// violation or a protocol error is a real defect that should surface
-			// with its own message, not vanish into a silent return that fails
-			// confusingly further down.
-			catch (Microsoft.Playwright.TimeoutException)
+			// Both types are needed, and neither alone is enough. There is no
+			// Microsoft.Playwright.TimeoutException in this version (CS0234 if
+			// you try) - Playwright raises a *System*.TimeoutException for
+			// "Timeout Nms exceeded", which does not derive from
+			// PlaywrightException, so catching only the latter would miss the
+			// timeout this clause primarily exists for. PlaywrightException
+			// still covers the non-timeout action failures (a button detached
+			// between the state read above and this click).
+			catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
 			{
 				// The button was unmounted between the read above and the click,
 				// or the budget ran out mid-click. Either way there is nothing

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Playwright;
 using TUnit.Core;
 using TUnit.Playwright;
@@ -163,19 +164,29 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 	/// LAST row of the whole list, several 10-row pages down, rather than
 	/// anywhere near the top.
 	///
-	/// Two details make this reliable, and both were wrong in the hand-rolled
-	/// copies this replaces:
+	/// Three details make this reliable, and the first two were wrong in the
+	/// hand-rolled copies this replaces:
 	/// <list type="bullet">
 	/// <item>The button is found by <c>data-testid</c>, never by accessible
 	/// name. LoadMoreButton renders <c>{loading ? loadingLabel : label}</c> on
 	/// the same element, so a name-based locator matches zero elements while a
 	/// page is in flight and a non-waiting <c>IsVisibleAsync</c> guard reads
 	/// false mid-load, ending the walk after a single click.</item>
-	/// <item><c>ClickAsync</c> is the only synchronization needed - the button
-	/// is <c>disabled={loading}</c> and Playwright's click auto-waits for
-	/// enabled. A <c>WaitForLoadStateAsync(NetworkIdle)</c> here would not
+	/// <item>A <c>WaitForLoadStateAsync(NetworkIdle)</c> between clicks does not
 	/// straddle the fetch at all, since useLoadMore only issues it from an
-	/// effect after React commits the page increment.</item>
+	/// effect after React commits the page increment - it can return before the
+	/// request has even been made.</item>
+	/// <item>Each iteration waits for the in-flight page to land <em>before</em>
+	/// clicking again, rather than leaning on <c>ClickAsync</c>'s
+	/// auto-wait-for-enabled to absorb it. That reliance is what made this
+	/// flaky (einsatzbereit CI run 31155273854, main): the button is
+	/// <c>disabled={loadingMore}</c> while a page loads, but when the
+	/// <em>last</em> page lands useLoadMore flips <c>hasMore</c> false and
+	/// ActivitySection unmounts the button entirely. A click issued during that
+	/// final load is therefore waiting on a button that gets detached rather
+	/// than re-enabled, and Playwright's detached-element retry then burns its
+	/// full 30s action timeout on a locator that will never resolve again -
+	/// "element was detached from the DOM, retrying".</item>
 	/// </list>
 	/// </summary>
 	protected async Task LoadMoreUntilVisibleAsync(
@@ -183,13 +194,115 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 	{
 		var loadMoreButton = Page.Locator($"{listSelector} [data-testid='load-more']");
 		var deadline = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
+		var clickedAtElementCount = -1;
 
-		while (!await target.IsVisibleAsync()
-			&& await loadMoreButton.IsVisibleAsync()
-			&& DateTimeOffset.UtcNow < deadline)
+		while (DateTimeOffset.UtcNow < deadline)
 		{
-			await loadMoreButton.ClickAsync();
+			if (await target.IsVisibleAsync())
+				return;
+
+			var (state, elementCount) = await ReadLoadMoreStateAsync(listSelector);
+
+			// Nothing left to page through. Return instead of stalling until the
+			// deadline, so the caller's own Expect reports the real problem (the
+			// row genuinely isn't in this list) rather than this helper eating
+			// the whole budget first.
+			if (state == LoadMoreState.Gone)
+				return;
+
+			// Either a page is in flight (button still mounted, but
+			// disabled={loadingMore}), or our own last click hasn't been
+			// committed by React yet - it re-renders a tick after ClickAsync
+			// returns, so an enabled button over an unchanged list means "not
+			// yet", not "click again". Both windows have to be waited out rather
+			// than clicked through: a second click during the *final* load waits
+			// on a button useLoadMore is about to unmount instead of re-enable
+			// (see this method's doc), and a second click before React commits
+			// double-advances `page`, whose cancelled fetch silently drops a
+			// whole page of rows - possibly the one holding the target.
+			if (state == LoadMoreState.Loading || elementCount == clickedAtElementCount)
+			{
+				await Task.Delay(100);
+				continue;
+			}
+
+			// Bound the click by what is left of the caller's budget, so a stuck
+			// click cannot overrun timeoutSeconds by Playwright's own separate
+			// 30s default action timeout.
+			var remainingMs = (deadline - DateTimeOffset.UtcNow).TotalMilliseconds;
+			if (remainingMs <= 0)
+				return;
+
+			clickedAtElementCount = elementCount;
+			try
+			{
+				await loadMoreButton.ClickAsync(new() { Timeout = (float)remainingMs });
+			}
+			catch (PlaywrightException)
+			{
+				// The button was unmounted between the read above and the click,
+				// or the budget ran out mid-click. Either way there is nothing
+				// more to page through - same as Gone above.
+				return;
+			}
 		}
+	}
+
+	private enum LoadMoreState
+	{
+		/// <summary>Mounted, rendered and enabled - safe to click.</summary>
+		Ready,
+
+		/// <summary>Mounted but <c>disabled={loadingMore}</c> - a page is in flight.</summary>
+		Loading,
+
+		/// <summary>Unmounted or not rendered - <c>hasMore</c> is false, the list is fully loaded.</summary>
+		Gone,
+	}
+
+	/// <summary>
+	/// Reads the load-more button's state and the list's current element count
+	/// in a single round trip, for <see cref="LoadMoreUntilVisibleAsync"/>.
+	///
+	/// Deliberately not separate <c>CountAsync</c>/<c>IsVisibleAsync</c>/
+	/// <c>IsEnabledAsync</c> locator calls: the button can unmount between any
+	/// two of them - the exact race that method exists to avoid - and
+	/// <c>IsEnabledAsync</c> throws once it has.
+	///
+	/// The element count is a progress signal, not an assertion: it only has to
+	/// grow when a page of rows is appended, so it counts every descendant
+	/// rather than assuming a row tag. A text-only change (the button's own
+	/// label flipping to its loading state) leaves it untouched, which is what
+	/// makes "unchanged count + enabled button" a reliable read of "React has
+	/// not committed our click yet".
+	/// </summary>
+	private async Task<(LoadMoreState State, int ElementCount)> ReadLoadMoreStateAsync(string listSelector)
+	{
+		var snapshot = (await Page.EvaluateAsync(
+			"""
+			({ list }) => {
+				const el = document.querySelector(`${list} [data-testid='load-more']`);
+				// getClientRects() is empty for a display:none element, or one
+				// inside a collapsed ancestor. The IsVisibleAsync() guard this
+				// read replaces treated that the same as absent, and so does
+				// 'gone' here.
+				const state = !el || el.getClientRects().length === 0
+					? 'gone'
+					: el.disabled ? 'loading' : 'ready';
+				return { state, elementCount: document.querySelectorAll(`${list} *`).length };
+			}
+			""",
+			new { list = listSelector }))!.Value;
+
+		var elementCount = snapshot.GetProperty("elementCount").GetInt32();
+		var state = snapshot.GetProperty("state").GetString() switch
+		{
+			"ready" => LoadMoreState.Ready,
+			"loading" => LoadMoreState.Loading,
+			_ => LoadMoreState.Gone,
+		};
+
+		return (state, elementCount);
 	}
 
 	/// <summary>


### PR DESCRIPTION
## What

Fixes the load-more pagination races behind the recent flaky `visual-tests` failures on `main`, and makes one unrelated flaky test diagnosable.

Every load-more failure observed on `main` traces to `VisualTestBase.LoadMoreUntilVisibleAsync` or to hand-rolled copies of it:

| CI run | Test | Mechanism |
|---|---|---|
| [31155273854](https://github.com/maik-hasler/einsatzbereit/actions/runs/31155273854) | `MyEngagementsScopeTabsTests` | detach timeout |
| [31151993151](https://github.com/maik-hasler/einsatzbereit/actions/runs/31151993151) | `LocalizedCheckInPinErrorTests` | name-based locator exits after one click |
| [31103665416](https://github.com/maik-hasler/einsatzbereit/actions/runs/31103665416) | `MyEngagementsScopeTabsTests` | dropped page |
| [31098911882](https://github.com/maik-hasler/einsatzbereit/actions/runs/31098911882) | `MyEngagementsTests` | dropped page |

(`AvatarAndLogoDisplayTests`, the other recent offender, was already fixed on `main` by `ddfc4fc`.)

## Why

**1. The walk clicked without waiting for the in-flight page.**

The old loop re-evaluated its condition the instant `ClickAsync` returned. A *disabled* button is still visible, so it clicked again mid-load. Two ways that bites:

- If the in-flight page is the **last** one, `useLoadMore` flips `hasMore` false and `ActivitySection.tsx:551` unmounts the button. The click is then waiting on an element that gets **detached** rather than re-enabled, and Playwright's retry burns its full 30s action timeout on a locator that never matches again - `element was detached from the DOM, retrying`.
- If React simply hasn't committed yet, the second click double-advances `page`, and the superseded fetch's cleanup discards ~10 rows. That is fatal here specifically because these targets are slot-less engagements that `GetByVolunteerAsync` sorts **last**, so they only appear on the final page.

The walk now resolves the button's state - `Gone` / `Loading` / `Ready` - in a single `EvaluateAsync` and only clicks a `Ready` button. Reading presence and enabled-ness together is load-bearing: as separate `CountAsync` / `IsEnabledAsync` calls the button can unmount *between* them, which is the same race, and `IsEnabledAsync` throws once it has.

The uncommitted-click guard is capped at 2s. An unchanged list is *not* proof React hasn't committed - a page that legitimately lands with zero new rows looks identical, and that happens for real here since sibling tests withdraw vera's engagements concurrently. Unbounded, the guard would have traded the flake for a stall.

The click is bounded by the caller's remaining budget so it cannot overrun `timeoutSeconds` by Playwright's separate 30s action timeout, and the surrounding catch covers **both** `PlaywrightException` and `System.TimeoutException`. That second type matters: there is no `Microsoft.Playwright.TimeoutException` in this version, and Playwright raises `System.TimeoutException` for `Timeout Nms exceeded`, which does not derive from `PlaywrightException` - so the original single-type catch never fired for the timeout it existed to absorb.

**2. Three tests never got migrated to the helper.**

`LocalizedCheckInPinErrorTests`, `EngagementCoreJourneysTests` and `CheckInModalDeletedOpportunityTests` still used the locator the helper's own doc warns against:

```csharp
Page.Locator("#activity").GetByRole(AriaRole.Button, new() { Name = "Load more" })
```

`LoadMoreButton` renders `{loading ? loadingLabel : label}` on the same element, so mid-load the accessible name is "Loading…", the locator matches **zero** elements, and the non-waiting `IsVisibleAsync` guard reads false - ending the walk after one click with the target pages away. The interleaved `WaitForLoadStateAsync(NetworkIdle)` does not cover for it: `useLoadMore` only issues the request from an effect after React commits, so network-idle can return before the fetch exists.

All three now call `LoadMoreUntilVisibleAsync` (bringing it to **six** call sites), each with the first-page wait its already-migrated siblings had.

`LoadMoreErrorPreservesItemsTests` keeps its name-based locator deliberately - it drives a mocked-failure route over its own `?tag=`-scoped dataset and asserts between discrete steps rather than walking.

**3. An unrelated flake, made diagnosable but not fixed.**

`OrganizationTests.CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation` failed once ([31158818536](https://github.com/maik-hasler/einsatzbereit/actions/runs/31158818536)) with the switcher still on the previous org, and has passed every run since. It is **not root-caused**. Four independent analyses - submit path, backend create flow, navigation path, test harness - failed to produce a mechanism that survived adversarial review; the strongest candidate rested on a misreading of the CI log's timestamps and was refuted unanimously.

Rather than guess, the test now waits for the create dialog to close (it only closes on success) before asserting the switcher. That splits three previously indistinguishable outcomes - create failed, create still in flight, create succeeded but navigation didn't happen - so the next occurrence says which.

## Testing

No new test: the change *is* the test-infrastructure fix, and all six `LoadMoreUntilVisibleAsync` call sites exercise it on every `visual-tests` run.

This sandbox cannot run either suite - Docker is unavailable and the agent proxy blocks `builds.dotnet.microsoft.com`, so there is no .NET SDK (both documented in root `AGENTS.md`). Verification is therefore repeated CI runs.

### Repeat-run results

| # | Run | `visual-tests` | Load-more tests |
|---|---|---|---|
| 1 | [31158818536](https://github.com/maik-hasler/einsatzbereit/actions/runs/31158818536) | 311/312 - `OrganizationTests` (unrelated, see 3) | all pass |
| 2 | [31160042603](https://github.com/maik-hasler/einsatzbereit/actions/runs/31160042603) | green | all pass |
| 3 | [31161825443](https://github.com/maik-hasler/einsatzbereit/actions/runs/31161825443) | green | all pass |
| 4 | [31163303575](https://github.com/maik-hasler/einsatzbereit/actions/runs/31163303575) | green | all pass |

For calibration: across recent completed `main` runs the load-more family failed at roughly 1 run in 4, so four consecutive clean runs is meaningful but not conclusive on its own - the run count above is the honest evidence, not a proof.

### Known residual, not fixed

The walk is offset pagination over concurrently mutated data. If a sibling test withdraws one of vera's upcoming engagements mid-walk, every later row shifts down an index, and the target - being last - can slip below the consumed offset window and be skipped. A retry-on-reload would hide this, but it would equally hide a residual double-click bug and destroy the signal from the runs above, so it is deliberately left out. The real cure is the accumulation itself: ~32 classes leave engagements on vera without cleanup, which is a much larger change than this.

## Live verification

Not applicable - this change touches `backend/tests/VisualTests/` only. No backend, frontend, or Keycloak runtime code is modified, so there is nothing deployable to observe on staging. Per root `AGENTS.md` the deploy-and-verify flow covers fixes in shipped code; the equivalent evidence for a test-harness fix is the repeated CI runs above.

## Checklist

- [x] `/self-review` run and findings addressed - it caught two real defects: the uncommitted-click grace period starting before `ClickAsync` rather than after it, and the over-broad catch that led to finding the `System.TimeoutException` bug above
- [x] CI is green
- [x] Documentation updated if this change affects behavior - the helper's XML doc now explains the unmount race and why click auto-wait alone is not sufficient synchronization