### PR TITLE
fix(frontend): stop scope-tab labels wrapping unevenly on /my-signups

### DIFF
--- a/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
@@ -7,17 +7,27 @@ namespace VisualTests;
 /// "Past") is a hand-rolled segmented control whose two segments sized to their
 /// own label content only (no width-equalizing utility), so the longer
 /// "Current &amp; upcoming" segment rendered visibly wider than "Past" - nearly
-/// 2:1 on live staging (162px vs. 87px in a 259px track). Fixed by adding
-/// flex-1/text-center to both buttons so the track splits evenly regardless of
-/// label length.
+/// 2:1 on live staging (162px vs. 87px in a 259px track). Fixed by making the
+/// track a CSS Grid with two minmax(0,1fr) columns, so it renders both segments
+/// at the width of the wider one regardless of label length. An equal-width
+/// flex-1 track (the original #1836 fix) has the same shrink-to-fit total
+/// width, so it instead squeezes both segments to half that width - which can
+/// compress the longer label below its own single-line width and wrap it, so
+/// grid is the fix that keeps both goals (equal width, no forced wrap) at once
+/// in a longer locale like German's "Aktuell &amp; Bevorstehend" / "Vergangen".
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class MyEngagementsScopeToggleTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
-	// Both segments share flex-1 on the same track, so their rendered widths
+	// Both segments share the same grid track width, so their rendered widths
 	// should match modulo getBoundingClientRect's sub-pixel rounding - far
 	// below the ~75px gap the unequal-width bug produced.
 	private const double MaxWidthDeltaPx = 2;
+
+	// A wrapped-to-two-lines segment renders roughly twice as tall as its
+	// single-line sibling - far above sub-pixel rounding - so an equal-height
+	// check across the pair is a direct proxy for "neither one wrapped".
+	private const double MaxHeightDeltaPx = 2;
 
 	[Test]
 	public async Task ScopeToggle_RendersUpcomingAndPastSegments_AtEqualWidth()
@@ -58,5 +68,58 @@ public class MyEngagementsScopeToggleTests(AspireFixture fixture) : VisualTestBa
 		}, () => "myEngagements scope toggle: 'Current & upcoming' and 'Past' segments should render at "
 			+ $"equal width (last observed upcoming={upcomingWidth:F1}px, past={pastWidth:F1}px, "
 			+ $"delta={widthDelta:F1}px, must be <{MaxWidthDeltaPx}px)");
