### PR TITLE
fix(frontend): hold the opportunity detail time-slot list to the reading measure

### DIFF
--- a/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
@@ -99,7 +99,9 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 		updateResponse.EnsureSuccessStatusCode();
 
 		// Draft first, then slots, then publish - time slots are seeded against
-		// the draft the same way MyEngagementsTimeSlotTests does it.
+		// the draft the same way MyEngagementsTimeSlotTests does it. No
+		// `validUntil`: VolunteerOpportunity.EnsureValidValidUntil rejects a
+		// deadline on anything but IndividualContact, so sending one here 400s.
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
 			title = $"Measure1794 {suffix}",
@@ -109,7 +111,6 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 			occurrence = "OneTime",
 			participationType = "ScheduledSlots",
 			checkInMethod = "None",
-			validUntil = DateTimeOffset.UtcNow.AddDays(30),
 			isDraft = true,
 		});
 		oppResponse.EnsureSuccessStatusCode();
@@ -144,10 +145,11 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 	}
 
 	/// <summary>
-	/// The narrow viewports the fix had to leave alone: below `lg` the two-column
-	/// grid collapses and the viewport, not `max-w-2xl`, is the constraining
-	/// width - so the blocks shared an edge before the fix and must still do so
-	/// after it, with the time-slot list no narrower than its neighbours.
+	/// The narrow viewports the fix had to leave alone. Below `lg` the two-column
+	/// grid collapses to one column, so whichever of the viewport or `max-w-2xl`
+	/// is narrower decides the width - at 375px that is the viewport, at 768px
+	/// still `max-w-2xl`. Either way all three blocks must land on the same edge,
+	/// with the time-slot list no narrower than its neighbours.
 	/// </summary>
 	[Test]
 	[Arguments(768, 1024)]
@@ -176,6 +178,6 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 			});
 		widths[0].Should().BeApproximately(widths[1], MaxEdgeDeltaPx,
 			$"at {width}px the time-slot list must still fill the same width as the at-a-glance band - "
-			+ "#1794's max-w-2xl must not narrow it below lg, where the viewport is the constraint");
+			+ "#1794's max-w-2xl must not leave it narrower than its neighbours below lg");
 	}
 }

