### PR TITLE
fix: stop anonymized/multi-slot engagements from blocking deletion

### DIFF
--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -6,11 +6,13 @@ using Application.Engagements.Common;
 using Domain.AuditLogs;
 using Domain.Engagements;
 using Domain.Primitives;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.CancelEngagement.v1;
 
 internal sealed class CancelEngagementCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	ILogger<CancelEngagementCommandHandler> logger)
 	: ICommandHandler<CancelEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -29,24 +31,32 @@ internal sealed class CancelEngagementCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		await EngagementCancellationHelper.CancelAndNotifyAsync(
+		var cancelled = await EngagementCancellationHelper.CancelAndNotifyAsync(
 			dbContext,
 			engagement,
 			request.Reason,
 			opportunity.Title,
+			logger,
 			cancellationToken);
 
-		// Audited here (not via EngagementCancelledDomainEvent) since that event is
-		// also raised for cascade cancellations from an opportunity/organization
-		// shadow-delete - those are already audited as their own action and would
-		// otherwise double up with a per-engagement entry (#1088).
-		var auditLog = AuditLog.Create(
-			request.RequestingUserId,
-			AuditActionType.EngagementCancelled,
-			AuditSubjectType.Engagement,
-			engagement.Id.Value,
-			request.Reason);
-		await dbContext.AuditLogs.AddAsync(auditLog, cancellationToken);
+		// Only when a cancellation actually happened - CancelAndNotifyAsync leaves an
+		// already-anonymized engagement (its volunteer deleted their account) untouched
+		// rather than throwing (einsatzbereit#1724), and an audit entry claiming
+		// "EngagementCancelled" for a no-op would be misleading.
+		if (cancelled)
+		{
+			// Audited here (not via EngagementCancelledDomainEvent) since that event is
+			// also raised for cascade cancellations from an opportunity/organization
+			// shadow-delete - those are already audited as their own action and would
+			// otherwise double up with a per-engagement entry (#1088).
+			var auditLog = AuditLog.Create(
+				request.RequestingUserId,
+				AuditActionType.EngagementCancelled,
+				AuditSubjectType.Engagement,
+				engagement.Id.Value,
+				request.Reason);
+			await dbContext.AuditLogs.AddAsync(auditLog, cancellationToken);
+		}
 
 		return engagement;
 	}

--- a/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
@@ -2,6 +2,7 @@ using Application.Common.Exceptions;
 using Application.Common.Persistence;
 using Domain.Engagements;
 using Domain.Notifications;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.Common;
 
@@ -18,13 +19,32 @@ namespace Application.Engagements.Common;
 /// </summary>
 internal static class EngagementCancellationHelper
 {
-	public static async Task CancelAndNotifyAsync(
+	// Returns whether the engagement was actually cancelled - callers that record their
+	// own audit trail (CancelEngagementCommandHandler) use this to avoid logging an
+	// "EngagementCancelled" entry for an engagement that was in fact left untouched.
+	public static async Task<bool> CancelAndNotifyAsync(
 		IApplicationDbContext dbContext,
 		Engagement engagement,
 		string? reason,
 		string opportunityTitle,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
+		// An anonymized engagement's volunteer has already deleted their account
+		// (Engagement.Anonymize()) - Cancel() refuses to touch it (by the same
+		// IsAnonymized guard every other mutator uses) and there is no volunteer left to
+		// notify, so both the state change and the notification below would be wrong to
+		// attempt. Without this guard a single anonymized-but-active engagement (checked
+		// in, then its volunteer's account deleted) would 409 every caller of this helper
+		// forever, with no way to clear it (einsatzbereit#1724).
+		if (engagement.IsAnonymized)
+		{
+			logger.LogInformation(
+				"Skipping cancellation of engagement {EngagementId}: its volunteer has deleted their account, nothing left to cancel or notify.",
+				engagement.Id.Value);
+			return false;
+		}
+
 		engagement.Cancel(reason, opportunityTitle).ThrowIfFailure();
 
 		var notification = Notification.Create(
@@ -33,5 +53,6 @@ internal static class EngagementCancellationHelper
 			engagement.Id.Value);
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
+		return true;
 	}
 }

--- a/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
@@ -7,6 +7,7 @@ using Domain.AuditLogs;
 using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Reports;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Organizations.AdminShadowDeleteOrganization.v1;
 
@@ -25,7 +26,8 @@ namespace Application.Organizations.AdminShadowDeleteOrganization.v1;
 /// </summary>
 internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	ILogger<AdminShadowDeleteOrganizationCommandHandler> logger)
 	: ICommandHandler<AdminShadowDeleteOrganizationCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -48,6 +50,7 @@ internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 				opportunity.Id,
 				request.AdminUserId,
 				now,
