### PR TITLE
fix: move sign-up email off the row lock, batch outbox SMTP, and add missing indexes/SQL-side filtering

### DIFF
--- a/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
@@ -86,6 +86,14 @@ internal static class EngagementOrganizerNotificationHelper
 		var organizerUsersById = (await dbContext.GetOrCreateUsersAsync(organizerIds, cancellationToken))
 			.ToDictionary(u => u.Id);
 
+		// Built up and sent as a single SendBatchAsync call after the loop (#1729,
+		// mirrors OpportunityNotificationHelper.NotifyActiveVolunteersAsync) instead
+		// of one SendAsync per organizer - this runs from the outbox, outside any
+		// open DB transaction, but a batch of 10+ subscribed organizers still meant
+		// 10+ sequential SMTP connect/authenticate/disconnect round trips per
+		// dispatched message.
+		var messages = new List<EmailMessage>(members.Count);
+
 		foreach (var organizer in members.Where(m => m.IsOrganisator))
 		{
 			var organizerId = UserId.Create(organizer.UserId).GetValueOrThrow();
@@ -110,12 +118,14 @@ internal static class EngagementOrganizerNotificationHelper
 			var unsubscribeUrl = unsubscribeLinkBuilder.Build(
 				organizerId, organizerUser.UnsubscribeToken, subscriptionType);
 
-			await emailService.SendAsync(
+			messages.Add(new EmailMessage(
 				organizer.Email,
 				content.Subject,
 				EmailFooter.Append(emailTemplateRenderer, organizerLanguage, content.Body, unsubscribeUrl),
-				engagementId.Value.ToString(),
-				cancellationToken);
+				engagementId.Value.ToString()));
 		}
+
+		if (messages.Count > 0)
+			await emailService.SendBatchAsync(messages, cancellationToken);
 	}
 }

--- a/backend/src/Application/Engagements/Common/EngagementVolunteerConfirmationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementVolunteerConfirmationHelper.cs
@@ -1,0 +1,84 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Engagements.Common;
+
+/// <summary>
+/// Emails the volunteer their own sign-up/reactivation receipt - shared by
+/// EngagementCreatedDomainEventHandler and EngagementReactivatedDomainEventHandler
+/// (einsatzbereit#1729). Runs off the transactional outbox rather than inline in
+/// the triggering create/reactivate request, so the time-slot row lock (#1142)
+/// held by CreateEngagementCommandHandler no longer stays open across a
+/// synchronous SMTP send. Unlike the organizer notification
+/// (EngagementOrganizerNotificationHelper), this is never gated by preference
+/// (#1055): it's the direct, synchronous-feeling response to the volunteer's own
+/// just-submitted action, not a repeatable notification about someone else's
+/// activity.
+/// </summary>
+internal static class EngagementVolunteerConfirmationHelper
+{
+	public static async Task NotifyAsync(
+		IApplicationDbContext dbContext,
+		IKeycloakUserService keycloakUserService,
+		IEmailService emailService,
+		IEmailTemplateRenderer emailTemplateRenderer,
+		EngagementId engagementId,
+		VolunteerOpportunityId opportunityId,
+		UserId volunteerId,
+		bool isSlotSignUp,
+		ILogger logger,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(opportunityId, cancellationToken);
+		if (opportunity is null)
+		{
+			// Deleted between the triggering command committing and the outbox
+			// dispatching this event - nothing left to confirm, and retrying would
+			// never resolve.
+			logger.LogWarning(
+				"Skipping volunteer confirmation for opportunity {OpportunityId}: it no longer exists",
+				opportunityId.Value);
+			return;
+		}
+
+		KeycloakUserProfile volunteer;
+		try
+		{
+			volunteer = await keycloakUserService.GetUserAsync(volunteerId.Value, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			// Same race as EngagementOrganizerNotificationHelper: an immediate
+			// account deletion can beat this event out of the outbox. Retrying
+			// would never resolve that, so skip rather than dead-letter forever.
+			logger.LogWarning(
+				ex,
+				"Skipping volunteer confirmation for engagement {EngagementId}: volunteer {VolunteerId} could not be looked up in Keycloak",
+				engagementId.Value,
+				volunteerId.Value);
+			return;
+		}
+
+		var volunteerName = volunteer.FirstName ?? volunteer.Username;
+		var volunteerUser = await dbContext.Users.FindAsync(volunteerId, cancellationToken);
+		var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser?.PreferredLanguage);
+
+		var content = emailTemplateRenderer.Render(
+			isSlotSignUp ? EmailTemplateKind.EngagementWaitlisted : EmailTemplateKind.EngagementRequestReceived,
+			volunteerLanguage,
+			new Dictionary<string, string>
+			{
+				["VolunteerName"] = volunteerName,
+				["OpportunityTitle"] = opportunity.Title,
+			});
+
+		await emailService.SendAsync(
+			volunteer.Email, content.Subject, content.Body, engagementId.Value.ToString(), cancellationToken);
+	}
+}

--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -1,7 +1,5 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
-using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Domain.Engagements;
@@ -14,10 +12,7 @@ namespace Application.Engagements.CreateEngagement.v1;
 
 internal sealed class CreateEngagementCommandHandler(
 	IApplicationDbContext dbContext,
-	IKeycloakOrganizationService keycloakOrganizationService,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer)
+	IKeycloakOrganizationService keycloakOrganizationService)
 	: ICommandHandler<CreateEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -98,36 +93,17 @@ internal sealed class CreateEngagementCommandHandler(
 			await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		}
 
-		var volunteer = await keycloakUserService.GetUserAsync(request.VolunteerId.Value, cancellationToken);
-		var volunteerName = volunteer.FirstName ?? volunteer.Username;
-		var isSlotSignUp = request.TimeSlotId is not null;
-
-		var volunteerUser = await dbContext.Users.FindAsync(request.VolunteerId, cancellationToken);
-		var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser?.PreferredLanguage);
-
-		var volunteerContent = emailTemplateRenderer.Render(
-			isSlotSignUp ? EmailTemplateKind.EngagementWaitlisted : EmailTemplateKind.EngagementRequestReceived,
-			volunteerLanguage,
-			new Dictionary<string, string>
-			{
-				["VolunteerName"] = volunteerName,
-				["OpportunityTitle"] = opportunity.Title,
-			});
-
-		// Never gated by preference (#1055): this is the direct, synchronous
-		// response to the volunteer's own just-submitted action, not a repeatable
-		// notification about someone else's activity - equivalent to an order
-		// receipt, which platforms conventionally don't let users opt out of.
-		//
-		// The organizer "New sign-up" email is NOT sent here (#1174): it moves
-		// off this request's DB transaction onto the outbox, delivered by
+		// Neither the organizer "New sign-up" email nor the volunteer's own
+		// sign-up receipt is sent here (#1174, #1729): both move off this
+		// request's DB transaction onto the outbox, delivered by
 		// EngagementCreatedDomainEventHandler/EngagementReactivatedDomainEventHandler
 		// once EngagementCreatedDomainEvent/EngagementReactivatedDomainEvent (raised
 		// above by Engagement.CreateSlotSignUp/CreateIndividualContact/Reactivate)
-		// is dispatched - see EngagementOrganizerNotificationHelper.
-		await emailService.SendAsync(
-			volunteer.Email, volunteerContent.Subject, volunteerContent.Body, engagement.Id.Value.ToString(), cancellationToken);
-
+		// is dispatched - see EngagementOrganizerNotificationHelper and
+		// EngagementVolunteerConfirmationHelper. This matters because the time-slot
+		// row lock (#1142) taken above is held for the rest of this transaction, so
+		// a synchronous SMTP send here would block every other volunteer trying to
+		// book the same slot behind a full mail round trip.
 		return engagement;
 	}
 }

--- a/backend/src/Application/Engagements/CreateEngagement/v1/EngagementCreatedDomainEventHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/EngagementCreatedDomainEventHandler.cs
@@ -9,9 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.CreateEngagement.v1;
 
