### PR TITLE
fix(frontend): give create-opportunity modal's close button its own accessible name

### DIFF
--- a/backend/tests/VisualTests/CreateOpportunityModalCloseButtonLabelTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityModalCloseButtonLabelTests.cs
@@ -1,0 +1,43 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1957: the header X close button and the footer's step-1
+/// text button both read their accessible name from the same
+/// createOpportunity.cancel translation key ("Cancel"/"Abbrechen"), so two
+/// distinct controls in the dialog were indistinguishable by accessible
+/// name (WCAG 2.2 SC 4.1.2). The close button now uses its own
+/// createOpportunity.close key.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class CreateOpportunityModalCloseButtonLabelTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task CreateOpportunityWizard_HeaderCloseButton_HasDistinctAccessibleNameFromFooterCancelButton()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var trigger = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" }).First;
+		await Expect(trigger).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await trigger.ClickAsync();
+
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var footerCancel = dialog.GetByTestId("modal-cancel");
+		await Expect(footerCancel).ToBeVisibleAsync();
+		await Expect(footerCancel).ToHaveTextAsync("Cancel");
+
+		var headerClose = dialog.GetByRole(AriaRole.Button, new() { Name = "Close", Exact = true });
+		await Expect(headerClose).ToBeVisibleAsync();
+
+		var footerCancelAsCloseCandidate = dialog.GetByRole(AriaRole.Button, new() { Name = "Cancel", Exact = true });
+		(await footerCancelAsCloseCandidate.CountAsync()).Should().Be(1,
+			"only the footer button should expose the \"Cancel\" accessible name - the header close "
+			+ "button must use its own distinct name instead of sharing it");
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -997,7 +997,7 @@ export default function CreateVolunteerOpportunityModal({
 					<button
 						type="button"
 						onClick={requestClose}
-						aria-label={t("createOpportunity.cancel")}
+						aria-label={t("createOpportunity.close")}
 						className="shrink-0 rounded-lg p-1.5 text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-800"
 					>
 						<CloseIcon className="h-5 w-5" />

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -293,6 +293,7 @@
       "charCount": "{{current}} / {{max}}",
       "creating": "Wird erstellt…",
       "cancel": "Abbrechen",
+      "close": "Schließen",
       "unknownError": "Unbekannter Fehler",
       "fieldRequired": "Bitte ausfüllen.",
       "useOrgAddress": "Adresse der Organisation übernehmen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -293,6 +293,7 @@
       "charCount": "{{current}} / {{max}}",
       "creating": "Creating…",
       "cancel": "Cancel",
+      "close": "Close",
       "unknownError": "Unknown error",
       "fieldRequired": "Please fill this in.",
       "useOrgAddress": "Use organization address",


### PR DESCRIPTION
## What

Gives the create-opportunity modal's header X close button its own accessible name, distinct from the footer's "Cancel" button.

## Why

Both the header close (X) button and the footer's step-1 text button read their accessible name from the same `createOpportunity.cancel` translation key, so two distinct controls both exposed the identical accessible name "Cancel"/"Abbrechen" - a WCAG 2.2 SC 4.1.2 (Name, Role, Value) violation. Screen reader / voice control users referencing "Cancel" by name couldn't disambiguate between the two.

Added a new `createOpportunity.close` key ("Close" / "Schließen" - both `en.json`/`de.json`, parity verified) and pointed the header close button's `aria-label` at it instead. The footer Cancel button is unchanged.

Closes #1957

## Testing

- `pnpm lint`, `pnpm check`, `pnpm test` (259 tests), `pnpm i18n:check`, `pnpm format:write` - all clean, no changes needed
- `dotnet build tests/VisualTests` - compiles clean
- Added `backend/tests/VisualTests/CreateOpportunityModalCloseButtonLabelTests.cs`: opens the wizard as `olaf` and asserts the header close button and footer Cancel button now expose distinct accessible names ("Close" vs "Cancel"), with only one control found by the "Cancel" accessible name. Runs against the local Aspire stack in CI (`dotnet.yml`'s `visual-tests` job) - not runnable locally in this sandbox (no Docker/Aspire orchestration, see root `AGENTS.md`'s Sandbox Limitations).

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate cut). The added `VisualTests` regression test above is the durable, CI-run assertion for this fix instead.

## Checklist

- [x] `/self-review` run and findings addressed (`a11y-check` and `i18n-check` subagents both reported no issues)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal accessible-name fix, no user-facing docs affected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TCF37y6N7GveBQxYGZRcGB)_