### PR TITLE
fix(frontend): gate organizer-only email preferences on org membership

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -398,6 +398,29 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		AssertNoViolations(result);
 	}
 
+	[Test]
+	public async Task ProfileSettingsPage_AsOrganizationMember_HasNoSeriousA11yViolations()
+	{
+		// #1783 gated the two organizer-only email preferences on organization
+		// membership, and the scan above signs in as vera, who has none - so
+		// without this sibling scan those two rows would render in production
+		// and never be scanned at all. Olaf belongs to seeded organizations,
+		// which is what makes them render here.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/profile/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Waiting on the gated checkbox itself, not the page chrome: the scan
+		// must not run before the rows it exists to cover have rendered.
+		await Expect(Page.Locator("#notifyOnNewSignUp"))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
 	// Keyed [NotInParallel] shared with AvatarAndLogoDisplayTests - this is the
 	// third and last writer of vera's single avatar_url field, and its upload
 	// racing that class's upload/delete pair is what produced the intermittent

--- a/backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs
+++ b/backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs
@@ -1,0 +1,176 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// #1783: /profile/settings rendered all five email-notification checkboxes
+/// unconditionally, including the two that only ever fire for the organizer of
+/// an opportunity ("New sign-ups for opportunities you organize", "Volunteer
+/// withdrawals from opportunities you organize"). A volunteer who belongs to no
+/// organization can never receive either, and the wording implies she organizes
+/// something - so both rows are now gated on organization membership.
+///
+/// Needs vera to deterministically have zero organizations, so - like
+/// HomePageOrgCtaTests and OrgAppRestructureTests - this class opts into
+/// fixture.ResetAsync() plus the keyed [NotInParallel], which excludes only the
+/// other classes sharing the "visualtests-db" key rather than the whole
+/// assembly.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+[NotInParallel("visualtests-db")]
+public class NotificationPreferencesOrganizerRowsTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const string NewSignUpLabel = "New sign-ups for opportunities you organize";
+	private const string WithdrawalLabel = "Volunteer withdrawals from opportunities you organize";
+
+	[Before(Test)]
+	public Task ResetVisualTestStateAsync() => Fixture.ResetAsync();
+
+	[Test]
+	public async Task ProfileSettings_VolunteerWithoutOrganization_HidesTheTwoOrganizerOnlyPreferences()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// The card renders its checkboxes only once both its own preferences
+		// fetch and the organization list have resolved, so waiting for any one
+		// of the volunteer rows means the gated ones would already be present
+		// if the gate were broken - the absence assertions below can't pass
+		// merely by running early.
+		await Expect(Page.Locator("#notifyOnEngagementConfirmed"))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		await Expect(Page.Locator("#notifyOnNewSignUp")).ToHaveCountAsync(0);
+		await Expect(Page.Locator("#notifyOnWithdrawal")).ToHaveCountAsync(0);
+		await Expect(Page.GetByText(NewSignUpLabel)).ToHaveCountAsync(0);
+		await Expect(Page.GetByText(WithdrawalLabel)).ToHaveCountAsync(0);
+
+		// The three volunteer preferences are untouched - the fix hides two
+		// rows, it doesn't collapse the card.
+		await Expect(Page.Locator("main input[type='checkbox']")).ToHaveCountAsync(3);
+		await Expect(Page.Locator("#notifyOnEngagementCancelled")).ToBeVisibleAsync();
+		await Expect(Page.Locator("#notifyOnEngagementReminder")).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Save preferences" }))
+			.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task ProfileSettings_OrganizationMember_StillShowsAllFivePreferences()
+	{
+		// Olaf belongs to (and organizes) seeded organizations, so the gate must
+		// let both rows through for him - otherwise the fix would have taken the
+		// settings away from the very people they exist for.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/profile/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.Locator("#notifyOnNewSignUp")).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(Page.Locator("#notifyOnWithdrawal")).ToBeVisibleAsync();
+		await Expect(Page.GetByText(NewSignUpLabel)).ToBeVisibleAsync();
+		await Expect(Page.GetByText(WithdrawalLabel)).ToBeVisibleAsync();
+		await Expect(Page.Locator("main input[type='checkbox']")).ToHaveCountAsync(5);
+	}
+
+	[Test]
+	public async Task ProfileSettings_SaveWithHiddenOrganizerRows_StillSendsTheirStoredValues()
+	{
+		// Hiding the rows must not drop them from the PUT payload: the endpoint
+		// takes all five flags, so a save that omitted (or defaulted) the two
+		// hidden ones would silently switch both off for anyone who later joins
+		// an organization - a data-loss bug introduced by the fix itself.
+		//
+		// vera is a shared account other classes drive concurrently (e.g.
+		// EmailDeliveryTests, which asserts on mail actually delivered to her),
+		// so this seeds only the two organizer flags - the three volunteer ones
+		// that gate her own emails are read and echoed back untouched - and
+		// restores even those in the finally below.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var backend = Fixture.GetEndpoint("backend");
+
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {vera.AccessToken}");
+
+		var original = await GetPreferencesAsync(http);
+		await PutPreferencesAsync(http, original with { NotifyOnNewSignUp = true, NotifyOnWithdrawal = true });
+
+		try
+		{
+			string? savedPayload = null;
+			await Page.RouteAsync("**/v1/users/me/notification-preferences", async route =>
+			{
+				// The browser's own PUT is let through untouched - this only
+				// snapshots what the page sent. The preflight OPTIONS hits the
+				// same URL and carries no body, hence the method check.
+				if (route.Request.Method == "PUT")
+				{
+					savedPayload = route.Request.PostData;
+				}
+
+				await route.ContinueAsync();
+			});
+
+			await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+			await Page.GotoAsync($"{origin}/profile/settings");
+			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+			await Expect(Page.Locator("#notifyOnEngagementConfirmed"))
+				.ToBeVisibleAsync(new() { Timeout = 20_000 });
+			await Expect(Page.Locator("#notifyOnNewSignUp")).ToHaveCountAsync(0);
+
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Save preferences" }).ClickAsync();
+			await Expect(Page.GetByText("Notification preferences saved.")).ToBeVisibleAsync(
+				new() { Timeout = 15_000 });
+
+			savedPayload.Should().NotBeNull("the Save button should have issued a PUT");
+			var sent = JsonSerializer.Deserialize<NotificationPreferences>(
+				savedPayload ?? "null", new JsonSerializerOptions(JsonSerializerDefaults.Web))
+				?? throw new InvalidOperationException($"Unexpected PUT payload: {savedPayload}");
+			sent.NotifyOnNewSignUp.Should().BeTrue(
+				"a hidden organizer preference must be sent back with the value the server returned");
+			sent.NotifyOnWithdrawal.Should().BeTrue(
+				"a hidden organizer preference must be sent back with the value the server returned");
+
+			// And it round-trips: re-reading from the API shows both still set.
+			var persisted = await GetPreferencesAsync(http);
+			persisted.NotifyOnNewSignUp.Should().BeTrue();
+			persisted.NotifyOnWithdrawal.Should().BeTrue();
+		}
+		finally
+		{
+			await PutPreferencesAsync(http, original);
+		}
+	}
+
+	private static async Task<NotificationPreferences> GetPreferencesAsync(HttpClient http)
+	{
+		var response = await http.GetAsync("/v1/users/me/notification-preferences");
+		response.EnsureSuccessStatusCode();
+		return await response.Content.ReadFromJsonAsync<NotificationPreferences>()
+			?? throw new InvalidOperationException("Notification preferences response was empty.");
+	}
+
+	private static async Task PutPreferencesAsync(HttpClient http, NotificationPreferences preferences)
+	{
+		var response = await http.PutAsJsonAsync("/v1/users/me/notification-preferences", preferences);
+		response.EnsureSuccessStatusCode();
+	}
+
+	private sealed record NotificationPreferences(
+		bool NotifyOnNewSignUp,
+		bool NotifyOnWithdrawal,
+		bool NotifyOnEngagementConfirmed,
+		bool NotifyOnEngagementCancelled,
+		bool NotifyOnEngagementReminder);
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -4,18 +4,12 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, Link } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
-import { useApiClient } from "../../hooks/useApiClient";
-import { useSharedOrgFetch } from "../../hooks/useSharedOrgFetch";
+import { useMyOrganizations } from "../../hooks/useMyOrganizations";
 import { signinRedirectForRegistration } from "../../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../../lib/authLocale";