--- a/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
@@ -1,0 +1,181 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1794: the opportunity detail page's main column presented
+/// two competing right edges at wide viewports. Every block in the reading
+/// column sat inside a `max-w-2xl` wrapper (672px) except the time-slot list,
+/// which was a direct child of the 792px grid column and so ran 120px further
+/// right than the at-a-glance band above it and the about-organization block
+/// below it. #1727 had made that deliberate - date/spot rows aren't prose - but
+/// the result read as misaligned blocks rather than one document, so the list
+/// is now held to the same measure.
+///
+/// The closing "more from organization" band deliberately keeps the full
+/// `max-w-6xl` wrapper as an end-of-page section break, so this asserts the
+/// main column's shared edge rather than a single edge for the whole page.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// The issue was reported at 1440px - the only width at which max-w-2xl is
+	// actually the constraining width for all three blocks (below lg the grid
+	// collapses to one column and the viewport constrains them instead).
+	private const int WideViewportWidth = 1440;
+	private const int WideViewportHeight = 900;
+
+	// Sub-pixel differences are expected from fractional layout rounding; a
+	// regression to the old markup reopens a 120px gap, so this tolerance
+	// cannot mask one.
+	private const double MaxEdgeDeltaPx = 2;
+
+	/// <summary>
+	/// Reads the right edge of all three main-column blocks in a single
+	/// EvaluateAsync call - as in OpportunityDetailPageSpacingTests, so nothing
+	/// can shift layout between reads - and asserts they agree.
+	/// </summary>
+	private async Task AssertMainColumnBlocksShareRightEdgeAsync(string label)
+	{
+		var atAGlance = Page.GetByTestId("opportunity-at-a-glance");
+		var timeSlots = Page.GetByTestId("opportunity-time-slots");
+		var aboutOrg = Page.GetByTestId("about-organization");
+
+		await Expect(atAGlance).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(timeSlots).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(aboutOrg).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var edges = Array.Empty<double>();
+		await PollUntilAsync(async () =>
+		{
+			edges = await Page.EvaluateAsync<double[]>(
+				"""
+				selectors => selectors.map(s => {
+					const box = document.querySelector(s).getBoundingClientRect();
+					return box.left + box.width;
+				})
+				""",
+				new[]
+				{
+					"[data-testid='opportunity-at-a-glance']",
+					"[data-testid='opportunity-time-slots']",
+					"[data-testid='about-organization']",
+				});
+			return edges.Max() - edges.Min() <= MaxEdgeDeltaPx;
+		}, () => $"{label}: the at-a-glance band ({edges.ElementAtOrDefault(0)}px), the time-slot list "
+			+ $"({edges.ElementAtOrDefault(1)}px) and the about-organization block "
+			+ $"({edges.ElementAtOrDefault(2)}px) must end at the same x - the main column holds one measure");
+	}
+
+	private async Task<string> SeedPublishedOpportunityWithSlotsAsync()
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgName = $"Measure1794 {suffix}";
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		// "About this organization" only renders when the profile carries at
+		// least one of these fields - it is one of the three edges under test.
+		var updateResponse = await http.PutAsJsonAsync($"/v1/organizations/{organizationId}", new
+		{
+			name = orgName,
+			description = "Seeded for #1794 detail-page measure regression coverage.",
+			contactEmail = $"contact-{suffix}@example.test",
+			contactPhone = "+49 555 0100",
+			website = "https://example.test",
+			address = new { street = "Teststrasse", houseNumber = "1", zipCode = "12345", city = "Musterstadt" },
+		});
+		updateResponse.EnsureSuccessStatusCode();
+
+		// Draft first, then slots, then publish - time slots are seeded against
+		// the draft the same way MyEngagementsTimeSlotTests does it.
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"Measure1794 {suffix}",
+			description = "Seeded for #1794 detail-page measure regression coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString()!;
+
+		var start = DateTimeOffset.UtcNow.AddDays(3);
+		var slotResponse = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = start.AddHours(2), maxParticipants = 5, recurrenceCount = 1 });
+		slotResponse.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		return opportunityId;
+	}
+
+	[Test]
+	public async Task DetailPage_MainColumnBlocks_ShareOneRightEdgeAtWideViewport()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await SeedPublishedOpportunityWithSlotsAsync();
+
+		await Page.SetViewportSizeAsync(WideViewportWidth, WideViewportHeight);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertMainColumnBlocksShareRightEdgeAsync($"{WideViewportWidth}px");
+	}
+
+	/// <summary>
+	/// The narrow viewports the fix had to leave alone: below `lg` the two-column
+	/// grid collapses and the viewport, not `max-w-2xl`, is the constraining
+	/// width - so the blocks shared an edge before the fix and must still do so
+	/// after it, with the time-slot list no narrower than its neighbours.
+	/// </summary>
+	[Test]
+	[Arguments(768, 1024)]
+	[Arguments(375, 812)]
+	public async Task DetailPage_MainColumnBlocks_ShareOneRightEdgeAtNarrowViewports(int width, int height)
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await SeedPublishedOpportunityWithSlotsAsync();
+
+		await Page.SetViewportSizeAsync(width, height);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertMainColumnBlocksShareRightEdgeAsync($"{width}px");
+
+		var widths = await Page.EvaluateAsync<double[]>(
+			"""
+			selectors => selectors.map(s => document.querySelector(s).getBoundingClientRect().width)
+			""",
+			new[]
+			{
+				"[data-testid='opportunity-time-slots']",
+				"[data-testid='opportunity-at-a-glance']",
+			});
+		widths[0].Should().BeApproximately(widths[1], MaxEdgeDeltaPx,
+			$"at {width}px the time-slot list must still fill the same width as the at-a-glance band - "
+			+ "#1794's max-w-2xl must not narrow it below lg, where the viewport is the constraint");
+	}
+}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -324,13 +324,12 @@ export default function VolunteerOpportunityDetailPage() {
 			and the CTA is better off in reading order anyway. */}
 				<div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start lg:gap-10">
 					<div className="min-w-0">
-						{/* Flush left inside the max-w-4xl wrapper, not centred within it.
-			#1727 deliberately let the banner and the time-slot list span the
-			full wrapper while prose stayed at a reading measure - but centring
-			the prose meant the page alternated between two column widths
-			(672px title, 896px slot rows, 672px again), reading as three
-			misaligned blocks rather than one document. Sharing a left edge
-			keeps #1727's wider media and a readable measure at the same time. */}
+						{/* Flush left inside the outer wrapper, not centred within it.
+			#1727 deliberately let the banner span the full wrapper while prose
+			stayed at a reading measure - but centring the prose meant the page
+			alternated between two column widths, reading as misaligned blocks
+			rather than one document. Sharing a left edge keeps #1727's wider
+			banner and a readable measure at the same time. */}
 						<div className="max-w-2xl">
 							{/* Report (and the owner's draft controls) sit on the same line
 							as the at-a-glance panel's top edge rather than floating alone
@@ -405,7 +404,10 @@ export default function VolunteerOpportunityDetailPage() {
 						it. One tinted panel with labelled columns gives them a hierarchy
 						and puts the page's first real colour below the band; the loose
 						lines collapse into a single meta row beneath it. */}
