### PR TITLE
fix: announce current language on language-switcher trigger

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -347,6 +347,16 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(langBtn).Not.ToHaveAttributeAsync("aria-haspopup", new Regex(".*"));
 		await Expect(langBtn).ToHaveAttributeAsync("aria-expanded", "false");
 
+		// #1940: the closed trigger's accessible name used to be just "Switch
+		// language"/"Sprache wechseln", overriding the visible "EN"/"DE" text
+		// with no indication of which language is currently active. It must
+		// now name the current language too, e.g. "..., currently English".
+		var expectedLanguageName = activeCode == "DE" ? "Deutsch" : "English";
+		await Expect(langBtn).ToHaveAttributeAsync(
+			"aria-label",
+			new Regex($".*{Regex.Escape(expectedLanguageName)}.*")
+		);
+
 		await langBtn.ClickAsync();
 
 		var dropdown = banner.GetByTestId("language-selector-menu");

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -40,7 +40,9 @@ export default function LanguageSelector({
 				type="button"
 				onClick={() => setOpen((o) => !o)}
 				aria-expanded={open}
-				aria-label={t("language.switchLanguage")}
+				aria-label={t("language.switchLanguageCurrent", {
+					language: t(`language.${currentCode}`),
+				})}
 				data-testid="language-selector-trigger"
 				className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm transition-colors ${transparent ? "border-white/30 text-white hover:bg-white/10" : "border-gray-200 text-gray-700 hover:bg-gray-50"}`}
 			>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -902,6 +902,7 @@
       "de": "Deutsch",
       "en": "English",
       "switchLanguage": "Sprache wechseln",
+      "switchLanguageCurrent": "Sprache wechseln, aktuell {{language}}",
       "switchedFromAccount": "Zu {{language}} gewechselt, basierend auf deinem Konto"
     },
     "auth": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -902,6 +902,7 @@
       "de": "Deutsch",
       "en": "English",
       "switchLanguage": "Switch language",
+      "switchLanguageCurrent": "Switch language, currently {{language}}",
       "switchedFromAccount": "Switched to {{language}} based on your account"
     },
     "auth": {


### PR DESCRIPTION
## What

The closed language-switcher trigger button now announces which language is currently active, e.g. "Switch language, currently English" / "Sprache wechseln, aktuell Deutsch", instead of just "Switch language" / "Sprache wechseln".

## Why

Closes #1940

A screen-reader user landing on the trigger previously heard only "Switch language, button" with no indication of which language was active - sighted users get that for free from the visible "DE"/"EN" short-code label. The open menu's active option already carries `aria-current` (#1772/#1825); this closes the remaining gap on the trigger's own accessible name.

## Testing

- Added `language.switchLanguageCurrent` to `frontend/src/locales/en.json` and `de.json`, interpolating the current language's native name (same `t(\`language.${code}\`)` pattern already used by `main.tsx`'s `language.switchedFromAccount` toast).
- `frontend/src/components/Header/LanguageSelector.tsx`'s trigger button now uses that key for its `aria-label`; the open menu's `<ul aria-label>` and the already-fixed `aria-current` on the active option are untouched, per the issue.
- Extended `HomePage_LanguageSelector_AnnouncesDisclosureSemantics` in `backend/tests/VisualTests/NavigationTests.cs` to assert the closed trigger's `aria-label` names the current language.
- Ran locally: `pnpm lint`, `pnpm format:check`, `pnpm check` (tsc), `pnpm test` (264 tests), and `node scripts/check-i18n-keys.js` - all green.
- Could not run the backend `VisualTests` suite in this sandbox (Docker/Aspire and the .NET SDK installer are both blocked by this environment's egress policy) - CI's `dotnet.yml` runs it on a real runner.

## Live verification

Skipped for this change at the requester's explicit instruction (no release candidate cut). The fix is covered by the extended `VisualTests` assertion above, which CI will run against the local Aspire stack.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs affected)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mkZKuS5ktafyFUfkmD1yM)_