### PR TITLE
fix(frontend): make the opportunity result count visible

### DIFF
--- a/backend/tests/VisualTests/OpportunityResultCountTests.cs
+++ b/backend/tests/VisualTests/OpportunityResultCountTests.cs
@@ -1,0 +1,191 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1778: /opportunities rendered its result count only into an
+/// sr-only paragraph (measured 1x1px on live staging), so a sighted user got no
+/// count at all - not on load, not after filtering, and no sense of how much was
+/// still behind "Load more". The strings themselves already existed and were
+/// already correctly worded in both locales; they simply never reached the screen.
+///
+/// The fix makes that same node visible rather than adding a second one, so these
+/// tests assert both halves: the count is genuinely painted (a real box, not the
+/// 1x1 clipped rect Tailwind's sr-only produces - the exact shape the issue
+/// measured) and it still carries the role="status" that announces it on every
+/// filter change. The one deliberate exception is an empty list, where it stays
+/// sr-only rather than printing "0 opportunities found." directly above
+/// EmptyState's "No opportunities found." - covered by the last assertions here.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityResultCountTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// useVolunteerOpportunitiesData's computePageSize pages in 9 at xl (>=1280px,
+	// 3 cols x 3 rows). Pinned explicitly rather than inherited from PageTest's
+	// default viewport, same as LoadMoreErrorPreservesItemsTests.
+	private const int WideViewportWidth = 1440;
+	private const int WideViewportHeight = 900;
+	private const int PageSize = 9;
+
+	private const string CountSelector = "[data-testid='opportunities-result-count']";
+
+	/// <summary>
+	/// Seeds one throwaway organization with an opportunity per title, all
+	/// carrying <paramref name="tag"/> so <c>/opportunities?tag=...</c> shows
+	/// exactly these and nothing else - the count under test has to be
+	/// deterministic while ~50 other classes concurrently seed their own
+	/// opportunities into the shared-session database (same tag-scoping pattern
+	/// as LoadMoreErrorPreservesItemsTests and ListLayoutGridTests).
+	/// </summary>
+	private static async Task SeedTaggedOpportunitiesAsync(
+		HttpClient http, string tag, IReadOnlyList<string> titles)
+	{
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"ResultCount {tag}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		foreach (var title in titles)
+		{
+			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+			{
+				title,
+				description = "Seeded by OpportunityResultCountTests.",
+				organizationId,
+				isRemote = true,
+				occurrence = "OneTime",
+				participationType = "IndividualContact",
+				checkInMethod = "None",
+				validUntil = DateTimeOffset.UtcNow.AddDays(30),
+				isDraft = false,
+				tags = new[] { tag },
+			});
+			response.EnsureSuccessStatusCode();
+		}
+	}
+
+	/// <summary>
+	/// Asserts the count paragraph reads <paramref name="expected"/> and is
+	/// actually on screen: a real text box, not the 1x1 clipped rect sr-only
+	/// leaves behind. A plain <c>ToBeVisibleAsync</c> would pass either way -
+	/// sr-only hides via clipping rather than display:none, so Playwright
+	/// considers it visible (see LiveRegionTests' note on the same trap).
+	/// </summary>
+	private async Task AssertCountRenderedAsync(string expected)
+	{
+		var count = Page.Locator(CountSelector);
+		await Expect(count).ToHaveTextAsync(expected, new() { Timeout = 15_000 });
+
+		var box = await count.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Height.Should().BeGreaterThan(8f,
+			$"\"{expected}\" must render at its natural line height, not be clipped into the "
+			+ "1x1 box sr-only produces - that clip is exactly what #1778 measured on staging");
+		box.Width.Should().BeGreaterThan(8f,
+			$"\"{expected}\" must render at its natural width, not be clipped to 1px by sr-only");
+	}
+
+	[Test]
+	public async Task OpportunitiesPage_ResultCount_IsVisibleOnLoad_AndUpdatesWhenLoadMoreAddsAPage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(WideViewportWidth, WideViewportHeight);
+
+		var olaf = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olaf.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var tag = $"count1778-{suffix}";
+
+		// One more than a page, so the first render is the "loaded, more
+		// available" wording and the second is the settled total.
+		var titles = new List<string>();
+		for (var i = 0; i < PageSize + 1; i++)
+			titles.Add($"ResultCount Opportunity {suffix}-{i}");
+		await SeedTaggedOpportunitiesAsync(http, tag, titles);
+
+		await Page.GotoAsync($"{origin}/opportunities?tag={tag}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertCountRenderedAsync($"{PageSize} opportunities loaded, more available.");
+
+		// Making it visible must not cost the announcement: the issue's own
+		// scoping note turns on this node still being an implicit live region.
+		await Expect(Page.Locator($"{CountSelector}[role='status']")).ToBeAttachedAsync();
+
+		// data-testid, not the accessible name: LoadMoreButton swaps its label
+		// for the loading one on the same element (see VisualTestBase's
+		// LoadMoreUntilVisibleAsync).
+		await Page.Locator("#opportunities [data-testid='load-more']").ClickAsync();
+
+		await AssertCountRenderedAsync($"{PageSize + 1} opportunities found.");
+	}
+
+	[Test]
+	public async Task OpportunitiesPage_ResultCount_FollowsTheKeywordFilter_AndStaysSrOnlyWhenTheListIsEmpty()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(WideViewportWidth, WideViewportHeight);
+
+		var olaf = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olaf.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var tag = $"count1778f-{suffix}";
+		// Long enough to appear in exactly one seeded title and in no other
+		// title, description or organization name the keyword filter searches
+		// (VolunteerOpportunityReadRepository matches all three).
+		var uniqueKeyword = $"Solitaire{suffix}";
+
+		await SeedTaggedOpportunitiesAsync(http, tag, [
+			$"ResultCount {uniqueKeyword}",
+			$"ResultCount Companion {suffix}-1",
+			$"ResultCount Companion {suffix}-2",
+		]);
+
+		await Page.GotoAsync($"{origin}/opportunities?tag={tag}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertCountRenderedAsync("3 opportunities found.");
+
+		// Driven through the page's own search box rather than a hand-written
+		// URL: "updates as filters change" is the half of #1778 a static
+		// first-render assertion can't prove.
+		var keywordInput = Page.GetByTestId("opportunities-keyword-input");
+		await keywordInput.FillAsync(uniqueKeyword);
+		await keywordInput.PressAsync("Enter");
+
+		// Singular wording included on purpose - resultCount_one existed but had
+		// never been rendered anywhere a sighted user could reach it.
+		await AssertCountRenderedAsync("1 opportunity found.");
+
+		await keywordInput.FillAsync($"nomatch{suffix}");
+		await keywordInput.PressAsync("Enter");
+
+		var emptyState = Page.Locator("#opportunities")
+			.GetByText("No opportunities found.", new() { Exact = true });
+		await Expect(emptyState).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The empty list is the one case the count deliberately stays hidden:
+		// "0 opportunities found." printed right above EmptyState's own "No
+		// opportunities found." is duplication on screen, while a screen reader
+		// still needs the zero to know the filter landed.
+		var count = Page.Locator(CountSelector);
+		await Expect(count).ToHaveTextAsync("0 opportunities found.");
+		var box = await count.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Height.Should().BeLessThan(8f,
+			"with no results the count must fall back to sr-only rather than repeat the empty state on screen");
+	}
+}

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -31,6 +31,12 @@ export default function OpportunityResultsList({
 }) {
 	const { t } = useTranslation();
 	const isInitialLoad = loading && items.length === 0;
+	const countMessage =
+		!error && !isInitialLoad
+			? hasMore
+				? t("opportunities.resultCountPartial", { count: items.length })
+				: t("opportunities.resultCount", { count: items.length })
+			: "";
 
 	return (
 		<>
@@ -39,18 +45,31 @@ export default function OpportunityResultsList({
 			identical pattern for why. Silent during the initial full-page
 			loading skeleton and on error; otherwise announces the settled
 			result count whenever a filter change, search, or "Load more"
-			rewrites the list - previously nothing did, so a screen-reader user
-			had no way to tell whether anything changed. Two different messages
-			depending on hasMore - "N found" implies N is the total match count,
-			which is false while more pages are still behind "Load more"; that
-			case gets its own "N loaded, more available" wording instead of
-			overclaiming a total the screen-reader user hasn't seen yet. */}
-			<p role="status" className="sr-only">
-				{!error && !isInitialLoad
-					? hasMore
-						? t("opportunities.resultCountPartial", { count: items.length })
-						: t("opportunities.resultCount", { count: items.length })
-					: ""}
+			rewrites the list. Two different messages depending on hasMore -
+			"N found" implies N is the total match count, which is false while
+			more pages are still behind "Load more"; that case gets its own
+			"N loaded, more available" wording instead of overclaiming a total
+			the user hasn't seen yet.
+
+			#1778: this one node is the sighted user's count too, rather than a
+			second visible copy of the same sentence that screen readers would
+			then meet twice. It stays sr-only while the list is empty, for two
+			reasons: "0 opportunities found." rendered directly above
+			EmptyState's "No opportunities found." is pure duplication, and
+			useLoadMore empties `items` a frame before `loading` flips on a
+			filter change, so a visible zero would flash on every refetch.
+			Screen readers still get the zero - there the announcement is the
+			only signal that the filter landed. */}
+			<p
+				role="status"
+				data-testid="opportunities-result-count"
+				className={
+					items.length > 0
+						? "mb-4 text-center text-sm text-gray-600"
+						: "sr-only"
+				}
+			>
+				{countMessage}
 			</p>
 			{loading && items.length === 0 && (
 				<div


### PR DESCRIPTION
## What

`/opportunities` now renders its result count on screen, directly under the filter row, instead of only into an `sr-only` paragraph. The same node is reused, so the count keeps the `role="status"` it already had.

## Why

`OpportunityResultsList.tsx` built the count string correctly and put it in a `1x1px` clipped paragraph, so no sighted user ever saw it - not on load, not after filtering, and no sense of how much was still behind "Mehr laden". Both locales already had the right wording (`resultCount` / `resultCountPartial`, singular and plural); it simply never reached the screen.

Two things the issue's scoping note called out are honoured here:

- **This is not an a11y defect and the fix does not add `aria-live`.** The paragraph already carried `role="status"`, an implicit polite live region, so screen readers were already announced the new count on filter changes. That behaviour is unchanged.
- **No sort control.** Explicitly out of scope per the issue.

The existing node is reused rather than a second visible copy added, so the sentence is not announced twice. It stays `sr-only` in exactly one case - an empty list - for two reasons: `"0 opportunities found."` printed directly above `EmptyState`'s own `"No opportunities found."` is duplication on screen, and `useLoadMore` empties `items` a frame before `loading` flips on a filter change, so a visible zero would flash on every refetch. Screen readers still get the zero, which is the one place the announcement carries something the visual empty state cannot.

Closes #1778

## Testing

New `backend/tests/VisualTests/OpportunityResultCountTests.cs`, two tests, both seeding tag-scoped opportunities so the count is deterministic against the shared session database:

- `..._IsVisibleOnLoad_AndUpdatesWhenLoadMoreAddsAPage` - 10 seeded opportunities at a 1440px viewport (page size 9) render `"9 opportunities loaded, more available."`, the node still carries `role="status"`, and clicking "Load more" turns it into `"10 opportunities found."`
- `..._FollowsTheKeywordFilter_AndStaysSrOnlyWhenTheListIsEmpty` - 3 seeded opportunities read `"3 opportunities found."`; searching through the page's own keyword box narrows it to the singular `"1 opportunity found."` (a form that had never been rendered anywhere reachable); a no-match search leaves `EmptyState` on screen with the count back to `sr-only` but still reading `"0 opportunities found."` for screen readers

Both assert the rendered *box size*, not just visibility: `sr-only` hides by clipping rather than `display:none`, so a plain `ToBeVisibleAsync` would have passed before this fix too.

Also run locally, all green: `pnpm format:write`, `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm test` (180 passed), `dotnet build tests/VisualTests` (0 warnings, 0 errors). `docker`-dependent suites are not runnable in this sandbox and run in CI.

## Live verification

Not performed - the RC/live-staging step was explicitly waived for this change by the requester. The behaviour is covered by the two Playwright tests above, which run against the full Aspire stack in CI (`visual-tests`, green on `a3d13c6`).

## Checklist

- [x] `/self-review` run and findings addressed (one finding: a stray interpolation-free `$"..."` in the test, fixed)
- [x] CI is green - all 12 checks passed on `a3d13c6`, including `visual-tests` (the job the two new tests run in), `integration-tests`, `fast-tests`, `format-check`, and the frontend lint/test/build/container checks
- [x] Documentation updated if this change affects behavior - no doc referenced the count's presentation; nothing to update