### PR TITLE
fix(frontend): confirm before blocking a user or granting platform admin

### DIFF
--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -60,7 +60,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = $"Unblock {username}" })).ToBeVisibleAsync();
 
 			await row.GetByRole(AriaRole.Button, new() { Name = $"Promote {username} to admin" }).ClickAsync();
-			await ConfirmDialogAsync("Yes, make admin");
+			await ConfirmDialogAsync("Yes, promote");
 			await Expect(row.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = $"Remove admin from {username}" })).ToBeVisibleAsync();
 		}

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -51,13 +51,80 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 			await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
 			await Expect(row.GetByText("Active")).ToBeVisibleAsync();
 
+			// Both actions confirm first since einsatzbereit#1773 - see
+			// AdministrationPage_BlockAndPromote_RequireConfirmationNamingTheUser
+			// below for why, and for the dismissal half of the behaviour.
 			await row.GetByRole(AriaRole.Button, new() { Name = $"Block {username}" }).ClickAsync();
+			await ConfirmDialogAsync("Yes, block");
 			await Expect(row.GetByText("Blocked")).ToBeVisibleAsync();
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = $"Unblock {username}" })).ToBeVisibleAsync();
 
 			await row.GetByRole(AriaRole.Button, new() { Name = $"Promote {username} to admin" }).ClickAsync();
+			await ConfirmDialogAsync("Yes, make admin");
 			await Expect(row.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = $"Remove admin from {username}" })).ToBeVisibleAsync();
