### PR TITLE
fix(frontend): give each achievement badge a distinct icon

### DIFF
--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -17,10 +17,18 @@ const EDGE_MARGIN = 8;
 // so getBoundingClientRect/offsetWidth would read 0 anyway).
 const TOOLTIP_WIDTH = 192;
 
+// Milestone (first-step/dedicated-5/centurion-100) and Streak (on-a-roll-7/
+// weekly-hero-4) each group two-to-three badges under one AchievementType,
+// so keying the icon on `type` alone gave every badge in a group the same
+// glyph (#1964). These per-key overrides give each real badge its own
+// shape; `type` remains the fallback for any badge key this switch doesn't
+// know about yet (e.g. a future catalog entry added only in appsettings.json).
 function AchievementTypeIcon({
+	badgeKey,
 	type,
 	className = "h-7 w-7",
 }: {
+	badgeKey: string;
 	type: string;
 	className?: string;
 }) {
@@ -32,6 +40,41 @@ function AchievementTypeIcon({
 		stroke: "currentColor",
 		"aria-hidden": true,
 	};
+
+	switch (badgeKey) {
+		case "first-step":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M3 3v1.5M3 21v-6m0 0 2.77-.693a9 9 0 0 1 6.208.682l.108.054a9 9 0 0 0 6.086.71l3.114-.732a48.524 48.524 0 0 1-.005-10.499l-3.11.732a9 9 0 0 1-6.085-.711l-.108-.054a9 9 0 0 0-6.208-.682L3 4.5M3 15V4.5"
+					/>
+				</svg>
+			);
+		case "centurion-100":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+					/>
+				</svg>
+			);
+		case "weekly-hero-4":
+			return (
+				<svg {...svgProps}>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M3.75 13.5 10.5 3v7.5h9L9.75 21v-7.5h-6Z"
+					/>
+				</svg>
+			);
+		default:
+			break;
+	}
 
 	switch (type) {
 		case "Milestone":
@@ -147,6 +190,7 @@ function BadgeCard({ catalog, earned }: BadgeCardProps) {
 					</span>
 				) : (
 					<AchievementTypeIcon
+						badgeKey={catalog.key}
 						type={typeName}
 						className={`h-7 w-7 ${isEarned ? "text-brand-600" : "text-gray-400"}`}
 					/>


### PR DESCRIPTION
## What

`AchievementTypeIcon` in `BadgeGrid.tsx` chose its glyph purely from the shared `AchievementType` (`Milestone`/`Streak`/`Hidden`), so badges belonging to the same type rendered the identical SVG - distinguishable only by unlocked (brand color) vs. locked (gray) coloring. This adds a per-badge-key override so each real badge gets its own icon shape.

## Why

Closes #1964

"Erster Schritt"/"Engagiert"/"100 Einsatze" (`first-step`/`dedicated-5`/`centurion-100`, all `Milestone`) shared one trophy glyph, and "Anmeldeserie"/"Wochenheld" (`on-a-roll-7`/`weekly-hero-4`, both `Streak`) shared one flame glyph. Only the intentional mystery badge ("Geheimes Abzeichen") already looked different from its peers.

`AchievementTypeIcon` now switches on `catalog.key` first - `first-step` gets a flag icon, `centurion-100` gets a star, `weekly-hero-4` gets a bolt - and falls back to the existing type-based icon (trophy/flame/sparkles/star) for `dedicated-5`, `on-a-roll-7`, `early-adopter`, and any future badge key the switch doesn't know about yet, so a new catalog entry added only via `appsettings.json`'s `BadgeCatalog` config still renders a sensible icon without a frontend change.

## Testing

- `pnpm check` (tsc --noEmit) - pass
- `pnpm lint` - pass, zero warnings
- `pnpm format:write` - no changes needed
- `pnpm test` (Vitest) - 259/259 tests pass
- `a11y-check` subagent run against the diff - no regression; icons remain purely decorative (`aria-hidden`), badge labelling is unaffected since it comes from the card's text, not the icon

No automated icon-shape assertions exist (and none are added) - this is a purely visual fix with no behavioral surface to unit-test; the backend badge catalog/keys are unchanged.

## Live verification

Skipped per explicit task instruction (no release candidate for this change). Verified locally instead: typecheck, lint, and the full Vitest suite all pass, and an `a11y-check` subagent pass confirmed no accessibility regression. The six badge icons can be visually confirmed on `/profile` (as `vera`/`vera123`) once this ships in a future release.

## Checklist

- [x] `/self-review` run and findings addressed (no findings beyond the a11y-check pass above; no locale/backend/architecture-relevant changes)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe badge icon shapes)

---
_Generated by [Claude Code](https://claude.ai/code/session_012871th3MSEsqNMBjYRFPBn)_