### PR TITLE
fix: show mobile CTA above the map on the opportunity detail page

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -235,6 +235,58 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_MobileActionRail_AsVera_HasNoSeriousA11yViolations()
+	{
+		// #1965: the sign-up CTA (and its deadline/status/login-prompt
+		// siblings) now renders a second time - testid-suffixed "-mobile" -
+		// right above the map on narrow viewports, with the desktop `<aside>`
+		// hidden below `lg` instead. Every detail-page scan above runs at
+		// Playwright's default 1280x720 viewport (above `lg`), so none of
+		// them ever render - or scan - this new mobile-only markup.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Mobile Rail Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"A11y Mobile Rail Test {suffix}",
+			description = "Seeded for #1965 mobile action-rail a11y coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.SetViewportSizeAsync(375, 812);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Proves the scan below actually saw the new mobile-only markup,
+		// rather than passing against a page where it never rendered.
+		await Expect(Page.GetByTestId("signup-cta-mobile")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task VolunteerOpportunityDetailPage_MapMarker_HasAccessibleName()
 	{
 		// #1681: SingleMarkerMap.tsx's Leaflet divIcon marker rendered an

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -47,7 +47,11 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 		await Page.GotoAsync(detailUrl);
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await Expect(Page.GetByText("Your sign-up")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		// Scoped to the desktop testid (#1965 added a second, lg:hidden copy of
+		// this same "Your sign-up" text right above the map for narrow
+		// viewports - an unscoped Page.GetByText would match both).
+		await Expect(Page.GetByTestId("application-status").GetByText("Your sign-up"))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }))
 			.Not.ToBeVisibleAsync();
 	}
@@ -89,7 +93,11 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 		await Page.GotoAsync(detailUrl);
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-		await Expect(Page.GetByText("Your sign-up")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		// Scoped to the desktop testid (#1965 added a second, lg:hidden copy of
+		// this same "Your sign-up" text right above the map for narrow
+		// viewports - an unscoped Page.GetByText would match both).
+		await Expect(Page.GetByTestId("application-status").GetByText("Your sign-up"))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }))
 			.Not.ToBeVisibleAsync();
 	}

