### PR TITLE
fix: swap ConfirmDialog to a single dismiss action on terminal error

### DIFF
--- a/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
+++ b/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
@@ -24,6 +24,11 @@ namespace VisualTests;
 /// withdrawn out-of-band while the confirm dialog is open, so the UI's own
 /// withdraw call - unaware of that change - hits Engagement.AlreadyTerminated
 /// (409 Conflict) once confirmed.
+///
+/// Also covers #1950: once that terminal error is showing, ConfirmDialog used
+/// to leave its original "Keep"/"Yes, withdraw" pair active, inviting a
+/// second attempt guaranteed to fail the same way. The dialog should instead
+/// swap to a single "Understood" acknowledgement that just dismisses it.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class WithdrawEngagementErrorMessageTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -96,5 +101,15 @@ public class WithdrawEngagementErrorMessageTests(AspireFixture fixture) : Visual
 		var errorBanner = dialog.GetByRole(AriaRole.Alert);
 		await Expect(errorBanner).ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await Expect(errorBanner).ToHaveTextAsync("Sign-up is already terminated.");
+
+		await Expect(dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, withdraw" }))
+			.Not.ToBeVisibleAsync();
+		await Expect(dialog.GetByRole(AriaRole.Button, new() { Name = "Keep" }))
+			.Not.ToBeVisibleAsync();
+
+		var understoodButton = dialog.GetByRole(AriaRole.Button, new() { Name = "Understood" });
+		await Expect(understoodButton).ToBeVisibleAsync();
+		await understoodButton.ClickAsync();
+		await Expect(dialog).Not.ToBeVisibleAsync();
 	}
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import Modal from "./Modal";
 import Button from "./Button";
@@ -32,6 +32,18 @@ export default function ConfirmDialog({
 	// textarea) rendered above it doesn't steal default focus from "Keep" -
 	// the safe, non-destructive action a confirm dialog should default to.
 	const actionsRef = useRef<HTMLDivElement>(null);
+	const errorRef = useRef<HTMLParagraphElement>(null);
+
+	// The confirm button that triggered this error is disabled while `loading`
+	// (browsers blur a focused element the instant it's disabled) and then
+	// unmounts entirely once `error` lands, replaced by the single
+	// acknowledgement button below - so without this, focus is stranded on
+	// <body> while the dialog is still open. Same "disabled blurs to body"
+	// fix OrgSettingsPage.tsx and DetailsStep.tsx apply for the same reason.
+	useEffect(() => {
+		if (!error) return;
+		errorRef.current?.focus();
+	}, [error]);
 
 	return (
 		<Modal
@@ -56,26 +68,44 @@ export default function ConfirmDialog({
 
 			{children && <div className="mt-3">{children}</div>}
 
-			{error && <ErrorBanner message={error} className="mt-3" />}
+			{error && (
+				<ErrorBanner
+					ref={errorRef}
+					message={error}
+					tabIndex={-1}
+					className="mt-3 focus:outline-none"
+				/>
+			)}
 
 			<div ref={actionsRef} className="mt-5 flex justify-end gap-3">
-				<Button
-					type="button"
-					variant="secondary"
-					onClick={onClose}
-					disabled={loading}
-				>
-					{t("confirmDialog.keep")}
-				</Button>
-				<Button
-					type="button"
-					variant="danger"
-					onClick={onConfirm}
-					disabled={loading}
-					aria-busy={loading}
-				>
-					{loading ? t("common.saving") : confirmLabel}
-				</Button>
+				{error ? (
+					// A terminal, non-retryable error means retrying is guaranteed to
+					// fail the same way (#1950) - swap the retry/cancel pair for a
+					// single acknowledgement instead of inviting a second attempt.
+					<Button type="button" variant="secondary" onClick={onClose}>
+						{t("confirmDialog.understood")}
+					</Button>
+				) : (
+					<>
+						<Button
+							type="button"
+							variant="secondary"
+							onClick={onClose}
+							disabled={loading}
+						>
+							{t("confirmDialog.keep")}
+						</Button>
+						<Button
+							type="button"
+							variant="danger"
+							onClick={onConfirm}
+							disabled={loading}
+							aria-busy={loading}
+						>
+							{loading ? t("common.saving") : confirmLabel}
+						</Button>
+					</>
+				)}
 			</div>
 		</Modal>
 	);

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -943,6 +943,7 @@
     },
     "confirmDialog": {
       "keep": "Behalten",
+      "understood": "Verstanden",
       "delete": {
         "title": "Einsatz löschen?",
         "message": "Möchtest du diesen Einsatz wirklich dauerhaft löschen? Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -943,6 +943,7 @@
     },
     "confirmDialog": {
       "keep": "Keep",
+      "understood": "Understood",
       "delete": {
         "title": "Delete opportunity?",
         "message": "Are you sure you want to permanently delete this opportunity? This cannot be undone.",


### PR DESCRIPTION
## What

`ConfirmDialog` now swaps its action row to a single "Understood" acknowledgement button whenever the `error` prop is set, instead of leaving the original "Keep" / danger-confirm button pair active.

## Why

Once the API rejects a confirm action with a terminal, non-retryable error (e.g. withdrawing an already-checked-in engagement), the dialog previously kept its red "Ja, zurückziehen" / "Yes, withdraw" button live, inviting a second attempt guaranteed to fail the same way. Since `ConfirmDialog` is shared by every confirm flow in the app, fixing it once in the shared component fixes this class of problem everywhere a confirm action can fail with a terminal error, not just for withdrawal.

Also restores focus to the error message once it appears: the button that triggered the error disables while `loading` (browsers blur a focused element the instant it's disabled) and then unmounts entirely once `error` lands and the button row swaps - without an explicit focus target, focus was stranded on `<body>` while the dialog stayed open. This follows the same pattern already used in `OrgSettingsPage.tsx` and `DetailsStep.tsx` for the same "disabled blurs to body" scenario.

Closes #1950

## Testing

- `pnpm lint`, `pnpm check` (tsc --noEmit), `pnpm test` (264 tests) - all green
- `pnpm i18n:check` - key parity confirmed for the new `confirmDialog.understood` key
- Ran the `a11y-check` and `i18n-check` subagents against the diff per `/self-review`; the a11y-check's focus-stranding finding is fixed in this PR (see "Why" above)
- Extended `backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs` (the existing #1849 regression test that reproduces a terminal withdraw error) with assertions that once the error banner shows, "Yes, withdraw" and "Keep" are gone, a single "Understood" button is shown, and clicking it dismisses the dialog

## Live verification

Not run for this PR - explicitly asked not to cut a release candidate for this change. The new TUnit assertions in `WithdrawEngagementErrorMessageTests.cs` exercise the fix end-to-end against a real Aspire-orchestrated stack in CI (`dotnet.yml`'s `VisualTests` run), which is the durable, reviewable coverage this repo relies on for this class of change.

## Checklist

- [x] `/self-review` run and findings addressed (focus-management gap found by `a11y-check`, fixed)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs reference this UI detail)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GkxE4ESpDhePqKrJKL7bSd)_