### PR TITLE
fix(frontend): give opportunity filter dropdown panels an accessible group name

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
@@ -165,6 +165,7 @@ export default function FilterDropdown({
 				<div
 					id={panelId}
 					ref={panelRef}
+					aria-label={label}
 					style={{ left: panelLeft }}
 					// Below Header.tsx's sticky z-40 - this panel's ancestors (the
 					// filter bar, <main>) are all unpositioned, so its z-index

--- a/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/FilterDropdown.tsx
@@ -165,6 +165,7 @@ export default function FilterDropdown({
 				<div
 					id={panelId}
 					ref={panelRef}
+					role="group"
 					aria-label={label}
 					style={{ left: panelLeft }}
 					// Below Header.tsx's sticky z-40 - this panel's ancestors (the


### PR DESCRIPTION
## What

Adds `aria-label={label}` to `FilterDropdown`'s opened panel `<div>`, reusing the same `label` string already passed to the trigger's `role="group"` wrapper.

## Why

`frontend/AGENTS.md`'s Accessibility section documents the project's dropdown disclosure pattern, and `FilterDropdown.tsx`'s trigger already implements the labeled-group half (`role="group" aria-label={label}` around the button + clear-button pair), but the opened panel itself had no accessible name. A screen-reader user tabbing through an open panel (e.g. "Kategorie" on `/opportunities`) heard a bare sequence of unlabeled toggle buttons with no indication they belong together as a group. This affects all six filter dropdowns on `/opportunities` (Standort, Kategorie, Typ, Format, Häufigkeit, Datum) - same component, same gap, one fix.

I did not switch the panel to a `<ul>` (the pattern used by `RowActionsMenu.tsx`/`OrganizationSwitcher.tsx`/`LanguageSelector.tsx` for uniform button lists) because `FilterDropdown`'s `children` vary across the six call sites in `VolunteerOpportunitiesList.tsx` - some are plain option-button lists, but the location panel also holds a text input + "near me" button + radius pills, and the date panel holds a full `MiniCalendar` widget. Neither could validly become `<ul>` children without a much larger structural refactor, so this uses the `aria-label`-on-`<div>` alternative the issue itself proposed.

Closes #1853

## Testing

- `pnpm lint` - clean
- `pnpm check` (tsc --noEmit) - clean
- `pnpm test` (Vitest) - 249/249 passing
- Existing `OpportunitiesPage_DateRangeFilterOpen_HasNoSeriousA11yViolations` / `OpportunitiesPage_DateRangeFilterWithMarkedDays_HasNoSeriousA11yViolations` (backend `VisualTests`) already exercise a `FilterDropdown` panel in its open state and will pick up this change in CI.

## Live verification

Not applicable - this change is not being cut as a release candidate or deployed to staging for this PR, per explicit instruction for this task. `dotnet.yml`'s CI run (which boots the real Aspire stack and drives it with Playwright) is the verification for this change.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no documented behavior changed beyond the fix itself)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MeoMPJBZoLTJFGFddYQdMW)_