### PR TITLE
fix: close GDPR erasure and email opt-out gaps for shadow-deleted users

### DIFF
--- a/backend/src/Api/Users/DeleteMyAccount/v1/DeleteMyAccountEndpoint.cs
+++ b/backend/src/Api/Users/DeleteMyAccount/v1/DeleteMyAccountEndpoint.cs
@@ -17,6 +17,7 @@ internal sealed class DeleteMyAccountEndpoint : IEndpoint
 			.WithTags("Users")
 			.Produces(StatusCodes.Status204NoContent)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)

--- a/backend/src/Api/Users/Unsubscribe/v1/UnsubscribeEndpoint.cs
+++ b/backend/src/Api/Users/Unsubscribe/v1/UnsubscribeEndpoint.cs
@@ -11,14 +11,21 @@ namespace Api.Users.Unsubscribe.v1;
 // One-click unsubscribe link embedded in transactional emails (#1055) - must work
 // for a recipient who never signed in, so this is intentionally unauthenticated
 // and identifies the target solely via the opaque per-user UnsubscribeToken.
+//
+// POST, not GET (#1725): the email footer links here through a frontend
+// confirmation page (UnsubscribeLinkBuilder builds that URL, not this one
+// directly) that only calls this endpoint once the recipient explicitly
+// clicks a confirm button. A GET here would let a mail scanner or link
+// prefetcher silently trigger the opt-out just by following the link in the
+// email body, without the recipient ever choosing to leave.
 internal sealed class UnsubscribeEndpoint
 	: IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app) =>
-		app.MapGet("/users/{userId:guid}/unsubscribe", UnsubscribeAsync)
+		app.MapPost("/users/{userId:guid}/unsubscribe", UnsubscribeAsync)
 			.WithName("Unsubscribe")
 			.WithTags("Users")
-			.Produces(StatusCodes.Status302Found)
+			.Produces(StatusCodes.Status204NoContent)
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
@@ -26,18 +33,11 @@ internal sealed class UnsubscribeEndpoint
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);
 
-	// Redirects into a branded, localized frontend route rather than returning raw
-	// HTML directly (#1675) - this endpoint has no locale of its own to render in,
-	// so the frontend's own i18n (German-default) takes over from here. Reuses the
-	// same Cors:Origins-derived frontend base URL as GetSitemapEndpoint/
-	// GetEngagementCalendarEndpoint, since there's no dedicated "frontend base URL"
-	// setting in this codebase.
 	private static async Task<IResult> UnsubscribeAsync(
 		[FromRoute] Guid userId,
 		[FromQuery] string type,
 		[FromQuery] Guid token,
 		[FromServices] ISender sender,
-		[FromServices] IConfiguration configuration,
 		CancellationToken cancellationToken)
 	{
 		if (!Enum.TryParse<EmailNotificationType>(type, out var notificationType))
@@ -49,9 +49,6 @@ internal sealed class UnsubscribeEndpoint
 			new UnsubscribeCommand(UserId.Create(userId).GetValueOrThrow(), token, notificationType),
 			cancellationToken);
 
-		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
-		var frontendBaseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
-
-		return Results.Redirect($"{frontendBaseUrl}/unsubscribed?type={Uri.EscapeDataString(type)}");
+		return Results.NoContent();
 	}
 }

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -1870,6 +1870,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "content": {
@@ -1965,7 +1975,7 @@
       }
     },
     "/v1/users/{userId}/unsubscribe": {
-      "get": {
+      "post": {
         "tags": [
           "Users"
         ],
@@ -1999,8 +2009,8 @@
           }
         ],
         "responses": {
-          "302": {
-            "description": "Found"
+          "204": {
+            "description": "No Content"
           },
           "400": {
             "description": "Bad Request",

--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -50,6 +50,15 @@ public interface IApplicationDbContext
 		UserId reporterId,
 		CancellationToken cancellationToken = default);
 
+	// Report.TargetId is an untyped uuid with no FK/navigation to User (it's
+	// polymorphic - User, Organization, or VolunteerOpportunity depending on
+	// TargetType), and this needs to see the *unfiltered* physical user row
+	// rather than EF's !IsDeleted query filter, so a merely shadow-deleted
+	// user (row still exists) is correctly left alone - returns the number of
+	// report rows deleted (einsatzbereit#1725).
+	Task<int> DeleteReportsTargetingNonExistentUsersAsync(
+		CancellationToken cancellationToken = default);
+
 	Task<List<VolunteerOpportunity>> GetVolunteerOpportunitiesByIdsAsync(
 		IReadOnlyCollection<VolunteerOpportunityId> opportunityIds,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Notifications/MarkAllNotificationsRead/v1/MarkAllNotificationsReadCommandHandler.cs
+++ b/backend/src/Application/Notifications/MarkAllNotificationsRead/v1/MarkAllNotificationsReadCommandHandler.cs
@@ -14,8 +14,9 @@ internal sealed class MarkAllNotificationsReadCommandHandler(
 		var unread = await dbContext.GetUnreadNotificationsForRecipientAsync(
 			request.RecipientId, cancellationToken);
 
+		var now = DateTimeOffset.UtcNow;
 		foreach (var n in unread)
-			n.MarkRead();
+			n.MarkRead(now);
 
 		return unread.Count;
 	}

--- a/backend/src/Application/Notifications/MarkNotificationRead/v1/MarkNotificationReadCommandHandler.cs
+++ b/backend/src/Application/Notifications/MarkNotificationRead/v1/MarkNotificationReadCommandHandler.cs
@@ -17,7 +17,7 @@ internal sealed class MarkNotificationReadCommandHandler(
 		if (notification is null || notification.RecipientId.Value != request.RequestingUserId)
 			return false;
 
-		notification.MarkRead();
+		notification.MarkRead(DateTimeOffset.UtcNow);
 		return true;
 	}
 }

--- a/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
+++ b/backend/src/Application/Users/DeleteMyAccount/v1/DeleteMyAccountCommandHandler.cs
@@ -42,31 +42,35 @@ internal sealed class DeleteMyAccountCommandHandler(
 		await dbContext.DeleteSearchAlertForUserAsync(request.UserId, cancellationToken);
 		await dbContext.DeleteReportsForReporterAsync(request.UserId, cancellationToken);
 
-		var user = await dbContext.Users.FindAsync(request.UserId, cancellationToken);
-		if (user is not null)
+		// IgnoreQueryFilters() lookup (einsatzbereit#1725) - a shadow-deleted user's
+		// row is hidden by UserConfiguration's !IsDeleted query filter but still
+		// physically exists, so dbContext.Users.FindAsync would silently no-op here
+		// (no avatar delete, no MarkAccountDeleted -> no Keycloak deletion) while
+		// this handler kept reporting success.
+		var user = await dbContext.FindUserIncludingDeletedAsync(request.UserId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("User.NotFound", "User not found."));
+
+		// The avatar's random object key (issue #1175) can't be reconstructed
+		// from the user id, so it has to come from the stored AvatarUrl instead
+		// of a guessed extension.
+		var avatarObjectKey = user.AvatarUrl is not null
+			? fileStorage.GetObjectKeyFromPublicUrl(user.AvatarUrl)
+			: null;
+
+		if (avatarObjectKey is not null)
 		{
-			// The avatar's random object key (issue #1175) can't be reconstructed
-			// from the user id, so it has to come from the stored AvatarUrl instead
-			// of a guessed extension.
-			var avatarObjectKey = user.AvatarUrl is not null
-				? fileStorage.GetObjectKeyFromPublicUrl(user.AvatarUrl)
-				: null;
-
-			if (avatarObjectKey is not null)
+			try
 			{
-				try
-				{
-					await fileStorage.DeleteAsync(avatarObjectKey, cancellationToken);
-				}
-				catch
-				{
-					// Object may already be gone or storage may be transiently unavailable; continue.
-				}
+				await fileStorage.DeleteAsync(avatarObjectKey, cancellationToken);
 			}
-
-			user.MarkAccountDeleted();
-			dbContext.Users.Delete(user);
+			catch
+			{
+				// Object may already be gone or storage may be transiently unavailable; continue.
+			}
 		}
+
+		user.MarkAccountDeleted();
+		dbContext.Users.Delete(user);
 
 		return true;
 	}

--- a/backend/src/Domain/Notifications/Notification.cs
+++ b/backend/src/Domain/Notifications/Notification.cs
@@ -15,6 +15,12 @@ public sealed class Notification
 
 	public bool IsRead { get; private set; }
 
+	// Stamped by MarkRead() with the moment it was actually read (#1725) -
+	// NotificationRetentionJob's read-retention window ("90 days after being
+	// read") must count from here, not from CreatedOn or the generic
+	// ModifiedOn (which any future unrelated mutation could also bump).
+	public DateTimeOffset? ReadOn { get; private set; }
+
 	public DateTimeOffset CreatedOn { get; private set; }
 
 	public DateTimeOffset? ModifiedOn { get; private set; }
@@ -46,13 +52,15 @@ public sealed class Notification
 			kind,
 			relatedEntityId);
 
-	public void MarkRead()
+	public void MarkRead(DateTimeOffset readOn)
 	{
 		IsRead = true;
+		ReadOn = readOn;
 	}
 
 	public void MarkUnread()
 	{
 		IsRead = false;
+		ReadOn = null;
 	}
 }

--- a/backend/src/Domain/Users/User.cs
+++ b/backend/src/Domain/Users/User.cs
@@ -141,6 +141,14 @@ public sealed class User
 			case EmailNotificationType.EngagementReminder:
 				NotifyOnEngagementReminder = false;
 				break;
+			default:
+				// Fail closed (#1725): without this arm, a future EmailNotificationType
+				// member falls through doing nothing while still returning
+				// Result.Success() below, reporting a successful opt-out that
+				// silently never took effect.
+				return Result.Failure(Error.Validation(
+					"User.UnknownEmailNotificationType",
+					$"Unknown email notification type '{type}'."));
 		}
 
 		return Result.Success();

