### PR TITLE
fix: enlarge OrgMembersPage action button touch targets to meet WCAG 2.2 24x24px

### DIFF
--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -363,17 +363,17 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		removeBox.Should().NotBeNull("Could not get bounding box for the Remove button");
 		leaveBox.Should().NotBeNull("Could not get bounding box for the Leave button");
 
-		promoteBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Promote hit target should meet the WCAG 2.2 24x24 minimum");
-		promoteBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Promote hit target should meet the WCAG 2.2 24x24 minimum");
-		removeBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Remove hit target should meet the WCAG 2.2 24x24 minimum");
-		removeBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Remove hit target should meet the WCAG 2.2 24x24 minimum");
-		leaveBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Leave hit target should meet the WCAG 2.2 24x24 minimum");
-		leaveBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Leave hit target should meet the WCAG 2.2 24x24 minimum");
+		(promoteBox!.Width >= MinTargetSize && promoteBox.Height >= MinTargetSize).Should().BeTrue(
+			$"Promote hit target should meet the WCAG 2.2 24x24 minimum (measured {promoteBox.Width:F1}x{promoteBox.Height:F1}px)");
+		(removeBox!.Width >= MinTargetSize && removeBox.Height >= MinTargetSize).Should().BeTrue(
+			$"Remove hit target should meet the WCAG 2.2 24x24 minimum (measured {removeBox.Width:F1}x{removeBox.Height:F1}px)");
+		(leaveBox!.Width >= MinTargetSize && leaveBox.Height >= MinTargetSize).Should().BeTrue(
+			$"Leave hit target should meet the WCAG 2.2 24x24 minimum (measured {leaveBox.Width:F1}x{leaveBox.Height:F1}px)");
 
 		// Promote sits directly left of the destructive Remove in the same row -
 		// their hit targets must stay clearly separated, not just non-overlapping.
 		double gap = removeBox.X - (promoteBox.X + promoteBox.Width);
