### PR TITLE
refactor(frontend): move the way home into the header nav

### DIFF
--- a/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
+++ b/backend/tests/VisualTests/HeaderBreadcrumbSharedImplementationTests.cs
@@ -15,7 +15,7 @@ namespace VisualTests;
 public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions()
+	public async Task AccountPages_ReplaceActionBar_WithHeaderNavHomeAndSectionLevelEditing()
 	{
 		// #758 made /profile the canonical example of the shared action bar.
 		// #1755 gave the three account pages (/profile, /my-signups,
@@ -28,7 +28,11 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 		// below. What this pins instead is that the two things the bar carried
 		// for /profile survived the move: the way back home, and the ability to
 		// edit - the latter now as the Profile details section's own button
-		// rather than a quick action in the page chrome.
+		// rather than a quick action in the page chrome, and the former as the
+		// header nav's "Home" entry rather than a link inside this page's band.
+		// The band's own copy of that link is gone: it said the same thing on
+		// every subpage, in the one place a visitor does not look for site
+		// navigation.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -41,7 +45,9 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 		await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
 			.ToHaveCountAsync(0);
 
-		var homeLink = Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" });
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToHaveCountAsync(0);
+		var homeLink = Page.GetByTestId("nav-home");
 		await Expect(homeLink).ToBeVisibleAsync();
 		await Expect(homeLink).ToHaveAttributeAsync("href", "/");
 
@@ -85,7 +91,7 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 	}
 
 	[Test]
-	public async Task ImprintAndPrivacyPolicyPages_ReplaceActionBar_WithInBandHomeLink()
+	public async Task ImprintAndPrivacyPolicyPages_CarryNeitherAnActionBarNorAnInBandHomeLink()
 	{
 		// Follow-up to #758: the legal pages were missed in the initial rollout
 		// (still on ToolbarContext.tsx, no action bar) and used German slugs
@@ -98,9 +104,10 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 		// 72px display type, so a grey strip immediately above it repeating
 		// that same title was pure duplication - and it drew a hard white line
 		// through the middle of the band treatment. The Home link #758 added
-		// still exists, it just lives inside the band now. The slugs, and the
-		// action bar on every *other* subpage, are unchanged - see
-		// ProfilePage_ActionBar_RendersDirectlyBeneathHeader_IconLed above.
+		// moved into that band, and has since moved on again into the header
+		// nav: one "Home" entry beside the other primary destinations, instead
+		// of a per-page link inside every subpage's hero. The slugs are
+		// unchanged.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -118,7 +125,8 @@ public class HeaderBreadcrumbSharedImplementationTests(AspireFixture fixture) : 
 			await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
 				.ToHaveCountAsync(0);
 			await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
-				.ToBeVisibleAsync();
+				.ToHaveCountAsync(0);
+			await Expect(Page.GetByTestId("nav-home")).ToBeVisibleAsync();
 		}
 	}
 

--- a/backend/tests/VisualTests/HeaderPrimaryNavTests.cs
+++ b/backend/tests/VisualTests/HeaderPrimaryNavTests.cs
@@ -8,6 +8,10 @@ namespace VisualTests;
 /// opportunity list lived inside the landing page behind an "#opportunities"
 /// fragment. These pin the destinations, on both breakpoints, signed out and
 /// signed in.
