### PR TITLE
feat(frontend): replace the org app's hero band with a compact header, and fix three dashboard widget defects

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -593,9 +593,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var frontend = Fixture.GetEndpoint("frontend");
 		await NavigateToOrgAppDashboardAsOlafAsync(frontend);
 
-		// #771: the tab bar is gone - reach the page via the dashboard's own
-		// widget links instead.
-		await Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
+		// Reached through the page header's own section rail (OrgPageHeader.tsx),
+		// the way an organizer reaches it.
+		await Page.GetByTestId("org-tab-opportunities").ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		// #973: OrgAppShell previously rendered no h1 on any org app page.
@@ -611,11 +611,11 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var frontend = Fixture.GetEndpoint("frontend");
 		await NavigateToOrgAppDashboardAsOlafAsync(frontend);
 
-		// The tab bar is gone (dashboard UX redesign) - reach Members via the
-		// Settings widget's member-count link instead (its accessible name is
-		// "N member(s)" - #834 made the count grammatically correct German/
-		// English plural forms, so match "member" to cover both N=1 and N>1).
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		// Members lives in the page header's section rail (OrgPageHeader.tsx) -
+		// the same rail an organizer uses, and unambiguous unlike a bare
+		// "member" name match, which the Settings widget's own member-count link
+		// also answers to.
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		// #973: OrgAppShell previously rendered no h1 on any org app page.
@@ -660,7 +660,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// OrgAppLayout only refetches org details on organizationId change -
 		// force a refetch, same as OrganizationTests.cs's equivalent setup.
 		await Page.ReloadAsync();
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 		// einsatzbereit#1294: this button's accessible name now interpolates
 		// the member's own name in the middle ("Promote {name} to Organizer"),
 		// so match with a regex rather than the old literal substring.

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -126,8 +126,8 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
 
-		// #771: the tab bar is gone - reach Opportunities via a dashboard widget link.
-		await Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
+		// Reached through the page header's own section rail (OrgPageHeader.tsx).
+		await Page.GetByTestId("org-tab-opportunities").ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		// "Manage sign-ups" only appears for published opportunities on the
@@ -171,7 +171,7 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
 
-		await Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
+		await Page.GetByTestId("org-tab-opportunities").ClickAsync();
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		var manageLink = Page.GetByRole(AriaRole.Link, new() { Name = "Manage sign-ups" }).First;
@@ -209,11 +209,11 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
 		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
 
-		// The tab bar is gone (dashboard UX redesign) - reach Members via the
-		// Settings widget's member-count link instead (its accessible name is
-		// "N member(s)" - #834 made the count grammatically correct German/
-		// English plural forms, so match "member" to cover both N=1 and N>1).
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		// Members lives in the page header's section rail (OrgPageHeader.tsx) -
+		// the same rail an organizer uses, and unambiguous unlike a bare
+		// "member" name match, which the Settings widget's own member-count link
+		// also answers to.
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard/members"), new() { Timeout = 15_000 });
 
 		var switcherBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" });

--- a/backend/tests/VisualTests/OrgAppCompactHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppCompactHeaderTests.cs
@@ -1,0 +1,166 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for the org app's compact page header (frontend
+/// OrgPageHeader.tsx), which replaced the public site's PageHeaderBand inside
+/// the org app shell. The band is a marketing surface - a brand-800 stage with
+/// 72px display type and a wavy bottom cap - and it pushed the dashboard's
+/// first widget roughly half a viewport down the page, on the one screen an
+/// organizer opens to find out what is going on right now. The header that
+/// replaced it states the organization, the page, its actions and the app's
+/// own sections in a fraction of that height.
+///
+/// The section rail is new here: before this, opportunities/sign-ups/members/
+/// settings were reachable only from the avatar dropdown's collapsible submenu
+/// or the mobile burger (see OrgAppMobileResponsiveTests, whose own summary is
+/// updated accordingly).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgAppCompactHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OrgDashboard_HasNoMarketingBand_AndPutsWidgetsHighOnThePage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// A freshly created org has no saved layout, so its dashboard renders
+		// the default widget set - deterministic regardless of what any other
+		// test in this session did to olaf's seeded organizations.
+		var organizationId = await CreateOrganizationAsync($"Visual CompactHeader {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		await Expect(Page.GetByTestId("org-app-header")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The band was the only brand-800 surface ever rendered inside <main>,
+		// and the only place the wave motif appeared there.
+		await Expect(Page.Locator("main .bg-brand-800")).ToHaveCountAsync(0);
+		await Expect(Page.Locator("main svg[viewBox='0 0 1440 60']")).ToHaveCountAsync(0);
+
+		// The page's own title is still a real h1 (axe's page-has-heading-one),
+		// just at an app scale rather than the band's 72px display size.
+		var heading = Page.Locator("main").GetByRole(AriaRole.Heading, new() { Level = 1 });
+		await Expect(heading).ToHaveTextAsync("Dashboard");
+		var headingFontSizePx = await heading.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).fontSize)");
+		headingFontSizePx.Should().BeLessThan(48,
+			"the org app states its page title at app scale - the band rendered it at 72px");
+
+		// The point of the change: chrome ends, and content begins, high on the
+		// page. The band alone ran ~420px tall plus a ~48px wave cap below the
+		// 64px sticky header, so the first widget started past 500px.
+		var headerBox = await Page.GetByTestId("org-app-header").BoundingBoxAsync();
+		headerBox.Should().NotBeNull();
+		(headerBox!.Y + headerBox.Height).Should().BeLessThan(360,
+			"the org app header must stay compact - it is chrome above the organizer's actual dashboard");
+
+		var gridBox = await Page.GetByTestId("dashboard-widget-grid").BoundingBoxAsync();
+		gridBox.Should().NotBeNull();
+		gridBox!.Y.Should().BeLessThan(400,
+			"the first widget row must be visible without scrolling on a 900px-tall viewport");
+
+		// The header is opaque here: nothing dark runs behind it in the org app
+		// any more, so it must not be left in the band's transparent treatment.
+		var headerClass = await Page.Locator("header").GetAttributeAsync("class");
+		headerClass.Should().NotBeNull().And.NotContain("bg-transparent");
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	[Test]
+	public async Task SectionRail_MarksTheCurrentSection_AndNavigatesBetweenThem()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual SectionRail {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		var rail = Page.GetByRole(AriaRole.Navigation, new() { Name = "Organization sections" });
+		await Expect(rail).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Every section of the org app is one click away from every other one.
+		await Expect(rail.GetByRole(AriaRole.Link)).ToHaveCountAsync(5);
+		await Expect(Page.GetByTestId("org-tab-dashboard")).ToHaveAttributeAsync("aria-current", "page");
+
+		await Page.GetByTestId("org-tab-engagements").ClickAsync();
+		await Page.WaitForURLAsync($"{origin}/app/{organizationId}/dashboard/engagements",
+			new() { Timeout = 15_000 });
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Heading, new() { Level = 1 }))
+			.ToHaveTextAsync("Sign-ups");
+		await Expect(Page.GetByTestId("org-tab-engagements")).ToHaveAttributeAsync("aria-current", "page");
+		await Expect(Page.GetByTestId("org-tab-dashboard")).Not.ToHaveAttributeAsync("aria-current", "page");
+
+		// The rail survives the narrowest viewport the suite covers - it scrolls
+		// horizontally rather than wrapping or pushing the page sideways.
+		await Page.SetViewportSizeAsync(375, 812);
+		await Expect(rail).ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("org-tab-settings")).ToHaveCountAsync(1);
+		var railBox = await rail.BoundingBoxAsync();
+		railBox.Should().NotBeNull();
+		railBox!.Width.Should().BeLessThanOrEqualTo(375,
+			"the section rail scrolls inside itself instead of widening the page");
+
+		await Page.SetViewportSizeAsync(1280, 720);
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	/// <summary>
+	/// Creates an organization through the API with the signed-in user's own
+	/// token, so the caller organizes it - same approach as
+	/// QuickCheckInWidgetTests, and faster than driving the switcher's
+	/// create-organization dialog.
+	/// </summary>
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	/// <summary>
+	/// Live staging accumulates test debris from the shared accounts (see the
+	/// root AGENTS.md note) - the same courtesy applies to the Aspire stack
+	/// this suite shares across its whole session.
+	/// </summary>
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
+++ b/backend/tests/VisualTests/OrgAppMobileResponsiveTests.cs
@@ -13,9 +13,11 @@ namespace VisualTests;
 /// collapsed behind the hamburger) is identical to the public site's and
 /// already covered by <c>MobileHeaderTests</c>. What's specific to the org app
 /// here is that the org switcher's own name must not overflow onto the
