### PR TITLE
fix(frontend): group notification preference checkboxes by audience

### DIFF
--- a/backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs
+++ b/backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs
@@ -18,6 +18,10 @@ namespace VisualTests;
 /// fixture.ResetAsync() plus the keyed [NotInParallel], which excludes only the
 /// other classes sharing the "visualtests-db" key rather than the whole
 /// assembly.
+///
+/// #1844 added the grouping tests below: once both audiences' rows are
+/// visible (Olaf), they render under two "As an organizer" / "As a
+/// volunteer" headings instead of one flat list.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 [NotInParallel("visualtests-db")]
@@ -79,6 +83,67 @@ public class NotificationPreferencesOrganizerRowsTests(AspireFixture fixture) : 
 		await Expect(Page.GetByText(NewSignUpLabel)).ToBeVisibleAsync();
 		await Expect(Page.GetByText(WithdrawalLabel)).ToBeVisibleAsync();
 		await Expect(Page.Locator("main input[type='checkbox']")).ToHaveCountAsync(5);
+	}
+
+	[Test]
+	public async Task ProfileSettings_OrganizationMember_GroupsPreferencesByAudience()
+	{
+		// #1844: for an account with both audiences (Olaf), the five checkboxes
+		// must read as two labelled groups - "As an organizer" / "As a
+		// volunteer" - instead of one undifferentiated list mixing both.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/profile/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.Locator("#notifyOnNewSignUp")).ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "As an organizer", Level = 3 }))
+			.ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "As a volunteer", Level = 3 }))
+			.ToBeVisibleAsync();
+
+		// Each group heading sits directly above its own rows, not interleaved
+		// with the other group's - verified by document order via InnerText
+		// rather than bounding boxes, since a wrapping layout would still be
+		// correct DOM order but different y-coordinates.
+		var mainText = await Page.Locator("main").InnerTextAsync();
+		var organizerHeadingIndex = mainText.IndexOf("As an organizer", StringComparison.Ordinal);
+		var volunteerHeadingIndex = mainText.IndexOf("As a volunteer", StringComparison.Ordinal);
+		var newSignUpIndex = mainText.IndexOf(NewSignUpLabel, StringComparison.Ordinal);
+		var confirmedIndex = mainText.IndexOf("Your sign-up is confirmed", StringComparison.Ordinal);
+
+		organizerHeadingIndex.Should().BeGreaterThanOrEqualTo(0);
+		volunteerHeadingIndex.Should().BeGreaterThan(organizerHeadingIndex,
+			"the organizer group heading must come before the volunteer group heading");
+		newSignUpIndex.Should().BeInRange(organizerHeadingIndex, volunteerHeadingIndex,
+			"the organizer-only row must render under the organizer heading, not the volunteer one");
+		confirmedIndex.Should().BeGreaterThan(volunteerHeadingIndex,
+			"the always-visible row must render under the volunteer heading");
+	}
+
+	[Test]
+	public async Task ProfileSettings_VolunteerWithoutOrganization_HasNoGroupHeadings()
+	{
+		// #1844: a plain volunteer only ever sees one audience of rows, so the
+		// grouping fix must not surface an empty or redundant group heading
+		// for her - just the flat list she already had.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/profile/settings");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.Locator("#notifyOnEngagementConfirmed"))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "As an organizer" }))
+			.ToHaveCountAsync(0);
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "As a volunteer" }))
+			.ToHaveCountAsync(0);
 	}
 
 	[Test]

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1112,6 +1112,8 @@
     "notificationPreferences": {
       "title": "E-Mail-Benachrichtigungen",
       "description": "Wähle aus, welche transaktionalen E-Mails du erhalten möchtest. Jede E-Mail enthält außerdem einen Abmeldelink für den jeweiligen Typ.",
+      "organizerGroupLabel": "Als Organisator:in",
+      "volunteerGroupLabel": "Als Freiwillige:r",
       "newSignUp": "Neue Anmeldungen für Einsätze, die du organisierst",
       "withdrawal": "Rückzüge von Freiwilligen bei Einsätzen, die du organisierst",
       "engagementConfirmed": "Deine Anmeldung wird bestätigt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1112,6 +1112,8 @@
     "notificationPreferences": {
       "title": "Email notifications",
       "description": "Choose which transactional emails you want to receive. Every email also includes an unsubscribe link for the type it belongs to.",
+      "organizerGroupLabel": "As an organizer",
+      "volunteerGroupLabel": "As a volunteer",
       "newSignUp": "New sign-ups for opportunities you organize",
       "withdrawal": "Volunteer withdrawals from opportunities you organize",
       "engagementConfirmed": "Your sign-up is confirmed",

--- a/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
+++ b/frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx
@@ -50,6 +50,40 @@ const PREFERENCE_ROWS: {
 	},
 ];
 
+// Extracted so the grouped (organizer + volunteer) and flat (volunteer-only)
+// layouts below render the exact same row markup instead of two copies of it.
+function PreferenceRowList({
+	rows,
+	preferences,
+	onToggle,
+}: {
+	rows: typeof PREFERENCE_ROWS;
+	preferences: NotificationPreferencesResponse;
+	onToggle: (key: PreferenceKey) => void;
+}) {
+	const { t } = useTranslation();
+	return (
+		<div className="space-y-3">
+			{rows.map((row) => (
+				<label
+					key={row.key}
+					htmlFor={row.key}
+					className="flex cursor-pointer items-start gap-3 py-1"
+				>
+					<input
+						type="checkbox"
+						id={row.key}
+						checked={preferences[row.key]}
+						onChange={() => onToggle(row.key)}
+						className="mt-0.5 h-4 w-4 accent-brand-600"
+					/>
+					<span className="text-sm text-gray-800">{t(row.labelKey)}</span>
+				</label>
+			))}
+		</div>
+	);
+}
+
 // Self-contained email-notification-preferences card (#1055), split out of
 // ProfileOverviewPage in the same style as DangerZoneCard, relocated to
 // ProfileSettingsPage - see #1684. Owns its own fetch/save/error state and
@@ -105,6 +139,12 @@ export default function NotificationPreferencesSection() {
 	const visibleRows = PREFERENCE_ROWS.filter(
 		(row) => !row.organizerOnly || organizerRowsVisible,
 	);
+	// #1844: once the organizer rows are visible, the flat list mixes two
+	// audiences of the same account with no separation - split it into the two
+	// groups below rather than growing a third layout for the always-volunteer
+	// case, where a single group heading would just repeat the card title.
+	const organizerRows = visibleRows.filter((row) => row.organizerOnly);
+	const volunteerRows = visibleRows.filter((row) => !row.organizerOnly);
 	// Held until the organization list resolves too, so the two organizer rows
 	// appear with the rest of the list instead of popping in a beat later.
 	const loading = preferencesLoading || orgsLoading;
@@ -177,24 +217,36 @@ export default function NotificationPreferencesSection() {
 						/>
 					)}
 
-					<div className="space-y-3">
-						{visibleRows.map((row) => (
-							<label
-								key={row.key}
-								htmlFor={row.key}
-								className="flex cursor-pointer items-start gap-3 py-1"
-							>
-								<input
-									type="checkbox"
-									id={row.key}
-									checked={preferences[row.key]}
-									onChange={() => toggle(row.key)}
-									className="mt-0.5 h-4 w-4 accent-brand-600"
+					{organizerRowsVisible ? (
+						<div className="space-y-4">
+							<div>
+								<h3 className="mb-3 text-sm font-semibold text-gray-900">
+									{t("notificationPreferences.organizerGroupLabel")}
+								</h3>
+								<PreferenceRowList
+									rows={organizerRows}
+									preferences={preferences}
+									onToggle={toggle}
 								/>
-								<span className="text-sm text-gray-800">{t(row.labelKey)}</span>
-							</label>
-						))}
-					</div>
+							</div>
+							<div>
+								<h3 className="mb-3 text-sm font-semibold text-gray-900">
+									{t("notificationPreferences.volunteerGroupLabel")}
+								</h3>
+								<PreferenceRowList
+									rows={volunteerRows}
+									preferences={preferences}
+									onToggle={toggle}
+								/>
+							</div>
+						</div>
+					) : (
+						<PreferenceRowList
+							rows={visibleRows}
+							preferences={preferences}
+							onToggle={toggle}
+						/>
+					)}
 
 					<Button type="submit" size="sm" disabled={saving}>
 						{saving


### PR DESCRIPTION
## What

Splits the five email-notification checkboxes on `/profile/settings` into two labelled groups - "As an organizer" / "As a volunteer" - when both audiences are visible for the account, instead of one flat, undifferentiated list.

## Why

For an account that is both organizer and volunteer (e.g. Olaf), the two organizer-facing rows ("New sign-ups for opportunities you organize", "Volunteer withdrawals from opportunities you organize") and the three volunteer-facing rows ("Your sign-up is confirmed", "Your sign-up is cancelled", "Reminder before your opportunity starts") addressed two different audiences of the same account with no visual separation. The row wording already distinguishes the two audiences, so nothing was ambiguous - just unstructured (Nielsen heuristic #4, consistency and standards).

Closes #1844

## Testing

- `frontend/src/pages/ProfileSettingsPage/NotificationPreferencesSection.tsx`: extracted the existing checkbox-row markup into a shared `PreferenceRowList` helper so the grouped (organizer + volunteer) and flat (volunteer-only, when there's only one audience) layouts render identical markup. When the organizer rows are visible, the list renders as two `<h3>`-headed groups ("As an organizer" / "As a volunteer"), matching the existing subheading pattern used in `ProfileOverviewPage`. When only the volunteer audience is visible, the original flat list is kept unchanged - a lone group heading there would just repeat the card's own title.
- Added two new translation keys (`notificationPreferences.organizerGroupLabel` / `volunteerGroupLabel`) to both `en.json` and `de.json`, following this repo's gender-neutral German phrasing convention (`Organisator:in` / `Freiwillige:r`).
- Added two new Playwright tests to `backend/tests/VisualTests/NotificationPreferencesOrganizerRowsTests.cs`:
  - `ProfileSettings_OrganizationMember_GroupsPreferencesByAudience` (Olaf) - asserts both group headings are visible and that each group's rows render under the correct heading, in document order.
  - `ProfileSettings_VolunteerWithoutOrganization_HasNoGroupHeadings` (Vera) - asserts neither group heading appears for an account with only one audience.
- The three existing tests in that same file (checkbox IDs, counts, save payload) are unaffected - checkbox `id`s, visible text, and counts are unchanged, only the surrounding grouping markup changed.
- Ran locally: `pnpm lint`, `pnpm check` (tsc), `pnpm format:write` (no changes), `pnpm i18n:check`, `pnpm test` (Vitest) - all green.
- Also ran `/self-review`, including the `a11y-check` and `i18n-check` subagents - no findings. `a11y-check` confirmed the new `<h3>`s nest correctly under the card's existing `<h2>` and that `backend/tests/VisualTests/AccessibilityTests.cs` already scans `/profile/settings` for both an organizer-member account (exercising the new grouped branch) and a plain volunteer (exercising the flat-fallback branch), so no new a11y test was needed.
- **Not run in this session:** `dotnet build` / `Application.UnitTests` / `ArchitectureTests` / the new `VisualTests` cases themselves - this sandbox's egress policy blocks the .NET SDK download (`builds.dotnet.microsoft.com`), so the .NET toolchain isn't available locally here. CI's `dotnet.yml` will build and run the full suite including the new `VisualTests` cases.

## Live verification

Per explicit instruction for this task, no release candidate was cut and nothing was deployed - only a PR was requested, to be merged after CI is green. This intentionally skips root `AGENTS.md`'s otherwise-mandatory deploy-and-verify flow for this change; the new `VisualTests` cases above are the durable, reviewable record of the fix and will run against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no user-facing docs describe this section's layout)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117a1kGjL3J7dKMPkTKkguW)_