### PR TITLE
fix: map placeholder note + synchronous geocoding on Einsatz create

### DIFF
--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -27,22 +27,24 @@
 	</PropertyGroup>
 
 	<Target Name="RenameOpenApiDocuments" AfterTargets="GenerateOpenApiDocuments">
-		<!-- GenerateOpenApiDocuments is itself incremental: a second consecutive
-		     build with no source changes skips regenerating wwwroot/Api.json
-		     entirely (it was already moved away by the Move below, on the
-		     previous run), but this AfterTargets target still runs regardless -
-		     naively erroring whenever wwwroot/Api.json is absent would false-
-		     positive on every such rebuild. Instead of trusting Api.json's mere
-		     absence, look at what's actually sitting in wwwroot/ once this run
-		     is done: openapi-v1.json is a committed file always present, so it's
-		     excluded here and only ever written by the Move below - anything
-		     else found is necessarily fresh output from this run. Nothing found
-		     means generation was skipped (no-op rebuild, nothing to move) - the
-		     already-committed openapi-v1.json is still correct, don't touch it.
-		     Something found under a name other than $(MSBuildProjectName).json is
-		     the real regression this guards against: the document name changed
-		     and would otherwise leave a stale openapi-v1.json committed forever
-		     with no error and no diff for CI's drift check to catch either. -->
+		<!--
+		GenerateOpenApiDocuments is itself incremental: a second consecutive
+		build with no source changes skips regenerating wwwroot/Api.json
+		entirely (it was already moved away by the Move below, on the
+		previous run), but this AfterTargets target still runs regardless -
+		naively erroring whenever wwwroot/Api.json is absent would false-
+		positive on every such rebuild. Instead of trusting Api.json's mere
+		absence, look at what's actually sitting in wwwroot/ once this run
+		is done: openapi-v1.json is a committed file always present, so it's
+		excluded here and only ever written by the Move below - anything
+		else found is necessarily fresh output from this run. Nothing found
+		means generation was skipped (no-op rebuild, nothing to move) - the
+		already-committed openapi-v1.json is still correct, don't touch it.
+		Something found under a name other than $(MSBuildProjectName).json is
+		the real regression this guards against: the document name changed
+		and would otherwise leave a stale openapi-v1.json committed forever
+		with no error and no diff for CI's drift check to catch either.
+		-->
 		<ItemGroup>
 			<_FreshOpenApiDocument Include="$(MSBuildProjectDirectory)/wwwroot/*.json" Exclude="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json" />
 		</ItemGroup>

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -27,10 +27,30 @@
 	</PropertyGroup>
 
 	<Target Name="RenameOpenApiDocuments" AfterTargets="GenerateOpenApiDocuments">
-		<Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/$(MSBuildProjectName).json')"
-					Text="GenerateOpenApiDocuments did not produce wwwroot/$(MSBuildProjectName).json. The OpenAPI document name has most likely changed - check what landed in wwwroot/ and update this target to match instead of letting openapi-v1.json go stale." />
-		<Move SourceFiles="$(MSBuildProjectDirectory)/wwwroot/$(MSBuildProjectName).json"
-					DestinationFiles="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json" />
+		<!-- GenerateOpenApiDocuments is itself incremental: a second consecutive
+		     build with no source changes skips regenerating wwwroot/Api.json
+		     entirely (it was already moved away by the Move below, on the
+		     previous run), but this AfterTargets target still runs regardless -
+		     naively erroring whenever wwwroot/Api.json is absent would false-
+		     positive on every such rebuild. Instead of trusting Api.json's mere
+		     absence, look at what's actually sitting in wwwroot/ once this run
+		     is done: openapi-v1.json is a committed file always present, so it's
+		     excluded here and only ever written by the Move below - anything
+		     else found is necessarily fresh output from this run. Nothing found
+		     means generation was skipped (no-op rebuild, nothing to move) - the
+		     already-committed openapi-v1.json is still correct, don't touch it.
+		     Something found under a name other than $(MSBuildProjectName).json is
+		     the real regression this guards against: the document name changed
+		     and would otherwise leave a stale openapi-v1.json committed forever
+		     with no error and no diff for CI's drift check to catch either. -->
+		<ItemGroup>
+			<_FreshOpenApiDocument Include="$(MSBuildProjectDirectory)/wwwroot/*.json" Exclude="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json" />
+		</ItemGroup>
+		<Error Condition="'@(_FreshOpenApiDocument)' != '' AND '%(_FreshOpenApiDocument.Filename)%(_FreshOpenApiDocument.Extension)' != '$(MSBuildProjectName).json'"
+					Text="GenerateOpenApiDocuments produced wwwroot/%(_FreshOpenApiDocument.Filename)%(_FreshOpenApiDocument.Extension) instead of wwwroot/$(MSBuildProjectName).json. The OpenAPI document name has most likely changed - check what landed in wwwroot/ and update this target to match instead of letting openapi-v1.json go stale." />
+		<Move SourceFiles="@(_FreshOpenApiDocument)"
+					DestinationFiles="$(MSBuildProjectDirectory)/wwwroot/openapi-v1.json"
+					Condition="'@(_FreshOpenApiDocument)' != ''" />
 	</Target>
 
 	<PropertyGroup>