+		}
+		finally
+		{
+			await DeleteKeycloakUserAsync(keycloak, userId);
+		}
+	}
+
+	/// <summary>
+	/// Regression for einsatzbereit#1773: blocking an account and granting
+	/// platform admin fired straight from onClick with no confirmation, while
+	/// the lower-stakes organization shadow-delete one tab over already had a
+	/// ConfirmDialog. One mis-click on a dense row of two adjacent buttons
+	/// handed a stranger full platform administration, or locked a volunteer
+	/// out, with no undo. Asserts the dialog names the person and that
+	/// dismissing it leaves Keycloak untouched - not just the row's rendering,
+	/// which would also stay put if the request had merely failed.
+	/// </summary>
+	[Test]
+	public async Task AdministrationPage_BlockAndPromote_RequireConfirmationNamingTheUser()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (username, userId) = await CreateDisposableUserAsync(keycloak);
+		try
+		{
+			await AuthHelper.LoginAsync(Page, frontend, "admin", "admin123");
+			await Page.GotoAsync($"{origin}/administration/users");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			await Page.Locator("#admin-user-search").FillAsync(username);
+			await Page.Locator("form")
+				.Filter(new() { Has = Page.Locator("#admin-user-search") })
+				.GetByRole(AriaRole.Button, new() { Name = "Search" })
+				.ClickAsync();
+
+			var row = Page.Locator("li").Filter(new() { HasTextString = username });
+			await Expect(row).ToBeVisibleAsync(new() { Timeout = 15_000 });
+			await Expect(row.GetByText("Active")).ToBeVisibleAsync();
+
+			var dialog = Page.GetByRole(AriaRole.Dialog);
+
+			await row.GetByRole(AriaRole.Button, new() { Name = $"Block {username}" }).ClickAsync();
+			await Expect(dialog).ToBeVisibleAsync();
+			await Expect(dialog.GetByText(username)).ToBeVisibleAsync();
+			await dialog.GetByRole(AriaRole.Button, new() { Name = "Keep" }).ClickAsync();
+			await Expect(dialog).Not.ToBeVisibleAsync();
+
+			await Expect(row.GetByText("Active")).ToBeVisibleAsync();
+			(await IsUserEnabledAsync(keycloak, userId)).Should()
+				.BeTrue("dismissing the block confirmation must not block the account");
+
+			await row.GetByRole(AriaRole.Button, new() { Name = $"Promote {username} to admin" }).ClickAsync();
+			await Expect(dialog).ToBeVisibleAsync();
+			await Expect(dialog.GetByText(username)).ToBeVisibleAsync();
+			await dialog.GetByRole(AriaRole.Button, new() { Name = "Keep" }).ClickAsync();
+			await Expect(dialog).Not.ToBeVisibleAsync();
+
+			await Expect(row.GetByText("Admin", new() { Exact = true })).Not.ToBeVisibleAsync();
+			(await HasAdminRealmRoleAsync(keycloak, userId)).Should()
+				.BeFalse("dismissing the promote confirmation must not grant platform admin");
 		}
 		finally
 		{
@@ -156,6 +223,46 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		await Expect(ownRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(ownRow.GetByText("You cannot change your own account here.")).ToBeVisibleAsync();
 		await Expect(ownRow.GetByRole(AriaRole.Button)).Not.ToBeVisibleAsync();
+	}
+
+	/// <summary>
+	/// Clicks a ConfirmDialog's danger action and waits for it to close. The
+	/// dialog is portaled to document.body (see Modal.tsx), so it is never
+	/// inside the row locator that opened it.
+	/// </summary>
+	private async Task ConfirmDialogAsync(string confirmLabel)
+	{
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await dialog.GetByRole(AriaRole.Button, new() { Name = confirmLabel }).ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
+	}
+
+	private static async Task<bool> IsUserEnabledAsync(Uri keycloak, string userId)
+	{
+		var adminToken = await GetAdminTokenAsync(keycloak);
+
+		using var adminHttp = new HttpClient { BaseAddress = keycloak };
+		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var response = await adminHttp.GetAsync($"/admin/realms/{Realm}/users/{userId}");
+		response.EnsureSuccessStatusCode();
+		var user = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return user.GetProperty("enabled").GetBoolean();
+	}
+
+	private static async Task<bool> HasAdminRealmRoleAsync(Uri keycloak, string userId)
+	{
+		var adminToken = await GetAdminTokenAsync(keycloak);
+
+		using var adminHttp = new HttpClient { BaseAddress = keycloak };
+		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+		var response = await adminHttp.GetAsync($"/admin/realms/{Realm}/users/{userId}/role-mappings/realm");
+		response.EnsureSuccessStatusCode();
+		var roles = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return roles.EnumerateArray()
+			.Any(role => role.GetProperty("name").GetString() == "admin");
 	}
 
 	private static async Task<(string Username, string UserId)> CreateDisposableUserAsync(Uri keycloak)

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -978,7 +978,7 @@
       },
       "adminBlockUser": {
         "title": "Konto sperren?",
-        "message": "{{name}} kann sich erst wieder anmelden, wenn du das Konto entsperrst. Eine bereits offene Sitzung bleibt bis zu ihrem Ablauf gültig.",
+        "message": "{{name}} kann sich erst wieder anmelden, wenn du das Konto entsperrst. Eine bereits offene Sitzung wird nicht sofort beendet.",
         "confirm": "Ja, sperren"
       },
       "adminUnblockUser": {
@@ -988,12 +988,12 @@
       },
       "adminPromoteUser": {
         "title": "Zum Plattform-Admin machen?",
-        "message": "{{name}} erhält die vollen Administrationsrechte: Zugriff auf alle Organisationen und Nutzerdaten sowie die Möglichkeit, Konten zu sperren und weitere Personen zu Admins zu machen. Die Änderung wirkt sich bei der nächsten Anmeldung aus.",
+        "message": "{{name}} erhält die vollen Admin-Rechte: Zugriff auf alle Organisationen und Nutzerdaten sowie die Möglichkeit, Konten zu sperren und weitere Personen zu Admins zu machen. Die Änderung wirkt sich erst bei der nächsten Anmeldung aus.",
         "confirm": "Ja, zum Admin machen"
       },
       "adminDemoteUser": {
         "title": "Admin-Rechte entziehen?",
-        "message": "{{name}} verliert den Zugriff auf die Administration und auf alle Organisationen, in denen die Person kein Mitglied ist. Die Änderung wirkt sich bei der nächsten Anmeldung aus.",
+        "message": "{{name}} verliert den Zugriff auf die Administration und auf alle Organisationen, in denen die Person kein Mitglied ist. Die Änderung wirkt sich erst bei der nächsten Anmeldung aus.",
         "confirm": "Ja, Admin-Rechte entziehen"
       },
       "clearReadNotifications": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -976,6 +976,26 @@
         "message": "Möchtest du \"{{name}}\" wirklich wiederherstellen? Der Inhalt wird wieder sichtbar.",
         "confirm": "Ja, wiederherstellen"
       },
