### PR TITLE
fix(frontend): shrink the dashboard calendar's default footprint to 4 rows

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
@@ -1,0 +1,179 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for the Calendar widget's footprint in the shipped default
+/// dashboard layout (DEFAULT_LAYOUT in frontend widgetCatalog.ts).
+///
+/// #1795: the Calendar shipped 8 columns wide and <b>6 rows</b> tall, and the
+/// grid's row height tracks its rendered column width (see
+/// .dashboard-widget-grid in global.css), so on a 1440px screen the first
+/// thing an organizer saw on their dashboard was ~900px of month grid holding
+/// a couple of event bars. It is now 4 rows - its own catalog minHeight, and
+/// still well above CalendarWidget's 400px internal floor, so the month view
+/// it opens on at full width keeps rendering legibly.
+///
+/// Only organizations that never customized their dashboard are affected: the
+/// page falls back to DEFAULT_LAYOUT solely when the API reports
+/// hasCustomLayout=false, and nothing migrates a stored layout - the second
+/// test here is the guard on that.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task DefaultLayout_GivesTheCalendarAProportionateFootprint_AndLeavesNoGapBelowIt()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// A freshly created org has no saved layout, so its dashboard renders
+		// DEFAULT_LAYOUT - deterministic regardless of what any other test in
+		// this session did to olaf's seeded organizations.
+		var organizationId = await CreateOrganizationAsync($"Visual CalFootprint {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		var calendar = Page.GetByTestId("widget-tile-Calendar");
+		await Expect(calendar).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The stored rect itself, straight off the tile's inline grid placement
+		// (index.tsx writes `${y} / span ${height}`) - the exact thing #1795
+		// changed, asserted without depending on any pixel measurement.
+		(await calendar.EvaluateAsync<string>("el => el.style.gridRow"))
+			.Should().Be("4 / span 4", "the Calendar defaults to 4 rows, not the 6 it shipped with");
+		(await Page.GetByTestId("widget-tile-Settings").EvaluateAsync<string>("el => el.style.gridRow"))
+			.Should().Be("8 / span 1",
+				"shrinking the Calendar must pull Settings up with it, not leave three empty rows");
+
+		// UpcomingOpportunities is 2 rows tall, so a 4-row Calendar renders
+		// roughly twice its height (rows plus one extra gap). Expressed as a
+		// ratio rather than a pixel count because the row height is a container
+		// query on the grid's own rendered width - at 6 rows this was ~3.1.
+		var upcomingBox = await Page.GetByTestId("widget-tile-UpcomingOpportunities").BoundingBoxAsync();
+		var calendarBox = await calendar.BoundingBoxAsync();
+		upcomingBox.Should().NotBeNull();
+		calendarBox.Should().NotBeNull();
+		((double)calendarBox!.Height / upcomingBox!.Height).Should().BeLessThan(2.5,
+			"the Calendar's height must stay proportionate to the widgets around it");
+
+		// Acceptance criterion: the widgets carrying actionable information are
+		// on the first screen of a 900px-tall viewport.
+		foreach (var testId in new[] { "CreateOpportunity", "ToDo", "UpcomingOpportunities" })
+		{
+			var box = await Page.GetByTestId($"widget-tile-{testId}").BoundingBoxAsync();
+			box.Should().NotBeNull();
+			(box!.Y + box.Height).Should().BeLessThan(900,
+				$"the {testId} widget must be fully above the fold at 1440x900");
+		}
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	[Test]
+	public async Task SavedLayout_KeepsItsOwnCalendarHeight_AndIsNotResetToTheNewDefault()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual CalSavedLayout {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+
+		// Keyboard corner placement (same state machine as a mouse click on two
+		// grid cells, see OrgDashboardCustomizeTests): the cursor starts on the
+		// Calendar's own top-left corner at (x=1, y=4), the second Enter locks
+		// it there, then 7x ArrowRight + 4x ArrowDown walks to (col=8, row=8)
+		// before the last Enter commits - keeping the full width but making the
+		// widget 5 rows tall, deliberately different from the new default of 4.
+		var moveButton = Page.GetByRole(AriaRole.Button, new() { Name = "Move or resize Calendar" });
+		await moveButton.FocusAsync();
+		await Page.Keyboard.PressAsync("Enter");
+		await Expect(Page.GetByTestId("dashboard-placement-status")).ToBeVisibleAsync();
+		await Page.Keyboard.PressAsync("Enter");
+		for (var i = 0; i < 7; i++)
+			await Page.Keyboard.PressAsync("ArrowRight");
+		for (var i = 0; i < 4; i++)
+			await Page.Keyboard.PressAsync("ArrowDown");
+		await Page.Keyboard.PressAsync("Enter");
+
+		await Expect(Page.GetByTestId("dashboard-placement-status")).Not.ToBeVisibleAsync();
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var calendar = Page.GetByTestId("widget-tile-Calendar");
+		await Expect(calendar).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The stored 5 rows survive: this organization has hasCustomLayout=true
+		// now, so DEFAULT_LAYOUT - whatever it currently says - never applies
+		// to it again.
+		string? gridRow = null;
+		await PollUntilAsync(async () =>
+		{
+			gridRow = await calendar.EvaluateAsync<string>("el => el.style.gridRow");
+			return gridRow == "4 / span 5";
+		}, () => "a saved layout must keep its own Calendar height rather than being reset to the "
+			+ $"default 4 rows (last observed: \"{gridRow}\")", timeoutMs: 10_000);
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	/// <summary>
+	/// Creates an organization through the API with the signed-in user's own
+	/// token, so the caller organizes it - same approach as
+	/// OrgAppCompactHeaderTests, and faster than driving the switcher's
+	/// create-organization dialog.
+	/// </summary>
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+	DEFAULT_LAYOUT,
+	WIDGET_CATALOG,
+	isValidPlacement,
+	type PlacedWidget,
+} from "./widgetCatalog";
+
+// #1795: the Calendar shipped at 6 rows tall, which at 1440px is ~900px of
+// the first screen an organizer opens handed to a month grid that usually
+// holds a couple of event bars. These guard the shape of the default the
+// issue settled on - and, just as importantly, that shrinking a widget in
+// DEFAULT_LAYOUT doesn't leave the stack below it floating over a gap.
+describe("DEFAULT_LAYOUT", () => {
+	it("gives the Calendar a footprint proportionate to its content", () => {
+		const calendar = DEFAULT_LAYOUT.find((w) => w.widgetKey === "Calendar");
+		expect(calendar).toBeDefined();
+		expect(calendar?.height).toBe(4);
+	});
+
+	// Widths deliberately differ - UpcomingOpportunities is stretched to the
+	// full 8 columns here while its catalog default is 4 - but heights are the
+	// documented invariant: a widget taller than it needs to be leaves dead
+	// space inside its own card.
+	it("keeps every widget at its own catalog default height", () => {
+		for (const widget of DEFAULT_LAYOUT) {
+			const entry = WIDGET_CATALOG[widget.widgetKey];
+			expect({ key: widget.widgetKey, height: widget.height }).toEqual({
+				key: widget.widgetKey,
+				height: entry.defaultHeight,
+			});
+		}
+	});
+
+	it("places every widget legally on the grid", () => {
+		for (const widget of DEFAULT_LAYOUT) {
+			expect(isValidPlacement(widget)).toBe(true);
+		}
+	});
+
+	it("stacks without overlaps or vertical gaps", () => {
+		// Rows are only ever fully occupied or fully free in this layout, so
+		// "no gaps" is just: the set of occupied rows is 1..bottom with nothing
+		// missing, and no cell is claimed twice.
+		const occupied = new Set<string>();
+		let bottom = 0;
+		for (const widget of DEFAULT_LAYOUT) {
+			for (let y = widget.y; y < widget.y + widget.height; y++) {
+				bottom = Math.max(bottom, y);
+				for (let x = widget.x; x < widget.x + widget.width; x++) {
+					const cell = `${x},${y}`;
+					expect(occupied.has(cell)).toBe(false);
+					occupied.add(cell);
+				}
+			}
+		}
+
+		const rows = new Set(
+			[...occupied].map((cell) => Number(cell.split(",")[1])),
+		);
+		for (let y = 1; y <= bottom; y++) {
+			expect(rows.has(y)).toBe(true);
+		}
+	});
+
+	it("puts actionable widgets above the Calendar", () => {
+		const rowOf = (key: PlacedWidget["widgetKey"]) =>
+			DEFAULT_LAYOUT.find((w) => w.widgetKey === key)?.y;
+		const calendarRow = rowOf("Calendar");
+		expect(calendarRow).toBeDefined();
+
+		for (const key of [
+			"CreateOpportunity",
+			"ToDo",
+			"UpcomingOpportunities",
+		] as const) {
+			const row = rowOf(key);
+			expect(row).toBeDefined();
+			expect(row as number).toBeLessThan(calendarRow as number);
+		}
+	});
+});

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
@@ -57,7 +57,16 @@ export const WIDGET_CATALOG: Record<WidgetKey, WidgetCatalogEntry> = {
 	Calendar: {
 		titleKey: "orgDashboard.calendarWidgetTitle",
 		defaultWidth: 8,
-		defaultHeight: 6,
+		// 4 rows, not the 6 this started at (#1795): at 1440px a row is
+		// ~150px, so 6 rows handed a month grid holding two event bars over
+		// 900px of the first screen an organizer opens. 4 rows sits exactly on
+		// minHeight below - still comfortably above CalendarWidget's own
+		// 400px floor, so the month grid it opens on at full width keeps
+		// rendering legibly - and gives back ~300px to the widgets carrying
+		// actionable information. The view stays month at this width
+		// (defaultViewForSize in CalendarWidget.tsx); the footprint was the
+		// problem, not the view.
+		defaultHeight: 4,
 		minWidth: 4,
 		minHeight: 4,
 	},
@@ -112,13 +121,21 @@ export interface PlacedWidget {
 // Layout applied when an organizer hasn't customized their dashboard yet:
 // ToDo+CreateOpportunity side by side, then UpcomingOpportunities, Calendar
 // and Settings each full-width below. Heights match each widget's own
-// defaultHeight above so no card leaves dead space.
+// defaultHeight above so no card leaves dead space, and each row starts
+// exactly where the one above it ends so the stack has no vertical gaps -
+// widgetCatalog.test.ts asserts both, so shrinking a widget here (as #1795
+// did to the Calendar) can't silently leave a hole below it.
+//
+// Only organizations that have never customized their dashboard ever see
+// this - OrgDashboardPage/index.tsx falls back to it solely when the API
+// reports hasCustomLayout: false, and nothing migrates or rewrites a saved
+// layout, so editing it leaves every stored layout exactly as it was.
 export const DEFAULT_LAYOUT: PlacedWidget[] = [
 	{ widgetKey: "CreateOpportunity", x: 1, y: 1, width: 4, height: 1 },
 	{ widgetKey: "ToDo", x: 5, y: 1, width: 4, height: 1 },
 	{ widgetKey: "UpcomingOpportunities", x: 1, y: 2, width: 8, height: 2 },
-	{ widgetKey: "Calendar", x: 1, y: 4, width: 8, height: 6 },
-	{ widgetKey: "Settings", x: 1, y: 10, width: 8, height: 1 },
+	{ widgetKey: "Calendar", x: 1, y: 4, width: 8, height: 4 },
+	{ widgetKey: "Settings", x: 1, y: 8, width: 8, height: 1 },
 ];
 
 export function classifyWidth(width: number): WidgetSizeClass {


### PR DESCRIPTION
## What

The Calendar widget's default height drops from **6 rows to 4** - in `DEFAULT_LAYOUT` and in its catalog entry, so a freshly added widget gets the same treatment. `Settings` moves from `y: 10` to `y: 8` so the two rows the calendar gives up don't turn into an empty gap below it. Nothing else about the default layout changes.

## Why

The dashboard grid's row height tracks its rendered column width (`.dashboard-widget-grid` in `global.css`), so at 1440px a row is ~150px - and 6 rows handed roughly 900px of the first screen an organizer opens to a month grid usually holding a couple of event bars.

Per the decision on the issue:

- **Month view stays.** `defaultViewForSize` still returns `month` at full width - the footprint was the problem, not the view.
- **4 rows is the floor, and it holds.** It is exactly the Calendar's existing `minHeight`, so no placement constraint needed changing, and it is still well above `CalendarWidget`'s own 400px internal floor - the month grid keeps rendering legibly, so the 5-row compromise the issue allowed for wasn't needed.
- **Saved layouts are untouched.** `OrgDashboardPage/index.tsx:134` applies `DEFAULT_LAYOUT` only when the API reports `hasCustomLayout: false`; nothing migrates or rewrites a stored layout. There is no migration in this change.
- **The widget order is unchanged** - the review's "actionable widgets pushed below the fold" observation came from a saved custom layout on staging, not from the default, so nothing was restructured on the strength of it.

Closes #1795

## Testing

Two new test files, both new coverage - `DEFAULT_LAYOUT` had none:

**`frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts`** (Vitest, runs in `frontend.yml`'s `test` job) asserts the Calendar's 4-row default, that every widget matches its catalog default height, that every placement is legal, that the stack has no overlaps *and no vertical gaps*, and that the actionable widgets sit above the Calendar. The gap assertion is the durable guard: it is what would have caught the orphaned `Settings` row had it been missed here.

**`backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs`** (TUnit + Playwright, runs in `dotnet.yml`'s `visual-tests` job) drives a freshly created organization at 1440x900:
- the Calendar tile's rendered grid placement is `4 / span 4` and `Settings` is `8 / span 1`
- the Calendar renders under 2.5x the height of the 2-row `UpcomingOpportunities` tile (it was ~3.1x at 6 rows) - a ratio rather than a pixel count, since the row height is a container query on the grid's own width
- `CreateOpportunity`, `ToDo` and `UpcomingOpportunities` are each fully above the fold
- a second test resizes the Calendar to 5 rows via keyboard corner placement, saves, reloads, and asserts it is still 5 rows - the guard that a saved layout is never reset to the new default

Run locally: `pnpm test` (23 files, 185 tests, all green), `pnpm lint`, `pnpm format:check`, `pnpm check`, and `dotnet build` of `VisualTests.csproj`. The Playwright and integration suites need real container networking, so they run on CI rather than in this sandbox.

## Live verification

Not performed - the release-candidate cut was explicitly out of scope for this task, so no RC was tagged and nothing was deployed to staging. The behavior is covered by the automated visual test above, which exercises the same assertions against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green - all 12 checks passed on `6fd9c56`, including `visual-tests` (which runs the new Playwright test) and `checks / test` (the new Vitest suite)
- [x] Documentation updated if this change affects behavior - the reasoning lives in code comments next to both changed values; no `AGENTS.md`/arc42 statement describes the default widget sizes