### PR TITLE
fix: narrow account pages' PageHeaderBand title to a content-page scale

### DIFF
--- a/backend/tests/VisualTests/AccountPageHeaderScaleTests.cs
+++ b/backend/tests/VisualTests/AccountPageHeaderScaleTests.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for #1841: the account pages (/profile, /profile/settings,
+/// /my-signups) reused PageHeaderBand's full marketing-hero type scale
+/// (72px, the same treatment HomePage's hero uses) for a two-word page title
+/// sitting above a short form or a thin list - disproportionate to that
+/// content, on the same band the legal/help/contact pages use to read as
+/// still-the-same-product on arrival from the landing page's footer (#1755).
+///
+/// PageHeaderBand's new `compactTitle` prop narrows the type scale for just
+/// that page family, keeping the band's brand surface (colour, wave cap, no
+/// BreadcrumbBar) unchanged - this is the one thing #1841 asked not to
+/// revisit. The legal/help pages therefore get their own assertion here too,
+/// pinning that the hero scale survives for the family this band was
+/// originally built for.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class AccountPageHeaderScaleTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	[Arguments("/profile", "My profile")]
+	[Arguments("/profile/settings", "Settings")]
+	[Arguments("/my-signups", "My sign-ups")]
+	public async Task AccountPage_RendersCompactTitle_NotTheMarketingHeroScale(string path, string title)
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}{path}");
+
+		var heading = Page.Locator("main").GetByRole(AriaRole.Heading, new() { Name = title, Level = 1 });
+		await Expect(heading).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Same 48px threshold OrgAppCompactHeaderTests uses for the org app's
+		// own compact header - well under the band's default lg:text-7xl
+		// (72px) and comfortably above the compact text-3xl/sm:text-4xl scale
+		// (30px/36px) this page family now renders at.
+		var headingFontSizePx = await heading.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).fontSize)");
+		headingFontSizePx.Should().BeLessThan(48,
+			$"{path} holds a short form or a thin list, not an introduction - " +
+			"the band's brand surface stays, but compactTitle narrows the h1");
+
+		// The brand surface itself - the one thing #1841 explicitly did not
+		// revisit - is unchanged: still the same dark band, wave cap and no
+		// BreadcrumbBar restating the title a second time.
+		await Expect(Page.Locator("main .bg-brand-800")).ToHaveCountAsync(1);
+		await Expect(Page.Locator("main svg[viewBox='0 0 1440 60']")).ToHaveCountAsync(1);
+		await Expect(Page.Locator("header + div nav[aria-label='Breadcrumb']")).ToHaveCountAsync(0);
+	}
+
+	[Test]
+	[Arguments("/help", "Help")]
+	[Arguments("/imprint", "Imprint")]
+	public async Task LegalOrHelpPage_KeepsTheFullMarketingHeroScale_Unaffected(string path, string title)
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}{path}");
+
+		var heading = Page.Locator("main").GetByRole(AriaRole.Heading, new() { Name = title, Level = 1 });
+		await Expect(heading).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var headingFontSizePx = await heading.EvaluateAsync<double>(
+			"el => parseFloat(getComputedStyle(el).fontSize)");
+		headingFontSizePx.Should().BeGreaterThanOrEqualTo(48,
+			$"{path} is the page family PageHeaderBand's hero scale was built for (#1755) - " +
+			"#1841 narrows compactTitle pages only, it does not revisit this");
+	}
+}

--- a/frontend/src/components/PageHeaderBand.tsx
+++ b/frontend/src/components/PageHeaderBand.tsx
@@ -24,6 +24,15 @@ interface Props {
 	 * want the default.
 	 */
 	fullWidth?: boolean;
+	/**
+	 * Use a content-page type scale (text-3xl/sm:text-4xl) for the <h1>
+	 * instead of the marketing-hero scale (text-5xl/sm:text-6xl/lg:text-7xl).
+	 * For pages in the band's account-page family whose content is a short
+	 * form or a thin list, not an introduction - see #1841. The band's brand
+	 * surface (colour, glow blobs, wave cap) is unchanged; only the title
+	 * shrinks.
+	 */
+	compactTitle?: boolean;
 }
 
 // Shared title band for the standalone public pages (help, contact, imprint,
