### PR TITLE
fix(frontend): announce a mid-session Keycloak-driven language switch

### DIFF
--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -414,9 +414,15 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 	///
 	/// <paramref name="password"/> must satisfy the realm's password policy
 	/// (<c>upperCase(1)</c>, <c>length(8)</c>) or Keycloak rejects the create.
+	///
+	/// <paramref name="attributes"/> seeds Keycloak user attributes (e.g.
+	/// <c>{"locale": ["de"]}</c>, mapped to the OIDC <c>locale</c> claim by the
+	/// realm's default "profile" client scope) - null omits the field entirely,
+	/// leaving Keycloak's own defaults in place.
 	/// </summary>
 	public async Task<Guid> CreateThrowawayUserAsync(
 		string username, string password, bool emailVerified, string[] requiredActions,
+		IReadOnlyDictionary<string, string[]>? attributes = null,
 		CancellationToken cancellationToken = default)
 	{
 		var adminToken = await GetAdminTokenAsync(cancellationToken);
@@ -430,6 +436,7 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 				emailVerified,
 				enabled = true,
 				requiredActions,
+				attributes,
 				credentials = new[] { new { type = "password", value = password, temporary = false } },
 			}),
 		};

--- a/backend/tests/VisualTests/SignInAccountLocaleTests.cs
+++ b/backend/tests/VisualTests/SignInAccountLocaleTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1842: onSigninCallback (main.tsx) silently applied
+/// the signed-in account's stored Keycloak locale as the app's UI language
+/// whenever it differed from the current session's language and the user had
+/// never made an explicit in-app choice - with nothing on screen marking that
+/// this had just happened. The fix surfaces the switch as a toast, held open
+/// long enough to survive the window.location.replace navigation that follows
+/// it (the same race useSessionExpiryHandler.ts already had to solve for its
+/// own toast-then-navigate sequence).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class SignInAccountLocaleTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// Satisfies the realm's passwordPolicy (upperCase(1), length(8)) - see
+	// KeycloakThemeTests.ThrowawayPassword's own doc comment for why this
+	// matters at user-creation time rather than at login.
+	private const string ThrowawayPassword = "Throwaway123";
+
+	[Test]
+	public async Task SignIn_AccountLocaleDiffersFromSessionLanguage_ShowsToastAndSwitchesLanguage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var username = $"localetoast1842-{Guid.NewGuid():N}";
+
+		// A fresh throwaway account, never signed in before and with no
+		// in-app language choice on record - the exact precondition
+		// onSigninCallback's hasExplicitLanguageChoice guard checks for. Its
+		// Keycloak "locale" attribute (mapped to the id_token's "locale"
+		// claim by the realm's default "profile" client scope) is seeded to
+		// "de", which differs from the "en" a fresh Playwright browser
+		// context resolves to via i18next's navigator-based detection - see
+		// OrgDashboardWidgetsTests' German-locale tests, which explicitly
+		// switch language via the header for that same reason.
+		var userId = await Fixture.CreateThrowawayUserAsync(
+			username, ThrowawayPassword, emailVerified: true, requiredActions: [],
+			attributes: new Dictionary<string, string[]> { ["locale"] = ["de"] });
+
+		try
+		{
+			// Mirrors AuthHelper.LoginAsync up to the final URL wait, which is
+			// deliberately not reused here: it waits for the post-redirect "/"
+			// URL, but the toast this test asserts on renders earlier, on the
+			// intermediate /callback page, before that redirect fires.
+			await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+			await Page.GotoAsync(frontend.ToString());
+			await Page.GetByRole(AriaRole.Button, new() { Name = "Sign in" }).First.ClickAsync();
+
+			await Page.Locator("#username").WaitForAsync(new() { Timeout = 30_000 });
+			await Page.Locator("#username").FillAsync(username);
+			await Page.Locator("#password").FillAsync(ThrowawayPassword);
+			await Page.Locator("#kc-login").ClickAsync();
+
+			var languageToast = Page.GetByRole(AriaRole.Alert)
+				.Filter(new() { HasTextString = "Switched to Deutsch based on your account" });
+			await Expect(languageToast).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+			await Page.WaitForURLAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/", new() { Timeout = 15_000 });
+
+			// Confirms i18n.changeLanguage actually completed and survived the
+			// hard navigation, not just that the toast fired - the header's
+			// user-menu button only carries this label once German is active.
+			await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Benutzermenü" }))
+				.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		}
+		finally
+		{
+			await Fixture.DeleteUserAsync(userId);
+		}
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -879,7 +879,8 @@
     "language": {
       "de": "Deutsch",
       "en": "English",
-      "switchLanguage": "Sprache wechseln"
+      "switchLanguage": "Sprache wechseln",
+      "switchedFromAccount": "Zu {{language}} gewechselt, basierend auf deinem Konto"
     },
     "auth": {
       "authError": "Authentifizierungsfehler: {{message}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -879,7 +879,8 @@
     "language": {
       "de": "Deutsch",
       "en": "English",
-      "switchLanguage": "Switch language"
+      "switchLanguage": "Switch language",
+      "switchedFromAccount": "Switched to {{language}} based on your account"
     },
     "auth": {
       "authError": "Authentication error: {{message}}",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -60,7 +60,25 @@ const oidcConfig = {
 			keycloakLocale &&
 			keycloakLocale !== i18n.language
 		) {
+			// Announce the switch before it happens (#1842) - otherwise it's an
+			// invisible side effect of a token refresh, indistinguishable from
+			// the UI randomly changing language mid-session. Computed while
+			// i18n.language is still the pre-switch language, so the sentence
+			// itself stays readable through the change it's describing.
+			dispatchToast(
+				"info",
+				i18n.t("language.switchedFromAccount", {
+					language: i18n.t(`language.${keycloakLocale}`),
+				}),
+			);
 			await i18n.changeLanguage(keycloakLocale);
+			// Give the toast a moment to actually paint before the redirect below
+			// tears the page down - the window.location.replace navigation is a
+			// real document unload, not a client-side route change, so without
+			// this the toast would at best flash for a frame or never render at
+			// all. Same race and same fix useSessionExpiryHandler.ts already
+			// applies to its own toast-then-navigate sequence.
+			await new Promise((resolve) => setTimeout(resolve, 2000));
 		}
 		const returnTo = (user?.state as { returnTo?: string })?.returnTo ?? "/";
 		window.location.replace(returnTo);


### PR DESCRIPTION
## What

`onSigninCallback` (`main.tsx`) now shows a toast ("Switched to Deutsch based on your account") the moment it silently applies the signed-in account's stored Keycloak locale to the app, instead of changing the language with no visible cause.

## Why

Reported in #1842: whenever a signed-in user's Keycloak account `locale` claim differs from the app's current language and the user never made an explicit in-app language choice, `onSigninCallback` calls `i18n.changeLanguage(...)` with no toast, banner, or other indication - including when `useSessionExpiryHandler`'s `signinRedirect` recovery (after a background silent-token-renewal failure) re-enters this same callback. The result: the UI language can flip mid-session with nothing on screen explaining why.

Closes #1842

## Implementation notes

- The toast text is computed while `i18n.language` is still the pre-switch language, so the sentence itself ("Switched to Deutsch...") stays readable through the change it's describing.
- `onSigninCallback` immediately follows up with `window.location.replace(returnTo)` - a real document unload, not a client-side route change - which would tear the toast down before it ever painted. Added a 2s hold before that navigation, mirroring the identical race `useSessionExpiryHandler.ts` already solved for its own toast-then-navigate sequence.
- **Known, deliberately out-of-scope limitation:** `onSigninCallback` also fires inside oidc-client-ts's hidden iframe during a background `automaticSilentRenew` (no dedicated `silent_redirect_uri` is configured, so it reuses `/callback`). A toast dispatched in that hidden-iframe execution context can never reach the visible top-level page - only i18next's `localStorage` write survives, which is what silently changes what the *next* page load resolves to. This fix covers the real-navigation paths where the toast is genuinely visible (an explicit sign-in, and `useSessionExpiryHandler`'s `signinRedirect` recovery re-entering `onSigninCallback` at the top level) - matching the issue's proposed "S"-effort scope. Fully covering the silent-iframe sub-case would need cross-frame notification (e.g. `BroadcastChannel`/`storage` event) and is a larger change than this issue asked for.

## Testing

- `pnpm check` / `pnpm lint` / `pnpm format:check` / `pnpm i18n:check` / `pnpm test` (249/249) all pass locally.
- Added `backend/tests/VisualTests/SignInAccountLocaleTests.cs`: creates a throwaway Keycloak user with `locale` attribute `"de"` (via a new optional `attributes` param on `AspireFixture.CreateThrowawayUserAsync`), signs in through the real Keycloak login UI, and asserts both the toast text and that the UI actually ends up in German afterward.
- Could not run `dotnet build`/VisualTests locally in this sandbox (no Docker, and this session's egress policy blocks the .NET SDK install) - relying on CI's `dotnet.yml` to validate the backend changes.

## Live verification

Not performed for this PR - deploying a release candidate / live-staging verification was explicitly out of scope for this change per the task instructions (no RC tag, no deploy). The added VisualTests regression (`SignInAccountLocaleTests.cs`) is the durable, CI-enforced record of the fix instead.

## Checklist

- [x] `/self-review` run and findings addressed (none found; `i18n-check` subagent confirmed `en.json`/`de.json` key parity)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs affected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwmUat9eJzBpf87x9q2xEe)_