+				logger,
 				cancellationToken);
 		}
 

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
@@ -8,13 +8,15 @@ using Application.VolunteerOpportunities.Common;
 using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Reports;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Organizations.DeleteOrganization.v1;
 
 internal sealed class DeleteOrganizationCommandHandler(
 	IApplicationDbContext dbContext,
 	IKeycloakOrganizationService keycloakOrganizationService,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	ILogger<DeleteOrganizationCommandHandler> logger)
 	: ICommandHandler<DeleteOrganizationCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -87,6 +89,7 @@ internal sealed class DeleteOrganizationCommandHandler(
 				opportunity.Id,
 				request.RequestingUserId,
 				now,
+				logger,
 				cancellationToken);
 		}
 

--- a/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
@@ -6,6 +6,7 @@ using Application.VolunteerOpportunities.Common;
 using Domain.AuditLogs;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
 
 namespace Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity.v1;
 
@@ -18,7 +19,8 @@ namespace Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportuni
 /// </summary>
 internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	ILogger<AdminShadowDeleteVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<AdminShadowDeleteVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -38,6 +40,7 @@ internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 			opportunityId,
 			request.AdminUserId,
 			DateTimeOffset.UtcNow,
+			logger,
 			cancellationToken);
 
 		var auditLog = AuditLog.Create(

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
@@ -60,6 +60,7 @@ internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
 			opportunity.Title,
 			NotificationKind.OpportunityCancelled,
 			engagementCancellationReason,
+			logger,
 			cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -5,6 +5,7 @@ using Domain.Notifications;
 using Domain.Reports;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
 
 namespace Application.VolunteerOpportunities.Common;
 
@@ -23,10 +24,11 @@ internal static class VolunteerOpportunityDeletionHelper
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
 		DateTimeOffset now,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
 		await ResolveEngagementsAndReportsAsync(
-			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, cancellationToken);
+			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, logger, cancellationToken);
 
 		dbContext.VolunteerOpportunities.Delete(opportunity);
 	}
@@ -45,10 +47,11 @@ internal static class VolunteerOpportunityDeletionHelper
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
 		DateTimeOffset now,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
 		await ResolveEngagementsAndReportsAsync(
-			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, cancellationToken);
+			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, logger, cancellationToken);
 
 		opportunity.MarkDeleted(now).ThrowIfFailure();
 	}
@@ -60,6 +63,7 @@ internal static class VolunteerOpportunityDeletionHelper
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
 		DateTimeOffset now,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
 		await VolunteerOpportunityEngagementCascadeHelper.NotifyAndCancelActiveEngagementsAsync(
@@ -69,6 +73,7 @@ internal static class VolunteerOpportunityDeletionHelper
 			opportunity.Title,
 			NotificationKind.OpportunityDeleted,
 			"Opportunity was deleted.",
+			logger,
 			cancellationToken);
 
 		var openReports = await dbContext.GetOpenReportsForTargetAsync(

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
@@ -4,6 +4,7 @@ using Application.Engagements.Common;
 using Application.Notifications;
 using Domain.Notifications;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
 
 namespace Application.VolunteerOpportunities.Common;
 
@@ -24,6 +25,7 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 		string opportunityTitle,
 		NotificationKind opportunityNotificationKind,
 		string engagementCancellationReason,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
 		await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
@@ -33,6 +35,9 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 			opportunityNotificationKind,
 			cancellationToken);
 
