### PR TITLE
docs: drop stale CI timing figure from arc42 QS-3.4 citation

### DIFF
--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -80,13 +80,13 @@ The CI/CD pipeline runs on GitHub Actions and covers three concerns: quality gat
 
 ===== Quality Gate (on every push / PR to `main`)
 
-The backend workflow (`dotnet.yml`) runs four independent jobs in parallel (no `needs` between them), each doing its own `dotnet build` via `dotnet run`:
+The backend workflow (`dotnet.yml`) runs a `build` job (`dotnet restore` + `dotnet build` for the whole solution) that `format-check`, `fast-tests`, `integration-tests`, and `visual-tests` all depend on via `needs: build`, each downloading that build artifact instead of building its own copy:
 
 * `format-check` - verifies `dotnet format`.
 * `fast-tests` - `Application.UnitTests` and `ArchitectureTests`, no containers.
 * `integration-tests` and `visual-tests` - both boot the Aspire AppHost stack (the same stack as local development) under Docker; `visual-tests` adds Playwright end-to-end checks.
 
-The frontend workflow (`frontend.yml`) runs lint, i18n key-parity, type-check, and build; `lint.yml` enforces ASCII dashes and EditorConfig. Typical `dotnet.yml` critical-path runtime is about 6 minutes, down from ~10 minutes before the jobs were split into parallel jobs in issue #773 - `visual-tests` remains the longest-running job - see TDR-2.
+The frontend workflow (`frontend.yml`) runs lint, i18n key-parity, type-check, and build; `lint.yml` enforces ASCII dashes and EditorConfig. `dotnet.yml`'s critical path is kept bounded and is actively tracked as the test suite grows - see TDR-2 for current timing data.
 
 The architecture docs build (`docs.yml`) also builds on every pull request touching `docs/**`, as a build-only check - GitHub Pages deployment stays gated to pushes on `main`, so a docs PR can never publish a preview.
 

--- a/docs/Architecture/src/10_quality_requirements.adoc
+++ b/docs/Architecture/src/10_quality_requirements.adoc
@@ -97,7 +97,7 @@ include::../images/quality-tree.puml[]
 
 |QS-3.4
 |A contributor opens a pull request.
-|The backend CI quality gate (`dotnet.yml`) returns a pass/fail verdict within about 6 minutes via three parallel test jobs, keeping the contribution feedback loop short. See TDR-2.
+|The backend CI quality gate (`dotnet.yml`) returns a pass/fail verdict within a bounded, actively-tracked time, keeping the contribution feedback loop short. See TDR-2 for current timing data.
 |===
 
 ==== Usability


### PR DESCRIPTION
## What

Reworded arc42 QS-3.4 (`10_quality_requirements.adoc`) to describe the backend CI quality gate's bounded-feedback-loop property qualitatively instead of citing a specific "about 6 minutes via three parallel test jobs" figure, and fixed the same stale claims about the pipeline's job structure/timing in `07_deployment_view.adoc`.

## Why

QS-3.4 cited TDR-2 for "about 6 minutes via three parallel test jobs" as a current, citable fact. But TDR-2's own most recent entry - the 2026-07-28 restructuring that introduced a single upstream `build` job all test jobs now depend on via `needs: build` - explicitly calls that number "Preliminary - re-measure at n=20+ before treating 6 min as the new baseline" and later "Re-measure wall-clock once this has run for real." `.github/AGENTS.md`'s own `dotnet.yml` section says the same thing plainly: "Not yet measured over a real run at the time of writing." So chapter 10 was citing TDR-2 for a number TDR-2 itself flags as superseded and unconfirmed, and "three parallel test jobs" no longer matches the pipeline's actual build-then-fan-out shape.

Per the issue's suggested resolution, dropped the specific figure in favor of the qualitative "bounded, actively-tracked time" phrasing (the same citation pattern TDR-2's own Links section already uses to describe QS-3.4), letting TDR-2 continue to own the number once it's re-measured. `07_deployment_view.adoc` had the identical problem (same stale "about 6 minutes" claim, plus "runs four independent jobs in parallel (no `needs` between them)", which no longer matches the current `build`-gated fan-out) - fixed alongside since it cites TDR-2 for the same now-inaccurate pipeline shape.

Closes #1880

## Testing

Docs-only prose change inside existing AsciiDoc table/paragraph structure - no build tooling available locally to render AsciiDoc, so verified manually: no Unicode dashes introduced, paragraphs kept on one unwrapped line per this repo's AsciiDoc convention, and cross-checked wording against TDR-2 and `.github/AGENTS.md` for accuracy.

## Live verification

Not applicable - docs-only change with no runtime/UI behavior to verify on staging.

## Checklist

- [x] `/self-review` run and findings addressed (none - docs-only, no domain-specific checks triggered)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (this PR *is* the documentation fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_012rgGZ5hoNjvbMGg5xwgBKi)_