### PR TITLE
fix(tests): retry org-creation setup calls under sustained VisualTests load

### DIFF
--- a/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
+++ b/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
@@ -192,7 +192,7 @@ public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBas
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var response = await http.PostAsJsonAsync("/v1/organizations", new
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new
 		{
 			name = $"VisualTests {label} {suffix}",
 		});

--- a/backend/tests/VisualTests/OrgSettingsFormActionsTests.cs
+++ b/backend/tests/VisualTests/OrgSettingsFormActionsTests.cs
@@ -236,7 +236,7 @@ public class OrgSettingsFormActionsTests(AspireFixture fixture) : VisualTestBase
 	{
 		var backend = Fixture.GetEndpoint("backend");
 		using var http = await CreateAuthenticatedHttpClientAsync(backend);
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Playwright;
 using TUnit.Core;
@@ -148,6 +150,44 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				throw new TimeoutException(timeoutMessage());
 			await Task.Delay(100);
 		}
+	}
+
+	/// <summary>
+	/// POSTs <paramref name="body"/> as JSON to <paramref name="requestUri"/> and
+	/// retries a handful of times with a short backoff if the response is a
+	/// transient 5xx, before returning whatever the final attempt returned.
+	/// Mirrors AspireFixture's PostTokenRequestWithRetryAsync, applied to the
+	/// same class of problem one level up: creating a test organization (POST
+	/// /v1/organizations) calls out to Keycloak's admin API in turn (create
+	/// organization, add member, assign the organisator role), and under this
+	/// suite's sustained concurrent load that chain can trip the same
+	/// resilience-pipeline rejection/timeout #1709 traces GetMembersAsync's
+	/// admin-API calls back to - surfacing as a 500 from our own backend that
+	/// is not attributable to the request this suite sent, and that a bare
+	/// re-run of just the failing test does not reproduce. Retrying the exact
+	/// same request is safe here in practice: the dominant failure mode is the
+	/// resilience pipeline rejecting or timing out the Keycloak call before any
+	/// organization exists, so there is nothing for a retry to collide with -
+	/// and on the rarer case where Keycloak's side did commit, the retry surfaces
+	/// as a 409 (never retried below) rather than silently duplicating anything.
+	/// Never retries a 4xx - that's a real failure, not a blip.
+	/// </summary>
+	protected static async Task<HttpResponseMessage> PostJsonWithRetryAsync(
+		HttpClient client, string requestUri, object body, CancellationToken cancellationToken = default)
+	{
+		const int maxAttempts = 3;
+		HttpResponseMessage response;
+		for (var attempt = 1; ; attempt++)
+		{
+			response = await client.PostAsJsonAsync(requestUri, body, cancellationToken);
+			if (response.StatusCode < HttpStatusCode.InternalServerError || attempt >= maxAttempts)
+				break;
+
+			response.Dispose();
+			await Task.Delay(TimeSpan.FromMilliseconds(500 * attempt), cancellationToken);
+		}
+
+		return response;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## What

Retries the `CreateOrganizationAsync` test-setup helper (POST `/v1/organizations`) on a transient 5xx, in the two VisualTests classes where CI observed it fail.

## Why

A CI run on `main` (run [31807397068](https://github.com/maik-hasler/einsatzbereit/actions/runs/31807397068)) failed two otherwise-unrelated VisualTests with:

```
TUnit.Engine.Exceptions.TestFailedException: [Test Failure] HttpRequestException: Response status code does not indicate success: 500 (Internal Server Error).
  at OrgAppLayoutErrorStatesTests.CreateOrganizationAsync(String label)
  at OrgAppLayoutErrorStatesTests.OrgShellWhileOffline_ShowsOfflineState_WithoutARetryThatCannotWork()
...
  at OrgSettingsFormActionsTests.CreateOrganizationAsync(String name)
  at OrgSettingsFormActionsTests.EditMode_FailedSaveFromTheFormActionRow_BringsTheErrorBannerIntoView()
```

Both failures are in the tests' own setup helper, not in the assertions under test. Both failed within the same ~2-minute window as two heavy axe-core a11y scans that CI logged as still running after 1 minute - the exact "sustained concurrent load" scenario `KeycloakOrganizationService.GetMembersAsync`'s own comment already documents (#1709): `POST /v1/organizations` calls out to Keycloak's admin API in turn (create organization, add member, assign the organisator role), and under load that chain can trip the resilience pipeline's circuit breaker/timeout, surfacing as a 500 from our own backend that isn't attributable to either test. 430 of 432 tests passed in that same run, including many other organization-creation calls - consistent with an occasional load-induced blip rather than a deterministic bug.

This is the same class of problem `AspireFixture.PostTokenRequestWithRetryAsync` already exists to paper over for Keycloak's own token endpoint (see its doc comment). This PR adds the equivalent for organization creation: `VisualTestBase.PostJsonWithRetryAsync` retries a transient 5xx a handful of times with a short backoff, never a 4xx, and wires both failing helpers through it.

Closes #

## Testing

- `dotnet build` of the full dependency chain (`tests/VisualTests/VisualTests.csproj`, which pulls in the whole backend) succeeds with 0 warnings/0 errors from a clean checkout.
- Could not run `VisualTests` itself locally (no Docker/Aspire orchestration in this sandbox - see root `AGENTS.md`'s Sandbox Limitations). CI's `dotnet.yml` `visual-tests` job runs the full suite on a real runner and is the actual verification for this change.
- `/self-review` run: no P1/P2 findings. Change is confined to `backend/tests/VisualTests/**`, so none of the domain-specific check agents (nswag/ef-migration/architecture/a11y/i18n) apply.
- **CI result:** all 9 checks green on [run 31811135815](https://github.com/maik-hasler/einsatzbereit/actions/runs/31811135815), including `visual-tests` - both previously-failing tests (`OrgShellWhileOffline_ShowsOfflineState_WithoutARetryThatCannotWork`, `EditMode_FailedSaveFromTheFormActionRow_BringsTheErrorBannerIntoView`) passed.

## Live verification

Not applicable - this change touches only `backend/tests/VisualTests/**`, which is CI-only test infrastructure never built into the shipped Docker images. Cutting a release candidate and checking live staging would deploy byte-identical images to what's already running, so it wouldn't exercise this change at all. The real verification is CI's `dotnet.yml` `visual-tests` job on this PR, which ran the exact two previously-failing tests and passed.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - test-only change, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01So7TmHChggcnR3uEdUSWVS)_