-// Consumer of EngagementCreatedDomainEvent (#1174) - sends the organizer
-// "New sign-up" email. See EngagementOrganizerNotificationHelper for the
-// full rationale.
+// Consumer of EngagementCreatedDomainEvent - sends the organizer "New sign-up"
+// email (#1174) and the volunteer's own sign-up receipt (#1729). See
+// EngagementOrganizerNotificationHelper and EngagementVolunteerConfirmationHelper
+// for the full rationale.
 internal sealed class EngagementCreatedDomainEventHandler(
 	IApplicationDbContext dbContext,
 	IUnitOfWork unitOfWork,
@@ -39,6 +40,18 @@ internal sealed class EngagementCreatedDomainEventHandler(
 			notification.VolunteerId,
 			EmailTemplateKind.EngagementSignupNotifyOrganizer,
 			EmailNotificationType.NewSignUp,
+			logger,
+			cancellationToken);
+
+		await EngagementVolunteerConfirmationHelper.NotifyAsync(
+			dbContext,
+			keycloakUserService,
+			emailService,
+			emailTemplateRenderer,
+			notification.EngagementId,
+			notification.OpportunityId,
+			notification.VolunteerId,
+			notification.IsSlotSignUp,
 			logger,
 			cancellationToken);
 

--- a/backend/src/Application/Engagements/CreateEngagement/v1/EngagementReactivatedDomainEventHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/EngagementReactivatedDomainEventHandler.cs
@@ -9,12 +9,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.Engagements.CreateEngagement.v1;
 
-// Consumer of EngagementReactivatedDomainEvent (#1174): a withdrawn/cancelled
-// engagement is reused via Engagement.Reactivate (called from
-// CreateEngagementCommandHandler) rather than inserting a new row, but it still
-// deserves the same organizer "New sign-up" email a genuinely new engagement
-// gets. Mirrors EngagementCreatedDomainEventHandler - see
-// EngagementOrganizerNotificationHelper for the full rationale.
+// Consumer of EngagementReactivatedDomainEvent: a withdrawn/cancelled engagement
+// is reused via Engagement.Reactivate (called from CreateEngagementCommandHandler)
+// rather than inserting a new row, but it still deserves the same organizer
+// "New sign-up" email (#1174) and volunteer receipt (#1729) a genuinely new
+// engagement gets. Mirrors EngagementCreatedDomainEventHandler - see
+// EngagementOrganizerNotificationHelper and EngagementVolunteerConfirmationHelper
+// for the full rationale.
 internal sealed class EngagementReactivatedDomainEventHandler(
 	IApplicationDbContext dbContext,
 	IUnitOfWork unitOfWork,
@@ -42,6 +43,18 @@ internal sealed class EngagementReactivatedDomainEventHandler(
 			notification.VolunteerId,
 			EmailTemplateKind.EngagementSignupNotifyOrganizer,
 			EmailNotificationType.NewSignUp,
+			logger,
+			cancellationToken);
+
+		await EngagementVolunteerConfirmationHelper.NotifyAsync(
+			dbContext,
+			keycloakUserService,
+			emailService,
+			emailTemplateRenderer,
+			notification.EngagementId,
+			notification.OpportunityId,
+			notification.VolunteerId,
+			notification.IsSlotSignUp,
 			logger,
 			cancellationToken);
 

--- a/backend/src/Application/Engagements/GetEngagementCalendar/v1/GetEngagementCalendarQueryHandler.cs
+++ b/backend/src/Application/Engagements/GetEngagementCalendar/v1/GetEngagementCalendarQueryHandler.cs
@@ -29,31 +29,38 @@ internal sealed class GetEngagementCalendarQueryHandler(
 
 		var now = DateTimeOffset.UtcNow;
 		var sb = new StringBuilder();
-		sb.AppendLine("BEGIN:VCALENDAR");
-		sb.AppendLine("VERSION:2.0");
-		sb.AppendLine("PRODID:-//Einsatzbereit//EN");
-		sb.AppendLine("CALSCALE:GREGORIAN");
-		sb.AppendLine("METHOD:PUBLISH");
-		sb.AppendLine("BEGIN:VEVENT");
-		sb.AppendLine($"UID:{info.EngagementId}@einsatzbereit");
-		sb.AppendLine($"DTSTAMP:{FormatDateTime(now)}");
-		sb.AppendLine($"DTSTART:{FormatDateTime(info.StartDateTime)}");
-		sb.AppendLine($"DTEND:{FormatDateTime(info.EndDateTime)}");
+		AppendLine(sb, "BEGIN:VCALENDAR");
+		AppendLine(sb, "VERSION:2.0");
+		AppendLine(sb, "PRODID:-//Einsatzbereit//EN");
+		AppendLine(sb, "CALSCALE:GREGORIAN");
+		AppendLine(sb, "METHOD:PUBLISH");
+		AppendLine(sb, "BEGIN:VEVENT");
+		AppendLine(sb, $"UID:{info.EngagementId}@einsatzbereit");
+		AppendLine(sb, $"DTSTAMP:{FormatDateTime(now)}");
+		AppendLine(sb, $"DTSTART:{FormatDateTime(info.StartDateTime)}");
+		AppendLine(sb, $"DTEND:{FormatDateTime(info.EndDateTime)}");
 		AppendICalText(sb, "SUMMARY", info.OpportunityTitle);
 		if (!string.IsNullOrWhiteSpace(info.OpportunityDescription))
 			AppendICalText(sb, "DESCRIPTION", info.OpportunityDescription);
 		if (!string.IsNullOrWhiteSpace(info.Location))
 			AppendICalText(sb, "LOCATION", info.Location);
 		if (!string.IsNullOrWhiteSpace(opportunityUrl))
-			sb.AppendLine($"URL:{opportunityUrl}");
-		sb.AppendLine("END:VEVENT");
-		sb.AppendLine("END:VCALENDAR");
+			AppendLine(sb, $"URL:{opportunityUrl}");
+		AppendLine(sb, "END:VEVENT");
+		AppendLine(sb, "END:VCALENDAR");
 
 		return sb.ToString();
 	}
 
 	private static string FormatDateTime(DateTimeOffset dt) =>
 		dt.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'");
+
+	// RFC 5545 requires every line to end in CRLF. StringBuilder.AppendLine
+	// uses Environment.NewLine, which is "\n" (not "\r\n") on Linux - where
+	// this runs - so the file ended up mixing LF from here with the CRLF
+	// AppendICalText's line-folding below already used explicitly (#1729).
+	private static void AppendLine(StringBuilder sb, string line) =>
+		sb.Append(line).Append("\r\n");
 
 	private static void AppendICalText(StringBuilder sb, string property, string value)
 	{
@@ -70,7 +77,7 @@ internal sealed class GetEngagementCalendarQueryHandler(
 		var line = $"{property}:{escaped}";
 		if (line.Length <= 75)
 		{
-			sb.AppendLine(line);
+			AppendLine(sb, line);
 			return;
 		}
 
@@ -82,6 +89,6 @@ internal sealed class GetEngagementCalendarQueryHandler(
 			sb.Append($"\r\n {chunk}");
 			remaining = remaining[chunk.Length..];
 		}
-		sb.AppendLine();
+		sb.Append("\r\n");
 	}
 }

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -101,7 +101,7 @@ public sealed class Engagement
 			timeSlotEndDateTime,
 			message: null,
 			EngagementStatus.Pending);
-		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId));
+		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId, IsSlotSignUp: true));
 		return engagement;
 	}
 
@@ -124,7 +124,7 @@ public sealed class Engagement
 			timeSlotEndDateTime: null,
 			message,
 			EngagementStatus.Pending);
-		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId));
+		engagement.AddEvent(new EngagementCreatedDomainEvent(engagement.Id, volunteerId, opportunityId, IsSlotSignUp: false));
 		return engagement;
 	}
 
@@ -209,7 +209,7 @@ public sealed class Engagement
 		ReminderSentAt = null;
 		Status = EngagementStatus.Pending;
 		ReactivationCount++;
-		AddEvent(new EngagementReactivatedDomainEvent(Id, VolunteerId!.Value, OpportunityId));
+		AddEvent(new EngagementReactivatedDomainEvent(Id, VolunteerId!.Value, OpportunityId, IsSlotSignUp: timeSlotId is not null));
 		return Result.Success();
 	}
 

--- a/backend/src/Domain/Engagements/EngagementCreatedDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementCreatedDomainEvent.cs
@@ -4,8 +4,13 @@ using Domain.VolunteerOpportunities;
 
 namespace Domain.Engagements;
 
+// IsSlotSignUp is denormalized here (einsatzbereit#1729) rather than looked up
+// from the Engagement when this event is dispatched, so the outbox-delivered
+// volunteer confirmation email (EngagementVolunteerConfirmationHelper) can pick
+// the right template without an extra query.
 public sealed record EngagementCreatedDomainEvent(
 	EngagementId EngagementId,
 	UserId VolunteerId,
-	VolunteerOpportunityId OpportunityId)
+	VolunteerOpportunityId OpportunityId,
+	bool IsSlotSignUp)
 	: DomainEvent;

--- a/backend/src/Domain/Engagements/EngagementReactivatedDomainEvent.cs
+++ b/backend/src/Domain/Engagements/EngagementReactivatedDomainEvent.cs
@@ -4,8 +4,13 @@ using Domain.VolunteerOpportunities;
 
 namespace Domain.Engagements;
 
+// IsSlotSignUp is denormalized here (einsatzbereit#1729) rather than looked up
+// from the Engagement when this event is dispatched, so the outbox-delivered
+// volunteer confirmation email (EngagementVolunteerConfirmationHelper) can pick
+// the right template without an extra query.
 public sealed record EngagementReactivatedDomainEvent(
 	EngagementId EngagementId,
 	UserId VolunteerId,
-	VolunteerOpportunityId OpportunityId)
+	VolunteerOpportunityId OpportunityId,
+	bool IsSlotSignUp)
 	: DomainEvent;

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxOptions.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxOptions.cs
@@ -11,6 +11,13 @@ internal sealed class OutboxOptions
 	// being retried forever - see einsatzbereit#1317.
 	public int MaxAttempts { get; init; } = 5;
 
