### PR TITLE
fix(frontend): render dashboard widgets in saved position order on mobile

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -921,6 +921,66 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 			+ $"(last observed delta: {rowHeightDelta}px, must be <2px)");
 	}
 
+	[Test]
+	public async Task MobileViewport_RendersWidgetsInPositionOrder_NotArrayOrder()
+	{
+		// #1845: settlePlacement (widgetCatalog.ts) always prepends whichever
+		// widget just moved to the front of the layout array. That's harmless
+		// at lg+, where every tile still gets an explicit gridColumn/gridRow
+		// (see index.tsx's gridStyle), but below `lg` the grid collapses to a
+		// single stacked column with no gridStyle at all - plain document
+		// flow, where DOM order IS the visual order. Moving CreateOpportunity
+		// (DEFAULT_LAYOUT's very first widget, x=1/y=1) below every other
+		// widget used to still render it FIRST on mobile, because it was now
+		// first in the array despite being last by saved position.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual DashMobileOrder", pinnedOrgId!.Value);
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+
+		// Settings (DEFAULT_LAYOUT's last widget) ends at y=8 - moving
+		// CreateOpportunity to y=9 puts it below every other widget, with no
+		// overlap/displacement of anything else involved.
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Move or resize Create opportunity" }).ClickAsync();
+		await ClickGridCellAsync(col: 1, row: 9);
+		await ClickGridCellAsync(col: 4, row: 9);
+
+		await Expect(Page.GetByTestId("dashboard-placement-status")).Not.ToBeVisibleAsync();
+		await AssertWidgetOccupiesCellsAsync("CreateOpportunity", x: 1, y: 9, width: 4, height: 1);
+
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Page.ReloadAsync();
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(Page.GetByTestId("widget-tile-CreateOpportunity")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.SetViewportSizeAsync(375, 812);
+
+		// No fixed expected value to Expect() against up front - poll a fresh
+		// read of the rendered tile order until it settles (or the timeout
+		// proves it never does), rather than reading it once right after the
+		// viewport resize, since the isLargeViewport media-query listener's
+		// resulting re-render isn't necessarily synchronous with
+		// SetViewportSizeAsync returning.
+		string[] tileOrder = [];
+		await PollUntilAsync(async () =>
+		{
+			tileOrder = await Page.EvaluateAsync<string[]>(
+				"""
+				() => Array.from(document.querySelectorAll('[data-testid^="widget-tile-"]'))
+					.map(el => el.getAttribute('data-testid'))
+				""");
+			return tileOrder.Length > 0 && tileOrder[^1] == "widget-tile-CreateOpportunity";
+		}, () => "at mobile width, DOM order should follow each widget's saved position (y, then x) - "
+			+ "CreateOpportunity was moved below every other widget and should render last, but the "
+			+ $"last observed order was [{string.Join(", ", tileOrder)}]");
+	}
+
 	/// <summary>
 	/// Clicks the grid guide cell at 1-based (col, row) - the same cells an
 	/// organizer clicks to mark a placement's corners. Cells all share the

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -38,6 +38,7 @@ import {
 	compactLayout,
 	placeNewWidget,
 	sanitizeWidgetKey,
+	sortByPosition,
 	type PlacedWidget,
 	type WidgetKey,
 	type WidgetSizeClass,
@@ -159,6 +160,15 @@ export default function OrgDashboardPage() {
 	const availableToAdd = WIDGET_KEYS.filter(
 		(key) => !layout.some((w) => w.widgetKey === key),
 	);
+
+	// Below `lg` the grid collapses to a single stacked column (see the
+	// `gridStyle` ternary in the render loop below) - plain document flow,
+	// where DOM order IS visual order. `layout` itself carries no such
+	// guarantee (see sortByPosition in widgetCatalog.ts), which on lg+ is
+	// harmless (each tile is placed explicitly via `gridStyle`'s gridColumn/
+	// gridRow) but on mobile let a widget dragged to the bottom on desktop
+	// render first (#1845).
+	const mobileLayout = isLargeViewport ? layout : sortByPosition(layout);
 
 	// Memoized so CreateOpportunityWidget's React.memo (see that component)
 	// actually skips re-rendering while a placement is in progress - a fresh
@@ -517,7 +527,7 @@ export default function OrgDashboardPage() {
 			collapses to a single stacked column below `lg`, where this wouldn't
 			mean anything. */}
 			{guideCells}
-			{layout.map((widget) => {
+			{mobileLayout.map((widget) => {
 				const isPlacingThis = activeKey === widget.widgetKey;
 				const rect = isPlacingThis && previewRect ? previewRect : widget;
 				const sizeClass = isLargeViewport

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_LAYOUT,
 	WIDGET_CATALOG,
 	isValidPlacement,
+	sortByPosition,
 	type PlacedWidget,
 } from "./widgetCatalog";
 
@@ -78,5 +79,60 @@ describe("DEFAULT_LAYOUT", () => {
 			expect(row).toBeDefined();
 			expect(row as number).toBeLessThan(calendarRow as number);
 		}
+	});
+});
+
+// #1845: mobile rendering (single stacked column below `lg`, see
+// OrgDashboardPage/index.tsx) falls back to this instead of trusting a
+// layout array's own order, which reflects edit history (settlePlacement
+// always prepends whichever widget just moved) rather than position.
+describe("sortByPosition", () => {
+	it("orders widgets top-to-bottom, then left-to-right, regardless of input array order", () => {
+		// Same shape the bug actually produced: CreateOpportunity moved below
+		// everything else on the grid, but still first in the array because
+		// settlePlacement prepends whatever just moved.
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "CreateOpportunity", x: 1, y: 9, width: 4, height: 1 },
+			{ widgetKey: "ToDo", x: 4, y: 1, width: 3, height: 1 },
+			{ widgetKey: "VolunteerStats", x: 7, y: 1, width: 2, height: 1 },
+			{ widgetKey: "Calendar", x: 1, y: 4, width: 8, height: 4 },
+		];
+
+		expect(sortByPosition(widgets).map((w) => w.widgetKey)).toEqual([
+			"ToDo",
+			"VolunteerStats",
+			"Calendar",
+			"CreateOpportunity",
+		]);
+	});
+
+	it("breaks a tied row left-to-right by x", () => {
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "VolunteerStats", x: 7, y: 1, width: 2, height: 1 },
+			{ widgetKey: "CreateOpportunity", x: 1, y: 1, width: 3, height: 1 },
+			{ widgetKey: "ToDo", x: 4, y: 1, width: 3, height: 1 },
+		];
+
+		expect(sortByPosition(widgets).map((w) => w.widgetKey)).toEqual([
+			"CreateOpportunity",
+			"ToDo",
+			"VolunteerStats",
+		]);
+	});
+
+	it("does not mutate the input array", () => {
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "Settings", x: 1, y: 8, width: 8, height: 1 },
+			{ widgetKey: "Calendar", x: 1, y: 4, width: 8, height: 4 },
+		];
+		const original = [...widgets];
+
+		sortByPosition(widgets);
+
+		expect(widgets).toEqual(original);
+	});
+
+	it("already matches DEFAULT_LAYOUT's own order, since it was authored top-to-bottom", () => {
+		expect(sortByPosition(DEFAULT_LAYOUT)).toEqual(DEFAULT_LAYOUT);
 	});
 });

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
@@ -155,6 +155,18 @@ export const DEFAULT_LAYOUT: PlacedWidget[] = [
 	{ widgetKey: "Settings", x: 1, y: 8, width: 8, height: 1 },
 ];
 
