### PR TITLE
fix(frontend): truncate sign-up message preview on word boundaries

### DIFF
--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -514,9 +514,11 @@ export default function ActivitySection() {
 									)}
 									{/* Labelled, and out of the date region above - a quoted sentence
 									in the slot where a sibling card states a date reads as that
-									card's date, not as something the reader wrote. */}
+									card's date, not as something the reader wrote. line-clamp-2
+									(not truncate) so the ellipsis lands on a word boundary rather
+									than mid-word (#1933). */}
 									{e.message && (
-										<p className="mt-1.5 truncate text-xs text-gray-500">
+										<p className="mt-1.5 line-clamp-2 text-xs text-gray-500">
 											<span className="font-medium">
 												{t("myEngagements.yourMessage")}
 											</span>{" "}


### PR DESCRIPTION
## What

On `/my-signups`, the "Deine Nachricht:" preview of a volunteer's own submitted sign-up message now wraps across up to two lines and ellipsizes on a word boundary, instead of cutting off mid-word on a single line.

## Why

`ActivitySection.tsx` used Tailwind's single-line `truncate` utility (`overflow: hidden` + `white-space: nowrap` + a fixed-width ellipsis), which cuts at a fixed character/line width regardless of word boundaries - e.g. `"Ich wür..."` (cut inside "wür[de]"). This reads as unpolished on a page that's otherwise carefully finished.

Fix: swap `truncate` for `line-clamp-2`, an existing pattern already used elsewhere in the codebase for the same purpose (`OrganizationsPage.tsx`, `PublicOpportunityCard.tsx`, `OpportunityListItem.tsx`). Text now wraps normally (word boundaries) across up to two lines, and only ellipsizes if it still overflows - which also means short messages like the one in the report no longer get cut at all.

Closes #1933

## Testing

- `pnpm lint`, `pnpm check` (tsc --noEmit), `pnpm test` (259 tests, all passing) - all clean on the branch.
- `a11y-check` subagent reviewed the diff: CSS-only className swap, no change to the accessibility tree (full message text stays in the DOM either way), no new interactive elements, contrast unaffected. `/my-signups` already has axe coverage in `backend/tests/VisualTests/AccessibilityTests.cs` (`MyEngagementsPage_HasNoSeriousA11yViolations`) that exercises this element; no new test needed since this isn't a new page/route.
- No backend, i18n, or EF model changes - `nswag-check`/`ef-migration-check`/`i18n-check`/`architecture-check` don't apply to this diff.

## Live verification

Per explicit instruction for this task, no release candidate was cut and this fix was not verified against live staging - verification was local only (lint/typecheck/unit tests above). This is a pure Tailwind className swap (`truncate` -> `line-clamp-2`) using a utility already proven elsewhere in the app, so the risk profile is low, but a live check has not been performed.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this preview)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg5SdWK9w2dQK23qjty2Pj)_