### PR TITLE
fix(frontend): cap dashboard row bands to their own width

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1094,6 +1094,72 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrgDashboardPage_RowBandedLayout_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #1932: a saved layout with some rows narrower than the full grid
+		// now renders each row as its own independent, width-capped grid
+		// container (groupIntoRowBands in widgetCatalog.ts) instead of one
+		// shared full-width grid - a DOM shape the plain page-load scan above
+		// never reaches, since a fresh org's DEFAULT_LAYOUT always fills
+		// every row edge to edge. Settings (full width) plus VolunteerStats
+		// (a separate, narrower row right below it) reproduces the mixed
+		// shape - one uncapped band next to a capped one - that #1932's own
+		// fix is about.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var organizationId = await CreateOrganizationAsOlafAsync("A11yRowBanding");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await RemoveAllDashboardWidgetsAsync();
+
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await Expect(dialog).ToBeVisibleAsync();
+		await dialog.GetByTestId("add-widget-option-Settings").ClickAsync();
+		await dialog.GetByTestId("add-widget-option-VolunteerStats").ClickAsync();
+		await dialog.GetByTestId("add-widget-done").ClickAsync();
+
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		await Expect(Page.GetByTestId("widget-tile-Settings")).ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("widget-tile-VolunteerStats")).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	/// <summary>
+	/// Same per-widget removal loop OrgDashboardCustomizeTests.cs and
+	/// OrgDashboardRowBandingTests.cs each already have their own copy of -
+	/// kept local here too rather than shared, matching how every VisualTests
+	/// class in this suite already owns its own copy of this kind of setup
+	/// helper.
+	/// </summary>
+	private async Task RemoveAllDashboardWidgetsAsync()
+	{
+		foreach (var (testId, widgetTitle) in new[]
+		{
+			("CreateOpportunity", "Create opportunity"),
+			("ToDo", "Needs your attention"),
+			("VolunteerStats", "Volunteers"),
+			("UpcomingOpportunities", "Upcoming opportunities"),
+			("Calendar", "Calendar"),
+			("Settings", "Organization"),
+		})
+		{
+			var tile = Page.GetByTestId($"widget-tile-{testId}");
+			if (await tile.CountAsync() == 0)
+				continue;
+			await tile
+				.GetByRole(AriaRole.Button, new() { Name = $"Remove {widgetTitle} widget" })
+				.ClickAsync();
+		}
+	}
+
+	[Test]
 	public async Task OrgDashboardPage_EmptyOpportunitiesCreateOpportunityCta_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// #1122: UpcomingOpportunitiesWidget and QuickCheckInWidget's empty

