### PR TITLE
fix: harden shared-fetch rejections, achievement polling, dialog dismiss races, and lazy-load org form

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -39,6 +39,12 @@ export default function ConfirmDialog({
 			labelledBy="confirm-dialog-title"
 			maxWidth="max-w-sm"
 			initialFocusRef={actionsRef}
+			// An in-flight confirm/deny request whose result would otherwise be
+			// lost if Escape/backdrop dismissed the dialog before it settles -
+			// see einsatzbereit#1728. Every caller already passes `loading`, so
+			// this closes the gap for all of them (including callers that forgot
+			// their own guard) in one place instead of ten hand-rolled ones.
+			closeDisabled={loading}
 		>
 			<h2
 				id="confirm-dialog-title"

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import type {
@@ -7,9 +7,19 @@ import type {
 } from "../../client/api-client";
 import { orgTabPath } from "../../lib/orgTabs";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
-import CreateOrganizationModal from "../CreateOrganizationModal";
+import ModalLoadingFallback from "../ModalLoadingFallback";
 import Skeleton from "../Skeleton";
 import { ChevronDownIcon, PlusIcon } from "../icons";
+
+// Lazy-loaded: this component is statically imported by Header, which is
+// eager on every route (including the anonymous landing page) - without
+// this, react-hook-form + zod stay in the entry chunk regardless of whether
+// HomePage's own CreateOrganizationModal usage is lazy-loaded, since
+// bundlers keep a module in its statically-importing chunk even when a
+// *different* call site imports it dynamically (#1728).
+const CreateOrganizationModal = lazy(
+	() => import("../CreateOrganizationModal"),
+);
 
 export default function OrganizationSwitcher({
 	currentOrgId,
@@ -158,10 +168,16 @@ export default function OrganizationSwitcher({
 			</div>
 
 			{showModal && (
-				<CreateOrganizationModal
-					onClose={() => setShowModal(false)}
-					onSuccess={handleOrgCreated}
-				/>
+				<Suspense
+					fallback={
+						<ModalLoadingFallback onClose={() => setShowModal(false)} />
+					}
+				>
+					<CreateOrganizationModal
+						onClose={() => setShowModal(false)}
+						onSuccess={handleOrgCreated}
+					/>
+				</Suspense>
 			)}
 		</>
 	);

--- a/frontend/src/components/LoadMoreError.tsx
+++ b/frontend/src/components/LoadMoreError.tsx
@@ -6,18 +6,27 @@ interface Props {
 	message: string;
 	retrying: boolean;
 	onRetry: () => void;
+	"data-testid"?: string;
 }
 
 // Inline "load more failed" state - keeps whatever already rendered above it
 // in place and offers a retry, rather than the page's full error banner
 // (which would also hide those already-loaded rows). See einsatzbereit#1226.
-export default function LoadMoreError({ message, retrying, onRetry }: Props) {
+// Also doubles as the initial-load error state for lists that want a retry
+// affordance instead of a dead-end ErrorBanner (einsatzbereit#1728) - `message`/
+// `retrying`/`onRetry` read the same either way.
+export default function LoadMoreError({
+	message,
+	retrying,
+	onRetry,
+	"data-testid": testId,
+}: Props) {
 	const { t } = useTranslation();
 	// useId (not a fixed string) - OrgOpportunitiesPage renders a drafts and a
 	// published instance of this at once, which would otherwise collide.
 	const errorId = useId();
 	return (
-		<div className="mt-6 flex flex-col items-center gap-3">
+		<div className="mt-6 flex flex-col items-center gap-3" data-testid={testId}>
 			<ErrorBanner id={errorId} message={message} />
 			{/* aria-describedby ties this to the error text above - its own
 			accessible name ("Retry") says nothing about what it's retrying, and a

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -17,6 +17,14 @@ interface ModalProps {
 	backdropClassName?: string;
 	/** While true, Escape and the Tab focus trap are suspended - for when a nested dialog owns them instead. */
 	suspended?: boolean;
+	/**
+	 * While true, Escape and the backdrop click no longer call `onClose` - for
+	 * an in-flight action (e.g. a confirm dialog's delete request) whose
+	 * result would otherwise be lost if the dialog closed out from under it
+	 * before the request settles. The dialog's own action buttons are
+	 * expected to disable themselves separately (see ConfirmDialog).
+	 */
+	closeDisabled?: boolean;
 	/** Scopes the initial-focus search to a subtree instead of the whole dialog (e.g. to skip a header close button). */
 	initialFocusRef?: RefObject<HTMLElement | null>;
 	children: ReactNode;
@@ -29,6 +37,7 @@ export default function Modal({
 	className = "rounded-card bg-white p-6 shadow-modal",
 	backdropClassName = "bg-black/50",
 	suspended = false,
+	closeDisabled = false,
 	initialFocusRef,
 	children,
 }: ModalProps) {
@@ -68,7 +77,7 @@ export default function Modal({
 		function handleKeyDown(e: KeyboardEvent) {
 			if (suspended) return;
 			if (e.key === "Escape") {
-				onClose();
+				if (!closeDisabled) onClose();
 				return;
 			}
 			if (e.key !== "Tab" || !dialogRef.current) return;
@@ -88,7 +97,7 @@ export default function Modal({
 		}
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [onClose, suspended]);
+	}, [onClose, suspended, closeDisabled]);
 
 	// Portaled to document.body rather than rendered in place - a modal opened
 	// from inside a dashboard widget would otherwise live inside
@@ -112,7 +121,7 @@ export default function Modal({
 				// away with the rest of the content otherwise, uncovering whatever's
 				// behind the dialog once scrolled.
 				className={`fixed inset-0 ${backdropClassName}`}
-				onClick={onClose}
+				onClick={closeDisabled ? undefined : onClose}
 				tabIndex={-1}
 				aria-hidden="true"
 			/>

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
 import EmptyState from "../EmptyState";
 import Skeleton from "../Skeleton";
-import ErrorBanner from "../ErrorBanner";
 import LoadMoreError from "../LoadMoreError";
 import LoadMoreButton from "../LoadMoreButton";
 import OpportunityListItem from "./OpportunityListItem";
@@ -70,8 +69,10 @@ export default function OpportunityResultsList({
 				</div>
 			)}
 			{error && (
-				<ErrorBanner
+				<LoadMoreError
 					message={t("opportunities.error", { message: error })}
+					retrying={loading}
+					onRetry={onRetryLoadMore}
 					data-testid="opportunities-error"
 				/>
 			)}

--- a/frontend/src/hooks/useAchievementNotifier.ts
+++ b/frontend/src/hooks/useAchievementNotifier.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "./useApiClient";
@@ -47,18 +47,25 @@ export function useAchievementNotifier() {
 	const auth = useAuth();
 	const api = useApiClient();
 	const { t } = useTranslation();
-	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	// Scoped per user id (#1236) - a global key leaked between accounts on any
 	// shared browser (a kiosk, or the seeded vera/olaf/admin staging accounts).
 	const userId = auth.user?.profile?.sub;
 
+	// Pauses while the tab is hidden and catches up with an immediate fetch
+	// when it becomes visible again (mirrors useAccountMenu's unread-count
+	// poll) - without this, this hook is mounted on every route (AppLayout,
+	// OrgAppLayout) with a plain setInterval, so a backend outage became a
+	// recurring error toast every 60s on every page, in every open tab,
+	// including backgrounded ones.
 	useEffect(() => {
 		if (!auth.isAuthenticated) return;
 		const key = seenKeyFor(userId);
+		const controller = new AbortController();
+		let intervalId: ReturnType<typeof setInterval> | null = null;
 
 		const check = async () => {
 			try {
-				const achievements = await api.getMyAchievements();
+				const achievements = await api.getMyAchievements(controller.signal);
 				const seen = getSeenIds(key);
 				// First successful poll for this user/device: seed their existing
 				// achievements as already-seen (writing the marker unconditionally,
@@ -88,14 +95,39 @@ export function useAchievementNotifier() {
 					);
 				}
 			} catch (err) {
+				if (controller.signal.aborted) return;
 				console.error("[useAchievementNotifier] poll failed:", err);
 			}
 		};
 
+		const startPolling = () => {
+			if (intervalId !== null) return;
+			intervalId = setInterval(() => void check(), 60_000);
+		};
+
+		const stopPolling = () => {
+			if (intervalId === null) return;
+			clearInterval(intervalId);
+			intervalId = null;
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "visible") {
+				void check();
+				startPolling();
+			} else {
+				stopPolling();
+			}
+		};
+
 		void check();
-		intervalRef.current = setInterval(() => void check(), 60_000);
+		if (document.visibilityState === "visible") startPolling();
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
 		return () => {
-			if (intervalRef.current) clearInterval(intervalRef.current);
+			controller.abort();
+			stopPolling();
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [auth.isAuthenticated, userId]);

--- a/frontend/src/hooks/useSharedOrgFetch.ts
+++ b/frontend/src/hooks/useSharedOrgFetch.ts
@@ -34,9 +34,18 @@ export function useSharedOrgFetch<T>(
 			inFlight.set(key, promise);
 			// Dropped once settled - the next mount/refresh under this key issues
 			// a fresh request rather than serving indefinitely stale data.
-			void promise.finally(() => {
-				if (inFlight.get(key) === promise) inFlight.delete(key);
-			});
+			// The trailing .catch(() => {}) is load-bearing, not decorative: the
+			// promise returned by .finally() is a *new* derived promise with no
+			// rejection handler of its own (the .catch below at :46-48 attaches to
+			// a different link in the chain) - without this, every failed shared
+			// fetch reached window's unhandledrejection listener in main.tsx and
+			// fired a bogus app-wide error toast on top of whatever this hook's
+			// own error branch already rendered.
+			void promise
+				.finally(() => {
+					if (inFlight.get(key) === promise) inFlight.delete(key);
+				})
+				.catch(() => {});
 		}
 
 		promise

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -295,7 +295,6 @@ export default function EngagementManagementPage() {
 	}
 
 	function handleBulkCancelClose() {
-		if (bulkCancelling) return;
 		setBulkCancelOpen(false);
 		setBulkCancelReason("");
 		setBulkCancelError(null);
@@ -502,7 +501,6 @@ export default function EngagementManagementPage() {
 	}
 
 	function handleCancelClose() {
-		if (cancelling) return;
 		setConfirmCancelId(null);
 		setCancelReason("");
 		setCancelError(null);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useId, useState } from "react";
+import { lazy, Suspense, useEffect, useId, useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router";
 import type { OrganizationSummaryDto } from "../client/api-client";
 import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList/VolunteerOpportunitiesList";
-import CreateOrganizationModal from "../components/CreateOrganizationModal";
 import Button from "../components/Button";
+import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import Skeleton from "../components/Skeleton";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -22,6 +22,14 @@ import {
 	MapPinIcon,
 	SparklesIcon,
 } from "../components/icons";
+
+// Lazy-loaded: HomePage itself must stay a plain eager import (see App.tsx's
+// comment on why), but the org-creation form it conditionally renders pulls
+// in react-hook-form + zod (~27 KiB gzip) that an anonymous landing-page
+// visitor - the vast majority of this page's traffic - never needs (#1728).
+const CreateOrganizationModal = lazy(
+	() => import("../components/CreateOrganizationModal"),
+);
 
 // ── Page ─────────────────────────────────────────────────────────────────────
 
@@ -454,28 +462,36 @@ export default function HomePage() {
 			</div>
 
 			{showCreateOrgModal && (
-				<CreateOrganizationModal
-					onClose={() => setShowCreateOrgModal(false)}
-					onSuccess={async (org) => {
-						setShowCreateOrgModal(false);
-						// CreateOrganization grants the "organisator" realm role
-						// server-side, but the access token already held by the
-						// browser was minted before that grant and doesn't carry
-						// it yet - EinsatzbereitOrganisatorPolicy checks that
-						// static claim, so the org app shell's very next request
-						// (OrgAppLayout's GetOrganizationDetails call) would 403
-						// against the stale token before it ever reaches the
-						// live per-organization membership check. Best-effort:
-						// if silent renewal fails, still navigate - the org app
-						// shell's own error state takes over from there.
-						try {
-							await auth.signinSilent();
-						} catch {
-							/* see comment above */
-						}
-						navigate(`/app/${org.id?.value}/dashboard`);
-					}}
-				/>
+				<Suspense
+					fallback={
+						<ModalLoadingFallback
+							onClose={() => setShowCreateOrgModal(false)}
+						/>
+					}
+				>
+					<CreateOrganizationModal
+						onClose={() => setShowCreateOrgModal(false)}
+						onSuccess={async (org) => {
+							setShowCreateOrgModal(false);
+							// CreateOrganization grants the "organisator" realm role
+							// server-side, but the access token already held by the
+							// browser was minted before that grant and doesn't carry
+							// it yet - EinsatzbereitOrganisatorPolicy checks that
+							// static claim, so the org app shell's very next request
+							// (OrgAppLayout's GetOrganizationDetails call) would 403
+							// against the stale token before it ever reaches the
+							// live per-organization membership check. Best-effort:
+							// if silent renewal fails, still navigate - the org app
+							// shell's own error state takes over from there.
+							try {
+								await auth.signinSilent();
+							} catch {
+								/* see comment above */
+							}
+							navigate(`/app/${org.id?.value}/dashboard`);
+						}}
+					/>
+				</Suspense>
 			)}
 		</>
 	);

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -144,7 +144,6 @@ export default function ActivitySection() {
 	}
 
 	function handleWithdrawClose() {
-		if (withdrawing) return;
 		setConfirmWithdrawId(null);
 		setWithdrawError(null);
 	}
@@ -223,7 +222,6 @@ export default function ActivitySection() {
 	}
 
 	function handleDeleteFeedbackClose() {
-		if (deletingFeedback) return;
 		setConfirmDeleteFeedbackId(null);
 		setDeleteFeedbackError(null);
 	}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -771,7 +771,6 @@ export default function VolunteerOpportunityDetailPage() {
 					confirmLabel={t("confirmDialog.withdraw.confirm")}
 					onConfirm={handleWithdrawConfirm}
 					onClose={() => {
-						if (withdrawing) return;
 						setShowWithdrawConfirm(false);
 						setWithdrawError(null);
 					}}

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -129,7 +129,6 @@ export default function OrgEngagementsPage() {
 	}
 
 	function handleCancelClose() {
-		if (cancelling) return;
 		setConfirmCancelId(null);
 		setCancelReason("");
 		setCancelError(null);

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -620,7 +620,6 @@ export default function OrgMembersPage() {
 					confirmLabel={t("confirmDialog.removeMember.confirm")}
 					onConfirm={() => void handleConfirmRemoveMember()}
 					onClose={() => {
-						if (removingMember) return;
 						setRemoveTarget(null);
 						setRemoveMemberError(null);
 					}}

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -286,7 +286,6 @@ export default function OrgOpportunitiesPage() {
 	}
 
 	function handleCancelClose() {
-		if (cancelling) return;
 		setCancelTargetId(null);
 		setCancelReason("");
 		setCancelError(null);
@@ -670,7 +669,6 @@ export default function OrgOpportunitiesPage() {
 					confirmLabel={t("confirmDialog.delete.confirm")}
 					onConfirm={handleDeleteConfirm}
 					onClose={() => {
-						if (deleting) return;
 						setDeleteTargetId(null);
 						setDeleteError(null);
 					}}
@@ -686,7 +684,6 @@ export default function OrgOpportunitiesPage() {
 					confirmLabel={t("confirmDialog.unpublish.confirm")}
 					onConfirm={handleUnpublishConfirm}
 					onClose={() => {
-						if (unpublishing) return;
 						setUnpublishTargetId(null);
 						setUnpublishError(null);
 					}}


### PR DESCRIPTION
## What

Five related frontend runtime-resilience fixes from a 1.0 readiness analysis: an unhandled-rejection leak, a poller that never pauses, a dismissable in-flight delete, a dead-end error state, and a heavy form bundle sitting on the anonymous critical path.

## Why

Closes #1728

1. **`useSharedOrgFetch` leaked an unhandled rejection.** The promise returned by `.finally(...)` has no rejection handler of its own, so every failed shared fetch reached `window`'s `unhandledrejection` listener in `main.tsx` and fired a bogus app-wide `error.serverError` toast on top of whatever the component already rendered. Fixed with a trailing `.catch(() => {})`.
2. **The achievement poller never paused.** No `visibilitychange` gating and no `AbortController` - mounted on every route, so a backend outage became a recurring error toast every 60s on every page, in every open tab, including backgrounded ones. Now mirrors `useAccountMenu`'s pattern: pause when hidden, catch up with an immediate fetch on visibility, abort in-flight requests on cleanup.
3. **Account deletion (and nine other flows) silently swallowed their own failure if the confirm dialog was dismissed mid-request.** `Modal` called `onClose` unconditionally on Escape/backdrop-click with no in-flight gate. Ten call sites had grown their own `if (busy) return;` guard - `DangerZoneCard.tsx` (account deletion) didn't, and neither (previously unnoticed) did `OrgMembersPage`'s leave-organization dialog. Fixed at the root: `Modal` gained an optional `closeDisabled` prop, and `ConfirmDialog` now passes `closeDisabled={loading}` - every caller already passed `loading`, so this closes the gap for all eleven dialogs in one place. The ten redundant hand-rolled guards were removed as dead code now that `Modal` handles it centrally.
4. **The home opportunity list was the only list with no retry.** `OpportunityResultsList.tsx` rendered a bare `ErrorBanner` (no action) on initial-load failure, even though the retry callback (`retryLoadMore`) was already threaded in and unused for this branch. Swapped for `LoadMoreError`, matching every other list in the app.
5. **`react-hook-form` + `zod` (~27 KiB gzip) shipped on the anonymous landing critical path.** `HomePage.tsx` statically imported `CreateOrganizationModal`, which pulls in the whole form stack. Lazy-loading only `HomePage`'s usage wasn't sufficient, though: `Header/OrganizationSwitcher.tsx` also statically imports the same component, and `Header` is eager on every route (including the anonymous homepage) - bundlers keep a module in its statically-importing chunk even when a different call site imports it dynamically. Both call sites are now lazy-loaded behind `Suspense`/`ModalLoadingFallback` (the same pattern already used for `CreateVolunteerOpportunityModal`/`QRScannerModal`). Verified via `pnpm build`: `CreateOrganizationModal` and the `react-hook-form`/`zod` schema chunk no longer appear in the entry chunk.

## Testing

- `pnpm check` (tsc), `pnpm lint` (zero warnings), `pnpm test` (193 tests, 21 files) - all green.
- `pnpm build` + inspected `dist/assets/` to confirm `CreateOrganizationModal`/`schemas` are separate chunks, not merged into `index-*.js`.
- `node scripts/check-pwa-precache.js` and `node scripts/check-i18n-keys.js` - both pass (no locale keys added; no route/precache-manifest impact).
- `a11y-check` subagent reviewed the diff against `frontend/AGENTS.md`'s conventions: no violations. Confirmed the `closeDisabled` behavior is functionally equivalent to the removed per-call-site guards (Escape/backdrop already no-opped while `loading`, just via a different mechanism), and the lazy-load pattern matches existing usage.
- No new page/route was added, so no new `AccessibilityTests.cs` case is needed.

## Live verification

Skipped per explicit instruction for this task - no release candidate was cut and no live-staging verification was performed. All five fixes were verified locally via the checks above (type-check, lint, unit tests, production build + bundle inspection, PWA/i18n static checks, and an a11y review of the diff). Sandbox note: this session has no reliable Docker, so `VisualTests` (Playwright E2E) could not be run locally either - CI's `dotnet.yml` will cover that.

## Checklist

- [x] `/self-review`-equivalent manual review run (diff walked file-by-file; `a11y-check` subagent dispatched for the touched `.tsx` files) and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs affected; comments added inline explaining the non-obvious fixes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSvqAq9uXtdJLPU2m8igQg)_