+// Stable top-to-bottom, then left-to-right ordering by saved grid position -
+// what mobile rendering falls back to below the `lg` breakpoint, where the
+// grid collapses to a single stacked column with no explicit gridColumn/
+// gridRow per tile (see OrgDashboardPage/index.tsx's gridStyle) and DOM
+// order becomes the visual order. A layout array's own order can't be
+// trusted for that: settlePlacement above always prepends whichever widget
+// just moved, regardless of where it actually landed, so array order
+// reflects edit history rather than position (#1845).
+export function sortByPosition(widgets: PlacedWidget[]): PlacedWidget[] {
+	return [...widgets].sort((a, b) => a.y - b.y || a.x - b.x);
+}
+
 export function classifyWidth(width: number): WidgetSizeClass {
 	if (width <= 3) return "compact";
 	if (width <= 5) return "medium";


### PR DESCRIPTION
Below the `lg` breakpoint the widget grid collapses to a single stacked
column with no explicit gridColumn/gridRow per tile, so DOM order becomes
the visual order. The layout array's own order doesn't track that: settlePlacement
always prepends whichever widget just moved, regardless of where it landed, so
a widget dragged to the bottom on desktop could render first on mobile.

Adds sortByPosition (widgetCatalog.ts) and uses it to derive the mobile-only
render order in OrgDashboardPage, leaving the lg+ path (positioned explicitly
via gridStyle) untouched.

Fixes #1845