### PR TITLE
fix: geocode city-only opportunity deep links on load

### DIFF
--- a/backend/tests/VisualTests/CityOnlyDeepLinkLocationFilterTests.cs
+++ b/backend/tests/VisualTests/CityOnlyDeepLinkLocationFilterTests.cs
@@ -1,0 +1,56 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1962: a `city`-only deep link to /opportunities (bookmarked,
+/// shared, or hand-edited, e.g. `?city=Leipzig`) used to leave the "Location"
+/// filter chip inactive and show every opportunity unfiltered, even though the
+/// visitor's own URL clearly asked for a location filter - `hasLocation` only
+/// ever looked at `lat`/`lng`/`radius`, never `city` alone, and nothing tried
+/// to resolve the bare city name into coordinates.
+///
+/// The Aspire stack under test wires FakeGeocodingService in place of the real
+/// Nominatim-backed geocoder (see FakeGeocodingService.cs, AppHost.cs's
+/// `Geocoding__UseFakeService`), which always returns no results for
+/// SearchCitiesAsync - so this exercises the fix's "city can't be resolved"
+/// fallback deterministically: the chip must still surface the typed city as
+/// an active filter rather than reverting to blank/unfiltered, per the
+/// issue's own "at minimum" acceptance bar, and clearing it must be able to
+/// get back to the unfiltered list.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class CityOnlyDeepLinkLocationFilterTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OpportunitiesPage_CityOnlyDeepLink_ShowsLocationChipActiveWithTypedCity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/opportunities?city=Leipzig");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var locationChip = Page.GetByTestId("filter-location");
+		await Expect(locationChip).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(locationChip).ToHaveTextAsync("Leipzig", new() { Timeout = 15_000 });
+
+		// The chip's own clear (X) button only renders while FilterDropdown
+		// considers it active (`active = !!displayValue`) - its presence is
+		// itself part of what this asserts, not just setup for what follows.
+		var clearLocationButton = Page.GetByRole(AriaRole.Button, new() { Name = "Clear location filter" });
+		await Expect(clearLocationButton).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// hasFilters must also count the still-unresolved city, so the visitor
+		// has a "Reset" button back to the unfiltered list rather than one that
+		// looks like nothing is filtered while the chip disagrees.
+		var resetButton = Page.GetByRole(AriaRole.Button, new() { Name = "Reset" });
+		await Expect(resetButton).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await clearLocationButton.ClickAsync();
+
+		await Expect(locationChip).ToHaveTextAsync("Location", new() { Timeout = 15_000 });
+		Page.Url.Should().NotContain("city=Leipzig");
+	}
+}

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { dispatchToast } from "../../lib/toastBus";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
+import { useApiClient } from "../../hooks/useApiClient";
 import LocationSearchInput from "../LocationSearchInput";
 import FilterDropdown, {
 	DropdownOption,
@@ -18,6 +19,7 @@ import {
 import type { CitySuggestion } from "./useCitySuggestions";
 import { useSearchAlert } from "./useSearchAlert";
 import { resolveDateLocale } from "../../lib/format";
+import { sortByLabelPrefixMatch } from "../../lib/citySuggestionSort";
 import { SpinnerIcon } from "../Spinner";
 import {
 	BellIcon,
@@ -47,6 +49,7 @@ const CATEGORY_VALUES = [
 ] as const;
 
 const RADIUS_OPTIONS = [5, 10, 25, 50, 100];
+const DEFAULT_RADIUS_KM = "10";
 
 // No heading of its own: the only route that renders this list is
 // /opportunities, whose PageHeaderBand already states the eyebrow, title and
@@ -56,6 +59,7 @@ const RADIUS_OPTIONS = [5, 10, 25, 50, 100];
 export default function VolunteerOpportunitiesList() {
 	const { t, i18n } = useTranslation();
 	const locale = resolveDateLocale(i18n.language);
+	const api = useApiClient();
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const occurrence = searchParams.get("occurrence") ?? "";
@@ -75,6 +79,10 @@ export default function VolunteerOpportunitiesList() {
 		? categoriesParam.split(",").filter(Boolean)
 		: [];
 	const hasLocation = !!(lat && lng && radius);
+	// A `city`-only deep link has no coordinates yet (resolved below) but is
+	// still a location filter the visitor asked for - counts toward
+	// hasFilters/the "Standort" chip's active state even before it resolves.
+	const hasLocationFilter = hasLocation || !!city;
 
 	const [openFilter, setOpenFilter] = useState<string | null>(null);
 	const [locationCityInput, setLocationCityInput] = useState(city);
@@ -84,6 +92,44 @@ export default function VolunteerOpportunitiesList() {
 		openFilter !== null,
 		() => setOpenFilter(null),
 	);
+
+	// A `city`-only deep link (bookmarked, shared, or hand-edited) carries no
+	// coordinates to filter by - geocode it once on load so the same URL
+	// resolves to a working location filter instead of silently showing every
+	// opportunity unfiltered (#1962). Guarded on `city && !lat && !lng`, which
+	// never matches the UI's own paths: selectLocationSuggestion and
+	// handleNearMe always set city+lat+lng together in the same update.
+	useEffect(() => {
+		if (!city || lat || lng) return;
+		const controller = new AbortController();
+		(async () => {
+			try {
+				const places = await api.searchCities(city, controller.signal);
+				const [best] = sortByLabelPrefixMatch(
+					places.map((place) => ({
+						label: place.label,
+						lat: place.latitude,
+						lng: place.longitude,
+					})),
+					city,
+				);
+				if (!best) return;
+				const params = new URLSearchParams(window.location.search);
+				params.set("city", best.label);
+				params.set("lat", String(best.lat));
+				params.set("lng", String(best.lng));
+				params.set("radius", radius || DEFAULT_RADIUS_KM);
+				setSearchParams(params, { replace: true });
+			} catch {
+				// A city that can't be resolved (typo, unmapped place, transient
+				// geocoder failure) leaves the "Standort" chip showing the typed
+				// city as an active-but-unresolved filter instead of reverting to
+				// the unfiltered list.
+			}
+		})();
+		return () => controller.abort();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [city, lat, lng]);
 
 	const {
 		hasActiveAlert,
@@ -231,7 +277,7 @@ export default function VolunteerOpportunitiesList() {
 	}
 
 	function selectLocationSuggestion(suggestion: CitySuggestion) {
-		const currentRadius = searchParams.get("radius") || "10";
+		const currentRadius = searchParams.get("radius") || DEFAULT_RADIUS_KM;
 		const params = new URLSearchParams(window.location.search);
 		params.set("city", suggestion.label);
 		params.set("lat", suggestion.lat.toString());
@@ -251,7 +297,7 @@ export default function VolunteerOpportunitiesList() {
 		navigator.geolocation.getCurrentPosition(
 			(pos) => {
 				const { latitude, longitude } = pos.coords;
-				const currentRadius = radius || "10";
+				const currentRadius = radius || DEFAULT_RADIUS_KM;
 				const label = t("opportunities.nearMe");
 				const params = new URLSearchParams(window.location.search);
 				params.set("city", label);
@@ -271,7 +317,7 @@ export default function VolunteerOpportunitiesList() {
 	}
 
 	const hasFilters = !!(
-		hasLocation ||
+		hasLocationFilter ||
 		occurrence ||
 		participationType ||
 		isRemoteParam ||
@@ -315,7 +361,7 @@ export default function VolunteerOpportunitiesList() {
 		}
 	}
 
-	const locationDisplayValue = hasLocation ? `${city} · ${radius} km` : "";
+	const locationDisplayValue = hasLocation ? `${city} · ${radius} km` : city;
 
 	const categoryDisplayValue =
 		selectedCategories.length === 0
@@ -359,6 +405,7 @@ export default function VolunteerOpportunitiesList() {
 				>
 					{/* Location + Radius */}
 					<FilterDropdown
+						testId="filter-location"
 						icon={<MapPinIcon className="h-3.5 w-3.5" />}
 						label={t("opportunities.filterLabelLocation")}
 						displayValue={locationDisplayValue}


### PR DESCRIPTION
## What

Navigating directly to `/opportunities?city=Leipzig` (a hand-edited, bookmarked, or shared URL) now resolves the location filter the same way picking a city through the UI does, instead of silently showing every opportunity unfiltered.

## Why

`VolunteerOpportunitiesList.tsx` only ever treated the location filter as active when `lat && lng && radius` were all present in the URL. `city` alone was read into the text input's initial value but never applied to the actual filter or reflected in `hasLocation`/`locationDisplayValue` - so a `city`-only deep link showed the "Standort"/"Location" chip as inactive and returned every opportunity unfiltered, even though selecting the same city through the dropdown correctly filters and shows an active "Leipzig - 10 km" chip.

Closes #1962

## Changes

- `VolunteerOpportunitiesList.tsx` now geocodes a `city`-only deep link once on load (via the existing `/v1/maps/cities` lookup already used for the location search box), writing the resolved `lat`/`lng`/`radius` back into the URL - so the actual API filtering and the "Location" chip both pick it up exactly like a UI-driven city selection would.
- If the city can't be resolved (typo, unmapped place, transient geocoder failure), the "Location" chip still shows the typed city as an active-but-unresolved filter (and counts toward `hasFilters`/the "Reset" button) instead of reverting to blank/unfiltered - the issue's own "at minimum" acceptance bar.
- Deduplicated the `"10"` default-radius literal (previously repeated at two call sites) into a shared `DEFAULT_RADIUS_KM` constant now used at all three.

## Testing

- `pnpm lint`, `pnpm check` (tsc), `pnpm test` (Vitest, 259 tests) - all green
- `dotnet build tests/VisualTests`, `dotnet run --project tests/Application.UnitTests` (1045 tests), `dotnet run --project tests/ArchitectureTests` (429 tests) - all green
- Added `backend/tests/VisualTests/CityOnlyDeepLinkLocationFilterTests.cs`: navigates to `/opportunities?city=Leipzig` and asserts the "Location" chip shows `"Leipzig"` (active), its clear button and the "Reset" button are both visible, and clearing removes `city` from the URL and returns the chip to its inactive label. This repo's Aspire test stack wires `FakeGeocodingService` in place of the real Nominatim-backed geocoder, which always returns no matches - so this test deterministically exercises the "can't resolve the city" fallback path rather than the happy-path geocode (which needs real Nominatim data and is exactly what `/live-verify` against staging is for).
- `/self-review` run, plus the `a11y-check` subagent on the `.tsx` diff (no new a11y issues found; it did surface a pre-existing, unrelated `aria-label` reuse on the Remote/onsite filter's clear button, left untouched as out of scope for this fix)

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate was cut). The VisualTests regression above covers the deterministic fallback path in CI; the happy-path geocode resolution (real city -> real coordinates via Nominatim) is only exercisable against live staging and can be checked with `/live-verify` in a follow-up if desired.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this filter's edge-case behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvDuUbAkGYsoh6WUCBQ7fZ)_