### PR TITLE
fix(frontend): say why a refused wizard step jump did not happen

### DIFF
--- a/backend/tests/VisualTests/WizardBlockedStepJumpTests.cs
+++ b/backend/tests/VisualTests/WizardBlockedStepJumpTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1782: all four step buttons of the create-opportunity
+/// wizard render enabled, but clicking one that sits behind an invalid earlier
+/// step used to bail out of <c>handleStepClick</c> with no feedback tied to the
+/// refused navigation - the dialog simply stayed put. The only signal was the
+/// offending field turning red, which the user then had to connect to the click
+/// themselves, and which they cannot even see when that field lives on a step
+/// that isn't currently rendered. The buttons stay enabled (a disabled button
+/// takes itself out of the tab order, so it could not carry the explanation
+/// either); the refusal now names the step standing in the way, in an
+/// assertive live region wired to the refused button via aria-describedby.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class WizardBlockedStepJumpTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const string BlockedMessageSelector = "#create-opportunity-step-blocked";
+
+	[Test]
+	public async Task StepperJump_BlockedByTheCurrentStep_NamesItInAnAssertiveLiveRegion()
+	{
+		await OpenCreateWizardAsync();
+
+		// Step 1 is untouched and therefore invalid (title and description are
+		// both required), so the jump to step 4 must be refused.
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+
+		var blocked = Page.Locator($"{BlockedMessageSelector}[role='alert'][aria-live='assertive']");
+		await Expect(blocked).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(blocked).ToContainTextAsync("Step 4 is not available yet");
+		await Expect(blocked).ToContainTextAsync("step 1 (Basics)");
+
+		// The refusal has to be reachable from the control that was refused,
+		// not just announced once into the void.
+		await Expect(Page.GetByTestId("wizard-stepper-4"))
+			.ToHaveAttributeAsync("aria-describedby", "create-opportunity-step-blocked");
+
+		// And the jump really did not happen.
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("wizard-step-4")).Not.ToBeAttachedAsync();
+
+		// Fixing the named step retires the message on its own - the form
+		// validates on blur, so Tab out of the last field rather than relying
+		// on the fill alone.
+		await Page.Locator("#opportunity-title").FillAsync("Blocked step jump regression");
+		await Page.Locator("#opportunity-description").FillAsync("Regression test for #1782.");
+		await Page.Locator("#opportunity-description").PressAsync("Tab");
+		await Expect(blocked).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("wizard-stepper-4"))
+			.Not.ToHaveAttributeAsync("aria-describedby", "create-opportunity-step-blocked");
+
+		// With step 1 valid the same click now goes through.
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-4")).ToBeVisibleAsync();
+		await Expect(Page.Locator(BlockedMessageSelector)).Not.ToBeAttachedAsync();
+	}
+
+	[Test]
+	public async Task StepperJump_BlockedByAnIntermediateStep_NamesThatStepNotTheCurrentOne()
+	{
+		// The case the silent bail hurt most: the field standing in the way is
+		// on a step the user is not looking at, so the red rule painted onto
+		// that step's marker is the only clue, with nothing saying it is what
+		// stopped the jump.
+		await OpenCreateWizardAsync();
+
+		await Page.Locator("#opportunity-title").FillAsync("Intermediate step block");
+		await Page.Locator("#opportunity-description").FillAsync("Regression test for #1782.");
+
+		// Step 2's address may be pre-filled from the organization, so break it
+		// deliberately instead of depending on which fields arrive empty.
+		await Page.GetByTestId("wizard-stepper-2").ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-2")).ToBeVisibleAsync();
+		await Page.Locator("#opportunity-city").FillAsync("");
+
+		// Back to step 1 (a backwards jump is never validated), then forward
+		// past the broken step 2.
+		await Page.GetByTestId("wizard-stepper-1").ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+
+		var blocked = Page.Locator(BlockedMessageSelector);
+		await Expect(blocked).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(blocked).ToContainTextAsync("step 2 (Location)");
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+	}
+
+	private async Task OpenCreateWizardAsync()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		await Expect(Page.Locator("[role='dialog']")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -15,6 +15,7 @@ import { getApiErrorMessage, isApiErrorCode } from "../../lib/apiError";
 import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
 import Button from "../Button";
+import ErrorBanner from "../ErrorBanner";
 import ImageCropModal from "../ImageCropModal";
 import { Stepper } from "./shared";
 import BasicsStep from "./BasicsStep";
@@ -34,6 +35,9 @@ import type { OpportunityFormValues } from "./schema";
 
 const MAX_BANNER_BYTES = 2 * 1024 * 1024;
 const BANNER_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+/** Ties the refused-jump message to the step button that was refused. */
+const BLOCKED_JUMP_MESSAGE_ID = "create-opportunity-step-blocked";
 
 function advanceDate(
 	origin: Date,
@@ -221,6 +225,16 @@ export default function CreateVolunteerOpportunityModal({
 	// changing anything) - lets DetailsStep re-scroll/re-focus the error each
 	// time, since a dependency on the string alone wouldn't change.
 	const [errorToken, setErrorToken] = useState(0);
+	// Set when a stepper jump was refused because an earlier step is invalid:
+	// `target` is the step that was clicked, `blocking` the first one standing
+	// in its way. `attempt` is bumped on every refusal so an unchanged message
+	// still re-mounts (and gets re-announced) on a repeat click, same reason as
+	// `errorToken` above.
+	const [blockedJump, setBlockedJump] = useState<{
+		target: number;
+		blocking: number;
+		attempt: number;
+	} | null>(null);
 	const [orgAddress, setOrgAddress] = useState<AddressDto | null>(null);
 	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
@@ -341,6 +355,11 @@ export default function CreateVolunteerOpportunityModal({
 		};
 	}, [bannerPreview]);
 
+	// Any navigation that did go through retires the refusal message.
+	useEffect(() => {
+		setBlockedJump(null);
+	}, [step]);
+
 	function requestClose() {
 		// isDirty only tracks react-hook-form's own fields - time slots, the
 		// banner file and its removal all live in separate useState outside the
@@ -388,12 +407,30 @@ export default function CreateVolunteerOpportunityModal({
 		// Jumping ahead skips every step in between - validate all of their
 		// fields, not just the currently active one, so a step revisited and
 		// broken (e.g. going back to blank out the title) still blocks the
-		// jump instead of only surfacing at Publish-time.
-		const fields = Object.entries(STEP_FIELDS)
-			.filter(([s]) => Number(s) >= step && Number(s) < n)
-			.flatMap(([, stepFields]) => stepFields);
-		const valid = fields.length === 0 || (await trigger(fields));
-		if (!valid) return;
+		// jump instead of only surfacing at Publish-time. Validating one step
+		// at a time rather than one trigger() over the union of their fields
+		// still paints every offending step's rule red, and additionally tells
+		// us *which* step to name below.
+		let blocking: number | null = null;
+		for (let s = step; s < n; s++) {
+			const fields = STEP_FIELDS[s];
+			if (fields.length === 0) continue;
+			if (!(await trigger(fields)) && blocking === null) blocking = s;
+		}
+		if (blocking !== null) {
+			// Refusing in silence left the reason to be inferred from a field
+			// turning red - and the offending field can sit on a step that
+			// isn't even rendered, leaving nothing but an unexplained red rule
+			// somewhere in the stepper (#1782). Name the step that blocks the
+			// jump instead.
+			const blockingStep = blocking;
+			setBlockedJump((prev) => ({
+				target: n,
+				blocking: blockingStep,
+				attempt: (prev?.attempt ?? 0) + 1,
+			}));
+			return;
+		}
 		setStep(n);
 	}
 
@@ -863,6 +900,18 @@ export default function CreateVolunteerOpportunityModal({
 		t("createOpportunity.step3Title"),
 		t("createOpportunity.step4Title"),
 	];
+	// Only while the named step is in fact still invalid: fixing the field
+	// (revalidated on blur) retires the message on its own, without the user
+	// having to click the step again to find out whether it would work now.
+	const blockedJumpMessage =
+		blockedJump && errorSteps.has(blockedJump.blocking)
+			? t("createOpportunity.stepBlocked", {
+					target: blockedJump.target,
+					blocking: blockedJump.blocking,
+					blockingTitle: stepTitles[blockedJump.blocking - 1],
+				})
+			: null;
+
 	const stepSubtitles = [
 		t("createOpportunity.step1Subtitle"),
 		t("createOpportunity.step2Subtitle"),
@@ -969,7 +1018,26 @@ export default function CreateVolunteerOpportunityModal({
 						stepLabel={(n, label) =>
 							`${t("createOpportunity.stepOf", { current: n, total: TOTAL_STEPS })}: ${label}`
 						}
+						blocked={
+							blockedJump && blockedJumpMessage
+								? {
+										step: blockedJump.target,
+										messageId: BLOCKED_JUMP_MESSAGE_ID,
+									}
+								: undefined
+						}
 					/>
+					{blockedJump && blockedJumpMessage && (
+						// Keyed on the attempt counter so a repeat click on the same
+						// still-blocked step re-inserts the alert - an assertive live
+						// region whose text didn't change is not re-announced.
+						<ErrorBanner
+							key={blockedJump.attempt}
+							id={BLOCKED_JUMP_MESSAGE_ID}
+							message={blockedJumpMessage}
+							className="mt-3"
+						/>
+					)}
 				</div>
 
 				{/* Announces the active step to screen readers whenever it changes. */}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/shared.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/shared.tsx
@@ -15,12 +15,20 @@ export function Stepper({
 	onStepClick,
 	steps,
 	stepLabel,
+	blocked,
 }: {
 	current: number;
 	errorSteps: Set<number>;
 	onStepClick: (n: number) => void;
 	steps: string[];
 	stepLabel: (n: number, label: string) => string;
+	/**
+	 * The step whose last click was refused, plus the id of the element that
+	 * says why. The refusal message is announced once when it appears; wiring
+	 * it up as the button's description means re-focusing that same button
+	 * re-reads the reason instead of leaving it to be inferred (#1782).
+	 */
+	blocked?: { step: number; messageId: string };
 }) {
 	return (
 		<ol className="mt-4 flex items-stretch gap-1.5">
@@ -36,6 +44,9 @@ export function Stepper({
 							onClick={() => onStepClick(n)}
 							aria-current={isActive ? "step" : undefined}
 							aria-label={stepLabel(n, label)}
+							aria-describedby={
+								blocked?.step === n ? blocked.messageId : undefined
+							}
 							data-testid={`wizard-stepper-${n}`}
 							className="group flex w-full flex-col gap-1.5 rounded-md px-0.5 pb-1 text-left"
 						>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -215,6 +215,7 @@
     "createOpportunity": {
       "title": "Einsatz erstellen",
       "stepOf": "Schritt {{current}} von {{total}}",
+      "stepBlocked": "Schritt {{target}} ist noch nicht verfügbar: Bitte fülle zuerst Schritt {{blocking}} ({{blockingTitle}}) aus.",
       "step1Title": "Grunddaten",
       "step1Subtitle": "Gib deinem Einsatz einen klaren Titel und eine Beschreibung, damit Freiwillige wissen, was sie erwartet.",
       "step2Title": "Ort",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -215,6 +215,7 @@
     "createOpportunity": {
       "title": "Create opportunity",
       "stepOf": "Step {{current}} of {{total}}",
+      "stepBlocked": "Step {{target}} is not available yet: please complete step {{blocking}} ({{blockingTitle}}) first.",
       "step1Title": "Basics",
       "step1Subtitle": "Give your opportunity a clear title and description so volunteers know what to expect.",
       "step2Title": "Location",


### PR DESCRIPTION
## What

A refused jump in the create-opportunity wizard's stepper now says which step is standing in the way, instead of leaving the reason to be inferred from a field turning red somewhere.

## Why

All four step buttons render enabled. Clicking one that sits behind an invalid earlier step ran `trigger(fields)`, got `false`, and returned - with nothing tied to the navigation that just failed to happen.

It was never fully silent: the bailing `trigger()` call populates react-hook-form's errors as a side effect, so the offending field turns red and `errorSteps` paints that step's rule red. But that is a consequence the user has to connect to their own click, and when the offending field lives on a step that isn't currently rendered (jumping 1 -> 4 also validates 2 and 3), the only thing that reaches them is an unexplained red rule in the stepper.

The issue offered two fixes; this takes the second. The buttons stay enabled because a `disabled` button leaves the tab order, so it could not carry the explanation either - and knowing up front which steps are reachable would mean validating the whole form the moment the dialog opens, painting it red before the user has typed anything.

Closes #1782

### How it behaves now

- A refused jump renders the shared `ErrorBanner` under the stepper: *"Step 4 is not available yet: please complete step 1 (Basics) first."* (`role="alert"` + `aria-live="assertive"`, already part of that component).
- The banner's id is wired to the refused step button via `aria-describedby`, so re-focusing that button re-reads the reason rather than announcing it once into the void.
- It is keyed on an attempt counter, so clicking the same still-blocked step again re-inserts the alert - an assertive region whose text didn't change is not re-announced.
- It retires itself once the named step validates again (no second click needed to find out), and on the next navigation that does go through.
- `handleStepClick` now validates the skipped steps one at a time instead of one `trigger()` over the union of their fields. Same errors get painted; the loop additionally identifies *which* step to name. The first offending step wins - the loop does not short-circuit, so every skipped step still gets its rule painted as before.

`handleNext` is deliberately untouched: there the offending field is on the step the user is already looking at, which is the ordinary inline-validation pattern.

## Testing

- New `backend/tests/VisualTests/WizardBlockedStepJumpTests.cs`, two cases:
  - refused by the *current* step - asserts the message names step 1, that it is an assertive alert, that `wizard-stepper-4` points at it via `aria-describedby`, that the wizard really stayed on step 1, that fixing the fields retires the message on its own, and that the same click then goes through.
  - refused by an *intermediate* step - fills step 1, breaks step 2's city, returns to step 1 and jumps to 4: the message must name step 2 (Location), the step the user cannot even see, not the one they are on.
- `pnpm lint`, `pnpm format:check` (via `format:write`), `pnpm check`, `pnpm i18n:check`, `pnpm test` (180 passing), `pnpm build`: all green locally.
- `dotnet build` of the full solution and `dotnet format --verify-no-changes` green locally. The VisualTests suite itself needs Docker/Aspire, which this sandbox can't run - CI's `visual-tests` job covers it, and it passed with the two new tests included.
- Locale parity: `createOpportunity.stepBlocked` added to both `en.json` and `de.json`.

## Live verification

Not performed - no release candidate was cut, at the explicit request of the repo owner for this change. The assertions that would have gone into a throwaway staging script are instead in `WizardBlockedStepJumpTests.cs` (step 7 of the deploy-and-verify flow), which runs against the full local Aspire stack in CI. That job is green on this PR, so the behaviour is observed working end-to-end in a real browser - just not against `einsatzbereit.maik-hasler.de`.

## Checklist

- [x] `/self-review` run and findings addressed - reviewed the diff directly rather than fanning out to the check subagents (subagent use is disabled in this session). Areas covered by hand: no backend/API or entity changes, so nswag/EF checks are moot; a11y (live region semantics, `aria-describedby`, no new colour/contrast surface - reuses `ErrorBanner`); i18n key parity via `pnpm i18n:check`; ASCII-only dashes; tab/space conventions per `.editorconfig`.
- [x] CI is green - all 12 checks passed (`visual-tests`, `integration-tests`, `fast-tests`, `format-check`, backend `build`, frontend lint/test/build + production container smoke test, editorconfig, dash ban, PR title).
- [x] Documentation updated if this change affects behavior - no doc surface: this is user-facing wizard feedback, and the relevant behavior is documented by the new test.