### PR TITLE
fix: route notifications-fetch 401 through sessionExpiryBus

### DIFF
--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -201,6 +201,68 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		Page.Url.Should().StartWith(origin);
 	}
 
+	// Regression for #1850: a 401 on the notifications-list fetch specifically
+	// (e.g. the bell opened right as the session died) used to fall into
+	// NotificationDropdown's own local notifError/ErrorBanner/retry state,
+	// entirely independent of sessionExpiryBus - a user got a small,
+	// easy-to-miss banner instead of the same toast + redirect every other
+	// authenticated call produces. useAccountMenu's loadNotifications now
+	// routes a 401 specifically through notifySessionExpired() instead of
+	// setNotifError().
+	[Test]
+	public async Task NotificationsFetch401_ShowsSessionExpiredToast_NotLocalErrorBanner()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+
+		// Hold the sign-in redirect at the network layer instead of letting it
+		// navigate away, same technique as
+		// AuthenticatedRequest_Returns401_ShowsSessionExpiredToast above - keeps
+		// the SPA (and its toast/panel) on screen long enough to assert.
+		await Page.RouteAsync(
+			"**/realms/einsatzbereit/protocol/openid-connect/auth**",
+			route => route.AbortAsync());
+
+		// Only the notifications-list GET 401s - unread-count polling and every
+		// other authenticated call keep succeeding, isolating this assertion to
+		// the loadNotifications code path this fix touches. Matched on the exact
+		// path (not a glob wildcard for the query string) since a first call with
+		// no beforeUnixMs/beforeId has no "?" at all - api-client.ts strips a
+		// trailing "?" left by unset query params.
+		await Page.RouteAsync("**/v1/notifications**", async route =>
+		{
+			if (route.Request.Method != "GET"
+				|| new Uri(route.Request.Url).AbsolutePath != "/v1/notifications")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 401,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.2\",\"status\":401}",
+			});
+		});
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await bell.ClickAsync();
+
+		var panel = Page.GetByTestId("notification-panel");
+		await Expect(panel).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var sessionExpiredToast = Page.GetByRole(AriaRole.Alert)
+			.Filter(new() { HasTextString = "session has expired" });
+		await Expect(sessionExpiredToast).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		await Expect(Page.GetByTestId("notification-retry")).Not.ToBeVisibleAsync();
+	}
+
 	private async Task MockAllV1GetRequestsAsUnauthorizedAsync()
 	{
 		await Page.RouteAsync("**/v1/**", async route =>

--- a/frontend/src/hooks/useAccountMenu.ts
+++ b/frontend/src/hooks/useAccountMenu.ts
@@ -4,8 +4,9 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useApiClient } from "./useApiClient";
 import { useDismissableOverlay } from "./useDismissableOverlay";
-import { getApiErrorMessage } from "../lib/apiError";
+import { getApiErrorMessage, getApiErrorStatus } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
+import { notifySessionExpired } from "../lib/sessionExpiryBus";
 import { subscribeAvatarChanged } from "../lib/avatarBus";
 import type { NotificationSummary } from "../client/api-client";
 
@@ -166,6 +167,18 @@ export function useAccountMenu(
 			setNotifError(null);
 		} catch (err) {
 			if (requestId !== notifRequestRef.current) return;
+			// loadNotifications only ever runs while isLoggedIn (see the effect
+			// below), so a 401 here always means the session the UI still
+			// believes is live has died - never the "anonymous browsing" case
+			// createApiClient's own handleErrorResponse guards against. Route it
+			// through the same bus useSessionExpiryHandler listens on instead of
+			// the generic ErrorBanner, so it gets one consistent toast + redirect
+			// instead of a small in-panel banner a user only sees if they happen
+			// to have the dropdown open (einsatzbereit#1850).
+			if (getApiErrorStatus(err) === 401) {
+				notifySessionExpired();
+				return;
+			}
 			setNotifError(getApiErrorMessage(err, t("notifications.loadError")));
 		} finally {
 			if (requestId === notifRequestRef.current) setNotifLoading(false);


### PR DESCRIPTION
## What

A 401 on the notifications-list fetch now routes through `sessionExpiryBus` (the same toast + redirect path every other authenticated call uses) instead of being swallowed into `NotificationDropdown`'s own local `notifError`/`ErrorBanner`/retry state.

## Why

`useSessionExpiryHandler` is a deliberately-built global handler: on a reactive 401 (via `sessionExpiryBus`) or a proactive silent-renew failure, it shows a toast and redirects to sign-in, so the UI never keeps looking logged in once the session is actually dead.

`NotificationDropdown.tsx`'s notification-bell dropdown bypassed that entirely: a failed `getMyNotifications` fetch rendered through its own local `notifError` state into an `ErrorBanner` + Retry button, independent of `sessionExpiryBus`. `loadNotifications` (in `useAccountMenu.ts`) only ever runs while `isLoggedIn` is true, so a 401 there always means the session the UI still believes is live has died - never the "anonymous browsing" case `createApiClient`'s own `hadAccessToken` guard exists for. The fix calls `notifySessionExpired()` on a 401 in that catch branch instead of `setNotifError(...)`, so it funnels into `useSessionExpiryHandler` like every other authenticated call, giving the user one consistent, hard-to-miss signal instead of a small banner they'd only see if they happened to have the bell open.

Closes #1850

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest, 249 tests) - all green locally.
- Added `SessionExpiryTests.NotificationsFetch401_ShowsSessionExpiredToast_NotLocalErrorBanner` in `backend/tests/VisualTests/` per root `AGENTS.md` step 7 - mocks only the notifications-list GET as 401 (isolating the assertion to the `loadNotifications` code path this fix touches), opens the notification bell, and asserts the global "session has expired" toast appears while the local retry button never renders. This is the durable, CI-run regression test; it runs as part of `dotnet.yml`'s `visual-tests` job, which this sandboxed session cannot execute locally (no Docker/Aspire orchestration available here - see root `AGENTS.md`'s Sandbox Limitations), so it's unverified pending CI.

## Live verification

Skipped for this PR at the requester's explicit instruction (no RC tag, no deploy). No release-candidate was cut and nothing was deployed to staging. CI's `visual-tests` job is the verification path for this change; will be watched and any failures fixed.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs to update)


---
_Generated by [Claude Code](https://claude.ai/code/session_016ryvt2v96oHXtcAQnKriK6)_