### PR TITLE
fix(backend): resolve audit log subject names instead of raw UUIDs

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7213,6 +7213,7 @@
           "actionType",
           "subjectType",
           "subjectId",
+          "subjectDisplayName",
           "reason",
           "createdOn"
         ],
@@ -7238,6 +7239,9 @@
           "subjectId": {
             "type": "string",
             "format": "uuid"
+          },
+          "subjectDisplayName": {
+            "type": "string"
           },
           "reason": {
             "type": [

--- a/backend/src/Application/AuditLogs/ListAuditLogs/v1/AuditLogEntry.cs
+++ b/backend/src/Application/AuditLogs/ListAuditLogs/v1/AuditLogEntry.cs
@@ -7,5 +7,6 @@ public sealed record AuditLogEntry(
 	string ActionType,
 	string SubjectType,
 	Guid SubjectId,
+	string SubjectDisplayName,
 	string? Reason,
 	DateTimeOffset CreatedOn);

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminAuditLogReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminAuditLogReadRepository.cs
@@ -1,7 +1,12 @@
 using Application.AuditLogs;
 using Application.AuditLogs.ListAuditLogs.v1;
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Pagination;
+using Domain.AuditLogs;
+using Domain.Engagements;
+using Domain.Organizations;
+using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
@@ -24,19 +29,80 @@ internal sealed class AdminAuditLogReadRepository(
 			.Take(pageSize)
 			.ToListAsync(cancellationToken);
 
-		var actorIds = page.Select(a => a.ActorUserId.Value).Distinct().ToList();
-		var actorDisplayNames = actorIds.Count > 0
-			? await keycloakUserService.GetDisplayNamesAsync(actorIds, cancellationToken)
+		// An Engagement subject has no name of its own (#1837) - the closest
+		// recognizable label for an admin is the opportunity it was a sign-up
+		// for, so its opportunity id is resolved here and folded into the
+		// VolunteerOpportunity lookup below.
+		var engagementIds = page
+			.Where(a => a.SubjectType == AuditSubjectType.Engagement)
+			.Select(a => a.SubjectId)
+			.Distinct()
+			.Select(id => EngagementId.Create(id).GetValueOrThrow())
+			.ToList();
+		var engagementOpportunityIds = engagementIds.Count > 0
+			? await dbContext.EngagementsQuery
+				.Where(e => engagementIds.Contains(e.Id))
+				.ToDictionaryAsync(e => e.Id.Value, e => e.OpportunityId.Value, cancellationToken)
+			: new Dictionary<Guid, Guid>();
+
+		var opportunityIds = page
+			.Where(a => a.SubjectType == AuditSubjectType.VolunteerOpportunity)
+			.Select(a => a.SubjectId)
+			.Concat(engagementOpportunityIds.Values)
+			.Distinct()
+			.Select(id => VolunteerOpportunityId.Create(id).GetValueOrThrow())
+			.ToList();
+		var opportunityTitles = opportunityIds.Count > 0
+			// IgnoreQueryFilters: a shadow-deleted opportunity's audit trail
+			// (e.g. its own AdminShadowDeleted entry) should still resolve a name.
+			? await dbContext.VolunteerOpportunitiesQuery
+				.IgnoreQueryFilters()
+				.Where(vo => opportunityIds.Contains(vo.Id))
+				.ToDictionaryAsync(vo => vo.Id.Value, vo => vo.Title, cancellationToken)
+			: new Dictionary<Guid, string>();
+
+		var organizationIds = page
+			.Where(a => a.SubjectType == AuditSubjectType.Organization)
+			.Select(a => a.SubjectId)
+			.Distinct()
+			.Select(id => OrganizationId.Create(id).GetValueOrThrow())
+			.ToList();
+		var organizationNames = organizationIds.Count > 0
+			? await dbContext.OrganizationsQuery
+				.IgnoreQueryFilters()
+				.Where(o => organizationIds.Contains(o.Id))
+				.ToDictionaryAsync(o => o.Id.Value, o => o.Name, cancellationToken)
+			: new Dictionary<Guid, string>();
+
+		// Actor and User-subject ids share one Keycloak lookup - the two sets
+		// often overlap (e.g. paging through several actions by the same admin).
+		var userIds = page
+			.Select(a => a.ActorUserId.Value)
+			.Concat(page.Where(a => a.SubjectType == AuditSubjectType.User).Select(a => a.SubjectId))
+			.Distinct()
+			.ToList();
+		var userDisplayNames = userIds.Count > 0
+			? await keycloakUserService.GetDisplayNamesAsync(userIds, cancellationToken)
 			: new Dictionary<Guid, string>();
 
 		var items = page
 			.Select(a => new AuditLogEntry(
 				a.Id.Value,
 				a.ActorUserId.Value,
-				actorDisplayNames.GetValueOrDefault(a.ActorUserId.Value, string.Empty),
+				userDisplayNames.GetValueOrDefault(a.ActorUserId.Value, string.Empty),
 				a.ActionType.ToString(),
 				a.SubjectType.ToString(),
 				a.SubjectId,
+				a.SubjectType switch
+				{
+					AuditSubjectType.User => userDisplayNames.GetValueOrDefault(a.SubjectId, string.Empty),
+					AuditSubjectType.Organization => organizationNames.GetValueOrDefault(a.SubjectId, string.Empty),
+					AuditSubjectType.VolunteerOpportunity => opportunityTitles.GetValueOrDefault(a.SubjectId, string.Empty),
+					AuditSubjectType.Engagement => engagementOpportunityIds.TryGetValue(a.SubjectId, out var opportunityId)
+						? opportunityTitles.GetValueOrDefault(opportunityId, string.Empty)
+						: string.Empty,
+					_ => string.Empty,
+				},
 				a.Reason,
 				a.CreatedOn))
 			.ToList();

--- a/backend/tests/Application.UnitTests/AuditLogs/ListAuditLogs/ListAuditLogsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/AuditLogs/ListAuditLogs/ListAuditLogsQueryHandlerTests.cs
@@ -26,7 +26,7 @@ public class ListAuditLogsQueryHandlerTests
 	{
 		// Arrange
 		var entry = new AuditLogEntry(
-			Guid.NewGuid(), Guid.NewGuid(), "Admina Admin", "UserShadowDeleted", "User", Guid.NewGuid(), null, DateTimeOffset.UtcNow);
+			Guid.NewGuid(), Guid.NewGuid(), "Admina Admin", "UserShadowDeleted", "User", Guid.NewGuid(), "Volunteera Vera", null, DateTimeOffset.UtcNow);
 
 		_readRepo
 			.GetAuditLogsPagedAsync(1, 10, cancellationToken)

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12120,6 +12120,10 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid SubjectId { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("subjectDisplayName")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string SubjectDisplayName { get; set; } = default!;
+
         [System.Text.Json.Serialization.JsonPropertyName("reason")]
         public string? Reason { get; set; } = default!;
 

--- a/backend/tests/IntegrationTests/AuditLogTests.cs
+++ b/backend/tests/IntegrationTests/AuditLogTests.cs
@@ -23,8 +23,9 @@ public class AuditLogTests(
 		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
 		var admin = await adminClient.GetUserProfileAsync(cancellationToken);
 
+		var organizationName = $"TestOrg_{Guid.NewGuid()}";
 		var organization = await adminClient.CreateOrganizationAsync(
-			new CreateOrganizationRequest { Name = $"TestOrg_{Guid.NewGuid()}" }, cancellationToken);
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
 
 		await adminClient.AdminShadowDeleteOrganizationAsync(organization.Id.Value, cancellationToken);
 
@@ -37,6 +38,7 @@ public class AuditLogTests(
 				ActionType = "OrganizationShadowDeleted",
 				SubjectType = "Organization",
 				SubjectId = organization.Id.Value,
+				SubjectDisplayName = organizationName,
 				Reason = (string?)null,
 			}, options => options.ExcludingMissingMembers());
 	}
@@ -58,6 +60,52 @@ public class AuditLogTests(
 
 		result.Items.Should().ContainSingle(a => a.SubjectId == organization.Id.Value && a.ActionType == "OrganizationRestored")
 			.Which.ActorUserId.Should().Be(admin.Id);
+	}
+
+	// Regression coverage for einsatzbereit#1837 - an Engagement subject has no
+	// name of its own, so its audit-log entry should resolve the opportunity it
+	// was a sign-up for instead of leaving the display name blank.
+	[Test]
+	public async Task ListAuditLogs_ShouldResolveSubjectDisplayName_ForEngagementSubject_ToItsOpportunityTitle(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organization = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"TestOrg_{Guid.NewGuid()}" }, cancellationToken);
+		var opportunityTitle = $"TestOpportunity_{Guid.NewGuid()}";
+		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				Title = opportunityTitle,
+				Description = "Integration test opportunity",
+				OrganizationId = organization.Id.Value,
+				Street = "Test Street",
+				HouseNumber = "1",
+				ZipCode = "12345",
+				City = "Berlin",
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+			},
+			cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		await olafClient.CancelEngagementAsync(
+			engagement.Id,
+			new CancelEngagementRequest { Reason = "Event cancelled" },
+			cancellationToken);
+
+		var adminClient = await CreateAuthenticatedClientAsync("admin", "admin123");
+		var result = await adminClient.ListAuditLogsAsync(1, 20, cancellationToken);
+
+		result.Items.Should().ContainSingle(a => a.SubjectId == engagement.Id && a.ActionType == "EngagementCancelled")
+			.Which.SubjectDisplayName.Should().Be(opportunityTitle);
 	}
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6387,6 +6387,7 @@ export interface AuditLogEntry {
     actionType: string;
     subjectType: string;
     subjectId: string;
+    subjectDisplayName: string;
     reason: string | undefined;
     createdOn: Date;
 

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -1218,6 +1218,7 @@ interface AuditLogRow {
 	actionType: string;
 	subjectType: string;
 	subjectId: string;
+	subjectDisplayName: string;
 	reason: string | null;
 	createdOn: string;
 }
@@ -1261,6 +1262,7 @@ function AuditLogSection() {
 					actionType: entry.actionType,
 					subjectType: entry.subjectType,
 					subjectId: entry.subjectId,
+					subjectDisplayName: entry.subjectDisplayName,
 					reason: entry.reason ?? null,
 					createdOn: entry.createdOn as unknown as string,
 				})),
