### PR TITLE
fix(ci): render OFFSITE_S3_* secrets in reset-staging's .env

### DIFF
--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -94,6 +94,13 @@ jobs:
           # without it fails rendering the compose config entirely, same as
           # deploy-staging.
           ALERT_NOTIFICATION_EMAIL: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
+          # Off-host mirror target for minio-backup's offsite leg
+          # (docker-compose.yml, #1087) - also required (":?" guard), so a
+          # restart without these fails the same way ALERT_NOTIFICATION_EMAIL
+          # above does. See deploy-staging's matching secrets in publish.yml.
+          OFFSITE_S3_ENDPOINT: ${{ secrets.OFFSITE_S3_ENDPOINT }}
+          OFFSITE_S3_ACCESS_KEY: ${{ secrets.OFFSITE_S3_ACCESS_KEY }}
+          OFFSITE_S3_SECRET_KEY: ${{ secrets.OFFSITE_S3_SECRET_KEY }}
           # Whatever was actually running before the reset (captured above),
           # not docker-compose.yml's "staging" default - see the "Capture
           # currently deployed image tag" step above (#1733).
@@ -132,6 +139,9 @@ jobs:
             printf 'GRAFANA_ADMIN_USER="%s"\n' "$(escape "$GRAFANA_ADMIN_USER")"
             printf 'GRAFANA_ADMIN_PASSWORD="%s"\n' "$(escape "$GRAFANA_ADMIN_PASSWORD")"
             printf 'ALERT_NOTIFICATION_EMAIL="%s"\n' "$(escape "$ALERT_NOTIFICATION_EMAIL")"
+            printf 'OFFSITE_S3_ENDPOINT="%s"\n' "$(escape "$OFFSITE_S3_ENDPOINT")"
+            printf 'OFFSITE_S3_ACCESS_KEY="%s"\n' "$(escape "$OFFSITE_S3_ACCESS_KEY")"
+            printf 'OFFSITE_S3_SECRET_KEY="%s"\n' "$(escape "$OFFSITE_S3_SECRET_KEY")"
             printf 'IMAGE_TAG="%s"\n' "$(escape "$IMAGE_TAG")"
             # Not a secret - restarting after a reset should come back seeded
             # with demo organizations/opportunities, same as deploy-staging


### PR DESCRIPTION
## What

`reset-staging.yml`'s "Render .env" step now also renders `OFFSITE_S3_ENDPOINT`, `OFFSITE_S3_ACCESS_KEY` and `OFFSITE_S3_SECRET_KEY` into the host's `.env`, matching `deploy-staging`'s (`publish.yml`) equivalent step.

## Why

`docker-compose.yml`'s `minio-backup` service requires these three variables via `:?` guards:

```yaml
OFFSITE_S3_ENDPOINT: ${OFFSITE_S3_ENDPOINT:?set OFFSITE_S3_ENDPOINT in .env}
OFFSITE_S3_ACCESS_KEY: ${OFFSITE_S3_ACCESS_KEY:?set OFFSITE_S3_ACCESS_KEY in .env}
OFFSITE_S3_SECRET_KEY: ${OFFSITE_S3_SECRET_KEY:?set OFFSITE_S3_SECRET_KEY in .env}
```

`publish.yml`'s `deploy-staging` job renders these (off `staging`-environment secrets that already exist and back up `minio-backup`'s offsite leg, #1087), so a normal deploy works fine. `reset-staging.yml` never picked them up, even though its own header comment says the "Render .env" step is meant to be "kept byte-for-byte in sync" with `deploy-staging`'s. So the reset's "Wipe data volumes and restart stack" step fails inside `docker compose up -d` with a missing-env-variable error, right after the data volumes have already been deleted - deploying (`deploy-staging`) is unaffected because it renders these vars already.

No new secrets are required - `OFFSITE_S3_ENDPOINT`/`OFFSITE_S3_ACCESS_KEY`/`OFFSITE_S3_SECRET_KEY` already exist on the `staging` GitHub Environment (used by `deploy-staging`/`deploy-production`), and `reset-staging.yml` already runs in that same `environment: staging`.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reset-staging.yml'))"` - YAML parses cleanly.
- Compared the full secrets list in both "Render .env" steps line by line to confirm they now match (aside from `IMAGE_TAG`, which is intentionally sourced differently in each - the currently-deployed tag for a reset vs. the newly-published version for a deploy).

## Live verification

Not applicable - this is a CI workflow change with no app code touched. The only real way to verify it is to actually run `reset-staging.yml`, which is a manual, destructive workflow (wipes staging Postgres/MinIO/Grafana data) that `AGENTS.md` says should not be triggered without the repo owner's go-ahead. Happy to trigger a real run to confirm the fix if you'd like - just say the word.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - minimal mechanical change mirroring an existing pattern)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (no doc changes needed - `.github/AGENTS.md`'s description of `reset-staging.yml` was already accurate about intent, just not what the workflow actually did)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DpfRA1jf8p3uJRsUpru2ng)_