### PR TITLE
fix(frontend): branch the delete-organization hint on member count

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -438,6 +438,51 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task DangerZoneHint_BranchesOnMemberCount_TheWayTheDeleteButtonAlreadyDid()
+	{
+		// Regression for #1789: the danger zone's hint was one static string
+		// ("...Remove other members first.") passed unconditionally as
+		// DangerZonePanel's description, while only the button's `disabled`
+		// prop branched on member count. So the sole member - the one person
+		// who *can* delete - was told to remove members who are not there,
+		// next to an enabled Delete button.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1789 DangerZoneHint", pinnedOrgId!.Value);
+		var organizationId = Guid.Parse(Regex.Match(Page.Url, @"/app/([^/]+)/dashboard").Groups[1].Value);
+
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Edit settings" }).ClickAsync();
+
+		var deleteButton = Page.GetByRole(AriaRole.Button, new() { Name = "Delete Organization" });
+		await Expect(deleteButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Sole member: enabled button, and copy that agrees with it.
+		await Expect(deleteButton).ToBeEnabledAsync();
+		await Expect(Page.GetByText("You are this organization's sole remaining member, so you can delete it."))
+			.ToBeVisibleAsync();
+		await Expect(Page.GetByText("Remove other members first.")).ToHaveCountAsync(0);
+
+		// A second plain member (same escape hatch as the two-member members
+		// page test above, since accepting an invitation would grant Organizer
+		// too) makes the original sentence true again - and it must come back.
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		await Fixture.AddPlainMemberDirectlyAsync(organizationId, vera.UserId);
+
+		// OrgAppLayout only refetches org details on organizationId change, so
+		// without a reload the page keeps its pre-membership snapshot.
+		await Page.ReloadAsync();
+
+		await Expect(deleteButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(deleteButton).ToBeDisabledAsync();
+		await Expect(Page.GetByText(
+			"Only the organization's sole remaining member can delete it. Remove other members first."))
+			.ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task CreateOrganizationModal_AcceptsFullDetails_AndAppliesThemAtCreation()
 	{
 		// #712: the create-organization modal used to collect only Name -

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -524,6 +524,7 @@
       "dangerZone": "Gefahrenzone",
       "deleteOrganization": "Organisation löschen",
       "deleteOrganizationHint": "Nur das letzte verbleibende Mitglied kann die Organisation löschen. Entferne zuerst die anderen Mitglieder.",
+      "deleteOrganizationSoleMemberHint": "Du bist das letzte verbleibende Mitglied und kannst die Organisation löschen.",
       "deleteOrganizationError": "Organisation konnte nicht gelöscht werden.",
       "editDisabledNotOrganizerHint": "Nur Organisatoren können die Organisationseinstellungen bearbeiten."
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -524,6 +524,7 @@
       "dangerZone": "Danger zone",
       "deleteOrganization": "Delete Organization",
       "deleteOrganizationHint": "Only the organization's sole remaining member can delete it. Remove other members first.",
+      "deleteOrganizationSoleMemberHint": "You are this organization's sole remaining member, so you can delete it.",
       "deleteOrganizationError": "Could not delete organization.",
       "editDisabledNotOrganizerHint": "Only organizers can edit organization settings."
     },

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -262,7 +262,16 @@ export default function OrgSettingsPage() {
 							<DangerZonePanel
 								className="mt-8"
 								title={t("orgSettings.dangerZone")}
-								description={t("orgSettings.deleteOrganizationHint")}
+								// #1789: the "remove the other members first" sentence
+								// used to be passed unconditionally, so a sole member -
+								// the only person who *can* delete - read it next to an
+								// enabled button. Same predicate as `disabled` below, so
+								// text and control can no longer disagree.
+								description={t(
+									isSoleMember
+										? "orgSettings.deleteOrganizationSoleMemberHint"
+										: "orgSettings.deleteOrganizationHint",
+								)}
 								actionLabel={t("orgSettings.deleteOrganization")}
 								onAction={() => setShowDeleteConfirm(true)}
 								disabled={!isSoleMember}


### PR DESCRIPTION
## What

The org settings danger zone now picks its hint based on member count, the way the Delete button's `disabled` prop already did: a sole member reads "You are this organization's sole remaining member, so you can delete it.", everyone else keeps the existing "Remove other members first." sentence.

## Why

`DangerZonePanel`'s `description` was a single static key passed unconditionally, while only `disabled` branched on `isSoleMember`. Olaf, as the only member of his organization, was told to remove members who are not there - next to an enabled Delete button - and had no way to tell whether deletion would work.

The predicate was already in hand two lines away (`OrgSettingsPage.tsx:90`), so this is one branch and one new locale key, no new data fetching.

Two decisions worth recording:

- **`isSoleMember` stays the predicate here**, rather than adopting the members page's `isLastOrganizer`. The issue flagged that the two pages use different predicates; they guard different backend rules, so they should. Deleting requires being the last *member* (`DeleteOrganizationCommandHandler`'s `Organization.MultipleMembers` guard, `members.Count > 1`); leaving requires not being the last *organizer*. Aligning them would make one of the two hints wrong.
- **The backend error copy is untouched.** The identical sentence at `Organization.MultipleMembers` in both locale files fires only when the rule is actually violated, so it is correct where it is - only the pre-emptive hint needed to become conditional.

Closes #1789

## Testing

- New `OrganizationTests.DangerZoneHint_BranchesOnMemberCount_TheWayTheDeleteButtonAlreadyDid` (Playwright/TUnit) walks both branches on one org: sole member -> Delete enabled, sole-member sentence visible, the "Remove other members first." sentence absent; then a second plain member is added via `AspireFixture.AddPlainMemberDirectlyAsync` (an invitation would grant Organizer too) and after a reload the original sentence is back with Delete disabled.
- Ran locally: `pnpm lint`, `pnpm check`, `pnpm i18n:check` (1273 keys in parity), `pnpm test` (180 passed), `pnpm build`, and `dotnet build` of `VisualTests.csproj`. The Playwright suite itself needs Docker/Aspire, so it runs here in CI rather than in the sandbox.
- CI: all 12 checks green, including `visual-tests`, which is the job that actually executes the new regression test.
- `/self-review` run, no findings. The i18n and a11y checks were run inline rather than via their subagents (this session was instructed not to spawn agents); the a11y surface is unchanged text inside an existing panel, with no new interactive elements.

## Live verification

Not performed - the RC-and-verify flow was explicitly waived for this change by the requester. The change is a conditional string swap on an existing panel, fully covered by the visual test above; the next release candidate will carry it to staging.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (no docs describe this copy)