### PR TITLE
fix: match transparent-header border styling on bell and account menu

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -48,6 +48,27 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task HomePage_NotificationBellAndAccountMenu_HaveDarkTransparentTheme_OnHero()
+	{
+		// Regression for #1737: only LanguageSelector's button carried a
+		// border that switched color with the isTransparent prop - the
+		// notification bell and account-menu buttons stayed unbordered
+		// against the dark hero, looking inconsistent with the language
+		// selector's themed pill. Both must now carry the same translucent
+		// white border while the header is transparent.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(bell).ToHaveClassAsync(new Regex("border-white"));
+
+		var userMenuBtn = Page.GetByRole(AriaRole.Button, new() { Name = "User menu" });
+		await Expect(userMenuBtn).ToHaveClassAsync(new Regex("border-white"));
+	}
+
+	[Test]
 	public async Task HomePage_HasNoBreadcrumb()
 	{
 		// #574: pages that don't call usePageToolbar must not render a stray

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -60,7 +60,7 @@ export default function AccountControls({
 				<button
 					type="button"
 					onClick={() => setDropdownOpen((o) => !o)}
-					className="flex cursor-pointer items-center gap-1.5 rounded-full p-0.5 transition-all hover:ring-2 hover:ring-brand-200"
+					className={`flex cursor-pointer items-center gap-1.5 rounded-full border p-0.5 transition-all ${transparent ? "border-white/30 hover:bg-white/10" : "border-transparent hover:ring-2 hover:ring-brand-200"}`}
 					aria-label={t("nav.userMenu")}
 					aria-expanded={dropdownOpen}
 				>

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -94,7 +94,7 @@ export default function NotificationDropdown({
 				type="button"
 				data-testid={mobile ? "notification-bell-mobile" : "notification-bell"}
 				onClick={() => setNotifOpen((o) => !o)}
-				className={`relative cursor-pointer rounded-lg p-2 transition-colors ${transparent ? "text-white/90 hover:bg-white/10 hover:text-white" : "text-gray-500 hover:bg-brand-50 hover:text-brand-600"}`}
+				className={`relative cursor-pointer rounded-lg border p-2 transition-colors ${transparent ? "border-white/30 text-white/90 hover:bg-white/10 hover:text-white" : "border-transparent text-gray-500 hover:bg-brand-50 hover:text-brand-600"}`}
 				aria-label={bellLabel}
 				aria-controls={panelId}
 				aria-expanded={notifOpen}


### PR DESCRIPTION
## What

On the homepage's transparent (unscrolled) header, the notification bell and the account/avatar menu button now pick up the same translucent-white border treatment as the language selector, so all three desktop nav controls read as one consistent themed group instead of one styled pill next to two unstyled ones.

## Why

Closes #1737

`DesktopHeader.tsx` passes `isTransparent` down to all three controls, but only `LanguageSelector.tsx` fully implemented it - it always renders a `border` whose color branches on the prop. `NotificationDropdown.tsx`'s bell button varied text/hover color but had no `border` class at all, and `AccountControls.tsx`'s avatar button only forwarded the prop to the chevron icon's color, leaving the button itself (and its hover ring) unconditional. Both now follow the exact same `border` + conditional-color pattern already used by `LanguageSelector.tsx`.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (193/193), `pnpm format:write` - all clean, no diff
- `/self-review` run; delegated to the `a11y-check` subagent for the `.tsx` changes - reported clean (no focus-visible/contrast regression; the added border sits outside the existing focus ring and doesn't touch text color)
- Added `HomePage_NotificationBellAndAccountMenu_HaveDarkTransparentTheme_OnHero` to `backend/tests/VisualTests/NavigationTests.cs`, mirroring the existing `HomePage_LanguageSelector_HasDarkTransparentTheme_OnHero` regression test - asserts both buttons carry a `border-white` class while signed in on the transparent homepage hero. This ran (and passed) in CI's `dotnet.yml` `visual-tests` job on this PR, and again in `publish.yml`'s `Backend Visual Tests` job for the `v1.0.0-rc.343` tag.

## Live verification

A release candidate (`v1.0.0-rc.343`) was cut from this branch after PR CI went green. `publish.yml` ran end to end: `Backend Build`/`Fast Tests`/`Integration Tests`/`Visual Tests` all green, `Publish Backend`/`Publish Frontend`/`Publish Keycloak` all succeeded, `GitHub Release` created, and `Deploy to Staging` completed with its post-deploy health gate passing (`Deploy to Production` correctly skipped for an RC tag).

Independent interactive verification against `https://einsatzbereit.maik-hasler.de` via the `/live-verify` Playwright script could **not** be completed in this session: both `einsatzbereit.maik-hasler.de` and `api.maik-hasler.de` are blocked by this session's outbound egress policy (`gateway answered 403 to CONNECT` per the proxy's own diagnostics - the same class of block hit earlier trying to install the .NET SDK from `builds.dotnet.microsoft.com`). This is a session-level network restriction, not an application issue, so it wasn't worked around.

Evidence the fix is live and working:
- `Deploy to Staging`'s post-deploy health gate (run from GitHub's own runner, not this session) passed against the newly-deployed images containing this change.
- The regression test added above exercises the exact same assertion (`border-white` class present on both buttons while `isTransparent` is true) that a live-verify script would have checked, and passed against a real running Aspire stack (Postgres + Keycloak + backend + frontend) in CI.

Recommend a follow-up interactive spot-check on staging from a session with network access to `maik-hasler.de`, though the evidence above already gives reasonable confidence the fix works as intended.

## Checklist

- [x] `/self-review` run and findings addressed (a11y-check subagent: clean)
- [x] CI is green
- [x] Documentation updated if this change affects behavior (N/A - internal styling fix, no docs impact)
