### PR TITLE
fix(keycloak): suppress redundant back link on logout-confirm page

### DIFF
--- a/backend/tests/VisualTests/KeycloakThemeTests.cs
+++ b/backend/tests/VisualTests/KeycloakThemeTests.cs
@@ -366,8 +366,19 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 			$"{keycloak}/realms/{Realm}/protocol/openid-connect/logout?client_id={FrontendClientId}");
 
 		await Expect(Page.Locator("#kc-logout")).ToBeVisibleAsync(new() { Timeout = 15_000 });
-		await AssertThemeShellAsync("logout-confirm");
+
+		// Not AssertThemeShellAsync: its vertical-gap check requires .auth-back
+		// to be visible, which #1931 below deliberately makes untrue here.
+		await Expect(Page.Locator(".auth-card")).ToBeVisibleAsync();
+		await Expect(Page.Locator(".auth-logo")).ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 })).ToBeVisibleAsync();
 		await Expect(Page.Locator("#kc-logout-cancel")).ToBeVisibleAsync();
+
+		// #1931: this page's own Cancel link above is its only way out - the
+		// generic "Back to Einsatzbereit" safety net from template.ftl must not
+		// also render here, or the two identical-destination controls sit side
+		// by side with no visible distinction.
+		await Expect(Page.Locator(".auth-back")).ToHaveCountAsync(0);
 	}
 
 	[Test]

--- a/keycloak/themes/einsatzbereit/login/logout-confirm.ftl
+++ b/keycloak/themes/einsatzbereit/login/logout-confirm.ftl
@@ -8,9 +8,23 @@
 	page offered exactly one action, and it was the irreversible one. A
 	confirmation dialog with no way to say no is not a confirmation.
 -->
+<#-- Computed ahead of the macro call (rather than inside the "form" section
+below) so it can also decide showBackLink=false: when this page renders its
+own Cancel link, template.ftl's generic "Back to Einsatzbereit" safety net
+would just be a second, differently-worded control for the exact same
+destination and effect (#1931). -->
+<#if logoutConfirm.skipLink>
+	<#assign cancelUrl = "">
+<#elseif (client.baseUrl)?has_content>
+	<#assign cancelUrl = client.baseUrl>
+<#else>
+	<#assign cancelUrl = properties.siteUrl>
+</#if>
+
 <@layout.registrationLayout
 	pageTitle="logoutConfirmTitle"
-	eyebrow="stepSession"; section>
+	eyebrow="stepSession"
+	showBackLink=!cancelUrl?has_content; section>
 
 	<#if section = "header">
 		${msg("logoutConfirmTitle")}
@@ -18,14 +32,6 @@
 	<#elseif section = "form">
 		<div id="kc-logout-confirm" class="content-area">
 			<p class="instruction">${msg("logoutConfirmHeader")}</p>
-
-			<#if logoutConfirm.skipLink>
-				<#assign cancelUrl = "">
-			<#elseif (client.baseUrl)?has_content>
-				<#assign cancelUrl = client.baseUrl>
-			<#else>
-				<#assign cancelUrl = properties.siteUrl>
-			</#if>
 
 			<form class="form-actions" action="${url.logoutConfirmAction}" method="POST">
 				<input type="hidden" name="session_code" value="${logoutConfirm.code}">

--- a/keycloak/themes/einsatzbereit/login/template.ftl
+++ b/keycloak/themes/einsatzbereit/login/template.ftl
@@ -8,7 +8,7 @@
 	omits them, and so the strings stay in the message bundles with everything
 	else that gets translated.
 -->
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false pageTitle="loginTitle" eyebrow="" lead="">
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false pageTitle="loginTitle" eyebrow="" lead="" showBackLink=true>
 <!DOCTYPE html>
 <html lang="${locale.currentLanguageTag!'de'}">
 <head>
@@ -95,7 +95,12 @@
 
 		<#-- Way back to the product. Without it, a visitor who reaches these
 		pages and changes their mind is stuck on an origin (login.*) that has
-		no other link on it - browser Back is the only exit. -->
+		no other link on it - browser Back is the only exit. showBackLink=false
+		opts a page out when it already renders its own explicit cancel/exit
+		control (#1931: logout-confirm.ftl's "Cancel" link has the exact same
+		href and effect, so both rendered as two differently-worded controls
+		for one action). -->
+		<#if showBackLink>
 		<p class="auth-back">
 			<a href="${properties.siteUrl}" class="back-link">
 				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -105,6 +110,7 @@
 				${msg("backToSite")}
 			</a>
 		</p>
+		</#if>
 	</main>
 
 </div>


### PR DESCRIPTION
## What

On the Keycloak logout-confirmation screen, suppress the shared theme's generic "Back to Einsatzbereit" link whenever the page already renders its own "Cancel" link - the two had an identical `href` and identical effect, so the screen showed two differently-worded controls for one action.

## Why

Closes #1931

`logout-confirm.ftl` adds a page-specific Cancel link (falling back to `properties.siteUrl` since this realm's `frontend` client has no `baseUrl`) so the confirmation isn't a dead end. Separately, `template.ftl` renders a universal "Back to Einsatzbereit" safety-net link on every themed page for dead-end screens like expired-link or error pages. On logout-confirm specifically, both rendered at once, side by side, doing the exact same thing.

## Implementation

- `template.ftl`'s `registrationLayout` macro gains a `showBackLink=true` parameter; the generic back link now only renders `<#if showBackLink>`.
- `logout-confirm.ftl` computes its `cancelUrl` before invoking the macro (moved up from inside the "form" section, since the value doesn't depend on anything only available there) and passes `showBackLink=!cancelUrl?has_content` - so the generic link stays exactly when the page-specific Cancel link would *not* render (the `logoutConfirm.skipLink` case), and disappears exactly when Cancel does render.

No other themed page (`error.ftl`, `info.ftl`, etc.) is affected - their own exit controls are visually distinct primary CTAs rather than a second control with the same wording pattern as the generic link, and the issue scoped the fix to logout-confirm specifically.

## Testing

- `dotnet build tests/VisualTests/VisualTests.csproj` - compiles clean.
- Updated `KeycloakThemeTests.LogoutConfirm_OffersACancel` (`backend/tests/VisualTests/KeycloakThemeTests.cs`): still asserts the theme shell renders and `#kc-logout-cancel` is visible, and now additionally asserts `.auth-back` has a count of 0 on this page - the regression check for this issue. (Swapped out the shared `AssertThemeShellAsync` helper for this test since its vertical-gap check requires `.auth-back` to be visible, which is no longer true here by design.)
- This suite needs Docker/Aspire orchestration that isn't available in this sandbox; it runs in CI via `dotnet.yml`'s `visual-tests` job.

## Live verification

Not performed - no release candidate was cut for this change per explicit instruction. The updated `KeycloakThemeTests.LogoutConfirm_OffersACancel` test (see Testing above) is the durable, reviewable check for this fix and will run against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - diff is small and self-contained)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this link)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiuUTuhCycWAb6Kx49et4b)_