### PR TITLE
chore: remove restated and stale comments across backend and frontend

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -86,7 +86,6 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 			? OpportunityStatus.Draft
 			: OpportunityStatus.Published;
 
-		// Remote opportunities have no address. Drafts may omit address fields too.
 		var hasAnyAddressField =
 			!string.IsNullOrWhiteSpace(request.Street) ||
 			!string.IsNullOrWhiteSpace(request.HouseNumber) ||

--- a/backend/src/Application/Common/Geocoding/IGeocodingService.cs
+++ b/backend/src/Application/Common/Geocoding/IGeocodingService.cs
@@ -6,7 +6,6 @@ public sealed record CitySuggestion(string Label, double Latitude, double Longit
 
 public enum GeocodingOutcome
 {
-	/// <summary>A coordinate match was found.</summary>
 	Found,
 
 	/// <summary>The geocoding provider confirmed no match exists for this address; retrying the same query won't help.</summary>

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -459,8 +459,8 @@ internal sealed class ApplicationDbContext(
 	{
 		// Contains against a List<TimeSlotId?> (nullable-wrapped) translates
 		// fine - unwrapping the nullable value object inside the query (e.g.
-		// e.TimeSlotId!.Value) does not, see the GroupBy/.Value gotcha this
-		// mirrors elsewhere in this class.
+		// e.TimeSlotId!.Value) does not, see the same GroupBy/.Value gotcha in
+		// VolunteerOpportunityReadRepository.GetCalendarEventsAsync.
 		var nullableIds = timeSlotIds.Select(id => (TimeSlotId?)id).ToList();
 
 		// VolunteerId != null - see GetActiveEngagementsForOpportunityAsync above

--- a/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
@@ -71,7 +71,7 @@ public class CheckInEngagementCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the opportunity's.
+		// Arrange
 		var opportunity = CreateOpportunity();
 		var engagement = CreateConfirmedEngagement(opportunity.Id);
 		var engagementId = engagement.Id;

--- a/backend/tests/Application.UnitTests/Engagements/DeleteFeedback/DeleteFeedbackCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/DeleteFeedback/DeleteFeedbackCommandHandlerTests.cs
@@ -81,7 +81,7 @@ public class DeleteFeedbackCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenCallerIsNotTheEngagementOwner(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: a different volunteer attempts to delete someone else's feedback.
+		// Arrange
 		var (engagement, _) = CreateEngagementWithFeedback();
 		var engagementId = EngagementId.New();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);

--- a/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/SubmitFeedbackCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/SubmitFeedbackCommandHandlerTests.cs
@@ -78,7 +78,7 @@ public class SubmitFeedbackCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenCallerIsNotTheEngagementOwner(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: a different volunteer attempts to submit feedback for someone else's engagement.
+		// Arrange
 		var (engagement, _) = CreateCheckedInEngagementWithVolunteer();
 		var engagementId = EngagementId.New();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);

--- a/backend/tests/Application.UnitTests/Engagements/UpdateFeedback/UpdateFeedbackCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/UpdateFeedback/UpdateFeedbackCommandHandlerTests.cs
@@ -80,7 +80,7 @@ public class UpdateFeedbackCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenCallerIsNotTheEngagementOwner(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: a different volunteer attempts to update someone else's feedback.
+		// Arrange
 		var (engagement, _) = CreateEngagementWithFeedback();
 		var engagementId = EngagementId.New();
 		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganizationLogo/DeleteOrganizationLogoCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganizationLogo/DeleteOrganizationLogoCommandHandlerTests.cs
@@ -59,7 +59,7 @@ public class DeleteOrganizationLogoCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the target.
+		// Arrange
 		var orgId = Guid.NewGuid();
 		var organization = CreateOrganizationWithLogo(orgId);
 		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
@@ -78,7 +78,7 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotAMember(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller has no membership at all in the target organization.
+		// Arrange
 		_dbContext
 			.IsMemberAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);

--- a/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
@@ -140,7 +140,6 @@ public class SearchMemberCandidatesQueryHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller is not an organizer of the target organization.
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);

--- a/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
@@ -59,7 +59,7 @@ public class UploadOrganizationLogoCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the target.
+		// Arrange: caller is not an organizer of this organization.
 		var orgId = Guid.NewGuid();
 		var organization = CreateOrganization(orgId);
 		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);

--- a/backend/tests/Application.UnitTests/SearchAlerts/SearchAlertTests.cs
+++ b/backend/tests/Application.UnitTests/SearchAlerts/SearchAlertTests.cs
@@ -15,7 +15,6 @@ public class SearchAlertTests
 	private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
 	private static readonly IPinGenerator PinGenerator = Substitute.For<IPinGenerator>();
 
-	// Berlin.
 	private const double BerlinLatitude = 52.5200;
 	private const double BerlinLongitude = 13.4050;
 

--- a/backend/tests/Application.UnitTests/Users/RecordLogin/RecordLoginCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/RecordLogin/RecordLoginCommandHandlerTests.cs
@@ -96,7 +96,6 @@ public class RecordLoginCommandHandlerTests
 	public async Task Handle_ShouldNotSendAwardCommand_WhenStreakIsBelow7(CancellationToken cancellationToken)
 	{
 		var userId = UserId.New();
-		// Streak of 6: login 6 consecutive days then record the 7th day NOT via the handler
 		var streak = BuildStreakWithLoginCount(userId, 5);
 		_dbContext.GetUserStreakAsync(userId, cancellationToken).Returns(streak);
 
@@ -151,7 +150,6 @@ public class RecordLoginCommandHandlerTests
 		// Same day as last login - RecordLogin is a no-op, streak stays 7
 		await _sut.Handle(new RecordLoginCommand(userId, streak.LastLoginDate!.Value), cancellationToken);
 
-		// No award sent for repeated same-day call
 		await _sender.DidNotReceive().Send(
 			Arg.Any<AwardAchievementCommand>(),
 			Arg.Any<CancellationToken>());

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -296,7 +296,7 @@ public class CreateTimeSlotCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the opportunity's.
+		// Arrange
 		var opportunity = CreateOpportunity();
 		var opportunityId = Guid.CreateVersion7();
 		_opportunityRepo

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -337,7 +337,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller is not an organizer of the target organization.
+		// Arrange
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
@@ -67,7 +67,7 @@ public class DeleteOpportunityBannerCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the opportunity's.
+		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = CreateOpportunityWithBanner();
 		_opportunityRepo

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
@@ -79,7 +79,7 @@ public class DeleteTimeSlotCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the opportunity's.
+		// Arrange
 		var opportunity = CreateOpportunityWithTimeSlot(out var timeSlot);
 		var opportunityId = opportunity.Id.Value;
 		_opportunityRepo

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -288,7 +288,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: caller belongs to a different organization than the opportunity's.
+		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = CreateOpportunity();
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -321,7 +321,6 @@ public class UpdateTimeSlotCommandHandlerTests
 	public async Task Handle_ShouldUpdateCapacityOnTargetAndFollowingSlots_WhenScopeIsThisAndFollowing(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: a 3-occurrence weekly series.
 		var opportunity = CreateScheduledSlotsOpportunity();
 		var seriesId = Guid.CreateVersion7();
 		var slot1 = opportunity.AddTimeSlot(BaseStart, BaseEnd, 10, DateTimeOffset.UtcNow, seriesId, "Weekly", 3).Value;

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -1212,8 +1212,6 @@ public class VolunteerOpportunityTests
 		result.Error.Description.Should().Be("Check-in PIN must be 4 to 6 digits.");
 	}
 
-	// --- AddTimeSlot ---
-
 	[Test]
 	public void AddTimeSlot_ShouldAddSlot_WhenParticipationTypeIsScheduledSlots()
 	{

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1133,7 +1133,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 
 		await CreateOrganizationAsync(veraClient, cancellationToken);
 
-		// vera (organisator of org2, NOT org1) tries to confirm org1's engagement
 		var act = () => veraClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
 
 		var exception = await act.Should().ThrowAsync<ApiException>();
@@ -1206,7 +1205,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		// the delete itself silently not having taken effect.
 		(await fixture.CountRowsWhereAsync("volunteer_opportunity", "id", opportunity.Id)).Should().Be(0);
 
-		// vera (organisator of org2, NOT org1) tries to check in org1's engagement.
 		// With no opportunity row left to resolve an owning organization from, the
 		// ownership guard can no longer be evaluated at all - the handler must
 		// reject with NotFound rather than silently skipping the guard and letting
@@ -1891,7 +1889,6 @@ public class EngagementTests(IntegrationTestFixture fixture)
 			new SubmitFeedbackRequest { Rating = 5, Comment = "Great first session" },
 			cancellationToken);
 
-		// Organizer cancels the attended engagement to free up a spot for vera.
 		await olafClient.CancelEngagementAsync(
 			firstEngagement.Id,
 			new CancelEngagementRequest { Reason = "Freeing up a spot" },

--- a/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
@@ -32,7 +32,6 @@ public class CreateOpportunityRetryTests(AspireFixture fixture) : VisualTestBase
 
 		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
 
-		// Step 1: title/description.
 		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
 		await Page.Locator("#opportunity-description").FillAsync(
 			"Regression test for the #1227 retry-duplicate-draft bug.");

--- a/backend/tests/VisualTests/MobileHeaderTests.cs
+++ b/backend/tests/VisualTests/MobileHeaderTests.cs
@@ -12,7 +12,6 @@ public class MobileHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
 	[Test]
 	public async Task MobileHeader_NotificationBell_IsAdjacentToBurger_NotCentered()
 	{
-		// Resize to a typical mobile viewport before navigating.
 		await Page.SetViewportSizeAsync(MobileWidth, MobileHeight);
 
 		var frontend = Fixture.GetEndpoint("frontend");
@@ -50,7 +49,6 @@ public class MobileHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		await Page.WaitForTimeoutAsync(1_000);
 
-		// Bell should be visible on mobile viewport.
 		var bell = Page.GetByTestId("notification-bell-mobile");
 		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
@@ -63,14 +61,12 @@ public class MobileHeaderTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var burgerBox = await burger.BoundingBoxAsync();
 		burgerBox.Should().NotBeNull("Could not get bounding box for burger button");
 
-		// Bell center must be in the right half of the viewport (not in the middle).
 		double bellCenterX = bellBox!.X + bellBox.Width / 2.0;
 		bellCenterX.Should().BeGreaterThan(
 			MobileWidth / 2.0,
 			$"Bell center ({bellCenterX:F0}px) should be in the right half of the {MobileWidth}px viewport - it was centered before fix #497");
 
-		// Bell and burger must be adjacent: gap between bell's right edge and burger's
-		// left edge must be at most 60px (they are in the same flex wrapper).
+		// They sit in the same flex wrapper, so the gap between them should stay tight.
 		double gap = burgerBox!.X - (bellBox.X + bellBox.Width);
 		gap.Should().BeLessThanOrEqualTo(
 			60.0,

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -56,7 +56,6 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		await Expect(upcomingText).ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(Page.GetByText("ScopeTabsPast")).Not.ToBeVisibleAsync();
 
-		// Switching to "Past" flips which one is visible.
 		await Page.Locator("[data-testid='engagements-scope-past']").ClickAsync();
 		await Expect(Page.GetByText("ScopeTabsPast").First)
 			.ToBeVisibleAsync(new() { Timeout = 15_000 });

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -72,7 +72,6 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/my-signups");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		// Page heading must be visible.
 		await Expect(Page.Locator("h1").First).ToBeVisibleAsync();
 
 		var card = Page.Locator($"[data-engagement-id='{engagementId}']");

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -281,7 +281,6 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 			await Page.GotoAsync($"{origin}/app/{organizationId}/{path}");
 			await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-			// The path should render real content, not the ErrorBoundary fallback.
 			await Expect(errorBoundaryHeading).ToHaveCountAsync(0);
 
 			// A crash unmounts OrgAppLayout entirely (the ErrorBoundary sits

--- a/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppShellHeaderTests.cs
@@ -55,7 +55,6 @@ public class OrgAppShellHeaderTests(AspireFixture fixture) : VisualTestBase(fixt
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }))
 			.ToBeVisibleAsync();
 
-		// Clicking the logo navigates to the main site.
 		await logoLink.ClickAsync();
 		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 15_000 });
 	}

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -148,7 +148,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var dialog = Page.Locator("[role='dialog']");
 		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
 
-		// Step 1 content visible.
 		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
 
 		// Plain header (#676 Pitch 2 dropped the one-off gradient accent bar
@@ -551,7 +550,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
 		await Page.GetByTestId("modal-save-draft").ClickAsync();
 
-		// Saving a draft routes to the Opportunities tab.
 		await Expect(Page).ToHaveURLAsync(new Regex(@"/opportunities"), new() { Timeout = 30_000 });
 
 		// The success toast now names the Opportunities tab, instead of the old
@@ -702,7 +700,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var draftsSection = Page.GetByTestId("drafts-section");
 		var publishedSection = Page.GetByTestId("published-section");
 
-		// Both statuses are visible in one place, each under its own heading.
 		await Expect(draftsSection.GetByText(draftTitle)).ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(publishedSection.GetByText(publishedTitle)).ToBeVisibleAsync();
 
@@ -711,7 +708,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var draftRow = draftsSection.Locator("li", new() { HasText = draftTitle });
 		await draftRow.GetByTestId("opportunity-publish").ClickAsync();
 
-		// It moves out of Drafts and into the Published section.
 		await Expect(publishedSection.GetByText(draftTitle)).ToBeVisibleAsync(new() { Timeout = 15_000 });
 	}
 

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -237,7 +237,6 @@ export default function CreateVolunteerOpportunityModal({
 	const [orgAddress, setOrgAddress] = useState<AddressDto | null>(null);
 	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
-	// Banner
 	const [bannerFile, setBannerFile] = useState<File | null>(null);
 	const [bannerPreview, setBannerPreview] = useState<string | null>(
 		initialOpportunity?.bannerImageUrl ?? null,
@@ -1005,7 +1004,6 @@ export default function CreateVolunteerOpportunityModal({
 					</button>
 				</div>
 
-				{/* Stepper lives in its own row in the body, not the header. */}
 				<div className="border-b border-gray-100 px-6 pt-3 pb-3">
 					<Stepper
 						current={step}

--- a/frontend/src/components/VolunteerOpportunitiesList/CategoryGlyph.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/CategoryGlyph.tsx
@@ -11,8 +11,6 @@ import {
 	UserGroupIcon,
 } from "../icons";
 
-// Decorative banner icon shown on an opportunity card when it has no
-// uploaded banner image, mapped from the opportunity's category.
 export function CategoryGlyph({
 	category,
 	className = "h-10 w-10",

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -543,7 +543,6 @@ export default function VolunteerOpportunitiesList() {
 						/>
 					</FilterDropdown>
 
-					{/* Frequency */}
 					<FilterDropdown
 						testId="filter-frequency"
 						icon={<ClockIcon className="h-3.5 w-3.5" />}

--- a/frontend/src/contexts/OrgBreadcrumbContext.tsx
+++ b/frontend/src/contexts/OrgBreadcrumbContext.tsx
@@ -42,8 +42,7 @@ export function useOrgBreadcrumbExtra() {
 }
 
 // Lets a page nested under OrgAppLayout add a trailing breadcrumb segment
-// beyond its tab (e.g. the specific opportunity being managed), the same way
-// usePageToolbar lets AppLayout pages set their own breadcrumb trail.
+// beyond its tab (e.g. the specific opportunity being managed).
 export function useSetOrgBreadcrumbExtra(label: string | null | undefined) {
 	const { setExtra } = useOrgBreadcrumbCtx();
 	useEffect(() => {

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -56,10 +56,10 @@ export function useQuickActionsList() {
 }
 
 // Opt-in mechanism for a page nested under either AppLayout or OrgAppLayout
-// to publish the action-bar quick actions rendered right of the breadcrumb
-// (see Header.tsx's `breadcrumb.actions`) - the same shape as
-// useSetOrgBreadcrumbExtra/usePageToolbar. Not calling it means no quick
-// actions render for that page.
+// to publish the action-bar quick actions rendered by PageHeaderBand/
+// OrgPageHeader (both call useQuickActionsList) - the same shape as
+// useSetOrgBreadcrumbExtra. Not calling it means no quick actions render for
+// that page.
 //
 // `actions` MUST be a referentially stable array (useMemo, or a literal with
 // no per-render-changing dependencies) - a fresh array/objects on every

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -32,8 +32,6 @@ const CreateOrganizationModal = lazy(
 	() => import("../components/CreateOrganizationModal"),
 );
 
-// ── Page ─────────────────────────────────────────────────────────────────────
-
 export default function HomePage() {
 	const { t } = useTranslation();
 	usePageTitle(t("landing.pageTitle"));

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -90,7 +90,6 @@ export default function ActivitySection() {
 		null,
 	);
 
-	// --- Invitations ---
 	const [invitations, setInvitations] = useState<MyInvitationDto[]>([]);
 	const [invitationsLoading, setInvitationsLoading] = useState(true);
 	const [invitationsError, setInvitationsError] = useState<string | null>(null);

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -471,7 +471,6 @@ export default function ProfileOverviewPage() {
 								</div>
 							)}
 
-							{/* Profile details */}
 							<section className="mb-10">
 								<div className="flex items-center justify-between gap-3">
 									<SectionHeading>{t("profile.sectionDetails")}</SectionHeading>

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -540,7 +540,6 @@ export default function VolunteerOpportunityDetailPage() {
 								</span>
 							</div>
 
-							{/* Map */}
 							{!opportunity.isRemote &&
 								opportunity.latitude != null &&
 								opportunity.longitude != null && (
@@ -602,7 +601,6 @@ export default function VolunteerOpportunityDetailPage() {
 								</div>
 							)}
 						<div className="max-w-2xl">
-							{/* About this organization */}
 							{orgProfileError && !orgProfile && (
 								<div className="mb-6" data-testid="about-organization">
 									<SectionHeading>
@@ -718,7 +716,6 @@ export default function VolunteerOpportunityDetailPage() {
 									</div>
 								)}
 
-							{/* Your application status */}
 							{isAuthenticated && !isOwner && cue && !isDraft && (
 								<div
 									data-testid="application-status"
@@ -791,7 +788,6 @@ export default function VolunteerOpportunityDetailPage() {
 								</div>
 							)}
 
-							{/* Login prompt */}
 							{!isAuthenticated && !isDraft && (
 								<div
 									data-testid="login-prompt"


### PR DESCRIPTION
## What

Removes 39 comments and shortens 11 more across backend and frontend - all cases where a comment purely restated the code right next to it, documented a condition the code no longer implements, or pointed at a class/hook that doesn't exist anymore. No behavior changes; every edit touches only comment syntax (`//`, `///`, `{/* */}`).

## Why

Requested comment-bloat cleanup. Every comment in the codebase (1,146 files, ~4,600 comments) was evaluated individually against keep/shorten/delete criteria (WHY-explaining comments, TODOs with context, API docs, license headers, and footgun warnings are always kept) using two independent audit passes, each candidate double-checked by adversarial re-verification before being included here - a verifier had to fail to find any lost "why", trade-off, or non-obvious fact for a delete/shorten to survive into this diff.

Notable finds beyond plain restatement:
- `RecordLoginCommandHandlerTests.cs:99` - a comment whose numbers (streak of 6, 7th day) contradicted what the test actually builds (a 5-day streak, next day being the 6th)
- `CategoryGlyph.tsx:14-15` - documented a "shown only when no banner image" condition that no longer exists; the component now always renders at its call site
- `ApplicationDbContext.cs:460`, `OrgBreadcrumbContext.tsx:44`, `QuickActionsContext.tsx:58` - cross-references to a class/hook that had moved or been removed, corrected rather than deleted since the underlying explanation is still real and needed
- 12 near-identical `// Arrange: caller belongs to a different organization...` comments across test files - copy-pasted boilerplate that doesn't match what the mock setup actually constructs (a generic `Arg.Any<>()` stub, never a real second organization)

Bare `// Arrange`/`// Act`/`// Assert` test-section markers (~960+ instances) were intentionally left untouched - that's a separate, larger policy decision not part of this change.

Closes #

## Testing

No behavior changed, so no new/updated test assertions. Verified the diff is comment-only via `git diff --unified=0` review (every hunk is a `//`/`///`/`{/* */}` line removed or reworded, nothing else) and confirmed no orphaned blank lines were left behind by any deletion.

## Live verification

Not applicable - comment-only change, zero effect on runtime behavior, nothing to observe on staging.

## Checklist

- [x] `/self-review` run and findings addressed (delegated `nswag-check`, `ef-migration-check`, and `a11y-check` all confirmed no-op for this diff - no API surface, EF model, or accessibility-relevant markup changed)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFEfroSM52SNDznNy8WBeG)_