### PR TITLE
fix: seed Vera's local organization_membership row for org1

### DIFF
--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -270,6 +270,8 @@ internal sealed class ApplicationDbContextInitializer(
 
 		dbContext.Set<OrganizationMembership>().Add(
 			OrganizationMembership.Create(org.Id, UserId.Create(OlafId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+		dbContext.Set<OrganizationMembership>().Add(
+			OrganizationMembership.Create(org.Id, UserId.Create(VeraId).GetValueOrThrow(), OrganizationMemberRole.Member));
 
 		return org.Id;
 	}

--- a/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
+++ b/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
@@ -2,6 +2,8 @@ using System.Text.RegularExpressions;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using AwesomeAssertions;
+using Domain.Organizations;
+using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Infrastructure.Persistence;
 using Infrastructure.VolunteerOpportunities;
@@ -215,6 +217,35 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 				$"\"{title}\" advertises a shift within one day, so it must not cross midnight "
 				+ $"({startUtc:yyyy-MM-dd HH:mm} - {endUtc:yyyy-MM-dd HH:mm} UTC)");
 		}
+	}
+
+	// #1846: Vera is a genuine, Keycloak-confirmed member of org1 - EnsureMemberAsync
+	// added her there - but SeedOrg1Async only ever wrote a local OrganizationMembership
+	// row for Olaf (the organizer), never for Vera. GetMemberOrganizationsAsync (the
+	// query behind GET /v1/organizations, "my organizations") reads only that local
+	// table, so Vera's own account saw zero organizations despite the org's own Members
+	// page (Keycloak-sourced) correctly listing her as an active member.
+	[Test]
+	public async Task SeedAsync_SeedsLocalMembershipRowForVera_SoHerOwnOrganizationsQueryFindsIt(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var initializer = new ApplicationDbContextInitializer(
+			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+
+		await initializer.SeedAsync(cancellationToken);
+
+		var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
+		var veraOrganizations = await dbContext.GetMemberOrganizationsAsync(veraUserId, cancellationToken);
+
+		veraOrganizations.Should().ContainSingle(o => o.Name == "Lindenauer Nachbarschaftshilfe e.V.",
+			"Vera is a real, Keycloak-confirmed member of this organization - her own \"my organizations\" query "
+			+ "must see the same membership the organization's own Members page shows for her (#1846)");
+
+		var veraMembership = await dbContext.Set<OrganizationMembership>()
+			.SingleAsync(m => m.UserId == veraUserId, cancellationToken);
+		veraMembership.Role.Should().Be(OrganizationMemberRole.Member, "Vera was seeded as a plain member, not an organizer");
 	}
 
 	// The guard itself is correct and stays - re-seeding a populated database would have


### PR DESCRIPTION
## What

Fix `GET /v1/organizations` returning an empty list for a real, active organization member (Vera) by seeding her local `organization_membership` row alongside her existing Keycloak membership.

## Why

Closes #1846

`ApplicationDbContextInitializer.SeedOrg1Async` adds Vera as a Keycloak member of "Lindenauer Nachbarschaftshilfe e.V." via `EnsureMemberAsync`, but never wrote the paired local `OrganizationMembership` row - unlike the organizer path, which does this for Olaf right next to it. `GetMemberOrganizationsAsync` (the query behind `GET /v1/organizations`, the sole consumer of `frontend/src/hooks/useMyOrganizations.ts`) reads only that local table, so Vera's own account saw zero organizations despite the organization's own Members page (Keycloak-sourced) correctly listing her as an active member.

That empty list is what fed `NotificationPreferencesSection.tsx`'s `organizerRowsVisible` gate, hiding the two organizer-relevant notification checkboxes on `/profile/settings`, and per the issue's inference, likely also hid the org quick-link in the header nav that `useMyOrganizations` also drives.

Root cause investigated and confirmed by tracing both query paths (`GetMemberOrganizationsAsync` vs. the Members page's Keycloak-backed roster) end to end - they are not inconsistent with each other; the local `organization_membership` table itself was simply missing a row that Keycloak already had.

## Testing

- Added `ApplicationDbContextInitializerSeedAsyncTests.SeedAsync_SeedsLocalMembershipRowForVera_SoHerOwnOrganizationsQueryFindsIt`, which runs `SeedAsync` and asserts `GetMemberOrganizationsAsync(vera)` returns org1 with role `Member` - the exact query path the bug report describes.
- Could not build/run the suite locally in this sandbox: the `dotnet` SDK is not installed and the install is blocked by this session's network egress policy (`builds.dotnet.microsoft.com` returned 403 - not something to route around). Verified the change manually against the actual entity/method signatures instead (`OrganizationMembership.Create`, `IApplicationDbContext.GetMemberOrganizationsAsync`, `UserId.Create`), and a dedicated `ef-migration-check` review confirmed no EF Core migration is needed (pure seed-data change, no entity/configuration shape change). CI's `dotnet.yml` ran the full suite including the new test on a real runner - all green (`build`, `format-check`, `fast-tests`, `integration-tests`, `visual-tests`).

## Live verification

Skipped for this PR at the requester's explicit instruction - no release-candidate tag or deploy this round. The fix only affects freshly-seeded databases (local dev, or staging after `reset-staging.yml`'s destructive reseed), so it can't be observed on the current live staging environment without that reset. The new integration test above exercises the exact same seeding path. When an RC is eventually cut for this fix, live verification should confirm: after a staging reset, log in as `vera/vera123` and check that `/profile/settings` shows all 5 notification checkboxes.

## Checklist

- [x] `/self-review` run and findings addressed - report-only run, no findings; diff also passed a dedicated `ef-migration-check` review
- [x] CI is green
- [x] Documentation updated if this change affects behavior - none needed, internal seed-data fix with no API/behavior contract change