+      "adminBlockUser": {
+        "title": "Konto sperren?",
+        "message": "{{name}} kann sich erst wieder anmelden, wenn du das Konto entsperrst. Eine bereits offene Sitzung bleibt bis zu ihrem Ablauf gültig.",
+        "confirm": "Ja, sperren"
+      },
+      "adminUnblockUser": {
+        "title": "Konto entsperren?",
+        "message": "{{name}} kann sich danach wieder anmelden.",
+        "confirm": "Ja, entsperren"
+      },
+      "adminPromoteUser": {
+        "title": "Zum Plattform-Admin machen?",
+        "message": "{{name}} erhält die vollen Administrationsrechte: Zugriff auf alle Organisationen und Nutzerdaten sowie die Möglichkeit, Konten zu sperren und weitere Personen zu Admins zu machen. Die Änderung wirkt sich bei der nächsten Anmeldung aus.",
+        "confirm": "Ja, zum Admin machen"
+      },
+      "adminDemoteUser": {
+        "title": "Admin-Rechte entziehen?",
+        "message": "{{name}} verliert den Zugriff auf die Administration und auf alle Organisationen, in denen die Person kein Mitglied ist. Die Änderung wirkt sich bei der nächsten Anmeldung aus.",
+        "confirm": "Ja, Admin-Rechte entziehen"
+      },
       "clearReadNotifications": {
         "title": "Gelesene Benachrichtigungen löschen?",
         "message": "Dadurch werden alle gelesenen Benachrichtigungen dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -976,6 +976,26 @@
         "message": "Are you sure you want to restore \"{{name}}\"? It will become visible again.",
         "confirm": "Yes, restore"
       },
+      "adminBlockUser": {
+        "title": "Block this account?",
+        "message": "{{name}} will not be able to sign in again until you unblock the account. A session that is already open stays valid until it expires.",
+        "confirm": "Yes, block"
+      },
+      "adminUnblockUser": {
+        "title": "Unblock this account?",
+        "message": "{{name}} will be able to sign in again.",
+        "confirm": "Yes, unblock"
+      },
+      "adminPromoteUser": {
+        "title": "Grant platform admin?",
+        "message": "{{name}} gets full platform administration: every organization, all user data, and the ability to block accounts and make other people admins. This takes effect the next time they sign in.",
+        "confirm": "Yes, make admin"
+      },
+      "adminDemoteUser": {
+        "title": "Remove platform admin?",
+        "message": "{{name}} loses access to the administration area and to every organization they are not a member of. This takes effect the next time they sign in.",
+        "confirm": "Yes, remove admin"
+      },
       "clearReadNotifications": {
         "title": "Clear read notifications?",
         "message": "This permanently deletes all read notifications. This cannot be undone.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -978,7 +978,7 @@
       },
       "adminBlockUser": {
         "title": "Block this account?",
-        "message": "{{name}} will not be able to sign in again until you unblock the account. A session that is already open stays valid until it expires.",
+        "message": "{{name}} will not be able to sign in again until you unblock the account. A session that is already open is not ended immediately.",
         "confirm": "Yes, block"
       },
       "adminUnblockUser": {
@@ -987,13 +987,13 @@
         "confirm": "Yes, unblock"
       },
       "adminPromoteUser": {
-        "title": "Grant platform admin?",
-        "message": "{{name}} gets full platform administration: every organization, all user data, and the ability to block accounts and make other people admins. This takes effect the next time they sign in.",
-        "confirm": "Yes, make admin"
+        "title": "Promote to platform admin?",
+        "message": "{{name}} gets full admin rights: every organization, all user data, and the ability to block accounts and make other people admins. This only takes effect the next time they sign in.",
+        "confirm": "Yes, promote"
       },
       "adminDemoteUser": {
         "title": "Remove platform admin?",
-        "message": "{{name}} loses access to the administration area and to every organization they are not a member of. This takes effect the next time they sign in.",
+        "message": "{{name}} loses access to the administration area and to every organization they are not a member of. This only takes effect the next time they sign in.",
         "confirm": "Yes, remove admin"
       },
       "clearReadNotifications": {

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -479,6 +479,49 @@ function OrganizationsSection() {
 	);
 }
 