+	// How long a claimed-but-not-yet-processed row is treated as still in flight
+	// before a later poll (this replica or another) reclaims it - covers the
+	// process crashing between claiming a batch and finishing dispatch. Comfortably
+	// above the slowest realistic dispatch (a batch of synchronous SMTP sends), so
+	// a healthy in-progress batch is never reclaimed out from under itself (#1729).
+	public int ClaimTimeoutSeconds { get; init; } = 300;
+
 	// How long a successfully processed row is kept before OutboxRetentionJob
 	// prunes it - the table would otherwise grow without bound, since nothing else
 	// ever deletes a processed message. A dead-lettered row (ProcessedOnUtc

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
@@ -131,6 +131,15 @@ internal sealed class OutboxProcessorJob(
 				message.AttemptCount++;
 				metrics.RecordFailed();
 
+				// Release the claim on a failed (but not yet dead-lettered) attempt so
+				// the very next poll tick can immediately reclaim and retry it - the
+				// pre-existing retry contract this job has always had. Leaving
+				// ClaimedOnUtc stamped would otherwise gate the retry behind
+				// ClaimTimeoutSeconds (a stuck-worker recovery timeout, not a normal
+				// per-attempt backoff), turning "retry next tick" into "retry every few
+				// minutes at best" (#1729).
+				message.ClaimedOnUtc = null;
+
 				logger.LogError(
 					ex,
 					"Failed to dispatch outbox message {OutboxMessageId} of type {OutboxMessageType} (attempt {AttemptCount}/{MaxAttempts})",

--- a/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OutboxProcessorJob.cs
@@ -87,7 +87,8 @@ internal sealed class OutboxProcessorJob(
 		var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 		var dispatcher = scope.ServiceProvider.GetRequiredService<IDomainEventDispatcher>();
 
-		await ProcessBatchAsync(dbContext, dispatcher, logger, metrics, _options.BatchSize, _options.MaxAttempts, ct);
+		await ProcessBatchAsync(
+			dbContext, dispatcher, logger, metrics, _options.BatchSize, _options.MaxAttempts, _options.ClaimTimeoutSeconds, ct);
 	}
 
 	// Exposed so IntegrationTests can exercise the row-claiming behavior directly
@@ -100,104 +101,137 @@ internal sealed class OutboxProcessorJob(
 		OutboxMetrics metrics,
 		int batchSize,
 		int maxAttempts = 5,
+		int claimTimeoutSeconds = 300,
 		CancellationToken cancellationToken = default)
+	{
+		var messages = await ClaimBatchAsync(dbContext, batchSize, claimTimeoutSeconds, cancellationToken);
+
+		// Dispatch happens with no open transaction/connection held (#1729): each
+		// message's handler(s) can synchronously send one or more emails over SMTP
+		// (e.g. EngagementOrganizerNotificationHelper, one per subscribed
+		// organizer), and holding the FOR UPDATE SKIP LOCKED row lock - and the DB
+		// connection backing it - for that whole duration was the actual problem.
+		// ClaimBatchAsync's ClaimedOnUtc stamp (committed before this loop starts)
+		// is what now stops a concurrent replica from re-selecting the same
+		// messages while dispatch is in flight.
+		foreach (var message in messages)
+		{
+			try
+			{
+				var domainEvent = message.ToDomainEvent();
+				await dispatcher.DispatchAsync([domainEvent], cancellationToken);
+
+				message.ProcessedOnUtc = DateTime.UtcNow;
+				message.Error = null;
+				metrics.RecordDispatched();
+			}
+			catch (Exception ex)
+			{
+				message.Error = ex.Message;
+				message.AttemptCount++;
+				metrics.RecordFailed();
+
+				logger.LogError(
+					ex,
+					"Failed to dispatch outbox message {OutboxMessageId} of type {OutboxMessageType} (attempt {AttemptCount}/{MaxAttempts})",
+					message.Id,
+					message.Type,
+					message.AttemptCount,
+					maxAttempts);
+
+				if (message.AttemptCount >= maxAttempts)
+				{
+					// Dead-letter: stamping ProcessedOnUtc stops the WHERE processed_on_utc IS
+					// NULL query in ClaimBatchAsync from ever re-selecting this row again, so
+					// one poison message can no longer stall every message behind it in the
+					// batch forever. Error stays populated so this is distinguishable from a
+					// genuinely successful dispatch (which clears it). Recorded as its own
+					// metric status (not just another "failed") since a dead letter is a
+					// terminal give-up an operator should alert on differently than a
+					// transient failure that will simply retry next tick (#1008).
+					message.ProcessedOnUtc = DateTime.UtcNow;
+					metrics.RecordDeadLettered();
+
+					logger.LogError(
+						"Outbox message {OutboxMessageId} of type {OutboxMessageType} exceeded {MaxAttempts} attempts and was moved to dead-letter state",
+						message.Id,
+						message.Type,
+						maxAttempts);
+				}
+			}
+		}
+
+		// A single SaveChangesAsync for the whole batch instead of one per message.
+		// No manual transaction here - EF Core's own execution strategy already
+		// wraps a single SaveChangesAsync call as one retryable unit, and nothing
+		// in this call needs FOR UPDATE semantics anymore (that's ClaimBatchAsync's
+		// concern, already committed by this point).
+		if (messages.Count > 0)
+			await dbContext.SaveChangesAsync(cancellationToken);
+
+		// Total backlog remaining after this tick's batch, not just what this tick
+		// claimed - lets an operator alert on "outbox.pending" growing unbounded
+		// (dispatch is falling behind or stuck) independently of outbox.dispatch's
+		// per-attempt succeeded/failed counts (#1008).
+		var pendingCount = await dbContext.Set<OutboxMessage>()
+			.AsNoTracking()
+			.LongCountAsync(m => m.ProcessedOnUtc == null, cancellationToken);
+		metrics.RecordPending(pendingCount);
+
+		return messages.Count;
+	}
+
+	// Claims a batch of pending messages and stamps ClaimedOnUtc on them, all
+	// within one short transaction - this is the only part of outbox processing
+	// that still needs FOR UPDATE SKIP LOCKED row locks (#1729).
+	private static async Task<List<OutboxMessage>> ClaimBatchAsync(
+		ApplicationDbContext dbContext,
+		int batchSize,
+		int claimTimeoutSeconds,
+		CancellationToken cancellationToken)
 	{
 		// EnableRetryOnFailure (ServiceCollectionExtensions.cs) requires a
 		// manually-began transaction to run as one retryable unit via
 		// CreateExecutionStrategy() - see
 		// ApplicationDbContext.ExecuteInTransactionAsync's comment. A retried
-		// attempt re-runs this whole delegate, including re-dispatching
-		// messages - the same at-least-once semantics this job already has if
-		// the process crashes between a successful DispatchAsync and the
-		// commit below, just reachable slightly more often now.
+		// attempt re-runs this whole delegate, including re-claiming messages -
+		// harmless, since claiming is idempotent (it only ever moves
+		// ClaimedOnUtc forward).
 		var strategy = dbContext.Database.CreateExecutionStrategy();
 
-		return await strategy.ExecuteAsync<int>(async _ =>
+		return await strategy.ExecuteAsync(async _ =>
 		{
 			// FOR UPDATE SKIP LOCKED (#1392): without this, two replicas' timers ticking
 			// concurrently would both SELECT the same unprocessed rows and both dispatch
-			// them, since nothing previously marked a row "claimed" before dispatch - it was
-			// only marked ProcessedOnUtc after dispatch succeeded. Holding the row locks for
-			// this whole transaction (not just the SELECT) is what makes a second replica's
-			// concurrent SKIP LOCKED query skip these rows entirely instead of blocking on
-			// them, so it picks a disjoint batch instead of waiting to double-process this one.
+			// them. Held only for this claim+stamp transaction (not across dispatch) -
+			// a second replica's concurrent SKIP LOCKED query skips these rows entirely
+			// instead of blocking on them, so it picks a disjoint batch instead of
+			// waiting to double-process this one.
 			await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+			var staleCutoff = DateTime.UtcNow.AddSeconds(-claimTimeoutSeconds);
 
 			var messages = await dbContext.Set<OutboxMessage>()
 				.FromSqlInterpolated($@"
-					SELECT id, type, content, occurred_on_utc, processed_on_utc, error, attempt_count
+					SELECT id, type, content, occurred_on_utc, processed_on_utc, error, attempt_count, claimed_on_utc
 					FROM outbox_message
 					WHERE processed_on_utc IS NULL
+						AND (claimed_on_utc IS NULL OR claimed_on_utc <= {staleCutoff})
 					ORDER BY occurred_on_utc
 					LIMIT {batchSize}
 					FOR UPDATE SKIP LOCKED")
 				.ToListAsync(cancellationToken);
 
+			var claimedOnUtc = DateTime.UtcNow;
 			foreach (var message in messages)
-			{
-				try
-				{
-					var domainEvent = message.ToDomainEvent();
-					await dispatcher.DispatchAsync([domainEvent], cancellationToken);
+				message.ClaimedOnUtc = claimedOnUtc;
 
-					message.ProcessedOnUtc = DateTime.UtcNow;
-					message.Error = null;
-					metrics.RecordDispatched();
-				}
-				catch (Exception ex)
-				{
-					message.Error = ex.Message;
-					message.AttemptCount++;
-					metrics.RecordFailed();
-
-					logger.LogError(
-						ex,
-						"Failed to dispatch outbox message {OutboxMessageId} of type {OutboxMessageType} (attempt {AttemptCount}/{MaxAttempts})",
-						message.Id,
-						message.Type,
-						message.AttemptCount,
-						maxAttempts);
-
-					if (message.AttemptCount >= maxAttempts)
-					{
-						// Dead-letter: stamping ProcessedOnUtc stops the WHERE processed_on_utc IS
-						// NULL query above from ever re-selecting this row again, so one poison
-						// message can no longer stall every message behind it in the batch
-						// forever. Error stays populated so this is distinguishable from a
-						// genuinely successful dispatch (which clears it). Recorded as its own
-						// metric status (not just another "failed") since a dead letter is a
-						// terminal give-up an operator should alert on differently than a
-						// transient failure that will simply retry next tick (#1008).
-						message.ProcessedOnUtc = DateTime.UtcNow;
-						metrics.RecordDeadLettered();
-
-						logger.LogError(
-							"Outbox message {OutboxMessageId} of type {OutboxMessageType} exceeded {MaxAttempts} attempts and was moved to dead-letter state",
-							message.Id,
-							message.Type,
-							maxAttempts);
-					}
-				}
-			}
-
-			// A single SaveChangesAsync for the whole batch instead of one per message - the
-			// row locks from FOR UPDATE above are held for this transaction regardless, so
-			// batching the writes costs nothing extra.
 			if (messages.Count > 0)
 				await dbContext.SaveChangesAsync(cancellationToken);
 
 			await transaction.CommitAsync(cancellationToken);
 
-			// Total backlog remaining after this tick's batch, not just what this tick
-			// claimed - lets an operator alert on "outbox.pending" growing unbounded
-			// (dispatch is falling behind or stuck) independently of outbox.dispatch's
-			// per-attempt succeeded/failed counts (#1008).
-			var pendingCount = await dbContext.Set<OutboxMessage>()
-				.AsNoTracking()
-				.LongCountAsync(m => m.ProcessedOnUtc == null, cancellationToken);
-			metrics.RecordPending(pendingCount);
-
-			return messages.Count;
+			return messages;
 		}, cancellationToken);
 	}
 }

--- a/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/EngagementConfiguration.cs
@@ -120,6 +120,30 @@ internal sealed class EngagementConfiguration
 			.IsUnique()
 			.HasFilter("time_slot_id IS NULL AND status NOT IN ('Cancelled', 'Withdrawn')");
 
+		// Declared explicitly (rather than left to the FK-property index
+		// convention below) because the AutomaticCheckInJob index right after it
+		// needs a second, distinctly-named index over the same TimeSlotId
+		// property - the moment any explicit index covers a FK property, EF's
+		// convention stops auto-adding its own plain one, so this one has to
+		// stand in for it or it would disappear from the model entirely.
+		builder.HasIndex(e => e.TimeSlotId);
+
+		// AutomaticCheckInJob's hourly query (#1729) filters on exactly this
+		// predicate before joining to TimeSlot/VolunteerOpportunity to check the
+		// slot's end time - without a supporting index, every tick was a full
+		// scan of a monotonically growing table. Partial rather than a plain
+		// index (the one above) since confirmed-but-not-yet-checked-in
+		// engagements are a small, shrinking fraction of the table once it has
+		// any history - same reasoning as the outbox_message "unprocessed"
+		// partial index. The explicit model-level name ("PendingAutoCheckIn")
+		// is required, not just HasDatabaseName below - EF Core keys index
+		// identity by property set alone otherwise, so a second
+		// HasIndex(e => e.TimeSlotId) without it would redefine the plain index
+		// above in place instead of adding a second one alongside it.
+		builder.HasIndex(e => e.TimeSlotId, "IX_Engagement_TimeSlotId_PendingAutoCheckIn")
+			.HasDatabaseName("ix_engagement_time_slot_id_pending_auto_check_in")
+			.HasFilter("status = 'Confirmed' AND is_checked_in = false AND time_slot_id IS NOT NULL");
+
 		builder.HasOne<TimeSlot>()
 			.WithMany()
 			.HasForeignKey(e => e.TimeSlotId)

--- a/backend/src/Infrastructure/Persistence/Configurations/OutboxMessageConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/OutboxMessageConfiguration.cs
@@ -22,6 +22,8 @@ internal sealed class OutboxMessageConfiguration
 
 		builder.Property(m => m.AttemptCount).IsRequired().HasDefaultValue(0);
 
+		builder.Property(m => m.ClaimedOnUtc);
+
 		// Matches OutboxProcessorJob's batch query exactly - "WHERE
 		// processed_on_utc IS NULL ORDER BY occurred_on_utc LIMIT n" - a plain
 		// index on ProcessedOnUtc alone supports the filter but not the

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807175910_AddOutboxMessageClaimedOnUtc.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807175910_AddOutboxMessageClaimedOnUtc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260807175910_AddOutboxMessageClaimedOnUtc")]
+	partial class AddOutboxMessageClaimedOnUtc
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
@@ -242,10 +245,6 @@ namespace Infrastructure.Persistence.Migrations
 					b.HasIndex("VolunteerId", "TimeSlotId")
 						.IsUnique()
 						.HasDatabaseName("ix_engagement_volunteer_id_time_slot_id");
-
-					b.HasIndex(new[] { "TimeSlotId" }, "IX_Engagement_TimeSlotId_PendingAutoCheckIn")
-						.HasDatabaseName("ix_engagement_time_slot_id_pending_auto_check_in")
-						.HasFilter("status = 'Confirmed' AND is_checked_in = false AND time_slot_id IS NOT NULL");
 
 					b.ToTable("engagement", null, t =>
 						{

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807175910_AddOutboxMessageClaimedOnUtc.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807175910_AddOutboxMessageClaimedOnUtc.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddOutboxMessageClaimedOnUtc : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<DateTime>(
+				name: "claimed_on_utc",
+				table: "outbox_message",
+				type: "timestamp with time zone",
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "claimed_on_utc",
+				table: "outbox_message");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807175959_AddEngagementTimeSlotIdPendingAutoCheckInIndex.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807175959_AddEngagementTimeSlotIdPendingAutoCheckInIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260807175959_AddEngagementTimeSlotIdPendingAutoCheckInIndex")]
+	partial class AddEngagementTimeSlotIdPendingAutoCheckInIndex
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260807175959_AddEngagementTimeSlotIdPendingAutoCheckInIndex.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260807175959_AddEngagementTimeSlotIdPendingAutoCheckInIndex.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddEngagementTimeSlotIdPendingAutoCheckInIndex : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateIndex(
+				name: "ix_engagement_time_slot_id_pending_auto_check_in",
+				table: "engagement",
+				column: "time_slot_id",
+				filter: "status = 'Confirmed' AND is_checked_in = false AND time_slot_id IS NOT NULL");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropIndex(
+				name: "ix_engagement_time_slot_id_pending_auto_check_in",
+				table: "engagement");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Outbox/OutboxMessage.cs
+++ b/backend/src/Infrastructure/Persistence/Outbox/OutboxMessage.cs
@@ -15,6 +15,15 @@ internal sealed class OutboxMessage
 
 	public DateTime? ProcessedOnUtc { get; set; }
 
+	// Stamped by OutboxProcessorJob.ClaimBatchAsync the instant a batch is claimed,
+	// then left alone for the rest of dispatch (#1729) - the FOR UPDATE SKIP LOCKED
+	// row lock is only held for that brief claim+stamp transaction, not across the
+	// SMTP-heavy dispatch that follows it outside any open transaction. A second
+	// replica's claim query treats a row with a recent ClaimedOnUtc as already
+	// in flight and skips it; one older than OutboxOptions.ClaimTimeoutSeconds is
+	// treated as abandoned (the claiming process crashed) and reclaimed.
+	public DateTime? ClaimedOnUtc { get; set; }
+
 	public string? Error { get; set; }
 
 	// Incremented on every failed dispatch attempt; once it reaches OutboxOptions.MaxAttempts

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
@@ -22,10 +22,15 @@ internal sealed class AdminReportReadRepository(
 		int pageSize,
 		CancellationToken cancellationToken = default)
 	{
-		var allReports = await dbContext.ReportsQuery.ToListAsync(cancellationToken);
+		// Grouped, counted, ordered, and paged in a single SQL query (#1729) rather
+		// than pulling every report row into memory and doing all of that
+		// client-side - cost no longer grows linearly with total reports filed.
+		var groupedReports = dbContext.ReportsQuery
+			.GroupBy(r => new { r.TargetType, r.TargetId });
 
-		var groups = allReports
-			.GroupBy(r => (r.TargetType, r.TargetId))
+		var totalItems = await groupedReports.CountAsync(cancellationToken);
+
+		var page = await groupedReports
 			.Select(g => new
 			{
 				g.Key.TargetType,
@@ -36,14 +41,9 @@ internal sealed class AdminReportReadRepository(
 			})
 			.OrderByDescending(g => g.LastReportedOn)
 			.ThenBy(g => g.TargetId)
-			.ToList();
-
-		var totalItems = groups.Count;
-
-		var page = groups
 			.Skip((pageNumber - 1) * pageSize)
 			.Take(pageSize)
-			.ToList();
+			.ToListAsync(cancellationToken);
 
 		var opportunityIds = page.Where(g => g.TargetType == ReportTargetType.VolunteerOpportunity).Select(g => g.TargetId).ToList();
 		var organizationIds = page.Where(g => g.TargetType == ReportTargetType.Organization).Select(g => g.TargetId).ToList();

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -139,23 +139,87 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 		if (filter.HasRadius)
 		{
-			var candidates = await baseQuery.ToListAsync(cancellationToken);
-
 			var centerLat = filter.CenterLatitude!.Value;
 			var centerLon = filter.CenterLongitude!.Value;
 			var radiusKm = filter.RadiusKm!.Value;
 
-			var matched = candidates
-				.Where(s => s.Latitude.HasValue && s.Longitude.HasValue &&
-					GeoMath.DistanceKm(centerLat, centerLon, s.Latitude!.Value, s.Longitude!.Value) <= radiusKm)
-				.OrderBy(s => GeoMath.DistanceKm(centerLat, centerLon, s.Latitude!.Value, s.Longitude!.Value))
-				.ThenBy(s => s.Id)
-				.ToList();
+			// Haversine distance expressed with literal Math.* calls rather than a
+			// call to GeoMath.DistanceKm (#1729) - Npgsql's EF Core provider
+			// translates Math.Sin/Cos/Sqrt/Atan2 to SQL, but can't translate an
+			// arbitrary C# method, so filtering, ordering, and paging all now happen
+			// in Postgres instead of materializing the whole bounding box into
+			// memory and redoing all three client-side on every request/page.
+			// Split into two Selects so the "a" term (haversine's intermediate
+			// value, needed by both of Atan2's arguments) is written only once.
+			var withHaversineA = baseQuery
+				.Where(s => s.Latitude.HasValue && s.Longitude.HasValue)
+				.Select(s => new
+				{
+					s.Id,
+					s.Title,
+					s.Description,
+					s.OrganizationId,
+					s.Street,
+					s.HouseNumber,
+					s.ZipCode,
+					s.City,
+					s.Latitude,
+					s.Longitude,
+					s.IsRemote,
+					s.Occurrence,
+					s.ParticipationType,
+					s.CheckInMethod,
+					s.Category,
+					s.Tags,
+					s.CreatedOn,
+					s.ValidUntil,
+					s.NextTimeSlotStart,
+					s.NextTimeSlotEnd,
+					s.Status,
+					s.BannerImageUrl,
+					HaversineA =
+						(Math.Sin((s.Latitude!.Value - centerLat) * Math.PI / 180.0 / 2.0) * Math.Sin((s.Latitude!.Value - centerLat) * Math.PI / 180.0 / 2.0))
+						+ (Math.Cos(centerLat * Math.PI / 180.0) * Math.Cos(s.Latitude!.Value * Math.PI / 180.0)
+							* Math.Sin((s.Longitude!.Value - centerLon) * Math.PI / 180.0 / 2.0) * Math.Sin((s.Longitude!.Value - centerLon) * Math.PI / 180.0 / 2.0)),
+				});
 
-			var page = matched
+			var withDistance = withHaversineA
+				.Select(s => new
+				{
+					s.Id,
+					s.Title,
+					s.Description,
+					s.OrganizationId,
+					s.Street,
+					s.HouseNumber,
+					s.ZipCode,
+					s.City,
+					s.Latitude,
+					s.Longitude,
+					s.IsRemote,
+					s.Occurrence,
+					s.ParticipationType,
+					s.CheckInMethod,
+					s.Category,
+					s.Tags,
+					s.CreatedOn,
+					s.ValidUntil,
+					s.NextTimeSlotStart,
+					s.NextTimeSlotEnd,
+					s.Status,
+					s.BannerImageUrl,
+					DistanceKm = 6371.0 * 2.0 * Math.Atan2(Math.Sqrt(s.HaversineA), Math.Sqrt(1.0 - s.HaversineA)),
+				})
+				.Where(s => s.DistanceKm <= radiusKm);
+
+			var matchedCount = await withDistance.CountAsync(cancellationToken);
+
+			var page = await withDistance
+				.OrderBy(s => s.DistanceKm)
+				.ThenBy(s => s.Id)
 				.Skip((filter.PageNumber - 1) * filter.PageSize)
 				.Take(filter.PageSize)
-				.ToList();
+				.ToListAsync(cancellationToken);
 
 			var pageGuids = page.Select(x => x.Id).ToList();
 			var (maxPMap, partCountMap) = await LoadParticipantStatsAsync(pageGuids, cancellationToken);
@@ -178,7 +242,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				})
 				.ToList();
 
-			return new PagedList<VolunteerOpportunitySummary>(summaries, matched.Count, filter.PageNumber, filter.PageSize);
+			return new PagedList<VolunteerOpportunitySummary>(summaries, matchedCount, filter.PageNumber, filter.PageSize);
 		}
 
 		var total = await query.CountAsync(cancellationToken);

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -99,13 +99,19 @@ internal sealed class VolunteerOpportunityReadRepository(
 		// selector or read back off an already-projected anonymous property) defeats
 		// the Npgsql provider's translation of the whole query ("could not be
 		// translated"). Ordering by the value object (vo.Id) instead translates
-		// cleanly, since EF already has a converter registered for it.
+		// cleanly, since EF already has a converter registered for it. For the same
+		// reason, Id is kept as VolunteerOpportunityId (not unwrapped to .Value) all
+		// the way through this projection and the radius branch's below - the radius
+		// branch's own ThenBy(s => s.Id) tie-breaker re-derives whatever expression
+		// backs s.Id from the original entity, so unwrapping here would resurface the
+		// exact same translation failure one layer down. Callers below unwrap to
+		// .Value only after materialization (ToListAsync), in memory.
 		var baseQuery = query
 			.OrderByDescending(vo => vo.CreatedOn)
 			.ThenBy(vo => vo.Id)
 			.Select(vo => new
 			{
-				Id = vo.Id.Value,
+				vo.Id,
 				vo.Title,
 				vo.Description,
 				OrganizationId = vo.OrganizationId.Value,
@@ -143,15 +149,12 @@ internal sealed class VolunteerOpportunityReadRepository(
 			var centerLon = filter.CenterLongitude!.Value;
 			var radiusKm = filter.RadiusKm!.Value;
 
-			// Haversine distance expressed with literal Math.* calls rather than a
-			// call to GeoMath.DistanceKm (#1729) - Npgsql's EF Core provider
-			// translates Math.Sin/Cos/Sqrt/Atan2 to SQL, but can't translate an
-			// arbitrary C# method, so filtering, ordering, and paging all now happen
-			// in Postgres instead of materializing the whole bounding box into
-			// memory and redoing all three client-side on every request/page.
-			// Split into two Selects so the "a" term (haversine's intermediate
-			// value, needed by both of Atan2's arguments) is written only once.
-			var withHaversineA = baseQuery
+			// Distance is computed once here (haversine formula, #1729) and referenced
+			// in both the Where below and the OrderBy further down - filtering,
+			// ordering, and paging all happen in Postgres instead of materializing the
+			// whole bounding box into memory and redoing all three client-side on every
+			// request/page.
+			var withDistance = baseQuery
 				.Where(s => s.Latitude.HasValue && s.Longitude.HasValue)
 				.Select(s => new
 				{
@@ -177,38 +180,13 @@ internal sealed class VolunteerOpportunityReadRepository(
 					s.NextTimeSlotEnd,
 					s.Status,
 					s.BannerImageUrl,
-					HaversineA =
-						(Math.Sin((s.Latitude!.Value - centerLat) * Math.PI / 180.0 / 2.0) * Math.Sin((s.Latitude!.Value - centerLat) * Math.PI / 180.0 / 2.0))
-						+ (Math.Cos(centerLat * Math.PI / 180.0) * Math.Cos(s.Latitude!.Value * Math.PI / 180.0)
-							* Math.Sin((s.Longitude!.Value - centerLon) * Math.PI / 180.0 / 2.0) * Math.Sin((s.Longitude!.Value - centerLon) * Math.PI / 180.0 / 2.0)),
-				});
-
-			var withDistance = withHaversineA
-				.Select(s => new
-				{
-					s.Id,
-					s.Title,
-					s.Description,
-					s.OrganizationId,
-					s.Street,
-					s.HouseNumber,
-					s.ZipCode,
-					s.City,
-					s.Latitude,
-					s.Longitude,
-					s.IsRemote,
-					s.Occurrence,
-					s.ParticipationType,
-					s.CheckInMethod,
-					s.Category,
-					s.Tags,
-					s.CreatedOn,
-					s.ValidUntil,
-					s.NextTimeSlotStart,
-					s.NextTimeSlotEnd,
-					s.Status,
-					s.BannerImageUrl,
-					DistanceKm = 6371.0 * 2.0 * Math.Atan2(Math.Sqrt(s.HaversineA), Math.Sqrt(1.0 - s.HaversineA)),
+					DistanceKm = 6371.0 * 2.0 * Math.Atan2(
+						Math.Sqrt(Math.Pow(Math.Sin((s.Latitude!.Value - centerLat) * Math.PI / 180.0 / 2.0), 2) +
+							Math.Cos(centerLat * Math.PI / 180.0) * Math.Cos(s.Latitude.Value * Math.PI / 180.0) *
+							Math.Pow(Math.Sin((s.Longitude!.Value - centerLon) * Math.PI / 180.0 / 2.0), 2)),
+						Math.Sqrt(1.0 - (Math.Pow(Math.Sin((s.Latitude.Value - centerLat) * Math.PI / 180.0 / 2.0), 2) +
+							Math.Cos(centerLat * Math.PI / 180.0) * Math.Cos(s.Latitude.Value * Math.PI / 180.0) *
+							Math.Pow(Math.Sin((s.Longitude.Value - centerLon) * Math.PI / 180.0 / 2.0), 2)))),
 				})
 				.Where(s => s.DistanceKm <= radiusKm);
 
@@ -221,7 +199,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				.Take(filter.PageSize)
 				.ToListAsync(cancellationToken);
 
-			var pageGuids = page.Select(x => x.Id).ToList();
+			var pageGuids = page.Select(x => x.Id.Value).ToList();
 			var (maxPMap, partCountMap) = await LoadParticipantStatsAsync(pageGuids, cancellationToken);
 			var orgMap = await LoadOrganizationSummariesAsync(page.Select(x => x.OrganizationId), cancellationToken);
 
@@ -234,11 +212,11 @@ internal sealed class VolunteerOpportunityReadRepository(
 				.Select(x =>
 				{
 					var (orgName, orgLogoUrl) = orgMap[x.OrganizationId];
-					return ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
+					return ToSummary(x.Id.Value, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
 						x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 						x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 						x.Status, x.BannerImageUrl,
-						maxPMap.GetValueOrDefault(x.Id, 0), partCountMap.GetValueOrDefault(x.Id, 0));
+						maxPMap.GetValueOrDefault(x.Id.Value, 0), partCountMap.GetValueOrDefault(x.Id.Value, 0));
 				})
 				.ToList();
 
@@ -254,7 +232,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (rows.Count == 0)
 			return new PagedList<VolunteerOpportunitySummary>([], total, filter.PageNumber, filter.PageSize);
 
-		var guids = rows.Select(x => x.Id).ToList();
+		var guids = rows.Select(x => x.Id.Value).ToList();
 		var (maxParticipantsMap, participantCountMap) = await LoadParticipantStatsAsync(guids, cancellationToken);
 		var organizationSummaries = await LoadOrganizationSummariesAsync(rows.Select(x => x.OrganizationId), cancellationToken);
 
@@ -264,11 +242,11 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(x =>
 			{
 				var (orgName, orgLogoUrl) = organizationSummaries[x.OrganizationId];
-				return ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
+				return ToSummary(x.Id.Value, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
 					x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 					x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 					x.Status, x.BannerImageUrl,
-					maxParticipantsMap.GetValueOrDefault(x.Id, 0), participantCountMap.GetValueOrDefault(x.Id, 0));
+					maxParticipantsMap.GetValueOrDefault(x.Id.Value, 0), participantCountMap.GetValueOrDefault(x.Id.Value, 0));
 			})
 			.ToList();
 

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -1,4 +1,3 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
@@ -20,18 +19,12 @@ public class CreateEngagementCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IKeycloakOrganizationService _keycloakService =
 		Substitute.For<IKeycloakOrganizationService>();
-	private readonly IKeycloakUserService _keycloakUserService =
-		Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
 		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
 	private readonly IAggregateRepository<Notification, NotificationId> _notifRepo =
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
-	private readonly IAggregateRepository<User, UserId> _userRepo =
-		Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly CreateEngagementCommandHandler _sut;
 
@@ -83,22 +76,13 @@ public class CreateEngagementCommandHandlerTests
 		_dbContext.Engagements.Returns(_engagementRepo);
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
 		_dbContext.Notifications.Returns(_notifRepo);
-		_dbContext.Users.Returns(_userRepo);
 		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_keycloakUserService
-			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Test", "User", "volunteer@example.com"));
 		_dbContext.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
 			.Returns(0);
 		_dbContext.GetTerminalEngagementAsync(Arg.Any<UserId>(), Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns((Engagement?)null);
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_sut = new CreateEngagementCommandHandler(_dbContext, _keycloakService, _keycloakUserService, _emailService, _emailTemplateRenderer);
+		_sut = new CreateEngagementCommandHandler(_dbContext, _keycloakService);
 	}
 
 	// Individual-contact opportunities never have time slots - this is the fixture
@@ -517,68 +501,22 @@ public class CreateEngagementCommandHandlerTests
 		await _engagementRepo.Received(1).AddAsync(Arg.Any<Engagement>(), cancellationToken);
 	}
 
-	// --- Localized emails (#1052) ---
-
-	[Test]
-	public async Task Handle_ShouldRenderVolunteerEmail_InVolunteersPreferredLanguage(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunityId = VolunteerOpportunityId.New();
-		var volunteerId = UserId.New();
-		SetupOpportunityExists(opportunityId);
-		var volunteer = User.Create(volunteerId);
-		volunteer.SetPreferredLanguage("en");
-		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns(volunteer);
-		var command = new CreateEngagementCommand(opportunityId, volunteerId, TimeSlotId: null, "Hi!");
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementRequestReceived,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	[Test]
-	public async Task Handle_ShouldDefaultVolunteerEmailToGerman_WhenNoProfileExistsYet(
-		CancellationToken cancellationToken)
-	{
-		// Arrange - a volunteer who signs up without ever having loaded their
-		// profile page has no User row yet, so PreferredLanguage can't have
-		// been seeded; the recipient's language must still resolve, never NRE.
-		var opportunityId = VolunteerOpportunityId.New();
-		var volunteerId = UserId.New();
-		SetupOpportunityExists(opportunityId);
-		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns((User?)null);
-		var command = new CreateEngagementCommand(opportunityId, volunteerId, TimeSlotId: null, "Hi!");
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.EngagementRequestReceived,
-			"de",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
-	}
-
-	// --- Organizer notifications (#1174) ---
+	// --- Notifications and emails (#1174, #1729) ---
 	//
-	// The organizer "New sign-up" email (subscription-gated per #1055) is sent
-	// asynchronously via the outbox, by EngagementCreatedDomainEventHandler /
-	// EngagementReactivatedDomainEventHandler - see those handlers' tests for
-	// the subscription-preference coverage.
+	// Neither the organizer "New sign-up" email (subscription-gated per #1055)
+	// nor the volunteer's own sign-up receipt is sent synchronously from this
+	// handler anymore - both go out asynchronously via the outbox, by
+	// EngagementCreatedDomainEventHandler / EngagementReactivatedDomainEventHandler
+	// - see those handlers' tests (including localized-email and
+	// subscription-preference coverage) and EngagementVolunteerConfirmationHelper.
 
 	[Test]
-	public async Task Handle_ShouldNotEmailOrganizersSynchronously_RegardlessOfHowManyExist(
+	public async Task Handle_ShouldNotSendAnyEmailSynchronously_RegardlessOfHowManyOrganizersExist(
 		CancellationToken cancellationToken)
 	{
 		// Arrange - a rapid create/withdraw loop must no longer hold this
-		// request's DB transaction open across one synchronous SMTP send per
-		// organizer.
+		// request's DB transaction open across a synchronous SMTP send, whether
+		// for the organizers or for the volunteer's own receipt (#1142).
 		var opportunityId = VolunteerOpportunityId.New();
 		var timeSlotId = SetupOpportunityExistsWithTimeSlot(opportunityId);
 		_keycloakService.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -591,9 +529,9 @@ public class CreateEngagementCommandHandlerTests
 		// Act
 		await _sut.Handle(command, cancellationToken);
 
-		// Assert - exactly one email goes out synchronously: the volunteer's own
-		// receipt (#1055).
-		await _emailService.Received(1).SendAsync(
-			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		// Assert - nothing about this request talks to Keycloak's user endpoint
+		// or renders/sends an email; only the organizer membership lookup (needed
+		// for in-app Notification rows) remains.
+		await _keycloakService.Received(1).GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
@@ -25,6 +25,7 @@ public class EngagementCreatedDomainEventHandlerTests
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly IAggregateRepository<User, UserId> _userRepo = Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly EngagementCreatedDomainEventHandler _sut;
 
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
@@ -32,6 +33,7 @@ public class EngagementCreatedDomainEventHandlerTests
 	public EngagementCreatedDomainEventHandlerTests()
 	{
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Users.Returns(_userRepo);
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Vera", "Volunteer", "vera@example.com"));
@@ -70,17 +72,16 @@ public class EngagementCreatedDomainEventHandlerTests
 		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
 			.Returns("https://example.com/unsubscribe");
 
-		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.Received(1).SendAsync(
-			"olaf@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			Arg.Any<string>(),
+		// Assert - organizer emails go out as a single batch (#1729), not one
+		// SendAsync call per organizer.
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages => messages!.Any(m =>
+				m.To == "olaf@example.com" && m.Body.Contains("https://example.com/unsubscribe"))),
 			cancellationToken);
 	}
 
@@ -105,14 +106,14 @@ public class EngagementCreatedDomainEventHandlerTests
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns([optedOutOrganizer]);
 
-		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		// Assert - the only organizer opted out, so the batch is never sent at all.
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -129,7 +130,7 @@ public class EngagementCreatedDomainEventHandlerTests
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns<KeycloakUserProfile>(_ => throw new InvalidOperationException("404 Not Found"));
-		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
@@ -138,6 +139,8 @@ public class EngagementCreatedDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -147,7 +150,7 @@ public class EngagementCreatedDomainEventHandlerTests
 		// Arrange
 		var opportunityId = VolunteerOpportunityId.New();
 		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
-		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunityId);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunityId, IsSlotSignUp: false);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
@@ -156,6 +159,8 @@ public class EngagementCreatedDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -169,12 +174,104 @@ public class EngagementCreatedDomainEventHandlerTests
 		var organizationId = OrganizationId.New();
 		var opportunity = CreateOpportunity(organizationId);
 		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
-		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
 		// Assert
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	// --- Volunteer sign-up receipt (#1729) ---
+	//
+	// Sent from here rather than synchronously from CreateEngagementCommandHandler
+	// so the time-slot row lock (#1142) that handler holds no longer stays open
+	// across this SMTP send too.
+
+	[Test]
+	public async Task Handle_ShouldEmailVolunteer_WithTheirOwnSignUpReceipt(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"vera@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+	}
+
+	[Test]
+	[Arguments(true, EmailTemplateKind.EngagementWaitlisted)]
+	[Arguments(false, EmailTemplateKind.EngagementRequestReceived)]
+	public async Task Handle_ShouldPickVolunteerEmailTemplate_MatchingIsSlotSignUp(
+		bool isSlotSignUp, EmailTemplateKind expectedTemplate, CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, isSlotSignUp);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			expectedTemplate, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderVolunteerEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var volunteerId = UserId.New();
+		var volunteer = User.Create(volunteerId);
+		volunteer.SetPreferredLanguage("en");
+		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns(volunteer);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), volunteerId, opportunity.Id, IsSlotSignUp: false);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementRequestReceived,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDefaultVolunteerEmailToGerman_WhenNoProfileExistsYet(
+		CancellationToken cancellationToken)
+	{
+		// Arrange - a volunteer who signs up without ever having loaded their
+		// profile page has no User row yet, so PreferredLanguage can't have
+		// been seeded; the recipient's language must still resolve, never NRE.
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var volunteerId = UserId.New();
+		_userRepo.FindAsync(volunteerId, Arg.Any<CancellationToken>()).Returns((User?)null);
+		var domainEvent = new EngagementCreatedDomainEvent(EngagementId.New(), volunteerId, opportunity.Id, IsSlotSignUp: false);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.EngagementRequestReceived,
+			"de",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
@@ -25,6 +25,7 @@ public class EngagementReactivatedDomainEventHandlerTests
 	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly IUnsubscribeLinkBuilder _unsubscribeLinkBuilder = Substitute.For<IUnsubscribeLinkBuilder>();
+	private readonly IAggregateRepository<User, UserId> _userRepo = Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly EngagementReactivatedDomainEventHandler _sut;
 
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
@@ -32,6 +33,7 @@ public class EngagementReactivatedDomainEventHandlerTests
 	public EngagementReactivatedDomainEventHandlerTests()
 	{
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_dbContext.Users.Returns(_userRepo);
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new KeycloakUserProfile(Guid.NewGuid(), "volunteer", "Vera", "Volunteer", "vera@example.com"));
@@ -72,17 +74,16 @@ public class EngagementReactivatedDomainEventHandlerTests
 		_unsubscribeLinkBuilder.Build(Arg.Any<UserId>(), Arg.Any<Guid>(), Arg.Any<EmailNotificationType>())
 			.Returns("https://example.com/unsubscribe");
 
-		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.Received(1).SendAsync(
-			"olaf@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			Arg.Any<string>(),
+		// Assert - organizer emails go out as a single batch (#1729), not one
+		// SendAsync call per organizer.
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages => messages!.Any(m =>
+				m.To == "olaf@example.com" && m.Body.Contains("https://example.com/unsubscribe"))),
 			cancellationToken);
 	}
 
@@ -107,14 +108,14 @@ public class EngagementReactivatedDomainEventHandlerTests
 		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
 			.Returns([optedOutOrganizer]);
 
-		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		// Assert - the only organizer opted out, so the batch is never sent at all.
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -132,7 +133,7 @@ public class EngagementReactivatedDomainEventHandlerTests
 		_keycloakUserService
 			.GetUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns<KeycloakUserProfile>(_ => throw new InvalidOperationException("404 Not Found"));
-		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
@@ -141,6 +142,8 @@ public class EngagementReactivatedDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -150,7 +153,7 @@ public class EngagementReactivatedDomainEventHandlerTests
 		// Arrange
 		var opportunityId = VolunteerOpportunityId.New();
 		_opportunityRepo.FindAsync(opportunityId, cancellationToken).Returns((VolunteerOpportunity?)null);
-		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunityId);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunityId, IsSlotSignUp: false);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(domainEvent, cancellationToken);
@@ -159,6 +162,8 @@ public class EngagementReactivatedDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -169,12 +174,58 @@ public class EngagementReactivatedDomainEventHandlerTests
 		var organizationId = OrganizationId.New();
 		var opportunity = CreateOpportunity(organizationId);
 		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
-		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
 
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
 		// Assert
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
+	}
+
+	// --- Volunteer sign-up receipt (#1729) ---
+	//
+	// A reactivated engagement deserves the same volunteer receipt a genuinely
+	// new sign-up gets (mirrors EngagementCreatedDomainEventHandlerTests). Sent
+	// from here rather than synchronously from CreateEngagementCommandHandler so
+	// the time-slot row lock (#1142) that handler holds no longer stays open
+	// across this SMTP send too.
+
+	[Test]
+	public async Task Handle_ShouldEmailVolunteer_WithTheirOwnSignUpReceipt(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, IsSlotSignUp: false);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendAsync(
+			"vera@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+	}
+
+	[Test]
+	[Arguments(true, EmailTemplateKind.EngagementWaitlisted)]
+	[Arguments(false, EmailTemplateKind.EngagementRequestReceived)]
+	public async Task Handle_ShouldPickVolunteerEmailTemplate_MatchingIsSlotSignUp(
+		bool isSlotSignUp, EmailTemplateKind expectedTemplate, CancellationToken cancellationToken)
+	{
+		// Arrange
+		var organizationId = OrganizationId.New();
+		var opportunity = CreateOpportunity(organizationId);
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		var domainEvent = new EngagementReactivatedDomainEvent(EngagementId.New(), UserId.New(), opportunity.Id, isSlotSignUp);
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			expectedTemplate, Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/GetEngagementCalendar/GetEngagementCalendarQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/GetEngagementCalendar/GetEngagementCalendarQueryHandlerTests.cs
@@ -170,4 +170,38 @@ public class GetEngagementCalendarQueryHandlerTests
 		result!.Content.Should().Contain("\r\n ");
 		result.Content.Should().Contain(longTitle[..25]);
 	}
+
+	// Regression for #1729: StringBuilder.AppendLine uses Environment.NewLine,
+	// which is "\n" (not "\r\n") on Linux - mixing that with the folding logic's
+	// explicit "\r\n" produced a file that violated RFC 5545's CRLF requirement.
+	[Test]
+	public async Task Handle_ShouldUseCrLf_ForEveryLineEnding(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var engagementId = Guid.CreateVersion7();
+		var longTitle = new string('A', 100);
+		var info = new EngagementCalendarInfo(
+			engagementId,
+			Guid.CreateVersion7(),
+			longTitle,
+			"Description",
+			"Some Location",
+			DateTimeOffset.UtcNow.AddDays(1),
+			DateTimeOffset.UtcNow.AddDays(1).AddHours(2));
+		_readRepository
+			.GetCalendarInfoAsync(EngagementId.Create(engagementId).GetValueOrThrow(), cancellationToken)
+			.Returns(info);
+
+		var query = new GetEngagementCalendarQuery(engagementId, "https://einsatzbereit.example");
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert - every "\n" in the file must be immediately preceded by "\r",
+		// i.e. there is no bare LF anywhere once every CRLF is stripped out.
+		result.Should().NotBeNull();
+		result!.Content.Replace("\r\n", string.Empty).Should().NotContain("\n");
+		result.Content.Replace("\r\n", string.Empty).Should().NotContain("\r");
+	}
 }

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
@@ -75,12 +75,11 @@ public class EngagementWithdrawnDomainEventHandlerTests
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.Received(1).SendAsync(
-			"olaf@example.com",
-			Arg.Any<string>(),
-			Arg.Is<string>(body => body!.Contains("https://example.com/unsubscribe")),
-			Arg.Any<string>(),
+		// Assert - organizer emails go out as a single batch (#1729), not one
+		// SendAsync call per organizer.
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages => messages!.Any(m =>
+				m.To == "olaf@example.com" && m.Body.Contains("https://example.com/unsubscribe"))),
 			cancellationToken);
 	}
 
@@ -110,9 +109,9 @@ public class EngagementWithdrawnDomainEventHandlerTests
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
-		await _emailService.DidNotReceive().SendAsync(
-			"olaf@example.com", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		// Assert - the only organizer opted out, so the batch is never sent at all.
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -167,6 +166,8 @@ public class EngagementWithdrawnDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -185,6 +186,8 @@ public class EngagementWithdrawnDomainEventHandlerTests
 		await act.Should().NotThrowAsync();
 		await _emailService.DidNotReceive().SendAsync(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -979,6 +979,74 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		exception.Which.StatusCode.Should().Be(409);
 	}
 
+	// ── Concurrent overbooking prevention (#1142, #1729) ─────────────────────
+	//
+	// CreateEngagementCommandHandler's time-slot row lock (LockTimeSlotForUpdateAsync)
+	// is the only thing standing between a shared opportunity link and an
+	// overbooked shift. Every other test above exercises it against a mock or
+	// sequentially - this is the one place it runs against real concurrent
+	// requests hitting a real Postgres, proving the lock actually serializes
+	// them instead of letting two callers both read the same stale count.
+
+	[Test]
+	public async Task CreateEngagement_ShouldAllowExactlyOneSignUp_WhenManyVolunteersRaceForASingleSlot(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateScheduledSlotsOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var timeSlots = await olafClient.CreateTimeSlotAsync(
+			opportunity.Id,
+			new CreateTimeSlotRequest
+			{
+				StartDateTime = DateTimeOffset.UtcNow.AddDays(7),
+				EndDateTime = DateTimeOffset.UtcNow.AddDays(7).AddHours(2),
+				MaxParticipants = 1,
+				RecurrenceCount = 1,
+			},
+			cancellationToken);
+		var timeSlotId = timeSlots.Single().Id;
+		await olafClient.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		const int volunteerCount = 8;
+		var volunteerClients = new List<EinsatzbereitApi>(volunteerCount);
+		for (var i = 0; i < volunteerCount; i++)
+		{
+			var (_, username, password) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+			volunteerClients.Add(await CreateAuthenticatedClientAsync(username, password));
+		}
+
+		// Every volunteer's request is already in flight before any of them is
+		// awaited - Task.WhenAll on N distinct HTTP calls, not a sequential loop.
+		var signUpTasks = volunteerClients.Select(async client =>
+		{
+			try
+			{
+				await client.CreateEngagementAsync(
+					opportunity.Id, new CreateEngagementRequest { TimeSlotId = timeSlotId }, cancellationToken);
+				return true;
+			}
+			catch (ApiException ex) when (ex.StatusCode == 409)
+			{
+				return false;
+			}
+		}).ToList();
+
+		var results = await Task.WhenAll(signUpTasks);
+
+		results.Count(succeeded => succeeded).Should().Be(1,
+			"the time-slot row lock must let exactly one concurrent sign-up win a slot with MaxParticipants = 1");
+
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var nonTerminalCount = await dbContext.Set<Engagement>()
+			.CountAsync(e =>
+				e.OpportunityId == VolunteerOpportunityId.Create(opportunity.Id).GetValueOrThrow() &&
+				(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed),
+				cancellationToken);
+		nonTerminalCount.Should().Be(1, "the database must never end up with more live engagements than the slot's capacity");
+	}
+
 	// ── Cross-user withdrawal ─────────────────────────────────────────────────
 
 	[Test]

--- a/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
+++ b/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
@@ -61,7 +61,7 @@ public class OutboxMessageSerializationTests
 		yield return new EngagementCancelledDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), "Reason");
 		yield return new EngagementCreatedDomainEvent(
-			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), IsSlotSignUp: true);
 		yield return new EngagementCheckInUndoneDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		yield return new EngagementCheckedInDomainEvent(
@@ -75,7 +75,7 @@ public class OutboxMessageSerializationTests
 		yield return new EngagementFeedbackUpdatedDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), 5);
 		yield return new EngagementReactivatedDomainEvent(
-			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), IsSlotSignUp: true);
 		yield return new EngagementReminderDueDomainEvent(
 			EngagementId.New(), UserId.New(), VolunteerOpportunityId.New(), TimeSlotId.New());
 		yield return new EngagementWithdrawnDomainEvent(

--- a/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
+++ b/backend/tests/IntegrationTests/OutboxProcessorJobTests.cs
@@ -183,9 +183,15 @@ public class OutboxProcessorJobTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
-	public async Task ProcessBatchAsync_TwoConcurrentCalls_OnlyOneDispatchesTheLockedMessage(
+	public async Task ProcessBatchAsync_TwoConcurrentCalls_SecondCallDoesNotReclaimAMessageBeingDispatchedByTheFirst(
 		CancellationToken cancellationToken)
 	{
+		// Regression for #1729: dispatch now happens with no open transaction/row
+		// lock held (see OutboxProcessorJob.ClaimBatchAsync) so it no longer blocks
+		// on a synchronous SMTP send per organizer for the whole batch. What now
+		// stops a second replica from re-selecting the same message while A is
+		// still dispatching it is ClaimedOnUtc, stamped and committed by A's short
+		// claim transaction before dispatch even starts.
 		await using var seedContext = fixture.CreateApplicationDbContext();
 		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
 		await SeedOutboxMessageAsync(seedContext, domainEvent, cancellationToken);
@@ -202,17 +208,17 @@ public class OutboxProcessorJobTests(IntegrationTestFixture fixture)
 		var taskA = OutboxProcessorJob.ProcessBatchAsync(
 			contextA, gatedDispatcher, NullLogger.Instance, metrics, batchSize: 20, cancellationToken: cancellationToken);
 
-		// Wait until A's transaction has actually reached the dispatcher - meaning its
-		// SELECT ... FOR UPDATE SKIP LOCKED already committed the row lock - before
-		// starting B, so B's own SKIP LOCKED query has something real to skip instead of
-		// racing to see an as-yet-unlocked row.
+		// Wait until A has claimed the message (ClaimedOnUtc committed) and reached
+		// the dispatcher - A's claim transaction has already committed by this
+		// point, so nothing is locked anymore; only the ClaimedOnUtc stamp
+		// protects the row now.
 		await started.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
 
 		var recordingDispatcher = new RecordingDispatcher();
-		var selectedByB = await OutboxProcessorJob.ProcessBatchAsync(
+		var claimedByB = await OutboxProcessorJob.ProcessBatchAsync(
 			contextB, recordingDispatcher, NullLogger.Instance, metrics, batchSize: 20, cancellationToken: cancellationToken);
 
-		selectedByB.Should().Be(0, "the only pending message is locked by A's still-open transaction, so B's SKIP LOCKED query must skip it rather than dispatch it a second time");
+		claimedByB.Should().Be(0, "the message was just claimed by A - within the claim timeout, B's claim query must skip it rather than dispatch it a second time");
 		recordingDispatcher.DispatchedEvents.Should().BeEmpty();
 
 		release.SetResult();
@@ -224,6 +230,61 @@ public class OutboxProcessorJobTests(IntegrationTestFixture fixture)
 			.AsNoTracking()
 			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
 		message.ProcessedOnUtc.Should().NotBeNull();
+	}
+
+	[Test]
+	public async Task ProcessBatchAsync_MessageClaimedPastTheTimeout_IsReclaimedAndDispatched(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1729: a process that claims a batch and then crashes
+		// before dispatch completes must not leave those messages stuck forever -
+		// once ClaimedOnUtc is older than claimTimeoutSeconds, a later poll treats
+		// the claim as abandoned and reclaims the message.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(dbContext, domainEvent, cancellationToken);
+
+		var message = await dbContext.Set<OutboxMessage>()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		message.ClaimedOnUtc = DateTime.UtcNow.AddSeconds(-10);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		using var meterFactory = new TestMeterFactory();
+		var dispatcher = new RecordingDispatcher();
+		var claimed = await OutboxProcessorJob.ProcessBatchAsync(
+			dbContext, dispatcher, NullLogger.Instance, new OutboxMetrics(meterFactory),
+			batchSize: 20, claimTimeoutSeconds: 5, cancellationToken: cancellationToken);
+
+		claimed.Should().Be(1, "a claim older than claimTimeoutSeconds must be treated as abandoned and reclaimed");
+		dispatcher.DispatchedEvents.Should().ContainSingle();
+
+		var reprocessed = await dbContext.Set<OutboxMessage>()
+			.AsNoTracking()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		reprocessed.ProcessedOnUtc.Should().NotBeNull();
+	}
+
+	[Test]
+	public async Task ProcessBatchAsync_MessageClaimedWithinTheTimeout_IsNotReclaimed(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var domainEvent = new EngagementConfirmedDomainEvent(EngagementId.New(), UserId.New(), VolunteerOpportunityId.New());
+		await SeedOutboxMessageAsync(dbContext, domainEvent, cancellationToken);
+
+		var message = await dbContext.Set<OutboxMessage>()
+			.SingleAsync(m => m.Type == typeof(EngagementConfirmedDomainEvent).FullName, cancellationToken);
+		message.ClaimedOnUtc = DateTime.UtcNow;
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		using var meterFactory = new TestMeterFactory();
+		var dispatcher = new RecordingDispatcher();
+		var claimed = await OutboxProcessorJob.ProcessBatchAsync(
+			dbContext, dispatcher, NullLogger.Instance, new OutboxMetrics(meterFactory),
+			batchSize: 20, claimTimeoutSeconds: 300, cancellationToken: cancellationToken);
+
+		claimed.Should().Be(0, "a message claimed moments ago is presumed still in flight elsewhere");
+		dispatcher.DispatchedEvents.Should().BeEmpty();
 	}
 
 	// #1008: OutboxMessage.Error was persisted but never surfaced anywhere an operator

--- a/backend/tests/VisualTests/EngagementCalendarTests.cs
+++ b/backend/tests/VisualTests/EngagementCalendarTests.cs
@@ -113,5 +113,13 @@ public class EngagementCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 		var icsBody = await icsResponse.Content.ReadAsStringAsync();
 		icsBody.Should().Contain("BEGIN:VCALENDAR");
 		icsBody.Should().Contain($"UID:{engagementId}@einsatzbereit");
+
+		// Regression for #1729: every line must end in CRLF per RFC 5545 - the
+		// handler used to mix LF (from StringBuilder.AppendLine, which is
+		// Environment.NewLine - "\n" on Linux) with the CRLF its own line-folding
+		// used explicitly.
+		var withoutCrLf = icsBody.Replace("\r\n", string.Empty);
+		withoutCrLf.Should().NotContain("\n");
+		withoutCrLf.Should().NotContain("\r");
 	}
 }


### PR DESCRIPTION
## What

Six backend performance/concurrency fixes from the 1.0 readiness analysis in #1729:

1. `CreateEngagementCommandHandler` no longer sends the volunteer confirmation email inline while holding the time-slot row lock (#1142) - it now goes out via the outbox, the same way the organizer email already does.
2. `EngagementOrganizerNotificationHelper` batches organizer emails into a single `SendBatchAsync` call instead of one `SendAsync` per organizer.
3. `AdminReportReadRepository.GetFlaggedTargetsPagedAsync` is now a single grouped/paged SQL query instead of loading every `report` row into memory.
4. `VolunteerOpportunityReadRepository`'s radius search filters/orders/pages by distance in SQL (a literal `Math.*` haversine expression Npgsql can translate) instead of materializing the whole bounding box client-side.
5. `OutboxProcessorJob` now claims a batch and stamps `ClaimedOnUtc` in a short transaction, then dispatches (including any SMTP sends) with **no open transaction/connection held** - a stale claim (crashed process) is automatically reclaimed after `OutboxOptions.ClaimTimeoutSeconds`.
6. Added a partial index (`ix_engagement_time_slot_id_pending_auto_check_in`) backing `AutomaticCheckInJob`'s hourly query, which previously had no supporting index.

Also fixed: generated `.ics` calendar files mixed LF and CRLF line endings (RFC 5545 requires CRLF throughout) - `GetEngagementCalendarQueryHandler` was using `StringBuilder.AppendLine`, which is `Environment.NewLine` (`"\n"` on Linux), mixed with the line-folding logic's explicit `"\r\n"`.

## Why

Closes #1729

The time-slot row lock in `CreateEngagementCommandHandler` is the only thing preventing overbooking on a shared opportunity link, and it was held across two Keycloak calls plus a full synchronous SMTP session - a slow/unreachable mail server turned this into a queue on the hottest write path in the product. The outbox processor had the same shape of problem: `OutboxProcessorJob` held a `FOR UPDATE SKIP LOCKED` row lock (and its DB connection) across every SMTP send in a batch, including the organizer-notification fan-out. The admin moderation queue and radius search both loaded unbounded data into memory and did filtering/paging client-side, so their cost grew linearly with total rows rather than with the page size.

## Testing

- Added/updated unit tests in `Application.UnitTests` for the moved volunteer-confirmation-email logic (template selection, language resolution) and the organizer-email batching (`SendBatchAsync` instead of per-recipient `SendAsync`), across `EngagementCreatedDomainEventHandlerTests`, `EngagementReactivatedDomainEventHandlerTests`, `EngagementWithdrawnDomainEventHandlerTests`, and `CreateEngagementCommandHandlerTests`.
- Added a new integration test in `IntegrationTests/EngagementTests.cs` (`CreateEngagement_ShouldAllowExactlyOneSignUp_WhenManyVolunteersRaceForASingleSlot`) that creates a slot with `MaxParticipants = 1` and fires 8 genuinely concurrent `CreateEngagementAsync` calls via `Task.WhenAll`, asserting exactly one succeeds and the DB never ends up with more live engagements than capacity.
- Reworked `OutboxProcessorJobTests` concurrency test for the new claim/dispatch split, plus two new tests covering the stale-claim reclaim window (`ProcessBatchAsync_MessageClaimedPastTheTimeout_IsReclaimedAndDispatched` / `..._WithinTheTimeout_IsNotReclaimed`).
- Added a CRLF-only regression test for the `.ics` generator in both `Application.UnitTests` and `VisualTests` (`EngagementCalendarTests`).
- Two new EF Core migrations (`AddOutboxMessageClaimedOnUtc`, `AddEngagementTimeSlotIdPendingAutoCheckInIndex`) - verified via `dotnet ef migrations has-pending-model-changes` that the model and migrations are in sync.
- Ran locally: `Application.UnitTests` (1041/1041 passing) and `ArchitectureTests` (426/426 passing) against a temporarily-installed SDK (this sandbox has no network access to the pinned 10.0.302 SDK's official CDN; verified with a same-major-minor 10.0.110 SDK via apt, which uses the same EF Core/Roslyn NuGet packages as the pinned SDK for compilation and migration scaffolding). `IntegrationTests`/`VisualTests` need Docker/Aspire, which isn't available in this sandbox - they'll run in CI.
- Ran `/self-review` plus the `ef-migration-check` and `architecture-check` subagents; both came back clean.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed for this PR. CI (`dotnet.yml`) will run the full test suite including `IntegrationTests` and `VisualTests` on a real runner.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (inline comments only - no root/AGENTS.md-level docs affected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra3DSa3CqKJzVjm4tvXsC7)_