### PR TITLE
fix(frontend): align PublicOpportunityCard's participation-type badge wording

### DIFF
--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -198,6 +198,40 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	}
 
 	/// <summary>
+	/// #1943: the same participation type (no fixed capacity, interest-based)
+	/// read two different ways depending on which component rendered the
+	/// badge - OpportunityListItem's capacity chip said "By expression of
+	/// interest" while PublicOpportunityCard's chip, reached through this
+	/// section, went through a different i18n key and said "Express interest"
+	/// instead. Both now go through the same "opportunities.byInterest" copy.
+	/// </summary>
+	[Test]
+	public async Task OpportunityDetail_MoreFromOrganizationCard_MatchesTheGridsInterestWording()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var keyword = $"CardWording{Guid.NewGuid():N}";
+		using var organizer = await CreateOrganizerClientAsync(keycloak, backend);
+		var organizationId = await CreateOrganizationAsync(organizer, keyword);
+		var opportunityId =
+			await PublishInterestBasedOpportunityAsync(organizer, organizationId, $"{keyword} primary");
+		await PublishInterestBasedOpportunityAsync(organizer, organizationId, $"{keyword} sibling");
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var siblingCard = Page.GetByTestId("more-from-organization")
+			.Locator("li", new() { HasText = $"{keyword} sibling" });
+		await Expect(siblingCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(siblingCard.GetByText("By expression of interest", new() { Exact = true }))
+			.ToBeVisibleAsync();
+	}
+
+	/// <summary>
 	/// AC: hovering or tabbing to a card title has to show it is a link. The
 	/// grid's title is not focusable itself - the stretched link covering the
 	/// card is - so hover is asserted on the title and the keyboard half is

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -40,10 +40,10 @@ describe("formatParticipationType", () => {
 		);
 	});
 
-	it("translates anything else as individual contact", () => {
+	it("translates anything else as by-interest, matching the capacity chip's wording (#1943)", () => {
 		const t = fakeT();
 		expect(formatParticipationType("DirectContact", t)).toBe(
-			"opportunities.individualContact",
+			"opportunities.byInterest",
 		);
 	});
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -11,7 +11,7 @@ export function formatOccurrence(occurrence: string, t: TFunction): string {
 export function formatParticipationType(type: string, t: TFunction): string {
 	return type === "ScheduledSlots"
 		? t("opportunities.waitlist")
-		: t("opportunities.individualContact");
+		: t("opportunities.byInterest");
 }
 
 /** Remaining spots for a time slot/opportunity - null means unlimited capacity. */


### PR DESCRIPTION
## What

`PublicOpportunityCard`'s participation-type chip (and the detail page's "How it works" fact) now reads "By expression of interest" instead of "Express interest" for a no-fixed-capacity opportunity, matching the wording `OpportunityListItem`'s capacity chip and the detail page's own capacity badge already use.

## Why

`formatParticipationType()` (`frontend/src/lib/format.ts`) labelled a no-fixed-capacity opportunity via `opportunities.individualContact` ("Express interest"), while `OpportunityListItem`'s capacity chip and `VolunteerOpportunityDetailPage`'s own capacity badge use `opportunities.byInterest` ("By expression of interest") for the identical underlying state. A visitor browsing `/opportunities` who saw "By expression of interest" would click into the detail page and see a sibling opportunity from the same organization labelled "Express interest" one click later, in the "More opportunities from this organization" section (`PublicOpportunityCard`) and on the organization profile page.

`formatParticipationType` is only consumed by `PublicOpportunityCard` and the detail page's "How it works" fact row, so pointing it at `opportunities.byInterest` fixes both call sites consistently. `opportunities.individualContact` stays in use for the organizer-facing create-opportunity form (`FormatStep.tsx`) and the public list's type filter (`VolunteerOpportunitiesList.tsx`), which are option labels ("Scheduled slots" / "Express interest") rather than status badges, and weren't part of the reported divergence.

Closes #1943

## Testing

- `frontend/src/lib/format.test.ts` - updated the existing `formatParticipationType` unit test to assert the new `opportunities.byInterest` key.
- `backend/tests/VisualTests/OpportunityCardContractTests.cs` - added `OpportunityDetail_MoreFromOrganizationCard_MatchesTheGridsInterestWording`, which publishes two interest-based opportunities under one organization and asserts the sibling's `PublicOpportunityCard` (in the detail page's "More opportunities from this organization" section) reads "By expression of interest".
- Ran `pnpm vitest run src/lib/format.test.ts` locally (26/26 passed) and `pnpm format:write`. Could not run `pnpm lint`, `pnpm check`, or any `dotnet build`/VisualTests locally in this sandbox - the .NET SDK install is blocked by this environment's network policy (`builds.dotnet.microsoft.com` CONNECT rejected by the proxy), and Aspire/Testcontainers orchestration isn't available here regardless (see root `AGENTS.md`'s Sandbox Limitations). CI's `frontend.yml`/`dotnet.yml` will run the full checks.

## Live verification

Not performed - explicitly out of scope for this change per instruction (no release candidate cut). This is a pure i18n-copy fix (one string key swapped for another that already exists and is already live), so there's no new runtime behavior to smoke-test beyond what the new VisualTests case and CI's existing suite cover.

## Checklist

- [x] `/self-review` run and findings addressed (clean - no P1-P4 issues found)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - copy-only fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RFLREW15NTQSn3SR7s8fRf)_