### PR TITLE
fix: distinguish a failed member search from a genuinely empty one

### DIFF
--- a/backend/tests/VisualTests/MemberSearchErrorTests.cs
+++ b/backend/tests/VisualTests/MemberSearchErrorTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
+using Deque.AxeCore.Playwright;
 using Microsoft.Playwright;
 
 namespace VisualTests;
@@ -57,6 +58,14 @@ public class MemberSearchErrorTests(AspireFixture fixture) : VisualTestBase(fixt
 		// The whole point of #1942: a failed request must never be mistaken for
 		// a search that genuinely found nobody.
 		await Expect(Page.GetByText("No users found.")).Not.ToBeVisibleAsync();
+
+		// AccessibilityTests covers this page's baseline state, but not this
+		// failed-search one - and this test has already built it, so scan it
+		// here rather than standing up the same route intercept a second time
+		// over there (same rationale as OrgSettingsFormActionsTests's own
+		// failed-save test).
+		var axe = await Page.RunAxe();
+		axe.Violations.Where(v => v.Impact is "serious" or "critical").Should().BeEmpty();
 
 		await Page.UnrouteAsync($"**/v1/organizations/{organizationId}/members/search**");
 		await DeleteOrganizationAsync(backend, organizationId);

--- a/backend/tests/VisualTests/MemberSearchErrorTests.cs
+++ b/backend/tests/VisualTests/MemberSearchErrorTests.cs
@@ -1,0 +1,109 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1942: OrgMembersPage's "Invite member" search
+/// unconditionally cleared the candidate list in its request `.catch()`, so a
+/// failed search (e.g. a 400) rendered identically to a search that genuinely
+/// found nobody - both showed "No users found.", with no indication anything
+/// had gone wrong. The page now tracks a dedicated `memberSearchError` state
+/// and shows an ErrorBanner instead of the empty-results message when the
+/// request itself fails.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MemberSearchErrorTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task MemberSearch_FailedRequest_ShowsErrorBanner_NotNoResults()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual1942 MemberSearchError {Guid.NewGuid():N}");
+
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}/members/search**", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 400,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.1\",\"status\":400}",
+			});
+		});
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/members");
+		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.Locator("#member-search").FillAsync("admin");
+
+		var banner = Page.GetByRole(AriaRole.Alert).Filter(new() { HasTextString = "Could not search for users." });
+		await Expect(banner).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// The whole point of #1942: a failed request must never be mistaken for
+		// a search that genuinely found nobody.
+		await Expect(Page.GetByText("No users found.")).Not.ToBeVisibleAsync();
+
+		await Page.UnrouteAsync($"**/v1/organizations/{organizationId}/members/search**");
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	/// <summary>
+	/// Creates an organization through the API with the signed-in user's own
+	/// token - same approach as OrgSettingsFormActionsTests, faster than
+	/// driving the switcher's create-organization dialog.
+	/// </summary>
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	/// <summary>
+	/// The shared olaf account accumulates test debris across this suite's
+	/// session (see the root AGENTS.md note about live staging) - clean up the
+	/// organizations this test creates.
+	/// </summary>
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -542,6 +542,7 @@
       "leaveOrganizationLastOrganizerHint": "Du bist der:die einzige Organisator:in dieser Organisation - lösche stattdessen die Organisation, wenn du sie schließen möchtest.",
       "searching": "Suche läuft…",
       "noSearchResults": "Keine Nutzer:innen gefunden.",
+      "memberSearchError": "Nutzer:innen konnten nicht gesucht werden.",
       "inviteLabel": "Mitglied einladen",
       "invitePlaceholder": "Nach Benutzername oder E-Mail suchen…",
       "inviteRoleLabel": "Einladen als",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -542,6 +542,7 @@
       "leaveOrganizationLastOrganizerHint": "You're the only organizer of this organization - delete the organization instead if you want to close it.",
       "searching": "Searching…",
       "noSearchResults": "No users found.",