-		gap.Should().BeGreaterOrEqualTo(8,
+		(gap >= 8).Should().BeTrue(
 			$"Promote and Remove hit targets should stay clearly separated to avoid a mis-tap between a role change and a destructive action (measured {gap:F1}px)");
 	}
 

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -314,6 +314,70 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task MembersPage_ActionButtons_MeetMinimumTouchTargetSize()
+	{
+		// Regression for #1847: "Promote to organizer"/"Demote to member",
+		// "Remove" and "Leave" rendered as bare text-xs buttons with no padding
+		// beyond line-height, measuring ~16px tall at a 375px viewport - under
+		// half the WCAG 2.2 SC 2.5.8 24x24 CSS px minimum - with "Promote" and
+		// the destructive "Remove" only ~11px apart, a real mis-tap risk on a
+		// touch screen.
+		const float MinTargetSize = 24;
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual1847 TouchTarget", pinnedOrgId!.Value);
+
+		var match = Regex.Match(Page.Url, @"/app/([^/]+)/dashboard");
+		match.Success.Should().BeTrue();
+		var organizationId = Guid.Parse(match.Groups[1].Value);
+
+		var vera = await Fixture.SignInAsync("vera", "vera123");
+		await Fixture.AddPlainMemberDirectlyAsync(organizationId, vera.UserId);
+
+		// OrgAppLayout only refetches org details on organizationId change - force
+		// a refetch, same as the other member-row tests above.
+		await Page.ReloadAsync();
+
+		await Page.GetByTestId("org-tab-members").ClickAsync();
+
+		var veraRow = Page.Locator("li", new() { HasText = "vera@example.com" });
+		await Expect(veraRow).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// Resize down to the viewport the review measured the violation at,
+		// after navigating - the org app's section rail is reached through the
+		// default desktop viewport here, same as every other test in this file.
+		await Page.SetViewportSizeAsync(375, 812);
+
+		var promoteButton = veraRow.GetByRole(AriaRole.Button, new() { NameRegex = new Regex("Promote .* to organizer") });
+		var removeButton = veraRow.GetByRole(AriaRole.Button, new() { Name = "Remove" });
+		var leaveButton = Page.GetByRole(AriaRole.Button, new() { Name = "Leave" });
+		await Expect(leaveButton).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var promoteBox = await promoteButton.BoundingBoxAsync();
+		var removeBox = await removeButton.BoundingBoxAsync();
+		var leaveBox = await leaveButton.BoundingBoxAsync();
+		promoteBox.Should().NotBeNull("Could not get bounding box for the Promote button");
+		removeBox.Should().NotBeNull("Could not get bounding box for the Remove button");
+		leaveBox.Should().NotBeNull("Could not get bounding box for the Leave button");
+
+		promoteBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Promote hit target should meet the WCAG 2.2 24x24 minimum");
+		promoteBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Promote hit target should meet the WCAG 2.2 24x24 minimum");
+		removeBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Remove hit target should meet the WCAG 2.2 24x24 minimum");
+		removeBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Remove hit target should meet the WCAG 2.2 24x24 minimum");
+		leaveBox!.Width.Should().BeGreaterOrEqualTo(MinTargetSize, "Leave hit target should meet the WCAG 2.2 24x24 minimum");
+		leaveBox.Height.Should().BeGreaterOrEqualTo(MinTargetSize, "Leave hit target should meet the WCAG 2.2 24x24 minimum");
+
+		// Promote sits directly left of the destructive Remove in the same row -
+		// their hit targets must stay clearly separated, not just non-overlapping.
+		double gap = removeBox.X - (promoteBox.X + promoteBox.Width);
+		gap.Should().BeGreaterOrEqualTo(8,
+			$"Promote and Remove hit targets should stay clearly separated to avoid a mis-tap between a role change and a destructive action (measured {gap:F1}px)");
+	}
+
+	[Test]
 	public async Task Organizer_CanInviteMemberWithOrganizerRole_ViaRoleSelector()
 	{
 		// #1050: CreateInvitation now carries an intended role, defaulting to

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -548,12 +548,12 @@ export default function OrgMembersPage() {
 													? t("orgSettings.leaveOrganizationLastOrganizerHint")
 													: undefined
 											}
-											className="text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+											className="-m-2 p-2 text-xs text-red-700 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
 										>
 											{t("orgSettings.leaveOrganization")}
 										</button>
 									) : isOrganizer ? (
-										<div className="flex shrink-0 items-center gap-3">
+										<div className="flex shrink-0 items-center gap-6">
 											{(() => {
 												const memberName =
 													member.firstName && member.lastName
@@ -587,7 +587,7 @@ export default function OrgMembersPage() {
 																			name: memberName,
 																		})
 															}
-															className="text-xs text-brand-700 hover:text-brand-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
+															className="-m-2 p-2 text-xs text-brand-700 hover:text-brand-800 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
 														>
 															{member.isOrganisator
 																? t("orgSettings.demoteToMember")
@@ -604,7 +604,7 @@ export default function OrgMembersPage() {
 															aria-label={t("orgSettings.removeMemberNamed", {
 																name: memberName,
 															})}
-															className="text-xs text-red-700 hover:text-red-800"
+															className="-m-2 p-2 text-xs text-red-700 hover:text-red-800"
 														>
 															{t("orgSettings.removeMember")}
 														</button>


### PR DESCRIPTION
## What

Grows the tap targets of the "Promote to organizer"/"Demote to member", "Remove", and "Leave" action buttons on the organization members page (`OrgMembersPage.tsx`) to meet the WCAG 2.2 SC 2.5.8 24x24 CSS px minimum, and widens the gap between "Promote"/"Demote" and the destructive "Remove" button so a mis-tap between them is no longer a real risk.

## Why

`OrgMembersPage.tsx:564-611` rendered these as bare `text-xs` buttons with no padding beyond line-height. Measured live at a 375px viewport: "Promote ... to organizer" was 106x16px, "Remove ..." was 41x16px sitting only ~11px from Promote, and "Leave" was 29x16px - all under half the 24x24px minimum, with no applicable exception since these are standalone action controls.

The fix adds `-m-2 p-2` to each button - a matching padding/negative-margin pair that grows the CSS hit area by 8px on every side while leaving the visible label size and surrounding page layout unchanged (the negative margin cancels the padding's effect on the flex layout box). The flex gap between "Promote"/"Demote" and "Remove" is bumped from `gap-3` (12px) to `gap-6` (24px) so their now-larger hit areas keep >=8px of real separation instead of encroaching on each other.

Closes #1847

## Testing

- Added `MembersPage_ActionButtons_MeetMinimumTouchTargetSize` in `backend/tests/VisualTests/OrganizationTests.cs`: measures the rendered `BoundingBoxAsync()` of Promote/Remove/Leave at the 375px viewport the issue was measured at, asserting each is >=24x24px and that Promote/Remove stay >=8px apart. This runs alongside the existing axe-core scan (`OrgMembersPage_MemberRowWithPromoteDemoteButtons_AsOlaf_HasNoSeriousA11yViolations` in `AccessibilityTests.cs`), which covers DOM/semantics rather than pixel geometry.
- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (vitest, 249 tests) and `pnpm format:check` all pass locally.
- Could not run the backend `VisualTests`/Aspire stack locally (no Docker in this sandbox, per root `AGENTS.md`) - CI's `dotnet.yml` ran the full suite including this new test and it passed.

## Live verification

Skipped for this PR at the requester's explicit instruction (no RC tag, no deploy). The change is otherwise a small, low-risk Tailwind class change with a dedicated regression test that ran (and passed) in CI.

## Note

`OrgMembersPage.tsx`'s pending/declined/expired invitation rows ("Resend"/"Dismiss" buttons, ~lines 391-491) have the identical undersized-touch-target pattern but are outside this issue's reported scope, so they were left untouched here - flagging for a possible follow-up.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no doc-visible behavior change)