-/// bell/hamburger. There is no tab bar in the current org app UX - opportunities/
-/// members/settings are reached via the dashboard's own widget links and the
-/// burger menu's org submenu (see <c>OrganizationDashboardNavLinkTests</c>).
+/// bell/hamburger. The org app's sections (opportunities/sign-ups/members/
+/// settings) live in the page header's own section rail, covered by
+/// <c>OrgAppCompactHeaderTests</c> - including at this width, where it scrolls
+/// horizontally rather than widening the page. The burger menu's org submenu
+/// (see <c>OrganizationDashboardNavLinkTests</c>) still reaches them too.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrgAppMobileResponsiveTests(AspireFixture fixture) : VisualTestBase(fixture)

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -537,6 +537,88 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(reloadedEvent).ToHaveCSSAsync("background-color", "rgb(51, 102, 204)");
 	}
 
+	[Test]
+	public async Task UpcomingOpportunitiesWidget_ListsAPublishedOpportunity_WithItsNextSlotTime()
+	{
+		// The suite only ever asserted this widget's *empty* state, so nothing
+		// covered the one branch that touches the data: a populated row. A
+		// change that called a Date method on nextTimeSlotStart shipped past
+		// every frontend check because the generated API client types that
+		// field as Date while handing callers the raw JSON string (it parses
+		// with a plain JSON.parse and no reviver) - the widget threw and fell
+		// into its error boundary for any organization that actually had an
+		// upcoming opportunity. See lib/upcomingOpportunities.ts, whose unit
+		// tests pin the same contract at the pure-function level.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual Upcoming {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"Visual Upcoming Opportunity {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by the Upcoming Opportunities widget test",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(3);
+		var end = start.AddHours(2);
+		(await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 }))
+			.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		var upcomingWidget = Page.GetByTestId("widget-tile-UpcomingOpportunities");
+		await Expect(upcomingWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The row itself, its formatted slot time, and its capacity line - a
+		// crash inside the widget would replace all three with the tile's
+		// error-boundary fallback instead.
+		await Expect(upcomingWidget.GetByRole(AriaRole.Link, new() { Name = oppTitle }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(upcomingWidget).ToContainTextAsync(start.ToString("yyyy"));
+		await Expect(upcomingWidget).ToContainTextAsync("0/5 sign-ups");
+		await Expect(upcomingWidget.GetByText("This widget couldn't be displayed"))
+			.ToHaveCountAsync(0);
+	}
+
 	private async Task CreateOrganizationAsync(string namePrefix, Guid organizationId)
 	{
 		// New orgs are created via the org switcher's "Create organization" entry

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -133,8 +133,13 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 			Has = Page.GetByRole(AriaRole.Heading, new() { Name = "Organization", Exact = true }),
 		});
 
-		// Opportunities: reachable via a dashboard widget's "opportunities" link.
-		await Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
+		// Opportunities: reachable via a dashboard widget's "opportunities" link -
+		// scoped to that widget, since the page header's section rail (added with
+		// OrgPageHeader.tsx) carries its own "Opportunities" link now too and this
+		// test is specifically about the widgets being an independent second way
+		// to reach every subpage.
+		await Page.GetByTestId("widget-tile-UpcomingOpportunities")
+			.GetByRole(AriaRole.Link, new() { Name = "opportunities" }).First.ClickAsync();
 		await Page.WaitForURLAsync(
 			$"{origin}/app/{organizationId}/dashboard/opportunities", new() { Timeout = 10_000 });
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -50,11 +50,11 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// a rename of the seed data silently flips - and did.
 		await CreateOrganizationAsync("Visual579 InviteMember", pinnedOrgId!.Value);
 
-		// The tab bar is gone (dashboard UX redesign) - reach Members via the
-		// Settings widget's member-count link instead (its accessible name is
-		// "N member(s)" - #834 made the count grammatically correct German/
-		// English plural forms, so match "member" to cover both N=1 and N>1).
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		// Members lives in the page header's section rail (OrgPageHeader.tsx) -
+		// the same rail an organizer uses, and unambiguous unlike a bare
+		// "member" name match, which the Settings widget's own member-count link
+		// also answers to.
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		await Page.Locator("#member-search").FillAsync("vera");
 
@@ -91,7 +91,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual1170 MemberSearch", pinnedOrgId!.Value);
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		await Page.Locator("#member-search").FillAsync("ver");
 		await Page.WaitForTimeoutAsync(800);
@@ -116,11 +116,11 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual580 Leave", pinnedOrgId!.Value);
 
-		// The tab bar is gone (dashboard UX redesign) - reach Members via the
-		// Settings widget's member-count link instead (its accessible name is
-		// "N member(s)" - #834 made the count grammatically correct German/
-		// English plural forms, so match "member" to cover both N=1 and N>1).
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		// Members lives in the page header's section rail (OrgPageHeader.tsx) -
+		// the same rail an organizer uses, and unambiguous unlike a bare
+		// "member" name match, which the Settings widget's own member-count link
+		// also answers to.
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		var leaveButton = Page.GetByRole(AriaRole.Button, new() { Name = "Leave" });
 		await Expect(leaveButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
@@ -169,9 +169,11 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// pre-membership snapshot (olaf as sole member) - force a refetch.
 		await Page.ReloadAsync();
 
-		// The tab bar is gone (dashboard UX redesign) - reach Members via the
-		// Settings widget's member-count link, same as the sole-member test above.
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		// Members lives in the page header's section rail (OrgPageHeader.tsx) -
+		// the same rail an organizer uses, and unambiguous unlike a bare
+		// "member" name match, which the Settings widget's own member-count link
+		// also answers to.
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		var leaveButton = Page.GetByRole(AriaRole.Button, new() { Name = "Leave" });
 		await Expect(leaveButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
@@ -211,7 +213,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// as the SoleOrganizer test above.
 		await Page.ReloadAsync();
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		// Scope to vera's row by her stable seed email rather than her display
 		// name: other tests in this shared session (e.g. ProfileOverviewTests)
@@ -271,7 +273,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// pre-membership snapshot - force a refetch, same as other tests above.
 		await Page.ReloadAsync();
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		// Scope to vera's row by her stable seed email rather than her display
 		// name - see RemoveMember_ShowsConfirmationDialog_AndOnlyRemovesAfterConfirm
@@ -333,7 +335,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await CreateOrganizationAsync("Visual1050 InviteRole", pinnedOrgId!.Value);
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		await Page.Locator("#member-search").FillAsync("vera");
 
@@ -372,7 +374,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// reusing it here could 409 with AlreadyInvited depending on run order.
 		await CreateOrganizationAsync("Visual1040 DismissPending", pinnedOrgId!.Value);
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 
 		await Page.Locator("#member-search").FillAsync("vera");
 		var inviteButton = Page.GetByRole(AriaRole.Button, new() { Name = "Invite" });
@@ -664,7 +666,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		// #834: the widget link's accessible name is "1 member" (singular) for
 		// a fresh single-member org, so match "member" rather than "members".
-		await Page.GetByRole(AriaRole.Link, new() { Name = "member" }).ClickAsync();
+		await Page.GetByTestId("org-tab-members").ClickAsync();
 		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		await AssertMaxWidthContentLeftAlignedAsync("Organization members page");

--- a/frontend/src/components/OrgPageHeader.tsx
+++ b/frontend/src/components/OrgPageHeader.tsx
@@ -1,0 +1,128 @@
+import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import { ORG_TABS, orgTabPath } from "../lib/orgTabs";
+import { useQuickActionsList } from "../contexts/QuickActionsContext";
+import Button from "./Button";
+import { ChevronLeftIcon } from "./icons";
+
+interface Props {
+	organizationId: string;
+	orgName: string;
+	/** The current page's own name - the tab's label, or a nested page's title. */
+	title: string;
+	activeTabKey: string;
+	/** Only set on a nested page (e.g. an opportunity's sign-ups), pointing at
+	 * the tab that owns it. A tab page needs none: its own entry in the section
+	 * rail below already says where it sits. */
+	back?: { href: string; label: string } | null;
+}
+
+// The org app's page header. Deliberately NOT PageHeaderBand: that band is the
+// public site's opening statement (brand-800 stage, 72px display type, blur
+// blobs, a wave cap) and it costs ~400px before the first row of real content.
+// On the public site that trade is right - a visitor arriving from the landing
+// page is being introduced to a page. An organizer opening the app is not:
+// they came to see what is going on in their organization right now, and every
+// pixel spent restating "Dashboard" in display type is a pixel not spent on
+// the widgets that answer that question.
+//
+// So this is app chrome, not marketing chrome: one line of identity, one line
+// of title plus the page's own actions, and the section rail - roughly a
+// quarter of the band's height, with navigation in the space the band used for
+// atmosphere. It also stays out of HeaderOverlayContext (no useOverlaysHeader):
+// nothing dark runs behind the header here, so the header keeps its normal
+// opaque treatment.
+export default function OrgPageHeader({
+	organizationId,
+	orgName,
+	title,
+	activeTabKey,
+	back,
+}: Props) {
+	const { t } = useTranslation();
+	// Same QuickActionsContext PageHeaderBand reads, with the same keys and
+	// data-testids - the dashboard's Edit/Save/Cancel/Add-widget actions and
+	// the opportunity tab's Create action land here unchanged, just in
+	// on-light variants now that they no longer sit on brand-800.
+	const actions = useQuickActionsList();
+
+	return (
+		<div data-testid="org-app-header" className="mb-6 sm:mb-8">
+			{back && (
+				<Link
+					to={back.href}
+					className="mb-2 -ml-1 inline-flex items-center gap-1 rounded-lg px-1 py-1 text-sm font-medium text-gray-500 transition-colors hover:text-brand-700"
+				>
+					<ChevronLeftIcon className="h-4 w-4" />
+					{t("orgApp.backTo", { section: back.label })}
+				</Link>
+			)}
+			<div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+				{/* No logo mark here on purpose: the header's org switcher already
+				names the organization, and anything sitting left of the title
+				would push it off the left edge every page's content is aligned to.
+				The eyebrow says which organization this is; the h1 says which of
+				its pages you are on. */}
+				<div className="min-w-0">
+					<p className="truncate text-xs font-semibold tracking-widest text-gray-500 uppercase">
+						{orgName}
+					</p>
+					<h1 className="font-display text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
+						{title}
+					</h1>
+				</div>
+				{actions.length > 0 && (
+					<div className="flex shrink-0 items-center gap-2">
+						{actions.map((action) => (
+							<Button
+								key={action.key}
+								type="button"
+								onClick={action.onClick}
+								disabled={action.disabled}
+								title={action.title}
+								aria-label={action.label}
+								data-testid={`quick-action-${action.key}`}
+								variant={action.variant === "primary" ? "primary" : "outline"}
+								size="sm"
+								className="shrink-0"
+							>
+								{action.icon}
+								<span className="hidden sm:inline">{action.label}</span>
+							</Button>
+						))}
+					</div>
+				)}
+			</div>
+
+			{/* The org app's sections, in the app itself. Until now they were
+			reachable only from the avatar dropdown's collapsible submenu or the
+			mobile burger - so an organizer looking at their dashboard had no
+			visible route to sign-ups, opportunities, members or settings at all.
+			Horizontally scrollable rather than wrapped on narrow viewports, same
+			pattern as the account area's SubNavRail below `lg`. */}
+			<nav
+				aria-label={t("orgApp.sectionsNavLabel")}
+				className="mt-4 flex gap-1 overflow-x-auto border-b border-gray-200"
+			>
+				{ORG_TABS.map((tab) => {
+					const isActive = tab.key === activeTabKey;
+					return (
+						<Link
+							key={tab.key}
+							to={orgTabPath(organizationId, tab.key)}
+							aria-current={isActive ? "page" : undefined}
+							data-testid={`org-tab-${tab.key}`}
+							className={`shrink-0 border-b-2 px-3 py-2 text-sm whitespace-nowrap transition-colors ${
+								isActive
+									? "border-brand-600 font-semibold text-brand-700"
+									: "border-transparent font-medium text-gray-500 hover:border-gray-300 hover:text-gray-900"
+							}`}
+						>
+							{t(tab.labelKey)}
+						</Link>
+					);
+				})}
+			</nav>
+		</div>
+	);
+}

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -18,7 +18,7 @@ import {
 } from "../contexts/OrgBreadcrumbContext";
 import { QuickActionsProvider } from "../contexts/QuickActionsContext";
 import Header from "../components/Header/Header";
-import PageHeaderBand from "../components/PageHeaderBand";
+import OrgPageHeader from "../components/OrgPageHeader";
 import Footer from "../components/Footer";
 import Spinner from "../components/Spinner";
 import SkipLink from "../components/SkipLink";
@@ -39,9 +39,9 @@ export interface OrgAppContext {
 
 // Renders the org app shell body inside OrgBreadcrumbProvider so it can read
 // the nested-page title extra (see useSetOrgBreadcrumbExtra). Normally the
-// band shows the active tab's own name; a nested page (e.g. engagement
+// page header shows the active tab's own name; a nested page (e.g. engagement
 // management) overrides it with its own, which demotes the tab name to the
-// band's back link.
+// header's back link.
 function OrgAppShell({
 	organizationId,
 	org,
@@ -68,26 +68,18 @@ function OrgAppShell({
 	// when that roster couldn't be loaded (#1709).
 	const isOrganizer = org.requestingUserRole === "Organizer";
 
-	// The way back, one level up. This used to be a full BreadcrumbBar strip
-	// below the header - the last surface in the app still using it, and the
-	// reason the org app read as a third visual system next to the public site
-	// and the account area. PageHeaderBand carries it now, same as everywhere
-	// else, so "back" is a single link rather than a trail: from a nested page
-	// to its tab, and from a tab to the dashboard.
-	const dashboardTab = ORG_TABS.find((tab) => tab.key === "dashboard");
-	const isDashboardTab = activeTabKey === "dashboard";
+	// The way back, one level up - only from a nested page (e.g. an
+	// opportunity's sign-ups) to the tab that owns it. A tab page itself needs
+	// no back link any more: OrgPageHeader's section rail lists every tab with
+	// the current one marked, which says where you are and gets you anywhere
+	// else in one click rather than one click per level.
 	const back =
 		extra && organizationId
 			? {
 					href: orgTabPath(organizationId, activeTabKey),
 					label: activeTabLabel,
 				}
-			: !isDashboardTab && organizationId && dashboardTab
-				? {
-						href: `/app/${organizationId}/dashboard`,
-						label: t(dashboardTab.labelKey),
-					}
-				: null;
+			: null;
 
 	// #973: OrgAppShell is the only place that knows the current tab/nested-page
 	// title (activeTabLabel/extra, same source as the breadcrumb's last item) -
@@ -98,8 +90,8 @@ function OrgAppShell({
 	return (
 		// bg-gray-50 stays: it is the app canvas that makes the dashboard's
 		// white widget cards read as cards, and is a deliberate app-vs-marketing
-		// distinction rather than drift. What was drift - the breadcrumb strip
-		// and a bare <h1> where every other page has the brand band - is gone.
+		// distinction rather than drift - the same distinction OrgPageHeader
+		// draws by not carrying the public site's brand band up here.
 		<div className="flex min-h-screen flex-col bg-gray-50">
 			<SkipLink />
 			<Header
@@ -111,15 +103,16 @@ function OrgAppShell({
 				tabIndex={-1}
 				className="mx-auto w-full max-w-page flex-1 scroll-mt-24 px-4 pt-[var(--main-top-padding)] pb-8 focus:outline-none sm:px-6 lg:px-8"
 			>
-				{/* Same band as the public site and the account area. It reads
+				{/* App chrome, not the public site's PageHeaderBand - see
+				OrgPageHeader for why the org app parts ways with it here. It reads
 				QuickActionsContext itself, so the org app's "Create opportunity"
 				and dashboard edit-mode actions land in it without the bar. */}
-				<PageHeaderBand
-					fullWidth
-					eyebrow={org.name}
+				<OrgPageHeader
+					organizationId={org.id}
+					orgName={org.name}
 					title={pageTitle}
-					backHref={back?.href ?? `/app/${organizationId}/dashboard`}
-					backLabel={back?.label ?? t("orgOverview.tabDashboard")}
+					activeTabKey={activeTabKey}
+					back={back}
 				/>
 				{/* Scoped to this route (remounts, clearing any caught error, whenever
 				the location changes) so a render crash in a single tab replaces just

--- a/frontend/src/lib/upcomingOpportunities.test.ts
+++ b/frontend/src/lib/upcomingOpportunities.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import type { VolunteerOpportunitySummary } from "../client/api-client";
+import {
+	MAX_UPCOMING_ITEMS,
+	selectUpcomingOpportunities,
+} from "./upcomingOpportunities";
+
+// Every date field is built from an ISO *string*, not a Date, on purpose:
+// that is what the generated client actually hands callers at runtime (it
+// parses responses with a plain JSON.parse and no reviver), even though it
+// types these fields as Date. Constructing the fixtures the way the DTO's
+// TypeScript type suggests would test a shape production never sees.
+function makeOpportunity(
+	overrides: Partial<VolunteerOpportunitySummary>,
+): VolunteerOpportunitySummary {
+	return {
+		id: "opp-1",
+		title: "Opportunity",
+		description: undefined,
+		organizationId: "org-1",
+		organizationName: "Org",
+		street: undefined,
+		houseNumber: undefined,
+		zipCode: undefined,
+		city: undefined,
+		latitude: undefined,
+		longitude: undefined,
+		isRemote: true,
+		occurrence: "OneTime",
+		participationType: "ScheduledSlots",
+		checkInMethod: "QRCode",
+		category: undefined,
+		tags: [],
+		createdOn: "2026-01-01T00:00:00Z" as unknown as Date,
+		validUntil: undefined,
+		nextTimeSlotStart: undefined,
+		nextTimeSlotEnd: undefined,
+		totalMaxParticipants: undefined,
+		currentParticipantCount: 0,
+		status: "Published",
+		bannerImageUrl: undefined,
+		...overrides,
+	};
+}
+
+function upcoming(id: string, startIso: string): VolunteerOpportunitySummary {
+	return makeOpportunity({
+		id,
+		nextTimeSlotStart: startIso as unknown as Date,
+	});
+}
+
+describe("selectUpcomingOpportunities", () => {
+	it("keeps the wire value as a string the caller can format directly", () => {
+		const items = selectUpcomingOpportunities(
+			[upcoming("a", "2026-08-15T09:00:00Z")],
+			"Untitled draft",
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0].nextStart).toBe("2026-08-15T09:00:00Z");
+		expect(items[0].nextStartMs).toBe(
+			new Date("2026-08-15T09:00:00Z").getTime(),
+		);
+	});
+
+	it("drops opportunities with no upcoming slot", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				upcoming("has-slot", "2026-08-15T09:00:00Z"),
+				makeOpportunity({ id: "interest-based" }),
+			],
+			"Untitled draft",
+		);
+
+		expect(items.map((i) => i.id)).toEqual(["has-slot"]);
+	});
+
+	it("drops an unparseable start rather than rendering an invalid date", () => {
+		const items = selectUpcomingOpportunities(
+			[upcoming("broken", "not-a-date")],
+			"Untitled draft",
+		);
+
+		expect(items).toEqual([]);
+	});
+
+	it("orders by soonest slot first", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				upcoming("later", "2026-08-20T09:00:00Z"),
+				upcoming("soonest", "2026-08-13T09:00:00Z"),
+				upcoming("middle", "2026-08-15T09:00:00Z"),
+			],
+			"Untitled draft",
+		);
+
+		expect(items.map((i) => i.id)).toEqual(["soonest", "middle", "later"]);
+	});
+
+	it("caps the list at MAX_UPCOMING_ITEMS", () => {
+		const opportunities = Array.from(
+			{ length: MAX_UPCOMING_ITEMS + 3 },
+			(_, i) =>
+				upcoming(
+					`opp-${i}`,
+					`2026-08-${String(10 + i).padStart(2, "0")}T09:00:00Z`,
+				),
+		);
+
+		expect(
+			selectUpcomingOpportunities(opportunities, "Untitled draft"),
+		).toHaveLength(MAX_UPCOMING_ITEMS);
+	});
+
+	it("falls back to the caller's title for an untitled draft", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				makeOpportunity({
+					title: "",
+					nextTimeSlotStart: "2026-08-15T09:00:00Z" as unknown as Date,
+				}),
+			],
+			"Untitled draft",
+		);
+
+		expect(items[0].title).toBe("Untitled draft");
+	});
+
+	it("carries capacity through, with null meaning unlimited", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				makeOpportunity({
+					id: "capped",
+					nextTimeSlotStart: "2026-08-15T09:00:00Z" as unknown as Date,
+					currentParticipantCount: 3,
+					totalMaxParticipants: 10,
+				}),
+				makeOpportunity({
+					id: "unlimited",
+					nextTimeSlotStart: "2026-08-16T09:00:00Z" as unknown as Date,
+					currentParticipantCount: 2,
+					totalMaxParticipants: undefined,
+				}),
+			],
+			"Untitled draft",
+		);
+
+		expect(items.map((i) => [i.id, i.bookedCount, i.maxParticipants])).toEqual([
+			["capped", 3, 10],
+			["unlimited", 2, null],
+		]);
+	});
+
+	it("returns an empty array for an empty input", () => {
+		expect(selectUpcomingOpportunities([], "Untitled draft")).toEqual([]);
+	});
+});

--- a/frontend/src/lib/upcomingOpportunities.ts
+++ b/frontend/src/lib/upcomingOpportunities.ts
@@ -1,0 +1,64 @@
+import type { VolunteerOpportunitySummary } from "../client/api-client";
+
+export const MAX_UPCOMING_ITEMS = 5;
+
+export interface UpcomingItem {
+	id: string;
+	title: string;
+	/**
+	 * The next slot's start, as the ISO string it actually is on the wire.
+	 *
+	 * `VolunteerOpportunitySummary.nextTimeSlotStart` is *typed* `Date` by the
+	 * generated client, but that client is generated in plain-DTO mode - it
+	 * does `JSON.parse(text) as T` with no reviver and no class instances (see
+	 * processGetOrganizationOpportunities in api-client.ts), so nothing ever
+	 * turns that string into a Date. Calling a Date method on it throws, which
+	 * takes the whole widget down into its error boundary. Every date value
+	 * from this client is a string at runtime; keeping the string here, and
+	 * carrying a separate parsed timestamp for ordering, is what stops that
+	 * mismatch from reaching a render.
+	 */
+	nextStart: string;
+	/** Epoch ms parsed from nextStart - sort key only. */
+	nextStartMs: number;
+	bookedCount: number;
+	maxParticipants: number | null;
+}
+
+/**
+ * The soonest few opportunities that actually have an upcoming slot, soonest
+ * first. Interest-based opportunities have no time slot at all, so they used
+ * to fill the widget with rows carrying nothing but a title under a heading
+ * promising dates - and pushed the ones that really are upcoming out of the
+ * visible list.
+ *
+ * `unnamedTitle` is the caller's translated fallback for an untitled draft -
+ * passed in rather than translated here so this stays a pure function.
+ */
+export function selectUpcomingOpportunities(
+	opportunities: VolunteerOpportunitySummary[],
+	unnamedTitle: string,
+): UpcomingItem[] {
+	return opportunities
+		.flatMap((o): UpcomingItem[] => {
+			if (!o.nextTimeSlotStart) return [];
+			const nextStart = o.nextTimeSlotStart as unknown as string;
+			const nextStartMs = new Date(nextStart).getTime();
+			// A value the runtime can't read as a date sorts nowhere sensible
+			// and renders as "Invalid Date" - drop the row instead of showing
+			// one that says nothing.
+			if (Number.isNaN(nextStartMs)) return [];
+			return [
+				{
+					id: o.id,
+					title: o.title || unnamedTitle,
+					nextStart,
+					nextStartMs,
+					bookedCount: o.currentParticipantCount,
+					maxParticipants: o.totalMaxParticipants ?? null,
+				},
+			];
+		})
+		.sort((a, b) => a.nextStartMs - b.nextStartMs)
+		.slice(0, MAX_UPCOMING_ITEMS);
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -376,6 +376,8 @@
     },
     "orgApp": {
       "backToSite": "Zurück zu Einsatzbereit",
+      "sectionsNavLabel": "Bereiche der Organisation",
+      "backTo": "Zurück zu {{section}}",
       "notAuthorized": "Du hast keinen Zugriff auf diese Organisation.",
       "retry": "Erneut versuchen"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -376,6 +376,8 @@
     },
     "orgApp": {
       "backToSite": "Back to Einsatzbereit",
+      "sectionsNavLabel": "Organization sections",
+      "backTo": "Back to {{section}}",
       "notAuthorized": "You don't have access to this organization.",
       "retry": "Try again"
     },

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -239,7 +239,26 @@ function CalendarWidget({
 		`calendarEvents:${organizationId}:${refreshKey}:${rangeFrom.toISOString()}:${rangeTo.toISOString()}`,
 		() => api.getOrganizationCalendarEvents(organizationId, rangeFrom, rangeTo),
 	);
-	const calLoading = calData === null && !calError;
+
+	// The fetch key above changes on every view switch and every step forward
+	// or back through the calendar, and useSharedOrgFetch clears its data on a
+	// key change - so a plain `calData === null` loading flag tore the whole
+	// <Calendar> out of the tree and replaced it with a skeleton on every
+	// single navigation. That unmounted the toolbar button the organizer had
+	// just clicked (dropping keyboard focus to <body>, so "next month, next
+	// month" was impossible without a mouse) and made stepping through months
+	// flash the widget empty each time. Keeping the last loaded range on screen
+	// while the next one is in flight - stale-while-revalidate, marked with
+	// aria-busy - keeps the calendar mounted, so focus stays where it was and
+	// only the events swap. The skeleton is now what it says it is: a
+	// first-load placeholder.
+	const lastLoadedRef = useRef<OrganizationCalendarEventDto[] | null>(null);
+	useEffect(() => {
+		if (calData !== null) lastLoadedRef.current = calData;
+	}, [calData]);
+	const displayedCalData = calData ?? lastLoadedRef.current;
+	const calLoading = displayedCalData === null && !calError;
+	const calRefreshing = calData === null && displayedCalData !== null;
 
 	const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
 	const [pickerColor, setPickerColor] = useState<string>(() =>
@@ -258,7 +277,7 @@ function CalendarWidget({
 
 	const calEvents: CalEvent[] = useMemo(
 		() =>
-			(calData ?? []).flatMap((opp) =>
+			(displayedCalData ?? []).flatMap((opp) =>
 				opp.timeSlots.map((slot) => ({
 					id: slot.timeSlotId,
 					title: opp.title,
@@ -270,7 +289,7 @@ function CalendarWidget({
 					maxParticipants: slot.maxParticipants ?? null,
 				})),
 			),
-		[calData],
+		[displayedCalData],
 	);
 
 	// #983: opening on the current month whenever the organizer happens to
@@ -399,7 +418,13 @@ function CalendarWidget({
 					/>
 				)}
 				{!calLoading && !calError && (
-					<div className="rbc-container h-full">
+					// aria-busy while the next range is being fetched, so a screen
+					// reader isn't told the events on screen are the ones it just
+					// navigated to before they actually are.
+					<div
+						aria-busy={calRefreshing || undefined}
+						className={`rbc-container h-full transition-opacity ${calRefreshing ? "opacity-60" : ""}`}
+					>
 						<Calendar
 							localizer={localizer}
 							culture={resolveDateLocale(i18n.language)}

--- a/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/ToDoWidget.tsx
@@ -14,10 +14,16 @@ interface Kpis {
 
 interface Props {
 	organizationId: string;
+	// Bumped by the dashboard whenever an opportunity is published from one of
+	// the action widgets. These two counts are the first thing an organizer
+	// reads on the page, so they have to move with the rest of the board -
+	// before this they were fetched exactly once per mount and then sat stale
+	// while Calendar and Upcoming Opportunities refreshed around them.
+	refreshKey: number;
 	size: WidgetSizeClass;
 }
 
-function ToDoWidget({ organizationId, size }: Props) {
+function ToDoWidget({ organizationId, refreshKey, size }: Props) {
 	const { t } = useTranslation();
 	const api = useApiClient();
 
@@ -26,20 +32,34 @@ function ToDoWidget({ organizationId, size }: Props) {
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
+		// Switching organizations from the header switcher issues a second
+		// request while the first is still open; without this guard the slower
+		// response wins whichever order they land in, and one org's dashboard
+		// can end up showing another's counts. Same pattern as OrgAppLayout's
+		// own latestRequestRef.
+		let alive = true;
 		setLoading(true);
 		setError(null);
 		api
 			.getOrganizationDashboard(organizationId)
-			.then((data) =>
+			.then((data) => {
+				if (!alive) return;
 				setKpis({
 					pendingEngagements: data.pendingEngagements,
 					confirmedEngagementsTotal: data.confirmedEngagementsTotal,
-				}),
-			)
-			.catch(() => setError(t("orgDashboard.todoError")))
-			.finally(() => setLoading(false));
+				});
+			})
+			.catch(() => {
+				if (alive) setError(t("orgDashboard.todoError"));
+			})
+			.finally(() => {
+				if (alive) setLoading(false);
+			});
+		return () => {
+			alive = false;
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [organizationId]);
+	}, [organizationId, refreshKey]);
 
 	return (
 		<WidgetCard

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -11,19 +11,12 @@ import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import type { WidgetSizeClass } from "./widgetCatalog";
 import { formatDateTime } from "../../../lib/format";
+import {
+	selectUpcomingOpportunities,
+	type UpcomingItem,
+} from "../../../lib/upcomingOpportunities";
 
-const MAX_ITEMS = 5;
 const OPPORTUNITY_PAGE_SIZE = 100;
-
-// nextStart is non-nullable by construction: an opportunity without one isn't
-// "upcoming" and never reaches this list (see the filter below).
-interface UpcomingItem {
-	id: string;
-	title: string;
-	nextStart: Date;
-	bookedCount: number;
-	maxParticipants: number | null;
-}
 
 interface Props {
 	organizationId: string;
@@ -68,36 +61,19 @@ function UpcomingOpportunitiesWidget({
 	);
 	const error = opportunitiesError;
 
-	const items = useMemo<UpcomingItem[] | null>(() => {
-		if (!opportunities) return null;
-		return (
+	// Picking, ordering and capping lives in lib/upcomingOpportunities.ts so it
+	// can be unit-tested against the shapes this API client actually returns -
+	// notably that its "Date" fields arrive as strings (see that module).
+	const items = useMemo<UpcomingItem[] | null>(
+		() =>
 			opportunities
-				// "Upcoming" means it has a next slot. Interest-based opportunities
-				// have no time slot at all, so they used to fill this list with
-				// rows carrying nothing but a title, under a heading promising
-				// dates - and pushed the ones that actually are upcoming out of
-				// the visible MAX_ITEMS. Filtering before mapping is what lets
-				// UpcomingItem.nextStart be a plain Date rather than a nullable one
-				// every consumer below then has to re-check. flatMap rather than
-				// filter+map so TypeScript narrows the optional away for real,
-				// instead of the narrowing being asserted with a cast.
-				.flatMap((o): UpcomingItem[] =>
-					o.nextTimeSlotStart
-						? [
-								{
-									id: o.id,
-									title: o.title || t("orgDashboard.unnamedDraft"),
-									nextStart: o.nextTimeSlotStart,
-									bookedCount: o.currentParticipantCount,
-									maxParticipants: o.totalMaxParticipants ?? null,
-								},
-							]
-						: [],
-				)
-				.sort((a, b) => a.nextStart.getTime() - b.nextStart.getTime())
-				.slice(0, MAX_ITEMS)
-		);
-	}, [opportunities, t]);
+				? selectUpcomingOpportunities(
+						opportunities,
+						t("orgDashboard.unnamedDraft"),
+					)
+				: null,
+		[opportunities, t],
+	);
 
 	return (
 		<WidgetCard
@@ -157,7 +133,7 @@ function UpcomingOpportunitiesWidget({
 							</p>
 							{size !== "compact" && (
 								<p className="mt-0.5 text-xs text-gray-500">
-									{formatDateTime(item.nextStart.toISOString(), i18n.language)}
+									{formatDateTime(item.nextStart, i18n.language)}
 									{(item.maxParticipants === null ||
 										item.maxParticipants > 0) && (
 										<>

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -15,10 +15,12 @@ import { formatDateTime } from "../../../lib/format";
 const MAX_ITEMS = 5;
 const OPPORTUNITY_PAGE_SIZE = 100;
 
+// nextStart is non-nullable by construction: an opportunity without one isn't
+// "upcoming" and never reaches this list (see the filter below).
 interface UpcomingItem {
 	id: string;
 	title: string;
-	nextStart: Date | null;
+	nextStart: Date;
 	bookedCount: number;
 	maxParticipants: number | null;
 }
@@ -70,23 +72,29 @@ function UpcomingOpportunitiesWidget({
 		if (!opportunities) return null;
 		return (
 			opportunities
-				.map((o): UpcomingItem => ({
-					id: o.id,
-					title: o.title || t("orgDashboard.unnamedDraft"),
-					nextStart: o.nextTimeSlotStart ? new Date(o.nextTimeSlotStart) : null,
-					bookedCount: o.currentParticipantCount,
-					maxParticipants: o.totalMaxParticipants ?? null,
-				}))
 				// "Upcoming" means it has a next slot. Interest-based opportunities
 				// have no time slot at all, so they used to fill this list with
 				// rows carrying nothing but a title, under a heading promising
 				// dates - and pushed the ones that actually are upcoming out of
-				// the visible MAX_ITEMS.
-				.filter((item) => item.nextStart !== null)
-				.sort(
-					(a, b) =>
-						(a.nextStart as Date).getTime() - (b.nextStart as Date).getTime(),
+				// the visible MAX_ITEMS. Filtering before mapping is what lets
+				// UpcomingItem.nextStart be a plain Date rather than a nullable one
+				// every consumer below then has to re-check. flatMap rather than
+				// filter+map so TypeScript narrows the optional away for real,
+				// instead of the narrowing being asserted with a cast.
+				.flatMap((o): UpcomingItem[] =>
+					o.nextTimeSlotStart
+						? [
+								{
+									id: o.id,
+									title: o.title || t("orgDashboard.unnamedDraft"),
+									nextStart: o.nextTimeSlotStart,
+									bookedCount: o.currentParticipantCount,
+									maxParticipants: o.totalMaxParticipants ?? null,
+								},
+							]
+						: [],
 				)
+				.sort((a, b) => a.nextStart.getTime() - b.nextStart.getTime())
 				.slice(0, MAX_ITEMS)
 		);
 	}, [opportunities, t]);
@@ -147,32 +155,25 @@ function UpcomingOpportunitiesWidget({
 							<p className="truncate text-sm font-medium text-gray-900">
 								{item.title}
 							</p>
-							{size !== "compact" &&
-								(item.nextStart ||
-									item.maxParticipants === null ||
-									item.maxParticipants > 0) && (
-									<p className="mt-0.5 text-xs text-gray-500">
-										{item.nextStart &&
-											formatDateTime(
-												item.nextStart as unknown as string,
-												i18n.language,
-											)}
-										{item.nextStart &&
-											(item.maxParticipants === null ||
-												item.maxParticipants > 0) && (
-												<span className="mx-1.5">&middot;</span>
-											)}
-										{item.maxParticipants === null
-											? t("orgOpportunities.participantsUnlimited", {
-													count: item.bookedCount,
-												})
-											: item.maxParticipants > 0 &&
-												t("orgOpportunities.participants", {
-													booked: item.bookedCount,
-													max: item.maxParticipants,
-												})}
-									</p>
-								)}
+							{size !== "compact" && (
+								<p className="mt-0.5 text-xs text-gray-500">
+									{formatDateTime(item.nextStart.toISOString(), i18n.language)}
+									{(item.maxParticipants === null ||
+										item.maxParticipants > 0) && (
+										<>
+											<span className="mx-1.5">&middot;</span>
+											{item.maxParticipants === null
+												? t("orgOpportunities.participantsUnlimited", {
+														count: item.bookedCount,
+													})
+												: t("orgOpportunities.participants", {
+														booked: item.bookedCount,
+														max: item.maxParticipants,
+													})}
+										</>
+									)}
+								</p>
+							)}
 						</li>
 					))}
 				</ul>

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -298,7 +298,13 @@ export default function OrgDashboardPage() {
 	function renderWidget(key: WidgetKey, size: WidgetSizeClass) {
 		switch (key) {
 			case "ToDo":
-				return <ToDoWidget organizationId={organizationId} size={size} />;
+				return (
+					<ToDoWidget
+						organizationId={organizationId}
+						refreshKey={refreshKey}
+						size={size}
+					/>
+				);
 			case "UpcomingOpportunities":
 				return (
 					<UpcomingOpportunitiesWidget


### PR DESCRIPTION
## What

The org app (`/app/:organizationId/dashboard/...`) no longer opens with `PageHeaderBand`, the public site's wavy brand-800 hero. A new `OrgPageHeader` takes its place: organization eyebrow, page `h1`, the page's quick actions, and a rail of the app's sections - about a quarter of the height, with visible navigation in the space the band spent on atmosphere. Several dashboard widget defects are fixed alongside it.

**Header**
- `frontend/src/components/OrgPageHeader.tsx` (new) replaces the band inside the org app shell only. The public site, account and legal pages keep `PageHeaderBand` unchanged.
- The section rail (Dashboard / Opportunities / Sign-ups / Settings / Members) is new to the app surface. Until now those pages were reachable only from the avatar dropdown's collapsible submenu or the mobile burger, so an organizer looking at their dashboard had no visible route to any of them. It marks the current section with `aria-current="page"` and scrolls horizontally on narrow viewports instead of widening the page.
- A tab page drops its back link (the rail says where you are); a nested page keeps one, now reading "Back to {section}" so it doesn't collide with the rail's own link to that section.
- No logo mark or other ornament left of the title, so the `h1` stays on the same left edge as the content column below it.
- The header no longer declares itself to `HeaderOverlayContext` - nothing dark runs behind the site header in the org app any more, so it keeps its normal opaque treatment.

**Widget fixes**
- **Calendar unmounted itself on every navigation.** Its fetch key includes the visible date range, and `useSharedOrgFetch` clears data on a key change - so every view switch and every step through the months replaced the whole `<Calendar>` with a skeleton. That unmounted the toolbar button just clicked, dropping keyboard focus to `<body>`, so stepping through months was impossible without a mouse. It now keeps the last loaded range on screen while the next is in flight (`aria-busy`, dimmed), and the skeleton is a first-load placeholder again.
- **To-do counts never refreshed and could race.** They were fetched once per mount, so they sat stale while the widgets around them refreshed, and a fast organization switch could leave one organization's dashboard showing another's numbers. The widget now takes the dashboard's `refreshKey` and ignores superseded responses.
- **Upcoming opportunities: date fields are strings, not Dates.** The generated client types `nextTimeSlotStart` as `Date` but is generated in plain-DTO mode (`JSON.parse` with no reviver, no class instances), so it hands callers the raw ISO string - which is what the double casts at these call sites were compensating for. Selecting, ordering and capping the list moved into `lib/upcomingOpportunities.ts`, unit-tested against that real shape (including an unparseable start, now dropped instead of rendering "Invalid Date"); the widget formats the wire string and sorts on a separately parsed timestamp.

## Why

Requested directly: the wavy hero has no place in the organizer app, where the whole point is an extremely fast overview of what is going on, and several dashboard components still had rough edges and bugs. No tracking issue.

Closes #

## Testing

- `backend/tests/VisualTests/OrgAppCompactHeaderTests.cs` (new): asserts no `bg-brand-800` surface and no wave `<svg>` inside `<main>`, an `h1` below the band's display size, the header block ending above 360px and the first widget row starting above 400px on a 1440x900 viewport, an opaque site header, and the section rail marking/navigating between sections including at 375px width.
- `OrgDashboardWidgetsTests.UpcomingOpportunitiesWidget_ListsAPublishedOpportunity_WithItsNextSlotTime` (new): the suite only ever asserted that widget's *empty* state, so nothing covered a populated row - the one branch that touches the data, and the branch the first push of this PR broke. It now publishes an opportunity with a slot and asserts the row, its formatted time and its capacity line render with no error-boundary fallback.
- `frontend/src/lib/upcomingOpportunities.test.ts` (new, 8 cases): pins the same contract at the pure-function level, with fixtures built from ISO strings because that is what the client actually returns.
- Existing visual tests that reached Members/Opportunities through dashboard widget links because "the tab bar is gone" now go through the rail - the same route an organizer takes, and unambiguous where a bare `member` name match would now also hit the Settings widget's member-count link (`OrganizationTests`, `AccessibilityTests`, `NavigationTests`). `OrgDashboardWidgetsTests` keeps the widget link, scoped to its own tile, since covering the widgets as an independent second route is that test's whole point.
- `OrgAppMobileResponsiveTests`' summary updated: its "there is no tab bar in the current org app UX" note no longer holds.
- CI green on the merge commit: 338 visual tests, integration tests, fast tests, and the full frontend gate (lint/format/i18n/type-check/180 unit tests/production container smoke test).

## Live verification

**Deployed, but the live browser check could not be run from this session - reporting rather than claiming a pass.**

- Release candidate `v1.0.0-rc.351` was cut from `main` (which contains this change) and published: [run 31591123218](https://github.com/maik-hasler/einsatzbereit/actions/runs/31591123218). Every job succeeded, including the full backend suite against the release commit, and `Deploy to Staging` finished at 11:36 UTC with its post-deploy health gate green and no rollback triggered - so staging is running an image that contains this change.
- The `/live-verify` Playwright pass itself is **blocked**: this session's egress policy denies both `api.maik-hasler.de:443` and `einsatzbereit.maik-hasler.de:443` (the agent proxy answers `403` to CONNECT for both; recorded in its own failure log). That is an organization policy denial, not a transient network error, so it was not retried or routed around. Running `/live-verify` from a session that can reach those hosts is the remaining step.
- What does cover the change end to end in the meantime is step 7's durable record: the two new TUnit/Playwright tests above run against the full Aspire stack (real backend, Keycloak, frontend) and passed twice - on the PR's merge commit and again on the release commit inside the publish run linked above.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior
