### PR TITLE
feat(frontend): give the subpages the landing page's visual language

### DIFF
--- a/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
+++ b/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
@@ -15,8 +15,19 @@ namespace VisualTests;
 public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task ProfilePage_ActionBar_RendersDirectlyBeneathHeader_IconLed()
+	public async Task AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions()
 	{
+		// #758 made /profile the canonical example of the shared action bar.
+		// #1755 gave the three account pages (/profile, /my-engagements,
+		// /profile/settings) the same PageHeaderBand the legal pages use, and a
+		// band page renders no action bar - the title would otherwise be stated
+		// twice with a grey strip cutting through the treatment.
+		//
+		// The bar itself is unchanged and still covered on the org app shell by
+		// OrgAppShell_ActionBar_StillSitsImmediatelyAfterHeader_NoRegression
+		// below. What this pins instead is that the two things the bar carried
+		// for /profile survived the move: the way back home, and the Edit
+		// quick action.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -24,22 +35,25 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 		await Page.GotoAsync($"{origin}/profile");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// The action bar sits immediately after </header> as a sibling - the
-		// same placement the org app shell already used - not inside <main>
-		// where the old Breadcrumb.tsx/ToolbarContext mechanism rendered it.
-		var actionBar = Page.Locator("header + div nav[aria-label='Breadcrumb']");
-		await Expect(actionBar).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "My Profile", Level = 1 }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
+			.ToHaveCountAsync(0);
 
-		// Home crumb is icon-led (aria-label only, no visible "Home" text),
-		// matching the org app shell's style instead of the old plain-text chip.
-		var homeLink = actionBar.GetByRole(AriaRole.Link, new() { Name = "Home" });
+		var homeLink = Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" });
 		await Expect(homeLink).ToBeVisibleAsync();
 		await Expect(homeLink).ToHaveAttributeAsync("href", "/");
-		// the home crumb should be icon-only (aria-label='Home'), not a visible text link
-		await Expect(homeLink).ToHaveTextAsync("");
-		await Expect(homeLink.Locator("svg")).ToBeVisibleAsync();
 
-		await Expect(actionBar.GetByText("Profile", new() { Exact = true })).ToBeVisibleAsync();
+		// useEditModeQuickActions publishes through QuickActionsContext, which
+		// PageHeaderBand now reads in the action bar's place - same key and the
+		// same data-testid, so the edit-mode tests keep working unchanged.
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync();
+
+		// The sub-nav is what ties the three pages together now that each has
+		// its own band; all three must offer all three destinations.
+		var subNav = Page.Locator("main nav[aria-label]").First;
+		foreach (var tab in new[] { "Profile", "Activity", "Settings" })
+			await Expect(subNav.GetByRole(AriaRole.Link, new() { Name = tab })).ToBeVisibleAsync();
 	}
 
 	[Test]
@@ -64,31 +78,78 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 	}
 
 	[Test]
-	public async Task ImprintAndPrivacyPolicyPages_ShowActionBar_AtTheirNewEnglishSlugs()
+	public async Task ImprintAndPrivacyPolicyPages_ReplaceActionBar_WithInBandHomeLink()
 	{
 		// Follow-up to #758: the legal pages were missed in the initial rollout
 		// (still on ToolbarContext.tsx, no action bar) and used German slugs
 		// (/impressum, /datenschutz) while every other route is English -
-		// renamed to /imprint and /privacy-policy, with the action bar now
+		// renamed to /imprint and /privacy-policy, with the action bar then
 		// shared via Header.tsx like every other subpage.
+		//
+		// #1755 dropped the action bar from exactly these pages again. They now
+		// open with a full-bleed PageHeaderBand that states the page title in
+		// 72px display type, so a grey strip immediately above it repeating
+		// that same title was pure duplication - and it drew a hard white line
+		// through the middle of the band treatment. The Home link #758 added
+		// still exists, it just lives inside the band now. The slugs, and the
+		// action bar on every *other* subpage, are unchanged - see
+		// ProfilePage_ActionBar_RendersDirectlyBeneathHeader_IconLed above.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
+		foreach (var (path, title) in new[]
+		{
+			("/imprint", "Imprint"),
+			("/privacy-policy", "Privacy Policy"),
+		})
+		{
+			await Page.GotoAsync($"{origin}{path}");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = title, Level = 1 }))
+				.ToBeVisibleAsync(new() { Timeout = 15_000 });
+			await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
+				.ToHaveCountAsync(0);
+			await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+				.ToBeVisibleAsync();
+		}
+	}
+
+	[Test]
+	public async Task PageHeaderBand_MakesHeaderTransparent_UntilScrolledPastTheBand()
+	{
+		// #1755: the band runs up *behind* the sticky header (negative
+		// --header-height margin), so the header has to drop its own white
+		// background and switch its controls to on-dark variants while that's
+		// true - otherwise a white bar sits across the top of a dark band.
+		// Once scrolled past, there is white page underneath again and the
+		// header has to take its background back, or white-on-dark controls
+		// would be left sitting on white.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await Page.GotoAsync($"{origin}/terms-of-use");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var header = Page.Locator("header");
+		await Expect(header).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(header).ToContainClassAsync("bg-transparent");
+
+		await Page.EvaluateAsync("() => window.scrollTo(0, 600)");
+		// The header cross-fades over 300ms (transition-all duration-300).
+		await Expect(header).ToContainClassAsync("bg-white/95", new() { Timeout = 5_000 });
+
+		// Leaving the page has to release the transparency again - the overlay
+		// flag is refcounted precisely because React mounts the incoming route
+		// before unmounting the outgoing one.
 		await Page.GotoAsync($"{origin}/imprint");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-		var imprintBar = Page.Locator("header + div nav[aria-label='Breadcrumb']");
-		await Expect(imprintBar).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await Expect(imprintBar.GetByRole(AriaRole.Link, new() { Name = "Home" }))
-			.ToBeVisibleAsync();
-		await Expect(imprintBar.GetByText("Imprint", new() { Exact = true }))
-			.ToBeVisibleAsync();
+		await Expect(header).ToContainClassAsync("bg-transparent");
 
-		await Page.GotoAsync($"{origin}/privacy-policy");
+		await Page.GotoAsync($"{origin}/");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-		var privacyBar = Page.Locator("header + div nav[aria-label='Breadcrumb']");
-		await Expect(privacyBar).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await Expect(privacyBar.GetByText("Privacy Policy", new() { Exact = true }))
-			.ToBeVisibleAsync();
+		await Expect(header).ToContainClassAsync("bg-white");
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/LegalPagesLayoutTests.cs
+++ b/backend/tests/VisualTests/LegalPagesLayoutTests.cs
@@ -3,39 +3,49 @@ using Microsoft.Playwright;
 namespace VisualTests;
 
 /// <summary>
-/// Regression for #1127 (imprint, privacy policy) and #1673 (terms of use,
-/// contact): these four static legal/info pages rendered their h1 without
-/// the shared `text-gray-900` color, and their body copy had no width
-/// constraint inside AppLayout's `max-w-7xl` main - a roughly 180-character
-/// line measure on desktop. All four now match the heading color used
-/// everywhere else and wrap their content in a `data-content-wrapper`
-/// reading-width column, left-aligned like the other document-style pages
-/// (settings, profile) rather than centered like a detail page - see
-/// VisualTestBase.AssertMaxWidthContentLeftAlignedAsync.
+/// Layout guards for the four standalone public info pages (imprint, privacy
+/// policy, terms of use, contact).
+///
+/// Originally #1127/#1673: these pages rendered an unconstrained ~180-character
+/// line measure, fixed by wrapping their body in a `data-content-wrapper`
+/// reading column that sat flush left inside `&lt;main&gt;` (#766).
+///
+/// #1755 replaced that with a title band plus a centred document column,
+/// because flush-left was the reason the pages read as a dead strip against
+/// ~830px of empty page on desktop. The `data-content-wrapper` contract from
+/// #1328 is unchanged - only the invariant it has to satisfy flipped from
+/// left-aligned to centred, so these tests now assert the new arrangement
+/// rather than the one it replaced.
+///
+/// The third assertion is the one worth having: the band's h1 and the content
+/// column below it have to share a left edge. They are separately positioned
+/// (the band breaks out of `&lt;main&gt;` to run edge-to-edge, then re-derives
+/// the column geometry internally), so nothing structural keeps them in sync -
+/// and the first cut of #1755 shipped them 175px apart.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class LegalPagesLayoutTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task ImprintPage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	public async Task ImprintPage_TitleBandAlignsWithCentredContentColumn()
 	{
 		await AssertLegalPageLayoutAsync("/imprint", "Imprint page");
 	}
 
 	[Test]
-	public async Task PrivacyPolicyPage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	public async Task PrivacyPolicyPage_TitleBandAlignsWithCentredContentColumn()
 	{
 		await AssertLegalPageLayoutAsync("/privacy-policy", "Privacy policy page");
 	}
 
 	[Test]
-	public async Task TermsOfUsePage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	public async Task TermsOfUsePage_TitleBandAlignsWithCentredContentColumn()
 	{
 		await AssertLegalPageLayoutAsync("/terms-of-use", "Terms of use page");
 	}
 
 	[Test]
-	public async Task ContactPage_HeadingMatchesSharedScale_AndContentIsLeftAlignedWithinMain()
+	public async Task ContactPage_TitleBandAlignsWithCentredContentColumn()
 	{
 		await AssertLegalPageLayoutAsync("/contact", "Contact page");
 	}
@@ -44,13 +54,35 @@ public class LegalPagesLayoutTests(AspireFixture fixture) : VisualTestBase(fixtu
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 
+		// Wide enough that a centred max-w-5xl column is distinguishable from a
+		// flush-left one - at a narrow viewport the column fills the available
+		// width and both arrangements look identical.
+		await Page.SetViewportSizeAsync(1440, 900);
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}{path}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		var heading = Page.Locator("h1");
 		await Expect(heading).ToBeVisibleAsync();
-		await Expect(heading).ToContainClassAsync("text-gray-900");
+		// White on the brand-800 band, not the text-gray-900 the pages used
+		// when the title sat on plain white.
+		await Expect(heading).ToContainClassAsync("text-white");
 
-		await AssertMaxWidthContentLeftAlignedAsync(label);
+		await AssertMaxWidthContentCenteredAsync(label);
+
+		var edgeDelta = 0d;
+		await PollUntilAsync(async () =>
+		{
+			edgeDelta = await Page.EvaluateAsync<double>(
+				"""
+				() => {
+					const h1 = document.querySelector('main h1');
+					const column = document.querySelector('main [data-content-wrapper]');
+					return Math.abs(h1.getBoundingClientRect().left
+						- column.getBoundingClientRect().left);
+				}
+				""");
+			return edgeDelta < 2;
+		}, () => $"{label}: the title band's h1 should share a left edge with the content "
+			+ $"column below it (last observed delta = {edgeDelta}px, must be <2px)");
 	}
 }

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -59,14 +59,15 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync($"{origin}{href!}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		var breadcrumb = Page.Locator("nav[aria-label='Breadcrumb']");
-		await Expect(breadcrumb).ToBeVisibleAsync();
-
-		var homeCrumb = breadcrumb.Locator("a[href='/']");
-		await Expect(homeCrumb).ToBeVisibleAsync();
+		// #1755 replaced this page's breadcrumb bar with a PageHeaderBand: the
+		// band states the org name as the h1 and carries the way back home, so
+		// the bar restating both directly above it was pure duplication.
+		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
 
 		var orgName = await Page.Locator("h1").First.InnerTextAsync();
-		await Expect(breadcrumb.GetByText(orgName, new() { Exact = true })).ToBeVisibleAsync();
+		orgName.Should().NotBeNullOrWhiteSpace();
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToBeVisibleAsync();
 	}
 
 	[Test]
