### PR TITLE
fix(frontend): serve manifest.webmanifest as application/manifest+json

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -217,6 +217,19 @@ jobs:
           echo "$encoding"
           echo "$encoding" | grep -qi "gzip" || { echo "::error::${asset} was not served with Content-Encoding: gzip"; exit 1; }
 
+      # Regression for #1966: nginx had no explicit MIME type mapping for
+      # .webmanifest, so it fell back to default_type (application/octet-stream)
+      # instead of the application/manifest+json the W3C Web App Manifest spec
+      # requires - a strict installability check (some Lighthouse
+      # configurations, some non-Chromium engines) can refuse to treat a
+      # non-application/manifest+json response as a valid manifest.
+      - name: manifest.webmanifest is served with the correct Content-Type
+        run: |
+          content_type=$(curl -fsSI http://localhost:8081/manifest.webmanifest | tr -d '\r' | grep -i '^content-type:')
+          echo "$content_type"
+          echo "$content_type" | grep -qi "application/manifest+json" \
+            || { echo "::error::manifest.webmanifest was not served as application/manifest+json"; exit 1; }
+
       # The lint job's check:pwa-manifest validates what vite.config.ts
       # declares against the PNGs in public/; this validates what the built
       # image actually serves. Between the two sits the build - an asset that

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -62,6 +62,17 @@ server {
 		add_header Content-Security-Policy $csp_header always;
 	}
 
+	# nginx's default mime.types has no .webmanifest entry, so it falls back to
+	# default_type (application/octet-stream) instead of the
+	# application/manifest+json the W3C Web App Manifest spec requires
+	# (einsatzbereit#1966) - most browsers are lenient about it, but a strict
+	# installability check (some Lighthouse configs, some non-Chromium engines)
+	# can refuse to treat a non-application/manifest+json response as a valid
+	# manifest.
+	location = /manifest.webmanifest {
+		default_type application/manifest+json;
+	}
+
 	location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
 		expires 1y;
 		add_header Cache-Control "public, immutable" always;


### PR DESCRIPTION
## What

`GET /manifest.webmanifest` is now served with `content-type: application/manifest+json` instead of `application/octet-stream`.

## Why

nginx's default `mime.types` has no `.webmanifest` entry, so the static frontend deployment (`frontend/nginx.conf.template`) fell back to `default_type` (`application/octet-stream`). Per the [W3C Web App Manifest spec](https://www.w3.org/TR/appmanifest/), the manifest should be served as `application/manifest+json`. Browsers are generally lenient about this (Chrome's install prompt worked fine), but a stricter installability check (some Lighthouse configurations, some non-Chromium engines) can refuse to treat a non-`application/manifest+json` response as a valid manifest.

Closes #1966

Fixed by adding an exact-match `location = /manifest.webmanifest` block that sets `default_type application/manifest+json;`, ahead of the catch-all static-asset regex block. It doesn't override `add_header`, so all the existing security headers (CSP, HSTS, `nosniff`, etc.) are still inherited from the `server` block unchanged.

## Testing

- `pnpm check:nginx-csp` (existing static nginx-template check) still passes.
- Added a new `manifest.webmanifest is served with the correct Content-Type` step to `frontend-checks.yml`'s `docker-image` job, which builds and boots the real production nginx image and asserts the header directly - this is the only CI job that actually runs `nginx.conf.template` (`dotnet.yml`'s VisualTests boot the Vite dev server via Aspire, not nginx, so a VisualTests assertion would not have exercised this fix).

## Live verification

No release candidate was cut for this change (explicitly out of scope for this PR per repo owner's instruction). CI's new `docker-image` job assertion (see Testing above) builds and runs the actual production nginx image and directly reproduces the issue's repro steps (`curl -I .../manifest.webmanifest`), giving equivalent confidence without a staging deploy.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no docs reference the manifest's content-type)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBEKfot13GRre7m25DCfeZ)_