### PR TITLE
fix(frontend): demote Feedback heading and hide it when empty on Manage sign-ups page

### DIFF
--- a/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
@@ -1,0 +1,130 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1835: the "Feedback" section on the per-opportunity
+/// "Manage sign-ups" page (EngagementManagementPage) rendered its heading via
+/// PageSectionHeading - the same font-display text-2xl family as the page's
+/// own H1 (OrgPageHeader) - and stayed on screen with a permanent
+/// "No feedback yet." placeholder even when the opportunity had zero
+/// feedback submissions. The fix demotes the heading to a subordinate size
+/// and only renders the section once there is feedback (or a load error) to
+/// show.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementManagementFeedbackSectionTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task EngagementManagementPage_OmitsFeedbackSection_WhenNoFeedbackSubmitted()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (organizationId, opportunityId, _) = await SeedConfirmedEngagementAsync("NoFeedback");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync(
+			$"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback" }))
+			.Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task EngagementManagementPage_ShowsSubordinateFeedbackHeading_WhenFeedbackExists()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (organizationId, opportunityId, engagementId) =
+			await SeedConfirmedEngagementAsync("WithFeedback");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/check-in", null)).EnsureSuccessStatusCode();
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		(await veraHttp.PostAsJsonAsync($"/v1/engagements/{engagementId}/feedback", new { rating = 5, comment = "Great!" }))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync(
+			$"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var pageTitle = Page.Locator("main").GetByRole(AriaRole.Heading, new() { Level = 1 });
+		await Expect(pageTitle).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var feedbackHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback" });
+		await Expect(feedbackHeading).ToBeVisibleAsync();
+
+		// The bug was purely visual weight (same face/size family as the page's
+		// own H1), not structure - assert the rendered heading is actually
+		// smaller than the page title rather than just present.
+		var titleFontSize = await pageTitle.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).fontSize)");
+		var feedbackFontSize = await feedbackHeading.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).fontSize)");
+
+		feedbackFontSize.Should().BeLessThan(titleFontSize,
+			"the \"Feedback\" section heading must stay visually subordinate to the page's own title (#1835)");
+	}
+
+	private async Task<(string OrganizationId, string OpportunityId, string EngagementId)> SeedConfirmedEngagementAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		// Fresh organization rather than olaf's shared seed org - other
+		// VisualTests running concurrently in this shared Aspire session can
+		// mutate/delete shared orgs (see EngagementManagementCheckInPinTests).
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"FeedbackSection {label} Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"FeedbackSection {label} Opportunity {suffix}",
+			description = "Created by EngagementManagementFeedbackSectionTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString()!;
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		var applyResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = $"{label} application." });
+		applyResponse.EnsureSuccessStatusCode();
+		var engagement = await applyResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString()!;
+
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", null)).EnsureSuccessStatusCode();
+
+		return (organizationId, opportunityId, engagementId);
+	}
+}

--- a/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
@@ -31,7 +31,7 @@ public class EngagementManagementFeedbackSectionTests(AspireFixture fixture) : V
 			$"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback" }))
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback", Exact = true }))
 			.Not.ToBeVisibleAsync();
 	}
 
@@ -64,7 +64,7 @@ public class EngagementManagementFeedbackSectionTests(AspireFixture fixture) : V
 		var pageTitle = Page.Locator("main").GetByRole(AriaRole.Heading, new() { Level = 1 });
 		await Expect(pageTitle).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		var feedbackHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback" });
+		var feedbackHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Feedback", Exact = true });
 		await Expect(feedbackHeading).ToBeVisibleAsync();
 
 		// The bug was purely visual weight (same face/size family as the page's

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -576,7 +576,6 @@
       "averageRating": "{{rating}} von 5 ({{count}} Bewertungen)",
       "itemRatingLabel": "{{rating}} von 5 Sternen",
       "organizerTab": "Feedback",
-      "noFeedback": "Noch kein Feedback.",
       "loadMore": "Mehr laden",
       "starLabel_one": "{{count}} Stern",
       "starLabel_other": "{{count}} Sterne",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -576,7 +576,6 @@
       "averageRating": "{{rating}} out of 5 ({{count}} ratings)",
       "itemRatingLabel": "{{rating}} out of 5 stars",
       "organizerTab": "Feedback",
