### PR TITLE
fix: close i18n gaps in digest emails, zod errors, and locale plumbing

### DIFF
--- a/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
@@ -22,6 +22,10 @@ internal static class OutputCachingExtensions
 			cache.AddPolicy(OutputCachingPolicies.LongPublicRead, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.LongPublicReadSeconds)));
 
+			cache.AddPolicy(OutputCachingPolicies.LongPublicReadByLanguage, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.LongPublicReadSeconds))
+					.SetVaryByHeader("X-Language"));
+
 			cache.AddPolicy(OutputCachingPolicies.ShortPublicRead, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds)));
 

--- a/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
@@ -5,6 +5,13 @@ public static class OutputCachingPolicies
 	public const string LongPublicRead = "output-cache-long-public-read";
 	public const string ShortPublicRead = "output-cache-short-public-read";
 
+	// Same expiry as LongPublicRead, but for a response that varies by the caller's
+	// X-Language header (e.g. SearchCities) - LongPublicRead's cache key is only the
+	// request path + query string (see the OutputCachingExtensions.cs comment), so a
+	// language-dependent endpoint using it as-is could serve a response cached for one
+	// language to a caller requesting another (#1731).
+	public const string LongPublicReadByLanguage = "output-cache-long-public-read-by-language";
+
 	// A few seconds only, not ShortPublicReadSeconds - /health backs the deploy gate's
 	// and docker-compose's readiness probes, both of which need to observe a real
 	// dependency outage within a handful of seconds, not up to a full minute (#1172).

--- a/backend/src/Api/Maps/SearchCities/v1/SearchCitiesEndpoint.cs
+++ b/backend/src/Api/Maps/SearchCities/v1/SearchCitiesEndpoint.cs
@@ -21,7 +21,7 @@ internal sealed class SearchCitiesEndpoint : IEndpoint
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
-			.CacheOutput(OutputCachingPolicies.LongPublicRead)
+			.CacheOutput(OutputCachingPolicies.LongPublicReadByLanguage)
 			.MapToApiVersion(1);
 	}
 

--- a/backend/src/Application/Common/Email/EmailTemplateKind.cs
+++ b/backend/src/Application/Common/Email/EmailTemplateKind.cs
@@ -20,6 +20,11 @@ public enum EmailTemplateKind
 	OpportunityUpdated,
 	SearchAlertNewMatches,
 
+	// Count-independent phrasing for the single-match case (#1731) - selected at the
+	// send site (SearchAlertMatchesFoundNotificationHandler) instead of interpolating
+	// {Count} into SearchAlertNewMatches, which reads as "1 new opportunities".
+	SearchAlertNewMatchesSingle,
+
 	// Body-only fragment appended to every outgoing notification email via
 	// EmailFooter.Append - same "render separately, splice in" pattern as
 	// EngagementCancelledReasonSuffix above.