+		// GetActiveEngagementsForOpportunityAsync already excludes anonymized
+		// engagements (einsatzbereit#1724), so CancelAndNotifyAsync's own guard below
+		// is defense in depth here, not the primary fix.
 		var activeEngagements = await dbContext.GetActiveEngagementsForOpportunityAsync(
 			opportunityId, cancellationToken);
 		foreach (var engagement in activeEngagements)
@@ -45,6 +50,7 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 				engagement,
 				engagementCancellationReason,
 				opportunityTitle,
+				logger,
 				cancellationToken);
 		}
 	}

--- a/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
@@ -5,11 +5,13 @@ using Application.Common.Persistence;
 using Application.Engagements.Common;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
 
 namespace Application.VolunteerOpportunities.DeleteTimeSlot.v1;
 
 internal sealed class DeleteTimeSlotCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	ILogger<DeleteTimeSlotCommandHandler> logger)
 	: ICommandHandler<DeleteTimeSlotCommand, DeleteTimeSlotResult>
 {
 	public async ValueTask<DeleteTimeSlotResult> Handle(
@@ -81,6 +83,7 @@ internal sealed class DeleteTimeSlotCommandHandler(
 				engagement,
 				"The recurring time slot series was cancelled.",
 				opportunity.Title,
+				logger,
 				cancellationToken);
 		}
 

--- a/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
@@ -6,12 +6,14 @@ using Application.Engagements;
 using Application.VolunteerOpportunities.Common;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
 
 namespace Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 
 internal sealed class DeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository)
+	IEngagementReadRepository engagementReadRepository,
+	ILogger<DeleteVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<DeleteVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -39,6 +41,7 @@ internal sealed class DeleteVolunteerOpportunityCommandHandler(
 			opportunityId,
 			request.RequestingUserId,
 			DateTimeOffset.UtcNow,
+			logger,
 			cancellationToken);
 
 		return true;

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
@@ -56,6 +56,7 @@ internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
 			opportunity.Title,
 			NotificationKind.OpportunityUnpublished,
 			"Opportunity was unpublished.",
