### PR TITLE
docs: cut the building block view along business function, add the domain model

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -164,7 +164,7 @@ Rotating the staging host's SSH host key (a fresh box, a reinstall) requires upd
 
 All templates are in **English** (see `CONTRIBUTING.md`'s Language Convention). Fields:
 
-**Bug report:** Affected Persona (dropdown: Volunteer Vera/Organizer Olaf/Contributor Caro/Maintainer Milo/All), Priority (Low/Medium/High), Description, Steps to Reproduce, Environment, Additional Information
+**Bug report:** Affected Persona (dropdown: Volunteer Vera/Organizer Olaf/Platform Admin/Contributor Caro/Maintainer Milo/All - same order as the stakeholder table in arc42 chapter 1, end users before project-side roles), Priority (Low/Medium/High), Description, Steps to Reproduce, Environment, Additional Information
 
 **Chore:** Priority, Description, Acceptance Criteria (checkboxes)
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,7 @@ body:
       options:
         - Volunteer Vera
         - Organizer Olaf
+        - Platform Admin
         - Contributor Caro
         - Maintainer Milo
         - All

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -13,6 +13,7 @@ body:
       options:
         - Volunteer Vera
         - Organizer Olaf
+        - Platform Admin
         - Contributor Caro
         - Maintainer Milo
     validations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ These same test-user credentials are intentionally also live on the public stagi
 
 ## Key Conventions
 
-- Feature folders: `{Layer}/{Domain}/{Feature}/v1/` in both backend and frontend
+- Feature folders: `{Layer}/{Domain}/{Feature}/v1/` in the backend (`Api/`, `Application/` and `Domain/` all repeat the same module folders). The frontend is cut by artifact kind instead (`pages/`, `components/`, `hooks/`, `lib/`), with organizer routes grouped under `pages/app/` - see chapter 5 of the arc42 docs
 - Routes: `/v{version:apiVersion}/...`, namespaces: `.v1`
 - Commands/queries/DTOs: C# records
 - Commits: Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore:`, `test:`)

--- a/docs/Architecture/images/business-context.puml
+++ b/docs/Architecture/images/business-context.puml
@@ -6,10 +6,14 @@ title Business Context View
 
 Person(volunteer, "Volunteer Vera", "Searches for regional volunteer opportunities")
 Person(organizer, "Organizer Olaf", "Creates volunteer opportunities for their organization")
+Person(admin, "Platform Admin", "Moderates reported content and administers users and organizations")
 
 System(einsatzbereit, "Einsatzbereit", "Manages regional volunteer opportunities and volunteer registrations")
 
-Rel(volunteer, einsatzbereit, "Search and sign up for opportunities")
-Rel(organizer, einsatzbereit, "Manages organization's volunteer opportunities")
+Rel(volunteer, einsatzbereit, "Search and sign up for opportunities, give feedback")
+Rel(organizer, einsatzbereit, "Manages organization's volunteer opportunities and sign-ups")
+Rel(admin, einsatzbereit, "Reviews abuse reports, disables or restores content and accounts")
+Rel(einsatzbereit, volunteer, "Notifies about matches, confirmations and reminders")
+Rel(einsatzbereit, organizer, "Notifies about sign-ups and withdrawals")
 
 @enduml

--- a/docs/Architecture/images/component-backend.puml
+++ b/docs/Architecture/images/component-backend.puml
@@ -1,38 +1,34 @@
-@startuml Backend Component View
+@startuml Backend Module Internals
 
 !include <C4/C4_Component>
 
-title Component View - Backend API (Clean Architecture)
+title Level 3 - Inside a functional module (example: Volunteer Opportunities)
 
-Container_Boundary(api, "API Layer  [backend/src/Api/]") {
-		Component(endpoints, "Endpoints", "ASP.NET Core Minimal API", "Routes HTTP requests to Application layer via versioned endpoint classes. Handles request/response serialization.")
-		Component(auth_mw, "JWT Middleware", "ASP.NET Core Bearer Auth", "Validates JWT signature and expiry on every request using Keycloak's JWKS.")
+Container_Boundary(module, "Volunteer Opportunities module") {
+	Component(endpoint, "Endpoint", "Api/VolunteerOpportunities/{Feature}/v1/", "One Minimal API endpoint class per feature, plus its Request and Response records. Binds and validates the payload, then dispatches.")
+	Component(handler, "Command / Query Handler", "Application/VolunteerOpportunities/{Feature}/v1/", "One handler per feature. Enforces authorization and use-case rules, orchestrates the aggregate, returns Result<T>.")
+	Component(aggregate, "Aggregate + Value Objects", "Domain/VolunteerOpportunities/", "VolunteerOpportunity, TimeSlot, Address. Business invariants and state transitions. Raises domain events.")
+	Component(readrepo, "Read Repository Interface", "Application/VolunteerOpportunities/", "IVolunteerOpportunityReadRepository - the port queries read through.")
+	Component(impl, "Repository + Adapters", "Infrastructure/Persistence/, Infrastructure/VolunteerOpportunities/", "EF Core implementation of the ports, entity configurations, migrations, geocoding adapter.")
 }
 
-Container_Boundary(application, "Application Layer  [backend/src/Application/]") {
-		Component(queries, "Query Handlers", "In-house IQueryHandler", "Read-only use cases. Return data without modifying state. Use read repository interfaces.")
-		Component(commands, "Command Handlers", "In-house ICommandHandler", "State-changing use cases. Enforce business rules. Use write repository interfaces.")
-		Component(repo_interfaces, "Repository Interfaces", "C# Interfaces", "Abstractions for data access. Implemented by Infrastructure layer.")
-}
+Component_Ext(shared, "Shared Kernel", "Application/Common, Domain/Primitives", "ISender dispatch, pipeline behaviors (transaction, slow-request logging), Result/Error, OwnershipGuard, pagination.")
+Component_Ext(other, "Other modules", "Notifications, Achievements", "Subscribe to this module's domain events.")
 
-Container_Boundary(domain, "Domain Layer  [backend/src/Domain/]") {
-		Component(entities, "Entities", "C# Records / Classes", "Core business objects: VolunteerOpportunity, Organization, Engagement. No framework dependencies.")
-}
+Rel(endpoint, shared, "Dispatches via ISender")
+Rel(shared, handler, "Routes to")
+Rel(handler, aggregate, "Creates / modifies")
+Rel(handler, readrepo, "Queries through")
+Rel(impl, readrepo, "Implements")
+Rel(impl, aggregate, "Persists")
+Rel(aggregate, other, "Raises domain events to")
 
-Container_Boundary(infrastructure, "Infrastructure Layer  [backend/src/Infrastructure/]") {
-		Component(db_context, "ApplicationDbContext", "EF Core 10", "ORM context. Configures entity mappings and applies migrations.")
-		Component(repositories, "Repositories", "EF Core Repositories", "Implement repository interfaces. Map between EF entities and domain objects.")
-		Component(migrations, "Migrations", "EF Core Migrations", "Database schema history. Applied on startup in Development.")
-}
-
-Rel(endpoints, queries, "Dispatches via ISender")
-Rel(endpoints, commands, "Dispatches via ISender")
-Rel(auth_mw, endpoints, "Populates ClaimsPrincipal")
-Rel(queries, repo_interfaces, "Uses")
-Rel(commands, repo_interfaces, "Uses")
-Rel(commands, entities, "Creates / modifies")
-Rel(repositories, db_context, "Uses")
-Rel(repositories, entities, "Maps to / from")
-Rel(db_context, migrations, "Applies on startup")
+note bottom of impl
+	Dependencies point inward: Api -> Application -> Domain.
+	Infrastructure implements ports declared in Application
+	and is referenced only through them. Every module in
+	Level 2 is built the same way - see the Module Structure
+	concept in chapter 8.
+end note
 
 @enduml

--- a/docs/Architecture/images/container-view.puml
+++ b/docs/Architecture/images/container-view.puml
@@ -6,12 +6,13 @@ title Container View - Einsatzbereit
 
 Person(volunteer, "Volunteer", "Searches for and registers to volunteer opportunities")
 Person(organizer, "Organizer", "Creates and manages volunteer opportunities")
+Person(admin, "Platform Admin", "Moderates reported content, administers users and organizations")
 
 System_Boundary(einsatzbereit, "Einsatzbereit") {
-		Container(frontend, "Single Page Application", "React 19, Vite, TypeScript, Tailwind CSS 4", "Provides the web UI for volunteers and organizers. Handles OIDC login and token management.")
+		Container(frontend, "Single Page Application", "React 19, Vite, TypeScript, Tailwind CSS 4", "Provides the web UI for volunteers, organizers and platform admins. Handles OIDC login and token management.")
 		Container(backend, "Backend API", ".NET 10, ASP.NET Core Minimal API", "Implements business logic. Exposes versioned REST API. Validates JWT tokens. Manages data via EF Core.")
-		ContainerDb(db, "Application Database", "PostgreSQL 18", "Stores volunteer opportunities, organizations, engagements, and user associations.")
-		Container(keycloak, "Identity Provider", "Keycloak 26.7.1", "Handles authentication via OIDC. Manages users, roles, and organizations. Issues signed JWT access tokens.")
+		ContainerDb_Ext(db, "Application Database", "PostgreSQL 18 [third party]", "Stores volunteer opportunities, organizations, engagements, and user associations.")
+		Container_Ext(keycloak, "Identity Provider", "Keycloak 26.7.1 [third party]", "Handles authentication via OIDC. Manages users, roles, and organizations. Issues signed JWT access tokens.")
 }
 
 System_Ext(objectstore, "Object storage (MinIO / S3)", "Stores binary assets: logos, avatars, banners")
@@ -20,6 +21,7 @@ System_Ext(nominatim, "OpenStreetMap Nominatim", "Address geocoding (public, rat
 
 Rel(volunteer, frontend, "Uses", "HTTPS")
 Rel(organizer, frontend, "Uses", "HTTPS")
+Rel(admin, frontend, "Uses", "HTTPS")
 Rel(frontend, backend, "REST API calls", "HTTPS / JSON, JWT Bearer")
 Rel(frontend, keycloak, "Authenticates via", "OIDC Authorization Code Flow + PKCE")
 Rel(backend, db, "Reads and writes", "TCP / SQL (EF Core)")
@@ -29,5 +31,11 @@ Rel(backend, objectstore, "Stores / serves assets", "S3 API")
 Rel(backend, smtp, "Sends email", "SMTP")
 Rel(backend, nominatim, "Geocodes addresses", "HTTPS")
 Rel(keycloak, db, "Stores realm data", "TCP / SQL")
+
+note as ThirdParty
+	Greyed-out containers are third-party software the project
+	deploys and configures but does not develop (arc42 tip 5-20).
+	Only the SPA and the Backend API contain code written here.
+end note
 
 @enduml

--- a/docs/Architecture/images/domain-model.puml
+++ b/docs/Architecture/images/domain-model.puml
@@ -1,0 +1,155 @@
+@startuml Domain Model
+
+title Domain Model - Einsatzbereit
+
+hide circle
+hide methods
+skinparam classAttributeIconSize 0
+skinparam packageStyle rectangle
+skinparam nodesep 25
+skinparam ranksep 45
+
+package Organizations <<Rectangle>> {
+	class Organization <<aggregate root>> {
+		Name
+		Description
+		ContactEmail
+		Website
+		LogoUrl
+	}
+
+	class OrganizationMembership <<aggregate root>> {
+		Role
+	}
+
+	class OrganizationInvitation <<aggregate root>> {
+		IntendedRole
+		Status
+		ExpiresOn
+	}
+}
+
+package "Volunteer Opportunities" <<Rectangle>> {
+	class VolunteerOpportunity <<aggregate root>> {
+		Title
+		Description
+		Category
+		Tags
+		IsRemote
+		Occurrence
+		ParticipationType
+		CheckInMethod
+		Status
+		ApplicationDeadline
+		PublishedOn
+	}
+
+	class TimeSlot <<entity>> {
+		StartDateTime
+		EndDateTime
+		MaxParticipants
+		SeriesId
+	}
+}
+
+package Engagements <<Rectangle>> {
+	class Engagement <<aggregate root>> {
+		Status
+		Message
+		IsCheckedIn
+		FeedbackRating
+		FeedbackComment
+		ReactivationCount
+	}
+}
+
+package Users <<Rectangle>> {
+	class User <<aggregate root>> {
+		Bio
+		Skills
+		Languages
+		PreferredContact
+		EmailPreferences
+	}
+
+	class UserStreak <<aggregate root>> {
+		LoginStreak
+		ActivityStreak
+		TotalConfirmedEngagements
+	}
+
+	class SearchAlert <<aggregate root>> {
+		Categories
+		Tag
+		RadiusKm
+		LastNotifiedAt
+	}
+
+	class Achievement <<aggregate root>> {
+		Type
+		Key
+		UnlockedAt
+	}
+
+	class Notification <<aggregate root>> {
+		Kind
+		RelatedEntityId
+		IsRead
+	}
+}
+
+package Moderation <<Rectangle>> {
+	class Report <<aggregate root>> {
+		TargetType
+		Reason
+		Status
+	}
+
+	class AuditLog <<aggregate root>> {
+		ActionType
+		SubjectType
+		Reason
+	}
+}
+
+class Address <<value object>> {
+	Street
+	HouseNumber
+	ZipCode
+	City
+	Latitude
+	Longitude
+}
+
+Organization "1" *-- "0..*" VolunteerOpportunity : publishes
+VolunteerOpportunity "1" *-- "0..*" TimeSlot : offers shifts
+VolunteerOpportunity "1" o-- "0..*" Engagement : receives
+Engagement "0..*" --> "0..1" TimeSlot : booked for
+VolunteerOpportunity *-- Address
+Organization *-- Address
+
+Organization "1" *-- "0..*" OrganizationMembership
+Organization "1" *-- "0..*" OrganizationInvitation
+
+User "1" o-- "0..*" Engagement : signs up via
+User "1" o-- "0..*" OrganizationMembership : is member through
+User "1" o-- "0..*" OrganizationInvitation : invited as
+User "1" o-- "0..1" UserStreak
+User "1" o-- "0..1" SearchAlert : saves
+User "1" o-- "0..*" Achievement : earns
+User "1" o-- "0..*" Notification : receives
+User "1" o-- "0..*" Report : files
+User "1" o-- "0..*" AuditLog : acts in
+
+legend bottom left
+	Enum values are omitted here and defined in the glossary.
+	Address is stored inline on its owner, not as its own table;
+	only an opportunity's address carries coordinates.
+	Report and AuditLog reference their target polymorphically
+	(TargetType/SubjectType + a raw id), so they have no typed
+	association to the aggregate they concern.
+	Engagement.VolunteerId is nullable: an engagement outlives
+	the volunteer's account deletion in anonymized form.
+end legend
+
+@enduml

--- a/docs/Architecture/images/module-backend.puml
+++ b/docs/Architecture/images/module-backend.puml
@@ -1,0 +1,44 @@
+@startuml Backend Module View
+
+!include <C4/C4_Component>
+
+title Level 2 - Backend API, functional modules
+
+Container_Boundary(backend, "Backend API") {
+	Component(opportunities, "Volunteer Opportunities", "Api/ + Application/ + Domain/ + Infrastructure/ VolunteerOpportunities", "Opportunity lifecycle (draft, publish, unpublish, cancel), time slots and series, categories/tags, banner images, check-in PINs, address geocoding.")
+	Component(engagements, "Engagements", "Api/ + Application/ + Domain/ Engagements", "Sign-up, withdrawal, confirmation and cancellation, check-in, feedback, reminders, calendar and CSV export.")
+	Component(organizations, "Organizations", "Api/ + Application/ + Domain/ Organizations", "Organization profiles, memberships and roles, invitations sent by an organizer, dashboard layout.")
+	Component(invitations, "Invitations", "Api/ + Application/ Invitations", "The invitee's side of an invitation: list, accept, decline. Shares the Organizations aggregate.")
+	Component(users, "Users", "Api/ + Application/ + Domain/ Users", "Profiles, notification preferences, streaks, search alerts, account deletion, admin user administration.")
+	Component(achievements, "Achievements", "Api/ + Application/ + Domain/ + Infrastructure/ Achievements", "Badge catalog and awarding of milestone, streak and hidden achievements.")
+	Component(notifications, "Notifications", "Api/ + Application/ + Domain/ Notifications", "In-app notification inbox: create, read, mark read, retention.")
+	Component(reports, "Reports", "Api/ + Application/ + Domain/ Reports", "Abuse reports against opportunities, organizations and users; moderation queue.")
+	Component(auditlogs, "Audit Logs", "Api/ + Application/ + Domain/ AuditLogs", "Append-only record of administrative actions, readable by platform admins.")
+	Component(maps, "Maps", "Api/ + Application/ + Infrastructure/ Maps", "Map tile and city-search proxying so visitor IPs never reach OpenStreetMap directly (ADR-5).")
+	Component(meta, "Meta", "Api/ + Application/ Meta", "Server-rendered Open Graph metadata for opportunity and organization links.")
+	Component(sitemap, "Sitemap", "Api/ + Application/ Sitemap", "Generates sitemap.xml from published opportunities.")
+
+	Component(shared, "Shared Kernel", "Application/Common, Domain/Primitives, Infrastructure/Common", "Messaging (ISender), Result/Error primitives, authorization guards, pagination, persistence and storage abstractions, pipeline behaviors, background job host.")
+}
+
+Rel(engagements, opportunities, "Reads slots, capacity, status")
+Rel(invitations, organizations, "Accepts / declines")
+Rel(opportunities, maps, "Geocodes addresses")
+
+Rel_U(notifications, engagements, "Reacts to domain events")
+Rel_U(notifications, opportunities, "Reacts to domain events")
+Rel_U(notifications, organizations, "Reacts to domain events")
+Rel_U(achievements, engagements, "Reacts to domain events")
+
+Rel(opportunities, shared, "Uses")
+Rel(engagements, shared, "Uses")
+Rel(organizations, shared, "Uses")
+Rel(users, shared, "Uses")
+
+note right of shared
+	Every module uses the Shared Kernel.
+	Only four arrows are drawn to keep the
+	diagram readable.
+end note
+
+@enduml

--- a/docs/Architecture/images/technical-context.puml
+++ b/docs/Architecture/images/technical-context.puml
@@ -6,6 +6,7 @@ title Technical Context View
 
 Person(volunteer, "Volunteer", "Uses browser to access the platform")
 Person(organizer, "Organizer", "Uses browser to manage opportunities")
+Person(admin, "Platform Admin", "Uses browser to moderate and administer")
 
 System(einsatzbereit, "Einsatzbereit", "Volunteer coordination platform")
 
@@ -20,6 +21,7 @@ System_Ext(objectstore, "Object storage (MinIO / S3)", "Binary assets: logos, av
 
 Rel(volunteer, browser, "Opens")
 Rel(organizer, browser, "Opens")
+Rel(admin, browser, "Opens")
 Rel(browser, einsatzbereit, "HTTPS", "React SPA, REST API, OIDC")
 Rel(github_actions, einsatzbereit, "Deploys via", "Docker images")
 Rel(github_actions, ghcr, "Publishes images to")

--- a/docs/Architecture/src/01_introduction_and_goals.adoc
+++ b/docs/Architecture/src/01_introduction_and_goals.adoc
@@ -75,6 +75,12 @@ _A complete list of all quality goals with detailed scenarios can be found in Ch
 
 *Organizer Olaf* expects a simple way to post volunteer opportunities and reach volunteers without any technical knowledge.
 
+|Platform admins
+|End users (currently the maintainers)
+|_"If someone posts something abusive, I want it gone in two clicks - and I want to be able to prove afterwards what I did and why."_
+
+*Platform Admin* expects a moderation queue over reported content, the ability to disable and restore accounts, organizations and listings, and an audit trail of every such action. The role is held by the maintainers today, but it is a separate role in the system rather than a maintenance chore.
+
 |Contributors
 |GitHub Issues and Pull Requests
 |_"I want to contribute a feature over a weekend, not spend two days just understanding the project."_

--- a/docs/Architecture/src/03_context_and_scope.adoc
+++ b/docs/Architecture/src/03_context_and_scope.adoc
@@ -22,8 +22,11 @@ include::../images/business-context.puml[]
 |Organizer Olaf
 |Creates and manages volunteer opportunities for their organization or club. Posts what help is needed, where, and when.
 
+|Platform Admin
+|Keeps the platform usable for the other two: works through abuse reports, disables or restores accounts, organizations and opportunities, and reads the audit trail of those actions.
+
 |Einsatzbereit
-|Connects volunteers with organizations by managing regional volunteer opportunities and registrations.
+|Connects volunteers with organizations by managing regional volunteer opportunities and registrations, and notifies both sides when something concerning them changes.
 |===
 
 === Technical Context
@@ -92,4 +95,16 @@ include::../images/technical-context.puml[]
 
 |Organizer manages their opportunities
 |`GET /v1/volunteer-opportunities/{id}` is public; `PUT` and `DELETE` require the `organisator` role
+
+|Organizer invites a member to the organization
+|`POST /v1/organizations/{organizationId}/invitations`, requires an organizer membership row for that organization
+
+|Volunteer reports inappropriate content
+|`POST /v1/volunteer-opportunities/{opportunityId}/reports` (and the equivalents for organizations and users), authenticated via JWT
+
+|Admin works through the moderation queue
+|`GET /v1/admin/reports/targets` and `PUT /v1/admin/reports/{reportId}/dismiss`, require the `admin` role
+
+|Admin disables or restores an account or listing
+|`DELETE /v1/admin/users/{userId}` and `PUT /v1/admin/users/{userId}/restore`, require the `admin` role; both write an audit log entry
 |===

--- a/docs/Architecture/src/04_solution_strategy.adoc
+++ b/docs/Architecture/src/04_solution_strategy.adoc
@@ -19,8 +19,8 @@ The following table summarizes the key architectural decisions and how they addr
 |Each use case is encapsulated in one handler class. Finding the code for a feature means finding one file. No large service classes accumulating unrelated logic.
 
 |Appropriateness
-|Feature folder structure in both backend and frontend
-|Code is organized by domain feature, not by technical layer. Adding a new feature means adding a new folder - not modifying multiple existing ones.
+|Backend cut into functional modules, each with one folder per use case
+|The backend's `Api/`, `Application/` and `Domain/` layers repeat the same twelve module folders, and each use case is its own `{Feature}/v1/` folder. Adding a feature means adding folders instead of editing shared service classes. The frontend is cut by artifact kind instead - see <<section-building-block-view>> for why the two ends differ.
 
 |Maintainability
 |NSwag-generated API client for the frontend

--- a/docs/Architecture/src/05_building_block_view.adoc
+++ b/docs/Architecture/src/05_building_block_view.adoc
@@ -3,6 +3,31 @@ ifndef::imagesdir[:imagesdir: ../images]
 [[section-building-block-view]]
 == Building Block View
 
+The decomposition below uses one consistent cohesion criterion per level, named explicitly so a reader can tell whether a new piece of code belongs in an existing building block or needs a new one.
+
+[cols="1,2,3" options="header"]
+|===
+|Level |Cohesion criterion |Result
+
+|1
+|Deployment and runtime boundary
+|Four separately deployed containers.
+
+|2 (Backend)
+|Similar business function
+|Twelve functional modules plus a shared kernel.
+
+|2 (Frontend)
+|Similar technology and implementation rules, then route area
+|Artifact kinds (pages, components, hooks), with the organizer area separated by route.
+
+|3
+|Refinement of one module
+|The layer slice every backend module repeats.
+|===
+
+Level 3 is deliberately shown for one module only. The remaining eleven are built identically, which is documented once as the <<section-concepts, Module Structure>> concept rather than redrawn per module.
+
 === Level 1: System Overview (Whitebox)
 
 .Container View - Einsatzbereit
@@ -11,127 +36,224 @@ ifndef::imagesdir[:imagesdir: ../images]
 include::../images/container-view.puml[]
 ....
 
-Motivation::
-The system consists of four main containers: a React SPA for the UI, an ASP.NET Core API for business logic, Keycloak for identity management, and PostgreSQL for persistence.
-Authentication is centralized in Keycloak - neither the frontend nor the backend implements login logic directly.
+Rationale for this decomposition::
+The split follows deployment boundaries, not business function: each of the four containers is built, versioned and shipped as its own artifact and can be restarted independently. Business function is the criterion one level down, inside the Backend API.
+
+Two of the four containers are third-party software (greyed out in the diagram, arc42 tip 5-20). They appear in the building block view even though arc42 normally reserves it for self-written code, because authentication and persistence are delegated so completely that the remaining two containers cannot be understood without them - the Backend API implements no login logic at all. No code in this repository is compiled into them; the project contributes a realm configuration and an image build for Keycloak, and a schema plus migrations for PostgreSQL. In <<section-context-and-scope>> the same two appear as self-hosted neighbour systems, seen from outside the system boundary.
 
 Contained Building Blocks::
 
-[cols="1,2,2" options="header"]
+[cols="1,1,2,2" options="header"]
 |===
-|Container |Technology |Responsibility
+|Container |Origin |Technology |Responsibility
 
 |Single Page Application
+|Written here
 |React 19, Vite, TypeScript, Tailwind CSS 4
-|Provides the web UI for volunteers and organizers. Handles OIDC login redirect and token storage. Communicates with the backend API using a NSwag-generated client.
+|Provides the web UI for volunteers, organizers and platform admins. Handles OIDC login redirect and token storage. Communicates with the backend API using a NSwag-generated client.
 
 |Backend API
+|Written here
 |.NET 10, ASP.NET Core, Clean Architecture
 |Exposes the versioned REST API. Implements all business logic via CQRS handlers. Validates JWT tokens, enforces role-based authorization, persists data via EF Core.
 
 |Identity Provider
+|Third party
 |Keycloak 26.7.1
 |Handles user authentication via OIDC Authorization Code Flow. Manages users, roles (`user`, `organisator`, `admin`), and organizations. Issues and signs JWT access tokens.
 
 |Application Database
+|Third party
 |PostgreSQL 18
 |Stores all application data: volunteer opportunities, organizations, engagements, and user associations.
 |===
 
 Important Interfaces::
 
+The external interfaces below are consistent with the technical context in <<section-context-and-scope>>, which remains the authoritative list; this table adds the two interfaces internal to the system boundary. The one context interface without a Level-1 counterpart is GitHub Actions to GHCR, which touches build artifacts rather than a running building block - see <<section-deployment-view>>.
+
 [cols="1,3" options="header"]
 |===
 |Interface |Description
 
-|Frontend ↔ Backend API
+|Frontend to Backend API
 |REST over HTTPS, versioned (`/v1/...`). Authenticated requests carry a JWT Bearer token; public browsing is anonymous. Response format is JSON. The TypeScript client is generated from the OpenAPI spec.
 
-|Frontend ↔ Keycloak
+|Frontend to Keycloak
 |OIDC Authorization Code Flow with PKCE. Frontend redirects to Keycloak for login; receives access and refresh tokens on success.
 
-|Backend ↔ Keycloak
+|Backend to Keycloak
 |Backend fetches Keycloak's JWKS endpoint to validate JWT signatures. For organization and user management it also calls Keycloak's Admin REST API (`/admin/realms/...`) using a service-account admin token.
 
-|Backend ↔ PostgreSQL
+|Backend to PostgreSQL
 |EF Core 10 over TCP. Migrations are applied on startup in Development, and in other environments only when `Database:MigrateOnStartup` is enabled.
 
-|Backend ↔ Object storage (MinIO / S3)
+|Backend to Object storage (MinIO / S3)
 |Stores and serves binary assets: organization logos, user avatars, and opportunity banners.
 
-|Backend ↔ Mail server (SMTP)
+|Backend to Mail server (SMTP)
 |Sends notification and reminder emails (Mailpit locally, a real SMTP relay on staging).
 
-|Backend ↔ Geocoding (Nominatim)
-|Geocodes opportunity addresses at write time, throttled to about one request per second. See ADR-4.
+|Backend to Geocoding (Nominatim)
+|Geocodes opportunity addresses at write time, throttled to about one request per second. Map tiles and city search are proxied through the backend so visitor IPs never reach OpenStreetMap. See ADR-4 and ADR-5.
 |===
 
 === Level 2: Backend API (Whitebox)
 
-.Backend Component View - Clean Architecture
+.Backend Module View - Functional Modules
+[plantuml, "module-backend", png]
+....
+include::../images/module-backend.puml[]
+....
+
+Rationale for this decomposition::
+The modules are cut by business function, following the fact that a change request almost always arrives phrased as one ("organizers need to invite members", "volunteers should get a reminder"). The cut is carried through the layers that hold use cases and business rules: `Api/`, `Application/` and `Domain/` each contain the same module folders, so a feature is one folder per layer rather than a diff spread across shared service classes. `Infrastructure/` is the deliberate exception - it is organized by adapted technology (`Persistence/`, `Email/`, `Keycloak/`, `Storage/`, `Geocoding/`, `Maps/`), because an adapter belongs to the external system it wraps, not to the module that happens to call it first. Only where an implementation is genuinely module-specific rather than technology-specific does a module folder reappear there (`Infrastructure/Achievements/` for the badge catalog, `Infrastructure/VolunteerOpportunities/` for PIN generation).
+
+Two cuts are worth explaining because they do not follow entity ownership. *Invitations* is split from *Organizations* by actor rather than by aggregate: the organizer's side (create, resend, dismiss) lives in Organizations, the invitee's side (list, accept, decline) in Invitations, because the two are reached by different roles through different screens. *Maps*, *Meta* and *Sitemap* are thin modules with no aggregate of their own; they exist as modules because they are separately addressable capabilities with their own endpoints, not because they own domain state.
+
+Contained Building Blocks::
+
+[cols="1,3,2" options="header"]
+|===
+|Module |Responsibility |Source location
+
+|Volunteer Opportunities
+|Opportunity lifecycle (draft, publish, unpublish, cancel), time slots including recurring series, categories and tags, banner images, check-in PINs, address geocoding.
+|`{Api,Application,Domain,Infrastructure}/VolunteerOpportunities/`
+
+|Engagements
+|Sign-up and withdrawal, confirmation and cancellation by the organizer, check-in, feedback, reminders, calendar and CSV export.
+|`{Api,Application,Domain}/Engagements/`
+
+|Organizations
+|Organization profiles, memberships and member roles, invitations from the organizer's side, dashboard layout.
+|`{Api,Application,Domain}/Organizations/`
+
+|Invitations
+|The invitee's side of an organization invitation: list, accept, decline. Operates on the Organizations aggregate.
+|`{Api,Application}/Invitations/`
+
+|Users
+|Profiles, notification preferences, streaks, search alerts, account deletion, and the admin-facing user administration.
+|`{Api,Application,Domain}/Users/`, `Domain/SearchAlerts/`
+
+|Achievements
+|Badge catalog and awarding of milestone, streak and hidden achievements.
+|`{Api,Application,Domain,Infrastructure}/Achievements/`
+
+|Notifications
+|In-app notification inbox: creation from domain events, read state, deletion, retention.
+|`{Api,Application,Domain}/Notifications/`
+
+|Reports
+|Abuse reports against opportunities, organizations and users, and the moderation queue that resolves them.
+|`{Api,Application,Domain}/Reports/`
+
+|Audit Logs
+|Append-only record of administrative actions, readable by platform admins.
+|`{Api,Application,Domain}/AuditLogs/`
+
+|Maps
+|Map tile and city-search proxying so visitor IP addresses never reach OpenStreetMap directly (ADR-5).
+|`{Api,Application,Infrastructure}/Maps/`
+
+|Meta
+|Server-rendered Open Graph metadata so shared opportunity and organization links preview correctly.
+|`{Api,Application}/Meta/`
+
+|Sitemap
+|Generates `sitemap.xml` from published opportunities.
+|`{Api,Application}/Sitemap/`
+
+|Shared Kernel
+|Cross-module infrastructure every module depends on: `ISender` dispatch and pipeline behaviors, `Result`/`Error` primitives, authorization guards, pagination, persistence/storage/email ports, the outbox, and the background job host.
+|`Application/Common/`, `Domain/{Primitives,Common}/`, `Infrastructure/{Common,Persistence,Email,Keycloak,Storage,Geocoding,RateLimiting,BackgroundJobs}/`, `Aspire/ServiceDefaults/`
+|===
+
+Modules communicate in one of two ways. Direct calls go inward through the shared kernel only for reads a use case cannot complete without (Engagements reads opportunity status and slot capacity). Everything reactive - notifications, achievements, search-alert digests - runs off domain events raised by the aggregate and dispatched after commit, so the module that causes an event never references the modules that react to it.
+
+=== Level 3: Inside a Module (Whitebox, example)
+
+.Module Internals - Volunteer Opportunities
 [plantuml, "component-backend", png]
 ....
 include::../images/component-backend.puml[]
 ....
 
-The backend follows Clean Architecture with four layers. Dependencies flow inward only: API → Application → Domain. Infrastructure implements interfaces defined in Application.
+Rationale for this decomposition::
+Every functional module from Level 2 repeats the same internal shape, so only one is drawn (arc42 tip 5-27: refine only a few building blocks). The shape itself - Clean Architecture layering plus one folder per use case - is a cross-cutting concept and is described once in <<section-concepts>> under Module Structure, rather than repeated as a whitebox for each of the twelve modules.
 
-==== API Layer
+[cols="1,2,2" options="header"]
+|===
+|Element |Responsibility |Source location
 
-Responsibility:: Routes HTTP requests to the Application layer. Applies authentication middleware. Handles versioning and request/response serialization.
+|Endpoint
+|One Minimal API endpoint class per feature, with its `Request` and `Response` records. Binds and validates the payload, applies the authorization policy, then dispatches.
+|`Api/VolunteerOpportunities/{Feature}/v1/`
 
-Interfaces:: Exposes versioned ASP.NET Core Minimal API endpoints. Dispatches use cases through the application's `ISender` and reads JWT Bearer tokens via ASP.NET Core middleware.
+|Command / Query Handler
+|One handler per feature. Enforces use-case rules and ownership, orchestrates the aggregate, returns `Result<T>`.
+|`Application/VolunteerOpportunities/{Feature}/v1/`
 
-Location:: `backend/src/Api/`
+|Aggregate and Value Objects
+|`VolunteerOpportunity`, `TimeSlot`, `Address`. Holds business invariants and state transitions, raises domain events. No framework dependencies.
+|`Domain/VolunteerOpportunities/`
 
-==== Application Layer
+|Read Repository Interface
+|`IVolunteerOpportunityReadRepository` - the port queries read through, declared by the module that needs it.
+|`Application/VolunteerOpportunities/`
 
-Responsibility:: Implements all use cases as CQRS command and query handlers. Defines repository interfaces used for data access.
-
-Interfaces:: In-house messaging contracts (`ICommand`/`IQuery` with `ICommandHandler`/`IQueryHandler`, dispatched via `ISender`). Repository interfaces (`IVolunteerOpportunityReadRepository`, etc.).
-
-Location:: `backend/src/Application/`
-
-==== Domain Layer
-
-Responsibility:: Contains core business entities as plain C# classes/records. No framework dependencies. Defines business rules as domain logic.
-
-Location:: `backend/src/Domain/`
-
-==== Infrastructure Layer
-
-Responsibility:: Implements the interfaces (ports) defined in the Application layer. Persistence via EF Core (repositories, migrations); adapters for the external systems (Keycloak Admin API, SMTP email, Nominatim geocoding, MinIO object storage); domain-event dispatch and background jobs. Wires up all services in `ServiceCollectionExtensions`.
-
-Location:: `backend/src/Infrastructure/`
+|Repository and Adapters
+|EF Core implementation of the ports, entity configurations, migrations, and the geocoding adapter.
+|`Infrastructure/Persistence/`, `Infrastructure/VolunteerOpportunities/`
+|===
 
 === Level 2: Frontend SPA (Whitebox)
 
-==== Pages
+Rationale for this decomposition::
+The frontend is cut by artifact kind rather than by business function - the opposite of the backend. A React page composes shared components, hooks and helpers that are reused across unrelated domains (a modal, a date formatter, the toast bus), so grouping by domain would leave most files in a shared bucket anyway. The one functional split that does exist is by route area: everything an organizer reaches under `/app` lives in `pages/app/`, because that area has its own layout, navigation and authorization gate.
 
-Responsibility:: Top-level route components. Each page corresponds to a route and composes components.
+This asymmetry with the backend is deliberate, but it is an asymmetry: a feature that spans both ends is one folder per layer in the backend and a scattering of files in the frontend. It is the main reason a contributor's first change tends to take longer on the frontend side.
 
-Location:: `frontend/src/pages/`
+[cols="1,2,2" options="header"]
+|===
+|Element |Responsibility |Source location
 
-==== Components
+|Pages
+|Top-level route components, one per route. Public and volunteer-facing pages sit at the root; organizer pages are grouped under `app/`. A page with local sections or hooks becomes a folder with an `index.tsx`.
+|`frontend/src/pages/`, `frontend/src/pages/app/`
 
-Responsibility:: Reusable UI building blocks. Stateless or locally stateful React components styled with Tailwind CSS.
+|Components
+|Reusable UI building blocks - stateless or locally stateful, styled with Tailwind CSS. Includes the domain-flavoured ones (`SignUpModal`, `CheckInModal`, `PublicOpportunityCard`) and the generic ones (`Button`, `Modal`, `Field`).
+|`frontend/src/components/`
 
-Location:: `frontend/src/components/`
+|API Client
+|NSwag-generated TypeScript client. Provides typed methods for all backend endpoints. Never hand-edited.
+|`frontend/src/client/api-client.ts`
 
-==== API Client
+|Layouts
+|App shells (`AppLayout`, `OrgAppLayout`) and the `ProtectedRoute` authentication gate that guards routes requiring a signed-in user.
+|`frontend/src/layouts/`
 
-Responsibility:: NSwag-generated TypeScript client. Provides typed methods for all backend endpoints. Never hand-edited.
+|Contexts and Hooks
+|Global UI state (`ToastContext`, `ToolbarContext`, `QuickActionsContext`) and reusable logic (`useApiClient`, `useAchievementNotifier`, `useLoadMore`).
+|`frontend/src/contexts/`, `frontend/src/hooks/`
 
-Location:: `frontend/src/client/api-client.ts`
+|Helpers
+|Framework-free logic with unit tests alongside: formatting, status mapping, geo and colour maths, form schemas.
+|`frontend/src/lib/`
+|===
 
-==== Layouts
+=== Source Code Mapping
 
-Responsibility:: App shells (`AppLayout`, `OrgAppLayout`) and the `ProtectedRoute` authentication gate that guards routes requiring a signed-in user.
+The building block structure maps directly onto the directory structure, so no separate mapping table is needed beyond the source locations given above:
 
-Location:: `frontend/src/layouts/`
+* Level 1 containers map to the top-level directories `frontend/` and `backend/src/Api|Application|Domain|Infrastructure/`, plus `keycloak/` for the Keycloak image and realm.
+* Level 2 backend modules map to identically named folders repeated inside `Api/`, `Application/` and `Domain/`.
+* Level 3 features map to `{Feature}/v1/` folders inside a module.
 
-==== Contexts and Hooks
+Three parts of the repository sit outside that scheme and are named here so no shipped code is left unaccounted for:
 
-Responsibility:: Global UI state (`ToastContext`, `ToolbarContext`) and reusable logic (`useApiClient`, `useAchievementNotifier`, and others).
-
-Location:: `frontend/src/contexts/`, `frontend/src/hooks/`
+* `backend/src/Aspire/ServiceDefaults/` is compiled into the Backend API and belongs to the Shared Kernel. It contributes the OpenTelemetry, health-check and service-discovery defaults described in <<section-concepts>>.
+* `backend/src/Aspire/AppHost/` is local orchestration only and is never deployed - see <<section-deployment-view>>.
+* `backend/tests/` and `frontend/` test files carry no building block of their own; they are covered by the testing approach in <<section-concepts>>.

--- a/docs/Architecture/src/06_runtime_view.adoc
+++ b/docs/Architecture/src/06_runtime_view.adoc
@@ -3,7 +3,7 @@ ifndef::imagesdir[:imagesdir: ../images]
 [[section-runtime-view]]
 == Runtime View
 
-The following three scenarios cover the platform's most representative flows across the two primary personas: signing in, browsing opportunities (the main volunteer read path), and creating an opportunity (the main organizer write path).
+The following three scenarios cover the platform's most representative flows: signing in, browsing opportunities (the main volunteer read path), and creating an opportunity (the main organizer write path). They are deliberately few - arc42 advises documenting only the scenarios that are architecturally revealing. The Platform Admin flows from <<section-context-and-scope>> are not drawn here because they follow the same request path as the organizer scenario, differing only in the role the endpoint requires.
 
 === User Login (OIDC Authorization Code Flow)
 

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -5,7 +5,11 @@ ifndef::imagesdir[:imagesdir: ../images]
 
 Einsatzbereit runs in three environments: the local developer stack (orchestrated by .NET Aspire), the CI/CD pipeline (GitHub Actions), and the deployed staging/production host.
 
-=== Local Development (.NET Aspire)
+This chapter describes the infrastructure and which building blocks run where. The operational decisions behind that infrastructure - why the monitoring stack is self-hosted, what the backup strategy guards against, how alerting is routed - are cross-cutting and live in <<section-concepts>> under Operations.
+
+=== Infrastructure Level 1
+
+==== Local Development (.NET Aspire)
 
 .Deployment View - Local Development
 [plantuml, "deployment-local", png]
@@ -19,30 +23,34 @@ The entire stack runs locally via the .NET Aspire AppHost: a single `dotnet run 
 Quality and Performance Characteristics::
 Local development is optimized for fast iteration, not production performance. All services run on `localhost` with no TLS. Keycloak runs the upstream image with a dev-file database and a relaxed, auto-imported realm; the backend and frontend run from source with hot reload.
 
-.Service Allocation
+.Building Block to Node Mapping
+[cols="2,2,2" options="header"]
+|===
+|Building block (Level 1) |Node |Artifact
+
+|Single Page Application
+|Developer machine
+|Vite dev server from source, port 4321
+
+|Backend API
+|Developer machine
+|`dotnet` host process from source, port 5000
+
+|Identity Provider
+|Docker container
+|`quay.io/keycloak/keycloak:26.7.1`, port 8080
+
+|Application Database
+|Docker container
+|`postgres:18`, port 5432
+|===
+
+`backend/src/Aspire/AppHost` is the orchestrator itself and is the one project that exists only here - it is never part of a deployed artifact.
+
+.Supporting Services
 [cols="2,2,1,2" options="header"]
 |===
 |Service |Image / Source |Port |Notes
-
-|Frontend
-|Vite dev server (from source)
-|4321
-|Hot module replacement
-
-|Backend API
-|ASP.NET Core project (from source)
-|5000
-|Runs EF Core migrations on startup (Development)
-
-|Keycloak
-|`quay.io/keycloak/keycloak:26.7.1`
-|8080
-|Upstream image, dev-file DB, realm auto-imported (relaxed for local)
-
-|PostgreSQL
-|`postgres:18` (Aspire default)
-|5432
-|Application database `einsatzbereit`
 
 |pgAdmin
 |`dpage/pgadmin4`
@@ -60,7 +68,7 @@ Local development is optimized for fast iteration, not production performance. A
 |S3-compatible object storage (API on 9000, console on 9001)
 |===
 
-=== CI/CD Pipeline
+==== CI/CD Pipeline
 
 .Deployment View - CI/CD (GitHub Actions)
 [plantuml, "deployment-cicd", png]
@@ -68,9 +76,9 @@ Local development is optimized for fast iteration, not production performance. A
 include::../images/deployment-cicd.puml[]
 ....
 
-The CI/CD pipeline runs on GitHub Actions and covers three concerns: quality gates on every change, docs deployment, and release-time image publishing plus staging deployment.
+The CI/CD pipeline runs on GitHub Actions and covers three concerns: quality gates on every change, docs deployment, and release-time image publishing plus staging deployment. This environment builds and verifies the building blocks rather than serving them, so there is no building-block-to-node mapping for it; the artifacts it produces are the ones deployed in the next section.
 
-==== Quality Gate (on every push / PR to `main`)
+===== Quality Gate (on every push / PR to `main`)
 
 The backend workflow (`dotnet.yml`) runs four independent jobs in parallel (no `needs` between them), each doing its own `dotnet build` via `dotnet run`:
 
@@ -82,7 +90,7 @@ The frontend workflow (`frontend.yml`) runs lint, i18n key-parity, type-check, a
 
 The architecture docs build (`docs.yml`) also builds on every pull request touching `docs/**`, as a build-only check - GitHub Pages deployment stays gated to pushes on `main`, so a docs PR can never publish a preview.
 
-==== Image Publishing (on tag push)
+===== Image Publishing (on tag push)
 
 Images are published to GitHub Container Registry (GHCR) on version tag pushes. A single Git tag triggers the release of all components at the same version:
 
@@ -106,7 +114,7 @@ Images are published to GitHub Container Registry (GHCR) on version tag pushes. 
 
 Release candidate tags (`v{semver}-rc.N`) publish images and deploy via the `deploy-staging` job without moving the `latest` tag. Stable tags (no `-rc` suffix) publish images, move `latest`, and deploy via a separate `deploy-production` job. See link:https://github.com/maik-hasler/einsatzbereit/blob/main/VERSIONING.md[VERSIONING.md] for the full versioning and publishing strategy.
 
-=== Staging and Production
+==== Staging and Production
 
 .Deployment View - Staging / Production
 [plantuml, "deployment-staging", png]
@@ -118,14 +126,14 @@ Motivation::
 The deployed environment serves real users at `*.maik-hasler.de`. It runs `docker-compose.yml` on a single host (a Hetzner `cx43`: 8 vCPU / 16 GB RAM / 40 GB disk, provisioned via Terraform in a separate, private infrastructure repository), behind a shared, host-level Traefik reverse proxy that terminates TLS (certificates via ACME / Let's Encrypt). The same host also runs Blogfolio, an unrelated personal site - the two stacks share the machine but are otherwise fully independent (separate repos, separate deploy pipelines, no shared services beyond Traefik). This is the environment every release candidate is verified against before a change is considered done.
 
 Quality and Performance Characteristics::
-All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with tiered retention, and the MinIO bucket is backed up daily with a flat retention window (#1087); `minio-backup` then also mirrors both local backup outputs off-host to a Hetzner Object Storage bucket (closing the off-host gap #1087 left open) - the local backups alone still guard only against accidental deletion/corruption, not loss of the host itself, which the offsite mirror now also covers. Container images are the release artifacts pulled from GHCR; the backend applies EF Core migrations on startup (`Database:MigrateOnStartup`).
+All public traffic is HTTPS via Traefik. Container images are the release artifacts pulled from GHCR; the backend applies EF Core migrations on startup (`Database:MigrateOnStartup`). Backup and retention behaviour is described in <<section-concepts>> under Operations.
 
-.Service Allocation
+.Building Block to Node Mapping
 [cols="2,2,2,2" options="header"]
 |===
-|Service |Image |Hostname |Notes
+|Building block (Level 1) |Image |Hostname |Notes
 
-|Frontend
+|Single Page Application
 |`einsatzbereit-frontend:staging`
 |`einsatzbereit.maik-hasler.de`
 |Static SPA assets
@@ -135,15 +143,23 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |`api.maik-hasler.de`
 |`ASPNETCORE_ENVIRONMENT=Staging`; migrates on startup
 
-|Keycloak
+|Identity Provider
 |`einsatzbereit-keycloak:staging`
 |`login.maik-hasler.de`
 |Custom image with committed realm; PostgreSQL-backed
 
-|PostgreSQL
+|Application Database
 |`postgres:18`
 |internal
 |Two databases: `einsatzbereit` and `keycloak`
+|===
+
+The mapping is 1:1 today - every Level-1 building block runs as exactly one container on one host. There is no horizontal scaling and no second host, which is what makes the single-host risk in TDR-3 a real one rather than a theoretical one.
+
+.Supporting Services
+[cols="2,2,2,2" options="header"]
+|===
+|Service |Image |Hostname |Notes
 
 |db-backup
 |`prodrigestivill/postgres-backup-local:18`
@@ -163,22 +179,22 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |minio-backup
 |`minio/mc`
 |internal
-|Daily mirror of the einsatzbereit bucket (retention 7 days), then mirrors its own and db-backup's local output to a Hetzner Object Storage bucket (#1087)
+|Daily mirror of the einsatzbereit bucket, then mirrors its own and db-backup's local output off-host (#1087)
 
 |Grafana
 |`grafana/grafana`
 |`grafana.maik-hasler.de`
-|Dashboards; datasources are Prometheus (metrics), Loki (logs), Tempo (traces), and Alertmanager (alerts)
+|Dashboards; datasources are Prometheus, Loki, Tempo and Alertmanager
 
 |Prometheus
 |`prom/prometheus`
 |internal only
-|Metrics store; scrapes node-exporter, not exposed via Traefik; evaluates alert rules and forwards firing alerts to Alertmanager
+|Metrics store; scrapes node-exporter, evaluates alert rules
 
 |Alertmanager
 |`prom/alertmanager`
 |internal only
-|Routes firing alerts to email over the same SMTP relay as the backend/Keycloak, not exposed via Traefik
+|Routes firing alerts to email over the SMTP relay
 
 |node-exporter
 |`prom/node-exporter`
@@ -188,7 +204,7 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Loki
 |`grafana/loki`
 |internal only
-|Log store; receives pushes from Alloy, not exposed via Traefik
+|Log store; receives pushes from Alloy
 
 |Alloy
 |`grafana/alloy`
@@ -198,7 +214,7 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Tempo
 |`grafana/tempo`
 |internal only
-|Trace store; receives OTLP pushes directly from the backend, not exposed via Traefik
+|Trace store; receives OTLP pushes directly from the backend
 
 |Traefik
 |host-level (shared)
@@ -206,6 +222,29 @@ All public traffic is HTTPS via Traefik. PostgreSQL data is backed up daily with
 |Reverse proxy, TLS termination via ACME / Let's Encrypt
 |===
 
-Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`) via one of two jobs - `deploy-staging` for RC tags, `deploy-production` for stable tags (#1344). Both jobs deploy to the exact same host and `/opt/einsatzbereit` directory described in the table above - there is only one live host today, and it is deliberately staging/demo infrastructure rather than a hardened production box (see root `AGENTS.md`'s Test Users note). The two-job split exists so that pointing at a genuinely separate production host later is a matter of changing the `production` GitHub Environment's secrets, not restructuring the workflow; until then, a stable release replaces whatever RC was running with the `latest`-tagged images (RCs use the mutable `staging` tag instead), and the two jobs share a concurrency group so they never race against the same host. The deploy is health-gated (backend `/alive` and `/health`) and rolls back to the previous images on failure.
+Deployment is release-driven: a version tag triggers `publish.yml`, which builds and pushes the images to GHCR and then deploys to the host over SSH (`docker compose pull` + `up`) via one of two jobs - `deploy-staging` for RC tags, `deploy-production` for stable tags (#1344). Both jobs deploy to the exact same host and `/opt/einsatzbereit` directory described in the table above - there is only one live host today, and it is deliberately staging/demo infrastructure rather than a hardened production box (see root `AGENTS.md`'s Test Users note). The two-job split exists so that pointing at a genuinely separate production host later is a matter of changing the `production` GitHub Environment's secrets, not restructuring the workflow; until then, a stable release replaces whatever RC was running with the `latest`-tagged images (RCs use the mutable `staging` tag instead).
 
-Prometheus, Alertmanager, node-exporter, Loki, and Tempo sit on an internal-only `monitoring` Docker network with no Traefik route, since none of them has built-in auth and would leak scraped metrics, log, trace, or alert content if reachable from the internet. Grafana is the only service in this group with a public route, gated by its own admin login (`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`), and reads Prometheus (metrics), Loki (logs), Tempo (traces), and Alertmanager (alerts) as datasources. Alloy ships container logs to Loki; it discovers containers and streams their logs through a read-only mount of the host's Docker socket, the standard pattern for Docker-aware log shippers - this is a narrower grant than cAdvisor's (list containers and read their logs, not full host filesystem and cgroup access, which is why cAdvisor itself was left out of this pass), but a compromised container with socket access still has effective host-level reach, so it is not risk-free. Per-container metrics (cAdvisor) remain a possible follow-up if the host-level view here proves insufficient. Tempo has no equivalent shipper: the backend pushes traces to it directly over OTLP (see ADR 6), since the app already speaks OTLP natively via the Aspire service defaults. Alertmanager notifies over email (SMTP) rather than a push-based shipper, since alerts are pulled from Prometheus's own rule evaluation, not scraped or streamed from elsewhere.
+=== Infrastructure Level 2: Deployed Host
+
+The deployed host is the one infrastructure element whose internal structure matters, because network segmentation is what keeps the unauthenticated monitoring services off the internet. Everything above runs as containers on a single Docker daemon, split across three networks:
+
+[cols="1,3,3" options="header"]
+|===
+|Network |Members |Reachability
+
+|`proxy` (external, shared with Blogfolio)
+|Frontend, Backend API, Keycloak, MinIO, minio-init, minio-backup, Grafana
+|Attached to the host-level Traefik. Frontend, Backend API, Keycloak, MinIO and Grafana each have a route and a public hostname under `*.maik-hasler.de`; the two `mc` sidecars join only to reach MinIO.
+
+|`einsatzbereit-db`
+|PostgreSQL, Keycloak, Backend API, db-backup
+|Container-to-container only. PostgreSQL publishes no port and is reachable by name from this network alone.
+
+|`einsatzbereit-monitoring`
+|Prometheus, Alertmanager, node-exporter, Loki, Alloy, Tempo, Grafana, Backend API
+|No Traefik route except through Grafana. See <<section-concepts>> under Operations for why the rest are not exposed.
+|===
+
+Three containers deliberately straddle networks. The *Backend API* is on all three: `proxy` to serve public traffic, `db` to reach PostgreSQL, `monitoring` to push OTLP traces to Tempo. *Keycloak* is on `proxy` and `db` for the same reason at a smaller scale. *Grafana* is on `proxy` and `monitoring` so it can be publicly reachable while reading datasources that are not.
+
+Those three are therefore where an authentication gap has the widest blast radius, which is why Grafana carries its own admin login and the Backend API validates every JWT against Keycloak's JWKS. MinIO is the one supporting service with a public route of its own; it is reached over `proxy` rather than the database network, and the backend authenticates to it with a bucket-scoped service account rather than root credentials (#1353).

--- a/docs/Architecture/src/08_concepts.adoc
+++ b/docs/Architecture/src/08_concepts.adoc
@@ -3,6 +3,48 @@ ifndef::imagesdir[:imagesdir: ../images]
 [[section-concepts]]
 == Cross-cutting Concepts
 
+The concepts below are grouped the way arc42 suggests: what the system is about, how it is structured, how it is secured, what happens under the hood, how it is developed, and how it is operated. Term definitions are not repeated here - they live in <<section-glossary>>.
+
+=== Domain Model
+
+The domain model is the vocabulary the rest of this document uses. It is referenced by every module in <<section-building-block-view>> and by the runtime scenarios in <<section-runtime-view>>.
+
+.Domain Model
+[plantuml, "domain-model", png]
+....
+include::../images/domain-model.puml[]
+....
+
+An *Organization* publishes *Volunteer Opportunities*. An opportunity is the central aggregate: it says what help is needed, where, and when. It is either a `ScheduledSlots` opportunity, which carries one or more *Time Slots* that volunteers book, or an `IndividualContact` opportunity, which carries an application deadline instead and is arranged directly with the organizer. A recurring opportunity generates several time slots sharing a `SeriesId` so they can later be edited or cancelled together.
+
+A volunteer signing up creates an *Engagement*, which links a *User*, an opportunity and (for scheduled opportunities) one time slot. The engagement carries the whole lifecycle a sign-up goes through: `Pending` until the organizer confirms it, then check-in on the day, then optional feedback afterwards. Withdrawn or cancelled engagements are kept rather than deleted and can be reactivated a bounded number of times.
+
+Two modelling decisions are worth stating because they are not obvious from the diagram:
+
+* An engagement's `VolunteerId` is nullable. When a user deletes their account, their engagements are anonymized instead of removed, so an organizer's past participant counts stay correct and the opportunity's history is not silently rewritten.
+* *Report* and *Audit Log* reference what they concern polymorphically, through a `TargetType`/`SubjectType` enum plus a raw `Guid`. Moderation has to be able to point at any aggregate, and a typed foreign key per target type would either couple the moderation module to every other module or force a join table per type.
+
+Membership in an organization is its own aggregate, not a field on either side: *Organization Membership* holds the pair plus the member's role, and *Organization Invitation* holds a pending offer to create one. The local membership table, not the JWT, is the request-time source of truth for organizer access - see Authentication and Authorization below.
+
+The remaining aggregates hang off *User* and exist to support engagement rather than to record it: *Achievements* (badges), *User Streak* (login and activity counters), *Search Alert* (saved criteria, one per user, matched by a scheduled digest), and *Notification* (the in-app inbox).
+
+=== Module Structure
+
+Every functional module in <<section-building-block-view>> is built the same way. Documenting the shape once here is what allows Level 3 of the building block view to show a single example instead of twelve near-identical whiteboxes.
+
+*Clean Architecture layering.* Dependencies point inward only: `Api` to `Application` to `Domain`. `Infrastructure` implements ports declared in `Application` and is referenced only through them, so the domain and use cases compile without EF Core, Keycloak or any HTTP client. The rule is enforced by `backend/tests/ArchitectureTests`, not just by convention.
+
+*One folder per use case.* Each feature lives in `{Layer}/{Domain}/{Feature}/v1/` and consists of the request record, the handler, and the response record. Finding the code for a feature means finding one folder per layer; adding a feature means adding folders rather than editing shared service classes.
+
+*CQRS.* Use cases are split into commands and queries, dispatched through a small in-house mediator (`ISender`, no external library) with reflection-registered handlers. Two pipeline behaviors wrap every command: one opens a database transaction, the other logs slow requests.
+
+* *Queries* are read-only. They use dedicated read repository interfaces (`IVolunteerOpportunityReadRepository`) and may use projections without loading full aggregate state.
+* *Commands* change state. They return only what is needed (typically the new entity's ID) and enforce business rules before writing.
+
+*Domain events for cross-module reactions.* An aggregate raises domain events; they are dispatched after commit through the outbox. Notifications, achievements and emails are produced by handlers subscribing to those events, so the module that causes something never references the modules that react to it. This is what keeps Volunteer Opportunities free of any mention of Notifications.
+
+*Result instead of exceptions.* Domain and application logic signal failure with `Result` / `Result<T>` carrying an `Error`, not by throwing. See Error Handling below for how that reaches the client.
+
 === Authentication and Authorization
 
 Authentication and authorization are fully delegated to Keycloak. The application itself does not implement login, password management, or session handling.
@@ -30,7 +72,7 @@ Role-based access control is enforced at the API endpoint level using ASP.NET Co
 |All `user` permissions + create, update, and delete own organization's opportunities
 
 |`admin`
-|Full administrative access
+|Full administrative access: moderation queue, user and organization administration, audit log
 |===
 
 *Per-organization membership:*
@@ -42,15 +84,6 @@ Membership rows are written when a user is added to an organization, and once at
 *Token handling in the frontend:*
 
 Access and refresh tokens are stored in `localStorage` via the OIDC client's `WebStorageStateStore`, so the session survives a page reload. The refresh token is used to obtain new access tokens silently when the access token expires.
-
-=== CQRS (Command Query Responsibility Segregation)
-
-All use cases in the application layer follow the CQRS pattern, dispatched through a small in-house mediator (`ISender`, no external library) with reflection-registered handlers. Two pipeline behaviors wrap every command: one opens a database transaction, the other logs slow requests.
-
-* *Queries* are read-only operations. They return data and do not modify state. Queries use dedicated read repository interfaces (`IVolunteerOpportunityReadRepository`) and may use optimized read paths (e.g., projections) without loading full aggregate state.
-* *Commands* are state-changing operations. They return only what is needed (e.g., the created entity's ID) and enforce business rules before writing.
-
-Each use case lives in its own folder under `{Layer}/{Domain}/{Feature}/v1/` and consists of the request record, the handler, and the response record. This makes every use case self-contained and easy to locate.
 
 === Error Handling
 
@@ -105,13 +138,29 @@ The user interface is translated with i18next (`react-i18next`), backed by resou
 
 === Geocoding and Geo-Search
 
-Opportunity addresses are geocoded at write time, and spatial search uses a bounding-box prefilter plus in-memory Haversine refinement (no PostGIS). This concept is documented in full as an architecture decision - see ADR-4.
+Opportunity addresses are geocoded at write time, and spatial search uses a bounding-box prefilter plus in-memory Haversine refinement (no PostGIS). This concept is documented in full as an architecture decision - see ADR-4. Map tiles and city autocomplete are proxied through the backend rather than called from the browser, so visitor IP addresses are never sent to OpenStreetMap - see ADR-5.
+
+=== Testing
+
+Tests are organized by what they need to run, which is also how CI parallelizes them (see <<section-deployment-view>>):
+
+* `Application.UnitTests` and `ArchitectureTests` need no containers. The architecture tests (NetArchTest) enforce the Clean Architecture layer rules and the naming conventions described under Module Structure, so a violation fails the build rather than waiting for review.
+* `IntegrationTests` boot the Aspire AppHost stack under Docker and reset state between tests with Respawn.
+* `VisualTests` add Playwright end-to-end checks against the same stack, and are also where accessibility assertions live.
+* Frontend helper logic under `frontend/src/lib/` carries unit tests alongside the implementation.
+
+=== Development and Build
+
+* *Local orchestration.* One command (`dotnet run --project backend/src/Aspire/AppHost`) provisions PostgreSQL, pgAdmin, Keycloak, MinIO and Mailpit as containers and runs the backend and frontend from source. Contributors do not set up services by hand.
+* *Generated API client.* `frontend/src/client/api-client.ts` is generated by NSwag from the backend's OpenAPI document and is never hand-edited; a change to an endpoint or DTO requires regenerating it.
+* *Dependency management.* NuGet versions are centralized in `Directory.Packages.props`; Renovate opens update pull requests.
+* *Release artifacts.* Frontend, backend and Keycloak images are built and published together under a single version tag - see <<section-deployment-view>> and `VERSIONING.md`.
 
 === Logging and Observability
 
 The backend uses the .NET built-in `ILogger<T>` abstraction. Every request runs inside a logging scope that enriches its entries with the OpenTelemetry trace ID and the authenticated user ID.
 
-Observability is built on OpenTelemetry (via the Aspire service defaults): logs, metrics (ASP.NET Core, HTTP client, runtime), and distributed traces are exported over OTLP - collected by the Aspire dashboard in development, and by Grafana Tempo in staging/production, where `docker-compose.yml` points `OTEL_EXPORTER_OTLP_ENDPOINT` at it (ADR 6).
+Observability is built on OpenTelemetry (via the Aspire service defaults in `backend/src/Aspire/ServiceDefaults/`): logs, metrics (ASP.NET Core, HTTP client, runtime), and distributed traces are exported over OTLP - collected by the Aspire dashboard in development, and by Grafana Tempo in staging/production (ADR-6).
 
 Key logged events:
 
@@ -119,6 +168,20 @@ Key logged events:
 * Unhandled exceptions (with trace ID)
 * Slow requests (flagged by the performance pipeline behavior)
 
-No third-party observability SaaS (Datadog, Grafana Cloud, etc.) is wired in by default - a deliberate trade-off to keep operational complexity minimal; any OTLP backend can be pointed at the exporter, and the self-hosted Grafana stack (Prometheus, Loki, Tempo) already deployed alongside the app is what it points at in staging/production.
+=== Operations
 
-Prometheus evaluates alert rules (`docker-compose.yml`'s `prometheus-rules` config, mounted at `/etc/prometheus/alert.rules.yml`) and forwards firing alerts to a self-hosted Alertmanager, which emails them out over the same SMTP relay the backend and Keycloak already use (#1081) - again keeping the "self-hosted over SaaS" trade-off above rather than adding a third-party alerting/incident vendor. The only rule shipped so far is `InstanceDown` (any scrape target unreachable for 2 minutes); it is deliberately the one signal that needs no application-specific metric knowledge, left minimal until real staging traffic justifies additional thresholds.
+The infrastructure these concepts run on is described in <<section-deployment-view>>; this section covers the decisions behind it, which apply across services rather than to any one node.
+
+*Self-hosted over SaaS.* No third-party observability or alerting vendor is wired in by default - not Datadog, not Grafana Cloud, not an incident platform. The deployed environment runs its own Grafana, Prometheus, Loki, Tempo and Alertmanager instead. The trade-off is deliberate: it keeps operational complexity and cost inside one `docker-compose.yml` and avoids a data-sharing relationship with a vendor for a platform handling volunteer contact data. Any OTLP backend can be pointed at the exporter if that changes.
+
+*Exposure of the monitoring stack.* Prometheus, Alertmanager, node-exporter, Loki and Tempo sit on an internal-only `monitoring` Docker network with no reverse-proxy route, because none of them has built-in authentication and each would leak metric, log, trace or alert content if reachable from the internet. Grafana is the only one with a public route, gated by its own admin login.
+
+*Log and trace collection.* Grafana Alloy ships container logs to Loki, discovering containers through a read-only mount of the host's Docker socket. This is the standard pattern for Docker-aware log shippers and a narrower grant than cAdvisor's (list containers and read their logs, rather than full host filesystem and cgroup access, which is why cAdvisor was left out), but a compromised container with socket access still has effective host-level reach - it is not risk-free. Per-container metrics remain a possible follow-up if the host-level view proves insufficient. Tempo needs no shipper: the backend pushes traces to it directly over OTLP, since the application already speaks OTLP natively.
+
+*Alerting.* Prometheus evaluates alert rules and forwards firing alerts to Alertmanager, which emails them over the same SMTP relay the backend and Keycloak already use (#1081). The only rule shipped so far is `InstanceDown` (any scrape target unreachable for two minutes) - deliberately the one signal that needs no application-specific metric knowledge. It stays minimal until real staging traffic justifies additional thresholds.
+
+*Backup and recovery.* PostgreSQL is backed up daily with tiered retention (7 days / 4 weeks / 6 months); the object storage bucket is mirrored daily with a flat retention window. Both local backup outputs are then mirrored off-host to Hetzner Object Storage (#1087). Local backups alone guard only against accidental deletion or corruption; the offsite mirror is what covers loss of the host itself.
+
+*Data retention.* Read notifications are pruned relative to when they were read rather than when they were created, and abuse reports concerning a deleted account are pruned from the point that account was deleted (#1725). Both run as scheduled background jobs.
+
+*Deployment safety.* Deployments are health-gated on the backend's `/alive` and `/health` endpoints and roll back to the previous images on failure. Release-candidate and stable deploys share a concurrency group so they can never race against the same host.

--- a/docs/Architecture/src/12_glossary.adoc
+++ b/docs/Architecture/src/12_glossary.adoc
@@ -3,12 +3,86 @@ ifndef::imagesdir[:imagesdir: ../images]
 [[section-glossary]]
 == Glossary
 
+=== Domain Terms
+
+These are the terms the domain model in <<section-concepts>> is built from. They are the vocabulary used in code, in the UI and in this document; where a German UI string differs from the code identifier, both are given.
+
+[cols="1,3" options="header"]
+|===
+|Term |Definition
+
+|Achievement
+|A badge a volunteer unlocks, of type `Milestone` (a count reached), `Streak` (sustained activity) or `Hidden` (not shown until earned). Awarded automatically in reaction to domain events, never granted by hand.
+
+|Audit Log
+|Append-only record of an administrative action: who acted, what action, on which subject, and optionally why. Written whenever a platform admin disables, restores or changes an account, organization or listing. Readable only by admins.
+
+|Check-in
+|Confirmation that a volunteer actually showed up. The organizer chooses the method per opportunity: `None`, `QRCode`, `PINCode` (a short code the organizer reads out on site) or `Manual`.
+
+|Engagement
+|A volunteer's sign-up for one volunteer opportunity, and the record of how it went: `Pending` until the organizer confirms, then check-in, then optional feedback. Withdrawn or cancelled engagements are kept rather than deleted and can be reactivated a limited number of times. Survives the volunteer's account deletion in anonymized form.
+
+|Feedback
+|A rating and optional comment a volunteer leaves on a completed engagement, editable for a limited window after submission.
+
+|Invitation
+|An organizer's offer to a user to join an organization with an intended role. Expires after 14 days if not accepted or declined.
+
+|Membership
+|The link between a user and an organization, carrying the member's role (`Member` or `Organizer`). This local record - not the JWT role - decides at request time whether a user may modify a given organization.
+
+|Notification
+|An in-app message in a user's inbox, generated from a domain event (a sign-up arrived, an invitation was accepted, a matching opportunity was published). Distinct from the emails sent for the same events.
+
+|Occurrence
+|Whether an opportunity happens once (`OneTime`) or repeatedly (`Recurring`). Recurring opportunities generate a series of time slots that can be edited or cancelled together.
+
+|Organization
+|A club, NGO, or other entity that posts volunteer opportunities on the platform.
+
+|Organizer
+|A user with the `organisator` role who manages an organization's volunteer opportunities. Test persona: Olaf (`olaf` / `olaf123`).
+
+|Participation Type
+|How a volunteer takes part: `ScheduledSlots` (they book a concrete time slot) or `IndividualContact` (they apply before a deadline and arrange it with the organizer directly).
+
+|Platform Admin
+|A user with the `admin` role. Works through reported content, disables and restores accounts, organizations and listings, and reads the audit log. Test persona: `admin` / `admin123`.
+
+|Report
+|An abuse report filed by a user against an opportunity, an organization or another user. Moves from `Open` to either `Dismissed` or `Actioned` in the moderation queue.
+
+|Search Alert
+|A volunteer's saved search criteria. One per user; a scheduled digest job notifies them when newly published opportunities match.
+
+|Shadow Delete
+|An admin action that makes an account, organization or listing invisible to everyone else without destroying its data, so it can be restored. Distinct from a volunteer deleting their own account, which anonymizes their engagements permanently.
+
+|Streak
+|Counters tracking a volunteer's sustained activity: consecutive login days and consecutive active weeks, plus a total of confirmed engagements. Feeds the streak achievements.
+
+|Time Slot
+|One concrete shift within a volunteer opportunity: start, end, and an optional participant cap. Slots created by one recurring request share a series ID.
+
+|Volunteer
+|A user who searches for and signs up for volunteer opportunities. Test persona: Vera (`vera` / `vera123`).
+
+|Volunteer Opportunity
+|A concrete request for help posted by an organization. Describes what is needed, where, when, and what skills are required. Central aggregate of the domain; moves through `Draft`, `Published`, `Unpublished` and `Cancelled`.
+|===
+
+=== Technical Terms
+
 [cols="1,3" options="header"]
 |===
 |Term |Definition
 
 |ADR
 |Architecture Decision Record. A document that captures a significant architectural decision including its context, the decision itself, the rationale, considered alternatives, and consequences. ADRs are stored under `docs/ADRs/`.
+
+|Aggregate
+|A cluster of domain objects treated as one consistency boundary, with a single root entity as its only entry point. `VolunteerOpportunity` with its `TimeSlot` children is the clearest example; a handler loads and saves the root, never a child directly.
 
 |AGPL
 |GNU Affero General Public License. The open-source license under which Einsatzbereit is released. Derivative works - including those deployed as network services - must be released under the same license.
@@ -22,11 +96,11 @@ ifndef::imagesdir[:imagesdir: ../images]
 |CQRS
 |Command Query Responsibility Segregation. An architectural pattern that separates read operations (queries) from write operations (commands).
 
+|Domain Event
+|A record that something business-relevant happened, raised by an aggregate and dispatched after the transaction commits. How modules react to each other without referencing each other - see <<section-concepts>> under Module Structure.
+
 |EF Core
 |Entity Framework Core. The ORM (Object-Relational Mapper) used in the backend to interact with PostgreSQL. Manages the database schema via migrations.
-
-|Engagement
-|The act of a volunteer signing up to help with a specific volunteer opportunity. Modeled as an `Engagement` entity in the domain.
 
 |GHCR
 |GitHub Container Registry. The Docker image registry used to publish the frontend, backend, and Keycloak images on version releases.
@@ -46,27 +120,31 @@ ifndef::imagesdir[:imagesdir: ../images]
 |Mediator (ISender)
 |The application's small in-house CQRS dispatcher (`ISender`). Routes commands and queries to their handlers, decoupling the API layer from use-case implementation. The project deliberately uses this instead of the external MediatR library.
 
+|Module
+|A functional building block of the backend, cut by business function and repeated as a folder in `Api/`, `Application/` and `Domain/`. Listed in full in <<section-building-block-view>>.
+
 |NSwag
 |A .NET toolchain for generating API clients from OpenAPI specifications. The frontend TypeScript client (`api-client.ts`) is generated via NSwag and must never be hand-edited.
 
 |OIDC
 |OpenID Connect. An identity layer built on top of OAuth 2.0. Used for the authentication flow between the frontend, Keycloak, and the backend.
 
-|Organization
-|A club, NGO, or other entity that posts volunteer opportunities on the platform.
+|OTLP
+|OpenTelemetry Protocol. The wire format the backend exports logs, metrics and traces in - collected by the Aspire dashboard locally and by Grafana Tempo in staging (ADR-6).
 
-|Organizer
-|A user with the `organisator` role. Represents a person who manages an organization's volunteer opportunities. Test persona: Olaf (`olaf` / `olaf123`).
+|Outbox
+|A database table domain events are written to inside the same transaction as the state change that raised them, then dispatched by a background job. Guarantees an event is never lost or emitted for a rolled-back change.
 
 |PKCE
 |Proof Key for Code Exchange. An extension to the OAuth 2.0 Authorization Code Flow that prevents authorization code interception attacks. Required for public clients (SPAs) where a client secret cannot be kept confidential.
 
+|Shared Kernel
+|The cross-module code every module depends on: message dispatch, `Result`/`Error` primitives, authorization guards, pagination, and the persistence, storage and email ports.
+
 |TDR
 |Technical Debt Record. Captures a known technical debt or risk with its context, impact, severity, and proposed mitigation. Stored under `docs/TDRs/` and referenced from chapter 11.
 
-|Volunteer
-|A user who searches for and signs up for volunteer opportunities. Test persona: Vera (`vera` / `vera123`).
+|Value Object
+|A domain object identified by its values rather than an ID, immutable once created. `Address` is the one in this domain; it is stored inline on its owner rather than as its own table.
 
-|Volunteer Opportunity
-|A concrete request for help posted by an organization. Describes what is needed, where, when, and what skills are required. Core entity of the domain.
 |===


### PR DESCRIPTION
## What

Restructures the arc42 documentation so the functional decomposition is visible: the building block view now refines the backend into its twelve functional modules, chapter 8 gains a domain model, and the operational rationale that had accumulated in chapter 7 moves to chapter 8 where arc42 puts operations concepts.

## Why

The docs described the system almost entirely in technical terms. Concretely:

- **Chapter 5's only refinement was the four Clean Architecture layers** - the axis chapter 4 explicitly said the code is *not* organized on. The backend's `Api/`, `Application/` and `Domain/` each repeat the same twelve functional module folders, and none of them appeared anywhere in the docs. Achievements, audit logs, invitations, notifications, reports and search alerts were undocumented entirely, which breaks arc42's one completeness rule (tip 5-18: every line of code needs a building block above it).
- **No domain or data model existed** (tips 8-5/8-7). The glossary defined 16 technical terms against 5 functional ones.
- **Chapter 5 Level 2 duplicated chapter 8** - the layer/CQRS shape is identical for all twelve modules, which is exactly what tips 5-10 and 5-28 say to describe once as a concept instead of drawing per building block.
- **Chapter 7 was the longest chapter in the document** (211 lines, more than chapters 5 and 6 combined) yet was missing the mapping of building blocks onto nodes (tips 7-5/7-7) - the tables listed images and ports but never said which building block ran where.
- **Keycloak and PostgreSQL appeared as first-class building blocks** without third-party marking (tips 5-19/5-20), while chapter 3 listed the same two as external neighbours.
- **The Platform Admin had a role, a page, a moderation queue and an audit trail in the code**, but appeared in no view, no stakeholder list, and no issue-template persona dropdown.
- **Chapter 4 and root `AGENTS.md` both claimed the frontend uses feature folders.** It does not - it is organized by artifact kind.

No issue number; this came out of a review of the documentation against the current code.

### Chapter by chapter

**5 - Building Block View**
- Name the cohesion criterion per level explicitly (tip 5-17) and give every whitebox a rationale (tip 5-8); none had one before
- New Level 2 for the backend: twelve functional modules plus the shared kernel, each with responsibility and source location. Explains the two cuts that do not follow entity ownership (Invitations split from Organizations by actor; Maps/Meta/Sitemap owning no aggregate)
- Level 3 refines one module as an example (tip 5-27); the shape it repeats moves to chapter 8
- Keycloak and PostgreSQL marked third party, with the reason they are shown at all
- Frontend section describes what the frontend actually is (artifact kind, plus a route-area split), and names the asymmetry with the backend rather than hiding it
- Source code mapping section accounting for `Aspire/ServiceDefaults` (which ships), `Aspire/AppHost` (which does not) and tests

**8 - Cross-cutting Concepts**
- New domain model diagram and section covering all eleven aggregates, including the two non-obvious modelling decisions (nullable `VolunteerId`, polymorphic report/audit targets)
- New Module Structure concept, absorbing the old CQRS section
- New Testing and Development sections
- New Operations section holding the monitoring, alerting, backup, retention and deploy-safety rationale moved out of chapter 7

**7 - Deployment View**
- Building-block-to-node mapping per environment
- New Infrastructure Level 2 for the deployed host's three Docker networks, and which three containers straddle them
- Operational rationale moved to chapter 8, leaving infrastructure here

**1, 3, 4, 6, 12, `AGENTS.md` and the issue templates**
- Platform Admin added as persona, stakeholder and business-context actor, with its interactions mapped to real endpoints, and added to the bug-report and user-story persona dropdowns (`.github/ISSUE_TEMPLATE/`) where admin-facing issues previously had nothing to file under
- Frontend feature-folder claim corrected in both places it appeared
- Glossary split into domain and technical terms; 20 domain terms added

### Diagrams

New: `domain-model.puml`, `module-backend.puml`. Rewritten: `component-backend.puml` (now the Level-3 module internals). Updated: `container-view.puml` (third-party marking, admin persona), `business-context.puml`, `technical-context.puml`.

## Testing

Docs-only change, so no code tests apply. Verified by building the documentation exactly as `docs.yml` does:

- `asciidoctor -r asciidoctor-diagram -a imagesdir=images -b html5` on `Architecture.adoc` - exit 0, no warnings, no unresolved cross-references, all 13 PlantUML diagrams render
- Each new and changed diagram rendered and inspected individually; the domain model was reworked after the first version came out 3806px wide and unreadable (now 2013x952)
- All four issue-template YAML files parsed with `yaml.safe_load` after the dropdown change, since GitHub issue forms fail closed on a malformed form
- Both `lint.yml` gates checked locally: no U+2013/U+2014 anywhere in the diff, and no space-indented lines, trailing whitespace, missing final newlines or CRLF in any changed `.adoc`/`.puml`, no tabs in the changed YAML. The `editorconfig-checker` binary itself could not run in this sandbox (its GitHub release download is blocked), so those rules were checked by hand rather than by the tool
- Every factual claim was checked against the code rather than carried over: module folders per layer, endpoint routes in the chapter 3 mapping table, the aggregates and enum values in the domain model, Docker network membership per service in `docker-compose.yml`, and which projects are compiled into the shipped API

## Live verification

Not applicable - docs-only. No runtime behavior, no images, nothing deployable changes; the only build affected is `docs.yml`, which is exercised on this PR.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior