### PR TITLE
chore(deps): update aspnet-api-versioning to v10.2.1 and adopt Asp.Versioning.OpenApi

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -213,6 +213,7 @@ All versions centrally managed in `Directory.Packages.props`.
 | Package | Used in |
 |---|---|
 | `Asp.Versioning.Http` | Api - URL-segment versioning |
+| `Asp.Versioning.OpenApi` | Api - one OpenAPI document per API version |
 | `Microsoft.AspNetCore.Authentication.JwtBearer` | Api - JWT validation |
 | `NSwag.MSBuild` | Api - generates OpenAPI spec + TS client on build |
 | `EFCore.NamingConventions` | Infrastructure - snake_case |

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,8 +4,8 @@
 		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="Asp.Versioning.Http" Version="[10.0.1]" />
-		<PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="[10.0.1]" />
+		<PackageVersion Include="Asp.Versioning.Http" Version="[10.2.1]" />
+		<PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="[10.2.1]" />
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[10.0.11]" />
 		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="[10.0.11]" />
 		<PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="[10.0.11]" PrivateAssets="All" />

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,6 +6,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Asp.Versioning.Http" Version="[10.2.1]" />
 		<PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="[10.2.1]" />
+		<PackageVersion Include="Asp.Versioning.OpenApi" Version="[10.2.1]" />
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[10.0.11]" />
 		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="[10.0.11]" />
 		<PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="[10.0.11]" PrivateAssets="All" />

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -3,25 +3,12 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Http" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
+		<PackageReference Include="Asp.Versioning.OpenApi" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
 		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" />
 		<PackageReference Include="NSwag.MSBuild" />
 	</ItemGroup>
-
-	<!--
-	Asp.Versioning 10.2.0 ships Roslyn analyzers that 10.0.1 did not, and two of them fire on
-	Program.cs' OpenAPI wiring: AV0029 on builder.Services.AddOpenApi("v1", ...) and AV0030 on
-	app.MapOpenApi(). Both are warnings upstream and only break the build because this repo
-	sets TreatWarningsAsErrors. Satisfying them means moving to the Asp.Versioning.OpenApi
-	package, which regenerates the OpenAPI document and both NSwag clients, so it is tracked
-	as its own change in #1770; with a single API version it buys nothing yet. NoWarn sits
-	here rather than repo-wide because analyzers do not cross a ProjectReference, making Api
-	the only project they run in.
-	-->
-	<PropertyGroup>
-		<NoWarn>$(NoWarn);AV0029;AV0030</NoWarn>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Aspire\ServiceDefaults\ServiceDefaults.csproj" />
@@ -34,14 +21,16 @@
 	</ItemGroup>
 
 	<PropertyGroup>
+		<Description>API for the Einsatzbereit application</Description>
 		<OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/wwwroot</OpenApiDocumentsDirectory>
 		<OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
 	</PropertyGroup>
 
 	<Target Name="RenameOpenApiDocuments" AfterTargets="GenerateOpenApiDocuments">
+		<Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/$(MSBuildProjectName).json')"
+					Text="GenerateOpenApiDocuments did not produce wwwroot/$(MSBuildProjectName).json. The OpenAPI document name has most likely changed - check what landed in wwwroot/ and update this target to match instead of letting openapi-v1.json go stale." />
 		<Move SourceFiles="$(MSBuildProjectDirectory)/wwwroot/$(MSBuildProjectName).json"
-					DestinationFiles="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json"
-					Condition="Exists('$(MSBuildProjectDirectory)/wwwroot/$(MSBuildProjectName).json')" />
+					DestinationFiles="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json" />
 	</Target>
 
 	<PropertyGroup>

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -9,6 +9,20 @@
 		<PackageReference Include="NSwag.MSBuild" />
 	</ItemGroup>
 