+			logger,
 			cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -437,11 +437,19 @@ internal sealed class ApplicationDbContext(
 				FOR UPDATE")
 			.ToListAsync(cancellationToken);
 
+	// VolunteerId != null excludes an anonymized-but-active engagement (a checked-in
+	// engagement left non-terminal on purpose when its volunteer deleted their account,
+	// see DeleteMyAccountCommandHandler) - Engagement.Cancel() refuses to act on an
+	// anonymized aggregate, so an unfiltered read here would hand one to
+	// EngagementCancellationHelper.CancelAndNotifyAsync and permanently 409 the whole
+	// deletion cascade (einsatzbereit#1724). Mirrors the same predicate already used by
+	// EngagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync.
 	public async Task<List<Engagement>> GetActiveEngagementsForOpportunityAsync(
 		VolunteerOpportunityId opportunityId,
 		CancellationToken cancellationToken = default) =>
 		await Set<Engagement>()
 			.Where(e => e.OpportunityId == opportunityId
+				&& e.VolunteerId != null
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 			.ToListAsync(cancellationToken);
 
@@ -455,8 +463,11 @@ internal sealed class ApplicationDbContext(
 		// mirrors elsewhere in this class.
 		var nullableIds = timeSlotIds.Select(id => (TimeSlotId?)id).ToList();
 
+		// VolunteerId != null - see GetActiveEngagementsForOpportunityAsync above
+		// (einsatzbereit#1724).
 		return await Set<Engagement>()
 			.Where(e => nullableIds.Contains(e.TimeSlotId)
+				&& e.VolunteerId != null
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 			.ToListAsync(cancellationToken);
 	}
@@ -475,8 +486,14 @@ internal sealed class ApplicationDbContext(
 
 		var now = DateTimeOffset.UtcNow;
 
+		// VolunteerId != null - same reasoning as GetActiveEngagementsForOpportunityAsync
+		// above: without it, an anonymized-but-active engagement (checked-in, volunteer
+		// account deleted) permanently trips this guard and the organization can never be
+		// deleted, since the deletion this guard gates for is what would otherwise resolve
+		// it (einsatzbereit#1724).
 		var opportunityIdsWithActiveEngagements = await Set<Engagement>()
 			.Where(e => opportunityIds.Contains(e.OpportunityId)
+				&& e.VolunteerId != null
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 			.Select(e => e.OpportunityId)
 			.Distinct()

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -104,9 +104,21 @@ internal sealed class EngagementConfiguration
 		// Individual-contact engagements have no time slot, so the index above
 		// doesn't constrain them (Postgres treats every NULL as distinct) - keep the
 		// original one-engagement-per-opportunity rule for that case explicitly.
+		//
+		// The "AND status NOT IN (...)" half of the filter (einsatzbereit#1724) matters
+		// for a *time-slot* signup, not an individual-contact one: a volunteer can
+		// legitimately hold two Engagement rows for the same opportunity (differing only
+		// by time_slot_id) by signing up for two slots of the same recurring series
+		// (#1067). Deleting both slots at once cancels their engagements first, then
+		// hard-deletes the TimeSlot rows, which nulls time_slot_id on both engagements via
+		// its ON DELETE SET NULL FK below - without the status half of this filter, both
+		// now-Cancelled rows would land in this partial index at the same
+		// (volunteer_id, opportunity_id) and collide, 500ing the whole deletion.
+		// Excluding terminal engagements keeps only a genuinely-live individual-contact
+		// engagement covered, which is all this index ever needed to constrain.
 		builder.HasIndex(e => new { e.VolunteerId, e.OpportunityId })
 			.IsUnique()
-			.HasFilter("time_slot_id IS NULL");
+			.HasFilter("time_slot_id IS NULL AND status NOT IN ('Cancelled', 'Withdrawn')");
 
 		builder.HasOne<TimeSlot>()
 			.WithMany()

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807170000_RestrictEngagementOpportunityIndexToLiveStatuses.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807170000_RestrictEngagementOpportunityIndexToLiveStatuses.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260807170000_RestrictEngagementOpportunityIndexToLiveStatuses")]
+	partial class RestrictEngagementOpportunityIndexToLiveStatuses
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807170000_RestrictEngagementOpportunityIndexToLiveStatuses.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807170000_RestrictEngagementOpportunityIndexToLiveStatuses.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	// einsatzbereit#1724: ix_engagement_volunteer_id_opportunity_id and
+	// ix_engagement_volunteer_id_time_slot_id previously disagreed - a volunteer
+	// signed up for two time slots of the same recurring opportunity legitimately
+	// holds two rows sharing (volunteer_id, opportunity_id), differing only by
+	// time_slot_id. Deleting both slots at once cancels their engagements first,
+	// then hard-deletes the TimeSlot rows, which nulls time_slot_id on both
+	// engagements via its ON DELETE SET NULL FK - the two now-Cancelled rows then
+	// collided on this partial index (both matching volunteer_id + opportunity_id
+	// with time_slot_id IS NULL) and 500'd the deletion. Narrowing the filter to
+	// only live (non-terminal) engagements excludes cancelled/withdrawn rows from
+	// the index entirely, so two of them landing on the same (volunteer_id,
+	// opportunity_id, time_slot_id IS NULL) combination no longer collides.
+	public partial class RestrictEngagementOpportunityIndexToLiveStatuses : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement",
+				columns: new[] { "volunteer_id", "opportunity_id" },
+				unique: true,
+				filter: "time_slot_id IS NULL AND status NOT IN ('Cancelled', 'Withdrawn')");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_volunteer_id_opportunity_id",
+				table: "engagement",
+				columns: new[] { "volunteer_id", "opportunity_id" },
+				unique: true,
+				filter: "time_slot_id IS NULL");
+		}
+	}
+}

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Domain.Notifications;
 using Domain.Organizations;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.Engagements.CancelEngagement;
@@ -43,7 +44,7 @@ public class CancelEngagementCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_sut = new CancelEngagementCommandHandler(_dbContext);
+		_sut = new CancelEngagementCommandHandler(_dbContext, NullLogger<CancelEngagementCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -12,6 +12,7 @@ using Domain.Primitives;
 using Domain.Reports;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.Organizations.AdminShadowDeleteOrganization;
@@ -56,7 +57,8 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new AdminShadowDeleteOrganizationCommandHandler(_dbContext, _engagementReadRepository);
+		_sut = new AdminShadowDeleteOrganizationCommandHandler(
+			_dbContext, _engagementReadRepository, NullLogger<AdminShadowDeleteOrganizationCommandHandler>.Instance);
 	}
 
 	private static Organization CreateOrganization(Guid id) =>

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using Domain.Organizations;
 using Domain.Reports;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.Organizations.DeleteOrganization;