--- a/backend/src/Application/Users/SearchAlertDigest/v1/SearchAlertMatchesFoundNotificationHandler.cs
+++ b/backend/src/Application/Users/SearchAlertDigest/v1/SearchAlertMatchesFoundNotificationHandler.cs
@@ -61,7 +61,7 @@ internal sealed class SearchAlertMatchesFoundNotificationHandler(
 		var opportunitiesList = string.Join('\n', opportunities.Select(o => $"- {o.Title}"));
 
 		var content = emailTemplateRenderer.Render(
-			EmailTemplateKind.SearchAlertNewMatches,
+			opportunities.Count == 1 ? EmailTemplateKind.SearchAlertNewMatchesSingle : EmailTemplateKind.SearchAlertNewMatches,
 			language,
 			new Dictionary<string, string>
 			{

--- a/backend/src/Infrastructure/Email/Templates/de.json
+++ b/backend/src/Infrastructure/Email/Templates/de.json
@@ -43,6 +43,10 @@
     "subject": "{Count} neue Einsätze passen zu deiner gespeicherten Suche",
     "body": "Hallo {DisplayName},\n\nwir haben {Count} neue Einsätze gefunden, die zu deiner gespeicherten Suche passen:\n\n{OpportunitiesList}\n\nMelde dich bei Einsatzbereit an, um die Details zu sehen und dich anzumelden. Du kannst diese Benachrichtigung jederzeit auf der Suchseite deaktivieren.\n\nEinsatzbereit"
   },
+  "SearchAlertNewMatchesSingle": {
+    "subject": "Ein neuer Einsatz passt zu deiner gespeicherten Suche",
+    "body": "Hallo {DisplayName},\n\nwir haben einen neuen Einsatz gefunden, der zu deiner gespeicherten Suche passt:\n\n{OpportunitiesList}\n\nMelde dich bei Einsatzbereit an, um die Details zu sehen und dich anzumelden. Du kannst diese Benachrichtigung jederzeit auf der Suchseite deaktivieren.\n\nEinsatzbereit"
+  },
   "EmailFooter": {
     "subject": "",
     "body": "\n\n---\nMöchtest du diese Art von E-Mail nicht mehr erhalten? Hier abmelden: {UnsubscribeUrl}"

--- a/backend/src/Infrastructure/Email/Templates/en.json
+++ b/backend/src/Infrastructure/Email/Templates/en.json
@@ -43,6 +43,10 @@
     "subject": "{Count} new opportunities match your saved search",
     "body": "Hi {DisplayName},\n\nWe found {Count} new opportunities matching your saved search:\n\n{OpportunitiesList}\n\nLog in to Einsatzbereit to see the details and sign up. You can turn this alert off any time from the search page.\n\nEinsatzbereit"
   },
+  "SearchAlertNewMatchesSingle": {
+    "subject": "A new opportunity matches your saved search",
+    "body": "Hi {DisplayName},\n\nWe found a new opportunity matching your saved search:\n\n{OpportunitiesList}\n\nLog in to Einsatzbereit to see the details and sign up. You can turn this alert off any time from the search page.\n\nEinsatzbereit"
+  },
   "EmailFooter": {
     "subject": "",
     "body": "\n\n---\nDon't want to receive this type of email? Unsubscribe here: {UnsubscribeUrl}"

--- a/backend/tests/Application.UnitTests/Users/SearchAlertDigest/SearchAlertMatchesFoundNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/SearchAlertDigest/SearchAlertMatchesFoundNotificationHandlerTests.cs
@@ -98,6 +98,44 @@ public class SearchAlertMatchesFoundNotificationHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldRenderSingularTemplate_ForOneMatch(
+		CancellationToken cancellationToken)
+	{
+		var opportunity = CreateOpportunity();
+		_dbContext
+			.GetVolunteerOpportunitiesByIdsAsync(Arg.Any<IReadOnlyCollection<VolunteerOpportunityId>>(), cancellationToken)
+			.Returns([opportunity]);
+		var notification = new SearchAlertMatchesFoundDomainEvent(SearchAlertId.New(), UserId.New(), [opportunity.Id.Value]);
+
+		await _sut.Handle(notification, cancellationToken);
+
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.SearchAlertNewMatchesSingle,
+			Arg.Any<string>(),
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderPluralTemplate_ForMultipleMatches(
+		CancellationToken cancellationToken)
+	{
+		var first = CreateOpportunity();
+		var second = CreateOpportunity();
+		_dbContext
+			.GetVolunteerOpportunitiesByIdsAsync(Arg.Any<IReadOnlyCollection<VolunteerOpportunityId>>(), cancellationToken)
+			.Returns([first, second]);
+		var notification = new SearchAlertMatchesFoundDomainEvent(
+			SearchAlertId.New(), UserId.New(), [first.Id.Value, second.Id.Value]);
+
+		await _sut.Handle(notification, cancellationToken);
+
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.SearchAlertNewMatches,
+			Arg.Any<string>(),
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
 	public async Task Handle_ShouldSkip_WhenNoneOfTheMatchedOpportunitiesStillExist(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -148,6 +148,32 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 		secondBody.Should().Contain("Org Two").And.NotContain("Org One");
 	}
 
+	// Regression coverage for #1731: SearchCities' response varies by the caller's
+	// X-Language header (Nominatim returns different exonyms per language), so unlike
+	// LongPublicRead's plain path+query cache key, its policy must also vary by that
+	// header - otherwise a request in one language could be served a response cached
+	// for another.
+	[Test]
+	public async Task SearchCities_ShouldCacheEachLanguageSeparately(
+		CancellationToken cancellationToken)
+	{
+		using var httpClient = WithForwardedFor(fixture.CreateHttpClient(), "10.0.2.7");
+		const string route = "/v1/maps/cities?q=Berlin";
+
+		httpClient.DefaultRequestHeaders.Add("X-Language", "de");
+		await httpClient.GetAsync(route, cancellationToken);
+		var germanSecondRequest = await httpClient.GetAsync(route, cancellationToken);
+
+		httpClient.DefaultRequestHeaders.Remove("X-Language");
+		httpClient.DefaultRequestHeaders.Add("X-Language", "en");
+		var englishFirstRequest = await httpClient.GetAsync(route, cancellationToken);
+
+		germanSecondRequest.Headers.TryGetValues("Age", out _).Should().BeTrue(
+			"the second identical German-language request should be served from the output cache");
+		englishFirstRequest.Headers.TryGetValues("Age", out _).Should().BeFalse(
+			"a different X-Language must be a cache miss, not reuse the German response cached above");
+	}
+
 	// GetOrganizationOpportunities is authenticated and organizer-scoped - its response is not
 	// the same for every caller, so it must be excluded from output caching. Caching it under
 	// the default (caller-agnostic) cache key would risk serving one organizer's data to another.

--- a/frontend/src/components/CreateVolunteerOpportunityModal/schema.ts
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/schema.ts
@@ -14,16 +14,17 @@ const CHECK_IN_METHOD_VALUES = ["None", "QRCode", "PINCode", "Manual"] as const;
 export function buildOpportunityFormSchema(t: TFunction) {
 	const required = t("createOpportunity.fieldRequired");
 	const invalidPin = t("createOpportunity.checkInPinInvalid");
+	const tooLong = (max: number) => t("createOpportunity.fieldTooLong", { max });
 
 	return z
 		.object({
-			title: z.string().max(150),
-			description: z.string().max(2000),
+			title: z.string().max(150, tooLong(150)),
+			description: z.string().max(2000, tooLong(2000)),
 			isRemote: z.boolean(),
-			street: z.string().max(100),
-			houseNumber: z.string().max(10),
-			zipCode: z.string().max(5),
-			city: z.string().max(100),
+			street: z.string().max(100, tooLong(100)),
+			houseNumber: z.string().max(10, tooLong(10)),
+			zipCode: z.string().max(5, tooLong(5)),
+			city: z.string().max(100, tooLong(100)),
 			occurrence: z.enum(OCCURRENCE_VALUES),
 			participationType: z.enum(PARTICIPATION_TYPE_VALUES),
 			checkInMethod: z.enum(CHECK_IN_METHOD_VALUES),

--- a/frontend/src/components/TagsInput.tsx
+++ b/frontend/src/components/TagsInput.tsx
@@ -4,6 +4,12 @@ import { useTranslation } from "react-i18next";
 import Chip from "./Chip";
 import { labelClass } from "../lib/formClasses";
 
+// Mirrors VolunteerOpportunity.MaxTagsCount/MaxTagLength (#1678) - keeping the
+// same bounds here means the backend's VolunteerOpportunity.TooManyTags/
+// TagTooLong validation errors are not reachable in normal use (#1731).
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
 interface Props {
 	id: string;
 	label: string;
@@ -30,6 +36,18 @@ export default function TagsInput({
 		const trimmed = draft.trim();
 		setDraft("");
 		if (!trimmed) return;
+		if (value.length >= MAX_TAGS) {
+			setStatusMessage(
+				t("createOpportunity.tagLimitReached", { max: MAX_TAGS }),
+			);
+			return;
+		}
+		if (trimmed.length > MAX_TAG_LENGTH) {
+			setStatusMessage(
+				t("createOpportunity.tagTooLong", { max: MAX_TAG_LENGTH }),
+			);
+			return;
+		}
 		const alreadyPresent = value.some(
 			(tag) => tag.toLowerCase() === trimmed.toLowerCase(),
 		);
@@ -96,6 +114,7 @@ export default function TagsInput({
 					id={id}
 					type="text"
 					value={draft}
+					maxLength={MAX_TAG_LENGTH}
 					onChange={(e) => setDraft(e.target.value)}
 					onKeyDown={handleKeyDown}
 					onBlur={commitDraft}

--- a/frontend/src/lib/organizationFormSchema.test.ts
+++ b/frontend/src/lib/organizationFormSchema.test.ts
@@ -98,10 +98,16 @@ describe("buildOrganizationFormSchema", () => {
 		expect(zipIssue?.message).toBe("orgSettings.fieldRequired");
 	});
 
-	it("rejects a name longer than 100 characters", () => {
+	it("rejects a name longer than 100 characters with a translated message", () => {
 		const result = schema.safeParse(values({ name: "a".repeat(101) }));
 		expect(result.success).toBe(false);
 		expect(issuePaths(result)).toContain("name");
+		// Regression guard for #1731: zod's built-in message must not leak
+		// through untranslated for any bare .max() field.
+		const nameIssue = result.error?.issues.find(
+			(issue) => issue.path[0] === "name",
+		);
+		expect(nameIssue?.message).toBe("orgSettings.fieldTooLong");
 	});
 
 	it("trims whitespace-only address fields the same as empty ones", () => {

--- a/frontend/src/lib/organizationFormSchema.ts
+++ b/frontend/src/lib/organizationFormSchema.ts
@@ -11,18 +11,19 @@ export function buildOrganizationFormSchema(t: TFunction) {
 	const required = t("orgSettings.fieldRequired");
 	const invalidZip = t("orgSettings.zipInvalid");
 	const invalidWebsite = t("orgSettings.websiteInvalid");
+	const tooLong = (max: number) => t("orgSettings.fieldTooLong", { max });
 
 	return z
 		.object({
-			name: z.string().max(100),
-			description: z.string().max(1000),
-			contactEmail: z.string().max(254),
-			contactPhone: z.string().max(30),
-			website: z.string().max(500),
-			street: z.string().max(200),
-			houseNumber: z.string().max(20),
-			zipCode: z.string().max(10),
-			city: z.string().max(100),
+			name: z.string().max(100, tooLong(100)),
+			description: z.string().max(1000, tooLong(1000)),
+			contactEmail: z.string().max(254, tooLong(254)),
+			contactPhone: z.string().max(30, tooLong(30)),
+			website: z.string().max(500, tooLong(500)),
+			street: z.string().max(200, tooLong(200)),
+			houseNumber: z.string().max(20, tooLong(20)),
+			zipCode: z.string().max(10, tooLong(10)),
+			city: z.string().max(100, tooLong(100)),
 		})
 		.superRefine((data, ctx) => {
 			if (!data.name.trim())

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -225,6 +225,7 @@
       "checkInMethodNoneHint": "Teilnehmer:innen werden während des Einsatzes nicht eingecheckt. Sie werden automatisch als eingecheckt markiert, sobald der Zeitslot beendet ist - das schaltet für sie auch das Feedback frei.",
       "checkInMethodNoneIndividualWarning": "Einsätze mit individueller Kontaktaufnahme haben keinen Zeitslot, daher gibt es keinen automatischen Zeitpunkt zum Einchecken - Teilnehmer:innen werden nie als eingecheckt markiert und können kein Feedback abgeben. Wähle stattdessen Manuell, wenn du die Anwesenheit erfassen möchtest.",
       "checkInPinInvalid": "Die PIN muss 4 bis 6 Ziffern haben.",
+      "fieldTooLong": "Darf {{max}} Zeichen nicht überschreiten.",
       "generateRandomPin": "Zufällig generieren",
       "fieldCategory": "Kategorie",
       "fieldCategoryNone": "Keine",
@@ -235,6 +236,8 @@
       "tagAdded": "{{tag}} hinzugefügt.",
       "tagRemoved": "{{tag}} entfernt.",
       "tagAlreadyAdded": "{{tag}} bereits hinzugefügt.",
+      "tagLimitReached": "Du kannst bis zu {{max}} Schlagwörter hinzufügen.",
+      "tagTooLong": "Ein Schlagwort darf {{max}} Zeichen nicht überschreiten.",
       "fieldValidUntil": "Bewerbungsfrist",
       "validUntilHint": "Einsätze mit individueller Kontaktaufnahme haben keinen Zeitslot, daher zeigt eine Frist Freiwilligen, wie lange dieser Einsatz noch offen ist. Vor der Veröffentlichung erforderlich.",
       "validUntilRequiredForPublish": "Ein Einsatz mit individueller Kontaktaufnahme muss eine Bewerbungsfrist haben, bevor er veröffentlicht werden kann.",
@@ -455,6 +458,7 @@
       "fieldZip": "PLZ",
       "fieldCity": "Stadt",
       "fieldRequired": "Erforderlich",
+      "fieldTooLong": "Darf {{max}} Zeichen nicht überschreiten.",
       "zipInvalid": "Die PLZ muss genau 5 Zeichen lang sein.",
       "websiteInvalid": "Die Website muss eine gültige http:// oder https:// URL sein.",
       "savedSuccess": "Änderungen gespeichert.",
@@ -1338,6 +1342,9 @@
         "CannotDisableSelf": "Du kannst dein eigenes Konto nicht sperren.",
         "CannotDemoteSelf": "Du kannst dir nicht selbst die Admin-Rechte entziehen."
       },
+      "Concurrency": {
+        "Conflict": "Dieser Datensatz wurde in der Zwischenzeit von jemand anderem geändert. Bitte lade die Seite neu und versuche es erneut."
+      },
       "Address": {
         "StreetRequired": "Straße darf nicht leer sein.",
         "HouseNumberRequired": "Hausnummer darf nicht leer sein.",
@@ -1383,6 +1390,8 @@
         "WeakCheckInPin": "Diese PIN ist zu leicht zu erraten - wähle eine weniger vorhersehbare PIN.",
         "TitleTooLong": "Der Titel darf 200 Zeichen nicht überschreiten.",
         "DescriptionTooLong": "Die Beschreibung darf 5000 Zeichen nicht überschreiten.",
+        "TooManyTags": "Ein Einsatz kann nicht mehr als 20 Schlagwörter haben.",
+        "TagTooLong": "Jedes Schlagwort darf 50 Zeichen nicht überschreiten.",
         "ScheduledSlotsMustStartAsDraft": "Ein Einsatz mit der Teilnahmeart Zeitslots muss zunächst als Entwurf angelegt werden und kann erst nach Hinzufügen mindestens eines Zeitslots veröffentlicht werden.",
         "TitleRequired": "Titel darf nicht leer sein.",
         "DescriptionRequired": "Beschreibung darf nicht leer sein.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -225,6 +225,7 @@
       "checkInMethodNoneHint": "Participants aren't checked in during the event. They're automatically marked as checked in once the time slot has ended, which also unlocks feedback for them.",
       "checkInMethodNoneIndividualWarning": "Individual-contact opportunities have no time slot, so there's no automatic point to check participants in - they will never be marked as checked in or able to leave feedback. Choose Manual instead if you need attendance tracking.",
       "checkInPinInvalid": "PIN must be 4 to 6 digits.",
+      "fieldTooLong": "Must not exceed {{max}} characters.",
       "generateRandomPin": "Generate random",
       "fieldCategory": "Category",
       "fieldCategoryNone": "None",
@@ -235,6 +236,8 @@
       "tagAdded": "{{tag}} added.",
       "tagRemoved": "{{tag}} removed.",
       "tagAlreadyAdded": "{{tag}} already added.",
+      "tagLimitReached": "You can add up to {{max}} tags.",
+      "tagTooLong": "A tag must not exceed {{max}} characters.",
       "fieldValidUntil": "Application deadline",
       "validUntilHint": "Individual-contact opportunities have no time slot, so a deadline tells volunteers how long this request stays open. Required before publishing.",
       "validUntilRequiredForPublish": "An Individual contact opportunity must have a deadline before it can be published.",
@@ -455,6 +458,7 @@
       "fieldZip": "ZIP",
       "fieldCity": "City",
       "fieldRequired": "Required",
+      "fieldTooLong": "Must not exceed {{max}} characters.",
       "zipInvalid": "ZIP code must be exactly 5 characters.",
       "websiteInvalid": "Website must be a valid http:// or https:// URL.",
       "savedSuccess": "Changes saved.",
@@ -1338,6 +1342,9 @@
         "CannotDisableSelf": "You cannot block your own account.",
         "CannotDemoteSelf": "You cannot remove your own admin access."
       },
+      "Concurrency": {
+        "Conflict": "This record was changed by someone else in the meantime. Please reload and try again."
+      },
       "Address": {
         "StreetRequired": "Street must not be empty.",
         "HouseNumberRequired": "House number must not be empty.",
@@ -1383,6 +1390,8 @@
         "WeakCheckInPin": "This PIN is too easy to guess - choose a less predictable one.",
         "TitleTooLong": "Title must not exceed 200 characters.",
         "DescriptionTooLong": "Description must not exceed 5000 characters.",
+        "TooManyTags": "An opportunity cannot have more than 20 tags.",
+        "TagTooLong": "Each tag must not exceed 50 characters.",
         "ScheduledSlotsMustStartAsDraft": "A Scheduled slots opportunity must be created as a draft and published after adding at least one time slot.",
         "TitleRequired": "Title must not be empty.",
         "DescriptionRequired": "Description must not be empty.",

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
 import type { View } from "react-big-calendar";
 import { format, parse, startOfWeek, getDay } from "date-fns";
-import { enUS, de } from "date-fns/locale";
+import { enGB, de } from "date-fns/locale";
 // react-big-calendar's own stylesheet is imported eagerly from main.tsx
 // (before global.css), not here - see the comment there for why: this
 // widget only exists on the lazy-loaded OrgDashboardPage chunk, and an
@@ -21,7 +21,7 @@ import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import { visibleCalendarRange } from "../../../lib/calendarRange";
-import { formatDateTime } from "../../../lib/format";
+import { formatDateTime, resolveDateLocale } from "../../../lib/format";
 import { brandColor } from "../../../lib/brandColor";
 import {
 	readableTextColor,
@@ -41,9 +41,12 @@ function defaultViewForSize(size: WidgetSizeClass): View {
 	return "month";
 }
 
+// Keyed by resolveDateLocale's output (lib/format.ts's single source of
+// truth for i18n.language -> Intl/date-fns locale, #1267) rather than a
+// second, independently-drifting en-US/de ternary here (#1731).
 const rbcLocales = {
-	"en-US": enUS,
-	de,
+	"en-GB": enGB,
+	"de-DE": de,
 };
 const localizer = dateFnsLocalizer({
 	format,
@@ -399,7 +402,7 @@ function CalendarWidget({
 					<div className="rbc-container h-full">
 						<Calendar
 							localizer={localizer}
-							culture={i18n.language === "de" ? "de" : "en-US"}
+							culture={resolveDateLocale(i18n.language)}
 							events={calEvents}
 							view={calView}
 							onView={(v: View) => setCalView(v)}

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -345,6 +345,7 @@ export default function OrgSettingsPage() {
 							<Field label={t("orgSettings.fieldName")} id="org-name">
 								<input
 									id="org-name"
+									maxLength={100}
 									autoComplete="off"
 									aria-invalid={errors.name ? true : undefined}
 									aria-describedby={errors.name ? "org-name-error" : undefined}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
 				name: "Einsatzbereit",
 				short_name: "Einsatzbereit",
 				description:
-					"Volunteer coordination platform - find local volunteer opportunities and help your community.",
-				lang: "en",
+					"Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde.",
+				lang: "de",
 				start_url: "/",
 				display: "standalone",
 				background_color: "#ffffff",


### PR DESCRIPTION
## What

Fixes the six internationalisation gaps found by the 1.0 readiness analysis in #1731: an untranslatable plural in the search-alert digest email, zod's English error text leaking through the organization/opportunity forms, three backend error codes with no `apiError.*` translation, an English-only PWA manifest on a German-default product, a hardcoded `en-US`/`de` split in the dashboard calendar, and a `/v1/maps/cities` output-cache key that ignores `X-Language`.

## Why

Closes #1731

## Testing

- `dotnet run --project tests/Application.UnitTests` - 1036 passed, including 2 new tests asserting the digest handler picks `SearchAlertNewMatchesSingle` vs `SearchAlertNewMatches` by match count
- `dotnet run --project tests/ArchitectureTests` - 426 passed (no layering changes, run for completeness)
- `dotnet run --project tests/IntegrationTests -- --treenode-filter "/*/*/EmailTemplateRendererTests/*"` - 6 passed, confirming the new `SearchAlertNewMatchesSingle` template renders with no unresolved placeholders in both languages; added `SearchCities_ShouldCacheEachLanguageSeparately` to `OutputCachingTests.cs` for the cache-key fix (needs Testcontainers/Docker, so it runs in CI's `integration-tests` job, not locally in this sandbox)
- `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm test` (193 passed), `pnpm build` - all clean; confirmed the built `manifest.webmanifest` carries `"lang":"de"` and the German description
- `dotnet build backend/src/Api/Api.csproj` - 0 warnings/errors, generated OpenAPI spec unchanged (no endpoint/DTO shape changed)
- `/self-review` run: `nswag-check` and `a11y-check` came back clean; `i18n-check` flagged that my new German "too long" strings phrased differently ("darf ... lang sein") than the existing `*TooLong` convention ("darf ... nicht überschreiten") - fixed and re-verified

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed for this PR. Correctness was instead verified locally via the full backend unit/architecture test suites, the frontend lint/typecheck/vitest/build pipeline, and a manual self-review pass (including the built PWA manifest's actual output) - see Testing above. The `IntegrationTests`/`VisualTests` projects still run against a real stack in CI's `dotnet.yml`.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs beyond the translated strings themselves)


---
_Generated by [Claude Code](https://claude.ai/code/session_014s9WXmv9BeWK5JsWALbvws)_