+	<!--
+	Asp.Versioning 10.2.0 ships Roslyn analyzers that 10.0.1 did not, and two of them fire on
+	Program.cs' OpenAPI wiring: AV0029 on builder.Services.AddOpenApi("v1", ...) and AV0030 on
+	app.MapOpenApi(). Both are warnings upstream and only break the build because this repo
+	sets TreatWarningsAsErrors. Satisfying them means moving to the Asp.Versioning.OpenApi
+	package, which regenerates the OpenAPI document and both NSwag clients, so it is tracked
+	as its own change in #1770; with a single API version it buys nothing yet. NoWarn sits
+	here rather than repo-wide because analyzers do not cross a ProjectReference, making Api
+	the only project they run in.
+	-->
+	<PropertyGroup>
+		<NoWarn>$(NoWarn);AV0029;AV0030</NoWarn>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Aspire\ServiceDefaults\ServiceDefaults.csproj" />
 		<ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -41,7 +41,7 @@ builder.Services.AddInfrastructureServices(builder.Configuration);
 // accepted unbounded/missing values on every endpoint.
 builder.Services.AddValidation();
 
-builder.Services.AddApiVersioning(options =>
+var apiVersioning = builder.Services.AddApiVersioning(options =>
 	{
 		options.DefaultApiVersion = new ApiVersion(1);
 		options.ReportApiVersions = true;
@@ -132,8 +132,10 @@ builder.Services.AddExceptionHandler<ResultFailureExceptionHandler>();
 builder.Services.AddExceptionHandler<ConcurrencyExceptionHandler>();
 builder.Services.AddExceptionHandler<UnhandledExceptionHandler>();
 
-builder.Services.AddOpenApi("v1", options =>
+apiVersioning.AddOpenApi(versioned =>
 {
+	var options = versioned.Document;
+
 	options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
 	options.AddDocumentTransformer((document, _, _) =>
 	{
@@ -222,7 +224,7 @@ if (app.Environment.IsDevelopment())
 		app.Logger.LogError(ex, "An exception occurred while seeding the database");
 	}
 
-	app.MapOpenApi();
+	app.MapOpenApi().WithDocumentPerVersion();
 }
 else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 {


### PR DESCRIPTION
## What

Two commits:

1. **`615a29e`** - Renovate's `Asp.Versioning.Http` / `Asp.Versioning.Mvc.ApiExplorer` `10.0.1 -> 10.2.1` bump from #1714, with `AV0029`/`AV0030` suppressed so it builds.
2. **`1439cae`** - adopts `Asp.Versioning.OpenApi` so the rules are satisfied rather than suppressed, and removes the suppression again.

Supersedes #1714 (Renovate's branch cannot be pushed to from here). Closes #1770.

**The generated artifacts did not change.** `wwwroot/openapi-v1.json`, `frontend/src/client/api-client.ts` and `backend/tests/IntegrationTests/ApiClient.cs` are byte-identical after the migration - CI's drift check passed on commit 2 without any regeneration being needed.

## Why

#1714's `build` job failed with three errors:

```
Program.cs(135,1): error AV0029: AddApiVersioning().AddOpenApi() registers the OpenAPI services that describe API versions
obj/.../OpenApiXmlCommentSupport.generated.cs(601,20): error AV0029: (same, in the source-generated registration)
Program.cs(225,6): error AV0030: Call MapOpenApi().WithDocumentPerVersion() so that a document is generated for each API version
```

10.2.0 started shipping Roslyn analyzers inside `Asp.Versioning.Http` and `Asp.Versioning.Abstractions`; 10.0.1 shipped none. Both rules default to **Warning** - `backend/Directory.Build.props`' `TreatWarningsAsErrors` is what makes them fatal. `VersionedOpenApiAnalyzer` trips because the `AddApiVersioning()` chain calls `.AddApiExplorer(...)`, which flags the compilation as "versioned"; every plain `Microsoft.AspNetCore.OpenApi` registration in it is then reported.

## The change

- `builder.Services.AddOpenApi("v1", ...)` becomes `AddOpenApi()` on the `IApiVersioningBuilder`. The builder is held in a local so the document configuration can stay where it was in `Program.cs` rather than moving up into the versioning block.
- `app.MapOpenApi()` gains `.WithDocumentPerVersion()`.
- `<Description>` added to `Api.csproj`. This one is load-bearing rather than cosmetic: **AV0025 only activates once `VersionedOpenApiOptions` is referenced**, and it then reports every `AddOpenApi` call site when the assembly has no non-empty `AssemblyDescriptionAttribute`. Adopting the package without it would have traded two build errors for a third. It repeats what the document transformer already assigns, so the two cannot contradict each other.
- `RenameOpenApiDocuments` now `<Error>`s when the expected document is missing instead of silently skipping via `Condition="Exists(...)"`. This is the failure mode that made the migration risky in the first place: a renamed document would leave `openapi-v1.json` stale, NSwag would regenerate identical clients from it, and the drift check would stay green over a document that no longer matches the API.

### Why the document is unchanged

The document name is still `v1`: `ConfigureOpenApiOptions` calls `SetDocumentName(description.GroupName)`, and `GroupNameFormat = "'v'V"` yields `v1` - the same name registered by hand before, so `Microsoft.Extensions.ApiDescription.Server` still emits `wwwroot/Api.json` and the rename target still matches.

The `info` block survives because `VersionedOpenApiOptionsFactory` runs `OnCreated` - which registers the library's own transformers - *before* the configure callbacks, so the existing document transformer is registered last and its wholesale `document.Info = new OpenApiInfo { ... }` wins over `ApiExplorerTransformer`'s assembly-derived title and version.

Everything else the versioned pipeline adds turns out to be a no-op here: `ApiExplorerTransformer` assigns `parameter.Description` from model metadata, of which there is none to contribute; `XmlCommentsTransformer` is only registered when a documentation file exists, and `GenerateDocumentationFile` is not set; and `ModelMetadataSchemaTransformer`'s `[VisibleInApiVersion]` filtering has no attributes to act on.

## How this was prepared

`dotnet` could not be run for either commit. Every .NET SDK host is blocked by this session's egress policy - `builds.dotnet.microsoft.com`, `dotnetcli.azureedge.net`, `download.visualstudio.microsoft.com` and `aka.ms` all refuse CONNECT, which is also why `.claude/scripts/session-start.sh` did not bootstrap an SDK.

The analysis therefore came from the shipped 10.2.1 `.nupkg` contents (the analyzer assembly and its `buildTransitive` targets) and from the upstream source at commit `b4e6e0f`, which the packages record in their own `.nuspec`. Every rule gating on `Asp.Versioning.OpenApi.VersionedOpenApiOptions` was checked against the new shape ahead of pushing: AV0025 fires and is fixed by `<Description>`; AV0031 does not, because `.AddApiExplorer(...)` is still called. CI was the first actual compile and passed.

## Testing

All checks green on `1439cae`: `build`, `format-check`, `fast-tests`, `integration-tests`, `visual-tests`, `editorconfig`, `ban-typographic-dashes`, PR title.

No new tests. `integration-tests` and `visual-tests` boot the real API through Aspire, so they cover the thing most at risk here - that the rewired DI still starts the app. `/openapi/{document}.json` is only mapped in Development, so nothing in the suites consumes the document over HTTP, and `WithDocumentPerVersion()` does not execute outside Development at all.

One unrelated flake showed up along the way and is worth recording separately from this change: `NotificationForDeletedOpportunityTests.Notification_KeepsNullRelatedTitle_AfterOpportunityDeleted` failed once on a tree that differed from a green run only by deleted comments, then passed on re-run. It selects the *first* `EngagementCreated` notification belonging to the shared `olaf` account, while roughly twenty other test classes have `vera` apply to opportunities and produce `EngagementCreated` notifications for the same account concurrently - so `.First(...)` can pick a notification whose opportunity still exists, leaving `relatedTitle` non-null. Selecting by the opportunity the test itself created would make it deterministic. Not changed here to keep this PR to its subject.

## Live verification

Not cut. Commit 2 is a `refactor` rather than a bug fix or feature, and its externally observable surface is nil: the OpenAPI document is byte-identical, the endpoint serving it is Development-only, and the generated client the frontend ships against is unchanged. The startup wiring that did change is exercised by `integration-tests` and `visual-tests` booting the real stack. Say the word and I will cut an RC off this branch and run `/live-verify` before merge.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (`backend/AGENTS.md` package table)