--- a/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/NotificationRetentionJob.cs
@@ -102,7 +102,10 @@ internal sealed class NotificationRetentionJob(
 		CancellationToken cancellationToken = default) =>
 		await dbContext.Set<Notification>()
 			.Where(n =>
-				(n.IsRead && n.CreatedOn < readCutoff) ||
+				// #1725: the read branch used to key off CreatedOn, deleting a
+				// notification read a day after creation almost immediately
+				// instead of ReadRetentionDays after it was actually read.
+				(n.IsRead && n.ReadOn != null && n.ReadOn < readCutoff) ||
 				(!n.IsRead && n.CreatedOn < unreadCutoff))
 			.ExecuteDeleteAsync(cancellationToken);
 }

--- a/backend/src/Infrastructure/BackgroundJobs/ReportRetentionJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/ReportRetentionJob.cs
@@ -1,0 +1,114 @@
+using Domain.Reports;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+// Report rows had no automatic cleanup path at all (einsatzbereit#1725):
+// DeleteMyAccountCommandHandler only deletes reports the deleted user filed as
+// reporter (DeleteReportsForReporterAsync), never reports filed against them,
+// and AdminShadowDeleteUserCommandHandler only auto-resolves (MarkActioned)
+// open reports against a shadow-deleted user without ever deleting the row -
+// so reports accumulated forever with no disclosed retention period. This job
+// closes both gaps: any resolved report is pruned once it's older than
+// ResolvedRetentionDays, and a report naming a user as its target is pruned
+// immediately once that user's row is gone entirely (a hard self-deletion via
+// DeleteMyAccountCommandHandler) - a shadow-deleted user's row still
+// physically exists, so their reports are left alone by that second rule
+// until either they age out via the first rule or the account is later fully
+// erased.
+internal sealed class ReportRetentionJob(
+	IServiceScopeFactory scopeFactory,
+	ILogger<ReportRetentionJob> logger,
+	IOptions<ReportRetentionOptions> options)
+	: IHostedService, IAsyncDisposable
+{
+	private readonly ReportRetentionOptions _options = options.Value;
+
+	private Task _executeTask = Task.CompletedTask;
+	private CancellationTokenSource? _cts;
+	private PeriodicTimer? _timer;
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_timer = new PeriodicTimer(TimeSpan.FromHours(_options.RetentionCheckIntervalHours));
+		_executeTask = RunLoopAsync(_cts.Token);
+		return Task.CompletedTask;
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_cts is not null)
+			await _cts.CancelAsync();
+
+		try
+		{
+			await _executeTask.WaitAsync(cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_timer?.Dispose();
+		_cts?.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private async Task RunLoopAsync(CancellationToken ct)
+	{
+		if (_timer is null) return;
+
+		while (!ct.IsCancellationRequested && await _timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+		{
+			try
+			{
+				await TickAsync(ct).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// A row that should have been pruned this tick just gets picked up
+				// again on the next one - no data is lost by skipping a tick.
+				logger.LogError(ex, "Report retention tick failed; will retry on the next poll interval");
+			}
+		}
+	}
+
+	private async Task TickAsync(CancellationToken ct)
+	{
+		await using var scope = scopeFactory.CreateAsyncScope();
+		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+		var now = DateTimeOffset.UtcNow;
+		var deleted = await DeleteExpiredReportsAsync(
+			dbContext,
+			resolvedCutoff: now.AddDays(-_options.ResolvedRetentionDays),
+			ct);
+
+		if (deleted > 0)
+			logger.LogInformation("Pruned {Count} expired/orphaned report(s)", deleted);
+	}
+
+	// Exposed so IntegrationTests can exercise the deletion directly against a real
+	// Postgres without waiting on the real RetentionCheckIntervalHours.
+	internal static async Task<int> DeleteExpiredReportsAsync(
+		ApplicationDbContext dbContext,
+		DateTimeOffset resolvedCutoff,
+		CancellationToken cancellationToken = default)
+	{
+		var resolvedExpired = await dbContext.Set<Report>()
+			.Where(r => r.Status != ReportStatus.Open && r.ResolvedOn != null && r.ResolvedOn < resolvedCutoff)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		var orphanedTargetDeleted = await dbContext.DeleteReportsTargetingNonExistentUsersAsync(cancellationToken);
+
+		return resolvedExpired + orphanedTargetDeleted;
+	}
+}

--- a/backend/src/Infrastructure/BackgroundJobs/ReportRetentionOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/ReportRetentionOptions.cs
@@ -1,0 +1,13 @@
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class ReportRetentionOptions
+{
+	// How long a resolved (Dismissed/Actioned) report is kept before
+	// ReportRetentionJob prunes it - an Open report is never pruned by this
+	// rule alone, since it may still need moderator attention (einsatzbereit#1725).
+	public int ResolvedRetentionDays { get; init; } = 180;
+
+	// How often ReportRetentionJob checks for expired/orphaned rows - a
+	// low-frequency housekeeping concern, unlike a real-time processing job.
+	public int RetentionCheckIntervalHours { get; init; } = 24;
+}

--- a/backend/src/Infrastructure/BackgroundJobs/ReportRetentionOptionsSetup.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/ReportRetentionOptionsSetup.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.BackgroundJobs;
+
+internal sealed class ReportRetentionOptionsSetup(
+	IConfiguration configuration)
+	: IConfigureOptions<ReportRetentionOptions>
+{
+	public void Configure(ReportRetentionOptions options) =>
+		configuration.GetSection("ReportRetention").Bind(options);
+}

--- a/backend/src/Infrastructure/Email/UnsubscribeLinkBuilder.cs
+++ b/backend/src/Infrastructure/Email/UnsubscribeLinkBuilder.cs
@@ -1,14 +1,26 @@
 using Application.Common.Email;
 using Domain.Users;
-using Infrastructure.Common;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
 
 namespace Infrastructure.Email;
 
+// Points at a frontend confirmation page rather than the backend endpoint
+// directly (#1725) - the backend's unsubscribe endpoint is a state-changing
+// POST, which a plain-text email link can't trigger by itself; the frontend
+// page only calls it once the recipient explicitly clicks a confirm button,
+// so a mail scanner or link prefetcher merely loading this URL can no longer
+// silently opt anyone out. Reuses the same Cors:Origins-derived frontend base
+// URL as GetSitemapEndpoint/UnsubscribeEndpoint's former redirect, since
+// there's no dedicated "frontend base URL" setting in this codebase.
 internal sealed class UnsubscribeLinkBuilder(
-	IOptions<ApiOptions> options)
+	IConfiguration configuration)
 	: IUnsubscribeLinkBuilder
 {
-	public string Build(UserId userId, Guid unsubscribeToken, EmailNotificationType type) =>
-		$"{options.Value.PublicBaseUrl.TrimEnd('/')}/v1/users/{userId.Value}/unsubscribe?type={type}&token={unsubscribeToken}";
+	public string Build(UserId userId, Guid unsubscribeToken, EmailNotificationType type)
+	{
+		var origins = configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+		var frontendBaseUrl = origins.Length > 0 ? origins[0].TrimEnd('/') : "";
+
+		return $"{frontendBaseUrl}/unsubscribe?userId={userId.Value}&type={type}&token={unsubscribeToken}";
+	}
 }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -137,6 +137,20 @@ internal sealed class ApplicationDbContext(
 			.Where(r => r.ReporterId == reporterId)
 			.ExecuteDeleteAsync(cancellationToken);
 
+	// Raw SQL, not LINQ: a NOT EXISTS against the physical "user" table can't
+	// be expressed against Report.TargetId (a plain Guid with no FK/navigation
+	// to User - see the IApplicationDbContext doc comment), and needs to
+	// bypass EF's !IsDeleted query filter entirely rather than IgnoreQueryFilters()
+	// a LINQ subquery, so a merely shadow-deleted user's still-physically-present
+	// row is correctly left alone (einsatzbereit#1725).
+	public async Task<int> DeleteReportsTargetingNonExistentUsersAsync(
+		CancellationToken cancellationToken = default) =>
+		await Database.ExecuteSqlInterpolatedAsync($@"
+			DELETE FROM report
+			WHERE target_type = 'User'
+			  AND NOT EXISTS (SELECT 1 FROM ""user"" WHERE ""user"".id = report.target_id)",
+			cancellationToken);
+
 	public async Task<List<VolunteerOpportunity>> GetVolunteerOpportunitiesByIdsAsync(
 		IReadOnlyCollection<VolunteerOpportunityId> opportunityIds,
 		CancellationToken cancellationToken = default) =>

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -42,6 +42,8 @@ internal sealed class NotificationConfiguration
 		builder.Property(n => n.IsRead)
 			.IsRequired();
 
+		builder.Property(n => n.ReadOn);
+
 		builder.Property(n => n.CreatedOn);
 
 		builder.Property(n => n.ModifiedOn);
@@ -55,7 +57,12 @@ internal sealed class NotificationConfiguration
 		builder.HasIndex(n => new { n.RecipientId, n.CreatedOn });
 
 		// Supports NotificationRetentionJob's global prune scan (not scoped to a
-		// single recipient like the indexes above) - see einsatzbereit#1209.
+		// single recipient like the indexes above) - see einsatzbereit#1209. The
+		// unread branch still filters on CreatedOn; the read branch filters on
+		// ReadOn (#1725) - kept as two indexes since IsRead partitions the table
+		// into disjoint branches that each want a different second column.
 		builder.HasIndex(n => new { n.IsRead, n.CreatedOn });
+
+		builder.HasIndex(n => new { n.IsRead, n.ReadOn });
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807162634_AddNotificationReadOn.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807162634_AddNotificationReadOn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260807162634_AddNotificationReadOn")]
+	partial class AddNotificationReadOn
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807162634_AddNotificationReadOn.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807162634_AddNotificationReadOn.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddNotificationReadOn : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<DateTimeOffset>(
+				name: "read_on",
+				table: "notification",
+				type: "timestamp with time zone",
+				nullable: true);
+
+			// einsatzbereit#1725: backfill read_on for rows that were already read
+			// before this column existed. CreatedOn is the closest available proxy
+			// for "when it was read" (matches the pre-fix retention behavior for
+			// these rows exactly, rather than either deleting them immediately or
+			// granting them an indefinite extension).
+			migrationBuilder.Sql("UPDATE notification SET read_on = created_on WHERE is_read = true;");
+
+			migrationBuilder.CreateIndex(
+				name: "ix_notification_is_read_read_on",
+				table: "notification",
+				columns: new[] { "is_read", "read_on" });
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_notification_is_read_read_on",
+				table: "notification");
+
+			migrationBuilder.DropColumn(
+				name: "read_on",
+				table: "notification");
+		}
+	}
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -129,6 +129,8 @@ public static class ServiceCollectionExtensions
 		services.AddHostedService<CheckInAttemptPruneJob>();
 		services.ConfigureOptions<NotificationRetentionOptionsSetup>();
 		services.AddHostedService<NotificationRetentionJob>();