--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -3,7 +3,9 @@ using Api.Common.Endpoints;
 using Api.Common.OutputCaching;
 using Api.Common.RateLimiting;
 using Application.Common.Exceptions;
+using Application.Common.Geocoding;
 using Application.Common.Messaging;
+using Application.Maps.GeocodeAddress.v1;
 using Application.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 using Domain.Common;
 using Domain.Organizations;
@@ -99,6 +101,32 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 				request.HouseNumber ?? string.Empty,
 				request.ZipCode ?? string.Empty,
 				request.City ?? string.Empty).GetValueOrThrow();
+
+		// Resolved synchronously, before the create command ever dispatches -
+		// a bad address is rejected here with a 400 instead of the opportunity
+		// being created anyway and silently sitting with null coordinates until
+		// an organizer notices it missing from "near me" searches (#1963). A
+		// TransientFailure (Nominatim itself unreachable, not the address's
+		// fault) still lets creation through - VolunteerOpportunity.Create
+		// raises the geocoding-requested event for that case, so the existing
+		// outbox/retry job resolves it out of band, same as before.
+		if (address is not null)
+		{
+			var geocodingResult = await sender.Send(new GeocodeAddressQuery(address), cancellationToken);
+
+			if (geocodingResult.Outcome == GeocodingOutcome.NotFound)
+			{
+				return Results.Problem(
+					"Address could not be located. Please check the street, house number, zip code, and city.",
+					statusCode: StatusCodes.Status400BadRequest);
+			}
+
+			if (geocodingResult.Outcome == GeocodingOutcome.Found)
+			{
+				address = address.WithCoordinates(
+					geocodingResult.Coordinates!.Latitude, geocodingResult.Coordinates.Longitude).GetValueOrThrow();
+			}
+		}
 
 		var command = new CreateVolunteerOpportunityCommand(
 			request.Title ?? string.Empty,

--- a/backend/src/Application/Common/Geocoding/GeocodeCacheKey.cs
+++ b/backend/src/Application/Common/Geocoding/GeocodeCacheKey.cs
@@ -1,0 +1,10 @@
+namespace Application.Common.Geocoding;
+
+// Shared by GeocodeAddressQueryHandler (synchronous, create-time lookups) and
+// GeocodeVolunteerOpportunityAddressHandler (async outbox retries) so both
+// geocoding-result caches key identical addresses the same way.
+internal static class GeocodeCacheKey
+{
+	public static string For(string street, string houseNumber, string zipCode, string city) =>
+		$"geocode:{zipCode}|{street}|{houseNumber}|{city}".ToLowerInvariant();
+}

--- a/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQuery.cs
+++ b/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQuery.cs
@@ -1,0 +1,7 @@
+using Application.Common.Geocoding;
+using Application.Common.Messaging;
+using Domain.Common;
+
+namespace Application.Maps.GeocodeAddress.v1;
+
+public sealed record GeocodeAddressQuery(Address Address) : IQuery<GeocodingResult>;

--- a/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQueryHandler.cs
+++ b/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQueryHandler.cs
@@ -1,0 +1,47 @@
+using Application.Common.Geocoding;
+using Application.Common.Messaging;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Application.Maps.GeocodeAddress.v1;
+
+// Resolves an address to coordinates synchronously, in the caller's own
+// request - unlike GeocodeVolunteerOpportunityAddressHandler (the transactional-
+// outbox reaction used to retry a previously-failed/pending attempt out of
+// band), this is the first attempt, called directly from an endpoint before
+// it dispatches its create/update command, so a bad address (NotFound) can be
+// rejected immediately instead of silently saving with null coordinates and
+// only surfacing the problem later (#1963's underlying cause, addressed from
+// the create side here).
+internal sealed class GeocodeAddressQueryHandler(
+	IGeocodingService geocodingService,
+	IMemoryCache cache)
+	: IQueryHandler<GeocodeAddressQuery, GeocodingResult>
+{
+	// Mirrors GeocodeVolunteerOpportunityAddressHandler's cache duration -
+	// repeated identical addresses (e.g. several opportunities at the same
+	// venue) resolve from cache instead of each waiting out Nominatim's shared
+	// one-request-per-second throttle.
+	private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+
+	public async ValueTask<GeocodingResult> Handle(
+		GeocodeAddressQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var address = request.Address;
+		var cacheKey = GeocodeCacheKey.For(address.Street, address.HouseNumber, address.ZipCode, address.City);
+
+		if (cache.TryGetValue(cacheKey, out GeocodingResult? cached) && cached is not null)
+			return cached;
+
+		var result = await geocodingService.GeocodeAsync(
+			address.Street, address.HouseNumber, address.ZipCode, address.City, cancellationToken);
+
+		// Don't cache a TransientFailure - a temporary Nominatim hiccup would
+		// otherwise become a day-long false negative for every other address
+		// lookup sharing this address (mirrors SearchCitiesQueryHandler).
+		if (result.Outcome != GeocodingOutcome.TransientFailure)
+			cache.Set(cacheKey, result, CacheDuration);
+
+		return result;
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
@@ -21,11 +21,15 @@ internal sealed class CreateVolunteerOpportunityCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		// Geocoding (and the up-to-1.1s Nominatim throttle it can wait on, see
-		// NominatimGeocodingService) happens out of band after this command's
-		// transaction commits - VolunteerOpportunity.Create raises
-		// VolunteerOpportunityGeocodingRequestedDomainEvent for a non-remote
-		// address, picked up by GeocodeVolunteerOpportunityAddressHandler (#1388).
+		// request.Address (built by CreateVolunteerOpportunityEndpoint) already
+		// carries resolved coordinates on the happy path - it geocodes
+		// synchronously, before this command ever dispatches, precisely so that
+		// call can hold the up-to-1.1s Nominatim throttle (see
+		// NominatimGeocodingService) without holding this command's transaction
+		// open too (#1388, #1963). Only a TransientFailure there leaves address
+		// uncoordinated; VolunteerOpportunity.Create then raises
+		// VolunteerOpportunityGeocodingRequestedDomainEvent so
+		// GeocodeVolunteerOpportunityAddressHandler retries it out of band.
 		var opportunity = VolunteerOpportunity.Create(
 			request.OrganizationId,
 			request.Title,

--- a/backend/src/Application/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/v1/GeocodeVolunteerOpportunityAddressHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/v1/GeocodeVolunteerOpportunityAddressHandler.cs
@@ -2,7 +2,6 @@ using Application.Common.Exceptions;
 using Application.Common.Geocoding;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
-using Domain.Common;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -48,7 +47,7 @@ internal sealed class GeocodeVolunteerOpportunityAddressHandler(
 			return;
 
 		var address = opportunity.Address;
-		var cacheKey = BuildCacheKey(address);
+		var cacheKey = GeocodeCacheKey.For(address.Street, address.HouseNumber, address.ZipCode, address.City);
 
 		if (!cache.TryGetValue(cacheKey, out GeocodingResult? result) || result is null)
 		{
@@ -98,7 +97,4 @@ internal sealed class GeocodeVolunteerOpportunityAddressHandler(
 				break;
 		}
 	}
-
-	private static string BuildCacheKey(Address address) =>
-		$"geocode:{address.ZipCode}|{address.Street}|{address.HouseNumber}|{address.City}".ToLowerInvariant();
 }

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -268,7 +268,12 @@ public sealed class VolunteerOpportunity
 			validUntil,
 			now ?? DateTimeOffset.UtcNow);
 
-		if (!isRemote && address is not null)
+		// Create's caller (CreateVolunteerOpportunityEndpoint) resolves a fresh
+		// address synchronously before dispatching the create command (#1963),
+		// so address.Latitude is already set on the happy path - only an address
+		// that came back from a TransientFailure (network hiccup, not a bad
+		// address) still needs the async outbox retry to pick it up later.
+		if (!isRemote && address is not null && address.Latitude is null)
 			opportunity.AddEvent(new VolunteerOpportunityGeocodingRequestedDomainEvent(opportunity.Id));
 
 		return opportunity;

--- a/backend/tests/Application.UnitTests/Maps/GeocodeAddress/GeocodeAddressQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Maps/GeocodeAddress/GeocodeAddressQueryHandlerTests.cs
@@ -1,0 +1,131 @@
+using Application.Common.Geocoding;
+using Application.Maps.GeocodeAddress.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+
+namespace Application.UnitTests.Maps.GeocodeAddress;
+
+public sealed class GeocodeAddressQueryHandlerTests : IDisposable
+{
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+
+	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+	private readonly GeocodeAddressQueryHandler _sut;
+
+	public GeocodeAddressQueryHandlerTests()
+	{
+		_sut = new GeocodeAddressQueryHandler(_geocodingService, _cache);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnFoundWithCoordinates_WhenGeocodingFindsMatch(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.Found(new GeoCoordinates(52.52, 13.405)));
+
+		// Act
+		var result = await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+
+		// Assert
+		result.Outcome.Should().Be(GeocodingOutcome.Found);
+		result.Coordinates.Should().Be(new GeoCoordinates(52.52, 13.405));
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnNotFound_WhenGeocodingConfirmsNoMatch(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.NotFound);
+
+		// Act
+		var result = await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+
+		// Assert
+		result.Outcome.Should().Be(GeocodingOutcome.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnTransientFailure_WhenGeocodingProviderIsUnavailable(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
+
+		// Act
+		var result = await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+
+		// Assert
+		result.Outcome.Should().Be(GeocodingOutcome.TransientFailure);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotCallGeocodingServiceTwice_ForRepeatedIdenticalAddress(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.Found(new GeoCoordinates(52.52, 13.405)));
+
+		// Act
+		await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+		await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+
+		// Assert
+		await _geocodingService.Received(1)
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotCacheTransientFailure_SoARetryCanStillSucceed(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_geocodingService
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.TransientFailure);
+
+		// Act
+		await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+		await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+
+		// Assert
+		await _geocodingService.Received(2)
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotShareCache_BetweenDifferentAddresses(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var otherAddress = Address.Create("Nebenstraße", "2", "54321", "Hamburg").Value;
+		_geocodingService
+			.GeocodeAsync("Hauptstraße", "1", "12345", "Berlin", Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.Found(new GeoCoordinates(52.52, 13.405)));
+		_geocodingService
+			.GeocodeAsync("Nebenstraße", "2", "54321", "Hamburg", Arg.Any<CancellationToken>())
+			.Returns(GeocodingResult.NotFound);
+
+		// Act
+		var first = await _sut.Handle(new GeocodeAddressQuery(DefaultAddress), cancellationToken);
+		var second = await _sut.Handle(new GeocodeAddressQuery(otherAddress), cancellationToken);
+
+		// Assert
+		first.Outcome.Should().Be(GeocodingOutcome.Found);
+		second.Outcome.Should().Be(GeocodingOutcome.NotFound);
+	}
+
+	public void Dispose() => _cache.Dispose();
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -298,12 +298,15 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldSaveWithNullCoordinates_AndRaiseGeocodingRequestedEvent_ForNonRemoteAddress(
+	public async Task Handle_ShouldSaveWithNullCoordinates_AndRaiseGeocodingRequestedEvent_ForUncoordinatedNonRemoteAddress(
 		CancellationToken cancellationToken)
 	{
-		// Arrange: geocoding itself now happens out of band (see
-		// GeocodeVolunteerOpportunityAddressHandler) - Create only needs to
-		// persist with null coordinates and raise the event that triggers it.
+		// Arrange: TestAddress carries no coordinates, as if
+		// CreateVolunteerOpportunityEndpoint's synchronous geocoding attempt
+		// came back as a TransientFailure (Nominatim unreachable, not a bad
+		// address) - Create persists with null coordinates and raises the
+		// event that triggers GeocodeVolunteerOpportunityAddressHandler's
+		// out-of-band retry.
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
 
@@ -316,6 +319,26 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		result.Events.OfType<VolunteerOpportunityGeocodingRequestedDomainEvent>()
 			.Should().ContainSingle()
 			.Which.OpportunityId.Should().Be(result.Id);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotRaiseGeocodingRequestedEvent_ForAlreadyCoordinatedNonRemoteAddress(
+		CancellationToken cancellationToken)
+	{
+		// Arrange: the happy path - CreateVolunteerOpportunityEndpoint already
+		// resolved the address synchronously (GeocodeAddressQuery) before
+		// dispatching this command, so no out-of-band retry is needed (#1963).
+		var coordinatedAddress = TestAddress.WithCoordinates(52.52, 13.405).Value;
+		var command = new CreateVolunteerOpportunityCommand(
+			"Title", "Description", TestOrganizationId, false, coordinatedAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Address!.Latitude.Should().Be(52.52);
+		result.Address!.Longitude.Should().Be(13.405);
+		result.Events.Should().NotContain(e => e is VolunteerOpportunityGeocodingRequestedDomainEvent);
 	}
 
 	[Test]

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -317,6 +317,62 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_MapUnavailable_HasNoSeriousA11yViolations()
+	{
+		// #1963: a non-remote opportunity whose address hasn't resolved to
+		// coordinates now renders a "no map available" note in place of the
+		// map section instead of omitting it silently. VisualTests always runs
+		// against FakeGeocodingService (see VolunteerOpportunityDetailPage_MapMarker_HasAccessibleName
+		// above), which reports TransientFailure - a freshly seeded non-remote
+		// opportunity here always lands in that state, so no route patching is
+		// needed to reach it deterministically. Assert the placeholder is
+		// actually visible before scanning, same as the sibling tests in this
+		// file, so a future regression that made it stop rendering wouldn't
+		// silently reduce this to a no-op pass.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"No Map A11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var title = $"No Map A11y Test {suffix}";
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title,
+			description = "Seeded for the map-unavailable placeholder a11y regression (#1963).",
+			organizationId,
+			isRemote = false,
+			street = "Teststrasse",
+			houseNumber = "1",
+			zipCode = "12345",
+			city = "Musterstadt",
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(title, new() { Timeout = 15_000 });
+		await Expect(Page.GetByTestId("map-unavailable")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task ProfileOverviewPage_HasNoSeriousA11yViolations()
 	{
 		// #794: /profile was consolidated from a Profile/Activity tab switcher

--- a/backend/tests/VisualTests/MapUnavailablePlaceholderTests.cs
+++ b/backend/tests/VisualTests/MapUnavailablePlaceholderTests.cs
@@ -1,0 +1,64 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using TUnit.Core;
+
+namespace VisualTests;
+
+// #1963: a non-remote opportunity whose address hasn't (yet) resolved to
+// coordinates used to omit the map section entirely, with no acknowledgment
+// either way - two offers from the same organization could render the detail
+// page inconsistently depending on hidden geocoding success. Now a
+// "no map available" note takes its place instead.
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MapUnavailablePlaceholderTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OpportunityDetailPage_ShowsMapUnavailableNote_WhenCoordinatesAreMissing()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"No Map Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var title = $"No Map Test {suffix}";
+
+		// VisualTests always runs against FakeGeocodingService (AppHost.cs's
+		// Geocoding__UseFakeService override), which reports TransientFailure -
+		// this opportunity is created with null coordinates as a result, same
+		// as it would be while geocoding is still pending in production.
+		var oppResponse = await PostJsonWithRetryAsync(http, "/v1/volunteer-opportunities", new
+		{
+			title,
+			description = "Created by OpportunityDetailPage_ShowsMapUnavailableNote_WhenCoordinatesAreMissing",
+			organizationId,
+			isRemote = false,
+			street = "Teststrasse",
+			houseNumber = "1",
+			zipCode = "12345",
+			city = "Musterstadt",
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(title, new() { Timeout = 15_000 });
+
+		await Expect(Page.GetByTestId("map-unavailable")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.Locator(".leaflet-container")).Not.ToBeAttachedAsync();
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -200,6 +200,7 @@
       "reportOpportunity": "Einsatz melden",
       "deleteError": "Fehler beim Löschen",
       "availableTimeSlots": "Verfügbare Zeitslots",
+      "mapUnavailable": "Keine Karte für diese Adresse verfügbar.",
       "joinWaitlist": "Zeitslot auswählen",
       "expressInterest": "Interesse bekunden",
       "notFound": "Nicht gefunden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -200,6 +200,7 @@
       "reportOpportunity": "Report opportunity",
       "deleteError": "Error deleting",
       "availableTimeSlots": "Available time slots",
+      "mapUnavailable": "No map available for this address.",
       "joinWaitlist": "Select a slot",
       "expressInterest": "Express interest",
       "notFound": "Not found.",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -541,8 +541,8 @@ export default function VolunteerOpportunityDetailPage() {
 							</div>
 
 							{!opportunity.isRemote &&
-								opportunity.latitude != null &&
-								opportunity.longitude != null && (
+								(opportunity.latitude != null &&
+								opportunity.longitude != null ? (
 									<div className="mb-6 overflow-hidden rounded-card border border-gray-100 shadow-resting">
 										<Suspense fallback={<Skeleton className="h-64 w-full" />}>
 											<SingleMarkerMap
@@ -552,7 +552,21 @@ export default function VolunteerOpportunityDetailPage() {
 											/>
 										</Suspense>
 									</div>
-								)}
+								) : (
+									// Coordinates can be missing (geocoding failure/pending
+									// retry, see backend/AGENTS.md's "Domain events") - showing
+									// this note instead of omitting the section keeps the layout
+									// consistent with opportunities that do have a map (#1963).
+									<div
+										data-testid="map-unavailable"
+										className="mb-6 flex h-64 flex-col items-center justify-center gap-2 rounded-card border border-gray-100 bg-gray-50 shadow-resting"
+									>
+										<MapPinIcon className="h-6 w-6 text-gray-400" />
+										<p className="text-sm text-gray-500">
+											{t("opportunities.mapUnavailable")}
+										</p>
+									</div>
+								))}
 						</div>
 
 						{/* Time slots - held to the same max-w-2xl measure as the blocks


### PR DESCRIPTION
## What

Two changes:

1. The opportunity detail page now shows a "no map available" note instead of silently omitting the map section when an opportunity's coordinates are missing.
2. Creating a volunteer opportunity ("Einsatz") now resolves its address synchronously (rejecting an unresolvable address with `400` immediately) instead of only ever finding out minutes later via an async outbox retry.

## Why

**#1963:** Two offers from the same organization rendered the detail page's map section inconsistently, with no acknowledgment either way - `VolunteerOpportunityDetailPage.tsx` gated the map strictly on `latitude`/`longitude` being present, and simply omitted the section when they weren't. A repeat visitor comparing two listings from the same org experienced an unexplained layout difference that reads as a bug rather than a known state.

Closes #1963

**Geocoding synchronicity (raised directly by the repo owner):** the create-opportunity endpoint raised a domain event and let the transactional-outbox pipeline (#1388) resolve the address's coordinates out of band, fully decoupled from the request. That meant a bad address (one Nominatim can't find) was silently accepted - the opportunity got created anyway, sat with null coordinates, and stayed invisible to "near me" radius search indefinitely, with no feedback to the organizer that anything was wrong. This is the underlying cause #1963 above is a symptom of.

## Changes

- `VolunteerOpportunityDetailPage.tsx`: renders a placeholder (`MapPinIcon` + "no map available" text, same footprint as the map) instead of nothing when coordinates are missing. New `opportunities.mapUnavailable` key in `en.json`/`de.json`.
- New `Application/Maps/GeocodeAddress/v1/GeocodeAddressQuery` + handler - modeled directly on the existing `SearchCitiesQuery` (same "synchronous external lookup, no open DB transaction" shape). Its cache-key logic is shared with the existing async retry handler (`GeocodeVolunteerOpportunityAddressHandler`) via a small extracted `GeocodeCacheKey` helper.
- `CreateVolunteerOpportunityEndpoint` now sends `GeocodeAddressQuery` before dispatching the create command:
  - `NotFound` -> `400` immediately, nothing gets created.
  - `Found` -> coordinates attached right away, so a freshly created opportunity can appear in radius search and render its map immediately, no waiting on the outbox.
  - `TransientFailure` (Nominatim itself unreachable, not the address's fault) -> creation still succeeds with null coordinates, same as before; `VolunteerOpportunity.Create` still raises the geocoding-requested event for that case so the existing async outbox/retry job resolves it later. This keeps create resilient to a geocoding-provider outage rather than blocking on it.
- `VolunteerOpportunity.Create`'s domain-event condition now only raises `VolunteerOpportunityGeocodingRequestedDomainEvent` when the given address doesn't already carry coordinates.
- Also fixes an unrelated pre-existing bug in `Api.csproj`'s NSwag `RenameOpenApiDocuments` target, found while re-verifying this change locally: it false-errored on any second consecutive build with no source changes (`GenerateOpenApiDocuments`'s own incremental skip left nothing to move, but the `AfterTargets` check ran anyway). The original presence check also had a real blind spot even before this: `openapi-v1.json` is committed to git, so on any fresh checkout it would have silently masked a genuine document-rename regression too, since it only checked "does `Api.json` exist," never "does something else land in `wwwroot/`." Replaced it with a check for an actually-unexpected file in `wwwroot/` - verified all three scenarios directly (fresh build, repeated no-op build, and a simulated document-rename regression, which still correctly errors).

Scope note: this only changes the **create** flow. `Relocate`/`UpdateVolunteerOpportunity` still resolves address changes asynchronously - the repo owner's report was specifically about create, and this keeps the diff focused.

## Testing

- Backend: `dotnet build` (0 warnings/errors), `Application.UnitTests` (1045/1045 passed), `ArchitectureTests` (429/429 passed) - all run locally per root `AGENTS.md`'s sandbox guidance (no Docker/Aspire here).
- New `GeocodeAddressQueryHandlerTests` (Found/NotFound/TransientFailure outcomes + caching behavior, mirrors `SearchCitiesQueryHandlerTests`).
- New `CreateVolunteerOpportunityCommandHandlerTests` case asserting a pre-coordinated address does *not* raise the geocoding-requested event.
- New `backend/tests/VisualTests/MapUnavailablePlaceholderTests.cs` - asserts the placeholder renders and the Leaflet map is not attached when coordinates are missing.
- New `AccessibilityTests.cs` case (`VolunteerOpportunityDetailPage_MapUnavailable_HasNoSeriousA11yViolations`) - axe scan of the new placeholder state.
- Frontend: `pnpm build`, `pnpm lint`, `pnpm check` (tsc), `pnpm test` (259/259 passed), `pnpm format:check` - all clean.
- Proactively ran `architecture-check`, `nswag-check`, `i18n-check`, `a11y-check`, `ef-migration-check` against the diff - no violations found (a11y-check's one actionable suggestion, the new `AccessibilityTests.cs` case above, is already included).

## Live verification

Not performed - no release candidate was cut for this PR, per explicit instruction from the repo owner. VisualTests (including the two new test cases above) will run against the local Aspire stack in CI; the change was not smoke-tested against live staging.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (in-code comments only; no user-facing docs affected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FE9YWGnvLbw9JYvehQewYy)_