### PR TITLE
fix(frontend): stop /my-signups printing its own title twice

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -373,6 +373,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// Pinned to the page's <h1>: #1755 gave the page a header band whose
 		// title carries this name, and the section heading further down the
 		// page still carries it too, so an unqualified lookup matches both.
+		// #1796 made that second one sr-only (it is structure now, not a
+		// visible eyebrow) - it keeps its accessible name, so it keeps
+		// matching an unqualified lookup and the level pin is still needed.
 		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "My sign-ups", Level = 1 }))
 			.ToBeVisibleAsync(new() { Timeout = 20_000 });
 

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using AwesomeAssertions;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -104,5 +105,48 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// Leave vera's account clean for the rest of this shared Aspire session.
 		var withdrawResponse = await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
 		withdrawResponse.EnsureSuccessStatusCode();
+	}
+
+	[Test]
+	public async Task MyEngagementsPage_StatesItsTitleOnce_WithTheInContentHeadingSrOnly()
+	{
+		// #1796: /my-signups printed its own title twice - once as the header
+		// band's <h1> ("My sign-ups", myEngagementsPage.title) and again
+		// roughly 200px below it as a SectionHeading eyebrow rendering a second
+		// key with the same string ("My Sign-ups", myEngagements.title), where
+		// every other page's eyebrow carries a *category* the title does not
+		// repeat. That second one is sr-only now: it still marks where the
+		// invitations block ends and the sign-ups list begins for a screen
+		// reader, but it no longer costs vertical space on a page that is short
+		// of content, and the scope tabs move up into the space it held.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "My sign-ups", Level = 1 }))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		// Accessible-name matching is case-insensitive, so this finds the
+		// in-content heading whichever of the two casings it carries.
+		var inContentTitle = Page.Locator("#activity")
+			.GetByRole(AriaRole.Heading, new() { Name = "My sign-ups" });
+		await Expect(inContentTitle).ToHaveCountAsync(1);
+
+		// sr-only clips it to a 1px box: still in the accessibility tree, gone
+		// from the page. The eyebrow this replaces rendered ~16px tall, so a
+		// regression would blow well past this bound. Playwright counts an
+		// sr-only element as visible (it has a non-empty box), which is why
+		// this asserts geometry rather than Not.ToBeVisibleAsync().
+		var box = await inContentTitle.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Height.Should().BeLessThan(4,
+			"the in-content heading must stay sr-only - a second visible copy of the <h1> is what #1796 removed");
+
+		// What sits where that eyebrow did: the scope switcher, which now
+		// carries the group name the heading above it used to imply.
+		await Expect(Page.GetByRole(AriaRole.Group, new() { Name = "Time range" }))
+			.ToBeVisibleAsync();
 	}
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -611,6 +611,7 @@
       "noEngagementsHint": "Stöbre durch verfügbare Einsätze und melde dich für einen an.",
       "noPastEngagements": "Noch keine vergangenen Anmeldungen.",
       "exploreNeeds": "Einsätze erkunden",
+      "scopeLabel": "Zeitraum",
       "scopeUpcoming": "Aktuell & Bevorstehend",
       "scopePast": "Vergangen",
       "loadMore": "Mehr laden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -611,6 +611,7 @@
       "noEngagementsHint": "Browse available opportunities and volunteer for one that interests you.",
       "noPastEngagements": "No past sign-ups yet.",
       "exploreNeeds": "Explore opportunities",
+      "scopeLabel": "Time range",
       "scopeUpcoming": "Current & Upcoming",
       "scopePast": "Past",
       "loadMore": "Load more",

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -311,9 +311,25 @@ export default function ActivitySection() {
 				</div>
 			)}
 
-			<SectionHeading>{t("myEngagements.title")}</SectionHeading>
+			{/* No visible heading for the sign-ups list itself (#1796): this list
+			*is* the page, and PageHeaderBand's <h1> already names it in 72px
+			display type ~200px further up - so a SectionHeading repeating that
+			same string read as a category eyebrow that carried no category, and
+			pushed the scope tabs down a page that is short of content to begin
+			with. The invitations block above keeps its visible heading, because
+			that one names a section the <h1> does not.
 
-			<div className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+			The heading survives as an sr-only <h2> so the outline still marks
+			where the invitations block ends and the sign-ups list begins - the
+			one job the visible heading was doing that the <h1> can't do from
+			outside this section. */}
+			<h2 className="sr-only">{t("myEngagements.title")}</h2>
+
+			<div
+				role="group"
+				aria-label={t("myEngagements.scopeLabel")}
+				className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1"
+			>
 				<button
 					type="button"
 					data-testid="engagements-scope-upcoming"


### PR DESCRIPTION
## What

`/my-signups` rendered its title twice: the header band's `<h1>` ("My sign-ups", `myEngagementsPage.title`) and, roughly 200px below it, a `SectionHeading` eyebrow rendering a second key holding the same string (`myEngagements.title`). The in-content one is now an `sr-only` `<h2>`, and the scope tabs move up into the space it held.

## Why

Everywhere else in the app that eyebrow carries a *category* the title does not repeat (KONTO on the account pages, SUPPORT on `/help` and `/contact`). Here it repeated the `<h1>` verbatim, so it read as a category-less duplicate and cost vertical space on a page that is already short of content.

The heading is kept as `sr-only` rather than deleted outright: its one remaining job is marking where the invitations block ends and the sign-ups list begins, which the `<h1>` cannot do from outside the section. With no visible heading in front of them any more, the two scope tabs also picked up a `role="group"` + `aria-label` ("Time range" / "Zeitraum", new `myEngagements.scopeLabel` key) so they are still announced as one set.

Scope is one page, as the issue verified: `/profile` pairs its `<h1>` with "Profile details" and `/profile/settings` with "Email notifications", so neither has this problem.

Closes #1796

## Testing

- New `MyEngagementsTests.MyEngagementsPage_StatesItsTitleOnce_WithTheInContentHeadingSrOnly` - loads `/my-signups` as vera, asserts the `<h1>`, asserts exactly one in-content heading carries that name, asserts its bounding box is the ~1px `sr-only` box rather than a rendered eyebrow, and asserts the scope switcher exposes its group name. It asserts geometry rather than `Not.ToBeVisibleAsync()` because Playwright counts an `sr-only` element as visible.
- Updated the stale rationale comment on `AccessibilityTests.MyEngagementsPage_HasNoSeriousA11yViolations`' `Level = 1` pin - the second heading still carries the same accessible name, so the pin is still needed.
- Ran locally: `pnpm lint`, `pnpm check`, `pnpm format:write`, `pnpm i18n:check` (1273 keys, no drift), `pnpm test` (180 passed), and `dotnet build` of `VisualTests.csproj`. The Playwright/Aspire suites themselves need real container networking, so they run in CI rather than in this sandbox.

## Live verification

Not performed - the release candidate was explicitly skipped for this change at the requester's instruction. The assertions that would have been run against staging are in the TUnit test above instead, and they pass in CI against the full Aspire stack (`visual-tests`, run 31634401874).

## Checklist

- [x] Pre-PR review done (manually, not via the `/self-review` skill): re-read every touched file, checked the other callers of the two locale keys and every VisualTest that loads `/my-signups`, and ran the CI gates listed above locally
- [x] CI is green - all 13 checks passed, including `visual-tests`, `integration-tests` and the frontend `lint`/`test`/container smoke test
- [x] Documentation updated if this change affects behavior (n/a - no documented behavior changes)