### PR TITLE
fix(frontend): unify the three required-field conventions into one marker

### DIFF
--- a/backend/tests/VisualTests/RequiredFieldMarkerTests.cs
+++ b/backend/tests/VisualTests/RequiredFieldMarkerTests.cs
@@ -1,0 +1,98 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1797: required fields were marked three different ways -
+/// an aria-hidden asterisk from the wizard's own RequiredMark, an asterisk
+/// baked into the translation string with a literal space ("Name *", org
+/// settings) and a spelled-out "(required)" suffix (sign-up + feedback
+/// modals). The baked-in variant also made the org settings field announce
+/// as "Name star", because a marker inside a translated string cannot be
+/// aria-hidden.
+///
+/// These tests pin the single convention: one shared, aria-hidden asterisk
+/// rendered by the component, an accessible name with no marker in it, and
+/// one legend explaining the asterisk per form.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class RequiredFieldMarkerTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OrgSettings_NameField_MarksRequiredWithoutPollutingTheAccessibleName()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = match.Groups[1].Value;
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/settings");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync();
+
+		// The accessible name is the field name alone. Before the fix the
+		// asterisk lived in the string, so this resolved to "Name *" and a
+		// screen reader read the field as "Name star".
+		await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Name", Exact = true }))
+			.ToBeVisibleAsync();
+
+		await AssertLabelCarriesRequiredMarkAsync("org-name", "Name");
+		await AssertFormExplainsTheAsteriskAsync();
+	}
+
+	[Test]
+	public async Task CreateOpportunityWizard_TitleField_UsesTheSameMarkerAsTheRestOfTheProduct()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Title", Exact = true }))
+			.ToBeVisibleAsync();
+
+		await AssertLabelCarriesRequiredMarkAsync("opportunity-title", "Title");
+		await AssertFormExplainsTheAsteriskAsync();
+	}
+
+	/// <summary>
+	/// The marker is present on screen, sits directly against the label with no
+	/// space character in between, and is hidden from assistive technology (the
+	/// control's own required/aria-required is the accessible half).
+	/// </summary>
+	private async Task AssertLabelCarriesRequiredMarkAsync(string fieldId, string labelText)
+	{
+		var label = Page.Locator($"label[for='{fieldId}']");
+		await Expect(label).ToBeVisibleAsync();
+		await Expect(label).ToHaveTextAsync($"{labelText}*");
+
+		var mark = label.Locator("span[aria-hidden='true']");
+		await Expect(mark).ToHaveCountAsync(1);
+		await Expect(mark).ToHaveTextAsync("*");
+	}
+
+	/// <summary>
+	/// An asterisk needs a legend, and exactly one per form - that is the cost
+	/// of picking the compact marker over the spelled-out "(required)".
+	/// </summary>
+	private async Task AssertFormExplainsTheAsteriskAsync()
+	{
+		var legend = Page.GetByText("* Required field");
+		await Expect(legend).ToHaveCountAsync(1);
+		await Expect(legend).ToBeVisibleAsync();
+	}
+}

--- a/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
+++ b/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
@@ -56,9 +56,13 @@ public class SignUpModalMessageFieldTests(AspireFixture fixture) : VisualTestBas
 		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
 		await Page.WaitForSelectorAsync("[role='dialog']");
 
-		var messageField = Page.GetByLabel("Message (required)");
+		// The accessible name is the field name alone since #1797 unified the
+		// required marker: the visible marker is an aria-hidden asterisk and
+		// the native `required` below is what announces the field as required.
+		var messageField = Page.GetByRole(AriaRole.Textbox, new() { Name = "Message", Exact = true });
 		await Expect(messageField).ToBeVisibleAsync();
 		await Expect(messageField).ToHaveAttributeAsync("required", "");
