### PR TITLE
test: cover the already-applied volunteer in the mobile action-rail regression

### DIFF
--- a/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
@@ -20,6 +20,15 @@ namespace VisualTests;
 /// after the at-a-glance meta row and before the map, visible only below
 /// `lg`; the original sticky `<aside>` now hides below `lg` in turn so the
 /// two copies are never both visible at the same viewport.
+///
+/// #1948 filed the same underlying gap independently, from the specific
+/// perspective of a volunteer who already signed up: their "Deine Anmeldung /
+/// Bestätigt / Zurückziehen" status card sat below the map, time-slot list
+/// and organisation contact block on narrow viewports. The #1965 fix above
+/// already covers that block too - it is one of the four the shared rail
+/// renders - but no test exercised the already-applied state specifically,
+/// only the anonymous and not-yet-applied ones. See
+/// <see cref="ActionRail_ForVolunteerWithExistingEngagement_RendersAboveMapOnNarrowViewport"/>.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OpportunityDetailPageMobileActionRailTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -148,5 +157,39 @@ public class OpportunityDetailPageMobileActionRailTests(AspireFixture fixture) :
 
 		await AssertRailAboveMapAndNoDesktopDuplicateAsync(
 			Page.GetByTestId("signup-cta-mobile"), "signup-cta");
+	}
+
+	/// <summary>
+	/// Regression for #1948: a volunteer who already signed up sees their
+	/// status card (the <c>showApplicationStatus</c> block - status chip and
+	/// "Zurückziehen"/withdraw button) rather than the sign-up CTA covered by
+	/// <see cref="ActionRail_ForAuthenticatedNonOwner_RendersAboveMapOnNarrowViewport"/>
+	/// above; that block needs its own narrow-viewport coverage since the two
+	/// are mutually exclusive.
+	/// </summary>
+	[Test]
+	public async Task ActionRail_ForVolunteerWithExistingEngagement_RendersAboveMapOnNarrowViewport()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await SeedOpportunityWithMapAsync("VeraApplied");
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
+		var applyResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Seeded for #1948 mobile action-rail regression coverage." });
+		applyResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.SetViewportSizeAsync(NarrowViewportWidth, NarrowViewportHeight);
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await AssertRailAboveMapAndNoDesktopDuplicateAsync(
+			Page.GetByTestId("application-status-mobile"), "application-status");
 	}
 }


### PR DESCRIPTION
## What

Adds a third test case to `OpportunityDetailPageMobileActionRailTests` covering the specific scenario #1948 reported: a volunteer who already signed up sees their "Deine Anmeldung / Bestätigt / Zurückziehen" status card above the map on narrow viewports, not just below it.

## Why

Closes #1948

#1948 and #1965 were both filed the same day (2026-08-14) from the same live-staging review, describing the same underlying layout bug from two angles: #1965 focused on the general sign-up CTA dropping below the map/time-slots/contact-card on the 375px reflow, while #1948 focused specifically on a volunteer who had *already* signed up and needed to reach their status card (and the withdraw button) without scrolling past that same content.

#1965 was fixed and merged the next day via PR #1970, which renders the entire shared action rail - deadline card, application-status card, sign-up CTA, and login prompt - a second time right after the at-a-glance summary and before the map on narrow viewports (`VolunteerOpportunityDetailPage.tsx`'s `renderActionRail`, testid-suffixed `-mobile`). The application-status block #1948 describes is one of those four blocks, so the underlying bug was already fixed for #1948's scenario too - but the issue was never linked/closed, and no test exercised that specific state. The existing `OpportunityDetailPageMobileActionRailTests` only covered the anonymous visitor (login prompt) and the not-yet-applied authenticated visitor (sign-up CTA) cases.

This PR is test-only: it locks in the already-shipped fix for the exact scenario #1948 reported, closing the coverage gap rather than re-doing work that already landed.

## Testing

- Added `ActionRail_ForVolunteerWithExistingEngagement_RendersAboveMapOnNarrowViewport` to `backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs`: seeds a published `IndividualContact` opportunity with a map, creates an engagement for `vera` via a direct API call, then asserts the `application-status-mobile` block is visible and sits above the `.leaflet-container` map at a 375px viewport, with the desktop-only `application-status` copy hidden - mirroring the two existing cases in the same file.
- Could not run this locally: the sandbox has no Docker/Aspire orchestration (see root `AGENTS.md`'s Sandbox Limitations) and this session's egress policy blocks `builds.dotnet.microsoft.com`, so even installing the .NET SDK to compile-check failed. CI's `dotnet.yml` `visual-tests` job (real runner, Docker available) is the first place this test actually executes.

## Live verification

No release candidate was cut for this change (explicitly requested) and none is needed: the diff is test-only and adds coverage for a UI fix that already shipped to production via PR #1970/#1965. There is no new runtime behavior to observe on staging - the durable verification is CI's `VisualTests` (Playwright + Aspire) run on this PR, which is the mechanism root `AGENTS.md` designates for this kind of regression coverage in the first place.

## Checklist

- [x] `/self-review` run and findings addressed (clean - no findings; change is scoped to one test file, mirrors the existing two tests in the same class, and touches nothing that needs a domain-specific check per the skill's routing table)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - test-only change, no behavior change; updated the file's regression doc-comment to note #1948's angle on the same bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj9vE3bTmKq815WNzGfoju)_