### PR TITLE
fix(frontend): give unread notification rows a text alternative

### DIFF
--- a/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
+++ b/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
@@ -1,0 +1,141 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1786: an unread notification row was marked only by an
+/// empty decorative dot span plus a font-weight/colour difference, so read and
+/// unread rows were indistinguishable to a screen reader and unread state was
+/// announced only in aggregate on the bell (WCAG 2.2 A, 1.4.1 Use of Color).
+/// axe cannot catch this - an unlabelled decorative span violates no rule,
+/// which is why AccessibilityTests' NotificationDropdown_Open scan stayed green
+/// throughout - so the per-row marker needs its own targeted assertion.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class NotificationUnreadMarkerTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// Anchored at the start so it matches the row's own select button (whose
+	// accessible name now begins with the hidden marker) and never the sibling
+	// mark-unread action button, whose aria-label is "Mark as unread: {text}".
+	// The suite runs in English - nothing pins the locale, so Playwright's
+	// default en-US browser locale feeds i18next's navigator detector (see
+	// NavigationTests' html[lang="en"] assertion on a bare page load).
+	private static readonly Regex UnreadMarkerName = new("^Unread\\b");
+
+	[Test]
+	public async Task UnreadNotificationRow_ExposesHiddenUnreadMarker_ReadRowDoesNot()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		// A fresh org rather than olaf's shared seed org - other VisualTests in
+		// this shared Aspire session mutate/delete shared orgs concurrently.
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"NotifUnreadMarker Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		// CreateOrganizationEndpoint returns the raw domain aggregate, so its
+		// strongly-typed OrganizationId serializes as { "value": "<guid>" }.
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		// Two opportunities, so one notification can be flipped to read and the
+		// other left unread - both rows are then asserted against the same open
+		// panel rather than across two separate page states.
+		var readTitle = $"NotifUnreadMarker Read {suffix}";
+		var unreadTitle = $"NotifUnreadMarker Unread {suffix}";
+		var readOpportunityId = await CreateOpportunityAsync(olafHttp, organizationId, readTitle);
+		var unreadOpportunityId = await CreateOpportunityAsync(olafHttp, organizationId, unreadTitle);
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		// CreateEngagementCommandHandler writes the organizer's notification row
+		// inside the request's own transaction (only the emails go through the
+		// outbox), so both rows exist as soon as these POSTs return.
+		await ApplyAsync(veraHttp, readOpportunityId);
+		await ApplyAsync(veraHttp, unreadOpportunityId);
+
+		var readNotificationId = await GetNotificationIdByTitleAsync(olafHttp, readTitle);
+		var markReadResponse = await olafHttp.PostAsync($"/v1/notifications/{readNotificationId}/read", null);
+		markReadResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await bell.ClickAsync();
+
+		var panel = Page.GetByTestId("notification-panel");
+		await Expect(panel).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		// The list is fetched when the dropdown opens (only the unread count is
+		// polled), so the rows need the same generous wait as NotificationTests.
+		var unreadRow = panel.Locator("li", new() { HasText = unreadTitle }).First;
+		await Expect(unreadRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var readRow = panel.Locator("li", new() { HasText = readTitle }).First;
+		await Expect(readRow).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(unreadRow.GetByRole(AriaRole.Button, new() { NameRegex = UnreadMarkerName }))
+			.ToHaveCountAsync(1);
+		await Expect(readRow.GetByRole(AriaRole.Button, new() { NameRegex = UnreadMarkerName }))
+			.ToHaveCountAsync(0);
+
+		// The marker must stay invisible on screen - the coloured dot remains the
+		// visual shorthand. Not a Not.ToBeVisibleAsync() check: Tailwind's sr-only
+		// is clip-based rather than display:none (deliberately, so the node stays
+		// in the accessibility tree), which Playwright still counts as visible -
+		// same reasoning as LiveRegionTests' SuccessBanner assertion.
+		await Expect(unreadRow.Locator("span.sr-only")).ToHaveTextAsync("Unread");
+		await Expect(readRow.Locator("span.sr-only")).ToHaveCountAsync(0);
+	}
+
+	private static async Task<string> CreateOpportunityAsync(HttpClient http, string organizationId, string title)
+	{
+		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title,
+			description = "Created by NotificationUnreadMarkerTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		response.EnsureSuccessStatusCode();
+		var opportunity = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+
+	private static async Task ApplyAsync(HttpClient http, string opportunityId)
+	{
+		var response = await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Notify Olaf please." });
+		response.EnsureSuccessStatusCode();
+	}
+
+	private static async Task<string?> GetNotificationIdByTitleAsync(HttpClient http, string relatedTitle)
+	{
+		var response = await http.GetAsync("/v1/notifications");
+		response.EnsureSuccessStatusCode();
+		var page = await response.Content.ReadFromJsonAsync<JsonElement>();
+		// GetMyNotifications returns a NotificationsPage ({ items, hasMore }),
+		// not a bare array, since einsatzbereit#1384 added cursor pagination.
+		// Matching on the unique per-run title keeps this from picking up
+		// another test's EngagementCreated row in the shared session.
+		return page.GetProperty("items").EnumerateArray()
+			.First(n => n.GetProperty("relatedTitle").GetString() == relatedTitle)
+			.GetProperty("id").GetString();
+	}
+}

