### PR TITLE
fix(frontend): resolve initial locale synchronously before first paint

### DIFF
--- a/backend/tests/VisualTests/InitialLocaleResolutionTests.cs
+++ b/backend/tests/VisualTests/InitialLocaleResolutionTests.cs
@@ -1,0 +1,55 @@
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1934: i18next defaults <c>initAsync</c> to
+/// <c>true</c>, which defers changeLanguage() - and therefore setting
+/// <c>i18next.language</c> - into a setTimeout. i18n.ts (frontend) read
+/// <c>i18next.language</c> synchronously, one statement after calling
+/// <c>.init()</c>, to set <c>document.documentElement.lang</c> before first
+/// paint - so that assignment ran before the language had actually been
+/// resolved. Language *detection* itself (localStorage/navigator) is
+/// synchronous, so the fix (<c>initAsync: false</c>) removes the
+/// unnecessary extra tick instead of touching detection order.
+///
+/// This mirrors the issue's own reproduction: repeated full navigations
+/// between "/" and "/opportunities" with no language toggle touched at any
+/// point, on a context with no stored language choice, asserting both the
+/// html "lang" attribute and the actually rendered heading text stay
+/// deterministic across all of them (rather than flip between English and
+/// German with no user action).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class InitialLocaleResolutionTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Navigation_InitialLocale_StaysDeterministicAcrossFullPageLoads()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		// This suite's default browser context resolves to English with no
+		// stored choice (see NavigationTests's
+		// HomePage_LanguageSelector_SwitchingLanguage_LazilyLoadsAndAppliesTranslations),
+		// so "en" is the deterministic target for every one of these full
+		// navigations - none of them touch the language selector.
+		(string Url, string Heading)[] navigations =
+		[
+			(frontend.ToString(), "Your volunteering starts here."),
+			($"{origin}/opportunities", "Find opportunities"),
+			(frontend.ToString(), "Your volunteering starts here."),
+			($"{origin}/opportunities", "Find opportunities"),
+		];
+		foreach (var (url, heading) in navigations)
+		{
+			await Page.GotoAsync(url);
+			await Expect(Page.Locator("h1").First).ToHaveTextAsync(heading, new() { Timeout = 15_000 });
+			await Expect(Page.Locator("html")).ToHaveAttributeAsync("lang", "en");
+		}
+
+		var storedLanguage = await Page.EvaluateAsync<string?>("() => localStorage.getItem('i18nextLng')");
+		storedLanguage.Should().Be("en");
+	}
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -33,6 +33,17 @@ void i18next
 	.init({
 		fallbackLng: "de",
 		supportedLngs: ["de", "en"],
+		// i18next defers changeLanguage() (and therefore setting
+		// i18next.language) into a setTimeout by default (#1934) - this
+		// module's custom backend is async regardless (dynamic import), but
+		// language *detection* itself (localStorage/navigator, below) is
+		// synchronous, so there's no need to pay that extra tick. Without
+		// this, `document.documentElement.lang = i18next.language` below
+		// runs before the language is resolved at all, briefly setting
+		// lang="undefined" on every page load until the languageChanged
+		// listener corrects it - a real, deterministic race, not staging
+		// noise.
+		initAsync: false,
 		detection: {
 			order: ["localStorage", "navigator"],
 			caches: ["localStorage"],


### PR DESCRIPTION
## What

Sets `initAsync: false` on i18next's `init()` call in `frontend/src/i18n.ts`, so the initial locale is resolved synchronously before `document.documentElement.lang` is set, instead of racing an internal `setTimeout`.

## Why

Closes #1934

i18next defaults `initAsync` to `true`, which defers `changeLanguage()` - and therefore setting `i18next.language` - into a `setTimeout(load, 0)` (confirmed by reading i18next's own source). `frontend/src/i18n.ts` read `i18next.language` **synchronously**, one statement after calling `.init()`, to set `document.documentElement.lang` before first paint:

```ts
void i18next.use(lazyBackend).use(LanguageDetector).use(initReactI18next).init({ ... });
document.documentElement.lang = i18next.language; // ran BEFORE changeLanguage had resolved anything
```

That assignment ran before the language had actually been resolved at all, briefly setting `lang="undefined"` on every full page load until the `languageChanged` listener corrected it asynchronously - a real, deterministic race, independent of the shared-staging noise the issue also flagged as a possible explanation.

Language *detection* itself (localStorage -> navigator, in `detection.order`) is fully synchronous - it's only the `setTimeout` wrapper around `changeLanguage()` that's unnecessary here, since our custom backend (`lazyBackend`, dynamic `import()` per locale) is async regardless of this flag. Setting `initAsync: false` removes that extra tick without touching detection order or resource loading, matching the issue's suggested fix ("resolve the initial locale fully and synchronously before first paint from one deterministic source order").

The other half of the issue's suggested fix - not letting a later async source silently overwrite an already-rendered page's language - is already covered for the one real code path that does this (a signed-in user's Keycloak-account locale, `main.tsx`'s `onSigninCallback`): it's gated behind an explicit in-app choice flag and announced via toast (#1869/#1842). No other code path changes `i18next.language` outside an explicit user action (the language selector) or that already-announced flow.

## Testing

- `pnpm check` / `pnpm lint` / `pnpm test` (259 tests) - all pass
- `dotnet build` (full `Einsatzbereit.slnx`) - passes, 0 warnings
- `dotnet run --project tests/Application.UnitTests` (1045 tests) and `tests/ArchitectureTests` (429 tests) - all pass
- Added `backend/tests/VisualTests/InitialLocaleResolutionTests.cs`: mirrors the issue's own reproduction - repeated full navigations between `/` and `/opportunities` with no language toggle touched, on a context with no stored language choice, asserting both `html[lang]` and the rendered heading text stay deterministic ("en") across all of them, and that `localStorage.i18nextLng` never flips. Runs as part of `dotnet.yml`'s `visual-tests` job in CI (Docker/Aspire isn't available in this sandbox, so it hasn't been run locally - CI will confirm).

## Live verification

Not performed for this PR - the assignment was to implement, fix pipelines, and skip cutting a release candidate. The VisualTests regression above is the durable, CI-enforced record of the fix instead (runs against the local Aspire stack in `dotnet.yml`, no RC needed).

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal i18n init timing, no user-facing doc to update)


---
_Generated by [Claude Code](https://claude.ai/code/session_018LFrLW28QdAxR72HinVHNm)_