### PR TITLE
fix(frontend): darken low-contrast search placeholder text

### DIFF
--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -431,7 +431,7 @@ export default function VolunteerOpportunitiesList() {
 									onSelect={selectLocationSuggestion}
 									placeholder={t("opportunities.locationPlaceholder")}
 									ariaLabel={t("opportunities.filterLabelCity")}
-									inputClassName="w-full rounded-xl border border-gray-200 bg-gray-50 py-2 pr-8 pl-9 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-400 focus:bg-white"
+									inputClassName="w-full rounded-xl border border-gray-200 bg-gray-50 py-2 pr-8 pl-9 text-sm text-gray-900 placeholder:text-gray-600 focus:border-brand-400 focus:bg-white"
 								/>
 							</div>
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -315,7 +315,7 @@ export default function HomePage() {
 										}}
 										placeholder={t("landing.heroSearchLocationPlaceholder")}
 										ariaLabel={t("landing.heroSearchLocationLabel")}
-										inputClassName="w-full rounded-full border-0 bg-transparent py-3 pr-8 pl-10 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+										inputClassName="w-full rounded-full border-0 bg-transparent py-3 pr-8 pl-10 text-sm text-gray-900 placeholder:text-gray-600 focus:outline-none"
 									/>
 								</div>
 
@@ -328,7 +328,7 @@ export default function HomePage() {
 										value={heroKeyword}
 										onChange={(e) => setHeroKeyword(e.target.value)}
 										data-testid="hero-keyword-input"
-										className="w-full rounded-full border-0 bg-transparent py-3 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+										className="w-full rounded-full border-0 bg-transparent py-3 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-600 focus:outline-none"
 									/>
 								</div>
 

--- a/frontend/src/pages/OpportunitiesPage.tsx
+++ b/frontend/src/pages/OpportunitiesPage.tsx
@@ -58,7 +58,7 @@ export default function OpportunitiesPage() {
 								value={keyword}
 								onChange={(e) => setKeyword(e.target.value)}
 								data-testid="opportunities-keyword-input"
-								className="w-full rounded-full border-0 bg-transparent py-3 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+								className="w-full rounded-full border-0 bg-transparent py-3 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-600 focus:outline-none"
 							/>
 						</div>
 						<Button type="submit" size="lg" pill className="shrink-0 shadow-md">

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -130,7 +130,7 @@ export default function OrganizationsPage() {
 							value={searchInput}
 							onChange={(e) => handleSearchInputChange(e.target.value)}
 							placeholder={t("organizationsPage.searchPlaceholder")}
-							className="w-full rounded-full border border-white/20 bg-white/10 py-3 pr-4 pl-10 text-sm text-white backdrop-blur-sm placeholder:text-white/60 focus:border-white/40 focus:outline-none"
+							className="w-full rounded-full border border-white/20 bg-white/10 py-3 pr-4 pl-10 text-sm text-white backdrop-blur-sm placeholder:text-white/70 focus:border-white/40 focus:outline-none"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
## What

Darkens the placeholder text color on the homepage hero search, `/opportunities` search, and the org-directory search inputs, which relied on low-contrast `placeholder:text-gray-400` / `placeholder:text-white/60` text as the only visible cue to each field's purpose.

## Why

Closes #1937

The hero ("Stadt oder Postleitzahl", "Stichwort, Titel oder Organisation") and `/opportunities` search inputs measured ~2.49:1 contrast, below WCAG 2.2 AA's 4.5:1 floor (SC 1.4.3). The org-directory search on `/organizations` was flagged as likely affected too - independently recomputed at ~4.40:1, also failing AA.

- `frontend/src/pages/HomePage.tsx` - hero location + keyword inputs: `gray-400` -> `gray-600`
- `frontend/src/pages/OpportunitiesPage.tsx` - keyword input: `gray-400` -> `gray-600`
- `frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx` - location filter input: `gray-400` -> `gray-600`
- `frontend/src/pages/OrganizationsPage.tsx` - org search input: `white/60` -> `white/70`

`gray-600` on the inputs' actual `bg-gray-50` background computes to ~7.2:1; `white/70` composited over `OrganizationsPage`'s `bg-white/10` box on the `bg-brand-800` header computes to ~5.37:1 - both clear of the 4.5:1 floor.

All 4 inputs already carry an accessible name (`aria-label`, or on `OrganizationsPage` a real sr-only `<label>`), so this is a contrast-only fix - no markup/labeling change needed.

## Testing

- `pnpm format:write`, `pnpm lint`, `pnpm check`, `pnpm test` - all clean/passing
- `/self-review` run, including the `a11y-check` subagent (diff touches `.tsx` files) - independently recomputed the contrast ratios above and confirmed the fix is sufficient with no further a11y changes needed

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. `HomePage`, `OpportunitiesPage`, and `OrganizationsPage` already have `HasNoSeriousA11yViolations` axe-core scans in `backend/tests/VisualTests/AccessibilityTests.cs` (run against the local Aspire stack in CI's `dotnet.yml`), which exercise these exact inputs and their new placeholder colors - no new test needed since the routes/inputs weren't new.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKRdKCN8vgYhY5U84cGAru)_