### PR TITLE
docs: describe the actual navigator-first locale detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Einsatzbereit
 
-Volunteer coordination platform matching helpers with regional needs. English-source UI strings and code; German is the default served locale. See `CONTRIBUTING.md`'s Language Convention for the full breakdown.
+Volunteer coordination platform matching helpers with regional needs. English-source UI strings and code; the served locale is negotiated from the visitor's browser, defaulting to German only when that can't be detected. See `CONTRIBUTING.md`'s Language Convention for the full breakdown.
 
 ## Monorepo Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Every contribution counts - bug reports, ideas, documentation, or code.
 |---|---|
 | UI source strings (i18n keys in `frontend/src/locales/en.json`) | English - add or edit new keys here first |
 | UI German translation (`frontend/src/locales/de.json`) | German - keep in parity with `en.json` via `pnpm i18n:check` |
-| End-user-facing app and documentation | German (`<html lang="de">` is the default served locale; Einsatzbereit's primary audience is German-speaking) |
+| End-user-facing app and documentation | German (Einsatzbereit's primary audience is German-speaking; the UI negotiates the visitor's browser language at runtime and falls back to German - `<html lang="de">` - only when that can't be detected, see `frontend/src/i18n.ts`) |
 | Installed-app metadata (the web app manifest in `frontend/vite.config.ts`) | German only, deliberately - `lang: "de"`, with German `name`/`description`/`shortcuts`. It is built once at build time and served as a single static file, so localising it would mean serving a different manifest per locale; that is not worth building for a German-first audience |
 | Code, commits, issues, pull requests | English |
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -34,7 +34,11 @@ void i18next
 		fallbackLng: "de",
 		supportedLngs: ["de", "en"],
 		detection: {
-			order: ["localStorage", "navigator"],
+			// "navigator" deliberately excluded: German is the documented default served
+			// locale (root AGENTS.md / CONTRIBUTING.md's Language Convention), so an
+			// unset/undetectable language falls through to fallbackLng "de" instead
+			// of the browser's own language preference.
+			order: ["localStorage"],
 			caches: ["localStorage"],
 			lookupLocalStorage: "i18nextLng",
 		},

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -34,11 +34,7 @@ void i18next
 		fallbackLng: "de",
 		supportedLngs: ["de", "en"],
 		detection: {
-			// "navigator" deliberately excluded: German is the documented default served
-			// locale (root AGENTS.md / CONTRIBUTING.md's Language Convention), so an
-			// unset/undetectable language falls through to fallbackLng "de" instead
-			// of the browser's own language preference.
-			order: ["localStorage"],
+			order: ["localStorage", "navigator"],
 			caches: ["localStorage"],
 			lookupLocalStorage: "i18nextLng",
 		},


### PR DESCRIPTION
## What

Update `AGENTS.md` and `CONTRIBUTING.md`'s Language Convention to describe `frontend/src/i18n.ts`'s actual (navigator-first) locale detection, instead of asserting German as the default in absolute terms.

## Why

`detection.order` is `["localStorage", "navigator"]` with `fallbackLng: "de"`. `fallbackLng` only applies when neither detector yields a value i18next recognizes - a browser reporting e.g. `navigator.language = "en-US"` resolves to English on first visit, never reaching the German fallback. This ran counter to root `AGENTS.md`'s "German is the default served locale" and `CONTRIBUTING.md`'s Language Convention.

The issue offered two options: keep navigator-first detection and update the docs (Option B), or change the code so German always wins when undetected (Option A). **This PR went through both during development:**

- First attempt was Option A - drop `"navigator"` from `detection.order`. CI caught a problem the issue didn't anticipate: most of `backend/tests/VisualTests` implicitly relies on the app defaulting to English absent an explicit language switch - `AuthHelper.FastSignInAsync` waits for an English "User menu" button to confirm sign-in, and many tests assert English text right after `Page.GotoAsync` with no language seeded first. Making German the true default broke dozens of tests across the suite (sign-in helper failures cascading through almost every test that uses it, plus direct text-assertion failures) - a blast radius wildly disproportionate to the issue's "Effort: S" estimate for what's labeled a low-priority chore with two "equally defensible" options.
- Reverted `i18n.ts` to its original navigator-first order and went with **Option B** instead: close the gap from the documentation side. `AGENTS.md`'s intro line and `CONTRIBUTING.md`'s Language Convention row now say the served locale is negotiated from the visitor's browser, falling back to German (`<html lang="de">`) only when that can't be detected - matching what actually ships, with zero behavioral or test risk.

Closes #1843

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm test` (249 tests), `pnpm format:write` all pass locally
- `frontend/src/i18n.ts` diff against `main` is empty (fully reverted) - confirmed with `git diff origin/main -- frontend/src/i18n.ts`
- Searched the repo for other places asserting "German is the default served locale" in absolute terms (`vite.config.ts`'s PWA manifest comment, `check-pwa-manifest.js`, a couple of `VisualTests` comments) - those are about the static manifest/shell (genuinely always German, unrelated to the runtime i18next negotiation) or about real-visitor majority behavior, not the detection order itself, so left as-is

## Live verification

Intentionally skipped for this PR at the requester's explicit instruction (no RC tag, no deploy for this change). The change is docs-only - `frontend/src/i18n.ts` has zero net diff against `main` - so there is no runtime behavior to verify on staging.

## Checklist

- [x] `/self-review` run and findings addressed (see Testing - the CI failures from the first approach were the review signal that changed the approach; final diff is docs-only)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (this PR *is* the documentation update - `frontend/src/i18n.ts` itself is unchanged from `main`)