### PR TITLE
fix(engagements): surface the real withdrawal error instead of a generic fallback

### DIFF
--- a/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/WithdrawEngagement/v1/WithdrawEngagementEndpoint.cs
@@ -6,7 +6,6 @@ using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Engagements.WithdrawEngagement.v1;
 using Domain.Engagements;
-using Domain.Primitives;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
 
@@ -22,7 +21,9 @@ internal sealed class WithdrawEngagementEndpoint
 			.Produces<EngagementStatusResponse>()
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
@@ -41,23 +42,12 @@ internal sealed class WithdrawEngagementEndpoint
 			return Results.Problem("Unable to identify the current user.", statusCode: StatusCodes.Status401Unauthorized);
 		}
 
-		try
-		{
-			var command = new WithdrawEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId);
-			var engagement = await sender.Send(command, cancellationToken);
+		var command = new WithdrawEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId);
+		var engagement = await sender.Send(command, cancellationToken);
 
-			// A withdrawn engagement changes CurrentParticipantCount on the public listing.
-			await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
+		// A withdrawn engagement changes CurrentParticipantCount on the public listing.
+		await outputCacheStore.EvictVolunteerOpportunityListingCacheAsync(cancellationToken);
 
-			return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString()));
-		}
-		catch (ResultFailureException ex) when (ex.Error.Type == ErrorType.NotFound)
-		{
-			return Results.NotFound();
-		}
-		catch (ResultFailureException ex)
-		{
-			return Results.Problem(ex.Error.Description, statusCode: StatusCodes.Status400BadRequest);
-		}
+		return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString()));
 	}
 }

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5720,8 +5720,28 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -9800,6 +9800,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -9808,6 +9818,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -1050,7 +1050,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	// ── Cross-user withdrawal ─────────────────────────────────────────────────
 
 	[Test]
