### PR TITLE
fix(backend): send one notification per volunteer on opportunity cancellation

### DIFF
--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -31,15 +31,18 @@ internal sealed class CancelEngagementCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		var cancelled = await EngagementCancellationHelper.CancelAndNotifyAsync(
+		var cancelled = await EngagementCancellationHelper.CancelAsync(
 			dbContext,
 			engagement,
 			request.Reason,
 			opportunity.Title,
+			// The volunteer hears about this only here - no opportunity-level
+			// notification accompanies a single engagement cancellation.
+			notifyVolunteer: true,
 			logger,
 			cancellationToken);
 
-		// Only when a cancellation actually happened - CancelAndNotifyAsync leaves an
+		// Only when a cancellation actually happened - CancelAsync leaves an
 		// already-anonymized engagement (its volunteer deleted their account) untouched
 		// rather than throwing (einsatzbereit#1724), and an audit entry claiming
 		// "EngagementCancelled" for a no-op would be misleading.

--- a/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
@@ -7,10 +7,10 @@ using Microsoft.Extensions.Logging;
 namespace Application.Engagements.Common;
 
 /// <summary>
-/// Cancels an engagement and creates the same in-app notification that
-/// <see cref="CancelEngagement.v1.CancelEngagementCommandHandler"/> creates for an
-/// organizer-triggered cancellation - shared so engagements auto-cancelled by an
-/// opportunity deletion notify the volunteer identically instead of only via the
+/// Cancels an engagement and - unless the caller opts out - creates the same in-app
+/// notification that <see cref="CancelEngagement.v1.CancelEngagementCommandHandler"/>
+/// creates for an organizer-triggered cancellation, shared so engagements auto-cancelled
+/// by an opportunity deletion notify the volunteer identically instead of only via the
 /// opportunity-level notification (einsatzbereit#1057). The volunteer's cancellation
 /// email itself is not sent here (#1150): Cancel() raises EngagementCancelledDomainEvent,
 /// consumed post-commit by EngagementCancelledNotificationHandler, so it fires correctly
@@ -19,14 +19,24 @@ namespace Application.Engagements.Common;
 /// </summary>
 internal static class EngagementCancellationHelper
 {
+	/// <param name="notifyVolunteer">
+	/// Whether to create the <see cref="NotificationKind.EngagementCancelled"/> row.
+	/// False only where the caller has already notified this volunteer about the same
+	/// event through another path - see
+	/// <see cref="VolunteerOpportunities.Common.VolunteerOpportunityEngagementCascadeHelper"/>
+	/// (einsatzbereit#1790). The cancellation itself, and the
+	/// EngagementCancelledDomainEvent it raises (and with it the volunteer's email),
+	/// happen either way; only the in-app row is skipped.
+	/// </param>
 	// Returns whether the engagement was actually cancelled - callers that record their
 	// own audit trail (CancelEngagementCommandHandler) use this to avoid logging an
 	// "EngagementCancelled" entry for an engagement that was in fact left untouched.
-	public static async Task<bool> CancelAndNotifyAsync(
+	public static async Task<bool> CancelAsync(
 		IApplicationDbContext dbContext,
 		Engagement engagement,
 		string? reason,
 		string opportunityTitle,
+		bool notifyVolunteer,
 		ILogger logger,
 		CancellationToken cancellationToken)
 	{
@@ -46,6 +56,9 @@ internal static class EngagementCancellationHelper
 		}
 
 		engagement.Cancel(reason, opportunityTitle).ThrowIfFailure();
+
+		if (!notifyVolunteer)
+			return true;
 
 		var notification = Notification.Create(
 			engagement.VolunteerId!.Value,

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
@@ -60,6 +60,10 @@ internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
 			opportunity.Title,
 			NotificationKind.OpportunityCancelled,
 			engagementCancellationReason,
+			// The OpportunityCancelled notification above already tells the volunteer
+			// their sign-up is gone, so a second EngagementCancelled row per volunteer
+			// only repeated the same fact and inflated the unread badge (#1790).
+			notifyPerEngagement: false,
 			logger,
 			cancellationToken);
 

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -73,6 +73,10 @@ internal static class VolunteerOpportunityDeletionHelper
 			opportunity.Title,
 			NotificationKind.OpportunityDeleted,
 			"Opportunity was deleted.",
+			// Kept on: the OpportunityDeleted text says the opportunity was removed
+			// but not that the sign-up went with it, so the volunteer would otherwise
+			// never be told their engagement is cancelled (contrast #1790's cancel flow).
+			notifyPerEngagement: true,
 			logger,
 			cancellationToken);
 

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
@@ -18,6 +18,15 @@ namespace Application.VolunteerOpportunities.Common;
 /// </summary>
 internal static class VolunteerOpportunityEngagementCascadeHelper
 {
+	/// <param name="notifyPerEngagement">
+	/// Whether each cancelled engagement also gets its own
+	/// <see cref="NotificationKind.EngagementCancelled"/> notification on top of the
+	/// opportunity-level one. False only for the cancellation flow, whose
+	/// <see cref="NotificationKind.OpportunityCancelled"/> text already tells the volunteer
+	/// their sign-up is gone, so the second row was pure duplication
+	/// (einsatzbereit#1790). The delete and unpublish flows keep it: their
+	/// opportunity-level texts do not fully cover the sign-up outcome.
+	/// </param>
 	public static async Task NotifyAndCancelActiveEngagementsAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
@@ -25,6 +34,7 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 		string opportunityTitle,
 		NotificationKind opportunityNotificationKind,
 		string engagementCancellationReason,
+		bool notifyPerEngagement,
 		ILogger logger,
 		CancellationToken cancellationToken)
 	{
@@ -36,20 +46,27 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 			cancellationToken);
 
 		// GetActiveEngagementsForOpportunityAsync already excludes anonymized
-		// engagements (einsatzbereit#1724), so CancelAndNotifyAsync's own guard below
+		// engagements (einsatzbereit#1724), so CancelAsync's own guard below
 		// is defense in depth here, not the primary fix.
 		var activeEngagements = await dbContext.GetActiveEngagementsForOpportunityAsync(
 			opportunityId, cancellationToken);
 		foreach (var engagement in activeEngagements)
 		{
-			// Same notification + email path a single organizer-triggered cancel
-			// sends (#1057) - the volunteer shouldn't hear about this only via
-			// the opportunity-level notification above.
-			await EngagementCancellationHelper.CancelAndNotifyAsync(
+			// Same cancellation + email path a single organizer-triggered cancel takes
+			// (#1057). Whether the volunteer also gets a per-engagement in-app
+			// notification is the caller's call: NotifyActiveVolunteersAsync above
+			// already reached exactly this set of volunteers (both reads filter active,
+			// non-anonymized engagements of the opportunity by the same predicate), so
+			// a flow whose opportunity-level text already spells the sign-up outcome
+			// out would otherwise say the same thing twice (einsatzbereit#1790). Either
+			// way Cancel() raises EngagementCancelledDomainEvent, so the cancellation
+			// email still goes out.
+			await EngagementCancellationHelper.CancelAsync(
 				dbContext,
 				engagement,
 				engagementCancellationReason,
 				opportunityTitle,
+				notifyPerEngagement,
 				logger,
 				cancellationToken);
 		}

--- a/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
@@ -78,11 +78,14 @@ internal sealed class DeleteTimeSlotCommandHandler(
 		var engagementsToCancel = await dbContext.GetActiveEngagementsForTimeSlotsAsync(affectedIds, cancellationToken);
 		foreach (var engagement in engagementsToCancel)
 		{
-			await EngagementCancellationHelper.CancelAndNotifyAsync(
+			await EngagementCancellationHelper.CancelAsync(
 				dbContext,
 				engagement,
 				"The recurring time slot series was cancelled.",
 				opportunity.Title,
+				// Deleting slots out of a series raises no opportunity-level
+				// notification, so this is the volunteer's only in-app signal.
+				notifyVolunteer: true,
 				logger,
 				cancellationToken);
 		}

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
@@ -56,6 +56,7 @@ internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
 			opportunity.Title,
 			NotificationKind.OpportunityUnpublished,
 			"Opportunity was unpublished.",
+			notifyPerEngagement: true,
 			logger,
 			cancellationToken);
 

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -441,7 +441,7 @@ internal sealed class ApplicationDbContext(
 	// engagement left non-terminal on purpose when its volunteer deleted their account,
 	// see DeleteMyAccountCommandHandler) - Engagement.Cancel() refuses to act on an
 	// anonymized aggregate, so an unfiltered read here would hand one to
-	// EngagementCancellationHelper.CancelAndNotifyAsync and permanently 409 the whole
+	// EngagementCancellationHelper.CancelAsync and permanently 409 the whole
 	// deletion cascade (einsatzbereit#1724). Mirrors the same predicate already used by
 	// EngagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync.
 	public async Task<List<Engagement>> GetActiveEngagementsForOpportunityAsync(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
@@ -73,6 +73,41 @@ public class VolunteerOpportunityCancelledDomainEventHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldCreateExactlyOneNotification_ForAVolunteerWhoIsAlsoHavingAnEngagementCancelled(
+		CancellationToken cancellationToken)
+	{
+		// Regression for einsatzbereit#1790: the cascade used to write an
+		// OpportunityCancelled row *and* an EngagementCancelled row for the same
+		// volunteer in the same handler run, so Vera saw the same fact twice,
+		// timestamped in the same minute, with the unread badge counting both.
+		var opportunity = CreatePublishedOpportunity();
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, TimeSlotId.New());
+		_opportunityRepo.FindAsync(opportunity.Id, cancellationToken).Returns(opportunity);
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunity.Id, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([volunteerId.Value]);
+		_dbContext
+			.GetActiveEngagementsForOpportunityAsync(opportunity.Id, cancellationToken)
+			.Returns([engagement]);
+
+		var domainEvent = new VolunteerOpportunityCancelledDomainEvent(opportunity.Id, DefaultOrgId, "Venue flooded");
+
+		// Act
+		await _sut.Handle(domainEvent, cancellationToken);
+
+		// Assert - one row, and it's the opportunity-level one.
+		await _notifRepo.Received(1).AddAsync(Arg.Any<Notification>(), cancellationToken);
+		await _notifRepo.Received(1).AddAsync(
+			Arg.Is<Notification>(n => n!.RecipientId == volunteerId && n.Kind == NotificationKind.OpportunityCancelled),
+			cancellationToken);
+
+		// The engagement itself is still cancelled - only its notification is skipped,
+		// and Cancel() still raises the event that sends the volunteer's email.
+		engagement.Status.Should().Be(EngagementStatus.Cancelled);
+	}
+
+	[Test]
 	public async Task Handle_ShouldCancelActiveEngagements_WithOrganizerReasonIncluded(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -85,6 +85,45 @@ public class NotificationTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetMyNotifications_OpportunityCancelled_GivesTheVolunteerExactlyOneNotification(
+		CancellationToken cancellationToken)
+	{
+		// Regression for einsatzbereit#1790: cancelling an opportunity used to write
+		// both an OpportunityCancelled and an EngagementCancelled notification for the
+		// same volunteer inside one cascade run, so Vera got two rows in the same minute
+		// telling her the same thing and the unread badge counted both. Exactly one
+		// notification per affected volunteer is the assertion whose absence let that ship.
+		const string opportunityTitle = "Notification Opportunity Cancel Test";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, opportunityTitle, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		await olafClient.CancelVolunteerOpportunityAsync(
+			opportunity.Id,
+			new CancelVolunteerOpportunityRequest { Reason = "Venue flooded" },
+			cancellationToken);
+
+		// The cascade runs in VolunteerOpportunityCancelledDomainEventHandler, dispatched
+		// async by OutboxProcessorJob (polls every 5s) - same budget as OutboxTests.cs.
+		var processed = await fixture.WaitForOutboxMessageProcessedAsync(
+			"Domain.VolunteerOpportunities.VolunteerOpportunityCancelledDomainEvent", TimeSpan.FromSeconds(45));
+		processed.Should().BeTrue("OutboxProcessorJob should dispatch the cancelled event within a few poll cycles");
+
+		var veraNotifications = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+
+		var notification = veraNotifications.Items.Should().ContainSingle().Which;
+		notification.Kind.Should().Be("OpportunityCancelled");
+		notification.RelatedTitle.Should().Be(opportunityTitle);
+	}
+
+	[Test]
 	public async Task GetMyNotifications_EngagementWithdrawn_HasRelatedTitleAndOrganizerDashboardUrl(
 		CancellationToken cancellationToken)
 	{

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -852,7 +852,7 @@
         "OpportunityUpdated": "{{title}} wurde aktualisiert",
         "OpportunityDeleted": "Ein Einsatz, für den du dich angemeldet hast, wurde entfernt",
         "OpportunityUnpublished": "{{title}} wurde zurückgezogen und deine Anmeldung wurde abgesagt",
-        "OpportunityCancelled": "{{title}} wurde abgesagt und deine Anmeldung wurde abgesagt",
+        "OpportunityCancelled": "Der Einsatz {{title}} wurde abgesagt - deine Anmeldung ist damit hinfällig",
         "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten",
         "InvitationAccepted": "Deine Einladung, {{title}} beizutreten, wurde angenommen",
         "InvitationDeclined": "Deine Einladung, {{title}} beizutreten, wurde abgelehnt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -852,7 +852,7 @@
         "OpportunityUpdated": "{{title}} was updated",
         "OpportunityDeleted": "An opportunity you signed up for was removed",
         "OpportunityUnpublished": "{{title}} was taken down and your sign-up was cancelled",
-        "OpportunityCancelled": "{{title}} was cancelled and your sign-up was cancelled",
+        "OpportunityCancelled": "The opportunity {{title}} was cancelled - your sign-up no longer stands",
         "InvitationReceived": "You've been invited to join {{title}}",
         "InvitationAccepted": "Your invitation to join {{title}} was accepted",
         "InvitationDeclined": "Your invitation to join {{title}} was declined",


### PR DESCRIPTION
## What

Cancelling an opportunity now writes exactly one in-app notification per affected volunteer - the opportunity-level `OpportunityCancelled` one - instead of that plus a per-engagement `EngagementCancelled` row. The surviving message is also rephrased from the volunteer's side.

## Why

Implements the repo owner's decision in #1790: collapse to one notification, keep both notification kinds.

`VolunteerOpportunityCancelledDomainEventHandler` ran two notification paths over the same set of volunteers inside one cascade run:

| Path | What it created |
|---|---|
| `OpportunityNotificationHelper.NotifyActiveVolunteersAsync` | one `OpportunityCancelled` per active volunteer |
| the per-engagement loop -> `EngagementCancellationHelper` | a second `EngagementCancelled` for the same volunteer |

Both reads filter active, non-anonymized engagements of the opportunity by the *same* predicate (`EngagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync` and `ApplicationDbContext.GetActiveEngagementsForOpportunityAsync`), so the second path never reached anyone the first had missed - it only ever duplicated. Hence Vera's two rows in the same minute, and the unread badge counting both.

`EngagementCancellationHelper.CancelAndNotifyAsync` becomes `CancelAsync` with an explicit `notifyVolunteer` flag; the opportunity-cancellation cascade is the one caller passing `false`. **The cancellation itself is untouched** - `Cancel()` still raises `EngagementCancelledDomainEvent`, so `EngagementCancelledNotificationHandler` still sends the volunteer's cancellation email exactly as before. Only the duplicate in-app row is skipped.

**Both notification kinds stay, and the #1057 distinction is preserved for every other flow:**

| Flow | `notifyVolunteer` | Why |
|---|---|---|
| Cancel a single engagement | `true` | no opportunity-level notification accompanies it - this is the volunteer's only signal |
| Delete a time slot series | `true` | same, no opportunity-level notification is raised |
| Opportunity **delete** cascade | `true` | `OpportunityDeleted` says the opportunity was removed but not that the sign-up went with it |
| Opportunity **unpublish** cascade | `true` | unchanged - out of scope for the #1790 decision, see below |
| Opportunity **cancel** cascade | `false` | `OpportunityCancelled` already tells the volunteer their sign-up is gone |

### Two deviations worth your eyes

1. **Unpublish still double-notifies.** `OpportunityUnpublished` ("... wurde zurückgezogen und deine Anmeldung wurde abgesagt") *does* fully cover the sign-up outcome, so its extra `EngagementCancelled` row is the same duplication this PR removes for cancel. The decision in #1790 was scoped to cancellation, so I left it alone rather than widen silently - flipping that one call site to `false` is a one-line follow-up if you want it.
2. **Wording.** The comment suggested *"Der Einsatz «X» wurde abgesagt - deine Anmeldung ist damit erledigt."* I kept the shape but used `hinfällig` over `erledigt` (which reads as "taken care of" rather than "void"), dropped the guillemets and trailing period to match every neighbouring key in `kinds`, and wrote the English source string first per the repo's language convention:
   - EN `"The opportunity {{title}} was cancelled - your sign-up no longer stands"`
   - DE `"Der Einsatz {{title}} wurde abgesagt - deine Anmeldung ist damit hinfällig"`

   Neither repeats the verb about two subjects, which was the "reads like a template bug" complaint.

Closes #1790

## Testing

Added the regression guard the issue asked for, at two levels:

- **Integration** - `NotificationTests.GetMyNotifications_OpportunityCancelled_GivesTheVolunteerExactlyOneNotification`: Olaf cancels an opportunity Vera signed up for, waits for `OutboxProcessorJob` to dispatch the cancelled event, then asserts Vera's notification list contains a *single* item and that it is `OpportunityCancelled`. This is the assertion whose absence let the bug ship.
- **Unit** - `VolunteerOpportunityCancelledDomainEventHandlerTests.Handle_ShouldCreateExactlyOneNotification_ForAVolunteerWhoIsAlsoHavingAnEngagementCancelled`: same volunteer in both the read-repo result and the active-engagement list; asserts exactly one `AddAsync` and that the engagement still ends up `Cancelled`.

Run locally (Docker-dependent suites left to CI, per root `AGENTS.md`'s sandbox note):

| Check | Result |
|---|---|
| `dotnet build` (whole solution) | pass, 0 warnings |
| `Application.UnitTests` | pass, 1045/1045 |
| `ArchitectureTests` | pass, 422/422 |
| `pnpm lint` / `format:check` / `i18n:check` | pass (1272 locale keys in parity) |
| `IntegrationTests`, `VisualTests` | left to CI - need real container networking |

All 12 CI checks green on `d031f40`, including `integration-tests` (which runs the new regression test) and `visual-tests`.

No API surface changed, so no NSwag regeneration; no entity changed, so no EF migration.

## Live verification

**Not performed** - the task explicitly asked not to cut a release candidate, so steps 3-8 of root `AGENTS.md`'s deploy-and-verify flow were skipped. The durable record (step 7) is in place as the integration test above, which exercises the real cascade through `OutboxProcessorJob` against a real Postgres in CI. Live staging confirmation is outstanding and should happen on the next RC.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior

<sub>Self-review found one issue in my own first pass: the cascade dispatched between two helper wrappers via a 20-line `if`/`else` whose branches differed only by method name. Collapsed into the single `CancelAsync` + named-argument shape above before pushing.</sub>