### PR TITLE
fix(frontend): swap the header to the burger at lg so German nav labels stop wrapping

### DIFF
--- a/backend/tests/VisualTests/HeaderNavBreakpointTests.cs
+++ b/backend/tests/VisualTests/HeaderNavBreakpointTests.cs
@@ -1,0 +1,124 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Issue #1793: the header's desktop nav swapped to the burger at <c>md</c>
+/// (768px), but everything the bar carries measures ~904px wide with the
+/// German labels - so from 768px up to ~951px the full desktop nav rendered
+/// into a row too narrow for it and "Einsaetze finden" / "Fuer Organisationen"
+/// each broke across two lines, leaving a ragged two-line header on the most
+/// common tablet width. The swap is at <c>lg</c> (1024px) now, the first width
+/// where the labels actually fit.
+///
+/// German is the constraint and the default served locale; the English labels
+/// are short enough to fit either way, which is why these tests switch the app
+/// to German first rather than asserting against the shorter default.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class HeaderNavBreakpointTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const int TabletWidth = 768;
+	private const int DesktopWidth = 1024;
+	private const int ViewportHeight = 1024;
+
+	private static readonly string[] NavTestIds =
+	[
+		"nav-home",
+		"nav-findOpportunities",
+		"nav-forOrganizations",
+		"nav-help",
+	];
+
+	[Test]
+	public async Task HeaderNav_AtTabletWidth_HandsOverToTheBurgerInsteadOfWrapping()
+	{
+		await GoToHomePageInGermanAsync();
+
+		await Page.SetViewportSizeAsync(TabletWidth, ViewportHeight);
+
+		// The desktop bar is gone in its entirety - links, sign-in/register
+		// pair and language selector alike - rather than squeezed.
+		foreach (var testId in NavTestIds)
+		{
+			await Expect(Page.GetByTestId(testId)).ToBeHiddenAsync(new() { Timeout = 10_000 });
+		}
+
+		// ...and the burger is what a tablet visitor gets instead, opening the
+		// panel that carries the same destinations. Both halves matter: the
+		// desktop nav and the burger strip swap on one shared breakpoint, so a
+		// mismatch between them would leave this width with no navigation at all.
+		var burger = Page.GetByRole(AriaRole.Button, new() { Name = "Menü öffnen" });
+		await Expect(burger).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await burger.ClickAsync();
+		await Expect(Page.GetByTestId("mobile-nav-findOpportunities"))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	[Test]
+	public async Task HeaderNav_AtTheDesktopBreakpoint_KeepsEveryGermanLabelOnOneLine()
+	{
+		await GoToHomePageInGermanAsync();
+
+		// Exactly at the breakpoint - Tailwind's min-width is inclusive, so
+		// 1024 is the narrowest width that renders the desktop bar and thus the
+		// tightest fit it ever has to survive.
+		await Page.SetViewportSizeAsync(DesktopWidth, ViewportHeight);
+
+		var single = await SingleLineHeightAsync();
+
+		foreach (var testId in NavTestIds)
+		{
+			var link = Page.GetByTestId(testId);
+			await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+			var box = await link.BoundingBoxAsync();
+			box.Should().NotBeNull($"Could not measure the {testId} link");
+			box!.Height.Should().BeApproximately(
+				single,
+				1f,
+				$"{testId} must render on one line at {DesktopWidth}px - a taller box is a wrapped label");
+		}
+
+		// whitespace-nowrap turns a future too-long label into an overflowing
+		// row rather than a wrapped one, so pin the row's fit as well: a
+		// horizontally scrolling page would be the next shape of this bug.
+		var overflow = await Page.EvaluateAsync<int>(
+			"() => document.documentElement.scrollWidth - document.documentElement.clientWidth");
+		overflow.Should().BeLessThanOrEqualTo(0, "the header must not push the page into horizontal scroll");
+	}
+
+	/// <summary>
+	/// "Hilfe" is a single short word that cannot wrap at any width, so its own
+	/// rendered height is the one-line reference the other three are measured
+	/// against - self-calibrating, rather than a hardcoded pixel height that
+	/// would need updating whenever the link padding or type scale changes.
+	/// </summary>
+	private async Task<float> SingleLineHeightAsync()
+	{
+		var box = await Page.GetByTestId("nav-help").BoundingBoxAsync();
+		box.Should().NotBeNull("Could not measure the reference nav link");
+		return box!.Height;
+	}
+
+	private async Task GoToHomePageInGermanAsync()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.GotoAsync(frontend.GetLeftPart(UriPartial.Authority));
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Switched through the header control rather than seeded into
+		// localStorage before the first load: each language's JSON is fetched
+		// lazily (see NavigationTests), and going through the selector waits on
+		// that fetch the same way a real visitor's switch does.
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch language" })
+			.ClickAsync(new() { Timeout = 15_000 });
+		await Page.GetByRole(AriaRole.Option, new() { Name = "Deutsch" }).ClickAsync();
+
+		await Expect(Page.GetByTestId("nav-findOpportunities"))
+			.ToHaveTextAsync("Einsätze finden", new() { Timeout = 10_000 });
+	}
+}

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -9,6 +9,19 @@ import type { OrganizationSummaryDto } from "../../client/api-client";
 // Desktop-width-only nav: primary destinations, then signed-in account
 // controls (or sign-in/register buttons) plus the language selector.
 //