+	}
+
+	[Test]
+	public async Task ScopeToggle_German_RendersUpcomingAndPastSegmentsOnASingleLine()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		// FastSignInAsync itself waits on the English "User menu" aria-label
+		// (see OrgDashboardWidgetsTests), so switch language only afterwards.
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch language" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Deutsch" }).ClickAsync();
+
+		var upcomingTab = Page.GetByTestId("engagements-scope-upcoming");
+		var pastTab = Page.GetByTestId("engagements-scope-past");
+		await Expect(upcomingTab).ToContainTextAsync("Aktuell & Bevorstehend", new() { Timeout = 15_000 });
+		await Expect(pastTab).ToContainTextAsync("Vergangen", new() { Timeout = 15_000 });
+
+		// Widths and heights read in a single EvaluateAsync call rather than
+		// separate BoundingBoxAsync round trips, so nothing can reflow between
+		// the reads (see VisualTestBase.AssertMaxWidthContentCenteredAsync for
+		// the same pattern).
+		var widthDelta = 0d;
+		var heightDelta = 0d;
+		var upcomingWidth = 0d;
+		var pastWidth = 0d;
+		var upcomingHeight = 0d;
+		var pastHeight = 0d;
+		await PollUntilAsync(async () =>
+		{
+			var rects = await Page.EvaluateAsync<double[]>(
+				"""
+				() => {
+					const upcoming = document.querySelector("[data-testid='engagements-scope-upcoming']").getBoundingClientRect();
+					const past = document.querySelector("[data-testid='engagements-scope-past']").getBoundingClientRect();
+					return [upcoming.width, past.width, upcoming.height, past.height];
+				}
+				""");
+			upcomingWidth = rects[0];
+			pastWidth = rects[1];
+			upcomingHeight = rects[2];
+			pastHeight = rects[3];
+			widthDelta = Math.Abs(upcomingWidth - pastWidth);
+			heightDelta = Math.Abs(upcomingHeight - pastHeight);
+			return widthDelta < MaxWidthDeltaPx && heightDelta < MaxHeightDeltaPx;
+		}, () => "myEngagements scope toggle (German): 'Aktuell & Bevorstehend' and 'Vergangen' segments should "
+			+ "render at equal width and height, i.e. neither wraps to a second line (last observed "
+			+ $"upcoming={upcomingWidth:F1}x{upcomingHeight:F1}px, past={pastWidth:F1}x{pastHeight:F1}px, "
+			+ $"widthDelta={widthDelta:F1}px, heightDelta={heightDelta:F1}px, both must be <2px)");
 	}
 }

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -341,7 +341,7 @@ export default function ActivitySection() {
 					onClick={() => switchEngagementsScope("upcoming")}
 					disabled={engagementsLoading}
 					aria-current={engagementsScope === "upcoming" ? "true" : undefined}
-					className={`flex-1 rounded-md px-3 py-1.5 text-center text-sm font-medium transition-colors ${
+					className={`rounded-md px-3 py-1.5 text-center text-sm font-medium whitespace-nowrap transition-colors ${
 						engagementsScope === "upcoming"
 							? "bg-white text-brand-700 shadow-sm"
 							: "text-gray-600 hover:text-gray-900"
@@ -355,7 +355,7 @@ export default function ActivitySection() {
 					onClick={() => switchEngagementsScope("past")}
 					disabled={engagementsLoading}
 					aria-current={engagementsScope === "past" ? "true" : undefined}
-					className={`flex-1 rounded-md px-3 py-1.5 text-center text-sm font-medium transition-colors ${
+					className={`rounded-md px-3 py-1.5 text-center text-sm font-medium whitespace-nowrap transition-colors ${
 						engagementsScope === "past"
 							? "bg-white text-brand-700 shadow-sm"
 							: "text-gray-600 hover:text-gray-900"

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -333,7 +333,13 @@ export default function ActivitySection() {
 			<div
 				role="group"
 				aria-label={t("myEngagements.scopeLabel")}
-				className="mb-4 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1"
+				// max-w-full + overflow-x-auto: whitespace-nowrap below no longer
+				// lets an overlong label wrap onto a second line as a fallback, and
+				// global.css's html { overflow-x: clip } would otherwise make an
+				// overflow (e.g. from large OS/browser text-scaling) unreachable
+				// rather than just clipped - same safety net as .rbc-btn-group in
+				// global.css.
+				className="mb-4 inline-flex max-w-full overflow-x-auto rounded-lg border border-gray-200 bg-gray-50 p-1"
 			>
 				<button
 					type="button"

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -333,13 +333,20 @@ export default function ActivitySection() {
 			<div
 				role="group"
 				aria-label={t("myEngagements.scopeLabel")}
-				// max-w-full + overflow-x-auto: whitespace-nowrap below no longer
-				// lets an overlong label wrap onto a second line as a fallback, and
-				// global.css's html { overflow-x: clip } would otherwise make an
-				// overflow (e.g. from large OS/browser text-scaling) unreachable
-				// rather than just clipped - same safety net as .rbc-btn-group in
-				// global.css.
-				className="mb-4 inline-flex max-w-full overflow-x-auto rounded-lg border border-gray-200 bg-gray-50 p-1"
+				// grid-cols-2 (not flex): an intrinsically-sized flex-1 track squeezes
+				// both segments to an equal share of the shrink-to-fit container width
+				// - which is sized to the *sum* of their natural widths - so the
+				// longer "Aktuell & Bevorstehend" label got compressed below its own
+				// single-line width and wrapped, while "Vergangen" sat in a mostly
+				// empty, oversized box. CSS Grid's minmax(0,1fr) columns size
+				// every track to the *widest* column's natural content width instead
+				// of splitting the sum evenly, so both stay equal width - keeping
+				// #1836's equal-width fix - without ever squeezing either below its
+				// own single-line size. max-w-full + overflow-x-auto is the same
+				// fallback as .rbc-btn-group in global.css, in case a locale's longer
+				// label still doesn't fit at all (e.g. under large text-scaling) -
+				// scrolls instead of colliding with html's page-wide overflow-x: clip.
+				className="mb-4 inline-grid max-w-full grid-cols-2 overflow-x-auto rounded-lg border border-gray-200 bg-gray-50 p-1"
 			>
 				<button
 					type="button"


### PR DESCRIPTION
## What

Fixes the lopsided "Aktuell & Bevorstehend" / "Vergangen" scope-tab control on `/my-signups` (`ActivitySection.tsx`).

## Why

The two scope-tab buttons used `flex-1` to force equal width (added for #1836, where without it the segments rendered nearly 2:1, ~162px vs ~87px). The German label "Aktuell & Bevorstehend" is much longer than "Vergangen", and an equal-width `flex-1` track squeezes both segments to half of the container's shrink-to-fit total width - which compresses the longer label below its own single-line width and wraps it onto a second line, while the shorter "Vergangen" sits in a mismatched, oversized box. That's the crooked control from the reported screenshot.

My first attempt (drop `flex-1`, add `whitespace-nowrap`) fixed the wrap but reintroduced #1836's original unequal-width problem - confirmed by the existing `MyEngagementsScopeToggleTests.ScopeToggle_RendersUpcomingAndPastSegments_AtEqualWidth` regression test failing in CI (upcoming=146px vs past=49px). `a11y-check` also flagged that disabling wrap removed the only overflow fallback, risky under `global.css`'s site-wide `html { overflow-x: clip }`.

The actual fix: switch the track from `flex` to a two-column CSS Grid (`grid-cols-2`, i.e. `minmax(0,1fr)` columns). Verified empirically (headless Chromium) that an intrinsically-sized CSS Grid sizes every column to the *widest* column's natural content width, rather than splitting the total evenly like flex-basis-0 does - so both segments stay equal width (keeping #1836's fix) without ever squeezing either below its own single-line size (fixing the wrap). Kept `max-w-full overflow-x-auto` as a fallback for locales/text-scaling that still don't fit, mirroring `.rbc-btn-group`'s existing pattern in `global.css`.

No behavioral/semantic change - same `role="group"` wrapper, same two `<button>`s with `aria-current`, same click handlers.

## Testing

- `pnpm format:write` / `pnpm lint` / `pnpm check` (tsc --noEmit) - all clean
- `/self-review` run; `a11y-check` fanned out - no structural/semantic markup changed, existing `AccessibilityTests.cs` coverage for `/my-signups` re-runs against the live DOM automatically
- Added `MyEngagementsScopeToggleTests.ScopeToggle_German_RendersUpcomingAndPastSegmentsOnASingleLine` (TUnit VisualTests): switches to German on `/my-signups` and asserts both segments render at equal width *and* equal height (i.e. neither wraps to a second line) - alongside the existing #1836 equal-width test, which now passes again after this fix

## Live verification

Pending - will cut a release candidate and verify the fix on `https://einsatzbereit.maik-hasler.de/my-signups` (German locale) once CI is green, per root `AGENTS.md`'s mandatory deploy-and-verify flow. Will update this section with the result.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - visual-only fix)