-							<dl className="mb-5 grid gap-5 rounded-card bg-brand-50 p-5 sm:grid-cols-3 sm:p-6">
+							<dl
+								className="mb-5 grid gap-5 rounded-card bg-brand-50 p-5 sm:grid-cols-3 sm:p-6"
+								data-testid="opportunity-at-a-glance"
+							>
 								<div>
 									<dt className="flex items-center gap-2 text-xs font-semibold tracking-widest text-brand-700 uppercase">
 										<CalendarIcon className="h-4 w-4 shrink-0" />
@@ -492,11 +494,19 @@ export default function VolunteerOpportunityDetailPage() {
 								)}
 						</div>
 
-						{/* Time slots - a reading column has no reason to constrain a list of
-			date/spot rows, so this spans the wider outer wrapper (#1727). */}
+						{/* Time slots - held to the same max-w-2xl measure as the blocks
+			above and below it (#1794). #1727 had let this list span the full grid
+			column on the grounds that date/spot rows aren't prose, but at 1440px
+			that gave the main column a second right edge 120px out from its
+			neighbours', so the page read as three misaligned blocks rather than
+			one. One measure for the whole column wins over the marginally roomier
+			rows. */}
 						{opportunity.participationType === "ScheduledSlots" &&
 							opportunity.timeSlots.length > 0 && (
-								<div className="mb-6">
+								<div
+									className="mb-6 max-w-2xl"
+									data-testid="opportunity-time-slots"
+								>
 									<SectionHeading>
 										{t("opportunities.availableTimeSlots")}
 									</SectionHeading>


### PR DESCRIPTION
## What

Adds `max-w-2xl` to the time-slot block on the volunteer opportunity detail page, so the main column's blocks share one right edge instead of the list running 120px wider than its neighbours. Adds `OpportunityDetailPageMeasureTests` to lock that in.

## Why

At 1440px the detail page presented two competing right edges in the main column. Every block sat inside a `max-w-2xl` wrapper (672px, right edge x=816) except the time-slot list, which was a direct child of the 792px grid column (right edge x=936). #1727 had made that deliberate on the grounds that date/spot rows aren't prose, but the result read as misaligned blocks rather than one document.

Implemented per the repo owner's decision on the issue - the smallest change that resolves the finding. Explicitly out of scope, per that same decision:

- **Not** widening the main column to 792px (German prose would run ~95-110 characters per line).
- **Not** pulling "Weitere Einsaetze dieser Organisation" in to the same measure - it keeps the full `max-w-6xl` wrapper as a deliberate end-of-page section break.
- **Nothing to do about the right rail** - the `<aside>` is already `lg:sticky lg:top-24`, so the sign-up CTA already follows the reader.

Two stale comments were refreshed alongside the change: the time-slot comment cited #1727's now-reversed rationale, and the comment above the reading column named a `max-w-4xl` wrapper that has since become `max-w-6xl` and cited the time-slot list as spanning it.

Closes #1794

## Testing

- New `backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs`:
  - `DetailPage_MainColumnBlocks_ShareOneRightEdgeAtWideViewport` - at 1440px, the at-a-glance band, the time-slot list and the about-organization block end at the same x (within 2px of layout rounding; a regression reopens the 120px gap).
  - `DetailPage_MainColumnBlocks_ShareOneRightEdgeAtNarrowViewports` - the same assertion at 768px and 375px, plus a width check that `max-w-2xl` doesn't leave the list narrower than its neighbours below `lg`.
  - Both seed their own org (full profile, so "About this organization" renders) and a published `ScheduledSlots` opportunity with a time slot, so neither depends on ambient staging data.
- Two `data-testid` hooks added for those assertions (`opportunity-at-a-glance`, `opportunity-time-slots`); the existing `about-organization` hook was reused.
- The first CI run failed these three tests on the seed call: the helper was adapted from `OpportunityDetailPageSpacingTests`, which creates an `IndividualContact` opportunity where `validUntil` is required, but `VolunteerOpportunity.EnsureValidValidUntil` rejects a deadline on any other participation type. Fixed in 2ae6b42 by dropping the field.
- Ran locally: `pnpm lint`, `pnpm check`, and a full `dotnet build` including `VisualTests` - all clean. The Playwright/Aspire suites themselves need real container networking, so they run in CI rather than in the authoring sandbox.

## Live verification

Not performed - RC explicitly not cut for this change at the requester's direction. The behavior is covered by the automated visual tests above instead.

## Checklist

- [x] `/self-review` run and findings addressed - checked directly rather than via the subagent fan-out: the diff is frontend markup plus one new test file, with no API surface, locale, entity, or a11y-affecting changes for the domain checks to act on. `git status` after a full build confirms no NSwag-generated client drift.
- [x] CI is green - all 12 checks pass on 2ae6b42, including `visual-tests` (345 tests)
- [x] Documentation updated if this change affects behavior - no docs affected; the two stale in-file comments noted above were corrected