### PR TITLE
fix(frontend): use language-neutral static document title

### DIFF
--- a/backend/tests/VisualTests/InitialDocumentTitleTests.cs
+++ b/backend/tests/VisualTests/InitialDocumentTitleTests.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1945: <c>index.html</c>'s static, pre-hydration
+/// <c>&lt;title&gt;</c> was a full German sentence ("Einsatzbereit - Spontan
+/// Freiwilligenarbeit leisten. Finde deinen Einsatz."). Every route's real
+/// title is set by <c>usePageTitle</c> only after React mounts, so an
+/// English-resolving visitor's browser tab briefly showed that German
+/// sentence before hydration replaced it with the correct English per-route
+/// title.
+///
+/// Fetches the raw HTML byte-for-byte via <see cref="HttpClient"/> rather
+/// than reading <c>Page.TitleAsync()</c> after a Playwright navigation -
+/// <c>usePageTitle</c>'s effect runs on mount, well before the "load" event
+/// Playwright's default <c>GotoAsync</c> waits for, so a browser-driven read
+/// would already observe the post-hydration title and never exercise the
+/// static fallback this bug is actually about.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class InitialDocumentTitleTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task StaticHtml_DocumentTitle_IsLanguageNeutralFallback()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		using var http = new HttpClient { BaseAddress = frontend };
+		var html = await http.GetStringAsync("/");
+
+		var titleMatch = Regex.Match(html, "<title>(.*?)</title>", RegexOptions.Singleline);
+		titleMatch.Success.Should().BeTrue("index.html should declare a <title> element");
+
+		// The bare app name - the same neutral fallback usePageTitle.ts's
+		// APP_NAME resets document.title to once a page unmounts its own
+		// title, so the pre- and post-hydration title never disagree on
+		// language for a visitor who lands on a route with no title of its
+		// own yet.
+		titleMatch.Groups[1].Value.Should().Be("Einsatzbereit");
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="apple-touch-icon" href="/icons/icon-192.png" />
 		<meta name="theme-color" content="#2d8a5e" />
-		<title>Einsatzbereit - Spontan Freiwilligenarbeit leisten. Finde deinen Einsatz.</title>
+		<title>Einsatzbereit</title>
 		<meta name="description" content="Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde." />
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://einsatzbereit.maik-hasler.de/" />


### PR DESCRIPTION
## What

`frontend/index.html`'s static, pre-hydration `<title>` is now the bare app name ("Einsatzbereit") instead of the full German tagline ("Einsatzbereit - Spontan Freiwilligenarbeit leisten. Finde deinen Einsatz.").

## Why

Every route's real document title is set by `usePageTitle` only after React mounts. Until then, the browser shows whatever `index.html` declares statically - a full German sentence, regardless of the visitor's detected language. An English-resolving visitor (fresh browser profile, no stored `i18nextLng`) briefly saw that German title flash before hydration replaced it with the correct English per-route title.

The fix uses the exact same neutral fallback `usePageTitle.ts`'s `APP_NAME` already resets `document.title` to whenever a page has no title of its own - so the pre- and post-hydration title never disagree on language. `meta[name="description"]`/`og:*`/`twitter:*` are left untouched: they're never updated by JS and aren't visibly rendered during page load, so they don't flash - only the `<title>` element does.

Closes #1945

## Testing

- Added `backend/tests/VisualTests/InitialDocumentTitleTests.cs`, a new TUnit regression test that fetches `index.html` raw via `HttpClient` (bypassing the browser/JS entirely, since `usePageTitle`'s effect runs well before Playwright's `GotoAsync` "load" event would let a browser-driven read observe the pre-hydration state) and asserts the static `<title>` is exactly `"Einsatzbereit"`.
- `pnpm format:check` and `pnpm lint` pass (no frontend source/logic changed, only static markup).
- Could not run `dotnet build`/the VisualTests suite locally in this sandbox (`builds.dotnet.microsoft.com` is blocked by this environment's network policy, so the .NET SDK cannot be installed) - CI's `dotnet.yml` runs the full suite including this new test.

## Live verification

Not performed - explicitly out of scope for this change per the task instructions (no release candidate was cut). Given the sandbox limitation above, CI (`dotnet.yml`'s `visual-tests` job) is the first real execution of the new regression test; will monitor and fix if it fails.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhjZV8J39g4UDxBBpv1FKq)_