### PR TITLE
docs: fix README/Keycloak-version/keycloak-README/docs-tree drift

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.7.0
+          docker pull quay.io/keycloak/keycloak:26.7.1
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 
@@ -348,7 +348,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.7.0
+          docker pull quay.io/keycloak/keycloak:26.7.1
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.7.0
+          docker pull quay.io/keycloak/keycloak:26.7.1
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 
@@ -226,7 +226,7 @@ jobs:
 
       - name: Pre-pull Docker images
         run: |
-          docker pull quay.io/keycloak/keycloak:26.7.0
+          docker pull quay.io/keycloak/keycloak:26.7.1
           docker pull ghcr.io/axllent/mailpit:latest
           docker pull quay.io/minio/minio:latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Aspire AppHost provisions Postgres, Keycloak, backend API, and the Vite frontend
 | Service | URL | Credentials |
 |---|---|---|
 | Frontend | http://localhost:4321 | - |
-| Backend API | http://localhost:5000 | - |
+| Backend API | *dynamic port - see the Aspire dashboard* | - |
 | Keycloak admin | http://localhost:8080 | admin / admin |
 | pgAdmin | http://localhost:5050 | admin@admin.com / admin |
 | PostgreSQL | localhost:5432 | postgres / postgres |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ The app itself is served in German by default, since Einsatzbereit's primary aud
 - **Platform administration** to verify organizations, manage users, and toggle admin/enabled status.
 - **Notifications and a language selector** (German by default, English as a secondary language).
 - **Keycloak-backed authentication** via OIDC/PKCE, with Keycloak Organizations powering org membership.
+- **Achievements and badges** awarded for volunteering milestones, shown on the profile.
+- **Saved search alerts** - save a filtered opportunity search and get a digest email when new matches appear.
+- **Organization invitations** to join and manage an organization's membership.
+- **Reporting and moderation** for opportunities, organizations, and users, backed by a full admin audit log.
+- **Image uploads** for avatars, organization logos, and opportunity banners, stored in MinIO object storage.
+- **CSV export** of an organization's engagement data.
+- **Installable as a PWA** with offline support for previously visited pages.
 
 ---
 