+		services.ConfigureOptions<ReportRetentionOptionsSetup>();
+		services.AddHostedService<ReportRetentionJob>();
 
 
 		// IntegrationTests/VisualTests set Geocoding__UseFakeService=true (see

--- a/backend/tests/Application.UnitTests/Notifications/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandlerTests.cs
@@ -39,6 +39,7 @@ public class MarkAllNotificationsReadCommandHandlerTests
 		// Assert
 		result.Should().Be(3);
 		unread.Should().OnlyContain(n => n.IsRead);
+		unread.Should().OnlyContain(n => n.ReadOn != null);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/Notifications/MarkNotificationRead/MarkNotificationReadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkNotificationRead/MarkNotificationReadCommandHandlerTests.cs
@@ -37,6 +37,7 @@ public class MarkNotificationReadCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		notification.IsRead.Should().BeTrue();
+		notification.ReadOn.Should().NotBeNull();
 	}
 
 	[Test]
@@ -85,7 +86,7 @@ public class MarkNotificationReadCommandHandlerTests
 		var recipientUserId = UserId.New();
 		var notification = Notification.Create(
 			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
-		notification.MarkRead();
+		notification.MarkRead(DateTimeOffset.UtcNow);
 		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
 		var command = new MarkNotificationReadCommand(notification.Id, recipientUserId.Value);
 

--- a/backend/tests/Application.UnitTests/Notifications/MarkNotificationUnread/MarkNotificationUnreadCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/MarkNotificationUnread/MarkNotificationUnreadCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class MarkNotificationUnreadCommandHandlerTests
 		var recipientUserId = UserId.New();
 		var notification = Notification.Create(
 			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
-		notification.MarkRead();
+		notification.MarkRead(DateTimeOffset.UtcNow);
 		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
 		var command = new MarkNotificationUnreadCommand(notification.Id, recipientUserId.Value);
 
@@ -38,6 +38,7 @@ public class MarkNotificationUnreadCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		notification.IsRead.Should().BeFalse();
+		notification.ReadOn.Should().BeNull();
 	}
 
 	[Test]
@@ -64,7 +65,7 @@ public class MarkNotificationUnreadCommandHandlerTests
 		var recipientUserId = UserId.New();
 		var notification = Notification.Create(
 			recipientUserId, NotificationKind.EngagementCreated, Guid.NewGuid());
-		notification.MarkRead();
+		notification.MarkRead(DateTimeOffset.UtcNow);
 		_notificationRepo.FindAsync(notification.Id, cancellationToken).Returns(notification);
 		var command = new MarkNotificationUnreadCommand(notification.Id, Guid.NewGuid());
 

--- a/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/DeleteMyAccount/DeleteMyAccountCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Users.DeleteMyAccount.v1;
 using AwesomeAssertions;
 using Domain.Engagements;
 using Domain.Organizations;
+using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
@@ -31,6 +32,12 @@ public class DeleteMyAccountCommandHandlerTests
 		_dbContext
 			.GetOrganizerOrganizationsAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Organization>());