-      "noFeedback": "No feedback yet.",
       "loadMore": "Load more",
       "starLabel_one": "{{count}} star",
       "starLabel_other": "{{count}} stars",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -17,7 +17,6 @@ import Chip from "../components/Chip";
 import LoadMoreError from "../components/LoadMoreError";
 import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
-import PageSectionHeading from "../components/PageSectionHeading";
 import NotFoundPage from "./NotFoundPage";
 import { formatDate, formatDateTime, resolveDateLocale } from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -997,71 +996,74 @@ export default function EngagementManagementPage() {
 				</ConfirmDialog>
 			)}
 
-			{feedbackStats !== null ? (
+			{feedbackStats !== null && feedbackStats.feedbackCount > 0 ? (
 				<section className="mt-8">
-					<PageSectionHeading>{t("feedback.organizerTab")}</PageSectionHeading>
-					{feedbackStats.feedbackCount === 0 ? (
-						<EmptyState title={t("feedback.noFeedback")} />
-					) : (
-						<>
-							<p className="mb-4 text-sm text-gray-700">
-								{t("feedback.averageRating", {
-									rating:
-										feedbackStats.averageRating?.toLocaleString(locale, {
-											minimumFractionDigits: 1,
-											maximumFractionDigits: 1,
-										}) ?? "-",
-									count: feedbackStats.feedbackCount,
-								})}
-							</p>
-							<ul className="space-y-3">
-								{feedbackItems.map((item, idx) => (
-									<li key={idx} className={cardClass}>
-										<div
-											className="flex items-center gap-1"
-											role="img"
-											aria-label={t("feedback.itemRatingLabel", {
-												rating: item.rating,
-											})}
-										>
-											{[1, 2, 3, 4, 5].map((s) => (
-												<StarIcon
-													key={s}
-													className={`h-4 w-4 ${s <= item.rating ? "text-yellow-700" : "text-gray-500"}`}
-												/>
-											))}
-											<span className="ml-1 text-xs text-gray-500">
-												{formatDate(
-													item.submittedAt as unknown as string,
-													i18n.language,
-												)}
-											</span>
-										</div>
-										{item.comment && (
-											<p className="mt-1 text-sm text-gray-700">
-												{item.comment}
-											</p>
+					{/* Deliberately not PageSectionHeading (#1835): that's the
+					font-display text-2xl family shared with OrgPageHeader's own H1,
+					so a "Feedback" section read as a second page title rather than a
+					subordinate part of sign-up management. Also omitted entirely
+					(see the outer condition) once there is nothing to show, instead
+					of a permanent "No feedback yet." placeholder competing with the
+					sign-ups list above it. */}
+					<h2 className="mb-4 text-lg font-semibold text-gray-900">
+						{t("feedback.organizerTab")}
+					</h2>
+					<p className="mb-4 text-sm text-gray-700">
+						{t("feedback.averageRating", {
+							rating:
+								feedbackStats.averageRating?.toLocaleString(locale, {
+									minimumFractionDigits: 1,
+									maximumFractionDigits: 1,
+								}) ?? "-",
+							count: feedbackStats.feedbackCount,
+						})}
+					</p>
+					<ul className="space-y-3">
+						{feedbackItems.map((item, idx) => (
+							<li key={idx} className={cardClass}>
+								<div
+									className="flex items-center gap-1"
+									role="img"
+									aria-label={t("feedback.itemRatingLabel", {
+										rating: item.rating,
+									})}
+								>
+									{[1, 2, 3, 4, 5].map((s) => (
+										<StarIcon
+											key={s}
+											className={`h-4 w-4 ${s <= item.rating ? "text-yellow-700" : "text-gray-500"}`}
+										/>
+									))}
+									<span className="ml-1 text-xs text-gray-500">
+										{formatDate(
+											item.submittedAt as unknown as string,
+											i18n.language,
 										)}
-									</li>
-								))}
-							</ul>
-							{!feedbackLoading &&
-								!feedbackError &&
-								feedbackItems.length > 0 &&
-								hasMoreFeedback && (
-									<LoadMoreButton
-										loading={feedbackLoadingMore}
-										label={t("feedback.loadMore")}
-										loadingLabel={t("engagementManagement.loading")}
-										onClick={loadMoreFeedback}
-									/>
+									</span>
+								</div>
+								{item.comment && (
+									<p className="mt-1 text-sm text-gray-700">{item.comment}</p>
 								)}
-						</>
-					)}
+							</li>
+						))}
+					</ul>
+					{!feedbackLoading &&
+						!feedbackError &&
+						feedbackItems.length > 0 &&
+						hasMoreFeedback && (
+							<LoadMoreButton
+								loading={feedbackLoadingMore}
+								label={t("feedback.loadMore")}
+								loadingLabel={t("engagementManagement.loading")}
+								onClick={loadMoreFeedback}
+							/>
+						)}
 				</section>
 			) : feedbackError ? (
 				<section className="mt-8">
-					<PageSectionHeading>{t("feedback.organizerTab")}</PageSectionHeading>
+					<h2 className="mb-4 text-lg font-semibold text-gray-900">
+						{t("feedback.organizerTab")}
+					</h2>
 					<LoadMoreError
 						message={t("feedback.error", { message: feedbackError })}
 						retrying={feedbackLoading}


### PR DESCRIPTION
## What

On the per-opportunity "Manage sign-ups" page (`EngagementManagementPage.tsx`), demote the "Feedback" section heading to a subordinate size and omit the section entirely when there is no feedback to show.

## Why

The "Feedback" section heading used the shared `PageSectionHeading` component - the same `font-display text-2xl font-bold` family as the page's own H1 (`OrgPageHeader.tsx`) - so it read as a second, equally-weighted page title rather than a subordinate part of sign-up management. The section also rendered unconditionally as soon as feedback stats loaded, showing a permanent "No feedback yet." placeholder even for opportunities with zero feedback submissions, adding a fourth visually-competing block (toolbar, sign-ups list, row actions, feedback) with no clear focal point.

Closes #1835

## Changes

- Replaced `<PageSectionHeading>` with a plain `<h2 className="mb-4 text-lg font-semibold text-gray-900">` for the "Feedback" heading (both the with-content and error-state branches) - correct heading semantics preserved (h1 -> h2), just demoted visual weight.
- Changed the render condition from `feedbackStats !== null` to `feedbackStats !== null && feedbackStats.feedbackCount > 0`, so the whole section (heading + content) is omitted once there's nothing to show, instead of rendering a heading plus an `EmptyState` placeholder.
- Removed the now-unused `PageSectionHeading` import and the now-dead `feedback.noFeedback` translation key from `en.json`/`de.json`.

The row's duplicate `bg-green-50` status-pill styling ("Checked in" vs "Confirmed") mentioned as a sub-detail in the issue is explicitly called out there as *not* part of this finding, so it's left out of scope here.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm format:check`, `pnpm i18n:check`, `pnpm test` all pass locally.
- Added `backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs` with two new TUnit/Playwright cases against the Aspire stack:
  - `EngagementManagementPage_OmitsFeedbackSection_WhenNoFeedbackSubmitted` - asserts no "Feedback" heading renders for a fresh opportunity with zero feedback.
  - `EngagementManagementPage_ShowsSubordinateFeedbackHeading_WhenFeedbackExists` - seeds a confirmed, checked-in engagement with submitted feedback, then asserts the "Feedback" `<h2>` is visible **and** its computed font-size is smaller than the page's own H1 - directly encoding the "visually subordinate, not competing" acceptance criterion from the issue.
- Backend compilation of the new test file could not be verified locally in this sandbox (the .NET SDK install is blocked by this session's egress policy - `builds.dotnet.microsoft.com` is not on the allowed host list) - relying on CI's `dotnet.yml` (`build` + `visual-tests` jobs) to catch any compile/runtime issues, and will monitor and fix.

## Live verification

Not performed for this PR - per explicit instruction for this task, no release-candidate tag was cut and nothing was deployed to staging. Verification relies on the new automated Playwright/TUnit test above, which runs against the local Aspire stack in CI (`dotnet.yml`'s `visual-tests` job).

## Checklist

- [x] `/self-review` run and findings addressed (no issues found; `a11y-check` and `i18n-check` subagents also ran clean on this diff)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal UI-only fix, no docs reference this section)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K42rgLWf28UiqjZgDC5Nn4)_