### PR TITLE
fix: keep sign-in card at full opacity during entrance animation

### DIFF
--- a/backend/tests/VisualTests/KeycloakThemeTests.cs
+++ b/backend/tests/VisualTests/KeycloakThemeTests.cs
@@ -131,6 +131,53 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Login_AuthFadeUpKeyframe_NeverDipsBelowFullOpacity()
+	{
+		// Regression for #1960: the auth-fade-up keyframe used to fade opacity
+		// 0 -> 1 over 0.45s, so the card's heading, labels and the primary
+		// "Sign In" button rendered as low-contrast gray-green for the first
+		// second or so after load - the single most function-critical page in
+		// the product briefly looking broken, and interactable (by a password
+		// manager or screen reader) before the fade even settled. Asserts
+		// against the parsed @keyframes rule itself rather than sampling
+		// getComputedStyle during the real animation, which would depend on
+		// exactly when this test happens to sample relative to a CI runner's
+		// load timing - the CSSOM still exposes the rule's frames regardless
+		// of whether prefers-reduced-motion currently matches it.
+		await Page.GotoAsync(AuthUrl(locale: "en"));
+		await Expect(Page.Locator(".auth-card")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var fromOpacity = await Page.EvaluateAsync<string?>(@"
+			() => {
+				for (const sheet of document.styleSheets) {
+					let rules;
+					try { rules = sheet.cssRules; } catch { continue; }
+					for (const rule of rules) {
+						const keyframesRules = rule instanceof CSSKeyframesRule
+							? [rule]
+							: rule instanceof CSSMediaRule
+								? [...rule.cssRules].filter(r => r instanceof CSSKeyframesRule)
+								: [];
+						for (const kf of keyframesRules) {
+							if (kf.name !== 'auth-fade-up') continue;
+							for (const frame of kf.cssRules) {
+								if (frame.keyText === 'from' || frame.keyText === '0%') {
+									return frame.style.opacity || null;
+								}
+							}
+						}
+					}
+				}
+				return null;
+			}");
+
+		fromOpacity.Should().Be("1",
+			"the auth-fade-up keyframe's starting frame must stay at full opacity - "
+			+ "the sign-in card must never render at reduced contrast, not even "
+			+ "transiently during its entrance animation");
+	}
+
+	[Test]
 	public async Task Register_OmitsPasswordFields_AndSaysWhy()
 	{
 		// The realm has verifyEmail on, so Keycloak deliberately leaves the

--- a/keycloak/themes/einsatzbereit/login/resources/css/einsatzbereit.css
+++ b/keycloak/themes/einsatzbereit/login/resources/css/einsatzbereit.css
@@ -833,10 +833,17 @@ textarea.form-input {
 /* The frontend's own fade-up keyframe and 0.12s stagger, gated on the same
  * media query it uses. Two steps only - the card, then the way out from under
  * it - because the whole page is one card; a longer orchestration on four
- * form fields would be motion for its own sake. */
+ * form fields would be motion for its own sake.
+ *
+ * Unlike the frontend's decorative fade-up (which does animate opacity 0 -> 1,
+ * fine for marketing content nobody needs to read within the first second),
+ * this stays at opacity: 1 throughout and only animates the slide-up offset
+ * (#1960) - the sign-in card's heading, labels and "Sign In" button must be
+ * fully legible from the very first frame, since a password manager or screen
+ * reader can interact with the form before any entrance animation settles. */
 @media (prefers-reduced-motion: no-preference) {
 	@keyframes auth-fade-up {
-		from { opacity: 0; transform: translateY(12px); }
+		from { opacity: 1; transform: translateY(12px); }
 		to   { opacity: 1; transform: translateY(0); }
 	}
 


### PR DESCRIPTION
## What

The Keycloak sign-in card's entrance animation (`auth-fade-up`) now animates only the slide-up `transform` and holds `opacity: 1` throughout, instead of also fading opacity from `0` to `1`.

## Why

`.auth-card`'s `auth-fade-up` keyframe (`keycloak/themes/einsatzbereit/login/resources/css/einsatzbereit.css:837-845`) animated `opacity: 0 -> 1` over `0.45s`. During roughly the first 1-2 seconds after load, the sign-in card - heading, labels, and the primary "Sign In" button - rendered as pale, low-contrast gray-green while at partial opacity. The settled state passes WCAG AA comfortably; this was purely a transient entrance-animation state on the single most function-critical page in the product, and a password manager or screen reader can interact with the form before the fade completes.

Closes #1960

## Testing

- Added `KeycloakThemeTests.Login_AuthFadeUpKeyframe_NeverDipsBelowFullOpacity`: parses the live stylesheet's `auth-fade-up` `@keyframes` rule via the CSSOM and asserts the `from` frame's `opacity` is `"1"`. Checking the parsed keyframe rule rather than sampling `getComputedStyle` during the real animation avoids depending on exactly when the test happens to sample relative to a CI runner's load timing.
- `dotnet build` (full backend solution): succeeds, 0 warnings/errors.
- `dotnet run --project tests/ArchitectureTests`: 429/429 passed.
- `VisualTests` itself needs real container networking (Aspire/Testcontainers), which isn't available in this sandboxed session - it runs in `dotnet.yml` on a real CI runner.

## Live verification

Skipped for this PR at the requester's explicit instruction not to cut a release candidate. The change is CSS-only (a keyframe's starting `opacity` value) and is covered by the new `VisualTests` assertion above, which will run against the real Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed (no issues found)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - CSS/test only, no doc-affecting behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Px4t557Nz8V57T4LgAr4KJ)_