@@ -50,6 +59,14 @@ interface Props {
 //     transparent while that's true. --header-height is added back as top
 //     padding so the eyebrow doesn't start underneath the header bar.
 //
+// The account pages (ProfileOverviewPage, ProfileSettingsPage,
+// MyEngagementsPage) opt into `compactTitle` (#1841): they keep this band's
+// brand surface for the same continuity reason, but their content is a form
+// or a thin list, not an introduction, so the 72px marketing-hero title read
+// as disproportionate. The legal/help/contact pages this band was built for
+// keep the full hero scale - #1841 narrows the type scale for that one page
+// family, it does not revisit the brand-surface decision below.
+//
 // These pages carry no BreadcrumbBar (the pages using this band stopped
 // calling usePageToolbar in #1755): a separate grey bar restating the page
 // title directly above a band that states it in 72px display type was pure
@@ -69,6 +86,7 @@ export default function PageHeaderBand({
 	lead,
 	children,
 	fullWidth = false,
+	compactTitle = false,
 }: Props) {
 	useOverlaysHeader();
 	// Same QuickActionsContext the BreadcrumbBar reads. A page using this band
@@ -132,7 +150,13 @@ export default function PageHeaderBand({
 						<p className="animate-fade-up text-xs font-semibold tracking-widest text-brand-200 uppercase">
 							{eyebrow}
 						</p>
-						<h1 className="animate-fade-up-d1 mt-3 max-w-4xl font-display text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl">
+						<h1
+							className={`animate-fade-up-d1 mt-3 max-w-4xl font-display font-bold tracking-tight text-white ${
+								compactTitle
+									? "text-3xl sm:text-4xl"
+									: "text-5xl sm:text-6xl lg:text-7xl"
+							}`}
+						>
 							{title}
 						</h1>
 						{lead && (

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -316,9 +316,10 @@ export default function ActivitySection() {
 			)}
 
 			{/* No visible heading for the sign-ups list itself (#1796): this list
-			*is* the page, and PageHeaderBand's <h1> already names it in 72px
-			display type ~200px further up - so a SectionHeading repeating that
-			same string read as a category eyebrow that carried no category, and
+			*is* the page, and PageHeaderBand's <h1> already names it further up
+			(compactTitle since #1841 - still display type, just not 72px) - so a
+			SectionHeading repeating that same string read as a category eyebrow
+			that carried no category, and
 			pushed the scope tabs down a page that is short of content to begin
 			with. The invitations block above keeps its visible heading, because
 			that one names a section the <h1> does not.

--- a/frontend/src/pages/MyEngagementsPage/index.tsx
+++ b/frontend/src/pages/MyEngagementsPage/index.tsx
@@ -17,6 +17,7 @@ export default function MyEngagementsPage() {
 			<PageHeaderBand
 				eyebrow={t("profile.eyebrow")}
 				title={t("myEngagementsPage.title")}
+				compactTitle
 			/>
 
 			<div

--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -350,6 +350,7 @@ export default function ProfileOverviewPage() {
 			<PageHeaderBand
 				eyebrow={t("profile.eyebrow")}
 				title={t("profile.title")}
+				compactTitle
 			/>
 
 			<div

--- a/frontend/src/pages/ProfileSettingsPage/index.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/index.tsx
@@ -18,6 +18,7 @@ export default function ProfileSettingsPage() {
 			<PageHeaderBand
 				eyebrow={t("profile.eyebrow")}
 				title={t("profileSettings.title")}
+				compactTitle
 			/>
 
 			<div


### PR DESCRIPTION
## What

`PageHeaderBand` gains an opt-in `compactTitle` prop that renders its `<h1>` at a content-page type scale (`text-3xl`/`sm:text-4xl`) instead of the marketing-hero scale (`text-5xl`/`sm:text-6xl`/`lg:text-7xl`). `/profile`, `/profile/settings` and `/my-signups` now pass it; every other consumer (help, contact, imprint, terms, privacy policy, opportunities, org profile, opportunity detail, administration) is unchanged.

## Why

Closes #1841

The three account pages mount `PageHeaderBand` with a two-word title above a short form or a thin list (a five-checkbox settings form, a sign-ups list), but rendered it at the exact same 72px, full-bleed marketing-hero treatment `HomePage`'s own hero uses - disproportionate to that content, per the issue's F1 finding.

The issue explicitly flags this as revisiting a deliberate, documented decision (`PageHeaderBand.tsx:29-57`, #1755: giving these pages the landing page's own visual language so a visitor doesn't land somewhere that reads like a different product) rather than an oversight, and scopes the fix narrowly: keep the band's brand surface (colour, wave cap, no `BreadcrumbBar`) for continuity, only narrow the title's type scale, and only for this page family. `compactTitle` is additive and opt-in for exactly that reason - every other page keeps the original #1755 hero scale untouched.

## Testing

- `pnpm lint`, `pnpm format:write` (no changes), `pnpm check` (tsc) - all clean.
- Added `backend/tests/VisualTests/AccountPageHeaderScaleTests.cs`:
  - Asserts `/profile`, `/profile/settings`, `/my-signups` render their `<h1>` under 48px (the compact scale) while keeping the band's brand surface (`bg-brand-800`, wave-cap `<svg>`, no `BreadcrumbBar`).
  - Asserts `/help` and `/imprint` keep the original hero scale (>=48px), pinning that this change is scoped to the account-page family and does not revisit the #1755 brand-surface decision for the pages it was built for.
- No new route was added, so no new `AccessibilityTests.cs` case is needed - `/profile`, `/profile/settings` and `/my-signups` already have axe-core coverage there and it re-runs against the changed markup.
- `/self-review` run, including the `a11y-check` subagent (heading hierarchy, colour contrast on `text-white`/`bg-brand-800` at the smaller size, SVG `aria-hidden`) - no issues found.

## Live verification

Not performed for this PR - out of scope per explicit instruction for this task (no RC tag, no deploy). This is a CSS-scale change with no backend/API surface; CI's `dotnet.yml` (including the new `VisualTests` case above, which exercises the change against a real browser) and `frontend.yml` are the verification for this change.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (comments in `PageHeaderBand.tsx` and `ActivitySection.tsx` updated to reflect the new prop)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUKzorAD7vRBEaYQYjMvDo)_