-import {
-	clearActiveOrgId,
-	getActiveOrgId,
-	resolveActiveOrg,
-} from "../../lib/activeOrg";
+import { clearActiveOrgId } from "../../lib/activeOrg";
 import { clearSeenAchievements } from "../../hooks/useAchievementNotifier";
 import { getInitials } from "../../lib/initials";
-import type { OrganizationSummaryDto } from "../../client/api-client";
 import DesktopHeader from "./DesktopHeader";
 import MobileHeader from "./MobileHeader";
 import MobileMenu from "./MobileMenu";
@@ -37,7 +31,6 @@ export default function Header({
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const navigate = useNavigate();
-	const api = useApiClient();
 	const isLoggedIn = auth.isAuthenticated;
 	const user = auth.user?.profile;
 	const displayName = (user?.name ??
@@ -48,15 +41,15 @@ export default function Header({
 		Array.isArray(auth.user?.profile?.roles) ? auth.user?.profile?.roles : []
 	) as string[];
 	const isAdmin = roles.includes("admin");
-	// Shared with HomePage, which independently needs the same top-level
-	// organization list on the same mount (#1396) - see useSharedOrgFetch.
-	const [orgsData, , orgsError] = useSharedOrgFetch<OrganizationSummaryDto[]>(
-		`organizations:${isLoggedIn}`,
-		() => (isLoggedIn ? api.getOrganizations() : Promise.resolve([])),
-	);
-	const orgs = isLoggedIn ? (orgsData ?? []) : [];
-	const orgsLoading = isLoggedIn && orgsData === null && !orgsError;
-	const activeOrg = resolveActiveOrg(orgs, getActiveOrgId());
+	// Shared with HomePage and the profile settings page, which independently
+	// need the same organization list on the same mount (#1396) - the request
+	// itself is deduplicated, see useMyOrganizations/useSharedOrgFetch.
+	const {
+		orgs,
+		activeOrg,
+		loading: orgsLoading,
+		error: orgsError,
+	} = useMyOrganizations();
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [orgMenuOpen, setOrgMenuOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);

--- a/frontend/src/hooks/useMyOrganizations.ts
+++ b/frontend/src/hooks/useMyOrganizations.ts
@@ -1,0 +1,49 @@
+import { useAuth } from "react-oidc-context";
+import type { OrganizationSummaryDto } from "../client/api-client";
+import { getActiveOrgId, resolveActiveOrg } from "../lib/activeOrg";
+import { useApiClient } from "./useApiClient";
+import { useSharedOrgFetch } from "./useSharedOrgFetch";
+
+// The organizations the signed-in user belongs to, plus the one an org-scoped
+// link should open (resolveActiveOrg). Header and HomePage each derived this
+// from useSharedOrgFetch by hand; #1783 needed the same signal on a third
+// surface (the profile settings page, to hide organizer-only email
+// preferences from a volunteer who belongs to no organization), which would
+// have been a third copy of the same `isLoggedIn ? (data ?? []) : []` plus
+// loading/failed triad - so it lives here once instead.
+//
+// Only the derivation is shared: the underlying request is still deduplicated
+// across all callers on the same mount by useSharedOrgFetch's in-flight
+// registry (#1396), so any number of components may call this and the browser
+// still issues a single GET /v1/organizations.
+export function useMyOrganizations(): {
+	orgs: OrganizationSummaryDto[];
+	activeOrg: OrganizationSummaryDto | null;
+	loading: boolean;
+	failed: boolean;
+	error: string | null;
+} {
+	const auth = useAuth();
+	const api = useApiClient();
+	const isLoggedIn = auth.isAuthenticated;
+
+	const [orgsData, , error] = useSharedOrgFetch<OrganizationSummaryDto[]>(
+		`organizations:${isLoggedIn}`,
+		() => (isLoggedIn ? api.getOrganizations() : Promise.resolve([])),
+	);
+
+	const orgs = isLoggedIn ? (orgsData ?? []) : [];
+
+	return {
+		orgs,
+		activeOrg: resolveActiveOrg(orgs, getActiveOrgId()),
+		// useSharedOrgFetch leaves orgsData null both while the fetch is still
+		// in flight and after it rejects. Callers that gate something on "this
+		// user has no organizations" must be able to tell those apart - see
+		// HomePage's create-org CTA (HomePageOrgCtaTests.cs) - so both are
+		// surfaced separately rather than collapsed into an empty list.
+		loading: isLoggedIn && orgsData === null && !error,
+		failed: isLoggedIn && orgsData === null && !!error,
+		error,
+	};
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -11,8 +11,7 @@ import LatestOpportunitiesSection from "../components/LatestOpportunitiesSection
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import Skeleton from "../components/Skeleton";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { useApiClient } from "../hooks/useApiClient";
-import { useSharedOrgFetch } from "../hooks/useSharedOrgFetch";
+import { useMyOrganizations } from "../hooks/useMyOrganizations";
 import { WAVE_PATH } from "../lib/wavePath";
 import { signinLocaleArgs } from "../lib/authLocale";
 import { signinRedirectForRegistration } from "../lib/keycloakRegistration";
@@ -23,10 +22,7 @@ import {
 	UserGroupIcon,
 	ShieldCheckIcon,
 } from "../components/icons";
-import type {
-	Organization,
-	OrganizationSummaryDto,
-} from "../client/api-client";
+import type { Organization } from "../client/api-client";
 
 // Lazy-loaded: HomePage is eager (App.tsx keeps it out of the lazy route
 // map, see the comment there), so a static import here would pull
@@ -43,7 +39,6 @@ export default function HomePage() {
 	usePageTitle(t("landing.pageTitle"));
 	const auth = useAuth();
 	const navigate = useNavigate();
-	const api = useApiClient();
 
 	const heroTitleId = useId();
 	const missionTitleId = useId();
@@ -53,20 +48,18 @@ export default function HomePage() {
 	const [showOrgModal, setShowOrgModal] = useState(false);
 	const [searchParams, setSearchParams] = useSearchParams();
 
-	// Shared with Header, which independently needs the same top-level
-	// organization list on the same mount (#1396) - see useSharedOrgFetch.
-	const [orgsData, , orgsError] = useSharedOrgFetch<OrganizationSummaryDto[]>(
-		`organizations:${auth.isAuthenticated}`,
-		() => (auth.isAuthenticated ? api.getOrganizations() : Promise.resolve([])),
-	);
-	const orgs = auth.isAuthenticated ? (orgsData ?? []) : [];
-	// useSharedOrgFetch leaves orgsData null both while the fetch is still in
-	// flight and after it rejects - without distinguishing those, a signed-in
-	// organizer could see the "create an organization" CTA (and, if clicked,
-	// create a duplicate org) while their real org list was still loading or
-	// had failed to load (see HomePageOrgCtaTests.cs's regression test).
-	const orgsLoading = auth.isAuthenticated && orgsData === null && !orgsError;
-	const orgsFailed = auth.isAuthenticated && orgsData === null && !!orgsError;
+	// Shared with Header, which independently needs the same organization list
+	// on the same mount (#1396) - see useMyOrganizations/useSharedOrgFetch.
+	// Loading and failed are deliberately distinct there: without
+	// distinguishing them, a signed-in organizer could see the "create an
+	// organization" CTA (and, if clicked, create a duplicate org) while their
+	// real org list was still loading or had failed to load (see
+	// HomePageOrgCtaTests.cs's regression test).
+	const {
+		orgs,
+		loading: orgsLoading,
+		failed: orgsFailed,
+	} = useMyOrganizations();
 	const orgAppPath = resolveOrgAppPath(orgs, getActiveOrgId());
 
 	// Hero search - initialized from the URL so a back-navigation (or a

--- a/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { NotificationPreferencesResponse } from "../../client/api-client";
 import { useApiClient } from "../../hooks/useApiClient";
+import { useMyOrganizations } from "../../hooks/useMyOrganizations";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { cardClass } from "../../lib/surfaceClasses";
 import Button from "../../components/Button";
@@ -17,9 +18,24 @@ type PreferenceKey =
 	| "notifyOnEngagementCancelled"
 	| "notifyOnEngagementReminder";
 
-const PREFERENCE_ROWS: { key: PreferenceKey; labelKey: string }[] = [
-	{ key: "notifyOnNewSignUp", labelKey: "notificationPreferences.newSignUp" },
-	{ key: "notifyOnWithdrawal", labelKey: "notificationPreferences.withdrawal" },
+const PREFERENCE_ROWS: {
+	key: PreferenceKey;
+	labelKey: string;
+	// Both emails are sent to the organizer of an opportunity, which nobody
+	// can be without belonging to an organization first - so these two rows
+	// are filtered out for everyone else, see organizerRowsVisible below.
+	organizerOnly?: boolean;
+}[] = [
+	{
+		key: "notifyOnNewSignUp",
+		labelKey: "notificationPreferences.newSignUp",
+		organizerOnly: true,
+	},
+	{
+		key: "notifyOnWithdrawal",
+		labelKey: "notificationPreferences.withdrawal",
+		organizerOnly: true,
+	},
 	{
 		key: "notifyOnEngagementConfirmed",
 		labelKey: "notificationPreferences.engagementConfirmed",
@@ -41,10 +57,15 @@ const PREFERENCE_ROWS: { key: PreferenceKey; labelKey: string }[] = [
 export default function NotificationPreferencesSection() {
 	const api = useApiClient();
 	const { t } = useTranslation();
+	const {
+		orgs,
+		loading: orgsLoading,
+		failed: orgsFailed,
+	} = useMyOrganizations();
 
 	const [preferences, setPreferences] =
 		useState<NotificationPreferencesResponse | null>(null);
-	const [loading, setLoading] = useState(true);
+	const [preferencesLoading, setPreferencesLoading] = useState(true);
 	const [loadError, setLoadError] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
@@ -62,7 +83,7 @@ export default function NotificationPreferencesSection() {
 				if (!cancelled) setLoadError(t("notificationPreferences.loadError"));
 			})
 			.finally(() => {
-				if (!cancelled) setLoading(false);
+				if (!cancelled) setPreferencesLoading(false);
 			});
 
 		return () => {
@@ -70,6 +91,23 @@ export default function NotificationPreferencesSection() {
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
+
+	// #1783: a volunteer who belongs to no organization can never organize an
+	// opportunity, so the two organizer emails can never fire for her - and
+	// their labels ("... you organize") read as if she does. Hide them rather
+	// than offer settings with no effect. Their stored values are still saved
+	// untouched below, so they survive her later joining an organization.
+	//
+	// Fail open when the organization list itself failed to load: that state
+	// is indistinguishable from "no organizations" here, and silently dropping
+	// a real organizer's own settings is the worse of the two outcomes.
+	const organizerRowsVisible = orgs.length > 0 || orgsFailed;
+	const visibleRows = PREFERENCE_ROWS.filter(
+		(row) => !row.organizerOnly || organizerRowsVisible,
+	);
+	// Held until the organization list resolves too, so the two organizer rows
+	// appear with the rest of the list instead of popping in a beat later.
+	const loading = preferencesLoading || orgsLoading;
 
 	function toggle(key: PreferenceKey) {
 		setPreferences((prev) => (prev ? { ...prev, [key]: !prev[key] } : prev));
@@ -117,7 +155,11 @@ export default function NotificationPreferencesSection() {
 			{loading && (
 				<div className="space-y-2" role="status">
 					<span className="sr-only">{t("profile.loading")}</span>
-					{PREFERENCE_ROWS.map((row) => (
+					{/* visibleRows, not PREFERENCE_ROWS: membership is still
+					unknown here, so this is the volunteer-sized list - the card
+					then grows into the organizer rows rather than five
+					placeholders collapsing into three for everyone else. */}
+					{visibleRows.map((row) => (
 						<Skeleton key={row.key} className="h-5 w-64" />
 					))}
 				</div>
@@ -136,7 +178,7 @@ export default function NotificationPreferencesSection() {
 					)}
 
 					<div className="space-y-3">
-						{PREFERENCE_ROWS.map((row) => (
+						{visibleRows.map((row) => (
 							<label
 								key={row.key}
 								htmlFor={row.key}


### PR DESCRIPTION
## What

`/profile/settings` now renders the two organizer-only email-notification checkboxes ("New sign-ups for opportunities you organize", "Volunteer withdrawals from opportunities you organize") only for users who belong to at least one organization. The organization signal moves out of `Header.tsx` into a new `useMyOrganizations` hook that `Header`, `HomePage` and the settings card all share.

## Why

`NotificationPreferencesSection` mapped one flat `PREFERENCE_ROWS` constant unconditionally, with no role or organization gate anywhere in the file - so Vera, who belongs to no organization, was offered two settings that can never fire for her, worded as if she organizes something.

The issue notes the signal to gate on already exists but is not a hook: `Header.tsx` called `useSharedOrgFetch` + `resolveActiveOrg` inline, and `HomePage.tsx` carried its own copy of the same derivation. Rather than write a third copy, that derivation now lives in `frontend/src/hooks/useMyOrganizations.ts` and both existing call sites adopt it. The underlying request is still deduplicated by `useSharedOrgFetch` (#1396), and the header already fetches the list on every authenticated page - so the settings page issues **no additional request**.

Two deliberate details:

- **Hidden values are still saved.** The PUT payload keeps sending both organizer flags with the values the server returned, so they survive the user later joining an organization. Covered by a test.
- **Fail open on a failed org fetch.** A rejected `GET /v1/organizations` is indistinguishable from "no organizations" here, so the rows are shown - silently dropping a real organizer's own settings is the worse of the two outcomes. The card also holds its loading state until membership resolves, so the rows never pop in after first paint.

Closes #1783

## Testing

New `backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs`:

- `ProfileSettings_VolunteerWithoutOrganization_HidesTheTwoOrganizerOnlyPreferences` - vera sees 3 checkboxes, neither organizer row nor its label is in the DOM. Opts into `fixture.ResetAsync()` + the keyed `[NotInParallel("visualtests-db")]` so her membership state is deterministic, same as `HomePageOrgCtaTests`.
- `ProfileSettings_OrganizationMember_StillShowsAllFivePreferences` - olaf (seeded org member) still sees all 5.
- `ProfileSettings_SaveWithHiddenOrganizerRows_StillSendsTheirStoredValues` - seeds both organizer flags on, intercepts the browser's PUT and asserts they are echoed back true, re-reads the API to confirm the round trip, and restores the original values in a `finally`.

`AccessibilityTests.ProfileSettingsPage_AsOrganizationMember_HasNoSeriousA11yViolations` was added because the existing axe scan of that route signs in as vera - after this change the two gated rows would otherwise render in production and never be scanned.

Run locally: `pnpm lint`, `pnpm check`, `pnpm test` (180 passed), `pnpm format:check`, `pnpm i18n:check`, `pnpm build`, backend `dotnet build` (0 warnings) and `ArchitectureTests` (422 passed). `IntegrationTests`/`VisualTests` need real container networking, which the web sandbox does not have - they ran on CI, green (`visual-tests` included the three new tests and the new axe scan).

`/self-review` was run before opening this PR; both of its findings (missing axe coverage of the gated rows, skeleton row count) are addressed in the diff.

## Live verification

Not performed - the task explicitly asked for no release candidate to be cut, so there is no staging deploy to verify against. The behaviour is covered by the Playwright assertions above, which run against the full Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green (all 12 checks passing)
- [x] Documentation updated if this change affects behavior (no docs affected - no route, endpoint or convention changed)