-	public async Task WithdrawEngagement_ShouldReturn400_WhenUserWithdrawsAnotherUsersEngagement(
+	public async Task WithdrawEngagement_ShouldReturn403_WhenUserWithdrawsAnotherUsersEngagement(
 		CancellationToken cancellationToken)
 	{
 		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
@@ -1066,7 +1066,7 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		var act = () => olafClient.WithdrawEngagementAsync(engagement.Id, cancellationToken);
 
 		var exception = await act.Should().ThrowAsync<ApiException>();
-		exception.Which.StatusCode.Should().Be(400);
+		exception.Which.StatusCode.Should().Be(403);
 	}
 
 	// ── Cross-org ownership ───────────────────────────────────────────────────

--- a/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
+++ b/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1849: WithdrawEngagementEndpoint used to catch every
+/// ResultFailureException locally and collapse it into a bare
+/// Results.Problem(ex.Error.Description, statusCode: 400) - losing the
+/// errorCode extension ResultFailureExceptionHandler normally adds, and
+/// forcing every failure (even a Forbidden ownership check) onto 400.
+/// handleWithdrawConfirm (VolunteerOpportunityDetailPage.tsx) then checked
+/// `err instanceof Error`, which is never true for the parsed ProblemDetails
+/// object the NSwag client throws - so every withdrawal failure, regardless
+/// of cause, showed the generic "Error withdrawing" fallback instead of the
+/// server's actual rejection reason. Fixed by letting the endpoint's
+/// failures propagate to the global exception handler (matching
+/// CancelEngagementEndpoint's pattern) and switching the page to
+/// getApiErrorMessage(), the same mechanism #1250 fixed for the check-in PIN
+/// dialog (see LocalizedCheckInPinErrorTests).
+///
+/// Reproduced here via a stale-dialog double withdraw: the engagement is
+/// withdrawn out-of-band while the confirm dialog is open, so the UI's own
+/// withdraw call - unaware of that change - hits Engagement.AlreadyTerminated
+/// (409 Conflict) once confirmed.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class WithdrawEngagementErrorMessageTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task DetailPage_ShowsSpecificTerminatedMessage_NotGenericWithdrawFallback()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"WithdrawErrorMessage Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"WithdrawErrorMessage Opportunity {suffix}",
+			description = "Created by WithdrawEngagementErrorMessageTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Ready to help with WithdrawEngagementErrorMessageTests." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		// Only a Confirmed sign-up shows the withdraw button on this page's
+		// application-status card (VolunteerOpportunityDetailPage.tsx).
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Withdraw" }).ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+
+		// Withdraw out-of-band while the dialog sits open - the page's own state
+		// still thinks the sign-up is Confirmed, so confirming below sends a
+		// withdraw request the server can no longer honour.
+		(await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null))
+			.EnsureSuccessStatusCode();
+
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, withdraw" }).ClickAsync();
+
+		var errorBanner = dialog.GetByRole(AriaRole.Alert);
+		await Expect(errorBanner).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(errorBanner).ToHaveTextAsync("Sign-up is already terminated.");
+	}
+}

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5214,11 +5214,23 @@ export class EinsatzbereitApi {
             result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Unauthorized", status, _responseText, _headers, result401);
             });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
         } else if (status === 404) {
             return response.text().then((_responseText) => {
             let result404: any = null;
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
             });
         } else if (status === 500) {
             return response.text().then((_responseText) => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -641,7 +641,7 @@
       "deletedOpportunityTitle": "Dieser Einsatz wurde entfernt",
       "cancellationReason": "Grund: {{reason}}",
       "withdraw": "Zurückziehen",
-      "withdrawError": "Fehler beim Zurückziehen",
+      "withdrawError": "Anmeldung konnte nicht zurückgezogen werden. Bitte versuche es erneut.",
       "addToCalendar": "Zum Kalender hinzufügen",
       "addToCalendarGoogle": "Google Kalender",
       "addToCalendarOutlook": "Outlook.com",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -641,7 +641,7 @@
       "deletedOpportunityTitle": "This opportunity has been removed",
       "cancellationReason": "Reason: {{reason}}",
       "withdraw": "Withdraw",
-      "withdrawError": "Error withdrawing",
+      "withdrawError": "Could not withdraw your sign-up. Please try again.",
       "addToCalendar": "Add to calendar",
       "addToCalendarGoogle": "Google Calendar",
       "addToCalendarOutlook": "Outlook.com",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -267,7 +267,7 @@ export default function VolunteerOpportunityDetailPage() {
 			load();
 		} catch (err) {
 			setWithdrawError(
-				err instanceof Error ? err.message : t("myEngagements.withdrawError"),
+				getApiErrorMessage(err, t("myEngagements.withdrawError")),
 			);
 		} finally {
 			setWithdrawing(false);


### PR DESCRIPTION
## What

Withdrawing a sign-up now shows the server's actual rejection reason (or a specific, actionable fallback) instead of the generic "Error withdrawing" message reported in #1849.

## Why

`WithdrawEngagementEndpoint` was the only engagement endpoint that caught every `ResultFailureException` locally and collapsed it into a bare `Results.Problem(ex.Error.Description, statusCode: 400)`. That lost the `errorCode` extension the global `ResultFailureExceptionHandler` normally adds (which the frontend looks up via `apiError.<errorCode>` to show a specific translated message), and it forced every failure onto 400 - including a Forbidden ownership check that should be 403. Meanwhile `VolunteerOpportunityDetailPage.tsx`'s `handleWithdrawConfirm` checked `err instanceof Error`, which is never true for the parsed `ProblemDetails` object the NSwag client throws on a JSON error response - so regardless of the backend bug, every withdrawal failure fell straight to the generic `myEngagements.withdrawError` fallback.

Fixed both:
- Removed the endpoint's local catch so failures propagate to the global exception handler, matching the sibling `CancelEngagementEndpoint`'s pattern. Added `403`/`409` to the endpoint's declared responses (matching every error `Engagement.Withdraw()`/the handler can actually raise) and regenerated the NSwag clients.
- Switched `handleWithdrawConfirm` to `getApiErrorMessage()`, the same mechanism already used elsewhere on this page (`handlePublish`) and the one #1250 fixed for the check-in PIN dialog.
- Reworded the `myEngagements.withdrawError` fallback (now only shown for genuinely unmapped errors) from "Error withdrawing" to "Could not withdraw your sign-up. Please try again.", matching the house convention used by sibling fallback strings (`deleteError`/`submitError`/etc.), in both `en.json` and `de.json`.

Closes #1849

## Testing

- `backend/tests/IntegrationTests/EngagementTests.cs`: renamed `WithdrawEngagement_ShouldReturn400_WhenUserWithdrawsAnotherUsersEngagement` to `..._ShouldReturn403_...` and updated its expected status code, since a non-owner withdrawal is now correctly mapped to 403 Forbidden instead of 400.
- Added `backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs`: a browser-driven regression test reproducing the exact bug via a stale-dialog double withdraw (the engagement is withdrawn out-of-band while the confirm dialog is open, so confirming it hits `Engagement.AlreadyTerminated`/409) and asserting the dialog shows the specific translated message instead of the generic fallback.
- Ran locally (SDK note: this sandbox could only install .NET SDK 10.0.110 via apt, not the pinned 10.0.400 - `backend/global.json` was temporarily lowered for local verification only and reverted before committing; the committed pin is unchanged):
  - `dotnet build` - succeeds, NSwag regenerated `openapi-v1.json`/`api-client.ts`/`ApiClient.cs` cleanly (403/409 added only to the `WithdrawEngagement` operation)
  - `Application.UnitTests` - 1031/1031 passed
  - `ArchitectureTests` - 422/422 passed
  - `dotnet format --verify-no-changes` - clean
  - Frontend: `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm test` (249/249) - all clean
- `VisualTests` itself needs Docker/Aspire orchestration and a matching Playwright Chromium build that this sandbox can't provide (network-policy-blocked), so the new test is unverified locally - it will run for real in CI's `dotnet.yml` `visual-tests` job.
- Ran `/self-review`, which fanned out to `nswag-check`, `architecture-check`, `a11y-check`, and `i18n-check` - all four came back clean. `architecture-check` flagged one nit (a supposedly-unused `using Application.Common.Exceptions;`) that I verified is a false positive: `GetValueOrThrow()` is only defined in that namespace and is still used by `EngagementId.Create(...).GetValueOrThrow()`, matching the sibling `RemoveMemberEndpoint`.

## Live verification

Not performed for this PR - no RC tag was cut and nothing was deployed to staging, per explicit instruction for this task. The backend fix is covered by an updated integration test (status-code assertion) and a new VisualTests browser regression test that will run in CI; that VisualTests run is the durable verification for this change in lieu of a live-staging pass.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no user-facing docs beyond the UI strings themselves, which are updated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BFD6PYdLFhpijzyDjP1TPF)_