### PR TITLE
fix(frontend): route calendar widget's toolbar date-range header through formatDate

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -465,6 +465,118 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 	}
 
 	[Test]
+	public async Task CalendarWidget_ToolbarDateRangeHeader_UsesSharedDateFormat_NotAmbiguousDdMmYyyy()
+	{
+		// #1959: the Agenda/Week toolbar's date-range label (e.g. "14/08/2026 -
+		// 13/09/2026") came straight from react-big-calendar's own
+		// agendaHeaderFormat/dayRangeHeaderFormat defaults (date-fns' locale
+		// default 'P' token, or a year-less "MMMM dd" range for Week), never
+		// routed through the site's shared formatDate/formatDateTime helpers
+		// that every other date on the site - including this same widget's own
+		// event chips - goes through. A raw DD/MM/YYYY pair is genuinely
+		// ambiguous for a mixed EN/DE audience, and the Week range dropped the
+		// year entirely. Both are now built from formatDate, so this asserts
+		// the header always carries a spelled-out month and an explicit year
+		// on both sides, joined with the site's plain ASCII " - " rather than
+		// react-big-calendar's own Unicode en dash separator.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1959 {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		// Gives the widget a real event row alongside the toolbar header, same
+		// as the reported repro (comparing the header against an event row a
+		// few lines below it).
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"Visual1959 Opportunity {suffix}",
+			description = "Created by CalendarWidget toolbar date-format test",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(3);
+		var end = start.AddHours(2);
+		(await http.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/time-slots",
+			new { startDateTime = start, endDateTime = end, maxParticipants = 5, recurrenceCount = 1 }))
+			.EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		var calendarWidget = Page.Locator("section", new()
+		{
+			Has = Page.GetByRole(AriaRole.Heading, new() { Name = "Calendar", Exact = true }),
+		});
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var toolbarLabel = calendarWidget.Locator(".rbc-toolbar-label");
+		var viewGroup = calendarWidget.Locator(".rbc-btn-group").Last;
+
+		// "d MMM yyyy - d MMM yyyy" - the same shape formatDate (dateStyle:
+		// medium) produces everywhere else on the site, on both sides of the
+		// range regardless of whether the range crosses a month boundary.
+		const string sharedDateFormatPattern = @"^\d{1,2} [A-Za-z]+ \d{4} - \d{1,2} [A-Za-z]+ \d{4}$";
+
+		// The widget defaults to Month view (its own default for a "full"
+		// placement, see defaultViewForSize) - captured before switching so
+		// the waits below can confirm each click's re-render actually landed
+		// rather than reading InnerTextAsync() in a race with React's update.
+		var monthLabel = await toolbarLabel.InnerTextAsync();
+
+		await viewGroup.GetByRole(AriaRole.Button, new() { Name = "Agenda", Exact = true }).ClickAsync();
+		await Expect(toolbarLabel).Not.ToHaveTextAsync(monthLabel);
+		var agendaLabel = await toolbarLabel.InnerTextAsync();
+		Regex.IsMatch(agendaLabel, @"^\d{1,2}/\d{1,2}/\d{4}").Should().BeFalse(
+			$"the Agenda toolbar header must not fall back to a raw, locale-ambiguous DD/MM/YYYY pair (got \"{agendaLabel}\")");
+		agendaLabel.Should().NotContain("\u2013",
+			"the shared date formatter joins with a plain ASCII hyphen, not react-big-calendar's own en dash default");
+		agendaLabel.Should().MatchRegex(sharedDateFormatPattern,
+			$"the Agenda toolbar header must use the site's shared date format (got \"{agendaLabel}\")");
+
+		await viewGroup.GetByRole(AriaRole.Button, new() { Name = "Week", Exact = true }).ClickAsync();
+		await Expect(toolbarLabel).Not.ToHaveTextAsync(agendaLabel);
+		var weekLabel = await toolbarLabel.InnerTextAsync();
+		weekLabel.Should().NotContain("\u2013",
+			"the shared date formatter joins with a plain ASCII hyphen, not react-big-calendar's own en dash default");
+		weekLabel.Should().MatchRegex(sharedDateFormatPattern,
+			$"the Week toolbar header must carry an explicit year on both sides via the site's shared date format, "
+				+ $"not react-big-calendar's own year-less \"MMMM dd\" range default (got \"{weekLabel}\")");
+	}
+
+	[Test]
 	public async Task CalendarWidget_MobileViewport_ToolbarButtonsAndAgendaColumnStayReachable()
 	{
 		// #812: WidgetCard only set overflow-y-auto on its content wrapper, and

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -21,7 +21,11 @@ import ErrorBanner from "../../../components/ErrorBanner";
 import WidgetCard from "./WidgetCard";
 import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import { visibleCalendarRange } from "../../../lib/calendarRange";
-import { formatDateTime, resolveDateLocale } from "../../../lib/format";
+import {
+	formatDate,
+	formatDateTime,
+	resolveDateLocale,
+} from "../../../lib/format";
 import { brandColor } from "../../../lib/brandColor";
 import {
 	readableTextColor,
@@ -330,6 +334,25 @@ function CalendarWidget({
 		[t],
 	);
 
+	// react-big-calendar's own dayRangeHeaderFormat/agendaHeaderFormat defaults
+	// (see localizers/date-fns.js) render the week/agenda toolbar's date-range
+	// label via date-fns' locale-default 'P' token - raw, ambiguous DD/MM/YYYY
+	// for en-GB, never routed through the site's shared formatDate/formatDateTime
+	// helpers that every other date on the site (including this same widget's
+	// own event chips, CalEventChip above) goes through (#1959). Both format
+	// keys receive a {start, end} range and are keyed off i18n.language (not
+	// the `culture` arg RBC would otherwise pass in), so this has to be a
+	// per-render formatter rather than a module-scope constant like
+	// `localizer` above.
+	const calendarFormats = useMemo(() => {
+		const formatHeaderRange = ({ start, end }: { start: Date; end: Date }) =>
+			`${formatDate(start.toISOString(), i18n.language)} - ${formatDate(end.toISOString(), i18n.language)}`;
+		return {
+			dayRangeHeaderFormat: formatHeaderRange,
+			agendaHeaderFormat: formatHeaderRange,
+		};
+	}, [i18n.language]);
+
 	const handleSelectEvent = useCallback((event: object) => {
 		const e = event as CalEvent;
 		if (colorDebounceRef.current) clearTimeout(colorDebounceRef.current);
@@ -439,6 +462,7 @@ function CalendarWidget({
 							eventPropGetter={calendarEventPropGetter}
 							onSelectEvent={handleSelectEvent}
 							messages={calendarMessages}
+							formats={calendarFormats}
 						/>
 					</div>
 				)}


### PR DESCRIPTION
## What

The Calendar widget's toolbar date-range label (Agenda/Week views) now routes through the site's shared `formatDate` helper instead of react-big-calendar's own default formatter.

## Why

On `/app/{orgId}/dashboard`, the Calendar widget's Agenda-view toolbar header rendered its date range in raw `DD/MM/YYYY` (e.g. "14/08/2026 - 13/09/2026") - genuinely ambiguous for a mixed EN/DE audience - while the Week-view header dropped the year entirely (e.g. "August 14 - 20"). Both came straight from react-big-calendar's own `agendaHeaderFormat`/`dayRangeHeaderFormat` defaults, never routed through `formatDate`/`resolveDateLocale` in `frontend/src/lib/format.ts`, which every other date on the site - including this same widget's own event chips (`CalEventChip`) - already uses.

Fix: `CalendarWidget.tsx` now passes a memoized `formats` prop to `<Calendar>` overriding `dayRangeHeaderFormat` and `agendaHeaderFormat` with a formatter that calls `formatDate(iso, i18n.language)` on both sides of the range, joined with a plain ASCII " - " (matching the site's dash convention) instead of react-big-calendar's own Unicode en dash separator. `monthHeaderFormat` ("August 2026") and `dayHeaderFormat` ("Friday Aug 14") were left untouched - they're already locale-correct and unambiguous, and aren't "date-range" headers.

Closes #1959

## Testing

- `pnpm check` (tsc), `pnpm lint` (zero warnings), `pnpm format:write` - all clean.
- Added `CalendarWidget_ToolbarDateRangeHeader_UsesSharedDateFormat_NotAmbiguousDdMmYyyy` to `backend/tests/VisualTests/OrgDashboardWidgetsTests.cs` - creates an org with a published time slot, switches the dashboard's Calendar widget through Agenda and Week views, and asserts the toolbar header (a) never matches the old ambiguous `DD/MM/YYYY` pattern, (b) never contains react-big-calendar's own Unicode en dash separator, and (c) matches the shared `formatDate` shape (spelled-out month + explicit year on both sides of the range).
- `dotnet build` (Api + VisualTests projects), `ArchitectureTests` (426/426 passed), `Application.UnitTests` (1038/1038 passed) all run locally. `VisualTests` itself needs real container networking (Aspire/Testcontainers) which isn't available in this sandbox - see root `AGENTS.md`'s Sandbox Limitations - so the new test compiles and follows the existing suite's conventions but has not been executed locally; `dotnet.yml`'s `visual-tests` job will run it for real on this PR.

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). Regression coverage is instead captured as the automated VisualTests case above, which `dotnet.yml` runs on a real Aspire/Playwright runner as part of this PR's CI.

## Checklist

- [x] `/self-review` run and findings addressed (also ran the `a11y-check` subagent given the `.tsx` change - no issues, text-only change to an existing widget)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - internal formatting fix, no user-facing docs reference the old behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y356EWtw7ZXGmU6CM33hQt)_