@@ -51,7 +52,8 @@ public class DeleteOrganizationCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Guid>());
-		_sut = new DeleteOrganizationCommandHandler(_dbContext, _keycloakService, _engagementReadRepository);
+		_sut = new DeleteOrganizationCommandHandler(
+			_dbContext, _keycloakService, _engagementReadRepository, NullLogger<DeleteOrganizationCommandHandler>.Instance);
 	}
 
 	private void AllowRequestingUserInOrg(Guid orgId) =>

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -12,6 +12,7 @@ using Domain.Primitives;
 using Domain.Reports;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity;
@@ -51,7 +52,8 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository);
+		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(
+			_dbContext, _engagementReadRepository, NullLogger<AdminShadowDeleteVolunteerOpportunityCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.VolunteerOpportunities.DeleteTimeSlot;
@@ -39,7 +40,7 @@ public class DeleteTimeSlotCommandHandlerTests
 		_dbContext
 			.GetActiveEngagementsForTimeSlotsAsync(Arg.Any<IReadOnlyCollection<TimeSlotId>>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Engagement>());
-		_sut = new DeleteTimeSlotCommandHandler(_dbContext);
+		_sut = new DeleteTimeSlotCommandHandler(_dbContext, NullLogger<DeleteTimeSlotCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateOpportunityWithTimeSlot(out TimeSlot timeSlot)

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -11,6 +11,7 @@ using Domain.Primitives;
 using Domain.Reports;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Application.UnitTests.VolunteerOpportunities.DeleteVolunteerOpportunity;
@@ -47,7 +48,8 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_sut = new DeleteVolunteerOpportunityCommandHandler(_dbContext, _engagementReadRepository);
+		_sut = new DeleteVolunteerOpportunityCommandHandler(
+			_dbContext, _engagementReadRepository, NullLogger<DeleteVolunteerOpportunityCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -210,6 +210,63 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 		stillThere.Name.Should().Be("Sole Organizer Test Org");
 	}
 
+	[Test]
+	public async Task DeleteVolunteerOpportunity_ShouldSucceed_WhenAnAnonymizedEngagementIsCheckedIn(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1724: DeleteMyAccount deliberately leaves a checked-in
+		// engagement non-terminal (Withdraw() refuses a checked-in engagement,
+		// Engagement.cs) while anonymizing it (VolunteerId set to null). The
+		// opportunity-deletion cascade used to select active engagements without
+		// excluding anonymized ones, so this single row made
+		// DeleteVolunteerOpportunity 409 forever with no way to clear it - not
+		// even by cancelling the engagement directly, since Engagement.Cancel()
+		// refuses an anonymized aggregate too.
+		var (_, ephemeralUsername, ephemeralPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = "Anonymized Checked-In Engagement Test Org" }, cancellationToken);
+		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = "Anonymized Checked-In Engagement Test Opportunity",
+				Description = "Integration test opportunity for #1724",
+				OrganizationId = org.Id.Value,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			},
+			cancellationToken);
+
+		var engagement = await ephemeralClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { Message = "I want to help!" }, cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+
+		await ephemeralClient.DeleteMyAccountAsync(cancellationToken);
+
+		var deleteOpportunity = () => olafClient.DeleteVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+		await deleteOpportunity.Should().NotThrowAsync(
+			"an anonymized-but-checked-in engagement must not permanently block the deletion cascade (#1724)");
+
+		(await fixture.CountRowsWhereAsync("volunteer_opportunity", "id", opportunity.Id))
+			.Should().Be(0);
+
+		// The anonymized engagement itself survives as history - deletion cancels
+		// active engagements but never deletes them, and this one was skipped by
+		// the cascade (not cancelled) rather than tripping it.
+		(await fixture.CountRowsWhereAsync("engagement", "id", engagement.Id))
+			.Should().Be(1);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
 		string username, string password)
 	{

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1846,6 +1846,103 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		secondAfter.Id.Should().NotBe(firstEngagement.Id);
 	}
 