+// The four per-user actions and the copy each one confirms with. Every key is
+// spelled out in full rather than interpolated from the action name so they
+// stay greppable - and so scripts/check-i18n-keys.js sees each leaf key
+// referenced instead of reporting the whole subtree as dead.
+const USER_ACTION_COPY = {
+	block: {
+		title: "confirmDialog.adminBlockUser.title",
+		message: "confirmDialog.adminBlockUser.message",
+		confirm: "confirmDialog.adminBlockUser.confirm",
+		success: "administration.users.blockSuccess",
+		error: "administration.users.blockError",
+	},
+	unblock: {
+		title: "confirmDialog.adminUnblockUser.title",
+		message: "confirmDialog.adminUnblockUser.message",
+		confirm: "confirmDialog.adminUnblockUser.confirm",
+		success: "administration.users.unblockSuccess",
+		error: "administration.users.unblockError",
+	},
+	promote: {
+		title: "confirmDialog.adminPromoteUser.title",
+		message: "confirmDialog.adminPromoteUser.message",
+		confirm: "confirmDialog.adminPromoteUser.confirm",
+		success: "administration.users.promoteSuccess",
+		error: "administration.users.promoteError",
+	},
+	demote: {
+		title: "confirmDialog.adminDemoteUser.title",
+		message: "confirmDialog.adminDemoteUser.message",
+		confirm: "confirmDialog.adminDemoteUser.confirm",
+		success: "administration.users.demoteSuccess",
+		error: "administration.users.demoteError",
+	},
+} as const;
+
+type UserActionKind = keyof typeof USER_ACTION_COPY;
+
+function userDisplayName(row: AdminUserListItem): string {
+	return row.firstName && row.lastName
+		? `${row.firstName} ${row.lastName}`
+		: row.username;
+}
+
 function UsersSection() {
 	const { t } = useTranslation();
 	const auth = useAuth();
@@ -487,7 +530,18 @@ function UsersSection() {
 
 	const [search, setSearch] = useState("");
 	const [appliedSearch, setAppliedSearch] = useState("");
-	const [pendingUserId, setPendingUserId] = useState<string | null>(null);
+	// Blocking an account and granting platform admin used to fire straight
+	// from onClick, while the lower-stakes organization shadow-delete one tab
+	// over already confirmed - so one slip on a dense row of two adjacent
+	// buttons handed a stranger full platform administration, or locked a
+	// volunteer out, with no undo (#1773). All four now go through the same
+	// ConfirmDialog the other two admin sections use.
+	const [confirmAction, setConfirmAction] = useState<{
+		row: AdminUserListItem;
+		kind: UserActionKind;
+	} | null>(null);
+	const [actioning, setActioning] = useState(false);
+	const [actionError, setActionError] = useState<string | null>(null);
 
 	const {
 		items: rows,
@@ -512,68 +566,44 @@ function UsersSection() {
 		reset();
 	}
 
-	async function toggleEnabled(userId: string, next: boolean) {
-		setPendingUserId(userId);
+	// Errors land in the dialog's own ErrorBanner rather than a toast, matching
+	// OrganizationsSection/ReportsSection: the dialog stays open so the action
+	// can be retried in place instead of the row silently not changing.
+	async function confirmActionSubmit() {
+		if (!confirmAction) return;
+		const { row, kind } = confirmAction;
+		const copy = USER_ACTION_COPY[kind];
+		setActioning(true);
+		setActionError(null);
 		try {
-			await api.setUserEnabled(userId, { enabled: next });
-			setRows((prev) =>
-				prev.map((r) => (r.id === userId ? { ...r, enabled: next } : r)),
-			);
-			dispatchToast(
-				"success",
-				next
-					? t("administration.users.unblockSuccess")
-					: t("administration.users.blockSuccess"),
-			);
+			if (kind === "block" || kind === "unblock") {
+				const enabled = kind === "unblock";
+				await api.setUserEnabled(row.id, { enabled });
+				setRows((prev) =>
+					prev.map((r) => (r.id === row.id ? { ...r, enabled } : r)),
+				);
+			} else {
+				const isAdmin = kind === "promote";
+				await api.setUserAdminStatus(row.id, { isAdmin });
+				setRows((prev) =>
+					prev.map((r) =>
+						r.id === row.id
+							? {
+									...r,
+									realmRoles: isAdmin
+										? [...r.realmRoles, "admin"]
+										: r.realmRoles.filter((role) => role !== "admin"),
+								}
+							: r,
+					),
+				);
+			}
+			dispatchToast("success", t(copy.success));
+			setConfirmAction(null);
 		} catch (err) {
-			dispatchToast(
-				"error",
-				getApiErrorMessage(
-					err,
-					next
-						? t("administration.users.unblockError")
-						: t("administration.users.blockError"),
-				),
-			);
+			setActionError(getApiErrorMessage(err, t(copy.error)));
 		} finally {
-			setPendingUserId(null);
-		}
-	}
-
-	async function toggleAdmin(userId: string, next: boolean) {
-		setPendingUserId(userId);
-		try {
-			await api.setUserAdminStatus(userId, { isAdmin: next });
-			setRows((prev) =>
-				prev.map((r) =>
-					r.id === userId
-						? {
-								...r,
-								realmRoles: next
-									? [...r.realmRoles, "admin"]
-									: r.realmRoles.filter((role) => role !== "admin"),
-							}
-						: r,
-				),
-			);
-			dispatchToast(
-				"success",
-				next
-					? t("administration.users.promoteSuccess")
-					: t("administration.users.demoteSuccess"),
-			);
-		} catch (err) {
-			dispatchToast(
-				"error",
-				getApiErrorMessage(
-					err,
-					next
-						? t("administration.users.promoteError")
-						: t("administration.users.demoteError"),
-				),
-			);
-		} finally {
-			setPendingUserId(null);
+			setActioning(false);
 		}
 	}
 
@@ -639,11 +669,7 @@ function UsersSection() {
 						{rows.map((row) => {
 							const isSelf = row.id === currentUserId;
 							const isAdmin = row.realmRoles.includes("admin");
-							const isPending = pendingUserId === row.id;
-							const displayName =
-								row.firstName && row.lastName
-									? `${row.firstName} ${row.lastName}`
-									: row.username;
+							const displayName = userDisplayName(row);
 
 							return (
 								<li
@@ -689,9 +715,11 @@ function UsersSection() {
 														type="button"
 														variant="outline"
 														size="sm"
-														disabled={isPending}
 														onClick={() =>
-															void toggleEnabled(row.id, !row.enabled)
+															setConfirmAction({
+																row,
+																kind: row.enabled ? "block" : "unblock",
+															})
 														}
 														aria-label={
 															row.enabled
@@ -711,8 +739,12 @@ function UsersSection() {
 														type="button"
 														variant="outline"
 														size="sm"
-														disabled={isPending}
-														onClick={() => void toggleAdmin(row.id, !isAdmin)}
+														onClick={() =>
+															setConfirmAction({
+																row,
+																kind: isAdmin ? "demote" : "promote",
+															})
+														}
 														aria-label={
 															isAdmin
 																? t("administration.users.demoteNamed", {
@@ -750,6 +782,23 @@ function UsersSection() {
 								onClick={loadMore}
 							/>
 						))}
+					{confirmAction && (
+						<ConfirmDialog
+							title={t(USER_ACTION_COPY[confirmAction.kind].title)}
+							message={t(USER_ACTION_COPY[confirmAction.kind].message, {
+								name: userDisplayName(confirmAction.row),
+							})}
+							confirmLabel={t(USER_ACTION_COPY[confirmAction.kind].confirm)}
+							onConfirm={() => void confirmActionSubmit()}
+							onClose={() => {
+								if (actioning) return;
+								setConfirmAction(null);
+								setActionError(null);
+							}}
+							loading={actioning}
+							error={actionError}
+						/>
+					)}
 				</>
 			)}
 		</>


### PR DESCRIPTION
## What

On `/administration/users`, the per-row "Block" and "Promote to admin" actions called the API straight from `onClick`. All four user actions (block / unblock / promote / demote) now open the same `ConfirmDialog` that the organizations and reports sections already use, naming the person and stating the consequence.

## Why

The *lower-stakes* organization shadow-delete one tab over already confirmed, as does the reports section - two sections confirm, the user actions did not. One slip on a dense row of two adjacent buttons handed a stranger full platform administration, or locked a volunteer out, with no undo beyond finding the row again.

Closes #1773

Notes on the implementation:

- **Errors moved from a toast into the dialog's own `ErrorBanner`**, matching `OrganizationsSection`/`ReportsSection`. The dialog stays open so the action can be retried in place instead of the row silently not changing. Success toasts are unchanged.
- The two near-identical `toggleEnabled`/`toggleAdmin` handlers collapse into one confirm-driven `confirmActionSubmit`, and the per-row `isPending` disable goes away with them - the modal backdrop (`fixed inset-0`, above the page) already blocks the row underneath while a request is in flight.
- Copy keys are spelled out in full in a `USER_ACTION_COPY` map rather than interpolated from the action name, so they stay greppable and `scripts/check-i18n-keys.js`'s unused-key scan sees each leaf referenced.
- The dialog wording was checked against what the backend actually does. `SetUserEnabled` is a plain `PUT /users/{id} {enabled:false}` and `AssignAdminRoleAsync` only adds a realm role mapping - neither revokes existing sessions - so the copy says an already-open session is not ended immediately, and that admin changes only take effect at next sign-in. That matches the `administration.users.staleness` note already on the page.
- Untouched and still correct: the page continues to refuse to act on your own account (`isSelf`).

The second commit applies the copy findings from the i18n self-review: `Administrationsrechte` -> `Admin-Rechte` (the term the eight other places already use), one consistent verb across the English promote button/title/confirm, and `erst`/"only" added to the promote-demote copy so it matches the staleness hint on the same section.

## Testing

All 12 CI checks green on `b39e6e2`, including `visual-tests` and `integration-tests`.

Locally, before pushing:

| Check | Result |
|---|---|
| `pnpm i18n:check` | 1284 keys, no drift (parity, placeholders, unused-key scan) |
| `pnpm check` (tsc) | clean |
| `pnpm lint` + `format:write` | clean |
| `pnpm test` (vitest) | 180/180 passed |
| `Application.UnitTests` | 1044/1044 passed |
| `ArchitectureTests` | 422/422 passed |
| `VisualTests` compile | clean |

Tests changed in `backend/tests/VisualTests/AdminUserManagementTests.cs`:

- **Updated** `AdministrationPage_BlockAndPromote_UpdatesRowState` - it clicked both buttons and would otherwise break; it now confirms through the dialog first.
- **Added** `AdministrationPage_BlockAndPromote_RequireConfirmationNamingTheUser` - the regression test for this issue. Asserts the dialog appears, that its message names the person, and that dismissing it with "Keep" leaves the account enabled and un-promoted. The dismissal assertions read Keycloak's admin API directly (`IsUserEnabledAsync` / `HasAdminRealmRoleAsync`) rather than only the row's rendering, which would also look unchanged if the request had merely failed.

`IntegrationTests`/`VisualTests` need real container networking and were not run locally (see root `AGENTS.md`, Sandbox Limitations) - they ran green in CI.

## Live verification

Not performed: no release candidate was cut for this change, at the requester's explicit instruction. The usual step 6/7 flow in root `AGENTS.md` is therefore incomplete for this PR - the durable half (step 7, the automated TUnit assertions above, green in CI's `visual-tests`) is in place, but the change has not yet been observed on live staging.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green - all 12 checks passed on `b39e6e2`
- [x] Documentation updated if this change affects behavior - no docs describe this flow; the rationale lives in code comments and the issue

### Known, not fixed here

`ConfirmDialog` hardcodes its dismiss label as `t("confirmDialog.keep")` with no `cancelLabel` prop, so all four dialogs say "Keep"/"Behalten" - odd for *Unblock account?*, where nothing is being kept. Pre-existing (it already affects `unpublish` and `editTimeSlot`) and a change to a primitive with eight-plus callers, so out of scope for this issue.

Also surfaced by the a11y self-review and left alone for the same reason: both `ConfirmDialog` buttons take `disabled={loading}`, so activating Confirm disables the focused button and the browser drops focus to the document body. If the request then fails the dialog stays open but focus sits outside it, and `Modal`'s Tab trap only redirects from the first/last focusable within. The failure is still announced (`ErrorBanner` carries `role="alert"`), but a keyboard user cannot Tab straight back to retry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZu5CJcj5hNTq3ttPbuH4B)_