+///
+/// "Home" is one of those destinations now: it used to be a link inside every
+/// subpage's own PageHeaderBand hero instead, which put site navigation in a
+/// per-page surface and repeated it once per page.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class HeaderPrimaryNavTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -69,6 +73,62 @@ public class HeaderPrimaryNavTests(AspireFixture fixture) : VisualTestBase(fixtu
 
 		await link.ClickAsync();
 		await Page.WaitForURLAsync($"{origin}/opportunities", new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task DesktopHeader_OnASubpage_CarriesTheWayHome_TheBandDoesNot()
+	{
+		// Every subpage used to open with its own "back to the home page" link
+		// inside PageHeaderBand's hero - the same single destination restated
+		// per page, in the one place a visitor does not look for site
+		// navigation, and next to nothing else that navigates. It is a site
+		// destination, so it is a nav entry now: one "Home" link beside the
+		// other primary ones, on screen from every page at once.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/help");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToHaveCountAsync(0);
+
+		var link = Page.GetByTestId("nav-home");
+		await Expect(link).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(link).ToHaveAttributeAsync("href", "/");
+
+		await link.ClickAsync();
+		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 15_000 });
+		await Expect(Page.GetByTestId("hero-keyword-input"))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task MobileMenu_OnASubpage_CarriesTheSameWayHome()
+	{
+		// The two breakpoints render the same primary destinations from two
+		// separate arrays (DesktopHeader's LINKS, MobileMenu's PRIMARY_LINKS),
+		// so "home" being added to one and not the other is a live failure
+		// mode - and the band link this replaces was visible on both.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
+		await Page.GotoAsync($"{origin}/help");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToHaveCountAsync(0);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Open menu" }).ClickAsync();
+
+		var link = Page.GetByTestId("mobile-nav-home");
+		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await link.ClickAsync();
+		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 15_000 });
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -62,14 +62,19 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		// #1755 replaced this page's breadcrumb bar with a PageHeaderBand: the
-		// band states the org name as the h1 and carries the way back home, so
-		// the bar restating both directly above it was pure duplication.
+		// band states the org name as the h1, so the bar restating it directly
+		// above was pure duplication.
 		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
 
 		var orgName = await Page.Locator("h1").First.InnerTextAsync();
 		orgName.Should().NotBeNullOrWhiteSpace();
+
+		// The band carried a "Home" link too, until every subpage repeating the
+		// same one destination inside its own hero was replaced by a single
+		// "Home" entry in the header nav - on screen on every page at once.
 		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
-			.ToBeVisibleAsync();
+			.ToHaveCountAsync(0);
+		await Expect(Page.GetByTestId("nav-home")).ToBeVisibleAsync();
 	}
 
 	[Test]
@@ -103,8 +108,10 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// link to the owning organization in its eyebrow, which is where the
 		// middle crumb's job moved.
 		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+		// No in-band "Home" link either - that destination is a header nav
+		// entry now, see HeaderPrimaryNavTests.
 		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
-			.ToBeVisibleAsync();
+			.ToHaveCountAsync(0);
 		await Expect(Page.Locator("main a[href*='/organizations/']").First).ToBeVisibleAsync();
 
 		var title = await Page.Locator("h1").First.InnerTextAsync();