@@ -1303,6 +1305,7 @@ function AuditLogSection() {
 			<ul className="divide-y divide-gray-100 overflow-hidden rounded-card border border-gray-200">
 				{rows.map((row) => {
 					const href = auditSubjectHref(row.subjectType, row.subjectId);
+					const subjectLabel = row.subjectDisplayName || row.subjectId;
 					return (
 						<li key={row.id} className="px-4 py-3">
 							<div className="flex flex-wrap items-center gap-2">
@@ -1317,10 +1320,10 @@ function AuditLogSection() {
 										to={href}
 										className="text-sm text-brand-700 hover:underline"
 									>
-										{row.subjectId}
+										{subjectLabel}
 									</Link>
 								) : (
-									<span className="text-sm text-gray-500">{row.subjectId}</span>
+									<span className="text-sm text-gray-500">{subjectLabel}</span>
 								)}
 							</div>
 							<p className="mt-1 text-xs text-gray-500">


### PR DESCRIPTION
## What

The admin audit log's "Subject" column now shows a resolved, human-readable name (opportunity title / organization name / user name) instead of a raw subject UUID. For subject types without a linkable route (currently only `Engagement`/"Sign-up"), it shows the name as plain text instead of the ID.

## Why

`AuditLogRow`/`AuditLogSection` in `AdministrationPage.tsx` already resolved and showed a display name for the *actor* (`actorDisplayName`, falling back to `actorUserId`), but not for the *subject* - every row's subject cell showed the bare UUID (e.g. `019ffa6b-f187-7703-81c2-51b5554f998e`) instead of what it actually refers to, forcing an admin to click through (or, for subject types without a route, find the ID some other way) to tell what an entry is about.

Closes #1837

## Changes

- `AuditLogEntry` (Application) gains a `SubjectDisplayName` field, mirroring the existing `ActorDisplayName`.
- `AdminAuditLogReadRepository` resolves it per `AuditSubjectType`:
  - `User` -> Keycloak display name (now shares one batched lookup with the actor ids, since the two sets often overlap)
  - `Organization` -> `Organization.Name`
  - `VolunteerOpportunity` -> `VolunteerOpportunity.Title`
  - `Engagement` -> has no name of its own, so it resolves the opportunity it was a sign-up for and uses that opportunity's title (same pattern already used elsewhere for denormalizing an opportunity title onto an engagement-scoped event)
  - All lookups use `IgnoreQueryFilters()` where a soft-delete filter exists, since a shadow-deleted subject's own audit trail (e.g. its `...ShadowDeleted` entry) should still resolve a name.
- `AdministrationPage.tsx`'s audit log row now renders `row.subjectDisplayName || row.subjectId`, the same fallback pattern already used for the actor.
- Generated OpenAPI spec + TS/C# API clients regenerated to include the new field.

## Testing

- `Application.UnitTests` (`ListAuditLogsQueryHandlerTests`) - updated for the new field, full suite run locally: 1031/1031 passed.
- `ArchitectureTests` - run locally: 422/422 passed.
- `IntegrationTests` (`AuditLogTests`) - updated the existing organization-shadow-delete test to assert `SubjectDisplayName`, and added a new test covering the `Engagement` subject case (`ListAuditLogs_ShouldResolveSubjectDisplayName_ForEngagementSubject_ToItsOpportunityTitle`), asserting the resolved name equals the opportunity's title. Passed in CI (`integration-tests`).
- Frontend: `pnpm check` (tsc), `pnpm lint` (0 warnings), `pnpm test` (249/249 passed), `pnpm i18n:check` - all run locally and clean.
- `/self-review` run (`nswag-check`, `ef-migration-check`, `a11y-check` fanned out for the touched areas) - no issues found beyond one minor consistency fix applied before this PR (missing `.Distinct()` on the engagement-id lookup list).
- Full CI suite (`dotnet.yml`: build/format-check/fast-tests/integration-tests/visual-tests, `frontend.yml`, editorconfig, dash-check, PR title) - all green.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release-candidate tag, no staging deploy). `IntegrationTests`/`VisualTests` in CI (`dotnet.yml`) provide the automated coverage instead - see Testing above.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01MskfvEoY5ni5Aq4ciWqP3R)_