--- a/frontend/src/components/Header/NotificationItem.tsx
+++ b/frontend/src/components/Header/NotificationItem.tsx
@@ -30,7 +30,19 @@ export default function NotificationItem({
 			>
 				<span className="flex items-start gap-2">
 					{!n.isRead && (
-						<span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-500" />
+						<>
+							{/* Unread was signalled by this dot's colour and the row's font
+							weight alone (#1786) - the span is empty, so a screen reader
+							read an unread row exactly like a read one. The marker goes
+							inside the row's own button to join its accessible name,
+							rather than being a standalone live region like the bell's
+							aggregate count in NotificationDropdown. */}
+							<span
+								aria-hidden="true"
+								className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-500"
+							/>
+							<span className="sr-only">{t("notifications.unread")}</span>
+						</>
 					)}
 					<span className={!n.isRead ? "" : "pl-4"}>
 						{text}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -844,6 +844,7 @@
       "deleteNamed": "Löschen: {{notification}}",
       "deleteError": "Benachrichtigung konnte nicht gelöscht werden.",
       "deletedOpportunityPlaceholder": "einen gelöschten Einsatz",
+      "unread": "Ungelesen",
       "kinds": {
         "EngagementCreated": "Neue Anmeldung eingegangen für {{title}}",
         "EngagementConfirmed": "Deine Anmeldung für {{title}} wurde bestätigt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -844,6 +844,7 @@
       "deleteNamed": "Delete: {{notification}}",
       "deleteError": "Failed to delete notification.",
       "deletedOpportunityPlaceholder": "a deleted opportunity",
+      "unread": "Unread",
       "kinds": {
         "EngagementCreated": "New sign-up received for {{title}}",
         "EngagementConfirmed": "Your sign-up for {{title}} was confirmed",


### PR DESCRIPTION
## What

An unread notification row now carries a visually hidden `Unread` / `Ungelesen` marker inside the row's own select button, so unread state is part of that button's accessible name. The coloured dot stays as the visual shorthand and is marked `aria-hidden` now that it is purely decorative.

## Why

Unread state was conveyed by colour alone - an empty decorative `<span>` for the dot, plus `font-medium text-gray-900` vs `text-gray-500`. That fails WCAG 2.2 A, 1.4.1 Use of Color, and left the state entirely unannounced: a screen reader read an unread row exactly like a read one, and the bell's aggregate "6 ungelesen" count could not be reconciled with any individual row.

The per-item action buttons in the same component were already properly labelled, which made the row state the odd one out rather than a systemic gap.

`aria-label` on the row button was considered and rejected - it replaces the whole subtree in the accessible name, which would have dropped the formatted timestamp currently announced from the row's content.

Closes #1786

## Testing

New `backend/tests/VisualTests/NotificationUnreadMarkerTests.cs` builds one read row and one unread row for the same organizer, then asserts both against a single open panel:

- the unread row's select button matches accessible name `^Unread\b`, the read row's does not (anchored so it can never match the sibling `Mark as unread: {notification}` action button);
- the marker stays visually hidden - asserted on the `sr-only` span's text rather than with `Not.ToBeVisibleAsync()`, since Tailwind's `sr-only` is clip-based and Playwright still counts it as visible (same reasoning as `LiveRegionTests`).

This needs its own test rather than an `AccessibilityTests` case: axe cannot see the defect, since an unlabelled decorative span violates no rule - which is exactly why `NotificationDropdown_Open_HasNoSeriousA11yViolations` stayed green while the bug was live.

Run locally: `pnpm format:check`, `pnpm lint`, `pnpm check`, `pnpm i18n:check` (1273 keys, no drift), `pnpm test` (180 passed), `dotnet format --verify-no-changes`, and a `dotnet build` of `VisualTests` (0 warnings, 0 errors). The `VisualTests` suite itself needs Docker/Aspire and so runs in CI, not in the web sandbox.

In CI, `visual-tests` passes with the new test included. The first run was red on an unrelated pre-existing flake (`OrgAppLayoutErrorStatesTests`, a 500 from `POST /v1/organizations`); `main` @ `13bf829` is red on the same job on a *different* test (`HomePageOrgCtaTests`). It passed on re-run - see the comment thread for the full diagnosis.

## Live verification

Not done - the task explicitly asked not to cut a release candidate, so steps 3-6 of the deploy-and-verify flow were skipped. The durable step-7 assertion is in place and passes against the local Aspire stack in CI. This section should be filled in from an RC before merge if the usual flow applies.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (no docs change needed - no new route, primitive or convention)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EP1C9yqHS6edRsKi6q2tew)_