### PR TITLE
fix(frontend): cap dashboard edit-mode placeholder grid to 1 spare row when idle

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -191,6 +191,43 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 	}
 
 	[Test]
+	public async Task GridBackdrop_CapsIdleRowsPastLastWidget_AndExpandsWhileActivelyPlacing()
+	{
+		// #1902: the backdrop used to always render 4 spare rows past the
+		// last widget (or the live placement cursor/preview, whichever was
+		// lower), even while nothing was being placed - on a dashboard with
+		// only a handful of widgets that read as a wall of undifferentiated
+		// green placeholder tiles reaching well past the fold. It's now
+		// capped to a single spare row while idle, only opening back up to
+		// the old 4-row buffer once a placement (corner-to-corner flow or a
+		// real pointer drag) is actually in progress, giving the organizer
+		// room to drop a widget below the existing content. DEFAULT_LAYOUT's
+		// last widget (Settings) ends at row 8 (see widgetCatalog.ts), so
+		// idle is 8 content rows + 1 spare = 9 rows of 8 columns = 72 cells;
+		// mid-placement it's 8 + 4 = 12 rows = 96 cells.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await CreateOrganizationAsync("Visual DashBackdropCap", pinnedOrgId!.Value);
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+
+		await Expect(Page.GetByTestId("dashboard-grid-guide-cell")).ToHaveCountAsync(72);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Move or resize Organization" }).ClickAsync();
+		await Expect(Page.GetByTestId("dashboard-placement-status")).ToBeVisibleAsync();
+
+		await Expect(Page.GetByTestId("dashboard-grid-guide-cell")).ToHaveCountAsync(96);
+
+		await Page.Keyboard.PressAsync("Escape");
+		await Expect(Page.GetByTestId("dashboard-placement-status")).Not.ToBeVisibleAsync();
+
+		await Expect(Page.GetByTestId("dashboard-grid-guide-cell")).ToHaveCountAsync(72);
+	}
+
+	[Test]
 	public async Task DefaultLayout_WidgetTiles_RenderInsideBackdropBounds_NotStackedBelowIt()
 	{
 		// Regression guard for the same CSS technique the old auto-fit packer

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -385,6 +385,13 @@ export default function OrgDashboardPage() {
 	const previewBottom = previewRect
 		? previewRect.y + previewRect.height - 1
 		: 0;
+	// #1902: the backdrop only needs real headroom while a placement is
+	// actually in progress (corner-to-corner flow or a real pointer drag,
+	// both captured by activeKey) - a widget being dragged/resized needs
+	// room below the existing content to drop into. Idle, a single spare
+	// row is enough to read as "this grid is still editable" without
+	// papering the whole viewport in placeholder tiles past the last widget.
+	const guidePadding = activeKey !== null ? 4 : 1;
 	// Clamped, not just summed - `Array.from({ length })` below throws a
 	// RangeError (taking down the whole page, not just this component) for
 	// a non-finite or absurdly large length, and Math.min/max propagate NaN
@@ -394,7 +401,7 @@ export default function OrgDashboardPage() {
 	// upstream would otherwise become unrecoverable rather than just a
 	// visually-wrong backdrop.
 	const rawGuideRows =
-		Math.max(contentRows, cursor?.row ?? 0, previewBottom) + 4;
+		Math.max(contentRows, cursor?.row ?? 0, previewBottom) + guidePadding;
 	const guideRows = Number.isFinite(rawGuideRows)
 		? Math.min(GRID_MAX_ROWS + 4, rawGuideRows)
 		: GRID_MAX_ROWS + 4;


### PR DESCRIPTION
## What

Caps the dashboard's edit-mode placeholder-tile backdrop to 1 spare row past the last widget while idle, expanding back to 4 spare rows only while a placement (corner-to-corner flow or a real pointer drag) is actively in progress.

## Why

Entering edit mode on a dashboard with only a few widgets configured rendered a drag-target grid of pale-green placeholder tiles extending ~8 rows past the actual widgets, well below the fold - a lot of undifferentiated visual noise against the otherwise minimal product feel.

The issue flagged this as a decision, not a confirmed defect: is the full-viewport placeholder grid intentional, or should it be capped? Per the repo owner's decision, it should be capped to ~1 row past the last widget, expanding only during an active drag.

Closes #1902

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm format:write` - all clean
- Backend: `dotnet build`, `Application.UnitTests` (1038 passed), `ArchitectureTests` (426 passed), and `tests/VisualTests` builds successfully with the new test
- Added `GridBackdrop_CapsIdleRowsPastLastWidget_AndExpandsWhileActivelyPlacing` to `backend/tests/VisualTests/OrgDashboardCustomizeTests.cs`, asserting the backdrop is 72 cells (9 rows x 8 columns) while idle on the default layout, expands to 96 cells (12 rows) once a placement starts, and returns to 72 after cancelling - runs against the local Aspire stack in CI (`dotnet.yml`)
- `/self-review` run: no findings. `a11y-check` subagent confirmed this is out of scope for accessibility - the backdrop cells are already `aria-hidden="true"` regardless of count, and existing `AccessibilityTests.cs` coverage (`OrgDashboardPage_EditMode_AsOlaf_...` / `OrgDashboardPage_PlacingAWidget_AsOlaf_...`) already spans both the idle and actively-placing states this change touches

## Live verification

Skipped per explicit instruction not to cut a release candidate for this change. The new `VisualTests` case above is the durable, reviewable coverage for this fix and runs against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs reference this backdrop's row count)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MptbuZPPdbuFGxDHh3D55J)_