### PR TITLE
fix(frontend): equalize /my-signups scope toggle segment widths

### DIFF
--- a/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1836: the /my-signups scope toggle ("Current &amp; upcoming" /
+/// "Past") is a hand-rolled segmented control whose two segments sized to their
+/// own label content only (no width-equalizing utility), so the longer
+/// "Current &amp; upcoming" segment rendered visibly wider than "Past" - nearly
+/// 2:1 on live staging (162px vs. 87px in a 259px track). Fixed by adding
+/// flex-1/text-center to both buttons so the track splits evenly regardless of
+/// label length.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MyEngagementsScopeToggleTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// Both segments share flex-1 on the same track, so their rendered widths
+	// should match modulo getBoundingClientRect's sub-pixel rounding - far
+	// below the ~75px gap the unequal-width bug produced.
+	private const double MaxWidthDeltaPx = 2;
+
+	[Test]
+	public async Task ScopeToggle_RendersUpcomingAndPastSegments_AtEqualWidth()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var upcomingTab = Page.GetByTestId("engagements-scope-upcoming");
+		var pastTab = Page.GetByTestId("engagements-scope-past");
+		await Expect(upcomingTab).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(pastTab).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Both widths read in a single EvaluateAsync call rather than two
+		// separate BoundingBoxAsync round trips, so nothing can reflow between
+		// the two reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync
+		// for the same pattern).
+		var widthDelta = 0d;
+		var upcomingWidth = 0d;
+		var pastWidth = 0d;
+		await PollUntilAsync(async () =>
+		{
+			var widths = await Page.EvaluateAsync<double[]>(
+				"""
+				() => {
+					const upcoming = document.querySelector("[data-testid='engagements-scope-upcoming']");
+					const past = document.querySelector("[data-testid='engagements-scope-past']");
+					return [upcoming.getBoundingClientRect().width, past.getBoundingClientRect().width];
+				}
+				""");
+			upcomingWidth = widths[0];
+			pastWidth = widths[1];
+			widthDelta = Math.Abs(upcomingWidth - pastWidth);
+			return widthDelta < MaxWidthDeltaPx;
+		}, () => "myEngagements scope toggle: 'Current & upcoming' and 'Past' segments should render at "
+			+ $"equal width (last observed upcoming={upcomingWidth:F1}px, past={pastWidth:F1}px, "
+			+ $"delta={widthDelta:F1}px, must be <{MaxWidthDeltaPx}px)");
+	}
+}

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -340,7 +340,7 @@ export default function ActivitySection() {
 					onClick={() => switchEngagementsScope("upcoming")}
 					disabled={engagementsLoading}
 					aria-current={engagementsScope === "upcoming" ? "true" : undefined}
-					className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+					className={`flex-1 rounded-md px-3 py-1.5 text-center text-sm font-medium transition-colors ${
 						engagementsScope === "upcoming"
 							? "bg-white text-brand-700 shadow-sm"
 							: "text-gray-600 hover:text-gray-900"
@@ -354,7 +354,7 @@ export default function ActivitySection() {
 					onClick={() => switchEngagementsScope("past")}
 					disabled={engagementsLoading}
 					aria-current={engagementsScope === "past" ? "true" : undefined}
-					className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+					className={`flex-1 rounded-md px-3 py-1.5 text-center text-sm font-medium transition-colors ${
 						engagementsScope === "past"
 							? "bg-white text-brand-700 shadow-sm"
 							: "text-gray-600 hover:text-gray-900"


### PR DESCRIPTION
## What

Equalizes the width of the two segments in the `/my-signups` scope toggle ("Current & upcoming" / "Past") so they always split their track evenly, regardless of label length.

## Why

The scope toggle (`MyEngagementsPage/ActivitySection.tsx`) is a hand-rolled segmented control whose buttons used only content-driven width - no `flex-1`, no fixed/equal width. On live staging the "Current & upcoming" segment measured 162px against "Past" at 87px inside a 259px track (nearly 2:1), worse in English ("Current & upcoming" vs. "Past"). A segmented toggle conventionally implies two options of comparable visual weight.

Closes #1836

## Testing

- Added `flex-1 text-center` to both toggle `<button>` elements' `className` (no markup/ARIA changes).
- New automated TUnit/Playwright test: `backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs` - `ScopeToggle_RendersUpcomingAndPastSegments_AtEqualWidth` signs in as Vera, navigates to `/my-signups`, and asserts both segments' `getBoundingClientRect().width` match within 2px.
- Locally (frontend): `pnpm lint`, `pnpm check`, `pnpm test` (249 tests), `pnpm build`, `pnpm format:write` (no changes), `pnpm i18n:check` all pass.
- Backend build/VisualTests could not be run locally in this sandbox (no Docker/Aspire networking, and the .NET SDK installer host is blocked by this session's egress policy) - CI's `dotnet.yml` will run the new test.
- Ran this repo's `/self-review` and the `a11y-check` subagent against the diff: no issues found. `/my-signups` already has axe-core coverage in `AccessibilityTests.cs` (unchanged markup/ARIA, so no new a11y test needed).

## Live verification

Per explicit instruction for this task, no release candidate was cut and nothing was deployed to staging - this PR is verified via the automated VisualTests regression test above (runs against a local Aspire stack in CI) plus the local frontend checks listed above, not a live-staging Playwright pass.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - CSS-only fix, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkoaWnJaPTdsTZmAo4ZWsq)_