### PR TITLE
fix: dashboard link glue, dead lazy import, opportunity detail width, compact footer gaps

### DIFF
--- a/frontend/scripts/check-i18n-keys.js
+++ b/frontend/scripts/check-i18n-keys.js
@@ -52,6 +52,7 @@ function setsEqual(a, b) {
 const ALLOWED_IDENTICAL_KEYS = new Set(
 	[
 		"brand.name",
+		"footer.license",
 		"nav.administration",
 		"landing.heroStat3Label",
 		"opportunities.remote",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,11 @@ import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
 import HomePage from "./pages/HomePage";
+// Eager, not lazy: OrgAppLayout (eager, above) and EngagementManagementPage
+// both statically import this too, so it always lands in the entry chunk
+// regardless - a lazy() wrapper here just contradicted that and tripped
+// Vite's INEFFECTIVE_DYNAMIC_IMPORT warning on every build.
+import NotFoundPage from "./pages/NotFoundPage";
 
 // Route pages are lazy-loaded so each one becomes its own build chunk instead
 // of all being bundled (and precached by the PWA service worker) as a single
@@ -44,7 +49,6 @@ const EngagementManagementPage = lazy(
 const ProfileOverviewPage = lazy(() => import("./pages/ProfileOverviewPage"));
 const ProfileSettingsPage = lazy(() => import("./pages/ProfileSettingsPage"));
 const MyEngagementsPage = lazy(() => import("./pages/MyEngagementsPage"));
-const NotFoundPage = lazy(() => import("./pages/NotFoundPage"));
 const OrganizationProfilePage = lazy(
 	() => import("./pages/OrganizationProfilePage"),
 );

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -11,12 +11,15 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 	if (compact) {
 		return (
 			<footer className="border-t border-gray-200 bg-white py-4 text-center text-xs text-gray-500">
-				<Link to="/help" className="inline-block py-1 hover:text-gray-600">
-					{t("footer.help")}
-				</Link>
-				<span className="mx-2">&middot;</span>
 				<Link to="/imprint" className="inline-block py-1 hover:text-gray-600">
 					{t("footer.imprint")}
+				</Link>
+				<span className="mx-2">&middot;</span>
+				<Link
+					to="/terms-of-use"
+					className="inline-block py-1 hover:text-gray-600"
+				>
+					{t("footer.terms")}
 				</Link>
 				<span className="mx-2">&middot;</span>
 				<Link
@@ -25,6 +28,23 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 				>
 					{t("footer.privacy")}
 				</Link>
+				<span className="mx-2">&middot;</span>
+				<Link to="/contact" className="inline-block py-1 hover:text-gray-600">
+					{t("footer.contact")}
+				</Link>
+				<span className="mx-2">&middot;</span>
+				<Link to="/help" className="inline-block py-1 hover:text-gray-600">
+					{t("footer.help")}
+				</Link>
+				<span className="mx-2">&middot;</span>
+				<a
+					href="https://github.com/maik-hasler/einsatzbereit/blob/main/LICENSE"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-block py-1 hover:text-gray-600"
+				>
+					{t("footer.license")}
+				</a>
 			</footer>
 		);
 	}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -41,6 +41,7 @@
       "contact": "Kontakt",
       "help": "Hilfe",
       "followUs": "Folge uns",
+      "license": "AGPL-3.0",
       "copyright": "© {{year}} Einsatzbereit. Lizenziert unter <licenseLink>AGPL-3.0</licenseLink>."
     },
     "landing": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -41,6 +41,7 @@
       "contact": "Contact",
       "help": "Help",
       "followUs": "Follow us",
+      "license": "AGPL-3.0",
       "copyright": "© {{year}} Einsatzbereit. Licensed under <licenseLink>AGPL-3.0</licenseLink>."
     },
     "landing": {

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -242,17 +242,19 @@ export default function VolunteerOpportunityDetailPage() {
 
 	if (loading)
 		return (
-			<div className="mx-auto max-w-2xl" role="status">
+			<div className="mx-auto max-w-4xl" role="status">
 				<span className="sr-only">{t("opportunities.loading")}</span>
 				<Skeleton className="mb-6 h-56 w-full sm:h-72" />
-				<div className="mb-3 flex items-center justify-between gap-3">
-					<Skeleton className="h-6 w-32 rounded-full" />
-					<Skeleton className="h-8 w-20 rounded-lg" />
+				<div className="mx-auto max-w-2xl">
+					<div className="mb-3 flex items-center justify-between gap-3">
+						<Skeleton className="h-6 w-32 rounded-full" />
+						<Skeleton className="h-8 w-20 rounded-lg" />
+					</div>
+					<Skeleton className="mb-3 h-8 w-3/4" />
+					<Skeleton className="mb-2 h-4 w-full" />
+					<Skeleton className="mb-6 h-4 w-2/3" />
+					<Skeleton className="h-32 w-full" />
 				</div>
-				<Skeleton className="mb-3 h-8 w-3/4" />
-				<Skeleton className="mb-2 h-4 w-full" />
-				<Skeleton className="mb-6 h-4 w-2/3" />
-				<Skeleton className="h-32 w-full" />
 			</div>
 		);
 	if (error)
@@ -305,8 +307,10 @@ export default function VolunteerOpportunityDetailPage() {
 			.slice(0, 3) ?? [];
 
 	return (
-		<div data-content-wrapper className="mx-auto max-w-2xl">
-			{/* Banner image */}
+		<div data-content-wrapper className="mx-auto max-w-4xl">
+			{/* Banner image - spans the full width of this wider wrapper; a
+			reading column is right for prose below, but there's no reason to
+			confine a banner to it too (#1727). */}
 			{opportunity.bannerImageUrl && (
 				<img
 					src={opportunity.bannerImageUrl}
@@ -317,169 +321,174 @@ export default function VolunteerOpportunityDetailPage() {
 				/>
 			)}
 
-			{/* Org chip + action buttons */}
-			<div className="mb-3 flex items-center justify-between gap-3">
-				<div className="flex min-w-0 items-center gap-2">
-					<Link
-						to={`/organizations/${opportunity.organizationId}`}
-						className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-100"
-					>
-						{opportunity.organizationName}
-					</Link>
-					{isDraft && isOwner && (
-						<Chip
-							tone="warning"
-							size="sm"
-							data-testid="opportunity-detail-draft-badge"
+			<div className="mx-auto max-w-2xl">
+				{/* Org chip + action buttons */}
+				<div className="mb-3 flex items-center justify-between gap-3">
+					<div className="flex min-w-0 items-center gap-2">
+						<Link
+							to={`/organizations/${opportunity.organizationId}`}
+							className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-100"
 						>
-							{t("opportunities.draftBadge")}
-						</Chip>
-					)}
-				</div>
-				<div className="flex shrink-0 gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={handleShare}
-						data-testid="share-opportunity"
-						aria-label={t("opportunities.shareOpportunity")}
-					>
-						<ShareIcon className="h-4 w-4" />
-						<span className="hidden sm:inline">{t("opportunities.share")}</span>
-					</Button>
-					{isAuthenticated && !isOwner && (
+							{opportunity.organizationName}
+						</Link>
+						{isDraft && isOwner && (
+							<Chip
+								tone="warning"
+								size="sm"
+								data-testid="opportunity-detail-draft-badge"
+							>
+								{t("opportunities.draftBadge")}
+							</Chip>
+						)}
+					</div>
+					<div className="flex shrink-0 gap-2">
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => setShowReport(true)}
-							data-testid="report-opportunity"
-							aria-label={t("opportunities.reportOpportunity")}
+							onClick={handleShare}
+							data-testid="share-opportunity"
+							aria-label={t("opportunities.shareOpportunity")}
 						>
-							<FlagIcon className="h-4 w-4" />
+							<ShareIcon className="h-4 w-4" />
 							<span className="hidden sm:inline">
-								{t("opportunities.report")}
+								{t("opportunities.share")}
 							</span>
 						</Button>
-					)}
-					{isDraft && isOwner && (
-						<>
+						{isAuthenticated && !isOwner && (
 							<Button
 								variant="outline"
 								size="sm"
-								onClick={() => setShowEditModal(true)}
-								data-testid="opportunity-detail-edit"
+								onClick={() => setShowReport(true)}
+								data-testid="report-opportunity"
+								aria-label={t("opportunities.reportOpportunity")}
 							>
-								{t("opportunities.edit")}
+								<FlagIcon className="h-4 w-4" />
+								<span className="hidden sm:inline">
+									{t("opportunities.report")}
+								</span>
 							</Button>
-							<Button
-								type="button"
-								size="sm"
-								onClick={() => void handlePublish()}
-								disabled={publishing}
-								data-testid="opportunity-detail-publish"
-							>
-								{publishing
-									? t("opportunities.publishing")
-									: t("opportunities.publish")}
-							</Button>
-						</>
-					)}
-				</div>
-			</div>
-
-			{/* Title */}
-			<h1 className={`mb-1 text-gray-900 ${pageTitleClass}`}>
-				{opportunity.title}
-			</h1>
-			<p className="mb-3 text-xs text-gray-600">
-				{formatPostedAgo(opportunity.createdOn as unknown as string, t)}
-			</p>
-
-			{/* Description */}
-			{opportunity.description && (
-				<p className="mb-6 leading-relaxed text-gray-600">
-					{opportunity.description}
-				</p>
-			)}
-
-			{/* Info card */}
-			<div className={`mb-6 space-y-3 ${cardSubtleClass}`}>
-				<div className="flex items-center gap-3 text-sm text-gray-700">
-					<CalendarIcon className="h-4 w-4 shrink-0 text-gray-400" />
-					<span>{formatOccurrence(opportunity.occurrence, t)}</span>
-				</div>
-
-				<div className="flex items-center gap-3 text-sm text-gray-700">
-					<UserGroupIcon className="h-4 w-4 shrink-0 text-gray-400" />
-					<span>
-						{formatParticipationType(opportunity.participationType, t)}
-					</span>
-				</div>
-
-				{opportunity.isRemote ? (
-					<div className="flex items-center gap-3 text-sm text-green-700">
-						<GlobeIcon className="h-4 w-4 shrink-0 text-green-500" />
-						<span>{t("opportunities.remote")}</span>
+						)}
+						{isDraft && isOwner && (
+							<>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setShowEditModal(true)}
+									data-testid="opportunity-detail-edit"
+								>
+									{t("opportunities.edit")}
+								</Button>
+								<Button
+									type="button"
+									size="sm"
+									onClick={() => void handlePublish()}
+									disabled={publishing}
+									data-testid="opportunity-detail-publish"
+								>
+									{publishing
+										? t("opportunities.publishing")
+										: t("opportunities.publish")}
+								</Button>
+							</>
+						)}
 					</div>
-				) : (
+				</div>
+
+				{/* Title */}
+				<h1 className={`mb-1 text-gray-900 ${pageTitleClass}`}>
+					{opportunity.title}
+				</h1>
+				<p className="mb-3 text-xs text-gray-600">
+					{formatPostedAgo(opportunity.createdOn as unknown as string, t)}
+				</p>
+
+				{/* Description */}
+				{opportunity.description && (
+					<p className="mb-6 leading-relaxed text-gray-600">
+						{opportunity.description}
+					</p>
+				)}
+
+				{/* Info card */}
+				<div className={`mb-6 space-y-3 ${cardSubtleClass}`}>
 					<div className="flex items-center gap-3 text-sm text-gray-700">
-						<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
+						<CalendarIcon className="h-4 w-4 shrink-0 text-gray-400" />
+						<span>{formatOccurrence(opportunity.occurrence, t)}</span>
+					</div>
+
+					<div className="flex items-center gap-3 text-sm text-gray-700">
+						<UserGroupIcon className="h-4 w-4 shrink-0 text-gray-400" />
 						<span>
-							{opportunity.street} {opportunity.houseNumber},{" "}
-							{opportunity.zipCode} {opportunity.city}
+							{formatParticipationType(opportunity.participationType, t)}
 						</span>
 					</div>
-				)}
-			</div>
 
-			{/* Social proof */}
-			{opportunity.currentParticipantCount > 0 && (
-				<p className="mb-6 text-sm font-medium text-gray-600">
-					{t("opportunities.participantsJoined", {
-						count: opportunity.currentParticipantCount,
-					})}
-				</p>
-			)}
-
-			{/* Category and tags */}
-			{(opportunity.category ||
-				(opportunity.tags && opportunity.tags.length > 0)) && (
-				<div className="mb-6 flex flex-wrap gap-2">
-					{opportunity.category && (
-						<Chip tone="brand">
-							{t(`opportunities.category.${opportunity.category}`)}
-						</Chip>
+					{opportunity.isRemote ? (
+						<div className="flex items-center gap-3 text-sm text-green-700">
+							<GlobeIcon className="h-4 w-4 shrink-0 text-green-500" />
+							<span>{t("opportunities.remote")}</span>
+						</div>
+					) : (
+						<div className="flex items-center gap-3 text-sm text-gray-700">
+							<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
+							<span>
+								{opportunity.street} {opportunity.houseNumber},{" "}
+								{opportunity.zipCode} {opportunity.city}
+							</span>
+						</div>
 					)}
-					{opportunity.tags &&
-						opportunity.tags.map((tag) => (
-							<Chip
-								key={tag}
-								tone="neutral"
-								to={`/?tag=${encodeURIComponent(tag)}`}
-								aria-label={t("opportunities.filterByTag", { tag })}
-							>
-								{tag}
-							</Chip>
-						))}
 				</div>
-			)}
 
-			{/* Map */}
-			{!opportunity.isRemote &&
-				opportunity.latitude != null &&
-				opportunity.longitude != null && (
-					<div className="mb-6 overflow-hidden rounded-card border border-gray-100 shadow-resting">
-						<Suspense fallback={<Skeleton className="h-64 w-full" />}>
-							<SingleMarkerMap
-								latitude={opportunity.latitude}
-								longitude={opportunity.longitude}
-								label={`${opportunity.street} ${opportunity.houseNumber}, ${opportunity.zipCode} ${opportunity.city}`}
-							/>
-						</Suspense>
+				{/* Social proof */}
+				{opportunity.currentParticipantCount > 0 && (
+					<p className="mb-6 text-sm font-medium text-gray-600">
+						{t("opportunities.participantsJoined", {
+							count: opportunity.currentParticipantCount,
+						})}
+					</p>
+				)}
+
+				{/* Category and tags */}
+				{(opportunity.category ||
+					(opportunity.tags && opportunity.tags.length > 0)) && (
+					<div className="mb-6 flex flex-wrap gap-2">
+						{opportunity.category && (
+							<Chip tone="brand">
+								{t(`opportunities.category.${opportunity.category}`)}
+							</Chip>
+						)}
+						{opportunity.tags &&
+							opportunity.tags.map((tag) => (
+								<Chip
+									key={tag}
+									tone="neutral"
+									to={`/?tag=${encodeURIComponent(tag)}`}
+									aria-label={t("opportunities.filterByTag", { tag })}
+								>
+									{tag}
+								</Chip>
+							))}
 					</div>
 				)}
 
-			{/* Time slots */}
+				{/* Map */}
+				{!opportunity.isRemote &&
+					opportunity.latitude != null &&
+					opportunity.longitude != null && (
+						<div className="mb-6 overflow-hidden rounded-card border border-gray-100 shadow-resting">
+							<Suspense fallback={<Skeleton className="h-64 w-full" />}>
+								<SingleMarkerMap
+									latitude={opportunity.latitude}
+									longitude={opportunity.longitude}
+									label={`${opportunity.street} ${opportunity.houseNumber}, ${opportunity.zipCode} ${opportunity.city}`}
+								/>
+							</Suspense>
+						</div>
+					)}
+			</div>
+
+			{/* Time slots - a reading column has no reason to constrain a list of
+			date/spot rows, so this spans the wider outer wrapper (#1727). */}
 			{opportunity.participationType === "ScheduledSlots" &&
 				opportunity.timeSlots.length > 0 && (
 					<div className="mb-6">
@@ -516,200 +525,204 @@ export default function VolunteerOpportunityDetailPage() {
 					</div>
 				)}
 
-			{/* Application deadline */}
-			{opportunity.participationType === "IndividualContact" &&
-				opportunity.validUntil && (
-					<div className="mb-6 flex items-center gap-1.5 text-sm font-medium text-gray-600">
-						<span>
-							{t("opportunities.applyBy", {
-								date: formatDate(
-									opportunity.validUntil as unknown as string,
-									i18n.language,
-								),
-							})}
-						</span>
+			<div className="mx-auto max-w-2xl">
+				{/* Application deadline */}
+				{opportunity.participationType === "IndividualContact" &&
+					opportunity.validUntil && (
+						<div className="mb-6 flex items-center gap-1.5 text-sm font-medium text-gray-600">
+							<span>
+								{t("opportunities.applyBy", {
+									date: formatDate(
+										opportunity.validUntil as unknown as string,
+										i18n.language,
+									),
+								})}
+							</span>
+						</div>
+					)}
+
+				{/* Your application status */}
+				{isAuthenticated && !isOwner && cue && !isDraft && (
+					<div data-testid="application-status" className={`mb-6 ${cardClass}`}>
+						<div className="flex items-center justify-between gap-4">
+							<div>
+								<p className="mb-1 text-xs text-gray-500">
+									{t("opportunities.yourApplication")}
+								</p>
+								<Chip
+									tone={cue.status === "Confirmed" ? "success" : "warning"}
+									size="sm"
+								>
+									{t(`myEngagements.status.${cue.status}`)}
+								</Chip>
+							</div>
+							<Button
+								type="button"
+								variant="dangerOutline"
+								size="sm"
+								className="shrink-0"
+								onClick={() => setShowWithdrawConfirm(true)}
+								disabled={withdrawing}
+							>
+								{t("myEngagements.withdraw")}
+							</Button>
+						</div>
 					</div>
 				)}
 
-			{/* Your application status */}
-			{isAuthenticated && !isOwner && cue && !isDraft && (
-				<div data-testid="application-status" className={`mb-6 ${cardClass}`}>
-					<div className="flex items-center justify-between gap-4">
-						<div>
-							<p className="mb-1 text-xs text-gray-500">
-								{t("opportunities.yourApplication")}
+				{/* Sign-up CTA */}
+				{isAuthenticated && !isOwner && !cue && !isDraft && (
+					<div data-testid="signup-cta" className="mb-6 space-y-3">
+						{hasUnlimitedSlot ? (
+							<p className="text-sm font-medium text-teal-700">
+								{t("opportunities.unlimitedSpots")}
 							</p>
-							<Chip
-								tone={cue.status === "Confirmed" ? "success" : "warning"}
-								size="sm"
-							>
-								{t(`myEngagements.status.${cue.status}`)}
-							</Chip>
-						</div>
+						) : (
+							totalMax !== null &&
+							totalMax > 0 &&
+							spotsLeft !== null && (
+								<p
+									className={`text-sm font-medium ${
+										isFull
+											? "text-red-600"
+											: spotsLeft <= 5
+												? "text-orange-700"
+												: "text-gray-600"
+									}`}
+								>
+									{isFull
+										? t("opportunities.noSpotsLeft")
+										: spotsLeft <= 5
+											? t("opportunities.fewSpotsLeft", { count: spotsLeft })
+											: t("opportunities.spotsLeft", { count: spotsLeft })}
+								</p>
+							)
+						)}
 						<Button
-							type="button"
-							variant="dangerOutline"
-							size="sm"
-							className="shrink-0"
-							onClick={() => setShowWithdrawConfirm(true)}
-							disabled={withdrawing}
+							onClick={() => setShowSignUp(true)}
+							disabled={isFull}
+							fullWidth
+							size="lg"
 						>
-							{t("myEngagements.withdraw")}
+							{opportunity.participationType === "ScheduledSlots"
+								? t("opportunities.joinWaitlist")
+								: t("opportunities.expressInterest")}
 						</Button>
 					</div>
-				</div>
-			)}
+				)}
 
-			{/* Sign-up CTA */}
-			{isAuthenticated && !isOwner && !cue && !isDraft && (
-				<div data-testid="signup-cta" className="mb-6 space-y-3">
-					{hasUnlimitedSlot ? (
-						<p className="text-sm font-medium text-teal-700">
-							{t("opportunities.unlimitedSpots")}
+				{/* Login prompt */}
+				{!isAuthenticated && !isDraft && (
+					<div data-testid="login-prompt" className="mb-6 space-y-3">
+						<p className="text-sm text-gray-600">
+							{t("opportunities.loginPrompt")}
 						</p>
-					) : (
-						totalMax !== null &&
-						totalMax > 0 &&
-						spotsLeft !== null && (
-							<p
-								className={`text-sm font-medium ${
-									isFull
-										? "text-red-600"
-										: spotsLeft <= 5
-											? "text-orange-700"
-											: "text-gray-600"
-								}`}
-							>
-								{isFull
-									? t("opportunities.noSpotsLeft")
-									: spotsLeft <= 5
-										? t("opportunities.fewSpotsLeft", { count: spotsLeft })
-										: t("opportunities.spotsLeft", { count: spotsLeft })}
-							</p>
-						)
-					)}
-					<Button
-						onClick={() => setShowSignUp(true)}
-						disabled={isFull}
-						fullWidth
-						size="lg"
-					>
-						{opportunity.participationType === "ScheduledSlots"
-							? t("opportunities.joinWaitlist")
-							: t("opportunities.expressInterest")}
-					</Button>
-				</div>
-			)}
+						<Button
+							onClick={() => auth.signinRedirect(signinLocaleArgs())}
+							data-testid="opportunity-signin"
+							fullWidth
+							size="lg"
+						>
+							{t("nav.signIn")}
+						</Button>
+					</div>
+				)}
 
-			{/* Login prompt */}
-			{!isAuthenticated && !isDraft && (
-				<div data-testid="login-prompt" className="mb-6 space-y-3">
-					<p className="text-sm text-gray-600">
-						{t("opportunities.loginPrompt")}
-					</p>
-					<Button
-						onClick={() => auth.signinRedirect(signinLocaleArgs())}
-						data-testid="opportunity-signin"
-						fullWidth
-						size="lg"
-					>
-						{t("nav.signIn")}
-					</Button>
-				</div>
-			)}
-
-			{/* About this organization */}
-			{orgProfileError && !orgProfile && (
-				<div className="mb-6" data-testid="about-organization">
-					<SectionHeading>
-						{t("opportunities.aboutOrganization")}
-					</SectionHeading>
-					<LoadMoreError
-						message={orgProfileError}
-						retrying={retryingOrgProfile}
-						onRetry={retryLoadOrgProfile}
-					/>
-				</div>
-			)}
-			{orgProfile &&
-				(orgProfile.description ||
-					orgProfile.contactEmail ||
-					orgProfile.contactPhone ||
-					orgProfile.website ||
-					orgProfile.address) && (
+				{/* About this organization */}
+				{orgProfileError && !orgProfile && (
 					<div className="mb-6" data-testid="about-organization">
 						<SectionHeading>
 							{t("opportunities.aboutOrganization")}
 						</SectionHeading>
-						{orgProfile.description && (
-							<p className="mb-3 leading-relaxed text-gray-600">
-								{orgProfile.description}
-							</p>
-						)}
-						{(orgProfile.contactEmail ||
-							orgProfile.contactPhone ||
-							orgProfile.website ||
-							orgProfile.address) && (
-							<div
-								className={`space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
-							>
-								{orgProfile.contactEmail && (
-									<div className="flex items-center gap-3">
-										<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-										<a
-											href={`mailto:${orgProfile.contactEmail}`}
-											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-										>
-											{orgProfile.contactEmail}
-										</a>
-									</div>
-								)}
-								{orgProfile.contactPhone && (
-									<div className="flex items-center gap-3">
-										<PhoneIcon className="h-4 w-4 shrink-0 text-gray-400" />
-										<a
-											href={`tel:${orgProfile.contactPhone}`}
-											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-										>
-											{orgProfile.contactPhone}
-										</a>
-									</div>
-								)}
-								{orgProfile.website && (
-									<div className="flex items-center gap-3">
-										<GlobeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-										<a
-											href={orgProfile.website}
-											target="_blank"
-											rel="noopener noreferrer"
-											className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-										>
-											{orgProfile.website}
-										</a>
-									</div>
-								)}
-								{orgProfile.address && (
-									<div className="flex items-center gap-3">
-										<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
-										<span>
-											{orgProfile.address.street}{" "}
-											{orgProfile.address.houseNumber},{" "}
-											{orgProfile.address.zipCode} {orgProfile.address.city}
-										</span>
-									</div>
-								)}
-							</div>
-						)}
+						<LoadMoreError
+							message={orgProfileError}
+							retrying={retryingOrgProfile}
+							onRetry={retryLoadOrgProfile}
+						/>
 					</div>
 				)}
+				{orgProfile &&
+					(orgProfile.description ||
+						orgProfile.contactEmail ||
+						orgProfile.contactPhone ||
+						orgProfile.website ||
+						orgProfile.address) && (
+						<div className="mb-6" data-testid="about-organization">
+							<SectionHeading>
+								{t("opportunities.aboutOrganization")}
+							</SectionHeading>
+							{orgProfile.description && (
+								<p className="mb-3 leading-relaxed text-gray-600">
+									{orgProfile.description}
+								</p>
+							)}
+							{(orgProfile.contactEmail ||
+								orgProfile.contactPhone ||
+								orgProfile.website ||
+								orgProfile.address) && (
+								<div
+									className={`space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
+								>
+									{orgProfile.contactEmail && (
+										<div className="flex items-center gap-3">
+											<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />
+											<a
+												href={`mailto:${orgProfile.contactEmail}`}
+												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+											>
+												{orgProfile.contactEmail}
+											</a>
+										</div>
+									)}
+									{orgProfile.contactPhone && (
+										<div className="flex items-center gap-3">
+											<PhoneIcon className="h-4 w-4 shrink-0 text-gray-400" />
+											<a
+												href={`tel:${orgProfile.contactPhone}`}
+												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+											>
+												{orgProfile.contactPhone}
+											</a>
+										</div>
+									)}
+									{orgProfile.website && (
+										<div className="flex items-center gap-3">
+											<GlobeIcon className="h-4 w-4 shrink-0 text-gray-400" />
+											<a
+												href={orgProfile.website}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+											>
+												{orgProfile.website}
+											</a>
+										</div>
+									)}
+									{orgProfile.address && (
+										<div className="flex items-center gap-3">
+											<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
+											<span>
+												{orgProfile.address.street}{" "}
+												{orgProfile.address.houseNumber},{" "}
+												{orgProfile.address.zipCode} {orgProfile.address.city}
+											</span>
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+					)}
+			</div>
 
-			{/* More from this organization */}
+			{/* More from this organization - a wider grid than the reading
+			column above so a third card doesn't orphan onto its own row on
+			desktop (#1727). */}
 			{otherOrgOpportunities.length > 0 && (
 				<div className="mb-6" data-testid="more-from-organization">
 					<SectionHeading>
 						{t("opportunities.moreFromOrganization")}
 					</SectionHeading>
-					<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
 						{otherOrgOpportunities.map((opp) => (
 							<li
 								key={opp.id}

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -100,18 +100,20 @@ function ToDoWidget({ organizationId, size }: Props) {
 					</div>
 				</div>
 			)}
-			<Link
-				to={`/app/${organizationId}/dashboard/engagements?status=Pending`}
-				className="mt-4 inline-block text-sm font-medium text-brand-700 hover:underline"
-			>
-				{t("orgDashboard.viewPendingEngagements")}
-			</Link>
-			<Link
-				to={`/app/${organizationId}/dashboard/opportunities`}
-				className="mt-2 inline-block text-sm font-medium text-brand-700 hover:underline"
-			>
-				{t("orgDashboard.viewOpportunities")}
-			</Link>
+			<div className="mt-4 flex flex-col gap-2">
+				<Link
+					to={`/app/${organizationId}/dashboard/engagements?status=Pending`}
+					className="text-sm font-medium text-brand-700 hover:underline"
+				>
+					{t("orgDashboard.viewPendingEngagements")}
+				</Link>
+				<Link
+					to={`/app/${organizationId}/dashboard/opportunities`}
+					className="text-sm font-medium text-brand-700 hover:underline"
+				>
+					{t("orgDashboard.viewOpportunities")}
+				</Link>
+			</div>
 		</WidgetCard>
 	);
 }


### PR DESCRIPTION
## What

Fixes four of the five frontend layout/design defects reported in a full render sweep across 22 routes x 4 personas x 4 viewports:

1. `ToDoWidget.tsx`'s two dashboard links now stack in a flex column instead of running together as inline-block siblings past the compact widget size.
2. `NotFoundPage` is imported statically in `App.tsx` instead of `lazy()` - `OrgAppLayout.tsx` and `EngagementManagementPage.tsx` already import it statically, forcing it into the entry chunk regardless and tripping Vite's `INEFFECTIVE_DYNAMIC_IMPORT` warning on every build.
3. `VolunteerOpportunityDetailPage`'s banner image, time-slots list, and "more from this organization" grid now span a wider outer wrapper (`max-w-2xl` -> `max-w-4xl`), while prose content (title, description, info card, map, application status/CTA, about-organization) stays in a narrower inner reading column - fixes the ~430px dead margins at 1440px and the orphaned third card in the related-offers grid (now `xl:grid-cols-3`).
4. `Footer`'s compact variant (used by the logged-in app shell) now actually carries Terms of Use, Contact, and the GitHub/LICENSE link alongside Imprint/Privacy/Help, matching its own in-code comment's claim of carrying the "same legal links" as the full marketing footer.

**Intentionally not included:** the issue's second item (unifying `OrgOpportunitiesPage`'s four stacked status sections into `MyEngagementsPage`'s tabbed pattern, and dropping per-card status badges as "redundant"). `backend/tests/VisualTests/` has several tests (`OpportunityUnpublishCancelTests.cs`, `VolunteerOpportunityTests.cs`'s `OpportunitiesHub_ShowsDraftAndPublished_AndPublishesDraftInline`, `OrganizationEngagementsTabTests.cs`) that depend on Draft/Published/Unpublished/Cancelled all being visible **simultaneously** (an organizer publishing a draft watches it move between sections on the same screen) and on the per-card status badge existing with specific text - both deliberate, per the in-code `#984` rationale comment still in that file. A literal mutually-exclusive-tabs conversion would regress that tested, intentional behavior, so it needs a coordinated product/test decision rather than a drive-by UI change.

## Why

Closes #1727 (partially - see scope note above).

## Testing

- `pnpm check` (tsc), `pnpm lint` (zero warnings), `pnpm i18n:check`, `pnpm test` (193/193 unit tests), `pnpm build` (confirmed `INEFFECTIVE_DYNAMIC_IMPORT` warning is gone and no separate `NotFoundPage` chunk is emitted).
- Ran the `a11y-check` subagent against every changed `.tsx` file: no actionable a11y issues - heading order stays flat, no landmark-nesting from the new wrapper `div`s, the new external LICENSE link matches the existing house convention for `target="_blank"` links, and every pre-existing `data-testid` is preserved unchanged.
- No backend changes, so `backend/tests/VisualTests/` wasn't run locally (this sandbox has no Docker/Aspire - see root `AGENTS.md`'s Sandbox Limitations); CI's `dotnet.yml` will run the full suite including the opportunity-detail spacing/centering tests (`OpportunityDetailPageSpacingTests.cs`, `AssertMaxWidthContentCenteredAsync`) and the grid side-by-side tests (`ListLayoutGridTests.cs`) against these changes.

## Live verification

Not applicable - no release candidate was cut for this PR per explicit instruction. This is a frontend-only visual/layout change; if a live check is wanted later, `/live-verify` against staging or a fresh RC would be the way to do it.

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 findings; a11y-check subagent fanned out, clean)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no behavior change, layout only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QeofL8G5dexAjsNmdHtQ8k)_