### PR TITLE
fix(frontend): close account dropdown when navigating to one of its links

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -502,4 +502,30 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.Keyboard.PressAsync("Escape");
 		await Expect(profileLink).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
 	}
+
+	[Test]
+	public async Task AccountControls_UserMenu_ClosesAfterNavigatingToOwnLink()
+	{
+		// #1956: none of the dropdown's own links (My profile, My signups,
+		// Profile settings, Administration) closed the disclosure on click -
+		// only the outside-click/Escape handling in useAccountMenu did. The
+		// stale panel stayed rendered (aria-expanded="true", panel still
+		// visible) on top of the destination page until the user clicked
+		// elsewhere.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		var userMenuBtn = Page.GetByRole(AriaRole.Button, new() { Name = "User menu" });
+		await userMenuBtn.ClickAsync();
+
+		var profileLink = Page.GetByRole(AriaRole.Link, new() { Name = "My profile" });
+		await Expect(profileLink).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		await profileLink.ClickAsync();
+
+		await Page.WaitForURLAsync(new Regex(@"/profile$"), new() { Timeout = 15_000 });
+		await Expect(userMenuBtn).ToHaveAttributeAsync("aria-expanded", "false", new() { Timeout = 5_000 });
+		await Expect(profileLink).Not.ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
 }

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -79,6 +79,7 @@ export default function AccountControls({
 						<div className="py-1">
 							<Link
 								to="/profile"
+								onClick={() => setDropdownOpen(false)}
 								className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
 							>
 								<UserCircleIcon className="h-4 w-4" />
@@ -86,6 +87,7 @@ export default function AccountControls({
 							</Link>
 							<Link
 								to="/my-signups"
+								onClick={() => setDropdownOpen(false)}
 								className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
 							>
 								<HandRaisedIcon className="h-4 w-4" />
@@ -93,6 +95,7 @@ export default function AccountControls({
 							</Link>
 							<Link
 								to="/profile/settings"
+								onClick={() => setDropdownOpen(false)}
 								className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
 							>
 								<Cog6ToothIcon className="h-4 w-4" />
@@ -101,6 +104,7 @@ export default function AccountControls({
 							{isAdmin && (
 								<Link
 									to="/administration"
+									onClick={() => setDropdownOpen(false)}
 									className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
 								>
 									<Cog6ToothIcon className="h-4 w-4" />


### PR DESCRIPTION
## What

Closes the header account dropdown (avatar + chevron, "User menu"/"Benutzermenü") when a user clicks one of its own navigation links, instead of leaving it rendered and overlapping the destination page.

## Why

None of the four `Link`s inside `AccountControls.tsx`'s dropdown (Mein Profil, Meine Anmeldungen, Profileinstellungen, Administration) called `setDropdownOpen(false)` on click - only the outside-click handling in `useAccountMenu` closed it. After navigating, the trigger button kept reporting `aria-expanded="true"` and the panel stayed `display: block; visibility: visible`, overlapping the new page's content until the user clicked elsewhere.

The fix adds `onClick={() => setDropdownOpen(false)}` to each of the four `Link`s, matching how the analogous disclosures in this codebase already behave (`RowActionsMenu.tsx`'s row actions, `OrganizationSwitcher.tsx`'s `handleSwitch`).

Closes #1956

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm format:check` - all pass
- Backend: `dotnet build`, `Application.UnitTests` (1038/1038), `ArchitectureTests` (426/426) - all pass
- Added `AccountControls_UserMenu_ClosesAfterNavigatingToOwnLink` to `backend/tests/VisualTests/NavigationTests.cs`, asserting the trigger's `aria-expanded` returns to `"false"` and the "My profile" link becomes not-visible after clicking it and landing on `/profile`. This suite needs Docker/Aspire and runs in CI's `dotnet.yml`, not locally in this sandboxed session (see root `AGENTS.md`'s Sandbox Limitations).

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). The new `VisualTests` case above is the durable, reviewable regression coverage in its place and will run against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no doc-facing behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_0197Eshmi8i38RQtYK3dMAxk)_