+      "memberSearchError": "Could not search for users.",
       "inviteLabel": "Invite member",
       "invitePlaceholder": "Search by username or email…",
       "inviteRoleLabel": "Invite as",

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -54,6 +54,9 @@ export default function OrgMembersPage() {
 		MemberCandidateDto[]
 	>([]);
 	const [memberSearchLoading, setMemberSearchLoading] = useState(false);
+	const [memberSearchError, setMemberSearchError] = useState<string | null>(
+		null,
+	);
 	const [invitingUserId, setInvitingUserId] = useState<string | null>(null);
 	const [inviteRole, setInviteRole] = useState<"Member" | "Organizer">(
 		"Member",
@@ -76,6 +79,7 @@ export default function OrgMembersPage() {
 		if (memberSearch.length < 4) {
 			setMemberCandidates([]);
 			setMemberSearchLoading(false);
+			setMemberSearchError(null);
 			return;
 		}
 		memberSearchAbortRef.current?.abort();
@@ -83,15 +87,20 @@ export default function OrgMembersPage() {
 		memberSearchAbortRef.current = controller;
 		const timer = setTimeout(() => {
 			setMemberSearchLoading(true);
+			setMemberSearchError(null);
 			api
 				.searchMemberCandidates(org.id, memberSearch, controller.signal)
 				.then((results) => {
 					if (controller.signal.aborted) return;
 					setMemberCandidates(results);
+					setMemberSearchError(null);
 				})
-				.catch(() => {
+				.catch((err) => {
 					if (controller.signal.aborted) return;
 					setMemberCandidates([]);
+					setMemberSearchError(
+						getApiErrorMessage(err, t("orgSettings.memberSearchError")),
+					);
 				})
 				.finally(() => {
 					if (controller.signal.aborted) return;
@@ -315,6 +324,9 @@ export default function OrgMembersPage() {
 								{t("orgSettings.searching")}
 							</p>
 						)}
+						{memberSearchError && (
+							<ErrorBanner message={memberSearchError} className="mt-1" />
+						)}
 						{memberCandidates.length > 0 && (
 							<ul className="mt-1 divide-y divide-gray-100 rounded-card border border-gray-200 bg-white shadow-resting">
 								{memberCandidates.map((candidate) => (
@@ -349,6 +361,7 @@ export default function OrgMembersPage() {
 						)}
 						{memberSearch.length >= 4 &&
 							!memberSearchLoading &&
+							!memberSearchError &&
 							memberCandidates.length === 0 && (
 								<p role="status" className="mt-1 text-xs text-gray-500">
 									{t("orgSettings.noSearchResults")}


### PR DESCRIPTION
## What

The org Members page's "Invite member" search now tells a failed search request apart from one that genuinely found nobody, showing an error banner instead of silently claiming "No users found."

## Why

`OrgMembersPage.tsx`'s search request `.catch()` unconditionally cleared the candidate list to empty, with no distinction between "the request failed" and "the request succeeded with zero results." A live 400 while searching for an existing user (e.g. `admin`) therefore rendered identically to a genuinely empty search - Olaf had no way to tell a legitimate invite target apart from someone who doesn't exist on the platform, silently blocking the invite flow.

Closes #1942

## Changes

- `OrgMembersPage.tsx`: added a dedicated `memberSearchError` state, set from the search request's `.catch()` (via the existing `getApiErrorMessage` helper) and cleared on a new search attempt or a successful response. Rendered via the shared `ErrorBanner` component; the "No users found." message is suppressed while an error is showing, so the two states are never shown - or confused - at the same time.
- `en.json` / `de.json`: new `orgSettings.memberSearchError` key, matching the wording/style of the sibling `*Error` keys in the same block.
- `backend/tests/VisualTests/MemberSearchErrorTests.cs`: new Playwright/TUnit test that mocks a 400 on `GET .../members/search` and asserts the error banner appears while "No users found." does not.

## Testing

- `pnpm check` / `pnpm lint` / `pnpm test` / `pnpm i18n:check` - all green locally.
- `self-review` run; the `i18n-check` subagent confirmed key parity and wording consistency. The `a11y-check` subagent was also run against this diff (ErrorBanner is an already-accessible, existing primitive, and `jsx-a11y` lint is clean).
- Added `backend/tests/VisualTests/MemberSearchErrorTests.cs` (see above). This sandbox's network policy blocks the .NET SDK installer, so I could not run `dotnet build`/`dotnet run --project tests/VisualTests` locally to compile-check it - please treat CI's `dotnet.yml` run as the first real verification of this file, and I'll fix anything it flags.

## Live verification

Skipped for this PR at the requester's explicit instruction ("don't cut a RC") - no release candidate was cut and this fix has not been observed on live staging. Happy to run `/live-verify` against a staging deploy in a follow-up if wanted.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this error path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdyocT5tejnvzP15ZxaaSv)_