### PR TITLE
fix: update visual tests for the subpage redesign's layout changes

### DIFF
--- a/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
@@ -12,23 +12,34 @@ namespace VisualTests;
 /// other top-level block on the page carries, so whichever one rendered sat
 /// flush against the "About this organization" section right below it with
 /// zero gap. Fixed by adding `mb-6` to each of the three.
+///
+/// #1754's two-column redesign (`lg:grid-cols-[minmax(0,1fr)_20rem]`) moved
+/// all three blocks into a sticky rail beside the reading column, while
+/// "About this organization" stayed behind in the reading column - the two
+/// are no longer vertically stacked, so a "gap above" check no longer means
+/// anything (whichever column happens to be taller decides its sign, not any
+/// actual spacing bug). What still matters, and what the redesign's own
+/// `lg:gap-10` exists to guarantee, is that the rail never overlaps the
+/// reading column horizontally - these checks now assert that gap instead.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
-	// Comfortably below the intended 24px (`mb-6`) gap, but far enough above
-	// zero that a regression back to "flush against the next section" (the
-	// bug's actual symptom) cannot pass.
+	// Comfortably below the intended `lg:gap-10` (40px) column gap, but far
+	// enough above zero that a regression back to the rail actually
+	// overlapping the reading column (the bug's modern equivalent of "flush
+	// against the next section") cannot pass.
 	private const double MinExpectedGapPx = 16;
 
 	/// <summary>
-	/// Asserts a visible gap exists between the bottom of <paramref name="block"/>
-	/// and the top of the "About this organization" section, reading both boxes
-	/// in a single EvaluateAsync call so nothing can shift layout between the
-	/// two reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync for the
-	/// same pattern).
+	/// Asserts a visible horizontal gap exists between the right edge of the
+	/// "About this organization" section (in the reading column) and the left
+	/// edge of <paramref name="block"/> (in the sticky rail beside it), reading
+	/// both boxes in a single EvaluateAsync call so nothing can shift layout
+	/// between the two reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync
+	/// for the same pattern).
 	/// </summary>