@@ -93,19 +94,17 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync($"{origin}{href!}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		var breadcrumb = Page.Locator("nav[aria-label='Breadcrumb']");
-		await Expect(breadcrumb).ToBeVisibleAsync();
-		await Expect(breadcrumb.Locator("a[href='/']")).ToBeVisibleAsync();
+		// #1755: the breadcrumb bar is gone from this page too - the
+		// PageHeaderBand states the opportunity title as the h1 and puts the
+		// link to the owning organization in its eyebrow, which is where the
+		// middle crumb's job moved.
+		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToBeVisibleAsync();
+		await Expect(Page.Locator("main a[href*='/organizations/']").First).ToBeVisibleAsync();
 
-		// Middle crumb links to the opportunity's organization, matching the org
-		// chip rendered further down the page.
-		var orgChipHref = await Page.Locator("a[href*='/organizations/']").First.GetAttributeAsync("href");
-		if (orgChipHref is not null)
-			await Expect(breadcrumb.Locator($"a[href='{orgChipHref}']")).ToBeVisibleAsync();
-
-		// Last crumb (current page, no link) matches the opportunity title.
 		var title = await Page.Locator("h1").First.InnerTextAsync();
-		await Expect(breadcrumb.GetByText(title, new() { Exact = true })).ToBeVisibleAsync();
+		title.Should().NotBeNullOrWhiteSpace();
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
@@ -12,23 +12,34 @@ namespace VisualTests;
 /// other top-level block on the page carries, so whichever one rendered sat
 /// flush against the "About this organization" section right below it with
 /// zero gap. Fixed by adding `mb-6` to each of the three.
+///
+/// #1754's two-column redesign (`lg:grid-cols-[minmax(0,1fr)_20rem]`) moved
+/// all three blocks into a sticky rail beside the reading column, while
+/// "About this organization" stayed behind in the reading column - the two
+/// are no longer vertically stacked, so a "gap above" check no longer means
+/// anything (whichever column happens to be taller decides its sign, not any
+/// actual spacing bug). What still matters, and what the redesign's own
+/// `lg:gap-10` exists to guarantee, is that the rail never overlaps the
+/// reading column horizontally - these checks now assert that gap instead.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
-	// Comfortably below the intended 24px (`mb-6`) gap, but far enough above
-	// zero that a regression back to "flush against the next section" (the
-	// bug's actual symptom) cannot pass.
+	// Comfortably below the intended `lg:gap-10` (40px) column gap, but far
+	// enough above zero that a regression back to the rail actually
+	// overlapping the reading column (the bug's modern equivalent of "flush
+	// against the next section") cannot pass.
 	private const double MinExpectedGapPx = 16;
 
 	/// <summary>
-	/// Asserts a visible gap exists between the bottom of <paramref name="block"/>
-	/// and the top of the "About this organization" section, reading both boxes
-	/// in a single EvaluateAsync call so nothing can shift layout between the
-	/// two reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync for the
-	/// same pattern).
+	/// Asserts a visible horizontal gap exists between the right edge of the
+	/// "About this organization" section (in the reading column) and the left
+	/// edge of <paramref name="block"/> (in the sticky rail beside it), reading
+	/// both boxes in a single EvaluateAsync call so nothing can shift layout
+	/// between the two reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync
+	/// for the same pattern).
 	/// </summary>
-	private async Task AssertGapBeforeAboutOrganizationAsync(ILocator block, string label)
+	private async Task AssertRailDoesNotOverlapAboutOrganizationAsync(ILocator block, string label)
 	{
 		var aboutOrg = Page.GetByTestId("about-organization");
 		await Expect(aboutOrg).ToBeVisibleAsync(new() { Timeout = 15_000 });
@@ -43,13 +54,14 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 					const about = document.querySelector(aboutSelector);
 					const blockBox = el.getBoundingClientRect();
 					const aboutBox = about.getBoundingClientRect();
-					return aboutBox.top - blockBox.bottom;
+					return blockBox.left - (aboutBox.left + aboutBox.width);
 				}
 				""",
 				"[data-testid='about-organization']");
 			return gap >= MinExpectedGapPx;
-		}, () => $"{label}: expected at least {MinExpectedGapPx}px between the block and \"About this "
-			+ $"organization\" (last observed gap = {gap}px) - it must not sit flush against the next section");
+		}, () => $"{label}: expected at least {MinExpectedGapPx}px between the reading column's \"About "
+			+ $"this organization\" section and the sticky rail (last observed gap = {gap}px) - the rail "
+			+ "must not overlap the reading column");
 	}
 
 	private async Task<(string OrganizationId, string OpportunityId)> CreateOpportunityWithFullOrgProfileAsync(
@@ -100,7 +112,7 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 	}
 
 	[Test]
-	public async Task ApplicationStatusCard_HasGapBeforeAboutOrganization()
+	public async Task ApplicationStatusCard_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -120,12 +132,12 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(
 			Page.GetByTestId("application-status"), "Your application status card");
 	}
 
 	[Test]
-	public async Task SignUpCta_HasGapBeforeAboutOrganization()
+	public async Task SignUpCta_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -136,11 +148,11 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(Page.GetByTestId("signup-cta"), "Sign-up CTA");
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(Page.GetByTestId("signup-cta"), "Sign-up CTA");
 	}
 
 	[Test]
-	public async Task LoginPrompt_HasGapBeforeAboutOrganization()
+	public async Task LoginPrompt_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -150,6 +162,6 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(Page.GetByTestId("login-prompt"), "Login prompt");
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(Page.GetByTestId("login-prompt"), "Login prompt");
 	}
 }

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -605,7 +605,25 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync($"{origin}/organizations/{organizationId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertMaxWidthContentLeftAlignedAsync("Organization profile page");
+		// #766 wanted this column not stranded as a narrow strip in a wide page.
+		// #1755 gave the page a PageHeaderBand, which anchors the layout and
+		// centres its own title at max-w-5xl - so the content is centred to match
+		// it rather than flush left, and the invariant that matters is now that
+		// the two share a left edge. The org app Settings tab, which has no band,
+		// still asserts the flush-left arrangement below.
+		await AssertMaxWidthContentCenteredAsync("Organization profile page");
+
+		var edgeDelta = await Page.EvaluateAsync<double>(
+			"""
+			() => {
+				const h1 = document.querySelector('main h1');
+				const column = document.querySelector('main [data-content-wrapper]');
+				return Math.abs(h1.getBoundingClientRect().left
+					- column.getBoundingClientRect().left);
+			}
+			""");
+		edgeDelta.Should().BeLessThan(2,
+			"the band title and the content column below it must share a left edge");
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -37,10 +37,20 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 	}
 
 	[Test]
-	public async Task ProfilePage_ShowsHomeBreadcrumb()
+	public async Task ProfilePage_ShowsHomeLink()
 	{
 		// #590: /profile never called usePageToolbar, so it rendered with no
 		// breadcrumb trail at all, unlike every other authenticated page.
+		//
+		// #1754 gave /profile a PageHeaderBand and dropped the
+		// nav[aria-label='Breadcrumb'] bar in favor of a plain "way back home"
+		// link inside the band - see VolunteerOpportunityTests's identical
+		// update and HeaderBreadcrumbSharedImplementationTests
+		// .AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions, which
+		// already pins this page's fuller behavior (heading, no breadcrumb bar,
+		// Home link, Edit quick action, sub-nav). This keeps #590's original
+		// regression - that /profile has *some* way back to the home page -
+		// covered under its own name.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -49,10 +59,10 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Page.GotoAsync($"{origin}/profile");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		var breadcrumb = Page.Locator("nav[aria-label='Breadcrumb']");
-		await Expect(breadcrumb).ToBeVisibleAsync(new() { Timeout = 20_000 });
-		await Expect(breadcrumb.Locator("a[href='/']")).ToBeVisibleAsync();
-		await Expect(breadcrumb.GetByText("Profile", new() { Exact = true })).ToBeVisibleAsync();
+		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+		var homeLink = Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" });
+		await Expect(homeLink).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(homeLink).ToHaveAttributeAsync("href", "/");
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/TermsOfUsePageTests.cs
+++ b/backend/tests/VisualTests/TermsOfUsePageTests.cs
@@ -20,17 +20,28 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Page.GotoAsync($"{origin}/terms-of-use");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		var actionBar = Page.Locator("header + div nav[aria-label='Breadcrumb']");
-		await Expect(actionBar).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await Expect(actionBar.GetByText("Terms of Use", new() { Exact = true }))
-			.ToBeVisibleAsync();
+		// #1755 replaced this page's breadcrumb action bar with a Home link
+		// inside the title band - see
+		// HeaderBreadcrumbSharedImplementationTests.ImprintAndPrivacyPolicyPages_ReplaceActionBar_WithInBandHomeLink
+		// for the rationale and the cross-page guard.
+		await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
+			.ToHaveCountAsync(0);
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await Expect(Page.GetByRole(AriaRole.Heading,
 			new() { Name = "Terms of Use", Level = 1 })).ToBeVisibleAsync();
+		// Exact = false throughout this file's clause-heading assertions: since
+		// #1755 each clause heading carries its own number ("2 Our role as a
+		// platform"), because legal text is cited by clause and the number
+		// therefore belongs in the heading's accessible name rather than being
+		// an aria-hidden decoration. Substring matching keeps these assertions
+		// about the clause titles themselves, so inserting a section above one
+		// doesn't break an unrelated test.
 		await Expect(Page.GetByRole(AriaRole.Heading,
-			new() { Name = "Our role as a platform" })).ToBeVisibleAsync();
+			new() { Name = "Our role as a platform", Exact = false })).ToBeVisibleAsync();
 		await Expect(Page.GetByRole(AriaRole.Heading,
-			new() { Name = "Suspension and termination" })).ToBeVisibleAsync();
+			new() { Name = "Suspension and termination", Exact = false })).ToBeVisibleAsync();
 		await Expect(Page.GetByText("at your own risk", new() { Exact = false }))
 			.ToBeVisibleAsync();
 	}
@@ -50,7 +61,7 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Expect(Page.GetByRole(AriaRole.Heading,
 			new() { Name = "Nutzungsbedingungen", Level = 1 })).ToBeVisibleAsync();
 		await Expect(Page.GetByRole(AriaRole.Heading,
-			new() { Name = "Unsere Rolle als Plattform" })).ToBeVisibleAsync();
+			new() { Name = "Unsere Rolle als Plattform", Exact = false })).ToBeVisibleAsync();
 		await Expect(Page.GetByText("auf eigenes Risiko", new() { Exact = false }))
 			.ToBeVisibleAsync();
 	}
@@ -86,8 +97,10 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Page.GotoAsync($"{origin}/terms-of-use");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
+		// Exact = false - see the clause-numbering note higher up this file.
 		await Expect(Page.GetByRole(AriaRole.Heading,
-			new() { Name = "Organizations and volunteer opportunities" })).ToBeVisibleAsync();
+			new() { Name = "Organizations and volunteer opportunities", Exact = false }))
+			.ToBeVisibleAsync();
 		await Expect(Page.GetByText("verification badge", new() { Exact = false }))
 			.Not.ToBeVisibleAsync();
 

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -226,8 +226,11 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GotoAsync($"{origin}{href}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// #394 breadcrumb navigation present (aria-label is hardcoded "Breadcrumb").
-		await Expect(Page.Locator("nav[aria-label='Breadcrumb']"))
+		// #394 wanted a way back from this page; #1755 moved that into the
+		// PageHeaderBand and dropped the bar, so the Home link now lives in
+		// <main> rather than in a nav[aria-label='Breadcrumb'] strip.
+		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
 			.ToBeVisibleAsync();
 
 		// #373 share button present (matched by stable test id, locale-independent).

--- a/frontend/scripts/check-i18n-keys.js
+++ b/frontend/scripts/check-i18n-keys.js
@@ -96,6 +96,10 @@ const ALLOWED_IDENTICAL_KEYS = new Set(
 		"orgOverview.tabDashboard",
 		"orgOverview.calendarAgenda",
 		"orgOverview.eventChipUnlimited",
+		// "Support" is the established German loanword for this, and both
+		// pages' eyebrow names the same category in either language.
+		"help.eyebrow",
+		"contact.eyebrow",
 	].map((k) => `translation.${k}`),
 );
 

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -121,10 +121,15 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 	return (
 		<div
 			ref={cardRef}
+			// Locked badges recede to a dashed outline instead of a solid gray-50
+			// fill (#1755). With five of six locked, the filled version made the
+			// unearned ones the heaviest thing on the profile page and the single
+			// earned badge the quietest - exactly backwards. Text colours are
+			// unchanged, so the gray-500 label still clears the 4.5:1 floor.
 			className={`group relative flex flex-col items-center rounded-card border p-4 text-center transition-all ${
 				isEarned
 					? "border-brand-200 bg-white shadow-resting hover:shadow-raised"
-					: "border-gray-100 bg-gray-50"
+					: "border-dashed border-gray-200 bg-transparent"
 			}`}
 			tabIndex={isHidden ? undefined : 0}
 			role={isHidden ? undefined : "group"}
@@ -133,7 +138,7 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 		>
 			<div
 				className={`mb-3 flex h-14 w-14 items-center justify-center rounded-full ${
-					isEarned ? "bg-brand-50" : "bg-gray-100"
+					isEarned ? "bg-brand-50" : "bg-gray-50"
 				}`}
 			>
 				{isHidden ? (
@@ -219,10 +224,7 @@ export default function BadgeGrid({
 
 	if (loading) {
 		return (
-			<div
-				role="status"
-				className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6"
-			>
+			<div role="status" className="grid grid-cols-2 gap-3 sm:grid-cols-3">
 				<span className="sr-only">{t("achievements.loading")}</span>
 				{Array.from({ length: 6 }).map((_, i) => (
 					<Skeleton key={i} className="h-28 w-full" />
@@ -234,7 +236,7 @@ export default function BadgeGrid({
 	const earnedByKey = new Map(earned.map((a) => [a.key, a]));
 
 	return (
-		<div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
+		<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
 			{catalog.map((entry) => (
 				<BadgeCard
 					key={entry.key}

--- a/frontend/src/components/DocumentOutline.tsx
+++ b/frontend/src/components/DocumentOutline.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+
+export interface OutlineEntry {
+	/** Must match the id on the corresponding <DocumentSection>. */
+	id: string;
+	label: string;
+}
+
+interface Props {
+	entries: OutlineEntry[];
+	/** Accessible name for the nav landmark, e.g. "On this page". */
+	label: string;
+}
+
+// Sticky table of contents for the long legal texts. The privacy policy runs
+// to nine sections and the terms to seven; as flat prose they were only
+// readable front-to-back, with no way to see the shape of the document or jump
+// to the one clause a visitor actually came for (issue #1755). Legal text is
+// genuinely a numbered clause sequence, so an outline encodes real structure
+// here rather than decorating a list.
+//
+// Scroll position is tracked with IntersectionObserver rather than a scroll
+// handler so the browser does the work off the main thread. rootMargin's -96px
+// top inset keeps the sticky site header from claiming a section before it is
+// actually in view; the -70% bottom inset narrows the "active" strip to the
+// upper third of the viewport, so exactly one entry lights up at a time
+// instead of every section that happens to be on screen.
+export default function DocumentOutline({ entries, label }: Props) {
+	const [activeId, setActiveId] = useState<string | undefined>(entries[0]?.id);
+
+	// Derived string, not the array itself: the caller writes `entries` inline,
+	// so a new array identity arrives on every render and would re-run this
+	// effect (tearing down and rebuilding the observer) each time. Joining the
+	// ids gives a value that only changes when the outline really changes, and
+	// keeps the effect honest for exhaustive-deps - nothing else is referenced.
+	const ids = entries.map((entry) => entry.id).join(",");
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(
+			(observed) => {
+				const visible = observed.filter((entry) => entry.isIntersecting);
+				if (visible.length === 0) return;
+				const topmost = visible.reduce((a, b) =>
+					a.boundingClientRect.top <= b.boundingClientRect.top ? a : b,
+				);
+				setActiveId(topmost.target.id);
+			},
+			{ rootMargin: "-96px 0px -70% 0px" },
+		);
+
+		for (const id of ids.split(",")) {
+			const element = document.getElementById(id);
+			if (element) observer.observe(element);
+		}
+
+		return () => observer.disconnect();
+	}, [ids]);
+
+	return (
+		<nav aria-label={label} className="lg:sticky lg:top-24 lg:self-start">
+			<p className="mb-4 text-xs font-semibold tracking-widest text-gray-600 uppercase">
+				{label}
+			</p>
+			<ol className="space-y-1 border-l border-gray-200">
+				{entries.map((entry, index) => {
+					const isActive = entry.id === activeId;
+					return (
+						<li key={entry.id}>
+							<a
+								href={`#${entry.id}`}
+								aria-current={isActive ? "true" : undefined}
+								className={`-ml-px flex gap-3 border-l-2 py-1.5 pr-2 pl-4 text-sm transition-colors ${
+									isActive
+										? "border-brand-700 font-semibold text-brand-700"
+										: "border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-900"
+								}`}
+							>
+								<span aria-hidden="true" className="font-display tabular-nums">
+									{index + 1}
+								</span>
+								<span className="min-w-0">{entry.label}</span>
+							</a>
+						</li>
+					);
+				})}
+			</ol>
+		</nav>
+	);
+}

--- a/frontend/src/components/DocumentSection.tsx
+++ b/frontend/src/components/DocumentSection.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+interface Props {
+	/** Anchor target - must match the matching <DocumentOutline> entry. */
+	id: string;
+	/** Clause number shown above the title. Omit for unnumbered sections. */
+	number?: number;
+	title: string;
+	children: ReactNode;
+}
+
+// One clause of a legal document (terms, privacy policy). Shared by both so
+// the two texts can't drift into different heading scales and paragraph
+// rhythms, which is what they had done before issue #1755 - h2 at text-xl in
+// the body face, a uniform mb-8 between every section, and no separator, so
+// nine sections read as one undifferentiated column.
+//
+// The clause number is real content, not decoration: German legal texts are
+// cited by number. It therefore lives inside the <h2> rather than beside it,
+// so the heading's accessible name is "1 Scope" and a screen-reader user can
+// cite the same clause a sighted reader can - no aria-hidden flourish and no
+// separate sr-only string to translate.
+//
+// brand-700 (7.5:1 on white), not the accent gold: gold at ~2:1 would fail the
+// text contrast floor, and spending the page's one accent colour once per
+// clause would drown out the single gold note in the header band above.
+//
+// scroll-mt clears the sticky site header so an anchor jump doesn't park the
+// heading underneath it.
+export default function DocumentSection({
+	id,
+	number,
+	title,
+	children,
+}: Props) {
+	return (
+		<section
+			id={id}
+			aria-labelledby={`${id}-title`}
+			className="scroll-mt-28 border-t border-gray-200 pt-10 first:border-t-0 first:pt-0"
+		>
+			<h2 id={`${id}-title`} className="font-display text-gray-900">
+				{number !== undefined && (
+					<span className="block text-2xl font-bold text-brand-700 tabular-nums">
+						{number}
+					</span>
+				)}
+				<span className="mt-1 block text-3xl font-bold sm:text-4xl">
+					{title}
+				</span>
+			</h2>
+			<div className="mt-5 space-y-4 text-base leading-7 text-gray-700">
+				{children}
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -18,8 +18,25 @@ export default function EmptyState({
 	action,
 	compact = false,
 }: Props) {
+	// The full-size variant gets a dashed outline (#1755). Without one it was
+	// centred text floating in the page background, which on a short page - the
+	// admin Reports/Audit Log sections, My Activity with no sign-ups - read as
+	// a rendering failure rather than as "nothing here yet", and left every
+	// other section on those pages boxed while this one wasn't. Dashed rather
+	// than solid so it reads as an outline waiting to be filled, matching how
+	// BadgeGrid draws a not-yet-earned badge.
+	//
+	// `compact` stays bare on purpose: it exists for empty states already
+	// inside a widget card or dropdown panel, where a second frame would
+	// double up on the one around it.
 	return (
-		<div className={compact ? "py-4 text-center" : "py-12 text-center"}>
+		<div
+			className={
+				compact
+					? "py-4 text-center"
+					: "rounded-card border border-dashed border-gray-200 px-4 py-12 text-center"
+			}
+		>
 			<p
 				className={
 					compact

--- a/frontend/src/components/FaqAccordion.tsx
+++ b/frontend/src/components/FaqAccordion.tsx
@@ -1,0 +1,40 @@
+import { ChevronDownIcon } from "./icons";
+
+export interface FaqItem {
+	q: string;
+	a: string;
+}
+
+interface Props {
+	items: FaqItem[];
+	className?: string;
+}
+
+// The landing page's FAQ block and the Help page answer the same kind of
+// question and even link to each other ("More questions? See Help"), but were
+// two unrelated pieces of markup - a boxed accordion on one, a flat run of
+// h3/p pairs on the other, so following that link visibly left the design
+// system (issue #1755). One component now backs both.
+//
+// Native <details>/<summary> rather than a hand-rolled accordion: no open/close
+// state to wire up, and it is keyboard- and screen-reader-operable for free.
+// group-open:rotate-180 reads the element's own [open] attribute through
+// Tailwind's group variant, so the chevron animates without any JS tracking
+// which item is expanded.
+export default function FaqAccordion({ items, className = "" }: Props) {
+	return (
+		<div
+			className={`divide-y divide-gray-200 rounded-card border border-gray-100 bg-white px-6 shadow-resting ${className}`}
+		>
+			{items.map(({ q, a }) => (
+				<details key={q} className="group py-5">
+					<summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-base font-semibold text-gray-900 [&::-webkit-details-marker]:hidden">
+						{q}
+						<ChevronDownIcon className="h-4 w-4 shrink-0 text-gray-400 transition-transform group-open:rotate-180" />
+					</summary>
+					<p className="mt-3 text-sm leading-relaxed text-gray-600">{a}</p>
+				</details>
+			))}
+		</div>
+	);
+}

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -16,6 +16,7 @@ import {
 } from "../icons";
 
 export default function AccountControls({
+	transparent = false,
 	menu,
 	displayName,
 	initials,
@@ -24,6 +25,7 @@ export default function AccountControls({
 	onSignOut,
 	onNotificationNavigate,
 }: {
+	transparent?: boolean;
 	menu: AccountMenuState;
 	displayName: string;
 	initials: string;
@@ -49,6 +51,7 @@ export default function AccountControls({
 		<>
 			<NotificationDropdown
 				menu={menu}
+				transparent={transparent}
 				containerRef={notifRef}
 				onNavigate={onNotificationNavigate}
 			/>
@@ -57,7 +60,7 @@ export default function AccountControls({
 				<button
 					type="button"
 					onClick={() => setDropdownOpen((o) => !o)}
-					className="flex cursor-pointer items-center gap-1.5 rounded-full border border-transparent p-0.5 transition-all hover:ring-2 hover:ring-brand-200"
+					className={`flex cursor-pointer items-center gap-1.5 rounded-full border p-0.5 transition-all ${transparent ? "border-white/30 hover:bg-white/10" : "border-transparent hover:ring-2 hover:ring-brand-200"}`}
 					aria-label={t("nav.userMenu")}
 					aria-expanded={dropdownOpen}
 				>
@@ -74,7 +77,9 @@ export default function AccountControls({
 							{initials}
 						</span>
 					)}
-					<ChevronDownIcon className="h-4 w-4 text-gray-400" />
+					<ChevronDownIcon
+						className={`h-4 w-4 ${transparent ? "text-white/70" : "text-gray-400"}`}
+					/>
 				</button>
 
 				{dropdownOpen && (

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -9,6 +9,7 @@ import type { OrganizationSummaryDto } from "../../client/api-client";
 // buttons) plus the language selector.
 export default function DesktopHeader({
 	isLoggedIn,
+	isTransparent,
 	menu,
 	displayName,
 	initials,
@@ -20,6 +21,7 @@ export default function DesktopHeader({
 	onRegister,
 }: {
 	isLoggedIn: boolean;
+	isTransparent: boolean;
 	menu: AccountMenuState;
 	displayName: string;
 	initials: string;
@@ -39,6 +41,7 @@ export default function DesktopHeader({
 		>
 			{isLoggedIn ? (
 				<AccountControls
+					transparent={isTransparent}
 					menu={menu}
 					displayName={displayName}
 					initials={initials}
@@ -49,16 +52,26 @@ export default function DesktopHeader({
 				/>
 			) : (
 				<div className="flex items-center gap-3">
-					<Button type="button" onClick={onSignIn} variant="primary">
+					<Button
+						type="button"
+						onClick={onSignIn}
+						variant={isTransparent ? "onDark" : "primary"}
+					>
 						{t("nav.signIn")}
 					</Button>
-					<Button type="button" onClick={onRegister} variant="outline">
+					<Button
+						type="button"
+						onClick={onRegister}
+						variant={isTransparent ? "outlineOnDark" : "outline"}
+					>
 						{t("nav.register")}
 					</Button>
 				</div>
 			)}
-			<div className="h-6 w-px bg-gray-200" />
-			<LanguageSelector />
+			<div
+				className={`h-6 w-px ${isTransparent ? "bg-white/30" : "bg-gray-200"}`}
+			/>
+			<LanguageSelector transparent={isTransparent} />
 		</nav>
 	);
 }

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -31,6 +31,7 @@ function getInitials(name: string): string {
 export default function Header({
 	orgSwitcher,
 	breadcrumb,
+	overlaysBand = false,
 }: {
 	// When set, this header is rendered inside the org app shell: it grows an
 	// extra middle slot for the active organization's switcher between the
@@ -44,6 +45,11 @@ export default function Header({
 		items: BreadcrumbItem[];
 		actions?: QuickAction[];
 	};
+	// Set by AppLayout when the page below renders a dark band that runs up
+	// underneath this header (PageHeaderBand). The header then drops its own
+	// background and switches its controls to their on-dark variants until the
+	// reader scrolls past the band. See HeaderOverlayContext.
+	overlaysBand?: boolean;
 } = {}) {
 	const auth = useAuth();
 	const { t } = useTranslation();
@@ -86,6 +92,11 @@ export default function Header({
 		if (!mobileOpen) setOrgMenuOpen(false);
 	}, [mobileOpen]);
 
+	// Only while the band is actually behind the header - once scrolled past
+	// it there's white page underneath, so the header has to take its own
+	// background back or its white-on-dark controls would sit on white.
+	const isTransparent = overlaysBand && !scrolled;
+
 	function handleNotificationNavigate(actionUrl: string | null | undefined) {
 		navigate(actionUrl ?? "/my-engagements");
 	}
@@ -114,9 +125,13 @@ export default function Header({
 		<>
 			<header
 				className={`sticky top-0 z-40 transition-all duration-300 ${
-					scrolled
-						? "border-b border-transparent bg-white/95 shadow-md backdrop-blur-sm"
-						: "border-b border-gray-200 bg-white"
+					isTransparent && mobileOpen
+						? "border-b-0 bg-brand-800"
+						: isTransparent
+							? "border-b-0 bg-transparent"
+							: scrolled
+								? "border-b border-transparent bg-white/95 shadow-md backdrop-blur-sm"
+								: "border-b border-gray-200 bg-white"
 				}`}
 			>
 				<div className="mx-auto max-w-page px-4 sm:px-6 lg:px-8">
@@ -135,7 +150,7 @@ export default function Header({
 							<img
 								src="/logo.svg"
 								alt={t("brand.name")}
-								className="h-8 w-auto max-w-none shrink-0"
+								className={`h-8 w-auto max-w-none shrink-0 transition-all duration-300 ${isTransparent ? "brightness-0 invert" : ""}`}
 							/>
 						</Link>
 
@@ -153,6 +168,7 @@ export default function Header({
 
 						<DesktopHeader
 							isLoggedIn={isLoggedIn}
+							isTransparent={isTransparent}
 							menu={menu}
 							displayName={displayName}
 							initials={initials}
@@ -166,6 +182,7 @@ export default function Header({
 
 						<MobileHeader
 							isLoggedIn={isLoggedIn}
+							isTransparent={isTransparent}
 							mobileOpen={mobileOpen}
 							setMobileOpen={setMobileOpen}
 							menu={menu}
@@ -178,6 +195,7 @@ export default function Header({
 
 				{mobileOpen && (
 					<MobileMenu
+						isTransparent={isTransparent}
 						isLoggedIn={isLoggedIn}
 						avatarUrl={avatarUrl}
 						initials={initials}

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -10,7 +10,11 @@ const LANGUAGES = [
 
 type LangCode = (typeof LANGUAGES)[number]["code"];
 
-export default function LanguageSelector() {
+export default function LanguageSelector({
+	transparent = false,
+}: {
+	transparent?: boolean;
+}) {
 	const { i18n, t } = useTranslation();
 	const [open, setOpen] = useState(false);
 	const ref = useDismissableOverlay<HTMLDivElement>(open, () => setOpen(false));
@@ -28,23 +32,26 @@ export default function LanguageSelector() {
 				aria-haspopup="listbox"
 				aria-expanded={open}
 				aria-label={t("language.switchLanguage")}
-				className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-50"
+				className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm transition-colors ${transparent ? "border-white/30 text-white hover:bg-white/10" : "border-gray-200 text-gray-700 hover:bg-gray-50"}`}
 			>
 				<span
 					aria-hidden="true"
-					className="rounded border border-gray-300 px-1 py-0.5 text-xs leading-none font-bold tracking-wide text-gray-600"
+					className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${transparent ? "border-white/30 text-white" : "border-gray-300 text-gray-600"}`}
 				>
 					{current.short}
 				</span>
 				<span className="font-medium">{t(`language.${current.code}`)}</span>
-				<ChevronDownIcon open={open} className="h-3.5 w-3.5 text-gray-400" />
+				<ChevronDownIcon
+					open={open}
+					className={`h-3.5 w-3.5 ${transparent ? "text-white/70" : "text-gray-400"}`}
+				/>
 			</button>
 
 			{open && (
 				<ul
 					role="listbox"
 					aria-label={t("language.switchLanguage")}
-					className="absolute top-full left-0 z-50 mt-1 w-36 rounded-lg border border-gray-200 bg-white py-1 shadow-modal"
+					className={`absolute top-full left-0 z-50 mt-1 w-36 rounded-lg border py-1 shadow-modal ${transparent ? "border-white/20 bg-brand-800" : "border-gray-200 bg-white"}`}
 				>
 					{LANGUAGES.map((lang) => (
 						<li
@@ -63,24 +70,34 @@ export default function LanguageSelector() {
 									setOpen(false);
 								}}
 								className={`flex w-full items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
-									lang.code === currentCode
-										? "bg-brand-50 font-medium text-brand-700"
-										: "text-gray-700 hover:bg-gray-50"
+									transparent
+										? lang.code === currentCode
+											? "bg-white/15 font-medium text-white"
+											: "text-white/80 hover:bg-white/10 hover:text-white"
+										: lang.code === currentCode
+											? "bg-brand-50 font-medium text-brand-700"
+											: "text-gray-700 hover:bg-gray-50"
 								}`}
 							>
 								<span
 									aria-hidden="true"
 									className={`rounded border px-1 py-0.5 text-xs leading-none font-bold tracking-wide ${
-										lang.code === currentCode
-											? "border-brand-300 text-brand-700"
-											: "border-gray-300 text-gray-600"
+										transparent
+											? lang.code === currentCode
+												? "border-white/50 text-white"
+												: "border-white/30 text-white/80"
+											: lang.code === currentCode
+												? "border-brand-300 text-brand-700"
+												: "border-gray-300 text-gray-600"
 									}`}
 								>
 									{lang.short}
 								</span>
 								<span>{t(`language.${lang.code}`)}</span>
 								{lang.code === currentCode && (
-									<span className="ml-auto h-1.5 w-1.5 rounded-full bg-brand-500" />
+									<span
+										className={`ml-auto h-1.5 w-1.5 rounded-full ${transparent ? "bg-white/60" : "bg-brand-500"}`}
+									/>
 								)}
 							</button>
 						</li>

--- a/frontend/src/components/Header/MobileHeader.tsx
+++ b/frontend/src/components/Header/MobileHeader.tsx
@@ -9,6 +9,7 @@ import { MenuToggleIcon } from "../icons";
 // owns the overlay the burger button toggles.
 export default function MobileHeader({
 	isLoggedIn,
+	isTransparent,
 	mobileOpen,
 	setMobileOpen,
 	menu,
@@ -17,6 +18,7 @@ export default function MobileHeader({
 	onNotificationNavigate,
 }: {
 	isLoggedIn: boolean;
+	isTransparent: boolean;
 	mobileOpen: boolean;
 	setMobileOpen: Dispatch<SetStateAction<boolean>>;
 	menu: AccountMenuState;
@@ -31,6 +33,7 @@ export default function MobileHeader({
 			{isLoggedIn && (
 				<NotificationDropdown
 					menu={menu}
+					transparent={isTransparent}
 					mobile
 					containerRef={notifContainerRef}
 					onNavigate={onNotificationNavigate}
@@ -41,7 +44,7 @@ export default function MobileHeader({
 				ref={menuButtonRef}
 				type="button"
 				onClick={() => setMobileOpen((o) => !o)}
-				className="inline-flex items-center justify-center rounded-lg p-2 text-gray-500 transition-colors hover:bg-brand-50 hover:text-brand-600"
+				className={`inline-flex items-center justify-center rounded-lg p-2 transition-colors ${isTransparent ? "text-white hover:bg-white/10" : "text-gray-500 hover:bg-brand-50 hover:text-brand-600"}`}
 				aria-label={t("nav.openMenu")}
 				aria-expanded={mobileOpen}
 			>

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -13,6 +13,7 @@ import { ChevronDownIcon } from "../icons";
 // Mobile menu overlay (absolute-positioned so it doesn't push content down),
 // toggled open by MobileHeader's burger button.
 export default function MobileMenu({
+	isTransparent,
 	isLoggedIn,
 	avatarUrl,
 	initials,
@@ -27,6 +28,7 @@ export default function MobileMenu({
 	onRegister,
 	onSignOut,
 }: {
+	isTransparent: boolean;
 	isLoggedIn: boolean;
 	avatarUrl: string | null;
 	initials: string;
@@ -46,14 +48,19 @@ export default function MobileMenu({
 	onSignOut: () => void;
 }) {
 	const { t } = useTranslation();
-	// Shared by the profile link, admin link, and org-menu toggle below.
-	// hover:text-brand-700, not the lighter brand-600 - brand-600 on brand-50
-	// measures ~4.0:1, under axe-core's WCAG AA 4.5:1 floor (caught by
-	// AccessibilityTests.cs's MobileMenu_Open_AsOlaf_HasNoSeriousA11yViolations,
-	// which leaves the org-menu toggle in a real :hover state via
-	// Playwright's ClickAsync before scanning), while brand-700 clears it.
-	const menuItemVariant =
-		"text-gray-700 hover:bg-brand-50 hover:text-brand-700";
+	// Shared by the profile link, admin link, and org-menu toggle below - the
+	// only exact repeat of this variant in the file (other isTransparent
+	// ternaries here use their own one-off colors).
+	//
+	// On the opaque side: hover:text-brand-700, not the lighter brand-600 -
+	// brand-600 on brand-50 measures ~4.0:1, under axe-core's WCAG AA 4.5:1
+	// floor (caught by AccessibilityTests.cs's
+	// MobileMenu_Open_AsOlaf_HasNoSeriousA11yViolations, which leaves the
+	// org-menu toggle in a real :hover state via Playwright's ClickAsync
+	// before scanning), while brand-700 clears it.
+	const menuItemVariant = isTransparent
+		? "text-white/90 hover:bg-white/10 hover:text-white"
+		: "text-gray-700 hover:bg-brand-50 hover:text-brand-700";
 	// Only ever mounted while open (see Header.tsx), so dismissal listeners
 	// attach for this component's entire lifetime.
 	const rootRef = useDismissableOverlay<HTMLDivElement>(true, onClose, [
@@ -134,11 +141,23 @@ export default function MobileMenu({
 				// landscape-phone viewport) - overscroll-contain keeps a drag past
 				// this panel's own scroll bounds from rubber-banding the (locked)
 				// body underneath.
-				className="absolute top-full right-0 left-0 z-30 max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain border-t border-gray-100 bg-white shadow-modal md:hidden"
+				className={`absolute top-full right-0 left-0 z-30 max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
 			>
+				{/* Blur-blob lighting, matching the band the transparent header
+				sits over - a flat brand-900 panel dropping out of a lit band
+				read as a different surface entirely. */}
+				{isTransparent && (
+					<div
+						className="pointer-events-none absolute inset-0 overflow-hidden"
+						aria-hidden="true"
+					>
+						<div className="absolute -top-10 -left-20 h-64 w-64 rounded-full bg-brand-700 opacity-60 blur-3xl" />
+						<div className="absolute -top-8 -right-16 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl" />
+					</div>
+				)}
 				<div className="relative space-y-2 px-4 py-4">
 					<div className="pb-2">
-						<LanguageSelector />
+						<LanguageSelector transparent={isTransparent} />
 					</div>
 					{isLoggedIn ? (
 						<div className="space-y-1">
@@ -157,7 +176,9 @@ export default function MobileMenu({
 										{initials}
 									</div>
 								)}
-								<span className="text-sm font-medium text-gray-700">
+								<span
+									className={`text-sm font-medium ${isTransparent ? "text-white/90" : "text-gray-700"}`}
+								>
 									{displayName}
 								</span>
 							</div>
@@ -206,13 +227,15 @@ export default function MobileMenu({
 										/>
 									</button>
 									{orgMenuOpen && (
-										<div className="ml-3 space-y-1 border-l border-gray-200 pl-3">
+										<div
+											className={`ml-3 space-y-1 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
+										>
 											{ORG_TABS.map((tab) => (
 												<Link
 													key={tab.key}
 													to={orgTabPath(activeOrg.id, tab.key)}
 													onClick={onClose}
-													className="block rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-brand-50 hover:text-brand-700"
+													className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-700"}`}
 												>
 													{t(tab.labelKey)}
 												</Link>
@@ -224,7 +247,7 @@ export default function MobileMenu({
 							<button
 								type="button"
 								onClick={onSignOut}
-								className="block w-full rounded-lg px-3 py-2 text-left text-sm font-medium text-red-600 transition-colors hover:bg-red-50 hover:text-red-700"
+								className={`block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${isTransparent ? "text-red-400 hover:bg-white/10 hover:text-red-300" : "text-red-600 hover:bg-red-50 hover:text-red-700"}`}
 							>
 								{t("nav.signOut")}
 							</button>
@@ -234,7 +257,7 @@ export default function MobileMenu({
 							<Button
 								type="button"
 								onClick={onSignIn}
-								variant="primary"
+								variant={isTransparent ? "onDark" : "primary"}
 								fullWidth
 							>
 								{t("nav.signIn")}
@@ -242,7 +265,7 @@ export default function MobileMenu({
 							<Button
 								type="button"
 								onClick={onRegister}
-								variant="outline"
+								variant={isTransparent ? "outlineOnDark" : "outline"}
 								fullWidth
 							>
 								{t("nav.register")}

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -19,12 +19,14 @@ import { BellIcon } from "../icons";
 // additionally collapses the burger menu).
 export default function NotificationDropdown({
 	menu,
+	transparent = false,
 	mobile = false,
 	containerRef,
 	onNavigate,
 	onClose,
 }: {
 	menu: AccountMenuState;
+	transparent?: boolean;
 	mobile?: boolean;
 	containerRef: RefObject<HTMLDivElement | null>;
 	onNavigate: (actionUrl: string | null | undefined) => void;
@@ -92,7 +94,7 @@ export default function NotificationDropdown({
 				type="button"
 				data-testid={mobile ? "notification-bell-mobile" : "notification-bell"}
 				onClick={() => setNotifOpen((o) => !o)}
-				className="relative cursor-pointer rounded-lg border border-transparent p-2 text-gray-500 transition-colors hover:bg-brand-50 hover:text-brand-600"
+				className={`relative cursor-pointer rounded-lg border p-2 transition-colors ${transparent ? "border-white/30 text-white/90 hover:bg-white/10 hover:text-white" : "border-transparent text-gray-500 hover:bg-brand-50 hover:text-brand-600"}`}
 				aria-label={bellLabel}
 				aria-controls={panelId}
 				aria-expanded={notifOpen}

--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { EnvelopeIcon, GlobeIcon, MapPinIcon, PhoneIcon } from "./icons";
-import { cardSubtleClass } from "../lib/surfaceClasses";
+import { cardClass } from "../lib/surfaceClasses";
+import { pageTitleClass } from "../lib/headingClasses";
 
 interface OrganizationAddress {
 	street: string;
@@ -28,6 +29,29 @@ interface OrganizationProfileViewProps {
 	 * header already shows the org name.
 	 */
 	nameAs?: "h1" | "p";
+	/**
+	 * "sidebar" (default) floats the contact details beside the main content -
+	 * right for the public profile, whose children are a long opportunity list
+	 * that fills the wider column. "stacked" keeps one column: the org app's
+	 * Settings tab has only a short description and the danger-zone panel as
+	 * children, and splitting those into a 1fr/18rem grid squeezed the panel to
+	 * half width beside a mostly empty sidebar.
+	 */
+	layout?: "sidebar" | "stacked";
+	/**
+	 * The public profile page states the org name in a PageHeaderBand instead,
+	 * so it suppresses this component's own logo/name row rather than showing
+	 * the same identity twice. The org app's Settings tab keeps it - there the
+	 * band does not exist.
+	 */
+	showHeader?: boolean;
+	/**
+	 * Centres the content column. Only the public profile does this, because a
+	 * PageHeaderBand sits above it and centres its own title at the same
+	 * max-w-5xl - left-flush content under a centred band puts the two ~175px
+	 * apart. The org app Settings tab has no band and stays flush left per #766.
+	 */
+	centered?: boolean;
 }
 
 export default function OrganizationProfileView({
@@ -43,96 +67,135 @@ export default function OrganizationProfileView({
 	beforeContent,
 	children,
 	nameAs = "p",
+	layout = "sidebar",
+	showHeader = true,
+	centered = false,
 }: OrganizationProfileViewProps) {
 	const NameTag = nameAs;
 	const hasContactInfo = !!(contactEmail || contactPhone || website || address);
+	const useSidebar = layout === "sidebar" && hasContactInfo;
+
+	// White card, not the gray-50 cardSubtleClass it used before: a grey block
+	// was the single largest surface on these pages and set the flat tone the
+	// whole redesign is undoing (#1755). Built once and placed by whichever
+	// branch below runs, so the two layouts can't drift apart.
+	const contactCard = (
+		<div className={`space-y-2.5 text-sm text-gray-700 ${cardClass}`}>
+			{contactEmail && (
+				<div className="flex items-center gap-3">
+					<EnvelopeIcon className="h-4 w-4 shrink-0 text-brand-700" />
+					<a
+						href={`mailto:${contactEmail}`}
+						className="min-w-0 break-words text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+					>
+						{contactEmail}
+					</a>
+				</div>
+			)}
+			{contactPhone && (
+				<div className="flex items-center gap-3">
+					<PhoneIcon className="h-4 w-4 shrink-0 text-brand-700" />
+					<a
+						href={`tel:${contactPhone}`}
+						className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+					>
+						{contactPhone}
+					</a>
+				</div>
+			)}
+			{website && (
+				<div className="flex items-center gap-3">
+					<GlobeIcon className="h-4 w-4 shrink-0 text-brand-700" />
+					<a
+						href={website}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="min-w-0 break-words text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+					>
+						{website}
+					</a>
+				</div>
+			)}
+			{address && (
+				<div className="flex items-center gap-3">
+					<MapPinIcon className="h-4 w-4 shrink-0 text-brand-700" />
+					<span>
+						{address.street} {address.houseNumber}, {address.zipCode}{" "}
+						{address.city}
+					</span>
+				</div>
+			)}
+		</div>
+	);
 
 	return (
 		<>
-			<div className="mb-6 flex items-start justify-between gap-4">
-				<div className="flex items-center gap-4">
-					{logoUrl ? (
-						<img
-							src={logoUrl}
-							alt=""
-							width={64}
-							height={64}
-							className="h-16 w-16 rounded-full object-cover"
-						/>
-					) : (
-						<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-							{name.charAt(0).toUpperCase()}
-						</span>
-					)}
-					<div>
-						<NameTag className="text-xl font-bold text-gray-900">
-							{name}
-						</NameTag>
-						{subtitle}
+			{showHeader && (
+				<div className="mb-6 flex items-start justify-between gap-4">
+					<div className="flex items-center gap-4">
+						{logoUrl ? (
+							<img
+								src={logoUrl}
+								alt=""
+								width={64}
+								height={64}
+								className="h-16 w-16 rounded-full object-cover"
+							/>
+						) : (
+							<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+								{name.charAt(0).toUpperCase()}
+							</span>
+						)}
+						<div>
+							<NameTag
+								className={
+									nameAs === "h1"
+										? `text-gray-900 ${pageTitleClass}`
+										: "font-display text-2xl font-bold text-gray-900"
+								}
+							>
+								{name}
+							</NameTag>
+							{subtitle}
+						</div>
 					</div>
+					{actions}
 				</div>
-				{actions}
-			</div>
+			)}
 
-			<div data-content-wrapper className="max-w-2xl">
+			{/* max-w-5xl, was max-w-2xl: a 672px column inside <main>'s 90rem left
+			~700px of empty page beside it on desktop, which is the "dead column"
+			#766 was originally about - #766 fixed the alignment (flush left, not
+			centred) but left the width. Still flush left, per that issue; the
+			contact details now sit in a sidebar beside the prose instead of
+			below it, so the extra width carries content rather than air. */}
+			<div
+				data-content-wrapper
+				className={centered ? "mx-auto max-w-5xl" : "max-w-5xl"}
+			>
 				{beforeContent}
 
-				{description && (
-					<p className="mb-6 leading-relaxed text-gray-600">{description}</p>
-				)}
-
-				{hasContactInfo && (
-					<div
-						className={`mb-6 space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
-					>
-						{contactEmail && (
-							<div className="flex items-center gap-3">
-								<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-								<a
-									href={`mailto:${contactEmail}`}
-									className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-								>
-									{contactEmail}
-								</a>
-							</div>
+				<div
+					className={
+						useSidebar
+							? "grid gap-8 lg:grid-cols-[minmax(0,1fr)_18rem] lg:gap-12"
+							: ""
+					}
+				>
+					<div className="min-w-0">
+						{description && (
+							<p className="mb-6 max-w-2xl leading-relaxed text-gray-700">
+								{description}
+							</p>
 						)}
-						{contactPhone && (
-							<div className="flex items-center gap-3">
-								<PhoneIcon className="h-4 w-4 shrink-0 text-gray-400" />
-								<a
-									href={`tel:${contactPhone}`}
-									className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-								>
-									{contactPhone}
-								</a>
-							</div>
+						{!useSidebar && hasContactInfo && (
+							<div className="mb-6 max-w-md">{contactCard}</div>
 						)}
-						{website && (
-							<div className="flex items-center gap-3">
-								<GlobeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-								<a
-									href={website}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-								>
-									{website}
-								</a>
-							</div>
-						)}
-						{address && (
-							<div className="flex items-center gap-3">
-								<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
-								<span>
-									{address.street} {address.houseNumber}, {address.zipCode}{" "}
-									{address.city}
-								</span>
-							</div>
-						)}
+						{children}
 					</div>
-				)}
 
-				{children}
+					{useSidebar && <aside className="self-start">{contactCard}</aside>}
+				</div>
 			</div>
 		</>
 	);

--- a/frontend/src/components/PageHeaderBand.tsx
+++ b/frontend/src/components/PageHeaderBand.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import { WAVE_PATH } from "../lib/wavePath";
+import { useOverlaysHeader } from "../contexts/HeaderOverlayContext";
+import { useQuickActionsList } from "../contexts/QuickActionsContext";
+import Button from "./Button";
+import { ChevronLeftIcon } from "./icons";
+
+interface Props {
+	/**
+	 * Small uppercase kicker above the title - names the page's category.
+	 * ReactNode, not string: the opportunity page puts a link to the owning
+	 * organization here, which is the one piece of chrome that used to live in
+	 * the breadcrumb and has nowhere else to go once the bar is gone.
+	 */
+	eyebrow: ReactNode;
+	title: string;
+	/** Optional one-line standfirst under the title. */
+	lead?: string;
+	/** Optional trailing row (a "last updated" chip, a CTA). */
+	children?: ReactNode;
+}
+
+// Shared title band for the standalone public pages (help, contact, imprint,
+// legal texts). Those pages previously opened with a text-2xl <h1> on plain
+// white, so a visitor arriving from the landing page's footer landed on
+// something that shared none of its visual language - no display face, no
+// brand surface, no wave motif (see issue #1755).
+//
+// The band deliberately reuses what the landing page already established
+// rather than inventing a second system for subpages: brand-800 stage and
+// blur-blob lighting from the hero, WAVE_PATH bottom cap from the org-CTA and
+// founder bands, uppercase brand-200 eyebrow from every section heading there.
+//
+// Layout escapes, because AppLayout's <main> is a padded, max-w-page column
+// and this has to sit edge-to-edge and run *behind* the header:
+//
+//   - `left-1/2 w-screen -translate-x-1/2` breaks out horizontally, the same
+//     pattern HomePage's bands use (safe because global.css sets
+//     html { overflow-x: clip }).
+//   - The negative top margin cancels both <main>'s own top padding and the
+//     flow space the sticky header occupies, sliding the band up underneath
+//     it. The header keeps its z-40, so it paints over the band rather than
+//     being covered by it, and useOverlaysHeader below tells it to go
+//     transparent while that's true. --header-height is added back as top
+//     padding so the eyebrow doesn't start underneath the header bar.
+//
+// These pages carry no BreadcrumbBar (the pages using this band stopped
+// calling usePageToolbar in #1755): a separate grey bar restating the page
+// title directly above a band that states it in 72px display type was pure
+// duplication, and it drove a hard white line straight through the middle of
+// the treatment. The way back home is the link inside the band instead.
+export default function PageHeaderBand({
+	eyebrow,
+	title,
+	lead,
+	children,
+}: Props) {
+	const { t } = useTranslation();
+	useOverlaysHeader();
+	// Same QuickActionsContext the BreadcrumbBar reads. A page using this band
+	// renders no action bar (see the note above), so without this its
+	// usePageToolbar-published actions - the profile page's Edit/Save/Cancel -
+	// would have nowhere to go. Same keys and data-testids as BreadcrumbBar's
+	// buttons, on-dark variants because this sits on brand-800.
+	const actions = useQuickActionsList();
+
+	return (
+		<div className="relative left-1/2 -mt-[calc(var(--header-height)+var(--main-top-padding))] mb-12 w-screen -translate-x-1/2 sm:mb-16">
+			<div className="relative isolate overflow-hidden bg-brand-800">
+				<div
+					aria-hidden="true"
+					className="pointer-events-none absolute -top-32 -left-24 h-80 w-80 rounded-full bg-brand-700 opacity-60 blur-3xl"
+				/>
+				<div
+					aria-hidden="true"
+					className="pointer-events-none absolute -right-20 -bottom-32 h-72 w-72 rounded-full bg-accent-400 opacity-10 blur-3xl"
+				/>
+
+				{/* Two nested constraints, mirroring exactly what the band sits
+				inside: AppLayout's <main> (max-w-page + its responsive px-*),
+				then the max-w-5xl column each consuming page centres within
+				that. Reproducing both is what puts the title on the same left
+				edge as the text it heads - collapsing them into a single
+				max-w-5xl + px-8 lands 32px off, and dropping to max-w-page
+				alone lands ~175px off. The band's *background* still runs edge
+				to edge; only its text is brought into the document measure. */}
+				<div className="relative mx-auto max-w-page px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto max-w-5xl pt-[calc(var(--header-height)+2rem)] pb-14 sm:pt-[calc(var(--header-height)+3rem)] sm:pb-20">
+						{/* Replaces the BreadcrumbBar these pages used to render - one
+						way back, in the band, instead of a grey strip above it
+						repeating the title. */}
+						<Link
+							to="/"
+							className="animate-fade-up -ml-1 inline-flex items-center gap-1 rounded-lg px-1 py-1 text-sm font-medium text-brand-100 transition-colors hover:text-white"
+						>
+							<ChevronLeftIcon className="h-4 w-4" />
+							{t("breadcrumb.home")}
+						</Link>
+						{actions.length > 0 && (
+							<div className="animate-fade-up-d1 float-right ml-4 flex shrink-0 items-center gap-2">
+								{actions.map((action) => (
+									<Button
+										key={action.key}
+										type="button"
+										onClick={action.onClick}
+										disabled={action.disabled}
+										title={action.title}
+										aria-label={action.label}
+										data-testid={`quick-action-${action.key}`}
+										variant={
+											action.variant === "primary" ? "onDark" : "outlineOnDark"
+										}
+										className="shrink-0"
+									>
+										{action.icon}
+										<span className="hidden sm:inline">{action.label}</span>
+									</Button>
+								))}
+							</div>
+						)}
+						<p className="animate-fade-up mt-6 text-xs font-semibold tracking-widest text-brand-200 uppercase">
+							{eyebrow}
+						</p>
+						<h1 className="animate-fade-up-d1 mt-3 max-w-4xl font-display text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl">
+							{title}
+						</h1>
+						{lead && (
+							<p className="animate-fade-up-d2 mt-5 max-w-2xl text-base leading-relaxed text-brand-100 sm:text-lg">
+								{lead}
+							</p>
+						)}
+						{children && (
+							<div className="animate-fade-up-d3 mt-6">{children}</div>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{/* Bottom cap - rotated so the fill sits above the wavy edge, fading
+			this band's own brand-800 into the white page below (same direction
+			the founder band's closing cap uses on HomePage). */}
+			<svg
+				aria-hidden="true"
+				viewBox="0 0 1440 60"
+				preserveAspectRatio="none"
+				className="block h-8 w-full rotate-180 text-brand-800 sm:h-12"
+			>
+				<path d={WAVE_PATH} fill="currentColor" />
+			</svg>
+		</div>
+	);
+}

--- a/frontend/src/components/PageSectionHeading.tsx
+++ b/frontend/src/components/PageSectionHeading.tsx
@@ -2,13 +2,41 @@ import type { ReactNode } from "react";
 
 interface Props {
 	children: ReactNode;
+	/**
+	 * Optional one-line explanation of what the section holds. Passed in rather
+	 * than rendered by the caller so the heading and its own subtitle stay a
+	 * single spacing unit - see the note below.
+	 */
+	description?: ReactNode;
 }
 
 // Shared page-level section heading (dashboard/admin pages carved into
 // several named sections) - was hand-rolled slightly differently per page
 // - see issue #1110.
-const BASE_CLASSES = "mb-4 text-lg font-semibold text-gray-900";
+//
+// #1755 moved it onto --font-display at a larger step. At text-lg in the body
+// face it sat only two steps above the body copy underneath it and in the very
+// same typeface, so a page carved into several named sections didn't visibly
+// read as carved into anything - the "no real sections" half of that issue.
+// Barlow Condensed is narrow enough that text-2xl here occupies roughly the
+// width text-lg did before.
+const BASE_CLASSES = "font-display text-2xl font-bold text-gray-900";
 
-export default function PageSectionHeading({ children }: Props) {
-	return <h2 className={BASE_CLASSES}>{children}</h2>;
+export default function PageSectionHeading({ children, description }: Props) {
+	// With a description, the gap has to live on the pair, not the heading:
+	// callers that rendered their own <p> after this component got the
+	// heading's mb-4 *plus* the paragraph's own top margin between the two,
+	// which put a section's subtitle further from its heading than from the
+	// content below it - so it read as a caption for the list rather than as
+	// part of the heading (visible on OrgOpportunitiesPage's "Published").
+	if (description) {
+		return (
+			<div className="mb-4">
+				<h2 className={BASE_CLASSES}>{children}</h2>
+				<p className="mt-1 text-sm text-gray-500">{description}</p>
+			</div>
+		);
+	}
+
+	return <h2 className={`mb-4 ${BASE_CLASSES}`}>{children}</h2>;
 }

--- a/frontend/src/components/ProfileSubNav.tsx
+++ b/frontend/src/components/ProfileSubNav.tsx
@@ -4,17 +4,36 @@ import { useTranslation } from "react-i18next";
 const TABS = [
 	{ key: "profile", href: "/profile", labelKey: "profile.subNavProfile" },
 	{
+		key: "activity",
+		href: "/my-engagements",
+		labelKey: "profile.subNavActivity",
+	},
+	{
 		key: "settings",
 		href: "/profile/settings",
 		labelKey: "profile.subNavSettings",
 	},
 ] as const;
 
-// Local sub-navigation shared by ProfileOverviewPage and ProfileSettingsPage
-// (#1684) - the two account-scoped pages that were previously sections on
-// one overloaded /profile. Unlike ORG_TABS/orgTabPath (the org app shell's
-// equivalent), there's no nested-path helper to share: both destinations
-// are already flat top-level routes.
+// Local sub-navigation shared by ProfileOverviewPage, MyEngagementsPage and
+// ProfileSettingsPage (#1684) - the account-scoped pages that were previously
+// sections on one overloaded /profile. Unlike ORG_TABS/orgTabPath (the org app
+// shell's equivalent), there's no nested-path helper to share: all three
+// destinations are already flat top-level routes.
+//
+// #1684 split all three out but only wired two of them into this nav, leaving
+// /my-engagements reachable solely from the account menu and the notification
+// bell - so the three pages read as unrelated one-offs rather than one account
+// area, and each looked emptier than it is. Adding it here is the whole
+// consolidation: the routes stay separate (that split fixed a 1900-line page
+// and is what notification action links point at), only the chrome is shared.
+// Vertical from lg up (#1755): a horizontal tab strip under the title left the
+// page a stack of full-width bands with nothing beside them, and the strip's
+// own width changed per page so the underline jumped on every tab switch. As a
+// left rail it fills that space with navigation and stays put - the same
+// left-rail-plus-content shape DocumentOutline gives the legal pages, so the
+// account area and the document pages read as one system. Below lg it falls
+// back to the horizontal strip, where a rail would eat the whole viewport.
 export default function ProfileSubNav({
 	active,
 }: {
@@ -25,17 +44,21 @@ export default function ProfileSubNav({
 	return (
 		<nav
 			aria-label={t("profile.subNavLabel")}
-			className="mb-6 flex gap-1 border-b border-gray-200"
+			// lg:self-start is load-bearing: as a grid item the nav otherwise
+			// stretches to the row's full height, dragging its border-l rule
+			// hundreds of pixels past the last tab. Sticky for the same reason
+			// DocumentOutline is - the rail stays reachable down a long page.
+			className="mb-6 flex gap-1 border-b border-gray-200 lg:sticky lg:top-24 lg:mb-0 lg:flex-col lg:gap-0.5 lg:self-start lg:border-b-0 lg:border-l lg:border-gray-200"
 		>
 			{TABS.map((tab) => (
 				<Link
 					key={tab.key}
 					to={tab.href}
 					aria-current={active === tab.key ? "page" : undefined}
-					className={`border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+					className={`border-b-2 px-3 py-2 text-sm font-medium transition-colors lg:-ml-px lg:border-b-0 lg:border-l-2 lg:py-1.5 lg:pl-4 ${
 						active === tab.key
-							? "border-brand-600 text-brand-700"
-							: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+							? "border-brand-600 text-brand-700 lg:border-brand-700 lg:font-semibold"
+							: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 lg:hover:border-gray-300 lg:hover:text-gray-900"
 					}`}
 				>
 					{t(tab.labelKey)}

--- a/frontend/src/components/PublicOpportunityCard.tsx
+++ b/frontend/src/components/PublicOpportunityCard.tsx
@@ -1,0 +1,83 @@
+import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import type { PublicOpportunitySummaryDto } from "../client/api-client";
+import { formatOccurrence, formatParticipationType } from "../lib/format";
+import Chip from "./Chip";
+import { CalendarIcon, GlobeIcon, MapPinIcon } from "./icons";
+
+// The one card for a PublicOpportunitySummaryDto, shared by the organization
+// profile's "current needs" list and the opportunity detail page's "more from
+// this organization" teaser (#1755). Both hand-rolled their own version
+// before: a title, a clamped description and a row of three neutral chips, so
+// the two most important facts - when it runs and where - were the same weight
+// as everything else and the card had no anchor for the eye.
+//
+// Deliberately NOT VolunteerOpportunitiesList/OpportunityListItem, which is the
+// richer card the landing page grid uses: that one needs category, participant
+// counts and a banner image to render its glyph tile and spots-left line, and
+// none of those exist on this DTO. Matching its markup here would mean faking
+// data the public endpoint does not return.
+//
+// Instead this reuses the label/value language of the detail page's at-a-glance
+// panel: the date leads in brand-700 with its icon, location follows muted, and
+// the participation type is the single chip - so a card and the page it links
+// to describe an opportunity the same way.
+export default function PublicOpportunityCard({
+	opportunity,
+}: {
+	opportunity: PublicOpportunitySummaryDto;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<li className="group relative flex h-full flex-col rounded-card border border-gray-100 bg-white p-5 shadow-resting transition-shadow hover:shadow-raised">
+			<Link
+				to={`/volunteer-opportunities/${opportunity.id}`}
+				className="absolute inset-0 rounded-card"
+				aria-label={opportunity.title}
+			/>
+
+			<p className="flex items-center gap-2 text-sm font-semibold text-brand-700">
+				<CalendarIcon className="h-4 w-4 shrink-0" />
+				{formatOccurrence(opportunity.occurrence, t)}
+			</p>
+
+			<h3 className="mt-2 font-display text-xl font-bold text-gray-900 group-hover:text-brand-800">
+				{opportunity.title}
+			</h3>
+
+			{opportunity.description && (
+				<p className="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-600">
+					{opportunity.description}
+				</p>
+			)}
+
+			<div className="mt-3 flex items-start gap-2 text-sm text-gray-600">
+				{opportunity.isRemote ? (
+					<>
+						<GlobeIcon className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+						<span>{t("opportunities.remote")}</span>
+					</>
+				) : (
+					opportunity.street && (
+						<>
+							<MapPinIcon className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+							<span>
+								{opportunity.street} {opportunity.houseNumber},{" "}
+								{opportunity.zipCode} {opportunity.city}
+							</span>
+						</>
+					)
+				)}
+			</div>
+
+			{/* mt-auto pins the chip to the bottom so cards in a row line their
+			chips up regardless of how long the description above ran. */}
+			<div className="mt-auto pt-4">
+				<Chip tone="brand" size="sm">
+					{formatParticipationType(opportunity.participationType, t)}
+				</Chip>
+			</div>
+		</li>
+	);
+}

--- a/frontend/src/components/SectionHeading.tsx
+++ b/frontend/src/components/SectionHeading.tsx
@@ -7,8 +7,16 @@ interface Props {
 // Shared small-caps subsection heading - the same "Badges" title rendered
 // with different size/case/color depending on which page it appeared on
 // (own profile overview vs. public profile) - see issue #1110.
+//
+// #1755 moved it onto the landing page's own eyebrow recipe (brand-700,
+// tracking-widest) instead of text-gray-600/tracking-wider. Every section
+// label on the marketing pages already looked like this; the app's own
+// section labels were the odd ones out, and a low-contrast grey kicker is a
+// large part of why those pages read as flat. brand-700 clears 7.5:1 on
+// white, so this is a contrast improvement over the grey it replaces rather
+// than a trade.
 const BASE_CLASSES =
-	"mb-3 text-xs font-semibold tracking-wider text-gray-600 uppercase";
+	"mb-3 text-xs font-semibold tracking-widest text-brand-700 uppercase";
 
 export default function SectionHeading({ children }: Props) {
 	return <h2 className={BASE_CLASSES}>{children}</h2>;

--- a/frontend/src/contexts/HeaderOverlayContext.tsx
+++ b/frontend/src/contexts/HeaderOverlayContext.tsx
@@ -1,0 +1,71 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from "react";
+import type { ReactNode } from "react";
+
+interface HeaderOverlayValue {
+	/** True while a page is rendering a dark band underneath the header. */
+	isOverlaid: boolean;
+	setOverlaid: (overlaid: boolean) => void;
+}
+
+const HeaderOverlayContext = createContext<HeaderOverlayValue>({
+	isOverlaid: false,
+	setOverlaid: () => undefined,
+});
+
+// Lets a page tell the header "I'm painting a dark band behind you, go
+// transparent". Before #1755 the header hardcoded `location.pathname === "/"`
+// to decide this, which meant any new page wanting the treatment had to edit
+// the header - and the check silently stopped matching when the homepage hero
+// became a boxed card that no longer runs under the header.
+//
+// The declaration lives with the thing that creates the condition
+// (PageHeaderBand) rather than with the component reacting to it, so the two
+// can't drift apart.
+export function HeaderOverlayProvider({ children }: { children: ReactNode }) {
+	const [overlayCount, setOverlayCount] = useState(0);
+
+	// Counter, not a boolean: during a route change React mounts the incoming
+	// page before unmounting the outgoing one, so a plain flag would have the
+	// new band's "true" overwritten by the old band's cleanup "false", leaving
+	// the header opaque on top of a dark band.
+	const setOverlaid = useCallback((overlaid: boolean) => {
+		setOverlayCount((count) => count + (overlaid ? 1 : -1));
+	}, []);
+
+	const value = useMemo(
+		() => ({ isOverlaid: overlayCount > 0, setOverlaid }),
+		[overlayCount, setOverlaid],
+	);
+
+	return (
+		<HeaderOverlayContext.Provider value={value}>
+			{children}
+		</HeaderOverlayContext.Provider>
+	);
+}
+
+/** Read by AppLayout to decide how to render the header. */
+export function useHeaderOverlay(): boolean {
+	return useContext(HeaderOverlayContext).isOverlaid;
+}
+
+/**
+ * Declares that the calling component paints a dark band under the header for
+ * as long as it is mounted. useLayoutEffect, not useEffect - on a plain effect
+ * the header paints one opaque frame over the band before flipping, which
+ * reads as a flash of a white bar on every navigation into such a page.
+ */
+export function useOverlaysHeader(): void {
+	const { setOverlaid } = useContext(HeaderOverlayContext);
+	useLayoutEffect(() => {
+		setOverlaid(true);
+		return () => setOverlaid(false);
+	}, [setOverlaid]);
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -12,6 +12,10 @@ import {
 	QuickActionsProvider,
 	useQuickActionsList,
 } from "../contexts/QuickActionsContext";
+import {
+	HeaderOverlayProvider,
+	useHeaderOverlay,
+} from "../contexts/HeaderOverlayContext";
 
 function AppLayoutInner() {
 	useAchievementNotifier();
@@ -19,6 +23,7 @@ function AppLayoutInner() {
 	const location = useLocation();
 	const toolbarConfig = useToolbarConfig();
 	const quickActions = useQuickActionsList();
+	const headerOverlaysBand = useHeaderOverlay();
 	const breadcrumb =
 		toolbarConfig && toolbarConfig.breadcrumbs.length > 0
 			? {
@@ -30,7 +35,7 @@ function AppLayoutInner() {
 	return (
 		<div className="flex min-h-screen flex-col">
 			<SkipLink />
-			<Header breadcrumb={breadcrumb} />
+			<Header breadcrumb={breadcrumb} overlaysBand={headerOverlaysBand} />
 			<main
 				id="main-content"
 				tabIndex={-1}
@@ -62,7 +67,9 @@ export default function AppLayout() {
 	return (
 		<ToolbarProvider>
 			<QuickActionsProvider>
-				<AppLayoutInner />
+				<HeaderOverlayProvider>
+					<AppLayoutInner />
+				</HeaderOverlayProvider>
 			</QuickActionsProvider>
 		</ToolbarProvider>
 	);

--- a/frontend/src/lib/headingClasses.ts
+++ b/frontend/src/lib/headingClasses.ts
@@ -1,9 +1,20 @@
 // Shared <h1> size/weight so every page picks the same scale instead of its
 // own (see issue #981: text-xl/2xl/3xl/4xl all serving as "the page title").
+//
+// Both roles moved onto --font-display (Barlow Condensed) in #1755. The
+// landing page had been the only surface using the display face at all, so
+// every other page announced itself in the same Source Sans 3 at text-2xl as
+// its own body copy - the single biggest reason the subpages read as a
+// different, flatter product than the page visitors arrive from. Barlow
+// Condensed is narrow enough that these larger steps occupy roughly the width
+// the old text-2xl/3xl did in the body face, so the bump buys presence without
+// forcing titles onto a second line.
 
 /** Standard content-page heading (list/detail/settings pages). */
-export const pageTitleClass = "text-2xl font-bold sm:text-3xl";
+export const pageTitleClass =
+	"font-display text-4xl font-bold tracking-tight sm:text-5xl";
 
 /** Centered single-message state heading (errors, 404, access-denied) - a
 distinct role from a content page's title, kept visually larger. */
-export const statusTitleClass = "text-3xl font-bold";
+export const statusTitleClass =
+	"font-display text-5xl font-bold tracking-tight sm:text-6xl";

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -13,7 +13,8 @@
       "retrying": "Wird erneut versucht…",
       "loading": "Wird geladen…",
       "pageLoading": "Seite wird geladen…",
-      "skipToContent": "Zum Inhalt springen"
+      "skipToContent": "Zum Inhalt springen",
+      "onThisPage": "Auf dieser Seite"
     },
     "nav": {
       "primaryLabel": "Hauptnavigation",
@@ -199,7 +200,10 @@
       "participantsJoined_one": "{{count}} Person hat sich bereits angemeldet",
       "participantsJoined_other": "{{count}} Personen haben sich bereits angemeldet",
       "maxParticipants_one": "(max. {{count}} Person)",
-      "maxParticipants_other": "(max. {{count}} Personen)"
+      "maxParticipants_other": "(max. {{count}} Personen)",
+      "factWhen": "Wann",
+      "factFormat": "Ablauf",
+      "factWhere": "Wo"
     },
     "createOpportunity": {
       "title": "Einsatz erstellen",
@@ -744,7 +748,8 @@
       "section8Body2": "Darüber hinaus speichern wir einige Werte im lokalen Speicher (Local Storage) Ihres Browsers: Ihre gewählte Oberflächensprache, ob Sie diese Sprache bewusst selbst gewählt haben statt sie automatisch erkennen zu lassen, sowie welche Erfolgs-Benachrichtigungen Sie bereits gesehen haben (kontobezogen gespeichert). Die Zugriffs-, ID- und Refresh-Token Ihrer Sitzung werden getrennt davon im Sitzungsspeicher (Session Storage) Ihres Browsers abgelegt; dies ist technisch notwendig, um Sie angemeldet zu halten, und wird automatisch gelöscht, sobald Sie den Browser-Tab schließen. Diese Werte verlassen Ihren Browser nie. Das active-org-Cookie sowie diese lokalen Speicher- und Sitzungsspeicherwerte werden bei der Abmeldung gelöscht.",
       "section9Title": "Ihre Rechte",
       "section9Body1": "Sie haben das Recht auf Auskunft (Art. 15 DSGVO), Berichtigung (Art. 16 DSGVO), Löschung (Art. 17 DSGVO) und Einschränkung der Verarbeitung (Art. 18 DSGVO) Ihrer personenbezogenen Daten sowie das Recht auf Datenübertragbarkeit (Art. 20 DSGVO) und das Recht, der auf unserem berechtigten Interesse beruhenden Verarbeitung zu widersprechen (Art. 21 DSGVO). Ihr eigenes Konto und die meisten damit verbundenen Daten können Sie jederzeit selbst in Ihren Profileinstellungen löschen; für alle anderen Anliegen, einschließlich einer Kopie Ihrer Daten oder eines Widerspruchs, wenden Sie sich an die im Abschnitt „Verantwortliche Stelle“ oben genannte Adresse oder E-Mail-Adresse. Wir sind bemüht, innerhalb eines Monats zu antworten, wie es Art. 12 Abs. 3 DSGVO vorsieht.",
-      "section9Body2": "Außerdem haben Sie das Recht, sich bei einer Datenschutz-Aufsichtsbehörde zu beschweren (Art. 77 DSGVO), insbesondere in dem Bundesland, in dem Sie wohnen, arbeiten oder in dem der mutmaßliche Verstoß erfolgt ist. Die für uns zuständige Aufsichtsbehörde ist: Die Landesbeauftragte für den Datenschutz Niedersachsen, Prinzenstraße 5, 30159 Hannover."
+      "section9Body2": "Außerdem haben Sie das Recht, sich bei einer Datenschutz-Aufsichtsbehörde zu beschweren (Art. 77 DSGVO), insbesondere in dem Bundesland, in dem Sie wohnen, arbeiten oder in dem der mutmaßliche Verstoß erfolgt ist. Die für uns zuständige Aufsichtsbehörde ist: Die Landesbeauftragte für den Datenschutz Niedersachsen, Prinzenstraße 5, 30159 Hannover.",
+      "eyebrow": "Rechtliches"
     },
     "imprint": {
       "title": "Impressum",
@@ -758,14 +763,17 @@
       "section4aTitle": "Haftung für Inhalte",
       "section4aBody": "Die Inhalte dieser Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.",
       "section4bTitle": "Haftung für Links",
-      "section4bBody": "Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter verantwortlich."
+      "section4bBody": "Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter verantwortlich.",
+      "eyebrow": "Rechtliches"
     },
     "contact": {
       "title": "Kontakt",
       "reportSectionTitle": "Missbräuchliche Inhalte melden",
       "reportSectionBody": "Wenn dir ein Einsatz oder eine Organisation auffällt, die wie Spam, Betrug oder anderweitig illegale Inhalte aussieht, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Einsatz-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Unsere Administratoren prüfen jede Meldung und können die Inhalte entfernen.",
       "otherSectionTitle": "Andere Fragen oder Anliegen",
-      "otherSectionBody": "Bei allen anderen Anliegen wende dich bitte direkt an die Organisation, bei der du dich engagierst, oder an den im Impressum genannten Betreiber der Plattform."
+      "otherSectionBody": "Bei allen anderen Anliegen wende dich bitte direkt an die Organisation, bei der du dich engagierst, oder an den im Impressum genannten Betreiber der Plattform.",
+      "eyebrow": "Support",
+      "intro": "Melde ein Problem oder finde die richtige Stelle für deine Frage."
     },
     "help": {
       "title": "Hilfe",
@@ -785,7 +793,8 @@
       "organizersQ3": "Wie verwalte ich Anmeldungen von Freiwilligen?",
       "organizersA3": "Öffne einen Einsatz im Dashboard deiner Organisation, um alle Angemeldeten zu sehen, ihnen zu schreiben oder sie einzuchecken.",
       "contactTitle": "Noch Hilfe nötig?",
-      "contactBody": "Wenn dir etwas wie Spam, Betrug oder anderweitig illegale Inhalte auffällt, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Einsatz-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Für alles andere besuche unsere <contactLink>Kontaktseite</contactLink> oder schreibe uns direkt an maikhslr@gmail.com - wir antworten in der Regel innerhalb von 24 Stunden."
+      "contactBody": "Wenn dir etwas wie Spam, Betrug oder anderweitig illegale Inhalte auffällt, nutze die Schaltfläche „Melden“ auf der jeweiligen <opportunitiesLink>Einsatz-</opportunitiesLink> oder <organizationsLink>Organisationsseite</organizationsLink>. Für alles andere besuche unsere <contactLink>Kontaktseite</contactLink> oder schreibe uns direkt an maikhslr@gmail.com - wir antworten in der Regel innerhalb von 24 Stunden.",
+      "eyebrow": "Support"
     },
     "termsOfUse": {
       "title": "Nutzungsbedingungen",
@@ -803,7 +812,8 @@
       "section6Title": "Sperrung und Kündigung",
       "section6Body": "Wir können ein Konto sperren oder deaktivieren, das gegen diese Bedingungen verstößt, betrügerische oder unsichere Inhalte veröffentlicht oder Gegenstand belegter Meldungen anderer Nutzerinnen und Nutzer ist. Wo möglich, informieren wir das betroffene Konto über den Grund. Sie können die Nutzung der Plattform jederzeit beenden und die Löschung Ihres Kontos beantragen; Einzelheiten zum Umgang mit Ihren Daten finden Sie in unserer <privacyLink>Datenschutzerklärung</privacyLink>.",
       "section7Title": "Änderungen dieser Bedingungen",
-      "section7Body": "Wir können diese Bedingungen von Zeit zu Zeit aktualisieren, um Änderungen der Plattform oder rechtlicher Vorgaben widerzuspiegeln. Die fortgesetzte Nutzung der Plattform nach einer Aktualisierung gilt als Zustimmung zu den geänderten Bedingungen. Bei Fragen zu diesen Bedingungen kontaktieren Sie uns bitte über die in unserem <imprintLink>Impressum</imprintLink> genannten Angaben."
+      "section7Body": "Wir können diese Bedingungen von Zeit zu Zeit aktualisieren, um Änderungen der Plattform oder rechtlicher Vorgaben widerzuspiegeln. Die fortgesetzte Nutzung der Plattform nach einer Aktualisierung gilt als Zustimmung zu den geänderten Bedingungen. Bei Fragen zu diesen Bedingungen kontaktieren Sie uns bitte über die in unserem <imprintLink>Impressum</imprintLink> genannten Angaben.",
+      "eyebrow": "Rechtliches"
     },
     "notifications": {
       "bellLabel": "Benachrichtigungen",
@@ -983,7 +993,8 @@
       "currentNeeds": "Aktuelle Einsätze",
       "noOpportunities": "Keine aktuellen Einsätze vorhanden.",
       "report": "Melden",
-      "reportOrganization": "Organisation melden"
+      "reportOrganization": "Organisation melden",
+      "eyebrow": "Organisation"
     },
     "profileOverview": {
       "invitationsHeading": "Offene Einladungen"
@@ -1035,7 +1046,9 @@
       "saveError": "Speichern fehlgeschlagen.",
       "loadError": "Profil konnte nicht geladen werden.",
       "loading": "Wird geladen…",
-      "removeChip": "Entfernen"
+      "removeChip": "Entfernen",
+      "subNavActivity": "Aktivität",
+      "eyebrow": "Konto"
     },
     "profileSettings": {
       "title": "Einstellungen"
@@ -1101,8 +1114,7 @@
     },
     "breadcrumb": {
       "label": "Navigationspfad",
-      "home": "Startseite",
-      "profile": "Profil"
+      "home": "Startseite"
     },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,7 +13,8 @@
       "retrying": "Retrying…",
       "loading": "Loading…",
       "pageLoading": "Loading page…",
-      "skipToContent": "Skip to content"
+      "skipToContent": "Skip to content",
+      "onThisPage": "On this page"
     },
     "nav": {
       "primaryLabel": "Main navigation",
@@ -199,7 +200,10 @@
       "participantsJoined_one": "{{count}} person has already joined",
       "participantsJoined_other": "{{count}} people have already joined",
       "maxParticipants_one": "(max. {{count}} person)",
-      "maxParticipants_other": "(max. {{count}} people)"
+      "maxParticipants_other": "(max. {{count}} people)",
+      "factWhen": "When",
+      "factFormat": "How it works",
+      "factWhere": "Where"
     },
     "createOpportunity": {
       "title": "Create opportunity",
@@ -744,7 +748,8 @@
       "section8Body2": "We also store a small number of values in your browser's local storage: your selected interface language, whether you explicitly chose that language yourself rather than it being detected automatically, and which achievement notifications you have already seen (stored per account). Your session's access, ID, and refresh tokens are held separately in your browser's session storage, which is strictly necessary to keep you signed in and is cleared automatically when you close the browser tab. These values never leave your browser. The active-org cookie and these local storage and session storage values are cleared when you sign out.",
       "section9Title": "Your rights",
       "section9Body1": "You have the right to access (Art. 15 GDPR), rectification (Art. 16 GDPR), erasure (Art. 17 GDPR), and restriction of processing (Art. 18 GDPR) of your personal data, as well as the right to data portability (Art. 20 GDPR) and the right to object to processing carried out on the basis of our legitimate interest (Art. 21 GDPR). You can delete your own account and most associated data at any time from your profile settings; for any other request, including a copy of your data or an objection, contact us using the address or email given in the \"Responsible party\" section above. We aim to respond within one month, as required by Art. 12(3) GDPR.",
-      "section9Body2": "You also have the right to lodge a complaint with a data protection supervisory authority (Art. 77 GDPR), in particular in the German state where you live, work, or where an alleged infringement occurred. The authority responsible for us is: Die Landesbeauftragte für den Datenschutz Niedersachsen, Prinzenstraße 5, 30159 Hannover, Germany."
+      "section9Body2": "You also have the right to lodge a complaint with a data protection supervisory authority (Art. 77 GDPR), in particular in the German state where you live, work, or where an alleged infringement occurred. The authority responsible for us is: Die Landesbeauftragte für den Datenschutz Niedersachsen, Prinzenstraße 5, 30159 Hannover, Germany.",
+      "eyebrow": "Legal"
     },
     "imprint": {
       "title": "Imprint",
@@ -758,14 +763,17 @@
       "section4aTitle": "Liability for content",
       "section4aBody": "The contents of these pages have been created with the greatest care. However, we cannot guarantee the accuracy, completeness and timeliness of the content.",
       "section4bTitle": "Liability for links",
-      "section4bBody": "Our offer contains links to external third-party websites over whose content we have no influence. The respective provider is always responsible for the content of the linked pages."
+      "section4bBody": "Our offer contains links to external third-party websites over whose content we have no influence. The respective provider is always responsible for the content of the linked pages.",
+      "eyebrow": "Legal"
     },
     "contact": {
       "title": "Contact",
       "reportSectionTitle": "Reporting abusive content",
       "reportSectionBody": "If you come across an opportunity or organization that looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on its <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. Our administrators review every report and can remove the content.",
       "otherSectionTitle": "Other questions or concerns",
-      "otherSectionBody": "For anything else, please reach out to the organization you are volunteering with directly, or contact the platform operator listed in the imprint."
+      "otherSectionBody": "For anything else, please reach out to the organization you are volunteering with directly, or contact the platform operator listed in the imprint.",
+      "eyebrow": "Support",
+      "intro": "Report a problem, or find the right place to ask your question."
     },
     "help": {
       "title": "Help",
@@ -785,7 +793,8 @@
       "organizersQ3": "How do I manage volunteer sign-ups?",
       "organizersA3": "Open an opportunity from your organization's dashboard to see everyone who signed up, message them, or check them in.",
       "contactTitle": "Still need help?",
-      "contactBody": "If something looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on the relevant <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. For anything else, visit our <contactLink>Contact page</contactLink>, or email us directly at maikhslr@gmail.com - we usually reply within 24 hours."
+      "contactBody": "If something looks like spam, fraud, or otherwise illegal content, use the \"Report\" button on the relevant <opportunitiesLink>opportunity</opportunitiesLink> or <organizationsLink>organization</organizationsLink> page. For anything else, visit our <contactLink>Contact page</contactLink>, or email us directly at maikhslr@gmail.com - we usually reply within 24 hours.",
+      "eyebrow": "Support"
     },
     "termsOfUse": {
       "title": "Terms of Use",
@@ -803,7 +812,8 @@
       "section6Title": "Suspension and termination",
       "section6Body": "We may suspend or disable an account that violates these Terms, publishes fraudulent or unsafe content, or is the subject of substantiated reports from other users. Wherever possible, we will inform the affected account of the reason. You may stop using the Platform and request deletion of your account at any time; see our <privacyLink>Privacy Policy</privacyLink> for details on how your data is handled.",
       "section7Title": "Changes to these terms",
-      "section7Body": "We may update these Terms from time to time to reflect changes to the Platform or legal requirements. Continued use of the Platform after an update constitutes acceptance of the revised Terms. For questions about these Terms, please contact us via the details listed in our <imprintLink>Imprint</imprintLink>."
+      "section7Body": "We may update these Terms from time to time to reflect changes to the Platform or legal requirements. Continued use of the Platform after an update constitutes acceptance of the revised Terms. For questions about these Terms, please contact us via the details listed in our <imprintLink>Imprint</imprintLink>.",
+      "eyebrow": "Legal"
     },
     "notifications": {
       "bellLabel": "Notifications",
@@ -983,7 +993,8 @@
       "currentNeeds": "Current Opportunities",
       "noOpportunities": "No current opportunities available.",
       "report": "Report",
-      "reportOrganization": "Report organization"
+      "reportOrganization": "Report organization",
+      "eyebrow": "Organization"
     },
     "profileOverview": {
       "invitationsHeading": "Open Invitations"
@@ -1035,7 +1046,9 @@
       "saveError": "Failed to save profile.",
       "loadError": "Could not load profile.",
       "loading": "Loading…",
-      "removeChip": "Remove"
+      "removeChip": "Remove",
+      "subNavActivity": "Activity",
+      "eyebrow": "Account"
     },
     "profileSettings": {
       "title": "Settings"
@@ -1101,8 +1114,7 @@
     },
     "breadcrumb": {
       "label": "Breadcrumb",
-      "home": "Home",
-      "profile": "Profile"
+      "home": "Home"
     },
     "error": {
       "forbidden": "You do not have permission to do this.",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -12,7 +12,7 @@ import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
 import { inputClass, labelClass } from "../lib/formClasses";
 import { pageTitleClass } from "../lib/headingClasses";
-import { cardSubtleClass } from "../lib/surfaceClasses";
+import { cardClass } from "../lib/surfaceClasses";
 import { formatDateLong, formatDateTime } from "../lib/format";
 import { avatarColorClasses } from "../lib/avatarColor";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -69,9 +69,13 @@ export default function AdministrationPage() {
 				<ReportsSection />
 			</section>
 			<section>
-				<h2 className="mb-4 text-lg font-semibold text-gray-900">
+				{/* Was a hand-rolled h2 carrying PageSectionHeading's pre-#1755
+				recipe verbatim, so it kept the old text-lg body-face styling while
+				the three sections above it moved to the display face - the last
+				section on the page rendering visibly smaller than its siblings. */}
+				<PageSectionHeading>
 					{t("administration.auditLogHeading")}
-				</h2>
+				</PageSectionHeading>
 				<AuditLogSection />
 			</section>
 		</>
@@ -173,55 +177,63 @@ function OrganizationsSection() {
 
 	return (
 		<>
-			<form onSubmit={handleSearchSubmit} className="mb-4 flex items-end gap-3">
-				<div className="flex-1">
-					<label htmlFor="admin-org-search" className={labelClass}>
-						{t("administration.organizations.searchLabel")}
+			{/* Search plus the two scope toggles are one filter control, boxed
+			like the Members/Sign-ups toolbars (#1755) rather than three bare
+			rows stacked on the page background. */}
+			<div className={`mb-6 ${cardClass} sm:p-5`}>
+				<form
+					onSubmit={handleSearchSubmit}
+					className="mb-4 flex items-end gap-3"
+				>
+					<div className="flex-1">
+						<label htmlFor="admin-org-search" className={labelClass}>
+							{t("administration.organizations.searchLabel")}
+						</label>
+						<input
+							id="admin-org-search"
+							type="search"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							placeholder={t("administration.organizations.searchPlaceholder")}
+							className={inputClass}
+						/>
+					</div>
+					<Button type="submit">
+						{t("administration.organizations.searchButton")}
+					</Button>
+				</form>
+				<div className="mb-6 flex flex-wrap items-center gap-4">
+					<label
+						htmlFor="admin-org-flagged-only"
+						className="flex cursor-pointer items-center gap-2 py-1"
+					>
+						<input
+							type="checkbox"
+							id="admin-org-flagged-only"
+							checked={flaggedOnly}
+							onChange={(e) => setFlaggedOnly(e.target.checked)}
+							className="h-4 w-4 accent-brand-600"
+						/>
+						<span className="text-sm text-gray-800">
+							{t("administration.organizations.flaggedOnlyLabel")}
+						</span>
 					</label>
-					<input
-						id="admin-org-search"
-						type="search"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						placeholder={t("administration.organizations.searchPlaceholder")}
-						className={inputClass}
-					/>
+					<label
+						htmlFor="admin-org-deleted-only"
+						className="flex cursor-pointer items-center gap-2 py-1"
+					>
+						<input
+							type="checkbox"
+							id="admin-org-deleted-only"
+							checked={deletedOnly}
+							onChange={(e) => setDeletedOnly(e.target.checked)}
+							className="h-4 w-4 accent-brand-600"
+						/>
+						<span className="text-sm text-gray-800">
+							{t("administration.organizations.deletedOnlyLabel")}
+						</span>
+					</label>
 				</div>
-				<Button type="submit">
-					{t("administration.organizations.searchButton")}
-				</Button>
-			</form>
-			<div className="mb-6 flex flex-wrap items-center gap-4">
-				<label
-					htmlFor="admin-org-flagged-only"
-					className="flex cursor-pointer items-center gap-2 py-1"
-				>
-					<input
-						type="checkbox"
-						id="admin-org-flagged-only"
-						checked={flaggedOnly}
-						onChange={(e) => setFlaggedOnly(e.target.checked)}
-						className="h-4 w-4 accent-brand-600"
-					/>
-					<span className="text-sm text-gray-800">
-						{t("administration.organizations.flaggedOnlyLabel")}
-					</span>
-				</label>
-				<label
-					htmlFor="admin-org-deleted-only"
-					className="flex cursor-pointer items-center gap-2 py-1"
-				>
-					<input
-						type="checkbox"
-						id="admin-org-deleted-only"
-						checked={deletedOnly}
-						onChange={(e) => setDeletedOnly(e.target.checked)}
-						className="h-4 w-4 accent-brand-600"
-					/>
-					<span className="text-sm text-gray-800">
-						{t("administration.organizations.deletedOnlyLabel")}
-					</span>
-				</label>
 			</div>
 			{loading ? (
 				<div
@@ -492,26 +504,32 @@ function UsersSection() {
 
 	return (
 		<>
-			<form onSubmit={handleSearchSubmit} className="mb-6 flex items-end gap-3">
-				<div className="flex-1">
-					<label htmlFor="admin-user-search" className={labelClass}>
-						{t("administration.users.searchLabel")}
-					</label>
-					<input
-						id="admin-user-search"
-						type="search"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						placeholder={t("administration.users.searchPlaceholder")}
-						className={inputClass}
-					/>
-				</div>
-				<Button type="submit">{t("administration.users.searchButton")}</Button>
-			</form>
+			{/* Boxed like the organizations filter above - the staleness note
+			belongs with the search that produces the list it qualifies. */}
+			<div className={`mb-6 ${cardClass} sm:p-5`}>
+				<form onSubmit={handleSearchSubmit} className="flex items-end gap-3">
+					<div className="flex-1">
+						<label htmlFor="admin-user-search" className={labelClass}>
+							{t("administration.users.searchLabel")}
+						</label>
+						<input
+							id="admin-user-search"
+							type="search"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							placeholder={t("administration.users.searchPlaceholder")}
+							className={inputClass}
+						/>
+					</div>
+					<Button type="submit">
+						{t("administration.users.searchButton")}
+					</Button>
+				</form>
 
-			<p className="mb-4 text-xs text-gray-500">
-				{t("administration.users.staleness")}
-			</p>
+				<p className="mt-3 text-xs text-gray-500">
+					{t("administration.users.staleness")}
+				</p>
+			</div>
 
 			{loading ? (
 				<div
@@ -1030,7 +1048,7 @@ function ReportHistoryModal({
 			) : (
 				<ul className="max-h-96 space-y-3 overflow-y-auto">
 					{entries.map((entry) => (
-						<li key={entry.id} className={cardSubtleClass}>
+						<li key={entry.id} className={cardClass}>
 							<div className="flex items-center justify-between gap-2">
 								<span className="text-sm font-medium text-gray-900">
 									{t(`administration.reports.reason.${entry.reason}`)}

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -1,51 +1,94 @@
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
-import { pageTitleClass } from "../lib/headingClasses";
+import PageHeaderBand from "../components/PageHeaderBand";
+import { FlagIcon, EnvelopeIcon, ArrowRightIcon } from "../components/icons";
+import { cardClass } from "../lib/surfaceClasses";
 
 export default function ContactPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("contact.title"));
-	usePageToolbar([{ label: t("contact.title") }]);
+
+	const linkClass =
+		"font-medium text-brand-700 underline underline-offset-2 hover:text-brand-800";
 
 	return (
-		<div data-content-wrapper className="max-w-2xl">
-			<h1 className={`mb-8 text-gray-900 ${pageTitleClass}`}>
-				{t("contact.title")}
-			</h1>
+		<>
+			<PageHeaderBand
+				eyebrow={t("contact.eyebrow")}
+				title={t("contact.title")}
+				lead={t("contact.intro")}
+			/>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("contact.reportSectionTitle")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="contact.reportSectionBody"
-						components={{
-							opportunitiesLink: (
-								<Link to="/" className="text-brand-700 underline" />
-							),
-							// Organizations no longer have their own listing page -
-							// findable via the same homepage search as opportunities
-							// now (keyword search matches org names too), so this
-							// points to "/" same as opportunitiesLink.
-							organizationsLink: (
-								<Link to="/" className="text-brand-700 underline" />
-							),
-						}}
-					/>
-				</p>
-			</section>
+			{/* Two routes, not two paragraphs: the page's whole job is sending
+			someone to the right place, so each destination gets its own card with
+			the icon that names it. */}
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2"
+			>
+				<section
+					aria-labelledby="contact-report"
+					className={`${cardClass} sm:p-8`}
+				>
+					<div
+						aria-hidden="true"
+						className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-100 text-brand-700"
+					>
+						<FlagIcon className="h-5 w-5" />
+					</div>
+					<h2
+						id="contact-report"
+						className="mt-5 font-display text-2xl font-bold text-gray-900"
+					>
+						{t("contact.reportSectionTitle")}
+					</h2>
+					<p className="mt-3 leading-7 text-gray-700">
+						<Trans
+							i18nKey="contact.reportSectionBody"
+							components={{
+								opportunitiesLink: <Link to="/" className={linkClass} />,
+								// Organizations no longer have their own listing page -
+								// findable via the same homepage search as opportunities
+								// now (keyword search matches org names too), so this
+								// points to "/" same as opportunitiesLink.
+								organizationsLink: <Link to="/" className={linkClass} />,
+							}}
+						/>
+					</p>
+				</section>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("contact.otherSectionTitle")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("contact.otherSectionBody")}
-				</p>
-			</section>
-		</div>
+				<section
+					aria-labelledby="contact-other"
+					className={`${cardClass} sm:p-8`}
+				>
+					<div
+						aria-hidden="true"
+						className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-100 text-brand-700"
+					>
+						<EnvelopeIcon className="h-5 w-5" />
+					</div>
+					<h2
+						id="contact-other"
+						className="mt-5 font-display text-2xl font-bold text-gray-900"
+					>
+						{t("contact.otherSectionTitle")}
+					</h2>
+					<p className="mt-3 leading-7 text-gray-700">
+						{t("contact.otherSectionBody")}
+					</p>
+					{/* The body names the imprint as where the operator's details
+					live, so the page provides that jump instead of leaving the
+					reader to find it in the footer. */}
+					<Link
+						to="/imprint"
+						className="mt-5 inline-flex items-center gap-1.5 font-medium text-brand-700 transition-colors hover:text-brand-800"
+					>
+						{t("footer.imprint")}
+						<ArrowRightIcon />
+					</Link>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -595,90 +595,102 @@ export default function EngagementManagementPage() {
 				</div>
 			)}
 
-			<div className="mb-4 flex justify-end">
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={handleExport}
-					disabled={exporting}
-				>
-					<ArrowDownTrayIcon className="h-4 w-4" />
-					{exporting
-						? t("engagementManagement.exportButtonLoading")
-						: t("engagementManagement.exportButton")}
-				</Button>
-			</div>
-			{exportError && <ErrorBanner message={exportError} className="mb-4" />}
-
-			<div className="mb-4 flex flex-wrap items-end gap-3">
-				<div>
-					<label htmlFor="engagement-status-filter" className={labelClass}>
-						{t("engagementManagement.filterLabelStatus")}
-					</label>
-					<select
-						id="engagement-status-filter"
-						value={statusFilter}
-						onChange={(e) => setStatusFilter(e.target.value)}
-						className={inputClass}
+			{/* Export, the filters and the bulk-select row are one toolbar for
+			the list below, boxed like the Sign-ups and Members toolbars (#1755).
+			They were three separate bare rows - a right-floating Export button on
+			nothing, then two form fields on the page background, then a
+			full-width card holding a single checkbox. */}
+			<div className={`mb-6 ${cardClass} sm:p-5`}>
+				<div className="mb-4 flex justify-end">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleExport}
+						disabled={exporting}
 					>
-						<option value="">{t("engagementManagement.allStatuses")}</option>
-						{Object.entries(STATUS_LABELS).map(([value, label]) => (
-							<option key={value} value={value}>
-								{label}
-							</option>
-						))}
-					</select>
+						<ArrowDownTrayIcon className="h-4 w-4" />
+						{exporting
+							? t("engagementManagement.exportButtonLoading")
+							: t("engagementManagement.exportButton")}
+					</Button>
 				</div>
-				{opportunity && opportunity.timeSlots.length > 1 && (
+				{exportError && <ErrorBanner message={exportError} className="mb-4" />}
+
+				<div className="flex flex-wrap items-end gap-3">
 					<div>
-						<label htmlFor="engagement-timeslot-filter" className={labelClass}>
-							{t("engagementManagement.filterLabelTimeSlot")}
+						<label htmlFor="engagement-status-filter" className={labelClass}>
+							{t("engagementManagement.filterLabelStatus")}
 						</label>
 						<select
-							id="engagement-timeslot-filter"
-							value={timeSlotFilter}
-							onChange={(e) => setTimeSlotFilter(e.target.value)}
+							id="engagement-status-filter"
+							value={statusFilter}
+							onChange={(e) => setStatusFilter(e.target.value)}
 							className={inputClass}
 						>
-							<option value="">{t("engagementManagement.allTimeSlots")}</option>
-							{opportunity.timeSlots.map((slot) => (
-								<option key={slot.id} value={slot.id}>
-									{formatDateTime(
-										slot.startDateTime as unknown as string,
-										i18n.language,
-									)}{" "}
-									-{" "}
-									{formatDateTime(
-										slot.endDateTime as unknown as string,
-										i18n.language,
-									)}
+							<option value="">{t("engagementManagement.allStatuses")}</option>
+							{Object.entries(STATUS_LABELS).map(([value, label]) => (
+								<option key={value} value={value}>
+									{label}
 								</option>
 							))}
 						</select>
 					</div>
-				)}
-				<form
-					onSubmit={handleSearchSubmit}
-					className="flex flex-1 items-end gap-2"
-				>
-					<div className="min-w-0 flex-1">
-						<label htmlFor="engagement-search" className={labelClass}>
-							{t("engagementManagement.searchLabel")}
-						</label>
-						<input
-							id="engagement-search"
-							type="search"
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							placeholder={t("engagementManagement.searchPlaceholder")}
-							className={inputClass}
-						/>
-					</div>
-					<Button type="submit">
-						{t("engagementManagement.searchButton")}
-					</Button>
-				</form>
+					{opportunity && opportunity.timeSlots.length > 1 && (
+						<div>
+							<label
+								htmlFor="engagement-timeslot-filter"
+								className={labelClass}
+							>
+								{t("engagementManagement.filterLabelTimeSlot")}
+							</label>
+							<select
+								id="engagement-timeslot-filter"
+								value={timeSlotFilter}
+								onChange={(e) => setTimeSlotFilter(e.target.value)}
+								className={inputClass}
+							>
+								<option value="">
+									{t("engagementManagement.allTimeSlots")}
+								</option>
+								{opportunity.timeSlots.map((slot) => (
+									<option key={slot.id} value={slot.id}>
+										{formatDateTime(
+											slot.startDateTime as unknown as string,
+											i18n.language,
+										)}{" "}
+										-{" "}
+										{formatDateTime(
+											slot.endDateTime as unknown as string,
+											i18n.language,
+										)}
+									</option>
+								))}
+							</select>
+						</div>
+					)}
+					<form
+						onSubmit={handleSearchSubmit}
+						className="flex flex-1 items-end gap-2"
+					>
+						<div className="min-w-0 flex-1">
+							<label htmlFor="engagement-search" className={labelClass}>
+								{t("engagementManagement.searchLabel")}
+							</label>
+							<input
+								id="engagement-search"
+								type="search"
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+								placeholder={t("engagementManagement.searchPlaceholder")}
+								className={inputClass}
+							/>
+						</div>
+						<Button type="submit">
+							{t("engagementManagement.searchButton")}
+						</Button>
+					</form>
+				</div>
 			</div>
 
 			{loading && (
@@ -720,7 +732,7 @@ export default function EngagementManagementPage() {
 				))}
 
 			{isOrganizer && !loading && !error && actionableCount > 0 && (
-				<div className="mb-3 flex flex-wrap items-center gap-3 rounded-card border border-gray-200 bg-gray-50 p-3 text-sm">
+				<div className="mb-3 flex flex-wrap items-center gap-3 rounded-card border border-gray-100 bg-white p-3 text-sm shadow-resting">
 					<label
 						htmlFor="select-all-pending"
 						className="flex items-center gap-2"
@@ -864,7 +876,7 @@ export default function EngagementManagementPage() {
 											</Chip>
 										)}
 									</div>
-									<div className="flex shrink-0 flex-col items-end gap-2">
+									<div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
 										<span
 											className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[e.status] ?? "border-gray-200 bg-gray-100 text-gray-600"}`}
 										>
@@ -1052,7 +1064,7 @@ export default function EngagementManagementPage() {
 				<section className="mt-8">
 					<PageSectionHeading>{t("feedback.organizerTab")}</PageSectionHeading>
 					{feedbackStats.feedbackCount === 0 ? (
-						<p className="text-sm text-gray-500">{t("feedback.noFeedback")}</p>
+						<EmptyState title={t("feedback.noFeedback")} />
 					) : (
 						<>
 							<p className="mb-4 text-sm text-gray-700">

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -1,80 +1,95 @@
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
-import { pageTitleClass } from "../lib/headingClasses";
+import PageHeaderBand from "../components/PageHeaderBand";
+import FaqAccordion from "../components/FaqAccordion";
+import { HandRaisedIcon } from "../components/icons";
+import { cardClass } from "../lib/surfaceClasses";
 
 export default function HelpPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("help.title"));
-	usePageToolbar([{ label: t("help.title") }]);
+
+	// Two audiences, not a sequence - so the page splits by who is asking
+	// rather than numbering the questions. Each column reuses the same
+	// accordion the landing page's FAQ is built from, which is where the
+	// "More questions? See Help" link at the bottom of that FAQ leads.
+	const audiences = [
+		{
+			title: t("help.volunteersTitle"),
+			items: [
+				{ q: t("help.volunteersQ1"), a: t("help.volunteersA1") },
+				{ q: t("help.volunteersQ2"), a: t("help.volunteersA2") },
+				{ q: t("help.volunteersQ3"), a: t("help.volunteersA3") },
+			],
+		},
+		{
+			title: t("help.organizersTitle"),
+			items: [
+				{ q: t("help.organizersQ1"), a: t("help.organizersA1") },
+				{ q: t("help.organizersQ2"), a: t("help.organizersA2") },
+				{ q: t("help.organizersQ3"), a: t("help.organizersA3") },
+			],
+		},
+	];
+
+	const linkClass =
+		"font-medium text-brand-700 underline underline-offset-2 hover:text-brand-800";
 
 	return (
-		<div data-content-wrapper className="max-w-2xl">
-			<h1 className={`mb-2 text-gray-900 ${pageTitleClass}`}>
-				{t("help.title")}
-			</h1>
-			<p className="mb-8 leading-relaxed text-gray-700">{t("help.intro")}</p>
+		<>
+			<PageHeaderBand
+				eyebrow={t("help.eyebrow")}
+				title={t("help.title")}
+				lead={t("help.intro")}
+			/>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("help.volunteersTitle")}
-				</h2>
-				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ1")}</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("help.volunteersA1")}
-				</p>
-				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ2")}</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("help.volunteersA2")}
-				</p>
-				<h3 className="mb-1 text-lg font-medium">{t("help.volunteersQ3")}</h3>
-				<p className="leading-relaxed text-gray-700">
-					{t("help.volunteersA3")}
-				</p>
-			</section>
+			<div data-content-wrapper className="mx-auto max-w-5xl">
+				<div className="grid gap-10 lg:grid-cols-2 lg:gap-8">
+					{audiences.map(({ title, items }) => (
+						<section key={title} aria-label={title}>
+							<h2 className="mb-5 font-display text-3xl font-bold text-gray-900">
+								{title}
+							</h2>
+							<FaqAccordion items={items} />
+						</section>
+					))}
+				</div>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("help.organizersTitle")}
-				</h2>
-				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ1")}</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("help.organizersA1")}
-				</p>
-				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ2")}</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("help.organizersA2")}
-				</p>
-				<h3 className="mb-1 text-lg font-medium">{t("help.organizersQ3")}</h3>
-				<p className="leading-relaxed text-gray-700">
-					{t("help.organizersA3")}
-				</p>
-			</section>
-
-			<section>
-				<h2 className="mb-2 text-xl font-semibold">{t("help.contactTitle")}</h2>
-				<p className="leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="help.contactBody"
-						components={{
-							opportunitiesLink: (
-								<Link to="/" className="text-brand-700 underline" />
-							),
-							// Organizations no longer have their own listing page -
-							// findable via the same homepage search as opportunities
-							// now (keyword search matches org names too), so this
-							// points to "/" same as opportunitiesLink.
-							organizationsLink: (
-								<Link to="/" className="text-brand-700 underline" />
-							),
-							contactLink: (
-								<Link to="/contact" className="text-brand-700 underline" />
-							),
-						}}
-					/>
-				</p>
-			</section>
-		</div>
+				<section
+					aria-labelledby="help-contact"
+					className={`mt-12 flex flex-col gap-5 sm:flex-row sm:items-start sm:gap-6 ${cardClass} sm:p-8`}
+				>
+					<div
+						aria-hidden="true"
+						className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700"
+					>
+						<HandRaisedIcon className="h-6 w-6" />
+					</div>
+					<div>
+						<h2
+							id="help-contact"
+							className="font-display text-2xl font-bold text-gray-900"
+						>
+							{t("help.contactTitle")}
+						</h2>
+						<p className="mt-2 leading-7 text-gray-700">
+							<Trans
+								i18nKey="help.contactBody"
+								components={{
+									opportunitiesLink: <Link to="/" className={linkClass} />,
+									// Organizations no longer have their own listing page -
+									// findable via the same homepage search as opportunities
+									// now (keyword search matches org names too), so this
+									// points to "/" same as opportunitiesLink.
+									organizationsLink: <Link to="/" className={linkClass} />,
+									contactLink: <Link to="/contact" className={linkClass} />,
+								}}
+							/>
+						</p>
+					</div>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import VolunteerOpportunitiesList from "../components/VolunteerOpportunitiesList
 import type { CitySuggestion } from "../components/VolunteerOpportunitiesList/useCitySuggestions";
 import LocationSearchInput from "../components/LocationSearchInput";
 import Button from "../components/Button";
+import FaqAccordion from "../components/FaqAccordion";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import Skeleton from "../components/Skeleton";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -21,7 +22,6 @@ import {
 	PlusIcon,
 	UserGroupIcon,
 	ShieldCheckIcon,
-	ChevronDownIcon,
 } from "../components/icons";
 import type {
 	Organization,
@@ -596,15 +596,13 @@ export default function HomePage() {
 			{/* FAQ - closes the page on objection-handling rather than a third
 			pitch: cost, account requirement, org onboarding speed, and
 			license, in that order (volunteer concerns first, since the page
-			is volunteer-facing until the org CTA above). Native
-			<details>/<summary> instead of a hand-rolled accordion - no open/
-			close state to wire up, and it's keyboard/screen-reader operable
-			for free. group-open:rotate-180 reads the element's own [open]
-			attribute via Tailwind's group variant, so the chevron animates
-			without any JS tracking which item is expanded. mb-20 (not mt-20)
-			since this is the last content section before Footer - matches
-			how the org CTA used to own this same trailing gap before it
-			moved above the founder band. */}
+			is volunteer-facing until the org CTA above). The accordion itself
+			is shared with HelpPage (FaqAccordion) - the "More questions?"
+			link below leads there, and the two used to be visibly different
+			pieces of markup, so following it left the design system (#1755).
+			mb-20 (not mt-20) since this is the last content section before
+			Footer - matches how the org CTA used to own this same trailing
+			gap before it moved above the founder band. */}
 			<section aria-labelledby={faqTitleId} className="mb-20">
 				<div className="animate-fade-up mx-auto max-w-2xl text-center">
 					<p className="mb-3 text-xs font-semibold tracking-widest text-brand-700 uppercase">
@@ -618,17 +616,10 @@ export default function HomePage() {
 					</h2>
 				</div>
 
-				<div className="animate-fade-up-d1 mx-auto mt-10 max-w-2xl divide-y divide-gray-200 rounded-card border border-gray-100 bg-white px-6 shadow-resting">
-					{faqItems.map(({ q, a }) => (
-						<details key={q} className="group py-5">
-							<summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-base font-semibold text-gray-900 [&::-webkit-details-marker]:hidden">
-								{q}
-								<ChevronDownIcon className="h-4 w-4 shrink-0 text-gray-400 transition-transform group-open:rotate-180" />
-							</summary>
-							<p className="mt-3 text-sm leading-relaxed text-gray-600">{a}</p>
-						</details>
-					))}
-				</div>
+				<FaqAccordion
+					items={faqItems}
+					className="animate-fade-up-d1 mx-auto mt-10 max-w-2xl"
+				/>
 
 				<p className="animate-fade-up-d1 mt-6 text-center text-sm text-gray-600">
 					<Link

--- a/frontend/src/pages/ImprintPage.tsx
+++ b/frontend/src/pages/ImprintPage.tsx
@@ -1,72 +1,80 @@
 import { useTranslation } from "react-i18next";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
-import { pageTitleClass } from "../lib/headingClasses";
+import PageHeaderBand from "../components/PageHeaderBand";
+import { cardClass } from "../lib/surfaceClasses";
 
 export default function ImprintPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("imprint.title"));
-	usePageToolbar([{ label: t("imprint.title") }]);
+
+	// The first three blocks are all short records of the same shape (a name,
+	// an address, a way to reach someone), so they read as a row of cards
+	// rather than three prose sections. Two of them repeat the same name and
+	// address on purpose - DDG and MStV each require their own statement - and
+	// the card labels are what keep that reading as deliberate compliance
+	// rather than a duplication bug.
+	const records = [
+		{ title: t("imprint.section1Title"), body: t("imprint.section1Body") },
+		{ title: t("imprint.section2Title"), body: t("imprint.section2Body") },
+		{ title: t("imprint.section3Title"), body: t("imprint.section3Body") },
+	];
 
 	return (
-		<div data-content-wrapper className="max-w-2xl">
-			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
-				{t("imprint.title")}
-			</h1>
+		<>
+			<PageHeaderBand
+				eyebrow={t("imprint.eyebrow")}
+				title={t("imprint.title")}
+			/>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("imprint.section1Title")}
-				</h2>
-				<p
-					className="leading-relaxed text-gray-700"
-					style={{ whiteSpace: "pre-line" }}
+			<div data-content-wrapper className="mx-auto max-w-5xl">
+				{/* No clause numbers here, unlike the terms and privacy pages: the
+				imprint copy already cites its own statutory sections ("§ 5 DDG",
+				"§ 18 MStV"), so a second, unrelated numbering running alongside
+				would read as a competing citation scheme. */}
+				<div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+					{records.map(({ title, body }) => (
+						<section key={title} className={cardClass}>
+							<h2 className="text-xs font-semibold tracking-widest text-brand-700 uppercase">
+								{title}
+							</h2>
+							<p className="mt-3 leading-7 whitespace-pre-line text-gray-700">
+								{body}
+							</p>
+						</section>
+					))}
+				</div>
+
+				<section
+					aria-labelledby="imprint-disclaimer"
+					className="mt-12 border-t border-gray-200 pt-10"
 				>
-					{t("imprint.section1Body")}
-				</p>
-			</section>
+					<h2
+						id="imprint-disclaimer"
+						className="font-display text-3xl font-bold text-gray-900 sm:text-4xl"
+					>
+						{t("imprint.section4Title")}
+					</h2>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("imprint.section2Title")}
-				</h2>
-				<p
-					className="leading-relaxed text-gray-700"
-					style={{ whiteSpace: "pre-line" }}
-				>
-					{t("imprint.section2Body")}
-				</p>
-			</section>
-
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("imprint.section3Title")}
-				</h2>
-				<p
-					className="leading-relaxed text-gray-700"
-					style={{ whiteSpace: "pre-line" }}
-				>
-					{t("imprint.section3Body")}
-				</p>
-			</section>
-
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("imprint.section4Title")}
-				</h2>
-				<h3 className="mb-1 text-lg font-medium">
-					{t("imprint.section4aTitle")}
-				</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("imprint.section4aBody")}
-				</p>
-				<h3 className="mb-1 text-lg font-medium">
-					{t("imprint.section4bTitle")}
-				</h3>
-				<p className="leading-relaxed text-gray-700">
-					{t("imprint.section4bBody")}
-				</p>
-			</section>
-		</div>
+					<div className="mt-6 grid gap-8 sm:grid-cols-2">
+						<div>
+							<h3 className="text-lg font-semibold text-gray-900">
+								{t("imprint.section4aTitle")}
+							</h3>
+							<p className="mt-2 leading-7 text-gray-700">
+								{t("imprint.section4aBody")}
+							</p>
+						</div>
+						<div>
+							<h3 className="text-lg font-semibold text-gray-900">
+								{t("imprint.section4bTitle")}
+							</h3>
+							<p className="mt-2 leading-7 text-gray-700">
+								{t("imprint.section4bBody")}
+							</p>
+						</div>
+					</div>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/MyEngagementsPage/index.tsx
+++ b/frontend/src/pages/MyEngagementsPage/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { usePageTitle } from "../../hooks/usePageTitle";
-import { usePageToolbar } from "../../contexts/ToolbarContext";
-import { pageTitleClass } from "../../lib/headingClasses";
+import ProfileSubNav from "../../components/ProfileSubNav";
+import PageHeaderBand from "../../components/PageHeaderBand";
 import ActivitySection from "./ActivitySection";
 
 // Open invitations and sign-ups - split out of the overloaded /profile into
@@ -11,15 +11,23 @@ import ActivitySection from "./ActivitySection";
 export default function MyEngagementsPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("myEngagementsPage.title"));
-	usePageToolbar([{ label: t("myEngagementsPage.title") }]);
 
 	return (
 		<>
-			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
-				{t("myEngagementsPage.title")}
-			</h1>
+			<PageHeaderBand
+				eyebrow={t("profile.eyebrow")}
+				title={t("myEngagementsPage.title")}
+			/>
 
-			<ActivitySection />
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-8 lg:grid-cols-[11rem_minmax(0,1fr)] lg:gap-12"
+			>
+				<ProfileSubNav active="activity" />
+				<div className="min-w-0">
+					<ActivitySection />
+				</div>
+			</div>
 		</>
 	);
 }

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -8,24 +8,41 @@ export default function NotFoundPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("notFound.title"));
 
+	// The illustration used to be absolutely positioned behind the copy at 35%
+	// opacity, which put the dog's head directly across the heading and the
+	// description at common desktop viewport sizes (#1755). It now stacks above
+	// the text at full strength and carries the page instead of haunting it -
+	// a soft brand-100 glow behind it keeps the shape from floating on bare
+	// white, echoing the blur-blob lighting the landing hero uses.
 	return (
-		<div className="relative flex min-h-[70vh] items-center justify-center overflow-hidden px-4 text-center">
-			<PageEaten className="absolute top-1/2 w-85 translate-y-[-60%] text-brand-500 opacity-35 sm:w-105" />
-
-			{/* Content */}
-			<div className="relative z-10 max-w-md">
-				<h1
-					className={`mb-4 tracking-tight text-brand-700 ${statusTitleClass}`}
-				>
-					{t("notFound.title")}
-				</h1>
-
-				<p className="mb-8 text-black">{t("notFound.description")}</p>
-
-				<Button to="/" size="lg" className="shadow-lg">
-					{t("notFound.backHome")}
-				</Button>
+		<div className="mx-auto flex max-w-lg flex-col items-center px-4 py-10 text-center sm:py-16">
+			<div className="relative mb-8 flex items-center justify-center">
+				<div
+					aria-hidden="true"
+					className="pointer-events-none absolute h-56 w-56 rounded-full bg-brand-100 blur-3xl"
+				/>
+				{/* h-auto is load-bearing: the asset carries its own width/height
+				attributes (645x750), so setting only a width left the box 750px
+				tall and letterboxed the drawing inside ~258px of dead space top
+				and bottom. aria-hidden because the file also hardcodes a German
+				role="img" aria-label - which announced itself in German on the
+				English site and only restated the <h1> below in any case. */}
+				<PageEaten
+					aria-hidden="true"
+					className="relative h-auto w-52 text-brand-500 sm:w-64"
+				/>
 			</div>
+
+			<h1 className={`text-gray-900 ${statusTitleClass}`}>
+				{t("notFound.title")}
+			</h1>
+			<p className="mt-4 leading-relaxed text-gray-600">
+				{t("notFound.description")}
+			</p>
+
+			<Button to="/" size="lg" className="mt-8 shadow-md">
+				{t("notFound.backHome")}
+			</Button>
 		</div>
 	);
 }

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router";
+import { useParams } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import type { PublicOrganizationProfileResponse } from "../client/api-client";
@@ -12,15 +12,13 @@ import Skeleton from "../components/Skeleton";
 import LoadMoreError from "../components/LoadMoreError";
 import EmptyState from "../components/EmptyState";
 import Button from "../components/Button";
-import Chip from "../components/Chip";
 import { useApiClient } from "../hooks/useApiClient";
-import { formatOccurrence, formatParticipationType } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
 import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
-import { cardClass } from "../lib/surfaceClasses";
 import { FlagIcon } from "../components/icons";
+import PageHeaderBand from "../components/PageHeaderBand";
+import PublicOpportunityCard from "../components/PublicOpportunityCard";
 
 export default function OrganizationProfilePage() {
 	const { organizationId } = useParams<{ organizationId: string }>();
@@ -36,7 +34,6 @@ export default function OrganizationProfilePage() {
 	const [showReport, setShowReport] = useState(false);
 
 	usePageTitle(profile?.name ?? t("orgProfile.loading"));
-	usePageToolbar([{ label: profile?.name ?? t("orgProfile.loading") }]);
 
 	function load() {
 		if (!organizationId) return;
@@ -103,72 +100,43 @@ export default function OrganizationProfilePage() {
 
 	return (
 		<>
+			<PageHeaderBand
+				eyebrow={t("orgProfile.eyebrow")}
+				title={profile.name}
+				lead={profile.description ?? undefined}
+			>
+				{auth.isAuthenticated && (
+					<Button
+						variant="outlineOnDark"
+						size="sm"
+						onClick={() => setShowReport(true)}
+						data-testid="report-organization"
+						aria-label={t("orgProfile.reportOrganization")}
+					>
+						<FlagIcon className="h-4 w-4" />
+						<span className="hidden sm:inline">{t("orgProfile.report")}</span>
+					</Button>
+				)}
+			</PageHeaderBand>
+
 			<OrganizationProfileView
+				showHeader={false}
+				centered
 				name={profile.name}
 				logoUrl={profile.logoUrl}
-				description={profile.description}
 				contactEmail={profile.contactEmail}
 				contactPhone={profile.contactPhone}
 				website={profile.website}
 				address={profile.address}
-				nameAs="h1"
-				actions={
-					auth.isAuthenticated && (
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setShowReport(true)}
-							data-testid="report-organization"
-							aria-label={t("orgProfile.reportOrganization")}
-						>
-							<FlagIcon className="h-4 w-4" />
-							<span className="hidden sm:inline">{t("orgProfile.report")}</span>
-						</Button>
-					)
-				}
 			>
 				<SectionHeading>{t("orgProfile.currentNeeds")}</SectionHeading>
 
 				{profile.openOpportunities.length === 0 ? (
 					<EmptyState title={t("orgProfile.noOpportunities")} />
 				) : (
-					<ul className="space-y-3">
+					<ul className="grid gap-4 sm:grid-cols-2">
 						{profile.openOpportunities.map((opp) => (
-							<li
-								key={opp.id}
-								className={`relative ${cardClass} transition-shadow hover:shadow-raised`}
-							>
-								<Link
-									to={`/volunteer-opportunities/${opp.id}`}
-									className="absolute inset-0 rounded-card"
-									aria-label={opp.title}
-								/>
-								<strong className="block text-sm font-semibold text-gray-900">
-									{opp.title}
-								</strong>
-								{opp.description && (
-									<p className="mt-1 line-clamp-2 text-sm text-gray-500">
-										{opp.description}
-									</p>
-								)}
-								<div className="mt-2 flex flex-wrap gap-2">
-									<Chip tone="neutral" size="sm">
-										{formatOccurrence(opp.occurrence, t)}
-									</Chip>
-									<Chip tone="brand" size="sm">
-										{formatParticipationType(opp.participationType, t)}
-									</Chip>
-									{opp.isRemote ? (
-										<Chip tone="success" size="sm">
-											{t("opportunities.remote")}
-										</Chip>
-									) : opp.street ? (
-										<Chip tone="neutral" size="sm">
-											{opp.street} {opp.houseNumber}, {opp.zipCode} {opp.city}
-										</Chip>
-									) : null}
-								</div>
-							</li>
+							<PublicOpportunityCard key={opp.id} opportunity={opp} />
 						))}
 					</ul>
 				)}

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,169 +1,172 @@
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
-import { pageTitleClass } from "../lib/headingClasses";
+import PageHeaderBand from "../components/PageHeaderBand";
+import DocumentOutline from "../components/DocumentOutline";
+import DocumentSection from "../components/DocumentSection";
 
 export default function PrivacyPolicyPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("privacyPolicy.title"));
-	usePageToolbar([{ label: t("privacyPolicy.title") }]);
 
-	const linkClass = "text-brand-700 underline";
+	const linkClass =
+		"font-medium text-brand-700 underline underline-offset-2 hover:text-brand-800";
+
+	// Ids are stable slugs rather than the section numbers, so an anchor a
+	// visitor bookmarked still points at the same clause if a section is ever
+	// inserted above it.
+	const sections = [
+		{ id: "controller", label: t("privacyPolicy.section1Title") },
+		{ id: "data-collected", label: t("privacyPolicy.section2Title") },
+		{ id: "third-parties", label: t("privacyPolicy.section3Title") },
+		{ id: "legal-basis", label: t("privacyPolicy.section4Title") },
+		{ id: "retention", label: t("privacyPolicy.section5Title") },
+		{ id: "your-rights", label: t("privacyPolicy.section6Title") },
+		{ id: "cookies", label: t("privacyPolicy.section7Title") },
+		{ id: "security", label: t("privacyPolicy.section8Title") },
+		{ id: "changes", label: t("privacyPolicy.section9Title") },
+	];
 
 	return (
-		<div data-content-wrapper className="max-w-2xl">
-			<h1 className={`mb-2 text-gray-900 ${pageTitleClass}`}>
-				{t("privacyPolicy.title")}
-			</h1>
-			<p className="mb-6 text-sm text-gray-500">
-				{t("privacyPolicy.lastUpdated")}
-			</p>
+		<>
+			<PageHeaderBand
+				eyebrow={t("privacyPolicy.eyebrow")}
+				title={t("privacyPolicy.title")}
+			>
+				<span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1.5 text-sm font-medium text-brand-100">
+					{t("privacyPolicy.lastUpdated")}
+				</span>
+			</PageHeaderBand>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section1Title")}
-				</h2>
-				<p
-					className="leading-relaxed text-gray-700"
-					style={{ whiteSpace: "pre-line" }}
-				>
-					{t("privacyPolicy.section1Body")}
-				</p>
-			</section>
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-10 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-16"
+			>
+				<DocumentOutline entries={sections} label={t("common.onThisPage")} />
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section2Title")}
-				</h2>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section2Body1")}
-				</p>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section2Body2")}
-				</p>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section2Body3")}
-				</p>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section2Body4")}
-				</p>
-			</section>
-
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section3Title")}
-				</h2>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section3Body")}
-				</p>
-
-				<h3 className="mb-1 text-lg font-medium">
-					{t("privacyPolicy.section3aTitle")}
-				</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="privacyPolicy.section3aBody"
-						components={{
-							termsLink: <Link to="/terms-of-use" className={linkClass} />,
-						}}
-					/>
-				</p>
-
-				<h3 className="mb-1 text-lg font-medium">
-					{t("privacyPolicy.section3bTitle")}
-				</h3>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section3bBody")}
-				</p>
-
-				<h3 className="mb-1 text-lg font-medium">
-					{t("privacyPolicy.section3cTitle")}
-				</h3>
-				<p className="mb-2 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section3cBody")}
-				</p>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section3cLinksIntro")}{" "}
-					<a
-						href="https://wiki.osmfoundation.org/wiki/Privacy_Policy"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+				<div className="min-w-0 space-y-10">
+					<DocumentSection
+						id="controller"
+						number={1}
+						title={t("privacyPolicy.section1Title")}
 					>
-						{t("privacyPolicy.section3cLinkOsm")}
-					</a>
-					{", "}
-					<a
-						href="https://operations.osmfoundation.org/policies/nominatim/"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+						<p className="whitespace-pre-line">
+							{t("privacyPolicy.section1Body")}
+						</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="data-collected"
+						number={2}
+						title={t("privacyPolicy.section2Title")}
 					>
-						{t("privacyPolicy.section3cLinkNominatim")}
-					</a>
-				</p>
-			</section>
+						<p>{t("privacyPolicy.section2Body1")}</p>
+						<p>{t("privacyPolicy.section2Body2")}</p>
+						<p>{t("privacyPolicy.section2Body3")}</p>
+						<p>{t("privacyPolicy.section2Body4")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section4Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section4Body")}
-				</p>
-			</section>
+					<DocumentSection
+						id="third-parties"
+						number={3}
+						title={t("privacyPolicy.section3Title")}
+					>
+						<p>{t("privacyPolicy.section3Body")}</p>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section5Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section5Body")}
-				</p>
-			</section>
+						<h3 className="pt-2 text-lg font-semibold text-gray-900">
+							{t("privacyPolicy.section3aTitle")}
+						</h3>
+						<p>
+							<Trans
+								i18nKey="privacyPolicy.section3aBody"
+								components={{
+									termsLink: <Link to="/terms-of-use" className={linkClass} />,
+								}}
+							/>
+						</p>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section6Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section6Body")}
-				</p>
-			</section>
+						<h3 className="pt-2 text-lg font-semibold text-gray-900">
+							{t("privacyPolicy.section3bTitle")}
+						</h3>
+						<p>{t("privacyPolicy.section3bBody")}</p>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section7Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section7Body")}
-				</p>
-			</section>
+						<h3 className="pt-2 text-lg font-semibold text-gray-900">
+							{t("privacyPolicy.section3cTitle")}
+						</h3>
+						<p>{t("privacyPolicy.section3cBody")}</p>
+						<p>
+							{t("privacyPolicy.section3cLinksIntro")}{" "}
+							<a
+								href="https://wiki.osmfoundation.org/wiki/Privacy_Policy"
+								target="_blank"
+								rel="noopener noreferrer"
+								className={linkClass}
+							>
+								{t("privacyPolicy.section3cLinkOsm")}
+							</a>
+							{", "}
+							<a
+								href="https://operations.osmfoundation.org/policies/nominatim/"
+								target="_blank"
+								rel="noopener noreferrer"
+								className={linkClass}
+							>
+								{t("privacyPolicy.section3cLinkNominatim")}
+							</a>
+						</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section8Title")}
-				</h2>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section8Body1")}
-				</p>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section8Body2")}
-				</p>
-			</section>
+					<DocumentSection
+						id="legal-basis"
+						number={4}
+						title={t("privacyPolicy.section4Title")}
+					>
+						<p>{t("privacyPolicy.section4Body")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("privacyPolicy.section9Title")}
-				</h2>
-				<p className="mb-4 leading-relaxed text-gray-700">
-					{t("privacyPolicy.section9Body1")}
-				</p>
-				<p className="leading-relaxed text-gray-700">
-					{t("privacyPolicy.section9Body2")}
-				</p>
-			</section>
-		</div>
+					<DocumentSection
+						id="retention"
+						number={5}
+						title={t("privacyPolicy.section5Title")}
+					>
+						<p>{t("privacyPolicy.section5Body")}</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="your-rights"
+						number={6}
+						title={t("privacyPolicy.section6Title")}
+					>
+						<p>{t("privacyPolicy.section6Body")}</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="cookies"
+						number={7}
+						title={t("privacyPolicy.section7Title")}
+					>
+						<p>{t("privacyPolicy.section7Body")}</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="security"
+						number={8}
+						title={t("privacyPolicy.section8Title")}
+					>
+						<p>{t("privacyPolicy.section8Body1")}</p>
+						<p>{t("privacyPolicy.section8Body2")}</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="changes"
+						number={9}
+						title={t("privacyPolicy.section9Title")}
+					>
+						<p>{t("privacyPolicy.section9Body1")}</p>
+						<p>{t("privacyPolicy.section9Body2")}</p>
+					</DocumentSection>
+				</div>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -5,16 +5,15 @@ import { Trans, useTranslation } from "react-i18next";
 import type { MyProfileResponse, StreakSummary } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import { usePageTitle } from "../../hooks/usePageTitle";
-import { usePageToolbar } from "../../contexts/ToolbarContext";
 import { useEditModeQuickActions } from "../../hooks/useEditModeQuickActions";
 import { inputClass, labelClass, textareaClass } from "../../lib/formClasses";
-import { pageTitleClass } from "../../lib/headingClasses";
-import { cardSubtleClass } from "../../lib/surfaceClasses";
+import { cardClass, cardSubtleClass } from "../../lib/surfaceClasses";
 import Chip, { type ChipTone } from "../../components/Chip";
 import Dropdown from "../../components/Dropdown";
 import EmptyState from "../../components/EmptyState";
 import ProfileFieldsView from "../../components/ProfileFieldsView";
 import ProfileSubNav from "../../components/ProfileSubNav";
+import PageHeaderBand from "../../components/PageHeaderBand";
 import SectionHeading from "../../components/SectionHeading";
 import Skeleton from "../../components/Skeleton";
 import LoadMoreError from "../../components/LoadMoreError";
@@ -159,7 +158,6 @@ export default function ProfileOverviewPage() {
 	const [searchParams] = useSearchParams();
 	const navigate = useNavigate();
 	usePageTitle(t("profile.title"));
-	usePageToolbar([{ label: t("breadcrumb.profile") }]);
 
 	const [profile, setProfile] = useState<MyProfileResponse | null>(null);
 	const [profileLoading, setProfileLoading] = useState(true);
@@ -341,393 +339,444 @@ export default function ProfileOverviewPage() {
 		!form.state.preferredLanguage;
 
 	return (
+		// max-w-5xl (#1755): unconstrained this inherited <main>'s 90rem, which
+		// stretched the identity band to ~1376x130 around two lines of text and
+		// pulled the six badges out to 160px-wide slivers. The content is a
+		// person, a couple of stats and six badges - it needs a column, not the
+		// full page.
 		<>
-			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
-				{t("profile.title")}
-			</h1>
+			<PageHeaderBand
+				eyebrow={t("profile.eyebrow")}
+				title={t("profile.title")}
+			/>
 
-			<ProfileSubNav active="profile" />
-
-			{profileLoading && (
-				<div
-					className={`mb-6 flex items-center gap-4 ${cardSubtleClass}`}
-					role="status"
-				>
-					<span className="sr-only">{t("profile.loading")}</span>
-					<Skeleton className="h-16 w-16 shrink-0 rounded-full" />
-					<div className="flex-1 space-y-2">
-						<Skeleton className="h-5 w-40" />
-						<Skeleton className="h-4 w-24" />
-					</div>
-				</div>
-			)}
-
-			{!profileLoading && (
-				<>
-					{profileError && (
-						<LoadMoreError
-							message={profileError}
-							retrying={retryingProfileLoad}
-							onRetry={handleRetryProfileLoad}
-						/>
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-8 lg:grid-cols-[11rem_minmax(0,1fr)] lg:gap-12"
+			>
+				<ProfileSubNav active="profile" />
+				<div className="min-w-0">
+					{profileLoading && (
+						<div
+							className={`mb-6 flex items-center gap-4 ${cardSubtleClass}`}
+							role="status"
+						>
+							<span className="sr-only">{t("profile.loading")}</span>
+							<Skeleton className="h-16 w-16 shrink-0 rounded-full" />
+							<div className="flex-1 space-y-2">
+								<Skeleton className="h-5 w-40" />
+								<Skeleton className="h-4 w-24" />
+							</div>
+						</div>
 					)}
-					{/* Always mounted (not conditional on `successMessage`) so the live
+
+					{!profileLoading && (
+						<>
+							{profileError && (
+								<LoadMoreError
+									message={profileError}
+									retrying={retryingProfileLoad}
+									onRetry={handleRetryProfileLoad}
+								/>
+							)}
+							{/* Always mounted (not conditional on `successMessage`) so the live
 					region is registered before it ever gets content - see
 					CheckInModal.tsx's identical pattern for why. SuccessBanner itself
 					collapses to sr-only when `message` is empty, so this stays mounted
 					across the toggle. */}
-					<SuccessBanner message={successMessage} className="mb-4" />
+							<SuccessBanner message={successMessage} className="mb-4" />
 
-					{/* Identity + momentum hero */}
-					{!editing && (
-						<div
-							className={`mb-6 flex flex-col gap-4 ${cardSubtleClass} sm:flex-row sm:items-center sm:justify-between`}
-						>
-							<div className="flex items-center gap-4">
-								{avatarUrl ? (
-									<img
-										src={avatarUrl}
-										alt=""
-										width={64}
-										height={64}
-										className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-brand-100"
-									/>
-								) : (
-									<span className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-										{profile?.username?.charAt(0).toUpperCase() ?? "?"}
-									</span>
-								)}
-								<div>
-									<p className="text-xl font-semibold text-gray-900">
-										{form.state.firstName || form.state.lastName
-											? `${form.state.firstName} ${form.state.lastName}`.trim()
-											: profile?.username}
-									</p>
-									<p className="text-sm text-gray-500">@{profile?.username}</p>
-									<p className="text-sm text-gray-500">{profile?.email}</p>
-								</div>
-							</div>
-
-							{streaks && (
-								<div className="flex flex-wrap gap-3">
-									<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
-										<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
-											<FireIcon />
-										</span>
-										<div>
-											<p className="text-xl font-bold text-gray-900">
-												{streaks.loginStreak}
+							{/* Identity + momentum hero. Was a gray-50 panel (#1755): the
+					person is the subject of this page, and rendering their own
+					name, handle and avatar as a grey utility strip - the largest
+					flat surface on the page - was most of why it read as dead.
+					Pale-mint brand stage instead, the same tier the landing page's
+					founder band uses, with the avatar ringed in white so it reads
+					as a portrait rather than another tile. */}
+							{!editing && (
+								<div className="mb-8 flex flex-col gap-5 rounded-card bg-brand-100 p-5 sm:flex-row sm:items-center sm:justify-between sm:p-6">
+									<div className="flex items-center gap-4">
+										{avatarUrl ? (
+											<img
+												src={avatarUrl}
+												alt=""
+												width={72}
+												height={72}
+												className="h-18 w-18 shrink-0 rounded-full object-cover ring-3 ring-white"
+											/>
+										) : (
+											<span className="flex h-18 w-18 shrink-0 items-center justify-center rounded-full bg-white text-2xl font-semibold text-brand-700 ring-3 ring-white">
+												{profile?.username?.charAt(0).toUpperCase() ?? "?"}
+											</span>
+										)}
+										<div className="min-w-0">
+											<p className="font-display text-3xl font-bold text-gray-900">
+												{form.state.firstName || form.state.lastName
+													? `${form.state.firstName} ${form.state.lastName}`.trim()
+													: profile?.username}
 											</p>
-											<p className="text-xs text-gray-500">
-												{t("achievements.loginStreak", {
-													count: streaks.loginStreak,
-												})}
+											<p className="text-sm text-brand-800">
+												@{profile?.username}
+											</p>
+											<p className="truncate text-sm text-brand-800">
+												{profile?.email}
 											</p>
 										</div>
 									</div>
-									<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
-										<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
-											<CalendarIcon />
-										</span>
-										<div>
-											<p className="text-xl font-bold text-gray-900">
-												{streaks.activityStreak}
-											</p>
-											<p className="text-xs text-gray-500">
-												{t("achievements.activityStreak", {
-													count: streaks.activityStreak,
-												})}
-											</p>
+
+									{streaks && (
+										<div className="flex flex-wrap gap-3">
+											<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
+												<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+													<FireIcon />
+												</span>
+												<div>
+													<p className="text-xl font-bold text-gray-900">
+														{streaks.loginStreak}
+													</p>
+													<p className="text-xs text-gray-500">
+														{t("achievements.loginStreak", {
+															count: streaks.loginStreak,
+														})}
+													</p>
+												</div>
+											</div>
+											<div className="flex items-center gap-3 rounded-card border border-gray-100 bg-white px-4 py-3">
+												<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+													<CalendarIcon />
+												</span>
+												<div>
+													<p className="text-xl font-bold text-gray-900">
+														{streaks.activityStreak}
+													</p>
+													<p className="text-xs text-gray-500">
+														{t("achievements.activityStreak", {
+															count: streaks.activityStreak,
+														})}
+													</p>
+												</div>
+											</div>
 										</div>
-									</div>
+									)}
 								</div>
 							)}
-						</div>
-					)}
 
-					{/* Profile details */}
-					<section className="mb-6">
-						<SectionHeading>{t("profile.sectionDetails")}</SectionHeading>
-						<p className="mb-4 text-sm text-gray-600">
-							<Trans
-								i18nKey="profile.publicProfileNotice"
-								components={{
-									privacyLink: (
-										<Link to="/privacy-policy" className="underline" />
-									),
-								}}
-							/>
-						</p>
+							{/* Profile details */}
+							<section className="mb-10">
+								<SectionHeading>{t("profile.sectionDetails")}</SectionHeading>
 
-						{!editing &&
-							(isProfileFieldsEmpty ? (
-								<EmptyState
-									title={t("profile.emptyStateTitle")}
-									message={t("profile.emptyStateMessage")}
-									action={{
-										label: t("profile.emptyStateCta"),
-										onClick: () => setEditing(true),
-									}}
-								/>
-							) : (
-								<ProfileFieldsView
-									bio={form.state.bio}
-									skills={form.state.skills}
-									languages={form.state.languages}
-									preferredContact={form.state.preferredContact || null}
-									phone={form.state.phone || null}
-									preferredLanguage={form.state.preferredLanguage}
-								/>
-							))}
+								{!editing &&
+									(isProfileFieldsEmpty ? (
+										<EmptyState
+											title={t("profile.emptyStateTitle")}
+											message={t("profile.emptyStateMessage")}
+											action={{
+												label: t("profile.emptyStateCta"),
+												onClick: () => setEditing(true),
+											}}
+										/>
+									) : (
+										// Boxed, like the identity band above and the badges
+										// below: as bare label/value pairs on white this was the
+										// one section on the page with no surface of its own.
+										<div className={`${cardClass} sm:p-6`}>
+											<ProfileFieldsView
+												bio={form.state.bio}
+												skills={form.state.skills}
+												languages={form.state.languages}
+												preferredContact={form.state.preferredContact || null}
+												phone={form.state.phone || null}
+												preferredLanguage={form.state.preferredLanguage}
+											/>
+										</div>
+									))}
 
-						{editing && (
-							<form ref={formRef} onSubmit={handleSave} className="space-y-6">
-								<div>
-									<h3 className="mb-4 text-sm font-semibold text-gray-900">
-										{t("account.title")}
-									</h3>
-									<div className="space-y-5">
+								{/* Small print under the fields, not a lead paragraph above
+						them (#1755): as the first thing in the section it made a
+						privacy footnote look like the section's actual content, on a
+						page where the section otherwise holds very little. */}
+								{!editing && (
+									<p className="mt-4 text-xs text-gray-500">
+										<Trans
+											i18nKey="profile.publicProfileNotice"
+											components={{
+												privacyLink: (
+													<Link to="/privacy-policy" className="underline" />
+												),
+											}}
+										/>
+									</p>
+								)}
+
+								{editing && (
+									<form
+										ref={formRef}
+										onSubmit={handleSave}
+										className="space-y-6"
+									>
 										<div>
-											<p className={`mb-1 ${labelClass}`}>
-												{t("profile.fieldAvatar")}
-											</p>
-											<div className="flex items-center gap-4">
-												{avatarUrl ? (
-													<img
-														src={avatarUrl}
-														alt=""
-														width={64}
-														height={64}
-														className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
-													/>
-												) : (
-													<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
-														{profile?.username?.charAt(0).toUpperCase() ?? "?"}
-													</span>
-												)}
+											<h3 className="mb-4 text-sm font-semibold text-gray-900">
+												{t("account.title")}
+											</h3>
+											<div className="space-y-5">
 												<div>
-													<div className="flex items-center gap-3">
-														<FileUploadButton
-															id="avatar-upload"
-															label={
-																avatarUpload.uploading
-																	? t("profile.avatarUploading")
-																	: t("profile.avatarUpload")
-															}
-															accept="image/jpeg,image/png,image/webp"
-															onChange={avatarUpload.handleChange}
-															disabled={
-																avatarUpload.uploading || avatarUpload.removing
-															}
-															inputRef={avatarUpload.inputRef}
-															ariaDescribedBy={
-																avatarUpload.error
-																	? "avatar-upload-error"
-																	: undefined
-															}
-														/>
-														{avatarUrl && (
-															<button
-																type="button"
-																data-testid="avatar-remove"
-																onClick={() => void avatarUpload.handleRemove()}
-																disabled={
-																	avatarUpload.uploading ||
-																	avatarUpload.removing
-																}
-																className="text-sm font-medium text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-															>
-																{avatarUpload.removing
-																	? t("profile.avatarRemoving")
-																	: t("profile.avatarRemove")}
-															</button>
-														)}
-													</div>
-													<p className="mt-1 text-xs text-gray-500">
-														{t("profile.avatarHint")}
+													<p className={`mb-1 ${labelClass}`}>
+														{t("profile.fieldAvatar")}
 													</p>
-													{avatarUpload.error && (
-														<p
-															id="avatar-upload-error"
-															className="mt-1 text-xs text-red-600"
-															role="alert"
-														>
-															{avatarUpload.error}
+													<div className="flex items-center gap-4">
+														{avatarUrl ? (
+															<img
+																src={avatarUrl}
+																alt=""
+																width={64}
+																height={64}
+																className="h-16 w-16 rounded-full object-cover ring-2 ring-brand-100"
+															/>
+														) : (
+															<span className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+																{profile?.username?.charAt(0).toUpperCase() ??
+																	"?"}
+															</span>
+														)}
+														<div>
+															<div className="flex items-center gap-3">
+																<FileUploadButton
+																	id="avatar-upload"
+																	label={
+																		avatarUpload.uploading
+																			? t("profile.avatarUploading")
+																			: t("profile.avatarUpload")
+																	}
+																	accept="image/jpeg,image/png,image/webp"
+																	onChange={avatarUpload.handleChange}
+																	disabled={
+																		avatarUpload.uploading ||
+																		avatarUpload.removing
+																	}
+																	inputRef={avatarUpload.inputRef}
+																	ariaDescribedBy={
+																		avatarUpload.error
+																			? "avatar-upload-error"
+																			: undefined
+																	}
+																/>
+																{avatarUrl && (
+																	<button
+																		type="button"
+																		data-testid="avatar-remove"
+																		onClick={() =>
+																			void avatarUpload.handleRemove()
+																		}
+																		disabled={
+																			avatarUpload.uploading ||
+																			avatarUpload.removing
+																		}
+																		className="text-sm font-medium text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+																	>
+																		{avatarUpload.removing
+																			? t("profile.avatarRemoving")
+																			: t("profile.avatarRemove")}
+																	</button>
+																)}
+															</div>
+															<p className="mt-1 text-xs text-gray-500">
+																{t("profile.avatarHint")}
+															</p>
+															{avatarUpload.error && (
+																<p
+																	id="avatar-upload-error"
+																	className="mt-1 text-xs text-red-600"
+																	role="alert"
+																>
+																	{avatarUpload.error}
+																</p>
+															)}
+														</div>
+													</div>
+												</div>
+
+												<div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+													<Field
+														label={t("account.fieldUsername")}
+														id="username"
+													>
+														<input
+															id="username"
+															disabled
+															autoComplete="username"
+															value={profile?.username ?? ""}
+															className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+														/>
+													</Field>
+
+													<Field label={t("account.fieldEmail")} id="email">
+														<input
+															id="email"
+															disabled
+															type="email"
+															autoComplete="email"
+															value={profile?.email ?? ""}
+															className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+														/>
+														<p className="mt-1 text-xs text-gray-500">
+															{t("account.emailHint")}
 														</p>
-													)}
+													</Field>
+
+													<Field
+														label={t("account.fieldFirstName")}
+														id="first-name"
+													>
+														<input
+															id="first-name"
+															autoComplete="given-name"
+															value={form.state.firstName}
+															onChange={(e) =>
+																form.setFirstName(e.target.value)
+															}
+															className={inputClass}
+														/>
+													</Field>
+
+													<Field
+														label={t("account.fieldLastName")}
+														id="last-name"
+													>
+														<input
+															id="last-name"
+															autoComplete="family-name"
+															value={form.state.lastName}
+															onChange={(e) => form.setLastName(e.target.value)}
+															className={inputClass}
+														/>
+													</Field>
 												</div>
 											</div>
 										</div>
 
-										<div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
-											<Field label={t("account.fieldUsername")} id="username">
-												<input
-													id="username"
-													disabled
-													autoComplete="username"
-													value={profile?.username ?? ""}
-													className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+										<hr className="border-gray-200" />
+
+										<div className="space-y-5">
+											<Field label={t("profile.fieldBio")} id="bio">
+												<textarea
+													id="bio"
+													rows={4}
+													value={form.state.bio}
+													placeholder={t("profile.bioPlaceholder")}
+													onChange={(e) => form.setBio(e.target.value)}
+													className={textareaClass}
 												/>
 											</Field>
 
-											<Field label={t("account.fieldEmail")} id="email">
-												<input
-													id="email"
-													disabled
-													type="email"
-													autoComplete="email"
-													value={profile?.email ?? ""}
-													className={`${inputClass} cursor-not-allowed bg-gray-50 text-gray-500`}
+											<Field label={t("profile.fieldSkills")} id="skill-input">
+												<ChipInput
+													inputRef={form.skillInputRef}
+													inputId="skill-input"
+													chips={form.state.skills}
+													inputValue={form.state.skillInput}
+													placeholder={t("profile.skillsPlaceholder")}
+													onInputChange={form.setSkillInput}
+													onAdd={form.addSkill}
+													onRemove={form.removeSkill}
+													removeLabel={t("profile.removeChip")}
 												/>
-												<p className="mt-1 text-xs text-gray-500">
-													{t("account.emailHint")}
-												</p>
 											</Field>
 
 											<Field
-												label={t("account.fieldFirstName")}
-												id="first-name"
+												label={t("profile.fieldLanguages")}
+												id="lang-input"
 											>
+												<ChipInput
+													inputRef={form.langInputRef}
+													inputId="lang-input"
+													chips={form.state.languages}
+													inputValue={form.state.langInput}
+													placeholder={t("profile.languagesPlaceholder")}
+													onInputChange={form.setLangInput}
+													onAdd={form.addLanguage}
+													onRemove={form.removeLanguage}
+													removeLabel={t("profile.removeChip")}
+													tone="neutral"
+												/>
+											</Field>
+
+											<Field label={t("profile.fieldPhone")} id="phone">
 												<input
-													id="first-name"
-													autoComplete="given-name"
-													value={form.state.firstName}
-													onChange={(e) => form.setFirstName(e.target.value)}
+													id="phone"
+													type="tel"
+													autoComplete="tel"
+													value={form.state.phone}
+													placeholder={t("profile.phonePlaceholder")}
+													onChange={(e) => form.setPhone(e.target.value)}
 													className={inputClass}
 												/>
 											</Field>
 
-											<Field label={t("account.fieldLastName")} id="last-name">
-												<input
-													id="last-name"
-													autoComplete="family-name"
-													value={form.state.lastName}
-													onChange={(e) => form.setLastName(e.target.value)}
+											<Field
+												label={t("profile.fieldPreferredContact")}
+												id="preferred-contact"
+											>
+												<Dropdown
+													id="preferred-contact"
+													value={form.state.preferredContact}
+													onChange={(v) =>
+														form.setPreferredContact(v as ContactPref)
+													}
 													className={inputClass}
+													options={[
+														{
+															value: "",
+															label: t("profile.preferredContactNone"),
+														},
+														{
+															value: "Email",
+															label: t("profile.preferredContactEmail"),
+														},
+														{
+															value: "Phone",
+															label: t("profile.preferredContactPhone"),
+														},
+													]}
+												/>
+											</Field>
+
+											<Field
+												label={t("profile.fieldPreferredLanguage")}
+												id="preferred-language"
+											>
+												<Dropdown
+													id="preferred-language"
+													value={form.state.preferredLanguage}
+													onChange={(v) =>
+														form.setPreferredLanguage(v as PreferredLanguage)
+													}
+													className={inputClass}
+													options={[
+														{
+															value: "de",
+															label: t("profile.preferredLanguageDe"),
+														},
+														{
+															value: "en",
+															label: t("profile.preferredLanguageEn"),
+														},
+													]}
 												/>
 											</Field>
 										</div>
-									</div>
-								</div>
+									</form>
+								)}
+							</section>
+						</>
+					)}
 
-								<hr className="border-gray-200" />
-
-								<div className="space-y-5">
-									<Field label={t("profile.fieldBio")} id="bio">
-										<textarea
-											id="bio"
-											rows={4}
-											value={form.state.bio}
-											placeholder={t("profile.bioPlaceholder")}
-											onChange={(e) => form.setBio(e.target.value)}
-											className={textareaClass}
-										/>
-									</Field>
-
-									<Field label={t("profile.fieldSkills")} id="skill-input">
-										<ChipInput
-											inputRef={form.skillInputRef}
-											inputId="skill-input"
-											chips={form.state.skills}
-											inputValue={form.state.skillInput}
-											placeholder={t("profile.skillsPlaceholder")}
-											onInputChange={form.setSkillInput}
-											onAdd={form.addSkill}
-											onRemove={form.removeSkill}
-											removeLabel={t("profile.removeChip")}
-										/>
-									</Field>
-
-									<Field label={t("profile.fieldLanguages")} id="lang-input">
-										<ChipInput
-											inputRef={form.langInputRef}
-											inputId="lang-input"
-											chips={form.state.languages}
-											inputValue={form.state.langInput}
-											placeholder={t("profile.languagesPlaceholder")}
-											onInputChange={form.setLangInput}
-											onAdd={form.addLanguage}
-											onRemove={form.removeLanguage}
-											removeLabel={t("profile.removeChip")}
-											tone="neutral"
-										/>
-									</Field>
-
-									<Field label={t("profile.fieldPhone")} id="phone">
-										<input
-											id="phone"
-											type="tel"
-											autoComplete="tel"
-											value={form.state.phone}
-											placeholder={t("profile.phonePlaceholder")}
-											onChange={(e) => form.setPhone(e.target.value)}
-											className={inputClass}
-										/>
-									</Field>
-
-									<Field
-										label={t("profile.fieldPreferredContact")}
-										id="preferred-contact"
-									>
-										<Dropdown
-											id="preferred-contact"
-											value={form.state.preferredContact}
-											onChange={(v) =>
-												form.setPreferredContact(v as ContactPref)
-											}
-											className={inputClass}
-											options={[
-												{
-													value: "",
-													label: t("profile.preferredContactNone"),
-												},
-												{
-													value: "Email",
-													label: t("profile.preferredContactEmail"),
-												},
-												{
-													value: "Phone",
-													label: t("profile.preferredContactPhone"),
-												},
-											]}
-										/>
-									</Field>
-
-									<Field
-										label={t("profile.fieldPreferredLanguage")}
-										id="preferred-language"
-									>
-										<Dropdown
-											id="preferred-language"
-											value={form.state.preferredLanguage}
-											onChange={(v) =>
-												form.setPreferredLanguage(v as PreferredLanguage)
-											}
-											className={inputClass}
-											options={[
-												{
-													value: "de",
-													label: t("profile.preferredLanguageDe"),
-												},
-												{
-													value: "en",
-													label: t("profile.preferredLanguageEn"),
-												},
-											]}
-										/>
-									</Field>
-								</div>
-							</form>
-						)}
-					</section>
-				</>
-			)}
-
-			{/* Mounted unconditionally (not gated behind profileLoading) so its own
+					{/* Mounted unconditionally (not gated behind profileLoading) so its own
 			independent data fetch starts immediately, and so its section id
 			exists right away for the legacy ?tab=achievements scroll-to-section
 			effect above regardless of how long the profile fetch takes. */}
-			<AchievementsSection />
+					<AchievementsSection />
+				</div>
+			</div>
 
 			{avatarUpload.croppingFile && (
 				<ImageCropModal

--- a/frontend/src/pages/ProfileSettingsPage/DangerZoneCard.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/DangerZoneCard.tsx
@@ -46,6 +46,10 @@ export default function DangerZoneCard() {
 	return (
 		<>
 			<DangerZonePanel
+				// Capped to the same measure as the notification card above, so
+				// the two panels on this page share an edge instead of the red
+				// one running 600px wider than the white one (#1755).
+				className="max-w-3xl"
 				title={t("account.dangerZoneTitle")}
 				description={t("account.dangerZoneDescription")}
 				actionLabel={t("account.deleteAccountButton")}

--- a/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { NotificationPreferencesResponse } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
 import { getApiErrorMessage } from "../../lib/apiError";
-import { cardSubtleClass } from "../../lib/surfaceClasses";
+import { cardClass } from "../../lib/surfaceClasses";
 import Button from "../../components/Button";
 import PageSectionHeading from "../../components/PageSectionHeading";
 import Skeleton from "../../components/Skeleton";
@@ -101,7 +101,12 @@ export default function NotificationPreferencesSection() {
 	}
 
 	return (
-		<section className={`mb-6 ${cardSubtleClass}`}>
+		// White card, not the gray-50 cardSubtleClass: this is the page's primary
+		// content, not an aside, and a grey slab was the largest surface on it.
+		// max-w-3xl caps the measure inside the page's shared max-w-5xl column -
+		// a checkbox list has no reason to run the full width even though the
+		// column does (see the note on the page's own wrapper).
+		<section className={`mb-6 max-w-3xl ${cardClass} sm:p-6`}>
 			<PageSectionHeading>
 				{t("notificationPreferences.title")}
 			</PageSectionHeading>

--- a/frontend/src/pages/ProfileSettingsPage/index.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/index.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { usePageTitle } from "../../hooks/usePageTitle";
-import { usePageToolbar } from "../../contexts/ToolbarContext";
-import { pageTitleClass } from "../../lib/headingClasses";
 import ProfileSubNav from "../../components/ProfileSubNav";
+import PageHeaderBand from "../../components/PageHeaderBand";
 import NotificationPreferencesSection from "./NotificationPreferencesSection";
 import DangerZoneCard from "./DangerZoneCard";
 
@@ -13,21 +12,24 @@ import DangerZoneCard from "./DangerZoneCard";
 export default function ProfileSettingsPage() {
 	const { t } = useTranslation();
 	usePageTitle(t("profileSettings.title"));
-	usePageToolbar([
-		{ label: t("breadcrumb.profile"), href: "/profile" },
-		{ label: t("profileSettings.title") },
-	]);
 
 	return (
 		<>
-			<h1 className={`mb-6 text-gray-900 ${pageTitleClass}`}>
-				{t("profileSettings.title")}
-			</h1>
+			<PageHeaderBand
+				eyebrow={t("profile.eyebrow")}
+				title={t("profileSettings.title")}
+			/>
 
-			<ProfileSubNav active="settings" />
-
-			<NotificationPreferencesSection />
-			<DangerZoneCard />
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-8 lg:grid-cols-[11rem_minmax(0,1fr)] lg:gap-12"
+			>
+				<ProfileSubNav active="settings" />
+				<div className="min-w-0">
+					<NotificationPreferencesSection />
+					<DangerZoneCard />
+				</div>
+			</div>
 		</>
 	);
 }

--- a/frontend/src/pages/TermsOfUsePage.tsx
+++ b/frontend/src/pages/TermsOfUsePage.tsx
@@ -1,102 +1,126 @@
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
-import { pageTitleClass } from "../lib/headingClasses";
+import PageHeaderBand from "../components/PageHeaderBand";
+import DocumentOutline from "../components/DocumentOutline";
+import DocumentSection from "../components/DocumentSection";
 
 export default function TermsOfUsePage() {
 	const { t } = useTranslation();
 	usePageTitle(t("termsOfUse.title"));
-	usePageToolbar([{ label: t("termsOfUse.title") }]);
 
-	const linkClass = "text-brand-700 underline";
+	const linkClass =
+		"font-medium text-brand-700 underline underline-offset-2 hover:text-brand-800";
+
+	// Slug ids, not numbers - see the same note in PrivacyPolicyPage.
+	const sections = [
+		{ id: "scope", label: t("termsOfUse.section1Title") },
+		{ id: "accounts", label: t("termsOfUse.section2Title") },
+		{ id: "conduct", label: t("termsOfUse.section3Title") },
+		{ id: "content", label: t("termsOfUse.section4Title") },
+		{ id: "liability", label: t("termsOfUse.section5Title") },
+		{ id: "privacy", label: t("termsOfUse.section6Title") },
+		{ id: "changes", label: t("termsOfUse.section7Title") },
+	];
 
 	return (
-		<div data-content-wrapper className="max-w-2xl">
-			<h1 className={`mb-2 text-gray-900 ${pageTitleClass}`}>
-				{t("termsOfUse.title")}
-			</h1>
-			<p className="mb-8 text-sm text-gray-500">
-				{t("termsOfUse.lastUpdated")}
-			</p>
+		<>
+			<PageHeaderBand
+				eyebrow={t("termsOfUse.eyebrow")}
+				title={t("termsOfUse.title")}
+			>
+				<span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1.5 text-sm font-medium text-brand-100">
+					{t("termsOfUse.lastUpdated")}
+				</span>
+			</PageHeaderBand>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section1Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("termsOfUse.section1Body")}
-				</p>
-			</section>
+			<div
+				data-content-wrapper
+				className="mx-auto grid max-w-5xl gap-10 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-16"
+			>
+				<DocumentOutline entries={sections} label={t("common.onThisPage")} />
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section2Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("termsOfUse.section2Body")}
-				</p>
-			</section>
+				<div className="min-w-0 space-y-10">
+					<DocumentSection
+						id="scope"
+						number={1}
+						title={t("termsOfUse.section1Title")}
+					>
+						<p>{t("termsOfUse.section1Body")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section3Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("termsOfUse.section3Body")}
-				</p>
-			</section>
+					<DocumentSection
+						id="accounts"
+						number={2}
+						title={t("termsOfUse.section2Title")}
+					>
+						<p>{t("termsOfUse.section2Body")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section4Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="termsOfUse.section4Body"
-						components={{
-							contactLink: <Link to="/contact" className={linkClass} />,
-						}}
-					/>
-				</p>
-			</section>
+					<DocumentSection
+						id="conduct"
+						number={3}
+						title={t("termsOfUse.section3Title")}
+					>
+						<p>{t("termsOfUse.section3Body")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section5Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					{t("termsOfUse.section5Body")}
-				</p>
-			</section>
+					<DocumentSection
+						id="content"
+						number={4}
+						title={t("termsOfUse.section4Title")}
+					>
+						<p>
+							<Trans
+								i18nKey="termsOfUse.section4Body"
+								components={{
+									contactLink: <Link to="/contact" className={linkClass} />,
+								}}
+							/>
+						</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section6Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="termsOfUse.section6Body"
-						components={{
-							privacyLink: <Link to="/privacy-policy" className={linkClass} />,
-						}}
-					/>
-				</p>
-			</section>
+					<DocumentSection
+						id="liability"
+						number={5}
+						title={t("termsOfUse.section5Title")}
+					>
+						<p>{t("termsOfUse.section5Body")}</p>
+					</DocumentSection>
 
-			<section className="mb-8">
-				<h2 className="mb-2 text-xl font-semibold">
-					{t("termsOfUse.section7Title")}
-				</h2>
-				<p className="leading-relaxed text-gray-700">
-					<Trans
-						i18nKey="termsOfUse.section7Body"
-						components={{
-							imprintLink: <Link to="/imprint" className={linkClass} />,
-						}}
-					/>
-				</p>
-			</section>
-		</div>
+					<DocumentSection
+						id="privacy"
+						number={6}
+						title={t("termsOfUse.section6Title")}
+					>
+						<p>
+							<Trans
+								i18nKey="termsOfUse.section6Body"
+								components={{
+									privacyLink: (
+										<Link to="/privacy-policy" className={linkClass} />
+									),
+								}}
+							/>
+						</p>
+					</DocumentSection>
+
+					<DocumentSection
+						id="changes"
+						number={7}
+						title={t("termsOfUse.section7Title")}
+					>
+						<p>
+							<Trans
+								i18nKey="termsOfUse.section7Body"
+								components={{
+									imprintLink: <Link to="/imprint" className={linkClass} />,
+								}}
+							/>
+						</p>
+					</DocumentSection>
+				</div>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/UnsubscribeConfirmPage.tsx
+++ b/frontend/src/pages/UnsubscribeConfirmPage.tsx
@@ -4,7 +4,9 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { runtimeConfig } from "../lib/runtimeConfig";
 import Button from "../components/Button";
 import ErrorBanner from "../components/ErrorBanner";
+import { EnvelopeIcon } from "../components/icons";
 import { statusTitleClass } from "../lib/headingClasses";
+import { cardClass } from "../lib/surfaceClasses";
 
 // One-click-unsubscribe links in transactional emails point here instead of
 // straight at the backend's state-changing endpoint (#1725) - a mail scanner
@@ -37,23 +39,33 @@ export default function UnsubscribeConfirmPage() {
 		? `${runtimeConfig.apiUrl}/v1/users/${encodeURIComponent(userId ?? "")}/unsubscribe?type=${encodeURIComponent(type ?? "")}&token=${encodeURIComponent(token ?? "")}`
 		: undefined;
 
+	// Boxed rather than floating text on white - see the same note on
+	// UnsubscribePage, the step this one leads into (#1755).
 	return (
-		<div className="flex min-h-[70vh] items-center justify-center px-4 text-center">
-			<div className="max-w-md">
-				<h1 className={`mb-4 text-brand-700 ${statusTitleClass}`}>
+		<div className="mx-auto max-w-md py-10 sm:py-16">
+			<div className={`${cardClass} text-center sm:p-8`}>
+				<div
+					aria-hidden="true"
+					className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-brand-100 text-brand-700"
+				>
+					<EnvelopeIcon className="h-7 w-7" />
+				</div>
+				<h1 className={`mt-6 text-gray-900 ${statusTitleClass}`}>
 					{t("unsubscribeConfirm.title")}
 				</h1>
 				{isValid && confirmUrl ? (
 					<>
-						<p className="mb-8 text-black">
+						<p className="mt-4 leading-relaxed text-gray-700">
 							{t("unsubscribeConfirm.description", { type: typeLabel })}
 						</p>
-						<Button href={confirmUrl} size="lg">
+						<Button href={confirmUrl} size="lg" className="mt-8">
 							{t("unsubscribeConfirm.confirm")}
 						</Button>
 					</>
 				) : (
-					<ErrorBanner message={t("unsubscribeConfirm.invalidLink")} />
+					<div className="mt-6 text-left">
+						<ErrorBanner message={t("unsubscribeConfirm.invalidLink")} />
+					</div>
 				)}
 			</div>
 		</div>

--- a/frontend/src/pages/UnsubscribePage.tsx
+++ b/frontend/src/pages/UnsubscribePage.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { usePageTitle } from "../hooks/usePageTitle";
 import Button from "../components/Button";
+import { CheckIcon } from "../components/icons";
 import { statusTitleClass } from "../lib/headingClasses";
+import { cardClass } from "../lib/surfaceClasses";
 
 // Landing page the one-click unsubscribe link in transactional emails
 // redirects to after UnsubscribeEndpoint records the opt-out server-side
@@ -12,14 +14,26 @@ export default function UnsubscribePage() {
 	const { t } = useTranslation();
 	usePageTitle(t("unsubscribe.title"));
 
+	// Boxed rather than floating text on white: this is the end of a flow that
+	// started in an email client, so the confirmation needs an edge that says
+	// "this is the receipt" (#1755). Same treatment as UnsubscribeConfirmPage,
+	// the step immediately before it.
 	return (
-		<div className="flex min-h-[70vh] items-center justify-center px-4 text-center">
-			<div className="max-w-md">
-				<h1 className={`mb-4 text-brand-700 ${statusTitleClass}`}>
+		<div className="mx-auto max-w-md py-10 sm:py-16">
+			<div className={`${cardClass} text-center sm:p-8`}>
+				<div
+					aria-hidden="true"
+					className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-brand-100 text-brand-700"
+				>
+					<CheckIcon className="h-7 w-7" />
+				</div>
+				<h1 className={`mt-6 text-gray-900 ${statusTitleClass}`}>
 					{t("unsubscribe.title")}
 				</h1>
-				<p className="mb-8 text-black">{t("unsubscribe.description")}</p>
-				<Button to="/profile" size="lg">
+				<p className="mt-4 leading-relaxed text-gray-700">
+					{t("unsubscribe.description")}
+				</p>
+				<Button to="/profile" size="lg" className="mt-8">
 					{t("unsubscribe.manageInProfile")}
 				</Button>
 			</div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -72,7 +72,7 @@ export default function UserProfilePage() {
 					</div>
 				</div>
 				<Skeleton className="mb-4 h-4 w-32" />
-				<div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
+				<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
 					{Array.from({ length: 6 }).map((_, i) => (
 						<Skeleton key={i} className="h-28 w-full" />
 					))}
@@ -87,18 +87,23 @@ export default function UserProfilePage() {
 		return <p className="text-gray-500">{t("userProfile.notFound")}</p>;
 
 	return (
-		<>
-			<div className="mb-8 flex items-center gap-4">
+		// max-w-5xl (#1755): unconstrained this inherited <main>'s 90rem, which
+		// pulled the three badge columns out to ~450px each around cards holding
+		// an icon and two short lines. The identity block is boxed on the same
+		// brand-100 stage /profile uses, so a visitor's own profile and someone
+		// else's read as the same object rather than two unrelated pages.
+		<div className="max-w-5xl">
+			<div className="mb-8 flex items-center gap-4 rounded-card bg-brand-100 p-5 sm:p-6">
 				{profile.avatarUrl ? (
 					<img
 						src={profile.avatarUrl}
 						alt={profile.displayName}
-						width={64}
-						height={64}
-						className="h-16 w-16 rounded-full object-cover"
+						width={72}
+						height={72}
+						className="h-18 w-18 rounded-full object-cover ring-3 ring-white"
 					/>
 				) : (
-					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-100 text-2xl font-bold text-brand-700">
+					<div className="flex h-18 w-18 items-center justify-center rounded-full bg-white text-2xl font-bold text-brand-700 ring-3 ring-white">
 						{profile.displayName.charAt(0).toUpperCase()}
 					</div>
 				)}
@@ -106,7 +111,7 @@ export default function UserProfilePage() {
 					<h1 className={`text-gray-900 ${pageTitleClass}`}>
 						{profile.displayName}
 					</h1>
-					<p className="mt-0.5 text-sm text-gray-500">
+					<p className="mt-0.5 text-sm text-brand-800">
 						{t("userProfile.engagementCount", {
 							count: profile.engagementCount,
 						})}
@@ -144,6 +149,6 @@ export default function UserProfilePage() {
 				<SectionHeading>{t("achievements.badgesTitle")}</SectionHeading>
 				<BadgeGrid earned={profile.badges} catalog={catalog} loading={false} />
 			</section>
-		</>
+		</div>
 	);
 }

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -14,7 +14,6 @@ import {
 	formatParticipationType,
 	formatPostedAgo,
 } from "../lib/format";
-import { pageTitleClass } from "../lib/headingClasses";
 import Chip from "../components/Chip";
 import SectionHeading from "../components/SectionHeading";
 import SignUpModal from "../components/SignUpModal";
@@ -26,12 +25,13 @@ import Button from "../components/Button";
 import Skeleton from "../components/Skeleton";
 import LoadMoreError from "../components/LoadMoreError";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
+import PageHeaderBand from "../components/PageHeaderBand";
+import PublicOpportunityCard from "../components/PublicOpportunityCard";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { usePageToolbar } from "../contexts/ToolbarContext";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
 import { signinLocaleArgs } from "../lib/authLocale";
-import { cardClass, cardSubtleClass } from "../lib/surfaceClasses";
+import { cardClass } from "../lib/surfaceClasses";
 import {
 	CalendarIcon,
 	EnvelopeIcon,
@@ -64,17 +64,6 @@ export default function VolunteerOpportunityDetailPage() {
 	const [opportunity, setOpportunity] =
 		useState<VolunteerOpportunityDetails | null>(null);
 	usePageTitle(opportunity?.title);
-	usePageToolbar(
-		opportunity
-			? [
-					{
-						label: opportunity.organizationName,
-						href: `/organizations/${opportunity.organizationId}`,
-					},
-					{ label: opportunity.title },
-				]
-			: [],
-	);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [showSignUp, setShowSignUp] = useState(false);
@@ -245,7 +234,9 @@ export default function VolunteerOpportunityDetailPage() {
 			<div className="mx-auto max-w-4xl" role="status">
 				<span className="sr-only">{t("opportunities.loading")}</span>
 				<Skeleton className="mb-6 h-56 w-full sm:h-72" />
-				<div className="mx-auto max-w-2xl">
+				{/* Same flush-left reading column as the loaded page below, so the
+				skeleton doesn't sit at a different x than the content replacing it. */}
+				<div className="max-w-2xl">
 					<div className="mb-3 flex items-center justify-between gap-3">
 						<Skeleton className="h-6 w-32 rounded-full" />
 						<Skeleton className="h-8 w-20 rounded-lg" />
@@ -307,516 +298,542 @@ export default function VolunteerOpportunityDetailPage() {
 			.slice(0, 3) ?? [];
 
 	return (
-		<div data-content-wrapper className="mx-auto max-w-4xl">
-			{/* Banner image - spans the full width of this wider wrapper; a
+		<>
+			<PageHeaderBand
+				eyebrow={
+					<Link
+						to={`/organizations/${opportunity.organizationId}`}
+						className="text-brand-200 underline-offset-2 transition-colors hover:text-white hover:underline"
+					>
+						{opportunity.organizationName}
+					</Link>
+				}
+				title={opportunity.title}
+				lead={opportunity.description ?? undefined}
+			/>
+
+			<div data-content-wrapper className="mx-auto max-w-6xl">
+				{/* Banner image - spans the full width of this wider wrapper; a
 			reading column is right for prose below, but there's no reason to
 			confine a banner to it too (#1727). */}
-			{opportunity.bannerImageUrl && (
-				<img
-					src={opportunity.bannerImageUrl}
-					alt=""
-					width={1200}
-					height={480}
-					className="mb-6 h-56 w-full rounded-card object-cover shadow-resting sm:h-72"
-				/>
-			)}
+				{opportunity.bannerImageUrl && (
+					<img
+						src={opportunity.bannerImageUrl}
+						alt=""
+						width={1200}
+						height={480}
+						className="mb-6 h-56 w-full rounded-card object-cover shadow-resting sm:h-72"
+					/>
+				)}
 
-			<div className="mx-auto max-w-2xl">
-				{/* Org chip + action buttons */}
-				<div className="mb-3 flex items-center justify-between gap-3">
-					<div className="flex min-w-0 items-center gap-2">
-						<Link
-							to={`/organizations/${opportunity.organizationId}`}
-							className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 transition-colors hover:bg-brand-100"
-						>
-							{opportunity.organizationName}
-						</Link>
-						{isDraft && isOwner && (
-							<Chip
-								tone="warning"
-								size="sm"
-								data-testid="opportunity-detail-draft-badge"
-							>
-								{t("opportunities.draftBadge")}
-							</Chip>
-						)}
-					</div>
-					<div className="flex shrink-0 gap-2">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleShare}
-							data-testid="share-opportunity"
-							aria-label={t("opportunities.shareOpportunity")}
-						>
-							<ShareIcon className="h-4 w-4" />
-							<span className="hidden sm:inline">
-								{t("opportunities.share")}
-							</span>
-						</Button>
-						{isAuthenticated && !isOwner && (
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => setShowReport(true)}
-								data-testid="report-opportunity"
-								aria-label={t("opportunities.reportOpportunity")}
-							>
-								<FlagIcon className="h-4 w-4" />
-								<span className="hidden sm:inline">
-									{t("opportunities.report")}
+				{/* Two columns from lg up (#1755). What a visitor reads to decide -
+			what it is, when, where, who runs it - stays in the reading column;
+			what they act on (deadline, their own status, the sign-up button) moves
+			into a sticky rail beside it. The CTA used to sit inline after the
+			time-slot list, which on a long opportunity put the page's only
+			conversion point below the fold while ~500px of page sat empty next to
+			it. One column below lg, where a 20rem rail would just be a narrow box
+			and the CTA is better off in reading order anyway. */}
+				<div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start lg:gap-10">
+					<div className="min-w-0">
+						{/* Flush left inside the max-w-4xl wrapper, not centred within it.
+			#1727 deliberately let the banner and the time-slot list span the
+			full wrapper while prose stayed at a reading measure - but centring
+			the prose meant the page alternated between two column widths
+			(672px title, 896px slot rows, 672px again), reading as three
+			misaligned blocks rather than one document. Sharing a left edge
+			keeps #1727's wider media and a readable measure at the same time. */}
+						<div className="max-w-2xl">
+							{/* Share/Report (and the owner's draft controls) sit on the
+							same line as the at-a-glance panel's top edge rather than
+							floating alone above an empty stretch of column - the org chip
+							that used to anchor this row moved into the band's eyebrow. */}
+							<div className="mb-4 flex items-center justify-between gap-3">
+								<div className="flex min-w-0 items-center gap-2">
+									{isDraft && isOwner && (
+										<Chip
+											tone="warning"
+											size="sm"
+											data-testid="opportunity-detail-draft-badge"
+										>
+											{t("opportunities.draftBadge")}
+										</Chip>
+									)}
+								</div>
+								<div className="flex shrink-0 gap-2">
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={handleShare}
+										data-testid="share-opportunity"
+										aria-label={t("opportunities.shareOpportunity")}
+									>
+										<ShareIcon className="h-4 w-4" />
+										<span className="hidden sm:inline">
+											{t("opportunities.share")}
+										</span>
+									</Button>
+									{isAuthenticated && !isOwner && (
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setShowReport(true)}
+											data-testid="report-opportunity"
+											aria-label={t("opportunities.reportOpportunity")}
+										>
+											<FlagIcon className="h-4 w-4" />
+											<span className="hidden sm:inline">
+												{t("opportunities.report")}
+											</span>
+										</Button>
+									)}
+									{isDraft && isOwner && (
+										<>
+											<Button
+												variant="outline"
+												size="sm"
+												onClick={() => setShowEditModal(true)}
+												data-testid="opportunity-detail-edit"
+											>
+												{t("opportunities.edit")}
+											</Button>
+											<Button
+												type="button"
+												size="sm"
+												onClick={() => void handlePublish()}
+												disabled={publishing}
+												data-testid="opportunity-detail-publish"
+											>
+												{publishing
+													? t("opportunities.publishing")
+													: t("opportunities.publish")}
+											</Button>
+										</>
+									)}
+								</div>
+							</div>
+
+							{/* At-a-glance panel (#1755). The three facts a volunteer decides
+						on - when, how, where - were three identical grey icon rows in a
+						flat white box, with the category chip, the participant count and
+						the posted-on date orphaned as three more separate lines under
+						it. One tinted panel with labelled columns gives them a hierarchy
+						and puts the page's first real colour below the band; the loose
+						lines collapse into a single meta row beneath it. */}
+							<dl className="mb-5 grid gap-5 rounded-card bg-brand-50 p-5 sm:grid-cols-3 sm:p-6">
+								<div>
+									<dt className="flex items-center gap-2 text-xs font-semibold tracking-widest text-brand-700 uppercase">
+										<CalendarIcon className="h-4 w-4 shrink-0" />
+										{t("opportunities.factWhen")}
+									</dt>
+									<dd className="mt-2 text-sm font-medium text-gray-900">
+										{formatOccurrence(opportunity.occurrence, t)}
+									</dd>
+								</div>
+
+								<div>
+									<dt className="flex items-center gap-2 text-xs font-semibold tracking-widest text-brand-700 uppercase">
+										<UserGroupIcon className="h-4 w-4 shrink-0" />
+										{t("opportunities.factFormat")}
+									</dt>
+									<dd className="mt-2 text-sm font-medium text-gray-900">
+										{formatParticipationType(opportunity.participationType, t)}
+									</dd>
+								</div>
+
+								<div>
+									<dt className="flex items-center gap-2 text-xs font-semibold tracking-widest text-brand-700 uppercase">
+										{opportunity.isRemote ? (
+											<GlobeIcon className="h-4 w-4 shrink-0" />
+										) : (
+											<MapPinIcon className="h-4 w-4 shrink-0" />
+										)}
+										{t("opportunities.factWhere")}
+									</dt>
+									<dd className="mt-2 text-sm font-medium text-gray-900">
+										{opportunity.isRemote
+											? t("opportunities.remote")
+											: `${opportunity.street} ${opportunity.houseNumber}, ${opportunity.zipCode} ${opportunity.city}`}
+									</dd>
+								</div>
+							</dl>
+
+							{/* Meta row - category, tags, headcount and posted-on, previously
+						three separate stranded lines. */}
+							<div className="mb-6 flex flex-wrap items-center gap-2">
+								{opportunity.category && (
+									<Chip tone="brand">
+										{t(`opportunities.category.${opportunity.category}`)}
+									</Chip>
+								)}
+								{opportunity.tags?.map((tag) => (
+									<Chip
+										key={tag}
+										tone="neutral"
+										to={`/?tag=${encodeURIComponent(tag)}`}
+										aria-label={t("opportunities.filterByTag", { tag })}
+									>
+										{tag}
+									</Chip>
+								))}
+								{opportunity.currentParticipantCount > 0 && (
+									<span className="text-sm font-medium text-gray-700">
+										{t("opportunities.participantsJoined", {
+											count: opportunity.currentParticipantCount,
+										})}
+									</span>
+								)}
+								<span className="text-xs text-gray-500">
+									{formatPostedAgo(
+										opportunity.createdOn as unknown as string,
+										t,
+									)}
 								</span>
-							</Button>
-						)}
-						{isDraft && isOwner && (
-							<>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setShowEditModal(true)}
-									data-testid="opportunity-detail-edit"
-								>
-									{t("opportunities.edit")}
-								</Button>
-								<Button
-									type="button"
-									size="sm"
-									onClick={() => void handlePublish()}
-									disabled={publishing}
-									data-testid="opportunity-detail-publish"
-								>
-									{publishing
-										? t("opportunities.publishing")
-										: t("opportunities.publish")}
-								</Button>
-							</>
-						)}
-					</div>
-				</div>
+							</div>
 
-				{/* Title */}
-				<h1 className={`mb-1 text-gray-900 ${pageTitleClass}`}>
-					{opportunity.title}
-				</h1>
-				<p className="mb-3 text-xs text-gray-600">
-					{formatPostedAgo(opportunity.createdOn as unknown as string, t)}
-				</p>
-
-				{/* Description */}
-				{opportunity.description && (
-					<p className="mb-6 leading-relaxed text-gray-600">
-						{opportunity.description}
-					</p>
-				)}
-
-				{/* Info card */}
-				<div className={`mb-6 space-y-3 ${cardSubtleClass}`}>
-					<div className="flex items-center gap-3 text-sm text-gray-700">
-						<CalendarIcon className="h-4 w-4 shrink-0 text-gray-400" />
-						<span>{formatOccurrence(opportunity.occurrence, t)}</span>
-					</div>
-
-					<div className="flex items-center gap-3 text-sm text-gray-700">
-						<UserGroupIcon className="h-4 w-4 shrink-0 text-gray-400" />
-						<span>
-							{formatParticipationType(opportunity.participationType, t)}
-						</span>
-					</div>
-
-					{opportunity.isRemote ? (
-						<div className="flex items-center gap-3 text-sm text-green-700">
-							<GlobeIcon className="h-4 w-4 shrink-0 text-green-500" />
-							<span>{t("opportunities.remote")}</span>
+							{/* Map */}
+							{!opportunity.isRemote &&
+								opportunity.latitude != null &&
+								opportunity.longitude != null && (
+									<div className="mb-6 overflow-hidden rounded-card border border-gray-100 shadow-resting">
+										<Suspense fallback={<Skeleton className="h-64 w-full" />}>
+											<SingleMarkerMap
+												latitude={opportunity.latitude}
+												longitude={opportunity.longitude}
+												label={`${opportunity.street} ${opportunity.houseNumber}, ${opportunity.zipCode} ${opportunity.city}`}
+											/>
+										</Suspense>
+									</div>
+								)}
 						</div>
-					) : (
-						<div className="flex items-center gap-3 text-sm text-gray-700">
-							<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
-							<span>
-								{opportunity.street} {opportunity.houseNumber},{" "}
-								{opportunity.zipCode} {opportunity.city}
-							</span>
-						</div>
-					)}
-				</div>
 
-				{/* Social proof */}
-				{opportunity.currentParticipantCount > 0 && (
-					<p className="mb-6 text-sm font-medium text-gray-600">
-						{t("opportunities.participantsJoined", {
-							count: opportunity.currentParticipantCount,
-						})}
-					</p>
-				)}
-
-				{/* Category and tags */}
-				{(opportunity.category ||
-					(opportunity.tags && opportunity.tags.length > 0)) && (
-					<div className="mb-6 flex flex-wrap gap-2">
-						{opportunity.category && (
-							<Chip tone="brand">
-								{t(`opportunities.category.${opportunity.category}`)}
-							</Chip>
-						)}
-						{opportunity.tags &&
-							opportunity.tags.map((tag) => (
-								<Chip
-									key={tag}
-									tone="neutral"
-									to={`/?tag=${encodeURIComponent(tag)}`}
-									aria-label={t("opportunities.filterByTag", { tag })}
-								>
-									{tag}
-								</Chip>
-							))}
-					</div>
-				)}
-
-				{/* Map */}
-				{!opportunity.isRemote &&
-					opportunity.latitude != null &&
-					opportunity.longitude != null && (
-						<div className="mb-6 overflow-hidden rounded-card border border-gray-100 shadow-resting">
-							<Suspense fallback={<Skeleton className="h-64 w-full" />}>
-								<SingleMarkerMap
-									latitude={opportunity.latitude}
-									longitude={opportunity.longitude}
-									label={`${opportunity.street} ${opportunity.houseNumber}, ${opportunity.zipCode} ${opportunity.city}`}
-								/>
-							</Suspense>
-						</div>
-					)}
-			</div>
-
-			{/* Time slots - a reading column has no reason to constrain a list of
+						{/* Time slots - a reading column has no reason to constrain a list of
 			date/spot rows, so this spans the wider outer wrapper (#1727). */}
-			{opportunity.participationType === "ScheduledSlots" &&
-				opportunity.timeSlots.length > 0 && (
-					<div className="mb-6">
-						<SectionHeading>
-							{t("opportunities.availableTimeSlots")}
-						</SectionHeading>
-						<ul className="space-y-2">
-							{opportunity.timeSlots.map((ts) => (
-								<li
-									key={ts.id}
-									className={`flex items-center justify-between ${cardClass} text-sm text-gray-700`}
+						{opportunity.participationType === "ScheduledSlots" &&
+							opportunity.timeSlots.length > 0 && (
+								<div className="mb-6">
+									<SectionHeading>
+										{t("opportunities.availableTimeSlots")}
+									</SectionHeading>
+									<ul className="space-y-2">
+										{opportunity.timeSlots.map((ts) => (
+											<li
+												key={ts.id}
+												className={`flex items-center justify-between ${cardClass} text-sm text-gray-700`}
+											>
+												<span>
+													{formatDateTime(
+														ts.startDateTime as unknown as string,
+														i18n.language,
+													)}
+													{" - "}
+													{formatDateTime(
+														ts.endDateTime as unknown as string,
+														i18n.language,
+													)}
+												</span>
+												<span className="ml-3 shrink-0 text-xs text-gray-600">
+													{ts.maxParticipants == null
+														? t("opportunities.unlimitedSpots")
+														: t("opportunities.maxParticipants", {
+																count: ts.maxParticipants,
+															})}
+												</span>
+											</li>
+										))}
+									</ul>
+								</div>
+							)}
+						<div className="max-w-2xl">
+							{/* About this organization */}
+							{orgProfileError && !orgProfile && (
+								<div className="mb-6" data-testid="about-organization">
+									<SectionHeading>
+										{t("opportunities.aboutOrganization")}
+									</SectionHeading>
+									<LoadMoreError
+										message={orgProfileError}
+										retrying={retryingOrgProfile}
+										onRetry={retryLoadOrgProfile}
+									/>
+								</div>
+							)}
+							{orgProfile &&
+								(orgProfile.description ||
+									orgProfile.contactEmail ||
+									orgProfile.contactPhone ||
+									orgProfile.website ||
+									orgProfile.address) && (
+									<div className="mb-6" data-testid="about-organization">
+										<SectionHeading>
+											{t("opportunities.aboutOrganization")}
+										</SectionHeading>
+										{orgProfile.description && (
+											<p className="mb-3 leading-relaxed text-gray-600">
+												{orgProfile.description}
+											</p>
+										)}
+										{(orgProfile.contactEmail ||
+											orgProfile.contactPhone ||
+											orgProfile.website ||
+											orgProfile.address) && (
+											<div
+												className={`space-y-2.5 ${cardClass} text-sm text-gray-700`}
+											>
+												{orgProfile.contactEmail && (
+													<div className="flex items-center gap-3">
+														<EnvelopeIcon className="h-4 w-4 shrink-0 text-brand-700" />
+														<a
+															href={`mailto:${orgProfile.contactEmail}`}
+															className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+														>
+															{orgProfile.contactEmail}
+														</a>
+													</div>
+												)}
+												{orgProfile.contactPhone && (
+													<div className="flex items-center gap-3">
+														<PhoneIcon className="h-4 w-4 shrink-0 text-brand-700" />
+														<a
+															href={`tel:${orgProfile.contactPhone}`}
+															className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+														>
+															{orgProfile.contactPhone}
+														</a>
+													</div>
+												)}
+												{orgProfile.website && (
+													<div className="flex items-center gap-3">
+														<GlobeIcon className="h-4 w-4 shrink-0 text-brand-700" />
+														<a
+															href={orgProfile.website}
+															target="_blank"
+															rel="noopener noreferrer"
+															className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
+														>
+															{orgProfile.website}
+														</a>
+													</div>
+												)}
+												{orgProfile.address && (
+													<div className="flex items-center gap-3">
+														<MapPinIcon className="h-4 w-4 shrink-0 text-brand-700" />
+														<span>
+															{orgProfile.address.street}{" "}
+															{orgProfile.address.houseNumber},{" "}
+															{orgProfile.address.zipCode}{" "}
+															{orgProfile.address.city}
+														</span>
+													</div>
+												)}
+											</div>
+										)}
+									</div>
+								)}
+						</div>
+					</div>
+
+					{/* sticky needs a scroll container that is not the grid item itself;
+				lg:items-start on the grid keeps this from stretching to full row
+				height, which would make top-24 have nothing left to stick against. */}
+					<aside className="lg:sticky lg:top-24">
+						<div className="space-y-6">
+							{/* Application deadline */}
+							{opportunity.participationType === "IndividualContact" &&
+								opportunity.validUntil && (
+									// Carded like the rest of the rail, and without the mb-6 the
+									// wrapping space-y-6 already provides: as a bare line above
+									// the sign-up card it was the one thing in the rail with no
+									// surface, reading as text stranded above the panel rather
+									// than as the deadline for it.
+									<div
+										className={`flex items-center gap-1.5 text-sm font-medium text-gray-700 ${cardClass}`}
+									>
+										<span>
+											{t("opportunities.applyBy", {
+												date: formatDate(
+													opportunity.validUntil as unknown as string,
+													i18n.language,
+												),
+											})}
+										</span>
+									</div>
+								)}
+
+							{/* Your application status */}
+							{isAuthenticated && !isOwner && cue && !isDraft && (
+								<div
+									data-testid="application-status"
+									className={`${cardClass} sm:p-5`}
 								>
-									<span>
-										{formatDateTime(
-											ts.startDateTime as unknown as string,
-											i18n.language,
-										)}
-										{" - "}
-										{formatDateTime(
-											ts.endDateTime as unknown as string,
-											i18n.language,
-										)}
-									</span>
-									<span className="ml-3 shrink-0 text-xs text-gray-600">
-										{ts.maxParticipants == null
-											? t("opportunities.unlimitedSpots")
-											: t("opportunities.maxParticipants", {
-													count: ts.maxParticipants,
-												})}
-									</span>
-								</li>
+									<div className="flex items-center justify-between gap-4">
+										<div>
+											<p className="mb-1 text-xs text-gray-500">
+												{t("opportunities.yourApplication")}
+											</p>
+											<Chip
+												tone={
+													cue.status === "Confirmed" ? "success" : "warning"
+												}
+												size="sm"
+											>
+												{t(`myEngagements.status.${cue.status}`)}
+											</Chip>
+										</div>
+										<Button
+											type="button"
+											variant="dangerOutline"
+											size="sm"
+											className="shrink-0"
+											onClick={() => setShowWithdrawConfirm(true)}
+											disabled={withdrawing}
+										>
+											{t("myEngagements.withdraw")}
+										</Button>
+									</div>
+								</div>
+							)}
+
+							{/* Sign-up CTA */}
+							{isAuthenticated && !isOwner && !cue && !isDraft && (
+								<div
+									data-testid="signup-cta"
+									className={`space-y-3 ${cardClass} sm:p-5`}
+								>
+									{hasUnlimitedSlot ? (
+										<p className="text-sm font-medium text-teal-700">
+											{t("opportunities.unlimitedSpots")}
+										</p>
+									) : (
+										totalMax !== null &&
+										totalMax > 0 &&
+										spotsLeft !== null && (
+											<p
+												className={`text-sm font-medium ${
+													isFull
+														? "text-red-600"
+														: spotsLeft <= 5
+															? "text-orange-700"
+															: "text-gray-600"
+												}`}
+											>
+												{isFull
+													? t("opportunities.noSpotsLeft")
+													: spotsLeft <= 5
+														? t("opportunities.fewSpotsLeft", {
+																count: spotsLeft,
+															})
+														: t("opportunities.spotsLeft", {
+																count: spotsLeft,
+															})}
+											</p>
+										)
+									)}
+									<Button
+										onClick={() => setShowSignUp(true)}
+										disabled={isFull}
+										fullWidth
+										size="lg"
+									>
+										{opportunity.participationType === "ScheduledSlots"
+											? t("opportunities.joinWaitlist")
+											: t("opportunities.expressInterest")}
+									</Button>
+								</div>
+							)}
+
+							{/* Login prompt */}
+							{!isAuthenticated && !isDraft && (
+								<div
+									data-testid="login-prompt"
+									className={`space-y-3 ${cardClass} sm:p-5`}
+								>
+									<p className="text-sm text-gray-600">
+										{t("opportunities.loginPrompt")}
+									</p>
+									<Button
+										onClick={() => auth.signinRedirect(signinLocaleArgs())}
+										data-testid="opportunity-signin"
+										fullWidth
+										size="lg"
+									>
+										{t("nav.signIn")}
+									</Button>
+								</div>
+							)}
+						</div>
+					</aside>
+				</div>
+
+				{/* More from this organization - a wider grid than the reading
+			column above so a third card doesn't orphan onto its own row on
+			desktop (#1727). */}
+				{otherOrgOpportunities.length > 0 && (
+					<div className="mb-6" data-testid="more-from-organization">
+						<SectionHeading>
+							{t("opportunities.moreFromOrganization")}
+						</SectionHeading>
+						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+							{otherOrgOpportunities.map((opp) => (
+								<PublicOpportunityCard key={opp.id} opportunity={opp} />
 							))}
 						</ul>
 					</div>
 				)}
-
-			<div className="mx-auto max-w-2xl">
-				{/* Application deadline */}
-				{opportunity.participationType === "IndividualContact" &&
-					opportunity.validUntil && (
-						<div className="mb-6 flex items-center gap-1.5 text-sm font-medium text-gray-600">
-							<span>
-								{t("opportunities.applyBy", {
-									date: formatDate(
-										opportunity.validUntil as unknown as string,
-										i18n.language,
-									),
-								})}
-							</span>
-						</div>
-					)}
-
-				{/* Your application status */}
-				{isAuthenticated && !isOwner && cue && !isDraft && (
-					<div data-testid="application-status" className={`mb-6 ${cardClass}`}>
-						<div className="flex items-center justify-between gap-4">
-							<div>
-								<p className="mb-1 text-xs text-gray-500">
-									{t("opportunities.yourApplication")}
-								</p>
-								<Chip
-									tone={cue.status === "Confirmed" ? "success" : "warning"}
-									size="sm"
-								>
-									{t(`myEngagements.status.${cue.status}`)}
-								</Chip>
-							</div>
-							<Button
-								type="button"
-								variant="dangerOutline"
-								size="sm"
-								className="shrink-0"
-								onClick={() => setShowWithdrawConfirm(true)}
-								disabled={withdrawing}
-							>
-								{t("myEngagements.withdraw")}
-							</Button>
-						</div>
-					</div>
-				)}
-
-				{/* Sign-up CTA */}
-				{isAuthenticated && !isOwner && !cue && !isDraft && (
-					<div data-testid="signup-cta" className="mb-6 space-y-3">
-						{hasUnlimitedSlot ? (
-							<p className="text-sm font-medium text-teal-700">
-								{t("opportunities.unlimitedSpots")}
-							</p>
-						) : (
-							totalMax !== null &&
-							totalMax > 0 &&
-							spotsLeft !== null && (
-								<p
-									className={`text-sm font-medium ${
-										isFull
-											? "text-red-600"
-											: spotsLeft <= 5
-												? "text-orange-700"
-												: "text-gray-600"
-									}`}
-								>
-									{isFull
-										? t("opportunities.noSpotsLeft")
-										: spotsLeft <= 5
-											? t("opportunities.fewSpotsLeft", { count: spotsLeft })
-											: t("opportunities.spotsLeft", { count: spotsLeft })}
-								</p>
-							)
-						)}
-						<Button
-							onClick={() => setShowSignUp(true)}
-							disabled={isFull}
-							fullWidth
-							size="lg"
-						>
-							{opportunity.participationType === "ScheduledSlots"
-								? t("opportunities.joinWaitlist")
-								: t("opportunities.expressInterest")}
-						</Button>
-					</div>
-				)}
-
-				{/* Login prompt */}
-				{!isAuthenticated && !isDraft && (
-					<div data-testid="login-prompt" className="mb-6 space-y-3">
-						<p className="text-sm text-gray-600">
-							{t("opportunities.loginPrompt")}
-						</p>
-						<Button
-							onClick={() => auth.signinRedirect(signinLocaleArgs())}
-							data-testid="opportunity-signin"
-							fullWidth
-							size="lg"
-						>
-							{t("nav.signIn")}
-						</Button>
-					</div>
-				)}
-
-				{/* About this organization */}
-				{orgProfileError && !orgProfile && (
-					<div className="mb-6" data-testid="about-organization">
-						<SectionHeading>
-							{t("opportunities.aboutOrganization")}
-						</SectionHeading>
-						<LoadMoreError
-							message={orgProfileError}
-							retrying={retryingOrgProfile}
-							onRetry={retryLoadOrgProfile}
-						/>
-					</div>
-				)}
-				{orgProfile &&
-					(orgProfile.description ||
-						orgProfile.contactEmail ||
-						orgProfile.contactPhone ||
-						orgProfile.website ||
-						orgProfile.address) && (
-						<div className="mb-6" data-testid="about-organization">
-							<SectionHeading>
-								{t("opportunities.aboutOrganization")}
-							</SectionHeading>
-							{orgProfile.description && (
-								<p className="mb-3 leading-relaxed text-gray-600">
-									{orgProfile.description}
-								</p>
-							)}
-							{(orgProfile.contactEmail ||
-								orgProfile.contactPhone ||
-								orgProfile.website ||
-								orgProfile.address) && (
-								<div
-									className={`space-y-2.5 ${cardSubtleClass} text-sm text-gray-700`}
-								>
-									{orgProfile.contactEmail && (
-										<div className="flex items-center gap-3">
-											<EnvelopeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-											<a
-												href={`mailto:${orgProfile.contactEmail}`}
-												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-											>
-												{orgProfile.contactEmail}
-											</a>
-										</div>
-									)}
-									{orgProfile.contactPhone && (
-										<div className="flex items-center gap-3">
-											<PhoneIcon className="h-4 w-4 shrink-0 text-gray-400" />
-											<a
-												href={`tel:${orgProfile.contactPhone}`}
-												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-											>
-												{orgProfile.contactPhone}
-											</a>
-										</div>
-									)}
-									{orgProfile.website && (
-										<div className="flex items-center gap-3">
-											<GlobeIcon className="h-4 w-4 shrink-0 text-gray-400" />
-											<a
-												href={orgProfile.website}
-												target="_blank"
-												rel="noopener noreferrer"
-												className="text-brand-700 transition-colors hover:text-brand-800 hover:underline"
-											>
-												{orgProfile.website}
-											</a>
-										</div>
-									)}
-									{orgProfile.address && (
-										<div className="flex items-center gap-3">
-											<MapPinIcon className="h-4 w-4 shrink-0 text-gray-400" />
-											<span>
-												{orgProfile.address.street}{" "}
-												{orgProfile.address.houseNumber},{" "}
-												{orgProfile.address.zipCode} {orgProfile.address.city}
-											</span>
-										</div>
-									)}
-								</div>
-							)}
-						</div>
-					)}
-			</div>
-
-			{/* More from this organization - a wider grid than the reading
-			column above so a third card doesn't orphan onto its own row on
-			desktop (#1727). */}
-			{otherOrgOpportunities.length > 0 && (
-				<div className="mb-6" data-testid="more-from-organization">
-					<SectionHeading>
-						{t("opportunities.moreFromOrganization")}
-					</SectionHeading>
-					<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-						{otherOrgOpportunities.map((opp) => (
-							<li
-								key={opp.id}
-								className={`relative flex h-full flex-col ${cardClass} transition-shadow hover:shadow-raised`}
-							>
-								<Link
-									to={`/volunteer-opportunities/${opp.id}`}
-									className="absolute inset-0 rounded-card"
-									aria-label={opp.title}
-								/>
-								<strong className="block text-sm font-semibold text-gray-900">
-									{opp.title}
-								</strong>
-								{opp.description && (
-									<p className="mt-1 line-clamp-2 text-sm text-gray-500">
-										{opp.description}
-									</p>
-								)}
-								<div className="mt-2 flex flex-wrap gap-2">
-									<Chip tone="neutral" size="sm">
-										{formatOccurrence(opp.occurrence, t)}
-									</Chip>
-									<Chip tone="brand" size="sm">
-										{formatParticipationType(opp.participationType, t)}
-									</Chip>
-									{opp.isRemote ? (
-										<Chip tone="success" size="sm">
-											{t("opportunities.remote")}
-										</Chip>
-									) : opp.street ? (
-										<Chip tone="neutral" size="sm">
-											{opp.street} {opp.houseNumber}, {opp.zipCode} {opp.city}
-										</Chip>
-									) : null}
-								</div>
-							</li>
-						))}
-					</ul>
-				</div>
-			)}
-
-			{showSignUp && (
-				<SignUpModal
-					opportunityId={opportunity.id}
-					participationType={opportunity.participationType}
-					timeSlots={opportunity.timeSlots}
-					onClose={() => setShowSignUp(false)}
-					onSuccess={() => {
-						setShowSignUp(false);
-						load();
-					}}
-				/>
-			)}
-
-			{showWithdrawConfirm && (
-				<ConfirmDialog
-					title={t("confirmDialog.withdraw.title")}
-					message={t("confirmDialog.withdraw.message")}
-					confirmLabel={t("confirmDialog.withdraw.confirm")}
-					onConfirm={handleWithdrawConfirm}
-					onClose={() => {
-						setShowWithdrawConfirm(false);
-						setWithdrawError(null);
-					}}
-					loading={withdrawing}
-					error={withdrawError}
-				/>
-			)}
-
-			{showReport && (
-				<ReportContentModal
-					targetLabel={opportunity.title}
-					onSubmit={handleReportSubmit}
-					onClose={() => setShowReport(false)}
-				/>
-			)}
-
-			{showEditModal && (
-				<Suspense
-					fallback={
-						<ModalLoadingFallback onClose={() => setShowEditModal(false)} />
-					}
-				>
-					<CreateVolunteerOpportunityModal
-						organizationId={opportunity.organizationId}
-						initialOpportunity={opportunity}
-						onClose={() => setShowEditModal(false)}
+				{showSignUp && (
+					<SignUpModal
+						opportunityId={opportunity.id}
+						participationType={opportunity.participationType}
+						timeSlots={opportunity.timeSlots}
+						onClose={() => setShowSignUp(false)}
 						onSuccess={() => {
-							setShowEditModal(false);
+							setShowSignUp(false);
 							load();
 						}}
 					/>
-				</Suspense>
-			)}
-		</div>
+				)}
+
+				{showWithdrawConfirm && (
+					<ConfirmDialog
+						title={t("confirmDialog.withdraw.title")}
+						message={t("confirmDialog.withdraw.message")}
+						confirmLabel={t("confirmDialog.withdraw.confirm")}
+						onConfirm={handleWithdrawConfirm}
+						onClose={() => {
+							setShowWithdrawConfirm(false);
+							setWithdrawError(null);
+						}}
+						loading={withdrawing}
+						error={withdrawError}
+					/>
+				)}
+
+				{showReport && (
+					<ReportContentModal
+						targetLabel={opportunity.title}
+						onSubmit={handleReportSubmit}
+						onClose={() => setShowReport(false)}
+					/>
+				)}
+
+				{showEditModal && (
+					<Suspense
+						fallback={
+							<ModalLoadingFallback onClose={() => setShowEditModal(false)} />
+						}
+					>
+						<CreateVolunteerOpportunityModal
+							organizationId={opportunity.organizationId}
+							initialOpportunity={opportunity}
+							onClose={() => setShowEditModal(false)}
+							onSuccess={() => {
+								setShowEditModal(false);
+								load();
+							}}
+						/>
+					</Suspense>
+				)}
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -10,6 +10,7 @@ import { getApiErrorMessage } from "../../lib/apiError";
 import { formatDate } from "../../lib/format";
 import { inputClass, labelClass } from "../../lib/formClasses";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
+import { cardClass } from "../../lib/surfaceClasses";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import EmptyState from "../../components/EmptyState";
 import Skeleton from "../../components/Skeleton";
@@ -163,7 +164,13 @@ export default function OrgEngagementsPage() {
 				{t("orgEngagements.pageDescription")}
 			</p>
 
-			<div className="mb-4 flex flex-wrap items-end gap-3">
+			{/* Boxed, matching the invite panel on the Members tab (#1755): a
+			status select and a search field are one filter control, and as two
+			bare form fields on the page background they read as the start of a
+			form rather than as the toolbar for the list below them. */}
+			<div
+				className={`mb-6 flex flex-wrap items-end gap-3 ${cardClass} sm:p-5`}
+			>
 				<div>
 					<label htmlFor="org-engagement-status-filter" className={labelClass}>
 						{t("orgEngagements.filterLabelStatus")}
@@ -310,7 +317,11 @@ export default function OrgEngagementsPage() {
 										})}
 									</p>
 								</div>
-								<div className="flex shrink-0 flex-col items-end gap-2">
+								{/* One row, not a stack (#1755): as flex-col the status chip
+							floated above the Confirm/Cancel pair, so the card's right
+							corner read as two loosely related clusters at different
+							heights instead of one status-and-actions group. */}
+								<div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
 									<span
 										className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${ENGAGEMENT_STATUS_COLORS[e.status] ?? "border-gray-200 bg-gray-100 text-gray-600"}`}
 									>

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -14,10 +14,12 @@ import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import Button from "../../components/Button";
 import Chip from "../../components/Chip";
+import SectionHeading from "../../components/SectionHeading";
 import ErrorBanner from "../../components/ErrorBanner";
 import SuccessBanner from "../../components/SuccessBanner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { formatDateLong } from "../../lib/format";
+import { cardClass } from "../../lib/surfaceClasses";
 
 export default function OrgMembersPage() {
 	const { org, reloadOrg, isOrganizer } = useOutletContext<OrgAppContext>();
@@ -257,7 +259,11 @@ export default function OrgMembersPage() {
 
 	return (
 		<div>
-			<div data-content-wrapper className="max-w-2xl">
+			{/* max-w-4xl, was max-w-2xl (#1755): a member row carries a name, an
+			email, a role chip and up to two actions, which at 672px left the
+			actions crowded against the name while ~700px of page sat empty
+			beside them. Still flush left, per #766. */}
+			<div data-content-wrapper className="max-w-4xl">
 				{successMessage && (
 					<SuccessBanner message={successMessage} className="mb-4" />
 				)}
@@ -265,33 +271,45 @@ export default function OrgMembersPage() {
 					<ErrorBanner message={settingsError} className="mb-4" />
 				)}
 
+				{/* Boxed, and side by side from sm up: the search field and the role
+				select are one action ("invite this person, as this"), but as two
+				full-width controls stacked on bare page they read as the start of a
+				long form and gave the page no first section at all (#1755). */}
 				{isOrganizer && (
-					<div className="mb-6">
-						<label htmlFor="member-search" className={labelClass}>
-							{t("orgSettings.inviteLabel")}
-						</label>
-						<input
-							id="member-search"
-							type="search"
-							value={memberSearch}
-							onChange={(e) => handleMemberSearchChange(e.target.value)}
-							placeholder={t("orgSettings.invitePlaceholder")}
-							className={inputClass}
-						/>
-						<label htmlFor="invite-role" className={`mt-2 ${labelClass}`}>
-							{t("orgSettings.inviteRoleLabel")}
-						</label>
-						<select
-							id="invite-role"
-							value={inviteRole}
-							onChange={(e) =>
-								setInviteRole(e.target.value as "Member" | "Organizer")
-							}
-							className={inputClass}
-						>
-							<option value="Member">{t("orgSettings.roleMember")}</option>
-							<option value="Organizer">{t("orgSettings.organisator")}</option>
-						</select>
+					<div className={`mb-8 ${cardClass} sm:p-6`}>
+						<div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_12rem]">
+							<div>
+								<label htmlFor="member-search" className={labelClass}>
+									{t("orgSettings.inviteLabel")}
+								</label>
+								<input
+									id="member-search"
+									type="search"
+									value={memberSearch}
+									onChange={(e) => handleMemberSearchChange(e.target.value)}
+									placeholder={t("orgSettings.invitePlaceholder")}
+									className={inputClass}
+								/>
+							</div>
+							<div>
+								<label htmlFor="invite-role" className={labelClass}>
+									{t("orgSettings.inviteRoleLabel")}
+								</label>
+								<select
+									id="invite-role"
+									value={inviteRole}
+									onChange={(e) =>
+										setInviteRole(e.target.value as "Member" | "Organizer")
+									}
+									className={inputClass}
+								>
+									<option value="Member">{t("orgSettings.roleMember")}</option>
+									<option value="Organizer">
+										{t("orgSettings.organisator")}
+									</option>
+								</select>
+							</div>
+						</div>
 						{memberSearchLoading && (
 							<p role="status" className="mt-1 text-xs text-gray-500">
 								{t("orgSettings.searching")}
@@ -341,9 +359,9 @@ export default function OrgMembersPage() {
 
 				{invitations.some((i) => i.status === "Pending") && (
 					<div className="mb-6">
-						<h2 className="mb-2 text-sm font-medium text-gray-700">
+						<SectionHeading>
 							{t("orgSettings.pendingInvitations")}
-						</h2>
+						</SectionHeading>
 						<ul className="divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
 							{invitations
 								.filter((i) => i.status === "Pending")
@@ -389,9 +407,9 @@ export default function OrgMembersPage() {
 
 				{invitations.some((i) => i.status === "Declined") && (
 					<div className="mb-6">
-						<h2 className="mb-2 text-sm font-medium text-gray-700">
+						<SectionHeading>
 							{t("orgSettings.declinedInvitations")}
-						</h2>
+						</SectionHeading>
 						<ul className="divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
 							{invitations
 								.filter((i) => i.status === "Declined")
@@ -424,9 +442,9 @@ export default function OrgMembersPage() {
 
 				{invitations.some((i) => i.status === "Expired") && (
 					<div className="mb-6">
-						<h2 className="mb-2 text-sm font-medium text-gray-700">
+						<SectionHeading>
 							{t("orgSettings.expiredInvitations")}
-						</h2>
+						</SectionHeading>
 						<ul className="divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
 							{invitations
 								.filter((i) => i.status === "Expired")
@@ -491,110 +509,122 @@ export default function OrgMembersPage() {
 						message={t("orgSettings.noMembersHint")}
 					/>
 				) : (
-					<ul className="divide-y divide-gray-100">
-						{members.map((member) => (
-							<li
-								key={member.userId}
-								className="flex items-center justify-between py-3"
-							>
-								<div className="min-w-0">
-									<p className="truncate text-sm font-medium text-gray-900">
-										{member.firstName && member.lastName
-											? `${member.firstName} ${member.lastName}`
-											: member.username}
-									</p>
-									<p className="truncate text-xs text-gray-500">
-										{member.email}
-									</p>
-									{member.isOrganisator && (
-										<Chip tone="brand" size="sm" className="mt-0.5">
-											{t("orgSettings.organisator")}
-										</Chip>
-									)}
-								</div>
-								{member.userId === currentUserId ? (
-									<button
-										type="button"
-										onClick={() => setShowLeaveConfirm(true)}
-										disabled={isLastOrganizer}
-										title={
-											isLastOrganizer
-												? t("orgSettings.leaveOrganizationLastOrganizerHint")
-												: undefined
-										}
-										className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
-									>
-										{t("orgSettings.leaveOrganization")}
-									</button>
-								) : isOrganizer ? (
-									<div className="flex shrink-0 items-center gap-3">
-										{(() => {
-											const memberName =
-												member.firstName && member.lastName
-													? `${member.firstName} ${member.lastName}`
-													: member.username;
-											return (
-												<>
-													<button
-														type="button"
-														onClick={() =>
-															void handleChangeMemberRole(
-																member.userId,
-																member.isOrganisator ? "Member" : "Organizer",
-															)
-														}
-														disabled={
-															changingRoleUserId === member.userId ||
-															(member.isOrganisator && organizerCount <= 1)
-														}
-														title={
-															member.isOrganisator && organizerCount <= 1
-																? t("orgSettings.changeRoleLastOrganizerHint")
-																: undefined
-														}
-														aria-label={
-															member.isOrganisator
-																? t("orgSettings.demoteToMemberNamed", {
-																		name: memberName,
-																	})
-																: t("orgSettings.promoteToOrganizerNamed", {
-																		name: memberName,
-																	})
-														}
-														className="text-xs text-brand-700 hover:text-brand-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
-													>
-														{member.isOrganisator
-															? t("orgSettings.demoteToMember")
-															: t("orgSettings.promoteToOrganizer")}
-													</button>
-													<button
-														type="button"
-														onClick={() =>
-															setRemoveTarget({
-																userId: member.userId,
-																name: memberName,
-															})
-														}
-														aria-label={t("orgSettings.removeMemberNamed", {
-															name: memberName,
-														})}
-														className="text-xs text-red-700 hover:text-red-800"
-													>
-														{t("orgSettings.removeMember")}
-													</button>
-												</>
-											);
-										})()}
+					// Boxed like every other list on this page. It was the only one
+					// left as a bare divide-y on the page background, so the page's
+					// actual subject - who is in this organization - was the one
+					// thing with no surface of its own (#1755).
+					// cardClass's own p-4 is deliberately not used here: the padding
+					// belongs on each row, not the frame, which surfaceClasses.ts
+					// calls out as the one card-like case it doesn't cover.
+					<div className="overflow-hidden rounded-card border border-gray-100 bg-white shadow-resting">
+						<ul className="divide-y divide-gray-100">
+							{members.map((member) => (
+								<li
+									key={member.userId}
+									className="flex items-center justify-between gap-4 px-4 py-4"
+								>
+									<div className="min-w-0">
+										<p className="truncate text-sm font-medium text-gray-900">
+											{member.firstName && member.lastName
+												? `${member.firstName} ${member.lastName}`
+												: member.username}
+										</p>
+										<p className="truncate text-xs text-gray-500">
+											{member.email}
+										</p>
+										{member.isOrganisator && (
+											<Chip tone="brand" size="sm" className="mt-0.5">
+												{t("orgSettings.organisator")}
+											</Chip>
+										)}
 									</div>
-								) : null}
-							</li>
-						))}
-					</ul>
-				)}
-				{isLastOrganizer && (
-					<p className="mt-3 text-xs text-gray-500">
-						{t("orgSettings.leaveOrganizationLastOrganizerHint")}
-					</p>
+									{member.userId === currentUserId ? (
+										<button
+											type="button"
+											onClick={() => setShowLeaveConfirm(true)}
+											disabled={isLastOrganizer}
+											title={
+												isLastOrganizer
+													? t("orgSettings.leaveOrganizationLastOrganizerHint")
+													: undefined
+											}
+											className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+										>
+											{t("orgSettings.leaveOrganization")}
+										</button>
+									) : isOrganizer ? (
+										<div className="flex shrink-0 items-center gap-3">
+											{(() => {
+												const memberName =
+													member.firstName && member.lastName
+														? `${member.firstName} ${member.lastName}`
+														: member.username;
+												return (
+													<>
+														<button
+															type="button"
+															onClick={() =>
+																void handleChangeMemberRole(
+																	member.userId,
+																	member.isOrganisator ? "Member" : "Organizer",
+																)
+															}
+															disabled={
+																changingRoleUserId === member.userId ||
+																(member.isOrganisator && organizerCount <= 1)
+															}
+															title={
+																member.isOrganisator && organizerCount <= 1
+																	? t("orgSettings.changeRoleLastOrganizerHint")
+																	: undefined
+															}
+															aria-label={
+																member.isOrganisator
+																	? t("orgSettings.demoteToMemberNamed", {
+																			name: memberName,
+																		})
+																	: t("orgSettings.promoteToOrganizerNamed", {
+																			name: memberName,
+																		})
+															}
+															className="text-xs text-brand-700 hover:text-brand-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+														>
+															{member.isOrganisator
+																? t("orgSettings.demoteToMember")
+																: t("orgSettings.promoteToOrganizer")}
+														</button>
+														<button
+															type="button"
+															onClick={() =>
+																setRemoveTarget({
+																	userId: member.userId,
+																	name: memberName,
+																})
+															}
+															aria-label={t("orgSettings.removeMemberNamed", {
+																name: memberName,
+															})}
+															className="text-xs text-red-700 hover:text-red-800"
+														>
+															{t("orgSettings.removeMember")}
+														</button>
+													</>
+												);
+											})()}
+										</div>
+									) : null}
+								</li>
+							))}
+						</ul>
+						{/* Footer inside the card, not loose text under it: the hint
+						explains why the row above has a disabled "Leave" action, so it
+						belongs to the list rather than to the page (#1755). */}
+						{isLastOrganizer && (
+							<p className="border-t border-gray-100 bg-gray-50 px-4 py-3 text-xs text-gray-500">
+								{t("orgSettings.leaveOrganizationLastOrganizerHint")}
+							</p>
+						)}
+					</div>
 				)}
 			</div>
 

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -490,9 +490,10 @@ export default function OrgOpportunitiesPage() {
 		if (loading || error || items.length === 0) return null;
 		return (
 			<section data-testid={testId}>
-				<PageSectionHeading>{heading}</PageSectionHeading>
-				<p className="mt-1 text-sm text-gray-500">{description}</p>
-				<ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				<PageSectionHeading description={description}>
+					{heading}
+				</PageSectionHeading>
+				<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{items.map((item) => renderRow(item, showStatusBadge))}
 				</ul>
 				{hasMore &&

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -225,6 +225,11 @@ export default function OrgSettingsPage() {
 			<div data-content-wrapper className="max-w-2xl">
 				{!editing && (
 					<OrganizationProfileView
+						// Stacked, not the public profile's contact sidebar: this page
+						// is already inside its own max-w-2xl settings column, so a
+						// 1fr/18rem split here left ~340px for the description and
+						// squeezed the danger-zone panel below it to half width.
+						layout="stacked"
 						name={org.name}
 						logoUrl={logoUrl}
 						description={org.description}


### PR DESCRIPTION
The landing-page redesign left every other page behind: they opened with a text-2xl h1 on plain white, used no display face, and hugged the left edge of a 90rem column with two thirds of the page empty beside them. This brings them onto one system.

Shared primitives
- PageHeaderBand: full-bleed brand-800 title band with the WAVE_PATH cap, running up behind the sticky header. Reads QuickActionsContext so pages using it keep their Edit/Save/Cancel actions once the action bar is gone.
- HeaderOverlayContext: a band declares that it sits behind the header, which then goes transparent until scrolled past. Replaces the hardcoded `pathname === "/"` check, which no longer matched anything after the hero became a boxed card. Refcounted, because React mounts the incoming route before unmounting the outgoing one.
- DocumentOutline / DocumentSection: sticky scrollspy contents plus numbered clauses for the legal texts, which ran to nine unnavigable sections.
- FaqAccordion: one accordion for the landing FAQ and the Help page, which answer the same kind of question and link to each other.
- PublicOpportunityCard: one card for PublicOpportunitySummaryDto, shared by the org profile and the detail page's teaser. Deliberately not the landing grid's richer card - that needs category, headcounts and banner images the public endpoint does not return.

Tokens (broad reach)
- headingClasses moved onto Barlow Condensed; the landing page had been the only surface using the display face at all.
- SectionHeading to brand-700 eyebrows (also 4.9:1 -> 7.5:1), and PageSectionHeading to the display face with an optional description slot, so a heading and its own subtitle stay one spacing unit.
- EmptyState gained a dashed outline; centred text floating on the page background read as a rendering failure rather than "nothing here yet".

Restored the transparent header (Header, DesktopHeader, MobileHeader, MobileMenu, AccountControls, LanguageSelector, NotificationDropdown), removed along with the old route check in d6d14de1.

Also fixed while in here
- 404: the illustration sat behind the copy, putting the dog's head across the heading; the asset also kept its intrinsic height, letterboxing itself in ~258px of dead space, and hardcoded a German aria-label that announced itself in German on the English site.
- Opportunity detail: the column alternated between 672px and 896px; the sign-up CTA now sits in a sticky rail above the fold, with the cross-sell moved below the grid so mobile still reaches the CTA before it.
- Profile/Activity/Settings share one sub-nav and one width, so the tab underline no longer jumps between pages.

Tests
- LegalPagesLayoutTests, TermsOfUsePageTests, HeaderBreadcrumbSharedImplementationTests, NavigationTests, OrganizationTests, VolunteerOpportunityTests updated for the removed action bar and the centred columns, plus new assertions for the header-transparency cycle and for the band title sharing a left edge with its content column - the bug the first cut of this work shipped.

Verified: tsc, eslint, i18n:check, 167 unit tests, VisualTests build, and an axe-core sweep of 15 pages (zero serious/critical). The Playwright suite itself was not run - no Docker in this environment.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