+// The swap to the burger happens at `lg`, not `md` (issue #1793). Everything
+// this bar carries measures ~904px wide with the German labels - the four
+// links alone are 415px, the sign-in/register pair 213px, and the wordmark
+// 158px - so a `md` (768px) swap left the row 184px short and the two long
+// German labels ("Einsaetze finden", "Fuer Organisationen") broke across two
+// lines at every width from 768 to ~951. Tightening gaps and padding recovers
+// at most ~120px of that, so the labels genuinely do not fit a tablet-width
+// row; `lg` is the first breakpoint where they do. English is shorter and was
+// unaffected, which is why the wrap only showed in the served-by-default
+// locale. `whitespace-nowrap` on the links below states the same guarantee
+// locally: these labels are never allowed to wrap, at any width that renders
+// them.
+//
 // The destinations are the point of this component. Until /opportunities
 // became a route of its own, this <nav aria-label="Main navigation"> held no
 // links at all - just account controls - so a signed-in volunteer had no
@@ -55,12 +68,12 @@ export default function DesktopHeader({
 	return (
 		<nav
 			aria-label={t("nav.primaryLabel")}
-			className="hidden items-center gap-3 md:flex"
+			className="hidden items-center gap-3 lg:flex"
 		>
-			<ul className="mr-2 flex items-center gap-1 lg:gap-2">
+			<ul className="mr-2 flex items-center gap-2">
 				{LINKS.map((link) => {
 					const base =
-						"rounded-lg px-3 py-2 text-sm font-medium transition-colors";
+						"rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors";
 					const idle = isTransparent
 						? "text-brand-100 hover:text-white"
 						: "text-gray-600 hover:text-brand-800";

--- a/frontend/src/components/Header/MobileHeader.tsx
+++ b/frontend/src/components/Header/MobileHeader.tsx
@@ -7,6 +7,11 @@ import { MenuToggleIcon } from "../icons";
 // Mobile-width-only strip (notification bell + burger button), grouped so
 // they stay flush-right of <header>. Rendered alongside MobileMenu, which
 // owns the overlay the burger button toggles.
+//
+// `lg:hidden` here, `lg:flex` on DesktopHeader and `lg:hidden` on MobileMenu's
+// two elements are one breakpoint, not four - the three components have to
+// swap on the same width or a viewport gets both bars or neither (issue
+// #1793). See DesktopHeader for why that width is `lg` and not `md`.
 export default function MobileHeader({
 	isLoggedIn,
 	isTransparent,
@@ -29,7 +34,7 @@ export default function MobileHeader({
 	const { t } = useTranslation();
 
 	return (
-		<div className="flex items-center gap-1 md:hidden">
+		<div className="flex items-center gap-1 lg:hidden">
 			{isLoggedIn && (
 				<NotificationDropdown
 					menu={menu}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -137,7 +137,7 @@ export default function MobileMenu({
 				onClick={onClose}
 				tabIndex={-1}
 				aria-hidden="true"
-				className="fixed top-[var(--header-height)] right-0 bottom-0 left-0 z-30 bg-black/50 md:hidden"
+				className="fixed top-[var(--header-height)] right-0 bottom-0 left-0 z-30 bg-black/50 lg:hidden"
 			/>
 			<div
 				ref={panelRef}
@@ -150,7 +150,7 @@ export default function MobileMenu({
 				// landscape-phone viewport) - overscroll-contain keeps a drag past
 				// this panel's own scroll bounds from rubber-banding the (locked)
 				// body underneath.
-				className={`absolute top-full right-0 left-0 z-30 max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain border-t shadow-modal md:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
+				className={`absolute top-full right-0 left-0 z-30 max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain border-t shadow-modal lg:hidden ${isTransparent ? "border-white/20 bg-brand-900" : "border-gray-100 bg-white"}`}
 			>
 				{/* Blur-blob lighting, matching the band the transparent header
 				sits over - a flat brand-900 panel dropping out of a lit band


### PR DESCRIPTION
## What

Moves the header's desktop/mobile swap from `md` (768px) to `lg` (1024px) across `DesktopHeader`, `MobileHeader` and `MobileMenu`, and adds `whitespace-nowrap` to the nav link base class, so the German primary-nav labels never render wrapped.

## Why

Closes #1793

At 768px the full desktop bar rendered into a row too narrow for it, and "Einsätze finden" and "Für Organisationen" each broke across two lines - a ragged two-line header at the most common tablet width, in the locale served by default.

The issue offered two fixes and preferred the smaller one (`whitespace-nowrap` plus a tighter `gap`, keeping the nav visible at 768). I measured the bar in a real browser before choosing, and that option does not work: the labels genuinely do not fit a tablet-width row.

Measured at natural width, DE locale, signed out:

| Piece | Width |
|---|---|
| Wordmark | 158px |
| Four nav links (incl. gaps) | 415px |
| Sign-in / register pair | 213px |
| Language selector | 60px |
| Dividers + nav gaps | ~58px |
| **Total** | **~904px** |

A 768px viewport offers 720px of row (`max-w-page` + `sm:px-6`), so the bar was 184px short - and it stayed short all the way up to ~951px, which is why 900px wrapped too. Tightening every gap and padding in the bar recovers at most ~120px of that, so `whitespace-nowrap` alone would have traded the wrap for horizontal overflow. `lg` is the first breakpoint where the content actually fits (56px of slack at exactly 1024px). Signed in is the easier case - the avatar/bell pair is ~110px narrower than the sign-in/register pair it replaces - so signed out was the binding constraint.

The trade-off this accepts is the one the issue names: 768-1023px now gets the burger instead of a visible nav. The mobile panel carries the same primary destinations (plus the account and org submenus), so nothing becomes unreachable.

All three components move together on purpose - they have to swap on one shared width, or some viewport gets both bars or neither. The `<ul>`'s `gap-1 lg:gap-2` pair collapses to `gap-2` since the base value is now unreachable.

## Testing

- New `backend/tests/VisualTests/HeaderNavBreakpointTests.cs`, both cases in German (English labels fit either way, so they would not catch a regression):
  - `HeaderNav_AtTabletWidth_HandsOverToTheBurgerInsteadOfWrapping` - at 768px all four desktop nav links are hidden and the burger is visible and opens a panel carrying the same destinations.
  - `HeaderNav_AtTheDesktopBreakpoint_KeepsEveryGermanLabelOnOneLine` - at exactly 1024px every label renders at the same height as the unwrappable "Hilfe" reference link, and the page is not pushed into horizontal scroll (the failure mode `whitespace-nowrap` could otherwise introduce).
- CI `visual-tests`: 344 passed, 0 failed, 0 skipped - the two new cases ran against the full Aspire stack.
- `pnpm lint`, `pnpm check`, `pnpm test` (180 tests) and `pnpm format:write` all clean.
- Verified against a local Vite dev server driven by Playwright at 767 / 768 / 900 / 1023 / 1024 / 1280 / 1440px in DE: burger below 1024, desktop nav from 1024 up with all four labels single-line, and zero row or document overflow at every width.

No existing visual test uses a viewport between 768px and 1023px, so none of them change behaviour.

## Live verification

Not run - the task explicitly asked for no release candidate this time, so there is no staging deploy to verify against. The durable record required by the deploy-and-verify flow (step 7) is in place as the `HeaderNavBreakpointTests` cases above, which passed against the full Aspire stack in CI; the pre-deploy evidence is the local Playwright breakpoint sweep listed under Testing.

## Checklist

- [x] `/self-review` run and findings addressed - the fan-out subagents were not invoked (this session is configured not to spawn them); the areas they cover were checked directly instead, and none apply: no API/DTO change (NSwag), no entity change (EF migrations), no backend layer change, no new page or route (a11y), no locale key change (i18n).
- [x] CI is green - all 12 checks passed.
- [x] Documentation updated if this change affects behavior - the rationale lives in the component comments; `frontend/AGENTS.md`'s Header entry describes the file split, not breakpoints, so it needs no change.