-	private async Task AssertGapBeforeAboutOrganizationAsync(ILocator block, string label)
+	private async Task AssertRailDoesNotOverlapAboutOrganizationAsync(ILocator block, string label)
 	{
 		var aboutOrg = Page.GetByTestId("about-organization");
 		await Expect(aboutOrg).ToBeVisibleAsync(new() { Timeout = 15_000 });
@@ -43,13 +54,14 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 					const about = document.querySelector(aboutSelector);
 					const blockBox = el.getBoundingClientRect();
 					const aboutBox = about.getBoundingClientRect();
-					return aboutBox.top - blockBox.bottom;
+					return blockBox.left - (aboutBox.left + aboutBox.width);
 				}
 				""",
 				"[data-testid='about-organization']");
 			return gap >= MinExpectedGapPx;
-		}, () => $"{label}: expected at least {MinExpectedGapPx}px between the block and \"About this "
-			+ $"organization\" (last observed gap = {gap}px) - it must not sit flush against the next section");
+		}, () => $"{label}: expected at least {MinExpectedGapPx}px between the reading column's \"About "
+			+ $"this organization\" section and the sticky rail (last observed gap = {gap}px) - the rail "
+			+ "must not overlap the reading column");
 	}
 
 	private async Task<(string OrganizationId, string OpportunityId)> CreateOpportunityWithFullOrgProfileAsync(
@@ -100,7 +112,7 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 	}
 
 	[Test]
-	public async Task ApplicationStatusCard_HasGapBeforeAboutOrganization()
+	public async Task ApplicationStatusCard_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -120,12 +132,12 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(
 			Page.GetByTestId("application-status"), "Your application status card");
 	}
 
 	[Test]
-	public async Task SignUpCta_HasGapBeforeAboutOrganization()
+	public async Task SignUpCta_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -136,11 +148,11 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(Page.GetByTestId("signup-cta"), "Sign-up CTA");
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(Page.GetByTestId("signup-cta"), "Sign-up CTA");
 	}
 
 	[Test]
-	public async Task LoginPrompt_HasGapBeforeAboutOrganization()
+	public async Task LoginPrompt_DoesNotOverlapAboutOrganization()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -150,6 +162,6 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await AssertGapBeforeAboutOrganizationAsync(Page.GetByTestId("login-prompt"), "Login prompt");
+		await AssertRailDoesNotOverlapAboutOrganizationAsync(Page.GetByTestId("login-prompt"), "Login prompt");
 	}
 }

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -37,10 +37,20 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 	}
 
 	[Test]
-	public async Task ProfilePage_ShowsHomeBreadcrumb()
+	public async Task ProfilePage_ShowsHomeLink()
 	{
 		// #590: /profile never called usePageToolbar, so it rendered with no
 		// breadcrumb trail at all, unlike every other authenticated page.
+		//
+		// #1754 gave /profile a PageHeaderBand and dropped the
+		// nav[aria-label='Breadcrumb'] bar in favor of a plain "way back home"
+		// link inside the band - see VolunteerOpportunityTests's identical
+		// update and HeaderBreadcrumbSharedImplementationTests
+		// .AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions, which
+		// already pins this page's fuller behavior (heading, no breadcrumb bar,
+		// Home link, Edit quick action, sub-nav). This keeps #590's original
+		// regression - that /profile has *some* way back to the home page -
+		// covered under its own name.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -49,10 +59,10 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Page.GotoAsync($"{origin}/profile");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		var breadcrumb = Page.Locator("nav[aria-label='Breadcrumb']");
-		await Expect(breadcrumb).ToBeVisibleAsync(new() { Timeout = 20_000 });
-		await Expect(breadcrumb.Locator("a[href='/']")).ToBeVisibleAsync();
-		await Expect(breadcrumb.GetByText("Profile", new() { Exact = true })).ToBeVisibleAsync();
+		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+		var homeLink = Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" });
+		await Expect(homeLink).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(homeLink).ToHaveAttributeAsync("href", "/");
 	}
 
 	[Test]


### PR DESCRIPTION
## What

Fixes the two `visual-tests` failures on #1754 by updating two pre-existing regression tests that assumed layouts #1754 intentionally changed.

## Why

#1754's redesign made two changes that a couple of pre-existing `VisualTests` didn't get updated for:

1. **`OpportunityDetailPageSpacingTests`** (`#1111` regression): the application-status/sign-up-CTA/login-prompt cards used to sit in a single column directly above "About this organization", so the test asserted a vertical gap between them. #1754 moved those three cards into a sticky rail beside the reading column (`lg:grid-cols-[minmax(0,1fr)_20rem]`) - they're no longer vertically stacked with "About this organization" at all, so whether the old check passed or failed came down to which column happened to be taller for a given test's content, not any real spacing bug (`LoginPrompt_HasGapBeforeAboutOrganization` failed with a `-2px` "gap" purely by coincidence). Rewrote the shared helper to assert a horizontal gap instead - that the rail never overlaps the reading column - which is what the redesign's own `lg:gap-10` is actually there to guarantee, and renamed the three tests/helper to match.

2. **`ProfileOverviewTests.ProfilePage_ShowsHomeBreadcrumb`** (`#590` regression): expected the old `nav[aria-label='Breadcrumb']` bar on `/profile`. #1754 gave `/profile` a `PageHeaderBand` and dropped that bar in favor of a plain "Home" link inside the band - the exact same change `VolunteerOpportunityTests` was already updated for elsewhere in this branch, and that `HeaderBreadcrumbSharedImplementationTests.AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions` already pins in more detail. Updated the test to check for the Home link instead, matching that established pattern.

No application code changed - `backend/src/`/`frontend/src/` are untouched, only the two test files.

Closes #

## Testing

- Updated `OpportunityDetailPageSpacingTests.cs`'s three tests + shared helper to assert horizontal (rail vs. reading column) separation instead of vertical gap.
- Updated `ProfileOverviewTests.cs`'s `ProfilePage_ShowsHomeBreadcrumb` (renamed `ProfilePage_ShowsHomeLink`) to assert the `PageHeaderBand`'s Home link instead of the removed breadcrumb bar.
- Couldn't run `VisualTests` locally (no Docker/Aspire orchestration in this sandbox, and the .NET SDK download domain is blocked by this environment's network policy) - relying on CI's `visual-tests` job, which runs on a real runner.

## Live verification

Not applicable - this is a test-only fix with no application behavior change (see "What" above), so there's nothing new to observe on staging.

## Checklist

- [x] CI is green (pending this PR's own run)
- [ ] Documentation updated if this change affects behavior - N/A, no behavior change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jdye1uJcafJrCD4QfUR4sX)_