+	// ── Multi-slot signup deletion cascade (#1724) ───────────────────────────
+
+	[Test]
+	public async Task DeleteVolunteerOpportunity_ShouldSucceed_WhenOneVolunteerHasEngagementsForMultipleTimeSlots(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1724: a volunteer signing up for two slots of the same
+		// recurring opportunity legitimately holds two Engagement rows sharing
+		// (volunteer_id, opportunity_id), differing only by time_slot_id (#1067).
+		// Deleting the opportunity cancels both engagements, then hard-deletes
+		// their time slots, which nulls time_slot_id on both via its ON DELETE
+		// SET NULL FK - the two now-null rows used to collide on the
+		// (volunteer_id, opportunity_id) partial unique index and 500 the whole
+		// deletion.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateScheduledSlotsOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = "Weekly",
+				RecurrenceCount = 2,
+			},
+			cancellationToken);
+		var firstSlotId = timeSlots.ElementAt(0).Id;
+		var secondSlotId = timeSlots.ElementAt(1).Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = firstSlotId }, cancellationToken);
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = secondSlotId }, cancellationToken);
+
+		var deleteOpportunity = () => olafClient.DeleteVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+		await deleteOpportunity.Should().NotThrowAsync(
+			"two engagements sharing (volunteer_id, opportunity_id) must not collide once their time slots are hard-deleted (#1724)");
+
+		(await fixture.CountRowsWhereAsync("volunteer_opportunity", "id", opportunity.Id))
+			.Should().Be(0);
+	}
+
+	[Test]
+	public async Task DeleteTimeSlot_EntireSeries_ShouldSucceed_WhenOneVolunteerHasEngagementsForMultipleTimeSlots(
+		CancellationToken cancellationToken)
+	{
+		// Same regression as above (#1724), exercised via the "entire series"
+		// delete scope instead of a full opportunity delete -
+		// DeleteTimeSlotCommandHandler.DeleteSeriesAsync force-cancels active
+		// engagements for every affected slot before removing the slots
+		// themselves, hitting the same partial-index collision.
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateScheduledSlotsOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 10,
+				RecurrenceFrequency = "Weekly",
+				RecurrenceCount = 2,
+			},
+			cancellationToken);
+		var firstSlotId = timeSlots.ElementAt(0).Id;
+		var secondSlotId = timeSlots.ElementAt(1).Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var firstEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = firstSlotId }, cancellationToken);
+		var secondEngagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id, new CreateEngagementRequest { TimeSlotId = secondSlotId }, cancellationToken);
+
+		var deleteSeries = () => olafClient.DeleteTimeSlotAsync(
+			opportunity.Id, firstSlotId, "EntireSeries", cancellationToken);
+		await deleteSeries.Should().NotThrowAsync(
+			"two engagements sharing (volunteer_id, opportunity_id) must not collide once their time slots are hard-deleted (#1724)");
+
+		var firstEngagementId = EngagementId.Create(firstEngagement.Id).GetValueOrThrow();
+		var secondEngagementId = EngagementId.Create(secondEngagement.Id).GetValueOrThrow();
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var engagements = await dbContext.Set<Engagement>()
+			.AsNoTracking()
+			.Where(e => e.Id == firstEngagementId || e.Id == secondEngagementId)
+			.ToListAsync(cancellationToken);
+		engagements.Should().HaveCount(2);
+		engagements.Should().OnlyContain(e => e.Status == EngagementStatus.Cancelled);
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(


### PR DESCRIPTION
## What

Fixes two independent defects in the opportunity/time-slot/organization deletion cascade that make deletion fail permanently with no self-service recovery.

## Why

Closes #1724

**1. Anonymized-but-active engagements brick the whole cascade.** `DeleteMyAccountCommandHandler` deliberately leaves a checked-in engagement non-terminal (`Withdraw()` refuses a checked-in engagement) while anonymizing it (`VolunteerId` set to `null`). The deletion cascade's active-engagement queries in `ApplicationDbContext` had no `VolunteerId != null` predicate (unlike the sibling `EngagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync`), so they handed the anonymized row to `EngagementCancellationHelper.CancelAndNotifyAsync`, which threw because `Engagement.Cancel()` refuses to act on an anonymized aggregate. This made `DELETE /v1/volunteer-opportunities/{id}` (organizer and admin shadow-delete), the Cancel/Unpublish domain-event handlers, and `DeleteOrganization`'s blocking-opportunity guard all fail forever - and an organizer couldn't even manually clear the blocking engagement via `CancelEngagement`, since it routes through the same helper.

  Fixed by:
  - Adding `&& e.VolunteerId != null` to `GetActiveEngagementsForOpportunityAsync`, `GetActiveEngagementsForTimeSlotsAsync`, and the blocking-engagements subquery in `GetBlockingOpportunitiesForOrganizationAsync`.
  - Making `EngagementCancellationHelper.CancelAndNotifyAsync` skip and log (rather than throw) when the engagement is anonymized - there's no volunteer left to notify either. It now returns a `bool` indicating whether it actually cancelled anything, so `CancelEngagementCommandHandler` only writes an `EngagementCancelled` audit entry when something really changed.

**2. Two contradictory unique indexes on `engagement`.** A volunteer can legitimately hold two `Engagement` rows sharing `(volunteer_id, opportunity_id)` by signing up for two time slots of the same recurring opportunity (#1067). Deletion cancels engagements before removing their time slots, but never deletes the rows - when both slots are hard-deleted together, `ON DELETE SET NULL` nulls `time_slot_id` on both rows at once, and they used to collide on the `(volunteer_id, opportunity_id) WHERE time_slot_id IS NULL` partial unique index, rolling back the transaction and 500ing the request.

  Fixed by narrowing that index's filter to `time_slot_id IS NULL AND status NOT IN ('Cancelled', 'Withdrawn')` (migration `RestrictEngagementOpportunityIndexToLiveStatuses`) - since deletion always cancels engagements first, the two now-cancelled rows fall outside the index entirely instead of colliding.

## Testing

- `Application.UnitTests`: updated the six handler test suites whose constructors gained an `ILogger<T>` parameter (`CancelEngagementCommandHandlerTests`, `DeleteTimeSlotCommandHandlerTests`, `DeleteVolunteerOpportunityCommandHandlerTests`, `AdminShadowDeleteVolunteerOpportunityCommandHandlerTests`, `DeleteOrganizationCommandHandlerTests`, `AdminShadowDeleteOrganizationCommandHandlerTests`) to pass `NullLogger<T>.Instance`.
- `IntegrationTests`: added two new regression tests per the issue's suggested test coverage:
  - `AccountDeletionTests.DeleteVolunteerOpportunity_ShouldSucceed_WhenAnAnonymizedEngagementIsCheckedIn` - deletes a checked-in volunteer's account, then deletes the opportunity; asserts the delete succeeds and the anonymized engagement row survives as history.
  - `EngagementTests.DeleteVolunteerOpportunity_ShouldSucceed_WhenOneVolunteerHasEngagementsForMultipleTimeSlots` and `EngagementTests.DeleteTimeSlot_EntireSeries_ShouldSucceed_WhenOneVolunteerHasEngagementsForMultipleTimeSlots` - sign one volunteer up for two slots of one opportunity, then delete the opportunity / the entire series; asserts both succeed instead of 500ing.
- Ran `/self-review` and the `ef-migration-check` subagent against the migration/model-snapshot changes (no drift found - the migration was hand-written since the sandbox has no network access to install the .NET SDK; it should still get a `dotnet ef migrations add` diff-check as a sanity check before merge).

I could not run `dotnet build`/the test suites locally in this sandbox (outbound access to the .NET SDK installer is blocked by this environment's network policy), so this relies on CI's `dotnet.yml` for the actual build/test signal - I'll monitor it and fix anything that comes back red.

## Live verification

Not performed for this PR, per explicit instruction not to cut a release candidate. CI's `IntegrationTests` job exercises the new regression tests against a real Postgres instance, which is the closest available signal to a live check for this fix.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal bug fix, no user-facing behavior/doc change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQb67D6wjEeGD16NLoywHJ)_