### PR TITLE
fix(frontend): flag recently created organizations in admin org list

### DIFF
--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -8,7 +8,9 @@ import {
 	formatDateLong,
 	formatDateTime,
 	formatPostedAgo,
+	isRecentlyCreatedOrganization,
 	isSlotFull,
+	NEW_ORGANIZATION_THRESHOLD_DAYS,
 	resolveDateLocale,
 } from "./format";
 
@@ -215,6 +217,41 @@ describe("formatPostedAgo", () => {
 		const t = fakeT();
 		expect(formatPostedAgo(future.toISOString(), t)).toBe(
 			"opportunities.postedToday",
+		);
+	});
+});
+
+describe("isRecentlyCreatedOrganization", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("is true for an organization created just now", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		expect(isRecentlyCreatedOrganization(now.toISOString())).toBe(true);
+	});
+
+	it("is true right at the threshold boundary", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		const atThreshold = new Date(
+			now.getTime() - NEW_ORGANIZATION_THRESHOLD_DAYS * DAY_MS,
+		);
+		expect(isRecentlyCreatedOrganization(atThreshold.toISOString())).toBe(true);
+	});
+
+	it("is false once an organization is older than the threshold", () => {
+		const now = new Date("2024-03-15T12:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+		const pastThreshold = new Date(
+			now.getTime() - (NEW_ORGANIZATION_THRESHOLD_DAYS + 1) * DAY_MS,
+		);
+		expect(isRecentlyCreatedOrganization(pastThreshold.toISOString())).toBe(
+			false,
 		);
 	});
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -143,3 +143,12 @@ export function formatPostedAgo(dt: string, t: TFunction): string {
 		? t("opportunities.postedToday")
 		: t("opportunities.postedDaysAgo", { count: days });
 }
+
+/** Window (in days) within which an organization is flagged as recently
+ * created for admins, since it has no track record yet (#1947). */
+export const NEW_ORGANIZATION_THRESHOLD_DAYS = 14;
+
+export function isRecentlyCreatedOrganization(createdOn: string): boolean {
+	const days = differenceInCalendarDays(new Date(), new Date(createdOn));
+	return days <= NEW_ORGANIZATION_THRESHOLD_DAYS;
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1246,7 +1246,8 @@
         "memberCount_one": "{{count}} Mitglied",
         "memberCount_other": "{{count}} Mitglieder",
         "createdOn": "Erstellt am {{date}}",
-        "flaggedBadge": "Gemeldet"
+        "flaggedBadge": "Gemeldet",
+        "newBadge": "Neu"
       },
       "users": {
         "loading": "Nutzer:innen werden geladen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1246,7 +1246,8 @@
         "memberCount_one": "{{count}} member",
         "memberCount_other": "{{count}} members",
         "createdOn": "Created on {{date}}",
-        "flaggedBadge": "Flagged"
+        "flaggedBadge": "Flagged",
+        "newBadge": "New"
       },
       "users": {
         "loading": "Loading users…",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -13,7 +13,11 @@ import { getApiErrorMessage } from "../lib/apiError";
 import { dispatchToast } from "../lib/toastBus";
 import { inputClass, labelClass } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
-import { formatDateLong, formatDateTime } from "../lib/format";
+import {
+	formatDateLong,
+	formatDateTime,
+	isRecentlyCreatedOrganization,
+} from "../lib/format";
 import { avatarColorClasses } from "../lib/avatarColor";
 import { usePageTitle } from "../hooks/usePageTitle";
 import Chip from "../components/Chip";
@@ -383,6 +387,12 @@ function OrganizationsSection() {
 														{t("administration.organizations.flaggedBadge")}
 													</Chip>
 												)}
+												{!row.isDeleted &&
+													isRecentlyCreatedOrganization(row.createdOn) && (
+														<Chip tone="brand" size="sm">
+															{t("administration.organizations.newBadge")}
+														</Chip>
+													)}
 											</div>
 											<p className="mt-1 truncate text-xs text-gray-500">
 												{t("administration.organizations.memberCount", {


### PR DESCRIPTION
## What

Adds a non-gating "New" badge to `/administration/organizations` for organizations created within the last 14 days, alongside the existing "Aktiv"/"Verborgen" and "Flagged" chips.

## Why

Closes #1947

Per the issue's decision request, this repo already chose reactive moderation (report + hide) over proactive gating: #1530 removed the non-gating `IsVerified` badge specifically to avoid shipping "a trust signal that means nothing," and #1068's proactive review-queue idea was closed in favor of the reactive report/hide flow that exists today. Consistent with that direction, this PR does **not** add a pre-publish review queue or any gating on organization creation/publishing. Instead it gives admins a lightweight visual cue - purely on the admin-only org list - so they can spot fresh, unreviewed organizations faster within the existing reactive flow, without reviving the abandoned gating concept.

An organization is flagged "New" when it was created within the last 14 days (`isRecentlyCreatedOrganization` in `frontend/src/lib/format.ts`), using the `createdOn` field the admin list endpoint already returns - no backend or API change needed. The badge is suppressed for shadow-deleted organizations.

## Testing

- Added `isRecentlyCreatedOrganization` unit tests in `frontend/src/lib/format.test.ts` (just-created, at-threshold boundary, past-threshold), following the existing `formatPostedAgo` fake-timer pattern.
- `pnpm test` (267 tests), `pnpm lint`, `pnpm check`, `pnpm i18n:check` all pass locally.
- Ran the `a11y-check` and `i18n-check` subagents against the diff - both clean (plain-text chip, no new route/page, locale key parity intact).

## Live verification

Not performed for this change, per explicit instruction - no release candidate was cut and nothing was verified against live staging. This is a small, purely additive frontend display change (a conditional `Chip` derived from an existing API field), verified locally via the unit/lint/typecheck/i18n gates above instead.

## Checklist

- [x] `/self-review` run and findings addressed (no findings)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe the admin org list badges)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JUMY7rySz12EmeUECXA9Up)_