+		// Default: a plain, non-deleted user is found for any lookup - tests that
+		// only care about an unrelated side effect don't need to configure this
+		// themselves. Tests exercising the user-lookup path override it directly.
+		_dbContext
+			.FindUserIncludingDeletedAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(_ => User.Create(DefaultUserId));
 		_sut = new DeleteMyAccountCommandHandler(_dbContext, _fileStorage);
 	}
 
@@ -164,7 +171,7 @@ public class DeleteMyAccountCommandHandlerTests
 		// Arrange
 		var user = User.Create(DefaultUserId);
 		user.SetAvatarUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png");
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		_fileStorage
 			.GetObjectKeyFromPublicUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png")
 			.Returns($"user-avatars/{DefaultUserId.Value}/abc123.png");
@@ -188,7 +195,7 @@ public class DeleteMyAccountCommandHandlerTests
 	{
 		// Arrange
 		var user = User.Create(DefaultUserId);
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act
@@ -208,7 +215,7 @@ public class DeleteMyAccountCommandHandlerTests
 		// return type is string?.
 		var user = User.Create(DefaultUserId);
 		user.SetAvatarUrl("not-a-valid-storage-url");
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		_fileStorage.GetObjectKeyFromPublicUrl("not-a-valid-storage-url").Returns((string?)null);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
@@ -225,7 +232,7 @@ public class DeleteMyAccountCommandHandlerTests
 	{
 		// Arrange
 		var user = User.Create(DefaultUserId);
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act
@@ -236,18 +243,51 @@ public class DeleteMyAccountCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldSkipAvatarDeletionAndUserRowDelete_WhenLocalUserRowIsMissing(
+	public async Task Handle_ShouldThrowNotFound_WhenLocalUserRowIsMissing(
 		CancellationToken cancellationToken)
 	{
-		// Arrange - FindAsync is unconfigured and defaults to null, simulating a missing local user row.
+		// Arrange - issue #1725: a missing local row must never again be reported
+		// as a successful erasure. FindUserIncludingDeletedAsync overridden back
+		// to null for this specific call, overriding the constructor's default.
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns((User?)null);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act
-		await _sut.Handle(command, cancellationToken);
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
 
 		// Assert
+		var thrown = await act.Should().ThrowAsync<ResultFailureException>();
+		thrown.Which.Error.Type.Should().Be(ErrorType.NotFound);
 		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
 		_usersRepo.DidNotReceive().Delete(Arg.Any<User>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldFullyProcessDeletion_WhenUserWasPreviouslyShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - issue #1725: dbContext.Users.FindAsync is filtered by
+		// UserConfiguration's !IsDeleted query filter and would never see a
+		// shadow-deleted row. FindUserIncludingDeletedAsync must be used instead
+		// so avatar deletion, the UserAccountDeletedDomainEvent (-> Keycloak
+		// deletion), and the row's hard delete all still run.
+		var user = User.Create(DefaultUserId);
+		user.SetAvatarUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png");
+		user.MarkDeleted(DateTimeOffset.UtcNow).ThrowIfFailure();
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl($"https://example.com/user-avatars/{DefaultUserId.Value}/abc123.png")
+			.Returns($"user-avatars/{DefaultUserId.Value}/abc123.png");
+		var command = new DeleteMyAccountCommand(DefaultUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _fileStorage.Received(1).DeleteAsync($"user-avatars/{DefaultUserId.Value}/abc123.png", cancellationToken);
+		_usersRepo.Received(1).Delete(user);
+		user.Events.Should().ContainSingle().Which.Should().BeOfType<UserAccountDeletedDomainEvent>();
 	}
 
 	[Test]
@@ -259,7 +299,7 @@ public class DeleteMyAccountCommandHandlerTests
 		// UserAccountDeletedDomainEventHandler). The handler's only job is to raise that event
 		// on the aggregate once the local row is actually about to be deleted.
 		var user = User.Create(DefaultUserId);
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act
@@ -277,7 +317,7 @@ public class DeleteMyAccountCommandHandlerTests
 	{
 		// Arrange
 		var user = User.Create(DefaultUserId);
-		_usersRepo.FindAsync(DefaultUserId, cancellationToken).Returns(user);
+		_dbContext.FindUserIncludingDeletedAsync(DefaultUserId, cancellationToken).Returns(user);
 		var command = new DeleteMyAccountCommand(DefaultUserId);
 
 		// Act

--- a/backend/tests/Application.UnitTests/Users/UserTests.cs
+++ b/backend/tests/Application.UnitTests/Users/UserTests.cs
@@ -112,4 +112,25 @@ public class UserTests
 		result.IsSuccess.Should().BeTrue();
 		user.NotifyOnWithdrawal.Should().BeFalse();
 	}
+
+	[Test]
+	public void Unsubscribe_ShouldMakeIsSubscribedToFalse_ForEveryKnownEmailNotificationType()
+	{
+		// Data-driven regression guard for issue #1725: Unsubscribe's switch used
+		// to have no default arm, so a future EmailNotificationType member would
+		// fall through returning Result.Success() while leaving IsSubscribedTo
+		// true - a silently-failed opt-out. Iterating Enum.GetValues() means this
+		// test starts failing the moment a new member is added without also
+		// wiring up Unsubscribe for it, rather than only when someone remembers
+		// to hand-write a case for it.
+		foreach (var type in Enum.GetValues<EmailNotificationType>())
+		{
+			var user = User.Create(UserId.New());
+
+			var result = user.Unsubscribe(type, user.UnsubscribeToken);
+
+			result.IsSuccess.Should().BeTrue($"Unsubscribe should succeed for {type}");
+			user.IsSubscribedTo(type).Should().BeFalse($"IsSubscribedTo({type}) should be false after unsubscribing");
+		}
+	}
 }

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -180,6 +180,40 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task DeleteMyAccount_ShouldFullyEraseAccount_WhenUserWasPreviouslyShadowDeleted(
+		CancellationToken cancellationToken)
+	{
+		// #1725: DeleteMyAccountCommandHandler used to look up the local `user`
+		// row via the filtered dbContext.Users.FindAsync, which a shadow-deleted
+		// row (IsDeleted = true) is invisible to - the handler silently no-opped
+		// while still reporting success. Self-deletion must fully erase the
+		// account (Keycloak identity + local row) even for a user an admin
+		// already shadow-deleted.
+		var (ephemeralUserId, ephemeralUsername, ephemeralPassword) =
+			await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var ephemeralClient = await CreateAuthenticatedClientAsync(ephemeralUsername, ephemeralPassword);
+
+		// The first profile load lazily creates the local `user` row -
+		// AdminShadowDeleteUserAsync 404s otherwise (see AdminShadowDeleteUserTests).
+		await ephemeralClient.GetUserProfileAsync(cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		await adminClient.AdminShadowDeleteUserAsync(ephemeralUserId, cancellationToken);
+
+		await ephemeralClient.DeleteMyAccountAsync(cancellationToken);
+
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			"Domain.Users.UserAccountDeletedDomainEvent", TimeSpan.FromSeconds(45));
+		processed.Should().BeTrue("a shadow-deleted user's self-deletion must still delete the Keycloak identity");
+
+		var reLogin = () => fixture.GetAccessTokenAsync(ephemeralUsername, ephemeralPassword);
+		await reLogin.Should().ThrowAsync<Exception>();
+
+		(await fixture.CountRowsWhereAsync("user", "id", ephemeralUserId))
+			.Should().Be(0);
+	}
+
+	[Test]
 	public async Task DeleteMyAccount_ShouldBeBlocked_WhenUserIsSoleOrganizerOfAnOrganization(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -168,6 +168,7 @@ namespace IntegrationTests
         System.Threading.Tasks.Task<NotificationPreferencesResponse> GetNotificationPreferencesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task UnsubscribeAsync(System.Guid userId, string type, System.Guid token, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -3456,6 +3457,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 500)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3669,6 +3680,7 @@ namespace IntegrationTests
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>No Content</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task UnsubscribeAsync(System.Guid userId, string type, System.Guid token, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -3687,7 +3699,8 @@ namespace IntegrationTests
             {
                 using (var request_ = new System.Net.Http.HttpRequestMessage())
                 {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                 
@@ -3723,10 +3736,9 @@ namespace IntegrationTests
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 302)
+                        if (status_ == 204)
                         {
-                            string responseText_ = ( response_.Content == null ) ? string.Empty : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
-                            throw new ApiException("Found", status_, responseText_, headers_, null);
+                            return;
                         }
                         else
                         if (status_ == 400)
@@ -3757,13 +3769,6 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-
-                        if (status_ == 200 || status_ == 204)
-                        {
-
-                            return;
                         }
                         else
                         {

--- a/backend/tests/IntegrationTests/NotificationRetentionJobTests.cs
+++ b/backend/tests/IntegrationTests/NotificationRetentionJobTests.cs
@@ -27,9 +27,11 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 	public async Task DeleteExpiredNotificationsAsync_ReadNotificationPastReadRetention_IsRemoved(
 		CancellationToken cancellationToken)
 	{
+		// #1725: read branch keys off ReadOn, not CreatedOn - created long ago but
+		// only just past the read cutoff.
 		await using var dbContext = fixture.CreateApplicationDbContext();
 		var notificationId = await SeedNotificationAsync(
-			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(-1), cancellationToken);
+			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(-30), readOn: ReadCutoff.AddDays(-1), cancellationToken);
 
 		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
 			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
@@ -42,9 +44,11 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 	public async Task DeleteExpiredNotificationsAsync_ReadNotificationWithinReadRetention_IsNotRemoved(
 		CancellationToken cancellationToken)
 	{
+		// #1725: created long before the read cutoff, but only read recently -
+		// the old CreatedOn-based bug would have deleted this immediately.
 		await using var dbContext = fixture.CreateApplicationDbContext();
 		var notificationId = await SeedNotificationAsync(
-			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(1), cancellationToken);
+			dbContext, isRead: true, createdOn: ReadCutoff.AddDays(-30), readOn: ReadCutoff.AddDays(1), cancellationToken);
 
 		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
 			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
@@ -59,7 +63,7 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 	{
 		await using var dbContext = fixture.CreateApplicationDbContext();
 		var notificationId = await SeedNotificationAsync(
-			dbContext, isRead: false, createdOn: UnreadCutoff.AddDays(-1), cancellationToken);
+			dbContext, isRead: false, createdOn: UnreadCutoff.AddDays(-1), readOn: null, cancellationToken);
 
 		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
 			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
@@ -77,7 +81,26 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 		// survive until it also crosses the longer unread retention window.
 		await using var dbContext = fixture.CreateApplicationDbContext();
 		var notificationId = await SeedNotificationAsync(
-			dbContext, isRead: false, createdOn: ReadCutoff.AddDays(-1), cancellationToken);
+			dbContext, isRead: false, createdOn: ReadCutoff.AddDays(-1), readOn: null, cancellationToken);
+
+		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
+			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await NotificationShouldExistAsync(dbContext, notificationId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredNotificationsAsync_ReadNotificationWithNoReadOnStamp_IsNeverRemoved(
+		CancellationToken cancellationToken)
+	{
+		// Defensive guard (#1725): a row that is somehow marked read without a
+		// ReadOn stamp (e.g. a pre-migration legacy row the backfill missed)
+		// must not match either branch and be silently deleted with no
+		// evidence of when it was actually read.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var notificationId = await SeedNotificationAsync(
+			dbContext, isRead: true, createdOn: UnreadCutoff.AddDays(-1), readOn: null, cancellationToken);
 
 		var deleted = await NotificationRetentionJob.DeleteExpiredNotificationsAsync(
 			dbContext, ReadCutoff, UnreadCutoff, cancellationToken);
@@ -90,6 +113,7 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 		ApplicationDbContext dbContext,
 		bool isRead,
 		DateTimeOffset createdOn,
+		DateTimeOffset? readOn,
 		CancellationToken cancellationToken)
 	{
 		var notification = Notification.Create(
@@ -98,16 +122,21 @@ public class NotificationRetentionJobTests(IntegrationTestFixture fixture)
 			Guid.NewGuid());
 
 		if (isRead)
-			notification.MarkRead();
+			notification.MarkRead(readOn ?? createdOn);
 
 		dbContext.Set<Notification>().Add(notification);
 		await dbContext.SaveChangesAsync(cancellationToken);
 
 		// CreatedOn is stamped by AuditableEntityInterceptor on save - overwrite
 		// it directly afterward so seeded rows can simulate an arbitrary age.
+		// ReadOn isn't IAuditableEntity-tracked, so MarkRead's value above
+		// persists as-is; but the "isRead without a ReadOn stamp" case needs a
+		// direct override since MarkRead(DateTimeOffset) always sets it.
 		await dbContext.Set<Notification>()
 			.Where(n => n.Id == notification.Id)
-			.ExecuteUpdateAsync(s => s.SetProperty(n => n.CreatedOn, createdOn), cancellationToken);
+			.ExecuteUpdateAsync(s => s
+				.SetProperty(n => n.CreatedOn, createdOn)
+				.SetProperty(n => n.ReadOn, readOn), cancellationToken);
 
 		return notification.Id;
 	}

--- a/backend/tests/IntegrationTests/ReportRetentionJobTests.cs
+++ b/backend/tests/IntegrationTests/ReportRetentionJobTests.cs
@@ -1,0 +1,184 @@
+using System.Net.Http.Headers;
+using Application.Common.Exceptions;
+using AwesomeAssertions;
+using Domain.Reports;
+using Domain.Users;
+using Infrastructure.BackgroundJobs;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.BackgroundJobs.ReportRetentionJob.DeleteExpiredReportsAsync
+// directly (InternalsVisibleTo, see Infrastructure.csproj) against the real integration
+// Postgres, rather than waiting a real 24-hour tick for the pruning behavior (#1725)
+// to become observable.
+[ClassDataSource<IntegrationTestFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("IntegrationDb")]
+public class ReportRetentionJobTests(IntegrationTestFixture fixture)
+{
+	private static readonly DateTimeOffset ResolvedCutoff = DateTimeOffset.UtcNow.AddDays(-180);
+
+	[Before(Test)]
+	public Task ResetAsync() => fixture.ResetAsync();
+
+	[Test]
+	public async Task DeleteExpiredReportsAsync_ResolvedReportPastRetention_IsRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var reportId = await SeedReportAsync(
+			dbContext,
+			ReportTargetType.Organization,
+			targetId: Guid.NewGuid(),
+			resolvedOn: ResolvedCutoff.AddDays(-1),
+			cancellationToken);
+
+		var deleted = await ReportRetentionJob.DeleteExpiredReportsAsync(dbContext, ResolvedCutoff, cancellationToken);
+
+		deleted.Should().Be(1);
+		await ReportShouldNotExistAsync(dbContext, reportId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredReportsAsync_ResolvedReportWithinRetention_IsNotRemoved(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var reportId = await SeedReportAsync(
+			dbContext,
+			ReportTargetType.Organization,
+			targetId: Guid.NewGuid(),
+			resolvedOn: ResolvedCutoff.AddDays(1),
+			cancellationToken);
+
+		var deleted = await ReportRetentionJob.DeleteExpiredReportsAsync(dbContext, ResolvedCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await ReportShouldExistAsync(dbContext, reportId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredReportsAsync_OpenReportAgainstAnExistingTarget_IsNeverRemoved(
+		CancellationToken cancellationToken)
+	{
+		// An Open report is never pruned by the resolved-retention rule
+		// regardless of age, and targets an Organization here specifically to
+		// stay clear of the orphaned-User-target rule too.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var reportId = await SeedReportAsync(
+			dbContext,
+			ReportTargetType.Organization,
+			targetId: Guid.NewGuid(),
+			resolvedOn: null,
+			cancellationToken);
+
+		var deleted = await ReportRetentionJob.DeleteExpiredReportsAsync(dbContext, ResolvedCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await ReportShouldExistAsync(dbContext, reportId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredReportsAsync_ReportTargetingAUserRowThatNoLongerExists_IsRemoved(
+		CancellationToken cancellationToken)
+	{
+		// #1725: a report naming a user as its target must not outlive that
+		// user's account once it has been fully (hard-)deleted - regardless of
+		// the report's own resolution status or age.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var reportId = await SeedReportAsync(
+			dbContext,
+			ReportTargetType.User,
+			targetId: Guid.NewGuid(),
+			resolvedOn: null,
+			cancellationToken);
+
+		var deleted = await ReportRetentionJob.DeleteExpiredReportsAsync(dbContext, ResolvedCutoff, cancellationToken);
+
+		deleted.Should().Be(1);
+		await ReportShouldNotExistAsync(dbContext, reportId, cancellationToken);
+	}
+
+	[Test]
+	public async Task DeleteExpiredReportsAsync_ReportTargetingAShadowDeletedUser_IsNotRemoved(
+		CancellationToken cancellationToken)
+	{
+		// A shadow-deleted user's row still physically exists (hidden only by
+		// UserConfiguration's !IsDeleted query filter, which this job's raw SQL
+		// deliberately bypasses) - their reports are moderation history and
+		// must survive until either the resolved-retention rule applies or the
+		// account is later fully erased.
+		var (userId, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var userClient = await CreateAuthenticatedClientAsync(username, password);
+		await userClient.GetUserProfileAsync(cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		await adminClient.AdminShadowDeleteUserAsync(userId, cancellationToken);
+
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var reportId = await SeedReportAsync(
+			dbContext,
+			ReportTargetType.User,
+			targetId: userId,
+			resolvedOn: null,
+			cancellationToken);
+
+		var deleted = await ReportRetentionJob.DeleteExpiredReportsAsync(dbContext, ResolvedCutoff, cancellationToken);
+
+		deleted.Should().Be(0);
+		await ReportShouldExistAsync(dbContext, reportId, cancellationToken);
+	}
+
+	private static async Task<ReportId> SeedReportAsync(
+		ApplicationDbContext dbContext,
+		ReportTargetType targetType,
+		Guid targetId,
+		DateTimeOffset? resolvedOn,
+		CancellationToken cancellationToken)
+	{
+		var report = Report.Create(
+			targetType,
+			targetId,
+			UserId.Create(Guid.NewGuid()).GetValueOrThrow(),
+			ReportReason.Other,
+			details: null).GetValueOrThrow();
+
+		if (resolvedOn is not null)
+			report.Dismiss(UserId.Create(Guid.NewGuid()).GetValueOrThrow(), resolvedOn.Value).ThrowIfFailure();
+
+		dbContext.Set<Report>().Add(report);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		return report.Id;
+	}
+
+	private static async Task ReportShouldExistAsync(
+		ApplicationDbContext dbContext, ReportId id, CancellationToken cancellationToken)
+	{
+		var exists = await dbContext.Set<Report>()
+			.AsNoTracking()
+			.AnyAsync(r => r.Id == id, cancellationToken);
+		exists.Should().BeTrue();
+	}
+
+	private static async Task ReportShouldNotExistAsync(
+		ApplicationDbContext dbContext, ReportId id, CancellationToken cancellationToken)
+	{
+		var exists = await dbContext.Set<Report>()
+			.AsNoTracking()
+			.AnyAsync(r => r.Id == id, cancellationToken);
+		exists.Should().BeFalse();
+	}
+
+	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(
+		string username, string password)
+	{
+		var token = await fixture.GetAccessTokenAsync(username, password);
+		var httpClient = fixture.CreateHttpClient();
+		httpClient.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", token);
+		return new EinsatzbereitApi(httpClient);
+	}
+}

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1152,6 +1152,65 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task UnsubscribeConfirmPage_WithValidLink_HasNoSeriousA11yViolations()
+	{
+		// The confirmation interstitial the unsubscribe email link now points to
+		// (#1725) - scanned with a well-formed userId/type/token query string so
+		// the confirm button itself renders.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(
+			$"{frontend.GetLeftPart(UriPartial.Authority)}/unsubscribe?userId={Guid.NewGuid()}&type=EngagementReminder&token={Guid.NewGuid()}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
+	public async Task UnsubscribeConfirmPage_WithMissingParams_HasNoSeriousA11yViolations()
+	{
+		// The invalid-link branch (missing/incomplete query string) renders an
+		// ErrorBanner instead of the confirm button - scanned separately since
+		// it's a materially different DOM state from the happy path above.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/unsubscribe");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
+	public async Task UnsubscribeConfirmPage_ConfirmFailed_HasNoSeriousA11yViolations()
+	{
+		// A third DOM state neither test above reaches: description + confirm
+		// button *and* an ErrorBanner together, after the POST /unsubscribe
+		// call itself fails - reached by aborting that request and clicking
+		// through it.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.RouteAsync("**/unsubscribe**", async route =>
+		{
+			if (route.Request.Method == "POST")
+				await route.AbortAsync();
+			else
+				await route.ContinueAsync();
+		});
+
+		await Page.GotoAsync(
+			$"{frontend.GetLeftPart(UriPartial.Authority)}/unsubscribe?userId={Guid.NewGuid()}&type=EngagementReminder&token={Guid.NewGuid()}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Confirm unsubscribe" }).ClickAsync();
+		await Expect(Page.GetByRole(AriaRole.Alert)).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task SignUpModal_OpenTimeSlotDropdown_HasNoSeriousA11yViolations()
 	{
 		// #573: the native time slot <select> was replaced with a custom

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,9 @@ const TermsOfUsePage = lazy(() => import("./pages/TermsOfUsePage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));
 const HelpPage = lazy(() => import("./pages/HelpPage"));
 const UnsubscribePage = lazy(() => import("./pages/UnsubscribePage"));
+const UnsubscribeConfirmPage = lazy(
+	() => import("./pages/UnsubscribeConfirmPage"),
+);
 const VolunteerOpportunityDetailPage = lazy(
 	() => import("./pages/VolunteerOpportunityDetailPage"),
 );
@@ -146,6 +149,7 @@ export default function App() {
 				<Route path="/contact" element={<ContactPage />} />
 				<Route path="/help" element={<HelpPage />} />
 				<Route path="/unsubscribed" element={<UnsubscribePage />} />
+				<Route path="/unsubscribe" element={<UnsubscribeConfirmPage />} />
 				<Route
 					path="/volunteer-opportunities/:opportunityId"
 					element={<VolunteerOpportunityDetailPage />}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -1657,6 +1657,12 @@ export class EinsatzbereitApi {
             result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Unauthorized", status, _responseText, _headers, result401);
             });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
         } else if (status === 500) {
             return response.text().then((_responseText) => {
             let result500: any = null;
@@ -1770,6 +1776,9 @@ export class EinsatzbereitApi {
         return Promise.resolve<NotificationPreferencesResponse>(null as any);
     }
 
+    /**
+     * @return No Content
+     */
     unsubscribe(userId: string, type: string, token: string, signal?: AbortSignal): Promise<void> {
         let url_ = this.baseUrl + "/v1/users/{userId}/unsubscribe?";
         if (userId === undefined || userId === null)
@@ -1786,7 +1795,7 @@ export class EinsatzbereitApi {
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
-            method: "GET",
+            method: "POST",
             signal,
             headers: {
             }
@@ -1800,9 +1809,9 @@ export class EinsatzbereitApi {
     protected processUnsubscribe(response: Response): Promise<void> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 302) {
+        if (status === 204) {
             return response.text().then((_responseText) => {
-            return throwException("Found", status, _responseText, _headers);
+            return;
             });
         } else if (status === 400) {
             return response.text().then((_responseText) => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -709,7 +709,7 @@
       "section2Body1": "Beim Besuch dieser Website werden automatisch allgemeine technische Informationen verarbeitet (z. B. IP-Adresse, Browsertyp, Uhrzeit des Zugriffs), um einen sicheren und zuverlässigen Betrieb sicherzustellen. Auch wenn wir diese Daten nicht anderweitig mit Ihrer Identität verknüpfen, können sie personenbezogene Daten darstellen - einschließlich Ihrer IP-Adresse, entsprechend dem Breyer-Urteil des EuGH (C-582/14).",
       "section2Body2": "Bei der Registrierung und Anmeldung über unseren Authentifizierungsdienst (Keycloak) werden die von Ihnen eingegebenen Daten (z. B. Name, E-Mail-Adresse) gespeichert, um Ihnen die Nutzung der Plattform zu ermöglichen.",
       "section2Body3": "Darüber hinaus können Sie in Ihrem Profil freiwillig weitere Angaben hinterlegen, etwa eine Telefonnummer, unter der Organisationen Sie erreichen können, ein Profilbild, einen Text im Feld „Über mich“ sowie Fähigkeiten und Sprachen. An wen diese Angaben weitergegeben oder für wen sie sichtbar werden, ist in den folgenden Abschnitten beschrieben.",
-      "section2Body4": "Rechtsgrundlage für die oben beschriebenen technischen Zugriffsinformationen ist unser berechtigtes Interesse (Art. 6 Abs. 1 lit. f DSGVO) an einem sicheren und zuverlässigen Betrieb; Ihre IP-Adresse wird dabei ausschließlich vorübergehend im Arbeitsspeicher zur Durchsetzung von Anfragebegrenzungen verwendet und nicht gespeichert. Rechtsgrundlage für Ihre Registrierungs- und Kontodaten, einschließlich optionaler Angaben, die Sie freiwillig in Ihrem Profil hinterlegen, ist die Erfüllung des Nutzungsvertrags mit Ihnen (Art. 6 Abs. 1 lit. b DSGVO). Wir speichern Ihre Konto- und Profildaten, solange Ihr Konto besteht; löschen Sie Ihr Konto - das können Sie jederzeit in Ihren Profileinstellungen tun -, werden diese Daten unmittelbar gelöscht oder anonymisiert. Benachrichtigungen werden automatisch 90 Tage nach dem Lesen gelöscht, ungelesene nach 180 Tagen. Protokolle sicherheitsrelevanter Aktionen (siehe unten) werden ohne automatische Löschfrist aufbewahrt.",
+      "section2Body4": "Rechtsgrundlage für die oben beschriebenen technischen Zugriffsinformationen ist unser berechtigtes Interesse (Art. 6 Abs. 1 lit. f DSGVO) an einem sicheren und zuverlässigen Betrieb; Ihre IP-Adresse wird dabei ausschließlich vorübergehend im Arbeitsspeicher zur Durchsetzung von Anfragebegrenzungen verwendet und nicht gespeichert. Rechtsgrundlage für Ihre Registrierungs- und Kontodaten, einschließlich optionaler Angaben, die Sie freiwillig in Ihrem Profil hinterlegen, ist die Erfüllung des Nutzungsvertrags mit Ihnen (Art. 6 Abs. 1 lit. b DSGVO). Wir speichern Ihre Konto- und Profildaten, solange Ihr Konto besteht; löschen Sie Ihr Konto - das können Sie jederzeit in Ihren Profileinstellungen tun -, werden diese Daten unmittelbar gelöscht oder anonymisiert. Benachrichtigungen werden automatisch 90 Tage nach dem Lesen gelöscht, ungelesene nach 180 Tagen. Meldungen gegen einen Nutzer, eine Organisation oder einen Einsatz werden als Moderationsverlauf aufbewahrt; nach ihrer Bearbeitung werden sie automatisch nach 180 Tagen gelöscht, und eine Meldung, die einen Nutzer betrifft, wird unmittelbar gelöscht, sobald das Konto dieses Nutzers vollständig gelöscht wurde. Protokolle sicherheitsrelevanter Aktionen (siehe unten) werden ohne automatische Löschfrist aufbewahrt.",
       "section3Title": "Weitergabe von Daten",
       "section3Body": "Personenbezogene Daten werden nur in den in diesem Abschnitt und den folgenden Unterabschnitten beschriebenen Fällen an Dritte weitergegeben oder öffentlich zugänglich gemacht: bei Ihrer Anmeldung zu einem Einsatz, im Rahmen Ihres öffentlichen Profils sowie im Rahmen der eingebundenen Drittdienste zur Kartendarstellung und Ortssuche. Eine darüber hinausgehende Übermittlung findet nur statt, wenn Sie ausdrücklich eingewilligt haben oder wir gesetzlich dazu verpflichtet sind.",
       "section3aTitle": "Anmeldung zu einem Einsatz",
@@ -846,6 +846,15 @@
       "title": "Du wurdest abgemeldet",
       "description": "Du hast diese Art von E-Mail abbestellt. Du kannst sie jederzeit in deinen Benachrichtigungseinstellungen im Profil wieder aktivieren.",
       "manageInProfile": "Benachrichtigungseinstellungen verwalten"
+    },
+    "unsubscribeConfirm": {
+      "title": "E-Mail abbestellen?",
+      "description": "Du bist dabei, diese Art von E-Mail abzubestellen:",
+      "note": "Das wirkt sich nicht auf deine anderen Benachrichtigungseinstellungen aus - die kannst du jederzeit in deinem Profil ändern.",
+      "confirmButton": "Abbestellen bestätigen",
+      "confirming": "Wird abbestellt…",
+      "invalidLink": "Dieser Abmeldelink ist ungültig oder unvollständig.",
+      "error": "Beim Abbestellen ist etwas schiefgelaufen. Bitte versuche es erneut oder verwalte deine Benachrichtigungseinstellungen in deinem Profil."
     },
     "report": {
       "title": "Inhalt melden",
@@ -1330,6 +1339,7 @@
         "AlreadyDeleted": "Nutzer:in ist bereits schattengelöscht.",
         "NotDeleted": "Nutzer:in ist nicht schattengelöscht.",
         "InvalidUnsubscribeToken": "Der Abmelde-Link ist ungültig oder wurde bereits mit einem anderen Token verwendet.",
+        "UnknownEmailNotificationType": "Unbekannter E-Mail-Benachrichtigungstyp.",
         "SoleOrganizerOfOrganizations": "Du bist die:der einzige Organisator:in mindestens einer Organisation. Übertrage die Leitung an eine andere Person oder lösche diese Organisationen, bevor du dein Konto löschst."
       },
       "Users": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -709,7 +709,7 @@
       "section2Body1": "When visiting this website, general technical information is automatically processed (e.g. IP address, browser type, time of access) to ensure secure and reliable operation. This data can constitute personal data - including your IP address, per the Court of Justice of the EU's Breyer ruling (C-582/14) - even though we do not otherwise link it to your identity.",
       "section2Body2": "When registering and logging in via our authentication service (Keycloak), the data you enter (e.g. name, email address) is stored to enable you to use the platform.",
       "section2Body3": "You may also voluntarily add further details to your profile, such as a phone number organizations can reach you on, a profile picture, a short bio, and your skills and languages. Who this information is shared with or visible to is described in the following sections.",
-      "section2Body4": "The legal basis for the technical access information described above is our legitimate interest (Art. 6(1)(f) GDPR) in secure and reliable operation; your IP address is used only transiently, in memory, to enforce request rate limits, and is never stored. The legal basis for your registration and account data, including any optional profile fields you choose to add, is performance of the usage agreement with you (Art. 6(1)(b) GDPR). We retain your account and profile data for as long as your account exists; deleting your account, which you can do at any time from your profile settings, erases or anonymizes this data immediately. Notifications are deleted automatically 90 days after being read, or after 180 days if never read. Audit logs of security-relevant actions (see below) are retained without an automatic deletion period.",
+      "section2Body4": "The legal basis for the technical access information described above is our legitimate interest (Art. 6(1)(f) GDPR) in secure and reliable operation; your IP address is used only transiently, in memory, to enforce request rate limits, and is never stored. The legal basis for your registration and account data, including any optional profile fields you choose to add, is performance of the usage agreement with you (Art. 6(1)(b) GDPR). We retain your account and profile data for as long as your account exists; deleting your account, which you can do at any time from your profile settings, erases or anonymizes this data immediately. Notifications are deleted automatically 90 days after being read, or after 180 days if never read. Reports filed against a user, organization, or volunteer opportunity are retained as moderation history; once resolved, they are deleted automatically after 180 days, and a report naming a user as its subject is deleted immediately once that user's account has been fully deleted. Audit logs of security-relevant actions (see below) are retained without an automatic deletion period.",
       "section3Title": "Data sharing",
       "section3Body": "Personal data is only shared with third parties or made publicly accessible in the cases described in this section and its subsections below: when you sign up for an opportunity, as part of your public profile, and through the embedded third-party services for map display and location search. Any transfer beyond that only takes place if you have expressly consented or we are legally required to do so.",
       "section3aTitle": "Signing up for an opportunity",
@@ -846,6 +846,15 @@
       "title": "You've been unsubscribed",
       "description": "You have been unsubscribed from this type of email. You can re-enable it any time from your notification preferences in your profile.",
       "manageInProfile": "Manage notification preferences"
+    },
+    "unsubscribeConfirm": {
+      "title": "Unsubscribe from this email?",
+      "description": "You're about to unsubscribe from this type of email:",
+      "note": "This won't affect your other notification preferences - you can change those anytime from your profile.",
+      "confirmButton": "Confirm unsubscribe",
+      "confirming": "Unsubscribing…",
+      "invalidLink": "This unsubscribe link is invalid or incomplete.",
+      "error": "Something went wrong while unsubscribing. Please try again, or manage your notification preferences from your profile."
     },
     "report": {
       "title": "Report content",
@@ -1330,6 +1339,7 @@
         "AlreadyDeleted": "User is already shadow-deleted.",
         "NotDeleted": "User is not shadow-deleted.",
         "InvalidUnsubscribeToken": "The unsubscribe link is invalid or has already been used with a different token.",
+        "UnknownEmailNotificationType": "Unknown email notification type.",
         "SoleOrganizerOfOrganizations": "You are the sole organizer of one or more organizations. Transfer ownership to another organizer or delete these organizations before deleting your account."
       },
       "Users": {

--- a/frontend/src/pages/UnsubscribeConfirmPage.tsx
+++ b/frontend/src/pages/UnsubscribeConfirmPage.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useSearchParams, useNavigate } from "react-router";
+import { useTranslation } from "react-i18next";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { useApiClient } from "../hooks/useApiClient";
+import { getApiErrorMessage } from "../lib/apiError";
+import { statusTitleClass } from "../lib/headingClasses";
+import Button from "../components/Button";
+import ErrorBanner from "../components/ErrorBanner";
+
+const TYPE_LABEL_KEYS: Record<string, string> = {
+	NewSignUp: "notificationPreferences.newSignUp",
+	Withdrawal: "notificationPreferences.withdrawal",
+	EngagementConfirmed: "notificationPreferences.engagementConfirmed",
+	EngagementCancelled: "notificationPreferences.engagementCancelled",
+	EngagementReminder: "notificationPreferences.engagementReminder",
+};
+
+// Confirmation interstitial the one-click unsubscribe link in transactional
+// emails now points to, instead of directly at the backend's state-changing
+// endpoint (#1725) - a mail scanner or link prefetcher merely loading this
+// page can no longer silently opt anyone out, since nothing here mutates
+// state until the recipient explicitly clicks the confirm button below.
+// UnsubscribeLinkBuilder (backend) builds the userId/type/token query string.
+export default function UnsubscribeConfirmPage() {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const api = useApiClient();
+	const [searchParams] = useSearchParams();
+
+	const userId = searchParams.get("userId");
+	const type = searchParams.get("type");
+	const token = searchParams.get("token");
+
+	const [confirming, setConfirming] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	usePageTitle(t("unsubscribeConfirm.title"));
+
+	const linkIsValid = Boolean(userId && type && token);
+	const typeLabelKey = type ? TYPE_LABEL_KEYS[type] : undefined;
+
+	async function handleConfirm() {
+		if (!userId || !type || !token) return;
+
+		setConfirming(true);
+		setError(null);
+		try {
+			await api.unsubscribe(userId, type, token);
+			navigate(`/unsubscribed?type=${encodeURIComponent(type)}`);
+		} catch (err) {
+			setError(getApiErrorMessage(err, t("unsubscribeConfirm.error")));
+			setConfirming(false);
+		}
+	}
+
+	return (
+		<div className="flex min-h-[70vh] items-center justify-center px-4 text-center">
+			<div className="max-w-md">
+				<h1 className={`mb-4 text-brand-700 ${statusTitleClass}`}>
+					{t("unsubscribeConfirm.title")}
+				</h1>
+
+				{!linkIsValid && (
+					<ErrorBanner message={t("unsubscribeConfirm.invalidLink")} />
+				)}
+
+				{linkIsValid && (
+					<>
+						<p className="mb-2 text-black">
+							{t("unsubscribeConfirm.description")}
+						</p>
+						{typeLabelKey && (
+							<p className="mb-2 font-semibold text-gray-800">
+								{t(typeLabelKey)}
+							</p>
+						)}
+						<p className="mb-8 text-sm text-gray-600">
+							{t("unsubscribeConfirm.note")}
+						</p>
+
+						{error && <ErrorBanner message={error} className="mb-6" />}
+
+						<Button
+							type="button"
+							size="lg"
+							onClick={handleConfirm}
+							disabled={confirming}
+							aria-busy={confirming}
+						>
+							{confirming
+								? t("unsubscribeConfirm.confirming")
+								: t("unsubscribeConfirm.confirmButton")}
+						</Button>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## What

Fixes the GDPR erasure / email opt-out gap bundle from a 1.0 readiness analysis:

1. **Blocker:** `DeleteMyAccount` silently no-oped for a shadow-deleted user (row hidden by the `!IsDeleted` query filter), leaving the local row, avatar, and Keycloak identity intact while still reporting success.
2. Notification retention pruned read notifications by `CreatedOn` instead of read date, contradicting the privacy policy's "90 days after being read" promise.
3. Abuse reports had no retention limit and outlived the reported user's account deletion, undisclosed in the privacy policy.
4. The one-click email unsubscribe link was a state-changing anonymous `GET` - a mail scanner or link prefetcher could silently opt a recipient out.
5. `User.Unsubscribe`'s switch had no `default` arm, so a future `EmailNotificationType` would silently report success without taking effect.

## Why

Closes #1725

## Testing

- `DeleteMyAccountCommandHandlerTests`: reworked "missing user" test to assert `NotFound` instead of a silent no-op; added a shadow-deleted-user case asserting the full deletion path runs.
- `AccountDeletionTests` (integration): new case shadow-deletes an ephemeral user via the admin endpoint, then self-deletes, and asserts the Keycloak login fails and the local row is gone.
- `NotificationRetentionJobTests`: reworked to seed `ReadOn` independently of `CreatedOn`; added a defensive case for a read row with no `ReadOn` stamp.
- New `ReportRetentionJobTests` (integration): resolved-report retention, an always-open report is never pruned by that rule, an orphaned User-target report is pruned immediately, and a shadow-deleted user's report survives.
- `UserTests`: added a data-driven test over `Enum.GetValues<EmailNotificationType>()` asserting `IsSubscribedTo` is false after `Unsubscribe` for every member.
- New `UnsubscribeConfirmPage` + three `AccessibilityTests` cases (valid link, missing params, failed confirm).
- Ran locally: `dotnet build` (0 warnings/errors), `Application.UnitTests` (1034/1034 pass), `ArchitectureTests` (426/426 pass), frontend `pnpm check`/`lint`/`test` (189/189 pass)/`build`. `IntegrationTests`/`VisualTests` need Docker/a real browser, unavailable in this sandbox - left for CI.
- Ran `/self-review`, including `nswag-check`, `ef-migration-check`, `architecture-check`, `a11y-check`, and `i18n-check`; findings addressed (see commit history).

## Live verification

Skipped at the requester's explicit instruction for this change (no RC cut, no staging deploy). Coverage instead comes from the automated test suite above, including a new integration test replaying the exact shadow-delete-then-self-delete sequence against a real Postgres + Keycloak in CI's `IntegrationTests` job, and new `VisualTests` a11y cases for the new confirmation page.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (privacy policy: report retention disclosure)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WGArD678gbhRbtMgS2j1Cs)_