--- a/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
@@ -1,0 +1,152 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1965: on the 375px reflow, the opportunity detail page's
+/// sticky rail (deadline / application status / sign-up CTA / login prompt)
+/// dropped to single-column and landed after the at-a-glance summary, the
+/// category tags, the full-width Leaflet map (~250px tall) and the
+/// organisation contact card - roughly 700px of scrolling before the page's
+/// one conversion point was reachable, even though the same content sits at
+/// the very top of the page on desktop next to the reading column.
+///
+/// Fixed by rendering the rail's content a second time (VolunteerOpportunity
+/// DetailPage.tsx's `renderActionRail`, testid-suffixed "-mobile") right
+/// after the at-a-glance meta row and before the map, visible only below
+/// `lg`; the original sticky `<aside>` now hides below `lg` in turn so the
+/// two copies are never both visible at the same viewport.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityDetailPageMobileActionRailTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private const int NarrowViewportWidth = 375;
+	private const int NarrowViewportHeight = 812;
+
+	/// <summary>
+	/// Seeds a published, non-remote, IndividualContact opportunity (so both
+	/// the deadline-carrying blocks and the map are eligible to render), then
+	/// patches coordinates into the detail fetch - VisualTests always runs
+	/// against FakeGeocodingService (AppHost.cs), which never returns real
+	/// coordinates for a seeded address, so the map would never render
+	/// otherwise (same technique as SingleMarkerMapStaticTests.cs).
+	/// </summary>
+	private async Task<string> SeedOpportunityWithMapAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"MobileRail1965 {label} {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"MobileRail1965 {label} {suffix}",
+			description = "Seeded for #1965 mobile action-rail regression coverage.",
+			organizationId,
+			isRemote = false,
+			street = "Teststrasse",
+			houseNumber = "1",
+			zipCode = "12345",
+			city = "Musterstadt",
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString()!;
+
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			var response = await route.FetchAsync();
+			var body = JsonNode.Parse(await response.TextAsync())!.AsObject();
+			body["latitude"] = JsonValue.Create(52.52);
+			body["longitude"] = JsonValue.Create(13.405);
+
+			await route.FulfillAsync(new()
+			{
+				Response = response,
+				ContentType = "application/json",
+				Body = body.ToJsonString(),
+			});
+		});
+
+		return opportunityId;
+	}
+
+	/// <summary>
+	/// Asserts <paramref name="railBlock"/> is visible, sits above the map
+	/// (smaller y than the map's top edge) and that the desktop-only copy
+	/// with testid <paramref name="desktopTestId"/> is not visible at the
+	/// current (narrow) viewport - the two copies must never both be on
+	/// screen at once.
+	/// </summary>
+	private async Task AssertRailAboveMapAndNoDesktopDuplicateAsync(ILocator railBlock, string desktopTestId)
+	{
+		var map = Page.Locator(".leaflet-container");
+		await Expect(map).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(railBlock).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var railBox = await railBlock.BoundingBoxAsync();
+		var mapBox = await map.BoundingBoxAsync();
+		railBox.Should().NotBeNull();
+		mapBox.Should().NotBeNull();
+		railBox!.Y.Should().BeLessThan(mapBox!.Y,
+			"the mobile action rail must sit above the map, matching the priority the same content has "
+			+ "in the desktop sticky rail (#1965)");
+
+		await Expect(Page.GetByTestId(desktopTestId)).Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task ActionRail_ForAnonymousVisitor_RendersAboveMapOnNarrowViewport()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await SeedOpportunityWithMapAsync("Anonymous");
+
+		await Page.SetViewportSizeAsync(NarrowViewportWidth, NarrowViewportHeight);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertRailAboveMapAndNoDesktopDuplicateAsync(
+			Page.GetByTestId("login-prompt-mobile"), "login-prompt");
+	}
+
+	[Test]
+	public async Task ActionRail_ForAuthenticatedNonOwner_RendersAboveMapOnNarrowViewport()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await SeedOpportunityWithMapAsync("Vera");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.SetViewportSizeAsync(NarrowViewportWidth, NarrowViewportHeight);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertRailAboveMapAndNoDesktopDuplicateAsync(
+			Page.GetByTestId("signup-cta-mobile"), "signup-cta");
+	}
+}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -340,6 +340,150 @@ export default function VolunteerOpportunityDetailPage() {
 			.filter((opp) => opp.id !== opportunity.id)
 			.slice(0, 3) ?? [];
 
+	// The four mutually-exclusive-ish blocks the sticky rail can show. Named
+	// here (rather than inlined twice) because #1965 renders the same rail
+	// content a second time on narrow viewports - see renderActionRail below.
+	const showDeadlineCard =
+		opportunity.participationType === "IndividualContact" &&
+		!!opportunity.validUntil &&
+		!(isAuthenticated && !isOwner && !cue && !isDraft);
+	const showApplicationStatus =
+		isAuthenticated && !isOwner && !!cue && !isDraft;
+	const showSignUpCta = isAuthenticated && !isOwner && !cue && !isDraft;
+	const showLoginPrompt = !isAuthenticated && !isDraft;
+	const hasActionRail =
+		showDeadlineCard ||
+		showApplicationStatus ||
+		showSignUpCta ||
+		showLoginPrompt;
+
+	// The sticky rail's content, rendered once for the lg+ sidebar and once
+	// more (testIdSuffix "-mobile") right above the map for narrow viewports -
+	// on desktop the CTA sits at the top of the page next to the reading
+	// column, but below lg the rail drops to the DOM's end, after the at-a-
+	// glance summary, the map and the organisation contact card add up to
+	// ~700px of scrolling before the page's one conversion point is reachable
+	// (#1965). Only one instance is ever visible at a given viewport (the
+	// aside hides below lg, this copy hides at lg+), so duplicated ids don't
+	// collide and duplicated buttons are never both reachable at once.
+	// Takes the already-null-checked opportunity as a parameter rather than
+	// closing over the outer `opportunity` state directly - TS control-flow
+	// narrowing doesn't carry a `const`'s narrowed type into a nested function
+	// declared after the null check, so referencing `opportunity` in here
+	// would still type as possibly-null.
+	function renderActionRail(
+		testIdSuffix: string,
+		opp: VolunteerOpportunityDetails,
+	) {
+		return (
+			<>
+				{showDeadlineCard && (
+					<div
+						className={`flex items-center gap-1.5 text-sm font-medium text-gray-700 ${cardClass}`}
+					>
+						<span>
+							{t("opportunities.applyBy", {
+								date: formatDate(
+									opp.validUntil as unknown as string,
+									i18n.language,
+								),
+							})}
+						</span>
+					</div>
+				)}
+
+				{showApplicationStatus && cue && (
+					<div
+						data-testid={`application-status${testIdSuffix}`}
+						className={`${cardClass} sm:p-5`}
+					>
+						<div className="flex items-center justify-between gap-4">
+							<div>
+								<p className="mb-1 text-xs text-gray-500">
+									{t("opportunities.yourApplication")}
+								</p>
+								<Chip
+									tone={cue.status === "Confirmed" ? "success" : "warning"}
+									size="sm"
+								>
+									{t(`myEngagements.status.${cue.status}`)}
+								</Chip>
+							</div>
+							<Button
+								type="button"
+								variant="dangerOutline"
+								size="sm"
+								className="shrink-0"
+								onClick={() => setShowWithdrawConfirm(true)}
+								disabled={withdrawing}
+							>
+								{t("myEngagements.withdraw")}
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{/* Sign-up CTA */}
+				{showSignUpCta && (
+					<div
+						data-testid={`signup-cta${testIdSuffix}`}
+						className={`space-y-3 ${cardClass} sm:p-5`}
+					>
+						{/* Only the full state speaks here now: it explains why the
+						button below is disabled. The remaining places themselves are
+						stated in the meta row above, where every visitor sees them
+						rather than only signed-in non-owners (#1777). */}
+						{isFull && (
+							<p className="text-sm font-medium text-red-600">
+								{t("opportunities.noSpotsLeft")}
+							</p>
+						)}
+						<Button
+							onClick={() => setShowSignUp(true)}
+							disabled={isFull}
+							fullWidth
+							size="lg"
+						>
+							{opp.participationType === "ScheduledSlots"
+								? t("opportunities.joinWaitlist")
+								: t("opportunities.expressInterest")}
+						</Button>
+						{opp.participationType === "IndividualContact" &&
+							opp.validUntil && (
+								<p className="text-sm text-gray-600">
+									{t("opportunities.applyBy", {
+										date: formatDate(
+											opp.validUntil as unknown as string,
+											i18n.language,
+										),
+									})}
+								</p>
+							)}
+					</div>
+				)}
+
+				{showLoginPrompt && (
+					<div
+						data-testid={`login-prompt${testIdSuffix}`}
+						className={`space-y-3 ${cardClass} sm:p-5`}
+					>
+						<p className="text-sm text-gray-600">
+							{t("opportunities.loginPrompt")}
+						</p>
+						<Button
+							onClick={() => auth.signinRedirect(signinLocaleArgs())}
+							data-testid={`opportunity-signin${testIdSuffix}`}
+							fullWidth
+							size="lg"
+						>
+							{t("nav.signIn")}
+						</Button>
+					</div>
+				)}
+			</>
+		);
+	}
+
 	return (
 		<>
 			<PageHeaderBand
@@ -540,6 +684,18 @@ export default function VolunteerOpportunityDetailPage() {
 								</span>
 							</div>
 
+							{/* Mobile-only duplicate of the sticky rail (#1965) - see
+						renderActionRail's comment above. lg:hidden because the aside
+						below already carries the same content at lg+. */}
+							{hasActionRail && (
+								<div
+									className="mb-6 space-y-6 lg:hidden"
+									data-testid="opportunity-action-rail-mobile"
+								>
+									{renderActionRail("-mobile", opportunity)}
+								</div>
+							)}
+
 							{!opportunity.isRemote &&
 								opportunity.latitude != null &&
 								opportunity.longitude != null && (
@@ -688,125 +844,13 @@ export default function VolunteerOpportunityDetailPage() {
 						</div>
 					</div>
 
-					{/* sticky needs a scroll container that is not the grid item itself;
-				lg:items-start on the grid keeps this from stretching to full row
-				height, which would make top-24 have nothing left to stick against. */}
-					<aside className="lg:sticky lg:top-24">
-						<div className="space-y-6">
-							{/* Application deadline - only as a card of its own when there
-							is no sign-up card below to carry it (owner, draft, already
-							signed up, signed out). When the CTA is showing, the deadline
-							renders inside it instead: two stacked cards pushed the rail's
-							actual purpose - the button - a full card-height further down
-							a page that already opens with a banner image. */}
-							{opportunity.participationType === "IndividualContact" &&
-								opportunity.validUntil &&
-								!(isAuthenticated && !isOwner && !cue && !isDraft) && (
-									<div
-										className={`flex items-center gap-1.5 text-sm font-medium text-gray-700 ${cardClass}`}
-									>
-										<span>
-											{t("opportunities.applyBy", {
-												date: formatDate(
-													opportunity.validUntil as unknown as string,
-													i18n.language,
-												),
-											})}
-										</span>
-									</div>
-								)}
-
-							{isAuthenticated && !isOwner && cue && !isDraft && (
-								<div
-									data-testid="application-status"
-									className={`${cardClass} sm:p-5`}
-								>
-									<div className="flex items-center justify-between gap-4">
-										<div>
-											<p className="mb-1 text-xs text-gray-500">
-												{t("opportunities.yourApplication")}
-											</p>
-											<Chip
-												tone={
-													cue.status === "Confirmed" ? "success" : "warning"
-												}
-												size="sm"
-											>
-												{t(`myEngagements.status.${cue.status}`)}
-											</Chip>
-										</div>
-										<Button
-											type="button"
-											variant="dangerOutline"
-											size="sm"
-											className="shrink-0"
-											onClick={() => setShowWithdrawConfirm(true)}
-											disabled={withdrawing}
-										>
-											{t("myEngagements.withdraw")}
-										</Button>
-									</div>
-								</div>
-							)}
-
-							{/* Sign-up CTA */}
-							{isAuthenticated && !isOwner && !cue && !isDraft && (
-								<div
-									data-testid="signup-cta"
-									className={`space-y-3 ${cardClass} sm:p-5`}
-								>
-									{/* Only the full state speaks here now: it explains why the
-									button below is disabled. The remaining places themselves are
-									stated in the meta row above, where every visitor sees them
-									rather than only signed-in non-owners (#1777). */}
-									{isFull && (
-										<p className="text-sm font-medium text-red-600">
-											{t("opportunities.noSpotsLeft")}
-										</p>
-									)}
-									<Button
-										onClick={() => setShowSignUp(true)}
-										disabled={isFull}
-										fullWidth
-										size="lg"
-									>
-										{opportunity.participationType === "ScheduledSlots"
-											? t("opportunities.joinWaitlist")
-											: t("opportunities.expressInterest")}
-									</Button>
-									{opportunity.participationType === "IndividualContact" &&
-										opportunity.validUntil && (
-											<p className="text-sm text-gray-600">
-												{t("opportunities.applyBy", {
-													date: formatDate(
-														opportunity.validUntil as unknown as string,
-														i18n.language,
-													),
-												})}
-											</p>
-										)}
-								</div>
-							)}
-
-							{!isAuthenticated && !isDraft && (
-								<div
-									data-testid="login-prompt"
-									className={`space-y-3 ${cardClass} sm:p-5`}
-								>
-									<p className="text-sm text-gray-600">
-										{t("opportunities.loginPrompt")}
-									</p>
-									<Button
-										onClick={() => auth.signinRedirect(signinLocaleArgs())}
-										data-testid="opportunity-signin"
-										fullWidth
-										size="lg"
-									>
-										{t("nav.signIn")}
-									</Button>
-								</div>
-							)}
-						</div>
+					{/* Hidden below lg: the mobile-only copy right above the map (#1965)
+				carries the same content there instead. sticky needs a scroll
+				container that is not the grid item itself; lg:items-start on the
+				grid keeps this from stretching to full row height, which would
+				make top-24 have nothing left to stick against. */}
+					<aside className="hidden lg:sticky lg:top-24 lg:block">
+						<div className="space-y-6">{renderActionRail("", opportunity)}</div>
 					</aside>
 				</div>
 


### PR DESCRIPTION
## What

On the volunteer opportunity detail page, the sticky action rail (sign-up CTA / application status / login prompt) now also renders right after the at-a-glance summary and category tags, above the map, on narrow viewports. It's hidden below `lg` in its original desktop position and shown there instead; the desktop `<aside>` hides below `lg` in turn, so only one copy is ever visible at a given viewport.

## Why

On the 375px reflow, the rail dropped to the bottom of the single-column stack, landing after the at-a-glance summary card, category tags, the full-width Leaflet map (~250px tall) and the organisation contact card - roughly 700px of scrolling before the page's one conversion point ("Interesse bekunden" / Express interest) was reachable, even though it sits at the top of the page on desktop next to the reading column. Mobile is the realistic context for "found an offer, want to act now", so burying the primary action behind a map and a contact card adds friction exactly where it costs the most.

Closes #1965

## Testing

- `pnpm check`, `pnpm lint`, `pnpm format:check`, `pnpm test` (259 tests) - all pass
- `ArchitectureTests` (426 tests) and `Application.UnitTests` (1038 tests) - all pass (unaffected by this change, run per root `AGENTS.md`'s sandbox-limitation guidance)
- `VisualTests` project (including the new/edited files below) compiles cleanly - could not run it locally (no Docker/Aspire in this sandbox, see root `AGENTS.md`)
- Added `backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs`: asserts the mobile action rail renders above the map at 375px for both an anonymous visitor (login prompt) and an authenticated non-owner (sign-up CTA), and that the desktop copy is not visible at that viewport
- Added `AccessibilityTests.VolunteerOpportunityDetailPage_MobileActionRail_AsVera_HasNoSeriousA11yViolations`: axe-core scan of the new mobile-only markup at 375px (no existing detail-page scan reaches it, since they all run at the >1024px Playwright default viewport)
- Fixed a pre-existing test that would have broken from the new duplicate DOM content: `OpportunityApplicationStateTests`'s two `Page.GetByText("Your sign-up")` assertions were unscoped and would now match both the desktop and (hidden) mobile copy - scoped both to the desktop `application-status` testid
- `/self-review` run - see below

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). The mobile-only markup is covered instead by the new Playwright regression test and axe-core a11y test described above, both of which run in CI (`dotnet.yml`'s `visual-tests` job) against a real Aspire-orchestrated stack.

## Checklist

- [x] `/self-review` run and findings addressed (caught and fixed the `OpportunityApplicationStateTests` strict-mode regression described above)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this layout)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WmvLBHNZeaMzzLcbTsQhFD)_