### PR TITLE
chore(deps): drop the Microsoft.OpenApi pin and close the .NET 10.0.400 drift

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Check for pending EF Core model changes
         working-directory: backend
         run: |
-          dotnet tool install --global dotnet-ef --version 10.0.10
+          dotnet tool install --global dotnet-ef --version 10.0.11
           dotnet ef migrations has-pending-model-changes -p src/Infrastructure -s src/Api --no-build
 
       # visual-tests actually launches a browser on its own runner (a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ einsatzbereit/
 
 | | |
 |---|---|
-| Backend | .NET 10 (SDK 10.0.302, see `backend/global.json`), EF Core 10, PostgreSQL 18 |
+| Backend | .NET 10 (SDK 10.0.400, see `backend/global.json`), EF Core 10, PostgreSQL 18 |
 | Auth | Keycloak 26.7.1 (OIDC, JWT) |
 | Frontend | Vite SPA, React 19, React Router v8, Tailwind CSS 4 |
 | API client | NSwag-generated - **never hand-edit** `api-client.ts` |
@@ -27,7 +27,7 @@ einsatzbereit/
 
 ## Development Setup
 
-Required: .NET SDK **10.0.302** (enforced via `backend/global.json`).
+Required: .NET SDK **10.0.400** (enforced via `backend/global.json`).
 
 ```bash
 dotnet run --project backend/src/Aspire/AppHost

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ It is built from the AsciiDoc sources in `docs/Architecture/` via AsciiDoctor an
 
 ### Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/) - exact version pinned in `backend/global.json` (10.0.302)
+- [.NET 10 SDK](https://dotnet.microsoft.com/) - exact version pinned in `backend/global.json` (10.0.400)
 - [Docker](https://www.docker.com/) - Aspire runs PostgreSQL and Keycloak as containers
 - [pnpm](https://pnpm.io/) - frontend package manager
 

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -34,7 +34,6 @@
 		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.17.0]" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.17.0]" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.17.0]" />
-		<PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="[13.4.6]" />
 		<PackageVersion Include="Aspire.Hosting.JavaScript" Version="[13.4.6]" />
 		<PackageVersion Include="Aspire.Hosting.Testing" Version="[13.4.6]" />

--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,31 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/keycloak/keycloak"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^AGENTS\\.md$/",
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "SDK (?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+), see `backend/global\\.json`",
+        "\\.NET SDK \\*\\*(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)\\*\\*",
+        "pinned in `backend/global\\.json` \\((?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)\\)"
+      ],
+      "datasourceTemplate": "dotnet-version",
+      "depNameTemplate": "dotnet-sdk"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/dotnet\\.yml$/"
+      ],
+      "matchStrings": [
+        "dotnet tool install --global dotnet-ef --version (?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
+      ],
+      "datasourceTemplate": "nuget",
+      "depNameTemplate": "dotnet-ef"
     }
   ]
 }


### PR DESCRIPTION
## What

Removes the `Microsoft.OpenApi` transitive pin from `backend/Directory.Packages.props`, and cleans up three version strings the dotnet monorepo bump (#1764) left behind - the SDK version quoted in `README.md` / `AGENTS.md`, and the `dotnet-ef` tool version installed by the EF model-drift CI step. `renovate.json` gains custom managers for all three so they travel with the next bump instead of drifting again.

## Why

Closes #1762

#1764 moved `Microsoft.AspNetCore.OpenApi` to **10.0.11**, the servicing release carrying dotnet/aspnetcore#67543. Its nuspec now reads:

```xml
<dependency id="Microsoft.OpenApi" version="[2.7.5, 3.0.0)" exclude="Build,Analyzers" />
```

instead of exactly `2.0.0`, so the package that put the build inside GHSA-v5pm-xwqc-g5wc (`[2.0.0-preview.11, 2.7.4]`) is gone from the graph on its own. The pin that forced 2.7.5 is now dead weight, exactly as the issue anticipated, so it goes.

Two notes on the issue's acceptance criteria:

- Criterion 2 mentions removing "the `PackageVersion` entry **and its one-line comment**". There is no comment - #1760 shipped the pin bare (`git show 5590b7f:backend/Directory.Packages.props`), so only the entry existed to remove.
- Nothing else in the graph requires `Microsoft.OpenApi` - checked the nuspecs of `Microsoft.Extensions.ApiDescription.Server`, `NSwag.MSBuild` and both `Asp.Versioning.*` packages. The 2.7.5 floor came solely from the pin, and now comes solely from the framework package.

### The drift half

Renovate's `customManagers` currently only cover Keycloak, so nothing was watching these three, and #1764 left them stale:

| Where | Was | Now |
|---|---|---|
| `README.md`, `AGENTS.md` (x2) | SDK 10.0.302 | 10.0.400 (matches `backend/global.json`) |
| `.github/workflows/dotnet.yml` | `dotnet-ef --version 10.0.10` | 10.0.11 (matches the EF Core packages) |

The `dotnet-ef` mismatch was not breaking CI - EF's tooling only warns when the tool is older than the runtime - so this is drift cleanup, not a build fix.

The new doc manager deliberately reuses the depName (`dotnet-sdk`) and datasource (`dotnet-version`) that Renovate's own `global.json` handler emits, so the doc updates land **in the same PR** as the SDK bump rather than a separate one.

Removing the pin should also make Renovate retire #617 (`Microsoft.OpenApi` -> v3), which is currently red and could never merge anyway: 3.x sits outside the `[2.7.5, 3.0.0)` range the framework package now requires.

## Testing

Verified locally against a real restore, not just by reading nuspecs:

- `dotnet restore` (full solution) - clean, **no NU1903**. With `TreatWarningsAsErrors` in `Directory.Build.props` this is the check that matters, since NU1903 is a hard restore failure here rather than a warning.
- `dotnet restore src/Api/Api.csproj --packages <fresh dir>` - the Aspire-free path the Dockerfile uses, and the one the issue flags as the non-obvious failure mode. Restored into an empty package folder so the result is not a cache artifact.
- `Microsoft.OpenApi` resolves to exactly **2.7.5** in `Api`, `IntegrationTests` and `ArchitectureTests` (read back from each `project.assets.json`) - identical to what the pin used to force, so the resolved graph is unchanged.
- `dotnet build` - clean across `Api`, `Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, `AppHost`.
- `Application.UnitTests` 1044/1044 passed, `ArchitectureTests` 422/422 passed.
- `dotnet format --verify-no-changes --no-restore` - clean.
- NSwag regeneration produced no diff in the three generated files, as expected for a change that touches no API surface.
- Both new Renovate `matchStrings` sets replayed against their target files to confirm they actually capture the intended versions, and `dotnet-ef` 10.0.11 confirmed to exist on nuget.org before pinning CI to it.

`VisualTests` could not build locally - `cdn.playwright.dev` is blocked by the sandbox egress policy - and `IntegrationTests` / the Aspire stack need real Docker. Both run on a real runner in CI.

No new test is added: this change removes a package-version entry and updates version strings, and CI's own `Restore backend` step is the durable regression test - if the pin were still needed, NU1903 would fail that step.

## Live verification

Not applicable. This is a build/CI/dependency-configuration change with no runtime behavior change - no code, no API surface, no UI. Per the template's docs-only / CI-config exemption, no release candidate was cut. The meaningful proof is CI's own restore and full test suite on a real runner, reported below once green.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3gi3arARP24WcnhfBiVRq)_