### PR TITLE
fix(frontend): stop clearing the UI language choice on sign-out

### DIFF
--- a/backend/tests/VisualTests/SignOutLanguagePersistenceTests.cs
+++ b/backend/tests/VisualTests/SignOutLanguagePersistenceTests.cs
@@ -1,0 +1,52 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class SignOutLanguagePersistenceTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// #1838: handleSignOut (Header.tsx) used to clear "i18nextLng" and
+	// "einsatzbereit:language-explicit" alongside the #1676 account-tied
+	// storage cleanup, reverting an explicit UI language choice back to the
+	// browser-detected default on every sign-out. A UI language pick is a
+	// device preference, not account data - unlike DangerZoneCard's full
+	// account deletion, sign-out must leave it alone. A real LoginAsync (not
+	// FastSignInAsync) is required here since the assertion is that the
+	// language survives the real signoutRedirect() round trip through
+	// Keycloak and back.
+	[Test]
+	public async Task SignOut_PreservesExplicitLanguageChoice()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		// This suite's default browser context resolves to English with no
+		// stored choice (see NavigationTests's
+		// HomePage_LanguageSelector_SwitchingLanguage_LazilyLoadsAndAppliesTranslations),
+		// so switching to German here is a real change to persist, not a no-op.
+		await Page.GetByTestId("language-selector-trigger").ClickAsync();
+		await Page.GetByTestId("language-selector-menu")
+			.GetByRole(AriaRole.Button, new() { Name = "Deutsch" })
+			.ClickAsync();
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "de");
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Benutzermenü" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Abmelden" }).ClickAsync();
+
+		await Page.WaitForURLAsync($"{origin}/", new() { Timeout = 30_000 });
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Anmelden" }).First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "de");
+
+		var explicitChoice = await Page.EvaluateAsync<string?>(
+			"() => localStorage.getItem('einsatzbereit:language-explicit')");
+		var storedLanguage = await Page.EvaluateAsync<string?>(
+			"() => localStorage.getItem('i18nextLng')");
+
+		explicitChoice.Should().Be("true", "sign-out must not clear the explicit language choice flag");
+		storedLanguage.Should().Be("de", "sign-out must not revert the previously chosen UI language");
+	}
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -112,10 +112,12 @@ export default function Header({
 		// own session cookie is cleared by signoutRedirect below) - it's
 		// browser-stored data tied to this account that has no reason to
 		// outlive the session, per the privacy policy's cookies/storage section.
+		// The UI language choice is a device preference rather than account
+		// data, so it isn't cleared here (#1838) - only the full
+		// account-deletion flow in DangerZoneCard still clears it, where "no
+		// trace of the account left" is the actual intent.
 		clearActiveOrgId();
 		clearSeenAchievements(user?.sub);
-		localStorage.removeItem("i18nextLng");
-		localStorage.removeItem("einsatzbereit:language-explicit");
 		auth.signoutRedirect();
 	}
 


### PR DESCRIPTION
## What

`Header.tsx`'s `handleSignOut()` no longer clears the `i18nextLng` / `einsatzbereit:language-explicit` localStorage keys on sign-out.

## Why

Both keys used to be cleared alongside the #1676 account-tied storage cleanup (active org id, seen achievements) before ending the session. The #1676 rationale (browser-stored data tied to *this account* shouldn't outlive the session) is reasonable for those, but a UI language pick is a device preference, not account data - it shouldn't need re-selecting after every logout. Verified live on staging: switching to Deutsch, then signing out via "Abmelden", reverted the site (and the following Keycloak login screen) back to English.

`DangerZoneCard.tsx`'s full account-deletion flow (`handleDeleteAccount`) is left untouched - clearing the language choice there is the correct behavior, since "no trace of the account left" is the actual intent of that flow.

Closes #1838

## Testing

- `pnpm format:write`, `pnpm lint`, `pnpm check` all pass clean on the frontend change.
- Added `backend/tests/VisualTests/SignOutLanguagePersistenceTests.cs` (`SignOut_PreservesExplicitLanguageChoice`): logs in via a real `AuthHelper.LoginAsync` round trip (needed since the assertion covers the actual `signoutRedirect()` -> Keycloak -> back-to-frontend flow, not just the client-side handler), explicitly switches the UI language to German, signs out, and asserts both localStorage keys and `<html lang>` still read German after landing back on the (signed-out) home page.
- Couldn't run this new test locally in this sandbox - `dotnet` isn't on `PATH` and installing the pinned SDK is blocked by this session's network egress policy (`builds.dotnet.microsoft.com` returns 403 through the proxy). CI's `dotnet.yml` (`visual-tests` job) runs it on a real runner; will monitor and fix if it fails there.

## Live verification

Skipped for this PR per explicit instruction - no release-candidate tag was cut and nothing was deployed to staging. The added `VisualTests` case above is the durable, CI-run regression coverage for this fix in the meantime.

## Checklist

- [x] `/self-review` run and findings addressed (clean - also fanned out to `a11y-check` since the diff touches a `.tsx` component; confirmed no a11y implications, since the change is a pure non-rendering logic change with no JSX/markup touched)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no documented behavior changes beyond the bug being fixed)

---
_Generated by [Claude Code](https://claude.ai/code/session_013LPWzHcdW8d4maxht4XxFx)_