--- a/backend/tests/VisualTests/OrgDashboardRowBandingTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardRowBandingTests.cs
@@ -177,7 +177,11 @@ public class OrgDashboardRowBandingTests(AspireFixture fixture) : VisualTestBase
 	{
 		var backend = Fixture.GetEndpoint("backend");
 		using var http = await CreateAuthenticatedHttpClientAsync(backend);
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		// #1890: POST /v1/organizations calls out to Keycloak's admin API in
+		// turn, which can trip the resilience-pipeline rejection/timeout
+		// under this suite's sustained concurrent load - retry rather than
+		// fail outright on a transient 500.
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OrgDashboardRowBandingTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardRowBandingTests.cs
@@ -1,0 +1,210 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for #1932: a saved layout that never reached the full
+/// GRID_COLUMNS width on some of its rows (most commonly a lightly-
+/// customized layout that trimmed a widget down without ever widening it
+/// back out) used to render inside a container that always spanned the
+/// full page width regardless - leaving a permanent blank block next to
+/// whichever rows fell short, reading as unfinished on a wide viewport.
+/// OrgDashboardPage/index.tsx now splits the layout into independent row
+/// bands (groupIntoRowBands in widgetCatalog.ts) and caps each band's own
+/// container to the width its own widgets actually reach, so a narrow
+/// band's container ends right where its widgets end instead of always
+/// spanning the page - see widgetCatalog.test.ts for the split logic
+/// itself; this covers the resulting rendered layout.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgDashboardRowBandingTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task NarrowStandaloneWidget_RendersInABandCappedToItsOwnWidth_NotTheFullGrid()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual RowBandNarrow {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await RemoveAllWidgetsAsync();
+
+		// UpcomingOpportunities lands at (x=1, y=1, width=4, height=2) - see
+		// placeNewWidget in widgetCatalog.ts - the only widget on the grid,
+		// reaching column 4 of the 8-column grid.
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await dialog.GetByTestId("add-widget-option-UpcomingOpportunities").ClickAsync();
+		await dialog.GetByTestId("add-widget-done").ClickAsync();
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var tile = Page.GetByTestId("widget-tile-UpcomingOpportunities");
+		await Expect(tile).ToBeVisibleAsync();
+
+		// The tile's own immediate parent is its row band's own grid
+		// container (OrgDashboardPage/index.tsx) - if the band is correctly
+		// capped to this lone widget's own reach, the band's rendered width
+		// should be (close to) the tile's own width, not the full
+		// page-width grid the tile would otherwise only span half of.
+		double parentWidth = 0, tileWidth = 0;
+		await PollUntilAsync(async () =>
+		{
+			var widths = await tile.EvaluateAsync<double[]>(
+				"el => [el.parentElement.getBoundingClientRect().width, el.getBoundingClientRect().width]");
+			parentWidth = widths[0];
+			tileWidth = widths[1];
+			return tileWidth > 0;
+		}, () => "UpcomingOpportunities tile never reported a non-zero width");
+
+		Math.Abs(parentWidth - tileWidth).Should().BeLessThan(20,
+			"a standalone narrow widget's own row band should be capped to its own width, not the "
+			+ $"full page-width grid (tile width: {tileWidth}px, parent/band width: {parentWidth}px)");
+
+		// And that band really is capped, not just coincidentally as wide as
+		// the tile for some other reason - it should be meaningfully
+		// narrower than the page's own content column (~1376px at this
+		// viewport, see --container-page in global.css).
+		parentWidth.Should().BeLessThan(800,
+			"the band should be capped to roughly half the grid's width (UpcomingOpportunities is "
+			+ "4 of GRID_COLUMNS=8) rather than spanning the full ~1376px content column "
+			+ $"(last observed: {parentWidth}px)");
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	[Test]
+	public async Task MixedLayout_CapsOnlyTheNarrowBand_AndLeavesTheFullWidthRowUncapped()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual RowBandMixed {Guid.NewGuid():N}");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await RemoveAllWidgetsAsync();
+
+		// Settings lands first at (x=1, y=1, width=8, height=1) - full
+		// width. VolunteerStats is added next and lands right below it, at
+		// (x=1, y=2, width=4, height=1) - see placeNewWidget in
+		// widgetCatalog.ts - in its own separate, narrower band, since the
+		// two don't share any row.
+		await Page.GetByTestId("quick-action-add-widget").ClickAsync();
+		var dialog = Page.GetByRole(AriaRole.Dialog);
+		await dialog.GetByTestId("add-widget-option-Settings").ClickAsync();
+		await dialog.GetByTestId("add-widget-option-VolunteerStats").ClickAsync();
+		await dialog.GetByTestId("add-widget-done").ClickAsync();
+		await Page.GetByTestId("quick-action-save").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var settingsTile = Page.GetByTestId("widget-tile-Settings");
+		var statsTile = Page.GetByTestId("widget-tile-VolunteerStats");
+		await Expect(settingsTile).ToBeVisibleAsync();
+		await Expect(statsTile).ToBeVisibleAsync();
+
+		double settingsParentWidth = 0, statsParentWidth = 0, statsTileWidth = 0;
+		await PollUntilAsync(async () =>
+		{
+			var settingsWidths = await settingsTile.EvaluateAsync<double[]>(
+				"el => [el.parentElement.getBoundingClientRect().width, el.getBoundingClientRect().width]");
+			var statsWidths = await statsTile.EvaluateAsync<double[]>(
+				"el => [el.parentElement.getBoundingClientRect().width, el.getBoundingClientRect().width]");
+			settingsParentWidth = settingsWidths[0];
+			statsParentWidth = statsWidths[0];
+			statsTileWidth = statsWidths[1];
+			return settingsWidths[1] > 0 && statsTileWidth > 0;
+		}, () => "Settings/VolunteerStats tiles never reported a non-zero width");
+
+		// The full-width Settings row's own band needs no capping, so its
+		// container renders visibly wider than VolunteerStats' own capped
+		// one - a single shared full-width grid behind both (the pre-#1932
+		// behavior) would make the two equal instead.
+		(settingsParentWidth - statsParentWidth).Should().BeGreaterThan(200,
+			"the full-width Settings band and the narrower VolunteerStats band should render at "
+			+ $"visibly different widths (Settings band: {settingsParentWidth}px, "
+			+ $"VolunteerStats band: {statsParentWidth}px)");
+		Math.Abs(statsParentWidth - statsTileWidth).Should().BeLessThan(20,
+			"VolunteerStats' own band should be capped to its own width, not left spanning the same "
+			+ $"full-width grid as the Settings row above it (tile: {statsTileWidth}px, "
+			+ $"band: {statsParentWidth}px)");
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	/// <summary>
+	/// Same per-widget removal loop as OrgDashboardCustomizeTests - kept
+	/// local rather than shared, matching how each VisualTests class in
+	/// this suite already owns its own copy of this kind of setup helper.
+	/// </summary>
+	private async Task RemoveAllWidgetsAsync()
+	{
+		foreach (var (testId, widgetTitle) in new[]
+		{
+			("CreateOpportunity", "Create opportunity"),
+			("ToDo", "Needs your attention"),
+			("VolunteerStats", "Volunteers"),
+			("UpcomingOpportunities", "Upcoming opportunities"),
+			("Calendar", "Calendar"),
+			("Settings", "Organization"),
+		})
+		{
+			var tile = Page.GetByTestId($"widget-tile-{testId}");
+			if (await tile.CountAsync() == 0)
+				continue;
+			await tile
+				.GetByRole(AriaRole.Button, new() { Name = $"Remove {widgetTitle} widget" })
+				.ClickAsync();
+		}
+	}
+
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -3,6 +3,7 @@ import {
 	useEffect,
 	useMemo,
 	useState,
+	type CSSProperties,
 	type MouseEvent as ReactMouseEvent,
 	type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -36,6 +37,7 @@ import {
 	WIDGET_KEYS,
 	classifyWidth,
 	compactLayout,
+	groupIntoRowBands,
 	placeNewWidget,
 	sanitizeWidgetKey,
 	sortByPosition,
@@ -43,6 +45,12 @@ import {
 	type WidgetKey,
 	type WidgetSizeClass,
 } from "./widgetCatalog";
+
+// Lets a band's own container (see the `needsRowBanding` render branch
+// below) override --dashboard-grid-columns (global.css's
+// .dashboard-widget-grid rule) - csstype's CSSProperties has no index
+// signature for custom properties, so the plain type needs this widening.
+type BandGridStyle = CSSProperties & { "--dashboard-grid-columns": number };
 
 // Matches Tailwind's default `lg` breakpoint, which is also where the
 // widget grid switches from a single stacked column to the real 8-column
@@ -169,6 +177,22 @@ export default function OrgDashboardPage() {
 	// gridRow) but on mobile let a widget dragged to the bottom on desktop
 	// render first (#1845).
 	const mobileLayout = isLargeViewport ? layout : sortByPosition(layout);
+
+	// #1932: a layout that never reaches the full GRID_COLUMNS width on every
+	// row (most commonly a lightly-customized layout that trimmed some
+	// widgets down without ever widening them back out) used to render
+	// inside a container that always spanned the full page width regardless,
+	// leaving a permanent blank block next to whichever rows fell short.
+	// Bands split the layout into independent runs of rows (see
+	// groupIntoRowBands in widgetCatalog.ts) so each run's own container can
+	// be capped to the width its own widgets actually reach instead. Only
+	// computed outside edit mode (which needs the full canvas for
+	// placement) and at `lg`+ (mobile already collapses to one stacked
+	// column with nothing to cap) - and only actually used for rendering
+	// (see needsRowBanding below) once some band falls short, so the
+	// default, fully-packed DEFAULT_LAYOUT renders exactly as before.
+	const rowBands = !editing && isLargeViewport ? groupIntoRowBands(layout) : [];
+	const needsRowBanding = rowBands.some((band) => band.columns < GRID_COLUMNS);
 
 	// Memoized so CreateOpportunityWidget's React.memo (see that component)
 	// actually skips re-rendering while a placement is in progress - a fresh
@@ -472,6 +496,60 @@ export default function OrgDashboardPage() {
 		if (cell) placement.handleCellHover(cell);
 	}
 
+	// Shared per-widget tile renderer for both the plain grid (below) and each
+	// row band's own grid (see needsRowBanding below) - `rowOffset` remaps a
+	// widget's stored (grid-absolute) y into a position relative to whichever
+	// container is actually rendering it: 0 for the plain grid (where a
+	// widget's own y already is the grid row), or a band's own
+	// `startRow - 1` otherwise, since CSS grid rows are always relative to
+	// their own container.
+	function renderTile(widget: PlacedWidget, rowOffset = 0) {
+		const isPlacingThis = activeKey === widget.widgetKey;
+		const rect = isPlacingThis && previewRect ? previewRect : widget;
+		const sizeClass = isLargeViewport ? classifyWidth(rect.width) : "compact";
+		return (
+			<EditableWidgetTile
+				key={widget.widgetKey}
+				widgetKey={widget.widgetKey}
+				gridStyle={
+					isLargeViewport
+						? {
+								// Explicit start line (not just `span N`) is required
+								// here: the green backdrop cells above claim every
+								// single cell of the grid explicitly, which fully
+								// saturates CSS Grid's auto-placement algorithm for this
+								// row range. A widget tile placed with only a span (no
+								// start) would have nowhere left to auto-place into and
+								// would overflow into new auto-generated rows below the
+								// entire backdrop.
+								gridColumn: `${rect.x} / span ${rect.width}`,
+								gridRow: `${rect.y - rowOffset} / span ${rect.height}`,
+							}
+						: undefined
+				}
+				editing={editing}
+				showPlacementControls={isLargeViewport}
+				isPlacing={isPlacingThis}
+				hasAnchor={isPlacingThis && anchor !== null}
+				isCornerFlowActive={placingKey === widget.widgetKey}
+				placingDisabled={activeKey !== null && !isPlacingThis}
+				onAdvance={() => placement.handleAdvance(widget.widgetKey)}
+				onArrowKeyDown={(e) =>
+					placement.handleArrowKeyDown(e, widget.widgetKey)
+				}
+				onRemove={() => handleRemoveWidget(widget.widgetKey)}
+				onGripPointerDown={(e) =>
+					placement.startDrag(e, widget.widgetKey, "move")
+				}
+				onResizePointerDown={(e) =>
+					placement.startDrag(e, widget.widgetKey, "resize")
+				}
+			>
+				{renderWidget(widget.widgetKey, sizeClass)}
+			</EditableWidgetTile>
+		);
+	}
+
 	const grid = isEmpty ? (
 		<div data-testid="dashboard-empty-state">
 			<EmptyState
@@ -486,6 +564,56 @@ export default function OrgDashboardPage() {
 						: undefined
 				}
 			/>
+		</div>
+	) : needsRowBanding ? (
+		<div data-testid="dashboard-widget-grid" className="flex flex-col gap-4">
+			{/* #1932: only reachable outside edit mode (rowBands is empty
+			otherwise - see its definition above), so there's no backdrop/
+			placement surface to worry about here. Each band gets its own
+			independent grid, capped to the width its own widgets actually
+			reach (see groupIntoRowBands in widgetCatalog.ts) instead of always
+			spanning the full GRID_COLUMNS - so a lightly-customized layout
+			that trimmed some widgets down without ever widening them back out
+			doesn't leave the rest of that width sitting permanently blank
+			next to them. */}
+			{rowBands.map((band) => {
+				const bandStyle: BandGridStyle = {
+					gridTemplateColumns: `repeat(${band.columns}, minmax(0, 1fr))`,
+					maxWidth: `${(band.columns / GRID_COLUMNS) * 100}%`,
+					"--dashboard-grid-columns": band.columns,
+				};
+				return (
+					<div
+						key={band.startRow}
+						className="dashboard-widget-grid grid gap-4"
+						style={bandStyle}
+					>
+						{band.widgets.map((widget) =>
+							renderTile(widget, band.startRow - 1),
+						)}
+					</div>
+				);
+			})}
+			{isOrganizer && !layoutLoadFailed && (
+				// Same affordance as the unbanded branch's customize hint below,
+				// just outside any CSS grid entirely (a plain block, not
+				// gridRow-positioned within one) since there's no single shared
+				// grid left to position it inside of. Reuses the plain
+				// .dashboard-widget-grid row-height calc (default
+				// --dashboard-grid-columns, full width) so it renders exactly as
+				// tall as an ordinary content row.
+				<div className="dashboard-widget-grid grid">
+					<button
+						type="button"
+						data-testid="dashboard-customize-hint"
+						onClick={startEditing}
+						className="flex h-full items-center justify-center gap-1.5 rounded-md border border-dashed border-gray-200 text-sm text-gray-500 transition-colors hover:border-brand-300 hover:text-brand-600"
+					>
+						<PlusIcon />
+						{t("orgDashboard.customizeHint")}
+					</button>
+				</div>
+			)}
 		</div>
 	) : (
 		<div
@@ -534,54 +662,7 @@ export default function OrgDashboardPage() {
 			collapses to a single stacked column below `lg`, where this wouldn't
 			mean anything. */}
 			{guideCells}
-			{mobileLayout.map((widget) => {
-				const isPlacingThis = activeKey === widget.widgetKey;
-				const rect = isPlacingThis && previewRect ? previewRect : widget;
-				const sizeClass = isLargeViewport
-					? classifyWidth(rect.width)
-					: "compact";
-				return (
-					<EditableWidgetTile
-						key={widget.widgetKey}
-						widgetKey={widget.widgetKey}
-						gridStyle={
-							isLargeViewport
-								? {
-										// Explicit start line (not just `span N`) is required
-										// here: the green backdrop cells above claim every
-										// single cell of the grid explicitly, which fully
-										// saturates CSS Grid's auto-placement algorithm for this
-										// row range. A widget tile placed with only a span (no
-										// start) would have nowhere left to auto-place into and
-										// would overflow into new auto-generated rows below the
-										// entire backdrop.
-										gridColumn: `${rect.x} / span ${rect.width}`,
-										gridRow: `${rect.y} / span ${rect.height}`,
-									}
-								: undefined
-						}
-						editing={editing}
-						showPlacementControls={isLargeViewport}
-						isPlacing={isPlacingThis}
-						hasAnchor={isPlacingThis && anchor !== null}
-						isCornerFlowActive={placingKey === widget.widgetKey}
-						placingDisabled={activeKey !== null && !isPlacingThis}
-						onAdvance={() => placement.handleAdvance(widget.widgetKey)}
-						onArrowKeyDown={(e) =>
-							placement.handleArrowKeyDown(e, widget.widgetKey)
-						}
-						onRemove={() => handleRemoveWidget(widget.widgetKey)}
-						onGripPointerDown={(e) =>
-							placement.startDrag(e, widget.widgetKey, "move")
-						}
-						onResizePointerDown={(e) =>
-							placement.startDrag(e, widget.widgetKey, "resize")
-						}
-					>
-						{renderWidget(widget.widgetKey, sizeClass)}
-					</EditableWidgetTile>
-				);
-			})}
+			{mobileLayout.map((widget) => renderTile(widget))}
 			{/* #1939: a first-time organizer has no reason to suspect the blank
 			space below their widgets is customizable - this dashed "+" tile
 			sits in the row right after the current layout's last occupied row

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
 	DEFAULT_LAYOUT,
+	GRID_COLUMNS,
 	WIDGET_CATALOG,
+	groupIntoRowBands,
 	isValidPlacement,
 	sortByPosition,
 	type PlacedWidget,
@@ -134,5 +136,64 @@ describe("sortByPosition", () => {
 
 	it("already matches DEFAULT_LAYOUT's own order, since it was authored top-to-bottom", () => {
 		expect(sortByPosition(DEFAULT_LAYOUT)).toEqual(DEFAULT_LAYOUT);
+	});
+});
+
+// #1932: OrgDashboardPage/index.tsx only caps a band's own rendered width
+// below the full GRID_COLUMNS once one of these bands actually falls short
+// of it - these guard the split itself, independent of that rendering.
+describe("groupIntoRowBands", () => {
+	it("keeps every DEFAULT_LAYOUT band at the full GRID_COLUMNS width", () => {
+		// DEFAULT_LAYOUT (widgetCatalog.ts) is deliberately packed edge to edge
+		// on every row - a brand-new organization must render identically to
+		// today, with no band ever narrower than the full grid.
+		for (const band of groupIntoRowBands(DEFAULT_LAYOUT)) {
+			expect(band.columns).toBe(GRID_COLUMNS);
+		}
+	});
+
+	it("merges widgets whose Y ranges overlap into a single band, even indirectly through a taller widget", () => {
+		// Calendar (y=1..4) overlaps both A (y=1 only) and B (y=3 only) - A and
+		// B don't overlap each other directly, but share a band transitively
+		// through Calendar.
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "Calendar", x: 1, y: 1, width: 4, height: 4 },
+			{ widgetKey: "CreateOpportunity", x: 5, y: 1, width: 2, height: 1 },
+			{ widgetKey: "QuickCheckIn", x: 5, y: 3, width: 2, height: 2 },
+		];
+
+		const bands = groupIntoRowBands(widgets);
+
+		expect(bands).toHaveLength(1);
+		expect(bands[0].startRow).toBe(1);
+		expect(bands[0].columns).toBe(6);
+		expect(bands[0].widgets).toHaveLength(3);
+	});
+
+	it("splits widgets in adjacent but non-overlapping rows into separate bands", () => {
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "UpcomingOpportunities", x: 1, y: 1, width: 4, height: 2 },
+			{ widgetKey: "VolunteerStats", x: 1, y: 3, width: 4, height: 1 },
+		];
+
+		const bands = groupIntoRowBands(widgets);
+
+		expect(bands).toHaveLength(2);
+		expect(bands[0]).toMatchObject({ startRow: 1, columns: 4 });
+		expect(bands[1]).toMatchObject({ startRow: 3, columns: 4 });
+	});
+
+	it("caps a standalone widget's own band at its own reach, not the full grid", () => {
+		const widgets: PlacedWidget[] = [
+			{ widgetKey: "UpcomingOpportunities", x: 1, y: 5, width: 4, height: 2 },
+		];
+
+		const bands = groupIntoRowBands(widgets);
+
+		expect(bands).toEqual([{ startRow: 5, columns: 4, widgets: [widgets[0]] }]);
+	});
+
+	it("returns no bands for an empty layout", () => {
+		expect(groupIntoRowBands([])).toEqual([]);
 	});
 });

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
@@ -327,6 +327,64 @@ export function settlePlacement(
 	return [rect, ...compactAgainstObstacles(pushed, [rect])];
 }
 
+// A single horizontal run of the layout: a maximal group of widgets whose Y
+// ranges are connected, transitively (#1932). OrgDashboardPage/index.tsx
+// renders each band returned by groupIntoRowBands below as its own
+// independent grid container, capped to `columns` wide instead of always
+// spanning the full GRID_COLUMNS - so a band that never reaches the full
+// width (most commonly a lightly-customized layout that trimmed some
+// widgets down without ever widening them back out) doesn't leave the rest
+// of that width sitting permanently blank next to it. `startRow` is the
+// band's own topmost absolute row; a caller remaps each widget's stored
+// (grid-absolute) y into a position relative to the band's own container
+// via `y - startRow + 1`.
+export interface LayoutRowBand {
+	startRow: number;
+	columns: number;
+	widgets: PlacedWidget[];
+}
+
+// Splits `widgets` into row bands (see LayoutRowBand above). Two widgets
+// belong to the same band whenever their Y ranges overlap, transitively - a
+// row-by-row scan wouldn't work here: a single tall widget (e.g. a 4-row
+// Calendar) shares its band with anything beside it in ANY of those 4 rows,
+// not just the first one. Sorting by y and starting a new band only when a
+// widget's own y falls strictly past the current band's running bottom edge
+// is the standard interval-merging algorithm applied to just the Y axis,
+// ignoring x/width entirely - correct regardless of input order, including
+// ties (a widget sharing its y with the band's first widget always finds
+// bottom already >= its own y, from that first widget's own height alone).
+export function groupIntoRowBands(widgets: PlacedWidget[]): LayoutRowBand[] {
+	const sorted = [...widgets].sort((a, b) => a.y - b.y);
+	const bands: PlacedWidget[][] = [];
+	let bottom = -Infinity;
+	for (const widget of sorted) {
+		if (bands.length === 0 || widget.y > bottom) {
+			bands.push([]);
+			bottom = -Infinity;
+		}
+		bands[bands.length - 1].push(widget);
+		bottom = Math.max(bottom, widget.y + widget.height - 1);
+	}
+
+	return bands.map((bandWidgets) => ({
+		startRow: Math.min(...bandWidgets.map((w) => w.y)),
+		columns: Math.max(...bandWidgets.map((w) => w.x + w.width - 1)),
+		// sortByPosition (not just the y-only sort above, and not the input's
+		// own array order) so DOM/tab order within a band reads top-to-bottom,
+		// then left-to-right, the same way mobile's stacked single-column
+		// rendering already does - OrgDashboardPage/index.tsx renders each
+		// band as its own real CSS grid, so every widget still gets its own
+		// explicit gridColumn/gridRow and doesn't visually depend on this
+		// order, but a screen-reader/keyboard user tabbing through a band
+		// should still land on its widgets in reading order rather than
+		// whatever order edit history happened to leave them in the layout
+		// array (see sortByPosition's own doc comment for why that array
+		// order can't be trusted directly).
+		widgets: sortByPosition(bandWidgets),
+	}));
+}
+
 // Appends a newly added widget directly below every widget currently on the
 // grid, at its catalog default size - always non-overlapping since nothing
 // occupies the grid below the current bottom edge. The organizer then drags

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -342,16 +342,30 @@ overflow-y-auto already handles vertical scrolling. */
  * proportions warp between a wide monitor and a narrower one even though
  * its cell counts never changed. Container query units key off this
  * element's own measured width rather than the viewport, matching exactly
- * what a column's 1fr track resolves to (100cqw minus the 7 inter-column
- * gaps, split across 8 columns). Floored at 64px so rows stay usable on
- * the narrowest qualifying (`lg`, 1024px) viewport. */
+ * what a column's 1fr track resolves to (100cqw minus the N-1 inter-column
+ * gaps, split across N columns). Floored at 64px so rows stay usable on
+ * the narrowest qualifying (`lg`, 1024px) viewport.
+ *
+ * --dashboard-grid-columns defaults to the full GRID_COLUMNS (8) - a row
+ * band capped to fewer than that (#1932, see groupIntoRowBands in
+ * widgetCatalog.ts and OrgDashboardPage/index.tsx) overrides it inline so
+ * its own row height still tracks its own (narrower) rendered width the
+ * same way the full-width grid already does, instead of assuming 8
+ * columns' worth of gaps that aren't actually there. */
 .dashboard-widget-grid {
 	container-type: inline-size;
+	--dashboard-grid-columns: 8;
 }
 
 @media (min-width: 1024px) {
 	.dashboard-widget-grid {
-		grid-auto-rows: max(64px, calc((100cqw - 7rem) / 8));
+		grid-auto-rows: max(
+			64px,
+			calc(
+				(100cqw - (var(--dashboard-grid-columns) - 1) * 1rem) /
+					var(--dashboard-grid-columns)
+			)
+		);
 	}
 }
 


### PR DESCRIPTION
## What

The organizer dashboard's widget grid now splits a saved layout into independent horizontal "row bands" and caps each band's own rendered width to the columns its widgets actually reach, instead of always spanning the full 8-column grid.

## Why

Closes #1932

On a 1440px viewport, `/app/:organizationId/dashboard` for an organization whose layout doesn't reach the full grid width on every row rendered a large, permanent blank block next to the narrower rows - reading as unfinished/broken. I confirmed on live staging that the reported instance (Olaf's seed org) already has a saved, customized layout (`hasCustomLayout: true`) that's narrower than the shipped `DEFAULT_LAYOUT` on most rows, not a brand-new organization using the untouched default - `DEFAULT_LAYOUT` itself already fills every row edge to edge, so the issue's "Option A" (a denser starter layout) would not have changed anything for the layout actually observed. I went with **Option B** (cap/constrain the grid's available width) instead, since it fixes the width problem generally for any layout - default or customized - that leaves some rows narrower than others.

Implementation: `groupIntoRowBands` (`widgetCatalog.ts`) partitions a layout into bands - two widgets share a band whenever their Y ranges overlap, transitively (a tall widget like the Calendar can share a band with things beside it in any of its rows, not just the first). `OrgDashboardPage` renders each band as its own CSS grid, capped to `(band.columns / GRID_COLUMNS) * 100%` width with a matching `grid-template-columns` count, so column pixel width stays identical across bands (no widget grows or shrinks - only the leftover blank track disappears). This only applies in view mode (edit mode keeps the full 8-column canvas for placement) and only once some band actually falls short of the full width, so a fresh organization's fully-packed `DEFAULT_LAYOUT` renders exactly as it did before.

## Testing

- `pnpm check` / `pnpm lint` / `pnpm test` (264 tests) / `pnpm build` - all green
- `dotnet build` (full solution, incl. the new/changed VisualTests file) - green
- `dotnet run --project tests/Application.UnitTests` (1045 tests) and `tests/ArchitectureTests` (429 tests) - green
- Added `groupIntoRowBands` unit tests in `widgetCatalog.test.ts`: keeps every `DEFAULT_LAYOUT` band at the full width, merges Y-overlapping widgets transitively, splits adjacent-but-non-overlapping rows into separate bands, caps a standalone narrow widget to its own reach, empty-input case
- Added `backend/tests/VisualTests/OrgDashboardRowBandingTests.cs` (runs against the local Aspire stack in CI): a standalone narrow widget's own band is capped to its own width, and a mixed layout (full-width row + narrower row) caps only the narrow band while leaving the full-width one uncapped
- Added `OrgDashboardPage_RowBandedLayout_AsOlaf_HasNoSeriousA11yViolations` to `AccessibilityTests.cs` for axe-core coverage of the new banded DOM shape (raised by `/self-review`'s `a11y-check` pass - the original diff also left DOM/tab order within a band following edit-history array order instead of reading order, which I fixed by sorting each band's own widgets with the existing `sortByPosition` helper)

## Live verification

No release candidate was cut for this PR (explicit instruction for this task). I did verify the fix works as intended two ways short of a live-staging RC:

1. Reproduced the exact reported bug against **current** live staging as Olaf (`https://einsatzbereit.maik-hasler.de`) to confirm root cause: `GET .../dashboard/layout` returns `hasCustomLayout: true` with a layout that leaves several rows short of the full 8 columns.
2. Ran the built fix locally (`pnpm dev` + a throwaway Playwright script mocking the org-details/dashboard-layout API responses with that exact captured staging layout) and confirmed the grid now renders as separate width-capped bands with consistent per-column pixel width, and that a fresh org's unmodified `DEFAULT_LAYOUT` still renders as the single, unbanded full-width grid it always has.

The `OrgDashboardRowBandingTests.cs` VisualTests added above are the durable, CI-verified equivalent of that local check.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (inline comments in `widgetCatalog.ts`/`index.tsx`/`global.css` explain the new row-banding behavior; no user-facing docs needed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8rHz2e4ggoZSkE7XnPJyS)_