+		await Expect(Page.Locator("label[for='sign-up-message']")).ToHaveTextAsync("Message*");
 	}
 
 	private async Task<string> CreateIndividualContactOpportunityAsync(string label)

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -169,6 +169,7 @@ Shared UI primitives live in `src/components/` and `src/lib/` (no separate desig
 | ------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `Button`      | `components/Button.tsx`      | Every clickable action, button or link - `variant` (`primary`/`secondary`), `size` (`sm`/`md`/`lg`), `fullWidth`                     |
 | `formClasses` | `lib/formClasses.ts`         | `inputClass`, `textareaClass`, `labelClass` for every form control                                                                   |
+| `RequiredMark` | `components/RequiredMark.tsx` | The product's only required-field marker - an aria-hidden `*` appended by the component, never written into a translation string, plus the `RequiredFieldsLegend` that explains it (one per form). The control still needs its own `required`/`aria-required`: that is the accessible half |
 | `ErrorBanner` | `components/ErrorBanner.tsx` | Inline "action failed" message - the one boxed style every page's error state should share                                          |
 | `SuccessBanner` | `components/SuccessBanner.tsx` | Inline "action succeeded" message - the `ErrorBanner` twin, same box style in green                                                |
 | `EmptyState`  | `components/EmptyState.tsx`  | "Nothing here yet" placeholder with an optional CTA button                                                                           |

--- a/frontend/src/components/CreateOrganizationModal.tsx
+++ b/frontend/src/components/CreateOrganizationModal.tsx
@@ -19,6 +19,7 @@ import ConfirmDialog from "./ConfirmDialog";
 import ErrorBanner from "./ErrorBanner";
 import ImageCropModal from "./ImageCropModal";
 import FileUploadButton from "./FileUploadButton";
+import { RequiredFieldsLegend, RequiredMark } from "./RequiredMark";
 
 interface Props {
 	onClose: () => void;
@@ -159,6 +160,8 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 				className="flex min-h-0 flex-1 flex-col"
 			>
 				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
+					<RequiredFieldsLegend />
+
 					<div>
 						<p className={labelClass}>{t("orgSettings.fieldLogo")}</p>
 						<div className="mt-1 flex items-center gap-4">
@@ -205,6 +208,7 @@ export default function CreateOrganizationModal({ onClose, onSuccess }: Props) {
 					<div ref={nameFieldRef}>
 						<label htmlFor="create-org-name" className={`mb-1 ${labelClass}`}>
 							{t("organization.nameLabel")}
+							<RequiredMark />
 						</label>
 						<input
 							id="create-org-name"

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -16,6 +16,7 @@ import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
 import Button from "../Button";
 import ImageCropModal from "../ImageCropModal";
+import { RequiredFieldsLegend } from "../RequiredMark";
 import { Stepper } from "./shared";
 import BasicsStep from "./BasicsStep";
 import LocationStep from "./LocationStep";
@@ -288,6 +289,7 @@ export default function CreateVolunteerOpportunityModal({
 
 	const occurrence = watch("occurrence");
 	const participationType = watch("participationType");
+	const isRemote = watch("isRemote");
 	const isScheduledSlots = participationType === "ScheduledSlots";
 
 	useEffect(() => {
@@ -986,6 +988,13 @@ export default function CreateVolunteerOpportunityModal({
 					<p className="mb-4 text-sm leading-relaxed text-gray-500">
 						{stepSubtitles[step - 1]}
 					</p>
+
+					{/* Only steps 1 and 2 carry required fields, and step 2's are the
+					address ones - a remote opportunity has none, so the legend would
+					explain an asterisk that isn't on screen. */}
+					{(step === 1 || (step === 2 && !isRemote)) && (
+						<RequiredFieldsLegend className="-mt-2 mb-4" />
+					)}
 
 					{step === 1 && (
 						<BasicsStep

--- a/frontend/src/components/CreateVolunteerOpportunityModal/shared.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/shared.tsx
@@ -1,13 +1,7 @@
 import type { UseFormRegisterReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
-function RequiredMark() {
-	return (
-		<span className="ml-0.5 text-red-400" aria-hidden="true">
-			*
-		</span>
-	);
-}
+import { RequiredMark } from "../RequiredMark";
 
 export function Stepper({
 	current,

--- a/frontend/src/components/Field.tsx
+++ b/frontend/src/components/Field.tsx
@@ -1,18 +1,24 @@
 import { labelClass } from "../lib/formClasses";
+import { RequiredMark } from "./RequiredMark";
 
 export default function Field({
 	label,
 	id,
+	required = false,
 	children,
 }: {
 	label: string;
 	id?: string;
+	/** Renders the shared asterisk. The control itself still needs its own
+	 * `required`/`aria-required` - that is the accessible half. */
+	required?: boolean;
 	children: React.ReactNode;
 }) {
 	return (
 		<div>
 			<label htmlFor={id} className={labelClass}>
 				{label}
+				{required && <RequiredMark />}
 			</label>
 			{children}
 		</div>

--- a/frontend/src/components/RequiredMark.tsx
+++ b/frontend/src/components/RequiredMark.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from "react-i18next";
+
+// text-red-600 (5:1 on white), not the text-red-400 the wizard used before
+// this component was shared - the glyph is the only visual carrier of
+// "required", so it has to clear the AA text floor in frontend/AGENTS.md the
+// same way error copy does.
+const markClass = "text-red-600";
+
+/**
+ * The one required-field marker in the product (issue #1797).
+ *
+ * Three conventions used to coexist: this asterisk (create-opportunity
+ * wizard), an asterisk baked into the translation string with a literal
+ * space ("Name *", org settings) and a spelled-out "(required)" suffix
+ * (sign-up and feedback modals). A marker inside a translated string can't
+ * be aria-hidden, so org settings announced its field as "Name star".
+ *
+ * The asterisk won over the spelled-out variant because the wizard's
+ * floating labels sit in grid columns as narrow as 5rem ("PLZ",
+ * "Hausnummer") - a "(Pflichtfeld)" suffix does not fit there. It does need
+ * a legend, so every form that renders a mark also renders exactly one
+ * `RequiredFieldsLegend` above its fields.
+ *
+ * Keep it aria-hidden: the accessible half of "this field is required" is
+ * the control's own `required`/`aria-required`, so announcing the marker
+ * would only say it twice.
+ */
+export function RequiredMark() {
+	return (
+		<span className={`ml-0.5 ${markClass}`} aria-hidden="true">
+			*
+		</span>
+	);
+}
+
+/** Explains the asterisk. Render once per form, above the fields. */
+export function RequiredFieldsLegend({
+	className = "",
+}: {
+	className?: string;
+}) {
+	const { t } = useTranslation();
+	return (
+		// aria-hidden for the same reason the mark is: it explains a purely
+		// visual convention, and every marked control already announces itself
+		// as required on its own.
+		<p aria-hidden="true" className={`text-xs text-gray-500 ${className}`}>
+			<span className={markClass}>*</span> {t("common.requiredField")}
+		</p>
+	);
+}

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -9,6 +9,7 @@ import Dropdown from "./Dropdown";
 import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
+import { RequiredFieldsLegend, RequiredMark } from "./RequiredMark";
 
 interface Props {
 	opportunityId: string;
@@ -132,8 +133,12 @@ export default function SignUpModal({
 
 				{!isScheduledSlots && (
 					<div>
+						{/* Scoped to this branch: the slot-picker variant has no required
+						field, so its legend would explain an absent asterisk. */}
+						<RequiredFieldsLegend className="mb-2" />
 						<label htmlFor="sign-up-message" className={`mb-1 ${labelClass}`}>
 							{t("signUp.message")}
+							<RequiredMark />
 						</label>
 						<textarea
 							id="sign-up-message"

--- a/frontend/src/components/SubmitFeedbackModal.tsx
+++ b/frontend/src/components/SubmitFeedbackModal.tsx
@@ -7,6 +7,7 @@ import Modal from "./Modal";
 import Button from "./Button";
 import ErrorBanner from "./ErrorBanner";
 import { StarIcon } from "./icons";
+import { RequiredFieldsLegend, RequiredMark } from "./RequiredMark";
 import { labelClass } from "../lib/formClasses";
 
 interface SubmitFeedbackModalProps {
@@ -77,12 +78,22 @@ export default function SubmitFeedbackModal({
 			<p className="mb-5 text-sm text-gray-500">{opportunityTitle}</p>
 
 			<form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+				<RequiredFieldsLegend />
+
 				<div>
-					<p className={`mb-2 ${labelClass}`}>{t("feedback.ratingLabel")}</p>
+					<p className={`mb-2 ${labelClass}`}>
+						{t("feedback.ratingLabel")}
+						<RequiredMark />
+					</p>
+					{/* The stars are aria-pressed toggle buttons, so this is a plain
+					`group` - and ARIA does not allow aria-required on `group` (axe's
+					aria-allowed-attr would flag it). Folding "required" into the
+					group's own name is what carries the asterisk across to screen
+					readers here; it lives in the component, not in the string. */}
 					<div
 						className="flex gap-1"
 						role="group"
-						aria-label={t("feedback.ratingLabel")}
+						aria-label={`${t("feedback.ratingLabel")} (${t("common.requiredField")})`}
 					>
 						{[1, 2, 3, 4, 5].map((star) => (
 							<button

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -14,7 +14,8 @@
       "loading": "Wird geladen…",
       "pageLoading": "Seite wird geladen…",
       "skipToContent": "Zum Inhalt springen",
-      "onThisPage": "Auf dieser Seite"
+      "onThisPage": "Auf dieser Seite",
+      "requiredField": "Pflichtfeld"
     },
     "nav": {
       "primaryLabel": "Hauptnavigation",
@@ -348,7 +349,7 @@
       "selectTimeSlot": "Zeitslot wählen",
       "noTimeSlots": "Keine Zeitslots verfügbar.",
       "selectPlaceholder": "Bitte wählen…",
-      "message": "Nachricht (Pflichtfeld)",
+      "message": "Nachricht",
       "messagePlaceholder": "Beschreibe kurz, warum du dich engagieren möchtest…",
       "submitting": "Wird gesendet…",
       "submit": "Anmelden",
@@ -467,7 +468,7 @@
       "logoRemove": "Entfernen",
       "logoRemoving": "Wird entfernt…",
       "logoRemoveError": "Logo konnte nicht entfernt werden.",
-      "fieldName": "Name *",
+      "fieldName": "Name",
       "fieldDescription": "Beschreibung",
       "fieldContactEmail": "Kontakt-E-Mail",
       "fieldPhone": "Telefon",
@@ -546,7 +547,7 @@
       "buttonLabel": "Feedback geben",
       "submitted": "Feedback gegeben",
       "title": "Erfahrung bewerten",
-      "ratingLabel": "Bewertung (Pflichtfeld)",
+      "ratingLabel": "Bewertung",
       "commentLabel": "Kommentar (optional)",
       "commentPlaceholder": "Teile deine Erfahrung…",
       "submit": "Feedback absenden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -14,7 +14,8 @@
       "loading": "Loading…",
       "pageLoading": "Loading page…",
       "skipToContent": "Skip to content",
-      "onThisPage": "On this page"
+      "onThisPage": "On this page",
+      "requiredField": "Required field"
     },
     "nav": {
       "primaryLabel": "Main navigation",
@@ -348,7 +349,7 @@
       "selectTimeSlot": "Select time slot",
       "noTimeSlots": "No time slots available.",
       "selectPlaceholder": "Please select…",
-      "message": "Message (required)",
+      "message": "Message",
       "messagePlaceholder": "Briefly describe why you want to volunteer…",
       "submitting": "Submitting…",
       "submit": "Sign up",
@@ -467,7 +468,7 @@
       "logoRemove": "Remove",
       "logoRemoving": "Removing…",
       "logoRemoveError": "Failed to remove logo.",
-      "fieldName": "Name *",
+      "fieldName": "Name",
       "fieldDescription": "Description",
       "fieldContactEmail": "Contact email",
       "fieldPhone": "Phone",
@@ -546,7 +547,7 @@
       "buttonLabel": "Leave feedback",
       "submitted": "Feedback given",
       "title": "Rate your experience",
-      "ratingLabel": "Rating (required)",
+      "ratingLabel": "Rating",
       "commentLabel": "Comment (optional)",
       "commentPlaceholder": "Share your experience…",
       "submit": "Submit feedback",

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -18,6 +18,7 @@ import SuccessBanner from "../../components/SuccessBanner";
 import ImageCropModal from "../../components/ImageCropModal";
 import FileUploadButton from "../../components/FileUploadButton";
 import Field from "../../components/Field";
+import { RequiredFieldsLegend } from "../../components/RequiredMark";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 import { formatDateLong } from "../../lib/format";
 
@@ -282,6 +283,8 @@ export default function OrgSettingsPage() {
 							onSubmit={(e) => void handleSubmit(onSubmit)(e)}
 							className="space-y-5"
 						>
+							<RequiredFieldsLegend />
+
 							<div>
 								<p className={`mb-1 ${labelClass}`}>
 									{t("orgSettings.fieldLogo")}
@@ -347,7 +350,7 @@ export default function OrgSettingsPage() {
 								</div>
 							</div>
 
-							<Field label={t("orgSettings.fieldName")} id="org-name">
+							<Field label={t("orgSettings.fieldName")} id="org-name" required>
 								<input
 									id="org-name"
 									maxLength={100}


### PR DESCRIPTION
## What

Replaces the three (really four) ways required fields were marked with a single shared `RequiredMark` component, and moves the marker out of the translation strings entirely so spacing is defined in one place and the glyph is `aria-hidden` product-wide.

| Surface | Before | After |
|---|---|---|
| Create-opportunity wizard | `Titel*` (`RequiredMark`, `ml-0.5`, `aria-hidden`) | `Titel*` - same, now from the shared component |
| Org settings | `Name *` (asterisk baked into the string, **not** `aria-hidden`) | `Name*` |
| Sign-up / interest modal | `Nachricht (Pflichtfeld)` | `Nachricht*` |
| Feedback modal | `Bewertung (Pflichtfeld)` | `Bewertung*` |
| Create-organization modal | *nothing* - required with no visible marker at all | `Name*` |

The asterisk won over the spelled-out variant on a constraint the issue didn't weigh: the wizard's floating labels sit in grid columns as narrow as `5rem` (`PLZ`, `Hausnummer`), where a `(Pflichtfeld)` suffix does not fit. That convention needs a legend, so `RequiredFieldsLegend` ships alongside it and every form that renders a mark renders exactly one - scoped so it never explains an asterisk that isn't on screen (wizard steps 3-4, a remote opportunity's step 2, the sign-up modal's slot-picker branch).

Two changes beyond the letter of the issue, both deliberate:

- **The mark moves from `text-red-400` (~3.3:1) to `text-red-600` (~5:1).** It is now the only visual carrier of "required", so it has to clear the AA text floor in `frontend/AGENTS.md` the way error copy does. Consolidating into one component was the moment to fix it.
- **The create-organization modal's name field gets the mark.** It was required (`aria-required="true"`) with no visible indication at all - a fourth variant of the same inconsistency the issue is about.

## Why

Users learned one convention per screen instead of one per product. There was also an accessibility bug behind it: a marker inside a translated string cannot be `aria-hidden`, so org settings announced its field as **"Name star"**. The wizard already did this correctly; now everything does.

`RequiredMark` stays `aria-hidden` on purpose - the accessible half of "this field is required" is the control's own `required`/`aria-required`, so announcing the marker too would just say it twice. One exception is documented inline: the feedback modal's star rating is a `role="group"` of `aria-pressed` toggle buttons, and ARIA does not allow `aria-required` on `group` (axe's `aria-allowed-attr` would flag it), so "required" is folded into the group's composed accessible name instead - in the component, not the string.

Closes #1797

## Testing

- **New:** `backend/tests/VisualTests/RequiredFieldMarkerTests.cs` - pins the convention on two surfaces (org settings and the wizard): the accessible name is the field name alone (this is the assertion that fails if the marker ever creeps back into a string), the label's text is exactly `Name*`/`Title*` (no space - the spacing half of the issue), the mark is a single `aria-hidden` span, and the form carries exactly one legend.
- **Updated:** `SignUpModalMessageFieldTests.cs` - was asserting `GetByLabel("Message (required)")`. Now asserts an accessible name of exactly `Message` plus the visible `Message*`, alongside the existing native-`required` check.
- **Ran locally:** `pnpm lint`, `pnpm check`, `pnpm format:check`, `pnpm i18n:check` (1273 keys, no drift), `pnpm test` (180 passed).
- **CI: all 12 checks green**, including `visual-tests` - so the new assertions ran against a real Aspire stack with Playwright, verifying the rendered DOM rather than just compiling.
- `/self-review` run - no P1/P2 findings. It surfaced one pre-existing gap worth recording: the org form's address block is *conditionally* required (all-or-nothing once any part is filled). No convention marked it before and none does now - an asterisk can't express "required only if a sibling is filled". Out of scope here, not a regression.

## Live verification

**Not performed - deliberately deferred at the requester's instruction ("Don't cut a RC").** This change has not been observed on live staging, so the root `AGENTS.md` deploy-and-verify flow is incomplete for it and this PR should not be treated as having satisfied that gate.

The durable half of that flow is in place: the assertions are committed as TUnit tests (above) and passed in CI's `visual-tests` job against the full local stack, rather than living in a throwaway script. If you want the staging leg before merging, the follow-up is an RC branch off this one plus `/live-verify`.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green - all 12 checks
- [x] Documentation updated if this change affects behavior - `frontend/AGENTS.md`'s Design System table gains a `RequiredMark` row, so the next contributor reuses it instead of hand-rolling a fifth variant