@@ -71,9 +78,11 @@ A live staging deployment runs at **[einsatzbereit.maik-hasler.de](https://einsa
 | Layer | Tech |
 |---|---|
 | Backend | .NET 10, Clean Architecture (Api -> Application -> Domain, Infrastructure -> Domain), EF Core 10, PostgreSQL 18, CQRS-style command/query handlers, transactional outbox for domain events |
-| Auth | Keycloak 26.7.0 (OIDC, JWT, Keycloak Organizations) |
+| Auth | Keycloak 26.7.1 (OIDC, JWT, Keycloak Organizations) |
 | Frontend | Vite SPA, React 19, React Router v8, Tailwind CSS 4, react-oidc-context, Leaflet/react-leaflet |
 | API client | NSwag-generated TypeScript client from the backend OpenAPI spec - never hand-edited |
+| Object storage | MinIO (avatars, organization logos, opportunity banners) |
+| Observability | Grafana, Prometheus, Alertmanager, Tempo (distributed tracing) |
 | Tests | TUnit + Aspire.Hosting.Testing + Respawn + NetArchTest (Application.UnitTests, IntegrationTests, ArchitectureTests), Vitest (frontend pure-logic units), Playwright + axe-core (E2E and accessibility, `backend/tests/VisualTests`) |
 | CI/CD | GitHub Actions (build and test on every PR, Docker images to GHCR on tag push, auto-deploy to staging) |
 | Dependency updates | Renovate |
@@ -111,7 +120,7 @@ The Aspire AppHost provisions PostgreSQL, Keycloak, the backend API, and the Vit
 | Service | URL | Credentials |
 |---|---|---|
 | Frontend | http://localhost:4321 | - |
-| Backend API | http://localhost:5000 | - |
+| Backend API | *dynamic port - see the Aspire dashboard* | - |
 | Keycloak | http://localhost:8080 | admin / admin |
 | pgAdmin | http://localhost:5050 | admin@admin.com / admin |
 | PostgreSQL | localhost:5432 | postgres / postgres |

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -114,7 +114,7 @@ File.WriteAllText(
 	Path.Combine(keycloakRealmImportPath, "einsatzbereit-realm.json"),
 	localRealm.ToJsonString());
 
-var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.7.0")
+var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.7.1")
 	.WithEnvironment("KC_DB", "dev-file")
 	.WithBindMount(keycloakRealmImportPath, "/opt/keycloak/data/import", isReadOnly: true)
 	.WithBindMount(keycloakThemePath, "/opt/keycloak/themes/einsatzbereit", isReadOnly: true)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -20,14 +20,8 @@ docs/
 │   │   ├── 11_technical_risks.adoc
 │   │   ├── 12_glossary.adoc
 │   │   └── config.adoc         Locale/language config (German)
-│   └── images/
-│       ├── business-context.puml   PlantUML diagram
-│       └── quality-tree.puml       PlantUML diagram
-├── ADRs/
-│   ├── 1_monorepository.adoc   Accepted 2026-03-23
-│   ├── 2_arc42.adoc            Accepted 2026-03-25
-│   ├── 3_keycloak.adoc         Accepted 2026-03-25
-│   └── 4_geocoding_and_geo_search.adoc  Accepted 2026-05-13
+│   └── images/                 PlantUML diagrams (`.puml`) + `arc42-logo.png`, embedded via asciidoctor-diagram
+├── ADRs/                       See `09_architecture_decisions.adoc` for the current indexed list (number, status, date) - not duplicated here so it cannot go stale
 └── TDRs/                       Technical debt/risk records - see TDR Conventions below
 ```
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -2,11 +2,26 @@
 
 ## Production (`Dockerfile`)
 
-Optimiertes Multi-stage Image. Folgende Umgebungsvariablen müssen zur Laufzeit übergeben werden:
+Optimized multi-stage image. The values actually used on staging/production are set in `docker-compose.yml`'s `keycloak` service and sourced from `.env` (see `.env.example` at the repo root) - this table documents what each variable is for, it is not a second source of truth.
 
-| Variable | Beispiel |
-|---|---|
-| `KC_HOSTNAME` | `auth.example.com` |
-| `KC_DB_URL` | `jdbc:postgresql://db:5432/keycloak` |
-| `KC_DB_USERNAME` | `keycloak` |
-| `KC_DB_PASSWORD` | `secret` |
+| Variable | Purpose | Example |
+|---|---|---|
+| `KC_HOSTNAME` | Public hostname Keycloak is served at | `https://login.example.com` |
+| `KC_DB_URL` | JDBC connection string for Keycloak's own database | `jdbc:postgresql://db:5432/keycloak` |
+| `KC_DB_USERNAME` | Database username | `keycloak` |
+| `KC_DB_PASSWORD` | Database password | `secret` |
+| `KC_BOOTSTRAP_ADMIN_USERNAME` | Master-realm admin username | `admin` |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD` | Master-realm admin password | - |
+| `KEYCLOAK_BACKEND_SECRET` | Resolves the `${KEYCLOAK_BACKEND_SECRET}` placeholder in the imported realm (the `backend` client's secret) | - |
+| `KC_SMTP_HOST` | Resolves the realm's `smtpServer` host placeholder so `verifyEmail`/`resetPasswordAllowed` can send mail | `smtp.example.com` |
+| `KC_SMTP_PORT` | SMTP port | `587` |
+| `KC_SMTP_FROM` | From-address for outgoing mail | `no-reply@example.com` |
+| `KC_SMTP_USER` | SMTP auth username | - |
+| `KC_SMTP_PASSWORD` | SMTP auth password | - |
+| `KC_PROXY_HEADERS` | Trust `X-Forwarded-*` from the reverse proxy in front of Keycloak | `xforwarded` |
+
+`KEYCLOAK_BACKEND_SECRET` and the `KC_SMTP_*` values share the same underlying secrets as the backend's own `Keycloak__ClientSecret` and `Smtp__*` settings - see `docker-compose.yml` and `keycloak/AGENTS.md` for how the realm resolves them at import time.
+
+## Local development
+
+Local Aspire runs (`dotnet run --project backend/src/Aspire/AppHost`) do not use this image - `AppHost.cs` launches the stock `quay.io/keycloak/keycloak` container directly with `KC_DB=dev-file`, so none of the above applies there.

--- a/renovate.json
+++ b/renovate.json
@@ -53,11 +53,16 @@
       "managerFilePatterns": [
         "/^(keycloak/)?AGENTS\\.md$/",
         "/^docs/Architecture/src/.*\\.adoc$/",
-        "/^docs/Architecture/images/.*\\.puml$/"
+        "/^docs/Architecture/images/.*\\.puml$/",
+        "/^README\\.md$/",
+        "/^backend/src/Aspire/AppHost/AppHost\\.cs$/",
+        "/^\\.github/workflows/dotnet\\.yml$/",
+        "/^\\.github/workflows/publish\\.yml$/"
       ],
       "matchStrings": [
         "Keycloak (?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)",
-        "quay\\.io/keycloak/keycloak:(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
+        "quay\\.io/keycloak/keycloak:(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)",
+        "quay\\.io/keycloak/keycloak\",\\s*\"(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/keycloak/keycloak"


### PR DESCRIPTION
## What

Fixes five documentation-drift issues in the "front door" docs (README, AGENTS.md, keycloak/README.md, docs/AGENTS.md) flagged by a 1.0 readiness review.

## Why

Closes #1732

The deep arc42/ADR docs were already accurate, but the docs a 1.0 announcement would point people at had drifted:

1. **README Features/Tech Stack omitted ~7 shipped subsystems** - added bullets for achievements/badges, saved search alerts + digest emails, organization invitations, reporting/moderation (with admin audit log), image uploads (avatars/org logos/opportunity banners) + the MinIO object storage behind them, CSV export, and PWA install/offline. Added Object storage and Observability rows to the Tech Stack table. Verified each subsystem actually exists in the codebase before documenting it.
2. **Keycloak version inconsistent across sources** - the shipped image is 26.7.1, but `README.md` and `AppHost.cs` still said `26.7.0`. Fixed both. While tracing every reference I also found two CI workflow pre-pull steps (`dotnet.yml`, `publish.yml`) that pull the same image `AppHost.cs` uses for IntegrationTests/VisualTests and had silently drifted to `26.7.0` too - fixed those as well so the pre-pull cache actually matches what the test run needs. Extended `renovate.json`'s regex-based doc-sync manager to also watch `README.md`, `AppHost.cs`, and both workflow files so this can't drift again on the next Keycloak bump.
3. **`keycloak/README.md` was German-only and listed 4 of ~12 required env vars** - rewrote in English (per the repo's Language Convention) and listed the full runtime env var set the custom image's `docker-compose.yml` service actually consumes (`KC_BOOTSTRAP_ADMIN_*`, `KEYCLOAK_BACKEND_SECRET`, `KC_SMTP_*`, `KC_PROXY_HEADERS`, plus the original 4), cross-referenced against `docker-compose.yml` and `.env.example` as the actual source of truth rather than duplicating values that could drift again.
4. **`docs/AGENTS.md`'s directory tree was stale** - `images/` listed 2 of the actual 12 files, and the ADR list showed 4 of the actual 6 ADRs. Replaced the images enumeration with an accurate one-line description and replaced the ADR enumeration with a pointer at `09_architecture_decisions.adoc` (which is already a maintained, indexed table), so this section can't go stale the same way again.
5. **Documented local backend port didn't match reality** - README and AGENTS.md both said `http://localhost:5000`, but `AppHost.cs` never pins a backend port for Aspire (no `WithLaunchProfile`/explicit endpoint), so the actual port is whatever Aspire assigns. Replaced the hardcoded value with a pointer to the Aspire dashboard, which already surfaces the real URL on every run.

## Testing

Docs/config-only change - no application code behavior changed (the one `.cs`/`.yml` edits are string-literal version bumps). Verified:
- Each newly-documented subsystem exists via targeted greps against the backend/frontend source.
- The Keycloak version claim (26.7.1) against `keycloak/Dockerfile`.
- The renovate.json regex additions actually match the target files' content (tested with Python `re`) and the file remains valid JSON.
- No remaining `26.7.0` references anywhere in tracked docs/CI after the fix.
- No Unicode em/en dashes introduced (repo convention, checked the diff).

## Live verification

Not applicable - this is a documentation/config-only change with no runtime behavior to verify on staging. Per the user's explicit instruction for this task, no release candidate was cut.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01MUkdqrthk1d5c9ndaZkjEa)_