### PR TITLE
fix(keycloak): label the login theme's language switcher for screen readers

### DIFF
--- a/backend/tests/VisualTests/KeycloakThemeTests.cs
+++ b/backend/tests/VisualTests/KeycloakThemeTests.cs
@@ -114,6 +114,29 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Login_LanguageSwitcher_HasAccessibleName()
+	{
+		// #1944: the trigger's only visible content is the two-letter language
+		// code ("EN"/"DE"), so without an explicit label a screen reader
+		// announced just that code, not what the control does. The SPA's
+		// counterpart (Header/LanguageSelector.tsx) labels both its trigger
+		// button and its open menu via aria-label - this pins the same
+		// accessible names down here, and that both supported locales still
+		// show up once the menu opens.
+		await Page.GotoAsync(AuthUrl(locale: "en"));
+		await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		var trigger = Page.Locator(".lang-trigger");
+		await Expect(trigger).ToHaveAttributeAsync("aria-label", "Switch language");
+
+		await trigger.ClickAsync();
+		var menu = Page.Locator(".lang-menu");
+		await Expect(menu).ToBeVisibleAsync();
+		await Expect(menu).ToHaveAttributeAsync("aria-label", "Switch language");
+		await Expect(menu.Locator(".lang-item")).ToHaveCountAsync(2);
+	}
+
+	[Test]
 	public async Task Login_PrimaryButton_UsesTheProductsOwnGreen()
 	{
 		// Button.tsx documents that white text on brand-600 (#2d8a5e) measures

--- a/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
@@ -7,6 +7,7 @@ noAccount=Noch kein Konto?
 alreadyHaveAccount=Hast du bereits ein Konto?
 backToLogin=Zurück zur Anmeldung
 backToSite=Zurück zu Einsatzbereit
+switchLanguage=Sprache wechseln
 
 # Benennt den Schritt, zu dem die jeweilige Seite gehört. Die Registrierung
 # läuft über drei aufeinanderfolgende Keycloak-Seiten - Konto anlegen,

--- a/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
@@ -7,6 +7,7 @@ noAccount=Don''t have an account yet?
 alreadyHaveAccount=Already have an account?
 backToLogin=Back to Sign In
 backToSite=Back to Einsatzbereit
+switchLanguage=Switch language
 
 # Names the step of the funnel each page belongs to. Signing up runs across
 # three consecutive Keycloak screens - create account, confirm your address,

--- a/keycloak/themes/einsatzbereit/login/template.ftl
+++ b/keycloak/themes/einsatzbereit/login/template.ftl
@@ -28,13 +28,20 @@
 
 	<div class="top-controls">
 		<#if realm.internationalizationEnabled && locale.supported?has_content>
+		<#-- #1944: the SPA's Header/LanguageSelector.tsx labels both its
+		trigger and its menu via aria-label, so the control announces what it
+		does even though its visible content is just the current language
+		code. This disclosure already mirrors that trigger-plus-menu pattern
+		(<details>/<summary> is the browser-native equivalent of the SPA's
+		button + aria-expanded) but had no aria-label of its own - a screen
+		reader only heard the two-letter code. -->
 		<details class="lang-switcher">
-			<summary class="lang-trigger">
+			<summary class="lang-trigger" aria-label="${msg("switchLanguage")}">
 				<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
 				<span>${(locale.currentLanguageTag!'de')?upper_case}</span>
 				<svg class="lang-chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
 			</summary>
-			<ul class="lang-menu">
+			<ul class="lang-menu" aria-label="${msg("switchLanguage")}">
 				<#list locale.supported as l>
 					<li><a href="${l.url}" class="lang-item"<#if (l.locale!'') == (locale.currentLanguageTag!'')> aria-current="true"</#if>>${l.label}</a></li>
 				</#list>


### PR DESCRIPTION
## What

Gives the Keycloak login theme's language-switcher disclosure (`.lang-switcher` in `template.ftl`) an explicit `aria-label` on both its trigger and its open menu, matching the SPA's `Header/LanguageSelector.tsx`.

## Why

Closes #1944.

The issue's literal repro (Keycloak "always lists both languages as two separate links" vs. the SPA being "a single button that silently toggles, no menu") no longer matches `main`: both are already the same interaction model - a collapsed trigger (`<details>`/`<summary>` in Keycloak, a `<button>` with `aria-expanded` in the SPA) that discloses a menu listing both languages, with the active one marked via `aria-current`. That divergence looks like it was fixed independently at some point before this issue was filed, and staging (deployed only on release-candidate cuts, not on every merge to `main`) was still showing the older behavior the reporter observed on 2026-08-14.

Comparing the two implementations in detail turned up the one real gap left: the SPA's trigger and menu both carry an explicit `aria-label={t("language.switchLanguage")}` (`LanguageSelector.tsx`), so the control announces "Switch language"/"Sprache wechseln" regardless of its visible content. Keycloak's `<summary>` had no such label - its accessible name fell back to its visible text, just the two-letter language code ("DE"/"EN"), which doesn't say what the control does. This PR adds a `switchLanguage` message key (mirroring the SPA's exact wording in both locales) and applies it as `aria-label` on the trigger and the menu, closing that gap per the issue's own suggested fix ("mirror the SPA's pattern").

## Testing

- Added `Login_LanguageSwitcher_HasAccessibleName` to `backend/tests/VisualTests/KeycloakThemeTests.cs`, asserting both the trigger and the open menu carry the `aria-label`, and that both supported locales are listed once opened.
- `/self-review` run against the diff - no findings.
- Could not run `dotnet build`/the VisualTests suite locally in this sandbox (no Docker/container networking available for the Aspire stack, and this session's network policy blocked installing the .NET SDK) - relying on CI (`dotnet.yml`) to run the full suite, and will fix anything it flags.

## Live verification

Not performed for this PR - explicitly asked not to cut a release candidate for this change, so there is no release-candidate/live-staging deploy to verify against yet. The durable VisualTests assertion above is the reviewable record in the meantime; a future RC cut for this branch will exercise it against the live Keycloak login page.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - internal a11y-only markup change, no docs reference this control's markup)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGp1DrKCLjpBamhkvigFqB)_