### PR TITLE
fix: keep checked-in engagements upcoming until their time slot ends

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -286,16 +286,34 @@ internal sealed class EngagementReadRepository(
 		// but check-in is optional (CheckInMethod.None has no check-in action at all),
 		// so a shift nobody checked in for stayed "upcoming" permanently. An
 		// engagement with no time slot (IndividualContact) is unaffected either way.
+		//
+		// #1855: the "checked-in Confirmed engagement is always past" assumption above
+		// only holds once the slot has actually ended. CheckIn() (see Domain/Engagements/
+		// Engagement.cs) has no time-based guard at all - an organizer can check a
+		// volunteer in as soon as Confirmed, e.g. at arrival for a still-ongoing
+		// multi-hour shift, or (as filed) for a slot dated weeks out - so IsCheckedIn
+		// alone is not proof the shift is over. A checked-in engagement whose slot end
+		// is still in the future is therefore kept in "Current & upcoming" instead,
+		// the same way an un-checked-in one already is; only once TimeSlotEnd is null
+		// (no time slot at all, e.g. IndividualContact - nothing to compare "now"
+		// against) or has actually passed does check-in alone move it to Past.
 		scopedQuery = upcoming
 			? scopedQuery.Where(x =>
-				(x.Engagement.Status == EngagementStatus.Pending
-					|| (x.Engagement.Status == EngagementStatus.Confirmed && !x.Engagement.IsCheckedIn))
-				&& opportunityExists.Contains(x.Engagement.OpportunityId)
-				&& (x.TimeSlotEnd == null || x.TimeSlotEnd >= now))
+				opportunityExists.Contains(x.Engagement.OpportunityId)
+				&& (x.TimeSlotEnd == null || x.TimeSlotEnd >= now)
+				&& (x.Engagement.Status == EngagementStatus.Pending
+					|| (x.Engagement.Status == EngagementStatus.Confirmed && !x.Engagement.IsCheckedIn)
+					|| (x.Engagement.Status == EngagementStatus.Confirmed
+						&& x.Engagement.IsCheckedIn
+						&& x.TimeSlotEnd != null)))
 			: scopedQuery.Where(x =>
 				x.Engagement.Status == EngagementStatus.Cancelled
 				|| x.Engagement.Status == EngagementStatus.Withdrawn
-				|| (x.Engagement.Status == EngagementStatus.Confirmed && x.Engagement.IsCheckedIn)
+				|| (x.Engagement.Status == EngagementStatus.Confirmed
+					&& x.Engagement.IsCheckedIn
+					&& (!opportunityExists.Contains(x.Engagement.OpportunityId)
+						|| x.TimeSlotEnd == null
+						|| x.TimeSlotEnd < now))
 				|| ((x.Engagement.Status == EngagementStatus.Pending
 						|| (x.Engagement.Status == EngagementStatus.Confirmed && !x.Engagement.IsCheckedIn))
 					&& (!opportunityExists.Contains(x.Engagement.OpportunityId)

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -548,6 +548,123 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		upcoming.Items.Should().ContainSingle(e => e.Id == engagement.Id.Value);
 	}
 
+	// --- Checked-in engagement ahead of its time slot's end (#1855) ---
+
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldKeepCheckedInEngagement_InUpcomingBucket_WhenTimeSlotHasNotEndedYet(
+		CancellationToken cancellationToken)
+	{
+		// Engagement.CheckIn() has no time-based guard - an organizer can check a
+		// volunteer in as soon as it is Confirmed, e.g. at arrival for a
+		// still-ongoing multi-hour shift. Before #1855 IsCheckedIn alone moved a
+		// Confirmed engagement to Past regardless of the slot's own end time, so
+		// a shift that had not even started yet could show up as a completed,
+		// feedback-ready "Past" item.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"TestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.ScheduledSlots, CheckInMethod.Manual, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var futureSlot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(14), DateTimeOffset.UtcNow.AddDays(14).AddHours(8), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, futureSlot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		engagement.CheckIn().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var upcoming = await repository.GetByVolunteerAsync(volunteerId, upcoming: true, pageNumber: 1, pageSize: 10, cancellationToken);
+		var past = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		upcoming.Items.Should().ContainSingle(e => e.Id == engagement.Id.Value);
+		past.Items.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldMoveCheckedInEngagement_ToPastBucket_OnceTimeSlotHasEnded(
+		CancellationToken cancellationToken)
+	{
+		// Complements the regression above: once the slot has genuinely ended,
+		// a checked-in engagement still belongs in Past - #1855 only defers the
+		// move until the slot's own end time actually arrives, it does not stop
+		// checked-in engagements from ever reaching Past.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"TestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.ScheduledSlots, CheckInMethod.Manual, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var pastNow = DateTimeOffset.UtcNow.AddDays(-11);
+		var endedSlot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow.AddDays(-9), 10, pastNow).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, volunteerId, endedSlot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		engagement.CheckIn().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var upcoming = await repository.GetByVolunteerAsync(volunteerId, upcoming: true, pageNumber: 1, pageSize: 10, cancellationToken);
+		var past = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		upcoming.Items.Should().BeEmpty();
+		past.Items.Should().ContainSingle(e => e.Id == engagement.Id.Value);
+	}
+
+	[Test]
+	public async Task GetByVolunteerAsync_ShouldKeepCheckedInEngagementWithNoTimeSlot_InPastBucket(
+		CancellationToken cancellationToken)
+	{
+		// A checked-in IndividualContact engagement has no TimeSlotId at all, so
+		// there is no date to compare "now" against - #1855's new carve-out is
+		// scoped to a resolvable TimeSlotEnd and must leave this case exactly as
+		// before (Past), not reclassify it for lack of information either way.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var volunteerId = UserId.New();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"TestOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.Manual, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, volunteerId, "Please let me help.").GetValueOrThrow();
+		engagement.Confirm().ThrowIfFailure();
+		engagement.CheckIn().ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var upcoming = await repository.GetByVolunteerAsync(volunteerId, upcoming: true, pageNumber: 1, pageSize: 10, cancellationToken);
+		var past = await repository.GetByVolunteerAsync(volunteerId, upcoming: false, pageNumber: 1, pageSize: 10, cancellationToken);
+
+		upcoming.Items.Should().BeEmpty();
+		past.Items.Should().ContainSingle(e => e.Id == engagement.Id.Value);
+	}
+
 	// --- GetCheckedInByVolunteerAsync (engagement record, #1096) ---
 
 	[Test]

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -66,6 +66,108 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		cleanupResponse.EnsureSuccessStatusCode();
 	}
 
+	/// <summary>
+	/// Regression for #1855: Engagement.CheckIn() has no time-based guard, so an
+	/// organizer can check a volunteer in as soon as an engagement is Confirmed -
+	/// e.g. at arrival for a still-ongoing multi-hour shift, or (as filed) for a
+	/// slot dated weeks out. EngagementReadRepository.GetByVolunteerAsync used to
+	/// bucket any checked-in Confirmed engagement into "Past" unconditionally,
+	/// with no comparison against the slot's own end time (#1163 already fixed
+	/// the opposite-direction gap - an un-checked-in Confirmed engagement never
+	/// leaving "Current &amp; upcoming" once its slot had ended). The volunteer's
+	/// own "Past" tab then showed a "Checked in" chip and a "Leave feedback" CTA
+	/// for a shift with a displayed date that had not happened yet.
+	/// </summary>
+	[Test]
+	public async Task EngagementsTab_KeepsCheckedInEngagement_InUpcomingScope_WhileItsTimeSlotIsStillInTheFuture()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckedInFuture Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"CheckedInFuture Opportunity {suffix}";
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by MyEngagementsScopeTabsTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "Manual",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		// A multi-hour shift two weeks out - the same shape as the review finding
+		// that filed #1855 (a slot dated well in the future).
+		var start = DateTimeOffset.UtcNow.AddDays(14);
+		var slotResponse = await olafHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = start.AddHours(8), maxParticipants = 5, recurrenceCount = 1 });
+		slotResponse.EnsureSuccessStatusCode();
+		var slots = await slotResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var timeSlotId = slots[0].GetProperty("id").GetString();
+
+		(await olafHttp.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "ScheduledSlots", timeSlotId, message = (string?)null });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		// The organizer checks vera in well ahead of the slot's end - there is no
+		// time-based guard on CheckIn() (see Domain/Engagements/Engagement.cs).
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/check-in", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+
+		// Default "Current & upcoming" scope - the checked-in engagement belongs
+		// here, not "Past", since its own displayed date has not happened yet.
+		await Expect(Page.Locator("#activity [data-testid='engagement-card']").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await LoadMoreUntilVisibleAsync(card);
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(card).ToContainTextAsync(oppTitle);
+		await Expect(card.GetByText("Checked in")).ToBeVisibleAsync();
+
+		// "Past" must not present it as a completed, feedback-ready item (#1855).
+		// Waits for the Past scope's own fetch to actually land (a card or its
+		// empty state) before asserting absence - otherwise a still-loading list
+		// would trivially satisfy Not.ToBeVisibleAsync without proving anything.
+		var pastCardOrEmptyState = Page.Locator("#activity [data-testid='engagement-card']")
+			.Or(Page.GetByText("No past sign-ups yet."));
+		await Page.Locator("[data-testid='engagements-scope-past']").ClickAsync();
+		await Expect(pastCardOrEmptyState.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(card).Not.ToBeVisibleAsync();
+	}
+
 	private static async Task<string> ApplyAsync(HttpClient http, string opportunityId, string message)
 	{
 		var response = await http.PostAsJsonAsync(


### PR DESCRIPTION
## What

`EngagementReadRepository.GetByVolunteerAsync` now keeps a checked-in `Confirmed` engagement in the "Current & upcoming" bucket as long as its time slot has not ended yet, instead of unconditionally bucketing every checked-in engagement into "Past".

## Why

`Engagement.CheckIn()` has no time-based guard - an organizer can check a volunteer in as soon as an engagement is `Confirmed`, e.g. at arrival for a still-ongoing multi-hour shift, or (as filed) for a slot dated weeks out. The volunteer's own `/my-signups` "Past" tab then showed a "Checked in" chip and a "Leave feedback" CTA for a shift whose own displayed date had not happened yet - presented as fully completed when it wasn't.

`#1163` already fixed the opposite-direction gap (an un-checked-in `Confirmed` engagement never leaving "Current & upcoming" once its slot had ended); this closes the same root-cause gap from the checked-in side. An engagement with no time slot at all (`IndividualContact`) is unaffected either way, since there is no date to compare "now" against.

Closes #1855

## Testing

- `backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs`: three new regression tests against real Postgres - a checked-in engagement with a future time slot stays in "upcoming" and is absent from "past"; a checked-in engagement whose slot has already ended still moves to "past" (locks in the existing, correct direction); a checked-in engagement with no time slot at all stays in "past" (unaffected edge case).
- `backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs`: new end-to-end Playwright regression - an organizer checks a volunteer in for a slot two weeks out, and the volunteer's `/my-signups` page shows it under "Current & upcoming" (with the "Checked in" chip), never under "Past".
- Ran the repo's mandatory `/self-review` (self-review skill), which fanned out to the `ef-migration-check` subagent since the change touches `backend/src/Infrastructure/Persistence/**` - confirmed no EF Core migration is needed (pure query-logic change, no entity/schema change) and independently traced the new bucketing predicate's case coverage.

I was not able to run `dotnet build`/the test projects locally in this session - this sandbox's egress policy blocks `builds.dotnet.microsoft.com` (used to install the .NET SDK), so `dotnet` was never available on `PATH` here. I reviewed the diff carefully by hand (including a full case-by-case boolean-logic trace of the new query predicate) instead, and will watch this PR's CI (`dotnet.yml`) to catch and fix anything that surfaces there.

## Live verification

Skipped for this PR per explicit instruction for this task (no RC tag, no deployment). CI's `dotnet.yml` (`Application.UnitTests`, `ArchitectureTests`, `IntegrationTests` against real Postgres, `VisualTests` via Aspire + Playwright) is the verification for this change.

## Checklist

- [x] `/self-review` run and findings addressed (one flagged nit turned out to be incorrect on closer inspection - see Testing above; left as-is)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - internal bucketing logic only, no API/behavior contract change)


---
_Generated by [Claude Code](https://claude.ai/code/session_013486b3C3EifGBk8hX4a1Es)_