### PR TITLE
fix: escape literal apostrophes in Keycloak English auth messages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,22 @@ jobs:
             exit 1
           fi
 
+  ban-unescaped-keycloak-apostrophes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Ban unescaped apostrophes in Keycloak English messages
+        # Keycloak resolves these values through java.text.MessageFormat, which
+        # treats a bare ' as the start of a quoted-literal escape and silently
+        # drops it - a literal apostrophe has to be written as '' (#1854).
+        run: |
+          FILE=keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+          if grep -nE '^[^#[:space:]].*=' "$FILE" | grep -P "(?<!')'(?!')"; then
+            echo "::error::Unescaped apostrophe in $FILE - MessageFormat silently drops it. Escape literal apostrophes as '' (see #1854)."
+            exit 1
+          fi
+
   editorconfig:
     runs-on: ubuntu-latest
     steps:

--- a/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
@@ -1,9 +1,9 @@
 loginTitle=Sign In
 registerTitle=Create Account
 emailForgotTitle=Reset Password
-emailForgotIntro=Enter your username or email address. We'll send you a link to set a new password.
+emailForgotIntro=Enter your username or email address. We''ll send you a link to set a new password.
 doSubmitResetPassword=Send reset link
-noAccount=Don't have an account yet?
+noAccount=Don''t have an account yet?
 alreadyHaveAccount=Already have an account?
 backToLogin=Back to Sign In
 backToSite=Back to Einsatzbereit
@@ -35,32 +35,32 @@ missingPasswordMessage=Enter your password.
 missingEmailMessage=Enter an email address.
 missingFirstNameMessage=Enter your first name.
 missingLastNameMessage=Enter your last name.
-invalidEmailMessage=That doesn't look like a valid email address.
-invalidUserMessage=That username or password doesn't match.
-invalidUsernameOrEmailMessage=That username or email address doesn't match.
-invalidPasswordMessage=That password doesn't match.
+invalidEmailMessage=That doesn''t look like a valid email address.
+invalidUserMessage=That username or password doesn''t match.
+invalidUsernameOrEmailMessage=That username or email address doesn''t match.
+invalidPasswordMessage=That password doesn''t match.
 accountDisabledMessage=This account is disabled. Contact the platform operator.
 accountTemporarilyDisabledMessage=This account is temporarily locked. Try again later or contact the platform operator.
 usernameExistsMessage=That username is taken. Pick a different one.
 emailExistsMessage=An account with that email address already exists.
-readOnlyUsernameMessage=Your username can't be changed.
+readOnlyUsernameMessage=Your username can''t be changed.
 termsAcceptanceRequired=Accept the Terms of Use to continue.
 
 # Password rules, phrased as what to do rather than as a verdict on what you
 # typed. Keycloak's stock strings all open with "Invalid password:", which
 # repeats the obvious and buries the one thing that would let you fix it.
-notMatchPasswordMessage=The passwords don't match.
-invalidPasswordConfirmMessage=The passwords don't match.
+notMatchPasswordMessage=The passwords don''t match.
+invalidPasswordConfirmMessage=The passwords don''t match.
 invalidPasswordMinLengthMessage=Your password must be at least {0} characters long.
 invalidPasswordMaxLengthMessage=Your password can be at most {0} characters long.
 invalidPasswordMinUpperCaseCharsMessage=Your password needs at least {0} uppercase letters.
 invalidPasswordMinLowerCaseCharsMessage=Your password needs at least {0} lowercase letters.
 invalidPasswordMinDigitsMessage=Your password needs at least {0} digits.
 invalidPasswordMinSpecialCharsMessage=Your password needs at least {0} special characters.
-invalidPasswordNotUsernameMessage=Your password can't be the same as your username.
-invalidPasswordNotContainsUsernameMessage=Your password can't contain your username.
-invalidPasswordNotEmailMessage=Your password can't be the same as your email address.
-invalidPasswordHistoryMessage=Pick a password you haven't used in your last {0}.
+invalidPasswordNotUsernameMessage=Your password can''t be the same as your username.
+invalidPasswordNotContainsUsernameMessage=Your password can''t contain your username.
+invalidPasswordNotEmailMessage=Your password can''t be the same as your email address.
+invalidPasswordHistoryMessage=Pick a password you haven''t used in your last {0}.
 invalidPasswordBlacklistedMessage=That password appears in a list of commonly used passwords. Pick a different one.
 
 # ---------------------------------------------------------------------------