--- a/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
@@ -34,7 +34,10 @@ public class OrgAppShellHeaderTests(AspireFixture fixture) : VisualTestBase(fixt
 		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		// Logo replaces the old text link and sits top-left in the header.
-		var logoLink = Page.Locator("header a[href='/']");
+		// Narrowed to the link wrapping the wordmark: the header's primary nav
+		// carries a "Home" entry pointing at "/" as well, so a bare href
+		// selector matches two links.
+		var logoLink = Page.Locator("header a[href='/']:has(img)");
 		await Expect(logoLink.Locator("img")).ToBeVisibleAsync();
 		await Expect(Page.GetByText("Back to Einsatzbereit")).Not.ToBeVisibleAsync();
 

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -44,13 +44,15 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		//
 		// #1754 gave /profile a PageHeaderBand and dropped the
 		// nav[aria-label='Breadcrumb'] bar in favor of a plain "way back home"
-		// link inside the band - see VolunteerOpportunityTests's identical
-		// update and HeaderBreadcrumbSharedImplementationTests
-		// .AccountPages_ReplaceActionBar_WithBandHomeLinkAndQuickActions, which
-		// already pins this page's fuller behavior (heading, no breadcrumb bar,
-		// Home link, Edit quick action, sub-nav). This keeps #590's original
-		// regression - that /profile has *some* way back to the home page -
-		// covered under its own name.
+		// link inside the band; that link has since moved into the header nav,
+		// which every page carries anyway - see VolunteerOpportunityTests's
+		// identical update and HeaderBreadcrumbSharedImplementationTests
+		// .AccountPages_ReplaceActionBar_WithHeaderNavHomeAndSectionLevelEditing,
+		// which already pins this page's fuller behavior (heading, no
+		// breadcrumb bar, no in-band Home link, section-level Edit, sub-nav).
+		// This keeps #590's original regression - that /profile has *some* way
+		// back to the home page - covered under its own name, wherever that
+		// way happens to live.
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
@@ -60,9 +62,11 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
-		var homeLink = Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" });
+		var homeLink = Page.GetByTestId("nav-home");
 		await Expect(homeLink).ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await Expect(homeLink).ToHaveAttributeAsync("href", "/");
+		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
+			.ToHaveCountAsync(0);
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/TermsOfUsePageTests.cs
+++ b/backend/tests/VisualTests/TermsOfUsePageTests.cs
@@ -12,7 +12,7 @@ namespace VisualTests;
 public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task TermsOfUsePage_ShowsInBandHomeLink_AndCoreSections()
+	public async Task TermsOfUsePage_HasNoActionBar_AndShowsCoreSections()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -21,13 +21,15 @@ public class TermsOfUsePageTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
 		// #1755 replaced this page's breadcrumb action bar with a Home link
-		// inside the title band - see
-		// HeaderBreadcrumbSharedImplementationTests.ImprintAndPrivacyPolicyPages_ReplaceActionBar_WithInBandHomeLink
+		// inside the title band; that link is gone in turn, since the header
+		// nav now carries "Home" on every page - see
+		// HeaderBreadcrumbSharedImplementationTests.ImprintAndPrivacyPolicyPages_CarryNeitherAnActionBarNorAnInBandHomeLink
 		// for the rationale and the cross-page guard.
 		await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']"))
 			.ToHaveCountAsync(0);
 		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
-			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+			.ToHaveCountAsync(0);
+		await Expect(Page.GetByTestId("nav-home")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await Expect(Page.GetByRole(AriaRole.Heading,
 			new() { Name = "Terms of Use", Level = 1 })).ToBeVisibleAsync();

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -236,12 +236,16 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.GotoAsync($"{origin}{href}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// #394 wanted a way back from this page; #1755 moved that into the
-		// PageHeaderBand and dropped the bar, so the Home link now lives in
-		// <main> rather than in a nav[aria-label='Breadcrumb'] strip.
+		// #394 wanted a way back from this page. #1755 moved that into the
+		// PageHeaderBand and dropped the bar; the band's own "Home" link is
+		// gone in turn, because a link home is not a property of this page -
+		// it is a site destination, and it now sits in the header nav where it
+		// is reachable from every page rather than being restated inside each
+		// one's hero.
 		await Expect(Page.Locator("nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
 		await Expect(Page.Locator("main").GetByRole(AriaRole.Link, new() { Name = "Home" }))
-			.ToBeVisibleAsync();
+			.ToHaveCountAsync(0);
+		await Expect(Page.GetByTestId("nav-home")).ToBeVisibleAsync();
 
 		// #373 share button present (matched by stable test id, locale-independent).
 		await Expect(Page.GetByTestId("share-opportunity"))

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -14,7 +14,13 @@ import type { OrganizationSummaryDto } from "../../client/api-client";
 // links at all - just account controls - so a signed-in volunteer had no
 // route to the opportunity list except the account dropdown, while the mobile
 // hamburger did carry these same links. Desktop was the worse of the two.
+//
+// "home" leads the list because every subpage used to carry its own "back to
+// the home page" link inside its title band (see PageHeaderBand): the same one
+// destination re-stated per page, in the one place a visitor does not look for
+// site navigation. It is a nav destination, so it belongs in the nav.
 const LINKS = [
+	{ key: "home", to: "/", hash: false },
 	{ key: "findOpportunities", to: "/opportunities", hash: false },
 	{ key: "forOrganizations", to: "/#for-organizations", hash: true },
 	{ key: "help", to: "/help", hash: false },
@@ -78,6 +84,9 @@ export default function DesktopHeader({
 							) : (
 								<NavLink
 									to={link.to}
+									// "/" is a prefix of every route, so without `end` the
+									// home link would render as the active one everywhere.
+									end={link.to === "/"}
 									data-testid={`nav-${link.key}`}
 									className={({ isActive }) =>
 										`${base} ${isActive ? activeClass : idle}`

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -13,6 +13,7 @@ import { ChevronDownIcon } from "../icons";
 // Kept in sync with DesktopHeader's own LINKS - the two are the same primary
 // navigation at different breakpoints, so they must not drift apart.
 const PRIMARY_LINKS = [
+	{ key: "home", to: "/", hash: false },
 	{ key: "findOpportunities", to: "/opportunities", hash: false },
 	{ key: "forOrganizations", to: "/#for-organizations", hash: true },
 	{ key: "help", to: "/help", hash: false },

--- a/frontend/src/components/PageHeaderBand.tsx
+++ b/frontend/src/components/PageHeaderBand.tsx
@@ -1,11 +1,21 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router";
-import { useTranslation } from "react-i18next";
 import { WAVE_PATH } from "../lib/wavePath";
 import { useOverlaysHeader } from "../contexts/HeaderOverlayContext";
 import { useQuickActionsList } from "../contexts/QuickActionsContext";
 import Button from "./Button";
 import { ChevronLeftIcon } from "./icons";
+
+// Where the in-band back link goes, and what it is called - one level *up*,
+// never "home": the header's own nav carries the landing page now (see
+// DesktopHeader's LINKS), so the only caller left is the org app shell, whose
+// "up" is a nested page's tab or the dashboard. One object rather than two
+// optional strings, so a destination can't arrive without a name (an
+// unlabelled chevron) or the other way round.
+interface Back {
+	href: string;
+	label: string;
+}
 
 interface Props {
 	/**
@@ -21,19 +31,14 @@ interface Props {
 	/** Optional trailing row (a "last updated" chip, a CTA). */
 	children?: ReactNode;
 	/**
-	 * Where the in-band back link goes, and what it is called. Defaults to the
-	 * site root. The org app overrides both: inside that shell "back" means the
-	 * organization's dashboard, not the public landing page.
-	 */
-	backHref?: string;
-	backLabel?: string;
-	/**
 	 * Drop the inner max-w-5xl measure so the band's text starts on the same
 	 * left edge as a page whose content fills the full max-w-page column. The
 	 * org app's pages do; the account and legal pages centre a 5xl column and
 	 * want the default.
 	 */
 	fullWidth?: boolean;
+	/** One level up, when there is one. See the Back type above. */
+	back?: Back;
 }
 
 // Shared title band for the standalone public pages (help, contact, imprint,
@@ -64,17 +69,22 @@ interface Props {
 // calling usePageToolbar in #1755): a separate grey bar restating the page
 // title directly above a band that states it in 72px display type was pure
 // duplication, and it drove a hard white line straight through the middle of
-// the treatment. The way back home is the link inside the band instead.
+// the treatment.
+//
+// They carry no "back to the home page" link either. Every subpage repeating
+// the same one destination inside its hero was the wrong place for it: a link
+// home is not a property of any individual page, it belongs in the site nav
+// that is on screen everywhere - which is where it lives now (see
+// DesktopHeader's LINKS and MobileMenu's PRIMARY_LINKS). What stays here is
+// only a genuine one-level-up link, which today just means the org app shell.
 export default function PageHeaderBand({
 	eyebrow,
 	title,
 	lead,
 	children,
-	backHref = "/",
-	backLabel,
+	back,
 	fullWidth = false,
 }: Props) {
-	const { t } = useTranslation();
 	useOverlaysHeader();
 	// Same QuickActionsContext the BreadcrumbBar reads. A page using this band
 	// renders no action bar (see the note above), so without this its
@@ -112,16 +122,17 @@ export default function PageHeaderBand({
 					<div
 						className={`pt-[calc(var(--header-height)+1.5rem)] pb-10 sm:pt-[calc(var(--header-height)+2rem)] sm:pb-14 ${fullWidth ? "" : "mx-auto max-w-5xl"}`}
 					>
-						{/* Replaces the BreadcrumbBar these pages used to render - one
-						way back, in the band, instead of a grey strip above it
-						repeating the title. */}
-						<Link
-							to={backHref}
-							className="animate-fade-up -ml-1 inline-flex items-center gap-1 rounded-lg px-1 py-1 text-sm font-medium text-brand-100 transition-colors hover:text-white"
-						>
-							<ChevronLeftIcon className="h-4 w-4" />
-							{backLabel ?? t("breadcrumb.home")}
-						</Link>
+						{/* One level up, when there is one. See the Back type above
+						for why this is not a link home. */}
+						{back && (
+							<Link
+								to={back.href}
+								className="animate-fade-up -ml-1 inline-flex items-center gap-1 rounded-lg px-1 py-1 text-sm font-medium text-brand-100 transition-colors hover:text-white"
+							>
+								<ChevronLeftIcon className="h-4 w-4" />
+								{back.label}
+							</Link>
+						)}
 						{actions.length > 0 && (
 							<div className="animate-fade-up-d1 float-right ml-4 flex shrink-0 items-center gap-2">
 								{actions.map((action) => (
@@ -144,7 +155,11 @@ export default function PageHeaderBand({
 								))}
 							</div>
 						)}
-						<p className="animate-fade-up mt-6 text-xs font-semibold tracking-widest text-brand-200 uppercase">
+						{/* mt-6 only separates the eyebrow from a back link above it -
+						without one it would just be dead space at the top of the band. */}
+						<p
+							className={`animate-fade-up text-xs font-semibold tracking-widest text-brand-200 uppercase ${back ? "mt-6" : ""}`}
+						>
 							{eyebrow}
 						</p>
 						<h1 className="animate-fade-up-d1 mt-3 max-w-4xl font-display text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl">

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -71,9 +71,14 @@ function OrgAppShell({
 	// The way back, one level up. This used to be a full BreadcrumbBar strip
 	// below the header - the last surface in the app still using it, and the
 	// reason the org app read as a third visual system next to the public site
-	// and the account area. PageHeaderBand carries it now, same as everywhere
-	// else, so "back" is a single link rather than a trail: from a nested page
-	// to its tab, and from a tab to the dashboard.
+	// and the account area. PageHeaderBand carries it now, so "back" is a
+	// single link rather than a trail: from a nested page to its tab, and from
+	// a tab to the dashboard. Null on the dashboard itself - it is the top of
+	// this shell, and the band used to fall back to linking it to itself.
+	//
+	// This is the only remaining caller passing a back link to the band. The
+	// public and account pages used to pass none and get a "Home" link by
+	// default; that destination lives in the header nav now.
 	const dashboardTab = ORG_TABS.find((tab) => tab.key === "dashboard");
 	const isDashboardTab = activeTabKey === "dashboard";
 	const back =
@@ -118,8 +123,7 @@ function OrgAppShell({
 					fullWidth
 					eyebrow={org.name}
 					title={pageTitle}
-					backHref={back?.href ?? `/app/${organizationId}/dashboard`}
-					backLabel={back?.label ?? t("orgOverview.tabDashboard")}
+					back={back ?? undefined}
 				/>
 				{/* Scoped to this route (remounts, clearing any caught error, whenever
 				the location changes) so a render crash in a single tab replaces just

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -18,6 +18,7 @@
     },
     "nav": {
       "primaryLabel": "Hauptnavigation",
+      "home": "Startseite",
       "findOpportunities": "Einsätze finden",
       "forOrganizations": "Für Organisationen",
       "help": "Hilfe",
@@ -1126,9 +1127,6 @@
           "description": "Einer der ersten Freiwilligen auf der Plattform."
         }
       }
-    },
-    "breadcrumb": {
-      "home": "Startseite"
     },
     "error": {
       "forbidden": "Du hast keine Berechtigung für diese Aktion.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -18,6 +18,7 @@
     },
     "nav": {
       "primaryLabel": "Main navigation",
+      "home": "Home",
       "findOpportunities": "Find opportunities",
       "forOrganizations": "For organizations",
       "help": "Help",
@@ -1126,9 +1127,6 @@
           "description": "One of the first volunteers on the platform."
         }
       }
-    },
-    "breadcrumb": {
-      "home": "Home"
     },
     "error": {
       "forbidden": "You do not have permission to do this.",


### PR DESCRIPTION
## What

Removes the "Home" back link every subpage rendered inside its `PageHeaderBand` hero, and adds "Home" as the leading entry of the header's primary nav instead - on both breakpoints.

## Why

The band's link was the same single destination restated once per page, sitting inside a page-specific hero rather than in the site navigation, where a visitor actually looks for it. A link home is not a property of any individual page; it is a site destination, so it belongs in the nav that is on screen everywhere.

Details:

- `DesktopHeader`'s `LINKS` and `MobileMenu`'s `PRIMARY_LINKS` both gain a `home` entry. The desktop `NavLink` needs `end`, since `/` prefixes every route and the link would otherwise render active everywhere.
- `PageHeaderBand` loses its `backHref = "/"` default. Since #1767 (merged into this branch, see below) moved the org app shell onto its own `OrgPageHeader`, that leaves the band's back link with no caller at all, so the prop and its markup are removed rather than kept as dead code.
- The eyebrow loses its `mt-6` along with the link it used to sit under, so the band no longer opens with dead space.
- `nav.home` replaces the now-unused `breadcrumb.home` key in both locales.

The org app shell keeps its own one-level-up link (nested page -> the tab that owns it), which lives in `OrgPageHeader` and is untouched by this PR - that one is genuine hierarchy, not a link home.

## Merge with main

`main` moved twice under this branch while it was open. Merged in and resolved:

- **#1767** (`replace the org app's hero band with a compact header`) conflicted in `OrgAppLayout.tsx`. It supersedes this branch's edit to the same lines - both dropped the dashboard tab's self-referential back link, and main's version does more besides - so main's version was taken wholesale, and the band's now-callerless back plumbing was deleted.
- **#1768** merged cleanly.

## Testing

- `pnpm lint`, `pnpm check`, `pnpm format:check`, `pnpm i18n:check`, `pnpm test` (180 passing post-merge) - all green locally.
- Visual tests updated where they asserted the in-band link: `NavigationTests`, `VolunteerOpportunityTests`, `TermsOfUsePageTests`, `HeaderBreadcrumbSharedImplementationTests`, `ProfileOverviewTests` now assert `main` carries no "Home" link and the header nav entry is present.
- Two new tests in `HeaderPrimaryNavTests`: `DesktopHeader_OnASubpage_CarriesTheWayHome_TheBandDoesNot` and `MobileMenu_OnASubpage_CarriesTheSameWayHome` (the two breakpoints render their destinations from two separate arrays, so one gaining a link and the other not is a live failure mode).
- `OrgAppShellHeaderTests`'s logo locator (`header a[href='/']`) had to be narrowed to `:has(img)` - the new nav entry points at `/` too, so the bare selector hit Playwright's strict mode. That was the one failure in the first CI run; the second run was fully green (338 visual tests).
- The .NET SDK could not be installed in this sandbox (the egress proxy returns 403 for `builds.dotnet.microsoft.com`), so the C# test changes were compiled and run by CI rather than locally.
- Rendered locally against the Vite dev server at 1440/820/768/390 px: band opens straight on the eyebrow with no leftover gap, nav reads Home / Find opportunities / For organizations / Help, no horizontal overflow at any width. Also rendered a band with quick actions injected and no back link (the `/profile/settings` case) to confirm the floated action row still clears the `h1`.

**Known, pre-existing:** between 768 px and the `md` breakpoint the header nav already wrapped onto two lines before this change (measured deficit ~42 px at 768 px without the new link). The fourth link widens the range that wraps from roughly 768-790 px to roughly 768-860 px. Fixing it properly means moving the header's mobile/desktop switch from `md` to `lg`, which is a bigger change than this one - flagging rather than folding it in.

## Live verification

**Deployed, but the browser check could not be run from this session - flagging rather than claiming a pass.**

- RC `v1.0.0-rc.350` was cut from this branch and tagged; publish run [31587540149](https://github.com/maik-hasler/einsatzbereit/actions/runs/31587540149) is green end to end, including `Deploy to Staging` (10:48 UTC) and its own post-deploy health gate against the live host. So the change is live on `https://einsatzbereit.maik-hasler.de`. That RC predates the merge with main above, so staging carries this branch's change on the pre-merge base; the merge commit itself is covered by the PR's own CI run.
- The throwaway Playwright script of step 6 could not run: this session's egress policy answers 403 to `CONNECT einsatzbereit.maik-hasler.de:443` and `api.maik-hasler.de:443`, so neither the health `curl` nor a browser can reach staging from here. Per the proxy README, a policy denial is reported, not routed around.
- What stands in for it: the same assertions run in CI's `VisualTests` against a real Chromium driving the full Aspire stack (frontend, backend, Keycloak, Postgres) - `DesktopHeader_OnASubpage_CarriesTheWayHome_TheBandDoesNot` clicks the nav entry on `/help` and asserts the landing page, `MobileMenu_OnASubpage_CarriesTheSameWayHome` does the same at 390 px, and five further tests assert no "Home" link remains inside `main` on `/help`, `/imprint`, `/privacy-policy`, `/terms-of-use`, `/profile`, the organization profile and the opportunity detail page. That is the durable record step 7 asks for, and it is green.
- Worth a 30-second manual look on staging if you want the last mile: open `https://einsatzbereit.maik-hasler.de/help` and confirm "Startseite" sits in the header nav and nothing sits above the "SUPPORT" eyebrow in the dark band.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green (re-running on the merge commit)
- [x] Documentation updated if this change affects behavior (no doc references the removed link; the rationale lives in the code comments)
