### PR TITLE
fix(frontend): keep the type badge alongside the applicant count

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -232,6 +232,47 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	}
 
 	/// <summary>
+	/// #1941: the notApplicable-capacity slot swapped from stating the offer's
+	/// type ("By expression of interest") to the applicant count as soon as
+	/// *this* viewer had applied, while every other not-yet-applied offer on
+	/// the list kept showing its type - so which fact appeared in that slot
+	/// depended on the current viewer's own application state, not the offer
+	/// itself. The type now stays put, and the applicant count is an addition
+	/// next to it rather than a replacement.
+	/// </summary>
+	[Test]
+	public async Task OpportunityDetail_AnInterestBasedOffer_KeepsItsTypeBadgeAlongsideTheApplicantCount()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var keyword = $"CardInterestJoined{Guid.NewGuid():N}";
+		using var organizer = await CreateOrganizerClientAsync(keycloak, backend);
+		var organizationId = await CreateOrganizationAsync(organizer, keyword);
+		var opportunityId = await PublishInterestBasedOpportunityAsync(organizer, organizationId, keyword);
+
+		using var volunteer = await CreateVolunteerClientAsync(keycloak, backend);
+		(await volunteer.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "IndividualContact", message = (string?)null }))
+			.EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// The type badge stays put - it does not flip to the applicant count
+		// just because someone has applied.
+		await Expect(Page.GetByTestId("opportunity-capacity"))
+			.ToHaveTextAsync("By expression of interest", new() { Timeout = 15_000 });
+
+		// The applicant count is an addition next to it, not a replacement.
+		await Expect(Page.GetByTestId("opportunity-capacity-secondary"))
+			.ToHaveTextAsync("1 person has already joined");
+	}
+
+	/// <summary>
 	/// AC: hovering or tabbing to a card title has to show it is a link. The
 	/// grid's title is not focusable itself - the stretched link covering the
 	/// card is - so hover is asserted on the title and the keyboard half is

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -256,7 +256,7 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 		using var volunteer = await CreateVolunteerClientAsync(keycloak, backend);
 		(await volunteer.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
-			new { type = "IndividualContact", message = (string?)null }))
+			new { type = "IndividualContact", message = "I would love to help out with this one" }))
 			.EnsureSuccessStatusCode();
 
 		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -70,7 +70,7 @@ const CreateVolunteerOpportunityModal = lazy(
 function describeCapacity(
 	capacity: OpportunityCapacity,
 	t: TFunction,
-): { label: string; tone: string } {
+): { label: string; tone: string; secondaryLabel?: string } {
 	switch (capacity.kind) {
 		case "unlimited":
 			return {
@@ -78,14 +78,18 @@ function describeCapacity(
 				tone: "text-teal-700",
 			};
 		case "notApplicable":
-			// No cap to report, so the sign-up count is the only real number -
-			// and before anyone has signed up, not even that.
+			// The type badge stays put regardless of the current viewer's own
+			// application status; the joined count - once there is one - is an
+			// addition next to it, not a replacement, so which piece of
+			// information appears here doesn't depend on whether this
+			// particular viewer has already applied (#1941).
 			return {
-				label:
+				label: t("opportunities.byInterest"),
+				tone: "text-gray-700",
+				secondaryLabel:
 					capacity.booked > 0
 						? t("opportunities.participantsJoined", { count: capacity.booked })
-						: t("opportunities.byInterest"),
-				tone: "text-gray-700",
+						: undefined,
 			};
 		case "capped":
 			if (capacity.isFull) {
@@ -330,10 +334,11 @@ export default function VolunteerOpportunityDetailPage() {
 		opportunity.participationType,
 	);
 	const isFull = capacity.kind === "capped" && capacity.isFull;
-	const { label: capacityLabel, tone: capacityTone } = describeCapacity(
-		capacity,
-		t,
-	);
+	const {
+		label: capacityLabel,
+		tone: capacityTone,
+		secondaryLabel: capacitySecondaryLabel,
+	} = describeCapacity(capacity, t);
 
 	const otherOrgOpportunities =
 		orgProfile?.openOpportunities
@@ -667,15 +672,25 @@ export default function VolunteerOpportunityDetailPage() {
 							!cue && !isDraft`, so an anonymous visitor - most of this page's
 							traffic - never saw the remaining places at all and read the
 							per-slot maximum instead. That is what made a card saying "19
-							spots left" open a page saying "(max. 20 people)" (#1777).
-							Where there are no places to count, the sign-up count is the
-							only honest number, so that state says how many have joined. */}
+							spots left" open a page saying "(max. 20 people)" (#1777). */}
 								<span
 									data-testid="opportunity-capacity"
 									className={`text-sm font-medium ${capacityTone}`}
 								>
 									{capacityLabel}
 								</span>
+								{/* Addition, not a replacement, for the type badge above -
+								an "Interessenbekundung" offer keeps stating its type once it
+								has applicants, instead of the slot swapping to the applicant
+								count only for the viewer who happens to have applied (#1941). */}
+								{capacitySecondaryLabel && (
+									<span
+										data-testid="opportunity-capacity-secondary"
+										className="text-sm text-gray-600"
+									>
+										{capacitySecondaryLabel}
+									</span>
+								)}
 								<span className="text-xs text-gray-500">
 									{formatPostedAgo(
 										opportunity.createdOn as unknown as string,


### PR DESCRIPTION
## What

On `/volunteer-opportunities/{id}`, the notApplicable-capacity badge under the title now always states the offer's type ("By expression of interest"), and shows the applicant count as an *addition* next to it once there is one, instead of replacing the type label.

## Why

The badge previously swapped from `opportunities.byInterest` to `opportunities.participantsJoined` as soon as `capacity.booked > 0` - which happened as soon as the viewer themselves applied. Other, not-yet-applied offers on the list kept their "Interessenbekundung" badge, so which piece of information appeared in that slot depended on the current viewer's own application status, not the offer itself.

This implements the decision from the issue's own Implementation Proposal (show the count as an addition, not a replacement), which also matches the Acceptance Criteria: the badge now communicates both the type and the applicant count.

Closes #1941

## Testing

- `frontend/src/pages/VolunteerOpportunityDetailPage.tsx`: `describeCapacity`'s `notApplicable` case now always returns the type label, plus an optional `secondaryLabel` (the joined-count text) rendered as a second `<span data-testid="opportunity-capacity-secondary">` next to the existing `data-testid="opportunity-capacity"` span.
- Added `OpportunityDetail_AnInterestBasedOffer_KeepsItsTypeBadgeAlongsideTheApplicantCount` in `backend/tests/VisualTests/OpportunityCardContractTests.cs` - publishes an interest-based opportunity, applies as a volunteer, then asserts both testids render on the detail page (`"By expression of interest"` + `"1 person has already joined"`).
- Ran locally: `pnpm check` (tsc), `pnpm lint`, `pnpm format:check`, `pnpm i18n:check`, `pnpm test` (vitest) - all green. No locale keys were added/changed (`byInterest`/`participantsJoined` already existed).
- `a11y-check` subagent reviewed the diff: `text-gray-600` on the new span clears the contrast floor, no semantic grouping is required for the two adjacent spans, and no new page/route was added so no new `AccessibilityTests.cs` case is required.
- Could not run `dotnet build`/`VisualTests` locally in this sandbox (no Docker/Aspire orchestration available in this Claude Code on the web session) - CI's `dotnet.yml` will run the full backend suite including the new test.

## Live verification

Not applicable - per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. CI (`dotnet.yml`/`frontend.yml`) is the verification for this change.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs reference this specific wording)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFLWeqAwg8fSiqBXMcSgEX)_