@@ -71,11 +71,11 @@ invalidPasswordBlacklistedMessage=That password appears in a list of commonly us
 # Email verification. Reached by every new account: the realm has verifyEmail
 # on, which is also why the registration form collects no password.
 emailVerifyTitle=Confirm your email
-registerNoPasswordLead=We'll email you a link to confirm your address. You'll set your password right after.
+registerNoPasswordLead=We''ll email you a link to confirm your address. You''ll set your password right after.
 emailVerifyInstruction1=We sent a confirmation link to {0}. Open it to activate your account.
 emailVerifyInstruction2=No email yet? Check your spam folder, or
 emailVerifyInstruction3=send it again
-emailVerifyInstruction4=We'll send a confirmation link to {0}.
+emailVerifyInstruction4=We''ll send a confirmation link to {0}.
 emailVerifyResend=Send the email again
 emailVerifySend=Send confirmation email
 emailVerifySendCooldown=Wait {0} seconds before asking for another email.
@@ -85,7 +85,7 @@ emailVerifiedAlreadyMessage=Your email address was already confirmed.
 # Setting a password - after email confirmation on a new account, or from the
 # link in a password-reset email.
 updatePasswordTitle=Set a password
-updatePasswordLead=Pick a password you don't use anywhere else.
+updatePasswordLead=Pick a password you don''t use anywhere else.
 updatePasswordMessage=Set a password to finish activating your account.
 passwordNew=New password
 passwordConfirm=Repeat password
@@ -118,8 +118,8 @@ invalidCodeMessage=That link is no longer valid. Start again from Einsatzbereit.
 expiredActionMessage=That link has expired. Sign in to continue.
 expiredActionTokenNoSessionMessage=That link has expired.
 expiredActionTokenSessionExistsMessage=That link has expired. Start again.
-emailSentMessage=Check your inbox - we've sent you an email with the next step.
-emailSendErrorMessage=We couldn't send that email. Try again in a few minutes.
+emailSentMessage=Check your inbox - we''ve sent you an email with the next step.
+emailSendErrorMessage=We couldn''t send that email. Try again in a few minutes.
 accountUpdatedMessage=Your details are saved.
 accountPasswordUpdatedMessage=Your password is saved.
 


### PR DESCRIPTION
## What

Escapes every literal apostrophe in `keycloak/themes/einsatzbereit/login/messages/messages_en.properties` as `''`, and adds a CI lint job that fails on any future bare (non-doubled) apostrophe in that file.

## Why

Keycloak resolves this file's values through `java.text.MessageFormat`, which treats a bare `'` as the start of a quoted-literal escape and silently drops the text that follows - so "Don't have an account yet?" rendered live as "Dont have an account yet?", "We'll send you a link..." as "Well send you a link...", etc. German is unaffected since `messages_de.properties` has no apostrophes in the equivalent strings.

Fixed 18 lines across the login, registration, password-reset/update, and error-message screens (lines 4, 6, 38-41, 46, 52-53, 60-63, 74, 78, 88, 121-122 - the exact set identified in the issue).

Closes #1854

## Testing

- `grep -nE '^[^#[:space:]].*=' keycloak/themes/einsatzbereit/login/messages/messages_en.properties | grep -P "(?<!')'(?!')"` confirms zero remaining unescaped apostrophes in message values.
- Added a `ban-unescaped-keycloak-apostrophes` job to `.github/workflows/lint.yml` running the same check, so this class of typo fails CI instead of shipping silently. Verified locally: fails against a deliberately unescaped test line, passes against the fixed file.
- Checked `backend/tests/VisualTests/KeycloakThemeTests.cs` - it does not assert on any of the changed literal strings, so no test updates were needed there.
- All CI checks green on this PR, including the new `ban-unescaped-keycloak-apostrophes` job and the full `dotnet.yml` suite (`build`, `format-check`, `fast-tests`, `integration-tests`, `visual-tests`) and `keycloak-realm-import.yml`.

## Live verification

Per explicit instruction for this task, no release-candidate tag was cut and nothing was deployed - this PR is fix-and-verify-via-CI only, not the full deploy-and-verify flow from root `AGENTS.md`. The fix is a straightforward properties-file escaping change with no code path risk; the new CI guard (and the local greps above) is the verification for this PR. A live-staging check can be done on a future release that includes this fix.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior beyond the copy itself)