### PR TITLE
fix(frontend): anchor language selector dropdown to the trigger's right edge

### DIFF
--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -401,6 +401,33 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task HomePage_LanguageSelector_DropdownStaysInsideViewportAt1440px()
+	{
+		// #1936: the open <ul> was anchored "top-full left-0" with a fixed
+		// w-36 (144px) width, so it grew rightward from the trigger's left
+		// edge instead of the trigger's own right edge - at 1440px that pushed
+		// the panel's right edge past the viewport, clipping its border/
+		// background and truncating "Deutsch" with no visible box edge.
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await Page.GotoAsync(frontend.ToString());
+		await Expect(Page.Locator("h1").First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var banner = Page.GetByRole(AriaRole.Banner);
+		var langBtn = banner.GetByTestId("language-selector-trigger");
+		await langBtn.ClickAsync();
+
+		var dropdown = banner.GetByTestId("language-selector-menu");
+		await Expect(dropdown).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var box = await dropdown.BoundingBoxAsync();
+		box.Should().NotBeNull("Could not measure the language selector dropdown");
+		(box!.X + box.Width).Should().BeLessThanOrEqualTo(
+			1440, "the dropdown must not overflow past the right edge of the viewport");
+	}
+
+	[Test]
 	public async Task MobileMenu_ClosesOnEscape()
 	{
 		// #884: MobileMenu offered neither outside-click nor Escape dismissal

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -60,7 +60,7 @@ export default function LanguageSelector({
 				<ul
 					aria-label={t("language.switchLanguage")}
 					data-testid="language-selector-menu"
-					className={`absolute top-full left-0 z-50 mt-1 w-36 rounded-lg border py-1 shadow-modal ${transparent ? "border-white/20 bg-brand-800" : "border-gray-200 bg-white"}`}
+					className={`absolute top-full right-0 z-50 mt-1 w-36 rounded-lg border py-1 shadow-modal ${transparent ? "border-white/20 bg-brand-800" : "border-gray-200 bg-white"}`}
 				>
 					{LANGUAGES.map((lang) => (
 						<li key={lang.code}>


### PR DESCRIPTION
## What

Anchors the language selector's open dropdown panel to the trigger button's right edge (`right-0`) instead of its left edge (`left-0`).

## Why

The panel was positioned `absolute top-full left-0` with a fixed `w-36` (144px) width, growing rightward from the trigger's left edge instead of the trigger's own right edge. On a 1440px-wide viewport this pushed the panel's right edge outside the viewport, clipping its border/background and truncating "Deutsch" to "Deutsc". Sibling header dropdowns (`AccountControls.tsx`, `NotificationDropdown.tsx`) already anchor `right-0` for the same reason - `LanguageSelector` was the outlier.

Closes #1936

## Testing

- Added `NavigationTests.HomePage_LanguageSelector_DropdownStaysInsideViewportAt1440px` (`backend/tests/VisualTests/NavigationTests.cs`): opens the dropdown at a 1440x900 viewport and asserts its bounding box stays within the viewport's right edge.
- `pnpm lint` and `pnpm format:check` pass.
- `dotnet build tests/VisualTests/VisualTests.csproj` succeeds (Aspire/Docker not available in this sandbox, so the new test itself was verified to compile and follow the existing `language-selector-menu` test patterns, not run end-to-end locally; CI's `dotnet.yml` runs the full `VisualTests` suite on a real runner).
- `/self-review` run: no issues found. `a11y-check` subagent confirmed no a11y regression (purely a Tailwind positioning class swap, ARIA structure untouched) and that no new `AccessibilityTests.cs` entry is needed since no new page/route was added.

## Live verification

Not performed for this PR - explicitly skipped per task instructions (no release candidate cut). The added `VisualTests` case (`HomePage_LanguageSelector_DropdownStaysInsideViewportAt1440px`) is the durable, CI-enforced regression record for this fix and will run against the local Aspire stack in `dotnet.yml`.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior/docs change beyond the fix itself)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2hkMDvvsQHk5mt9FauToV)_