### PR TITLE
fix(frontend): show registered time slot on offer-detail status card

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2567,7 +2567,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -287,6 +287,86 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_ApplicationStatusWithTimeSlot_AsVera_HasNoSeriousA11yViolations()
+	{
+		// #1938: the sidebar "application-status" card (label + status Chip +
+		// Withdraw button) now also renders the registered slot's date/time -
+		// new content in a render state ("signed-in volunteer with an existing
+		// engagement") none of this file's other detail-page scans ever reach,
+		// since they all land on the sign-up-CTA/login-prompt/owner-draft
+		// states instead. Vera is a plain user, never an organizer, so
+		// isOwner is false and the status card (not the sign-up CTA) renders.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var organizerHttp = new HttpClient { BaseAddress = backend };
+		organizerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await organizerHttp.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Status Slot Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await organizerHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"A11y Status Slot Test {suffix}",
+			description = "Seeded for #1938 application-status time-slot a11y coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(5);
+		var slotResponse = await organizerHttp.PostAsJsonAsync($"/v1/volunteer-opportunities/{opportunityId}/time-slots", new
+		{
+			startDateTime = start,
+			endDateTime = start.AddHours(2),
+			maxParticipants = 5,
+			recurrenceCount = 1,
+		});
+		slotResponse.EnsureSuccessStatusCode();
+		var slots = await slotResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var timeSlotId = slots[0].GetProperty("id").GetString();
+
+		(await organizerHttp.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var volunteerHttp = new HttpClient { BaseAddress = backend };
+		volunteerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+
+		var engagementResponse = await volunteerHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "ScheduledSlots", timeSlotId, message = (string?)null });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await organizerHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Proves the scan below actually saw the new date/time row, rather than
+		// passing against a page where it never rendered.
+		await Expect(Page.GetByTestId("application-status").GetByText("Scheduled:")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task VolunteerOpportunityDetailPage_MapMarker_HasAccessibleName()
 	{
 		// #1681: SingleMarkerMap.tsx's Leaflet divIcon marker rendered an

--- a/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1938: on a multi-slot offer, the detail page's sidebar
+/// status card (data-testid="application-status") showed only the "Your
+/// sign-up" label and a status Chip - no date/time for the registered slot,
+/// even though the same signup's slot date/time was already shown correctly
+/// on /my-signups. Fixed by resolving the current user's engagement to its
+/// matching entry in the opportunity's own timeSlots and rendering that
+/// slot's date/time next to the status Chip.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityDetailStatusCardTimeSlotTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task ApplicationStatusCard_ShowsRegisteredTimeSlot_ForMultiSlotOpportunity()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var organizerHttp = new HttpClient { BaseAddress = backend };
+		organizerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await organizerHttp.PostAsJsonAsync("/v1/organizations", new { name = $"StatusCardSlot Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"StatusCardSlot Opportunity {suffix}";
+		var oppResponse = await organizerHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = oppTitle,
+			description = "Created by OpportunityDetailStatusCardTimeSlotTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		// Two time slots - the bug only reproduces on an offer with more than one,
+		// where the sidebar card can no longer show "the" slot without knowing
+		// which one the volunteer actually registered for.
+		var firstStart = DateTimeOffset.UtcNow.AddDays(5);
+		(await organizerHttp.PostAsJsonAsync($"/v1/volunteer-opportunities/{opportunityId}/time-slots", new
+		{
+			startDateTime = firstStart,
+			endDateTime = firstStart.AddHours(2),
+			maxParticipants = 5,
+			recurrenceCount = 1,
+		})).EnsureSuccessStatusCode();
+
+		var secondStart = firstStart.AddDays(7);
+		var secondSlotResponse = await organizerHttp.PostAsJsonAsync($"/v1/volunteer-opportunities/{opportunityId}/time-slots", new
+		{
+			startDateTime = secondStart,
+			endDateTime = secondStart.AddHours(4),
+			maxParticipants = 5,
+			recurrenceCount = 1,
+		});
+		secondSlotResponse.EnsureSuccessStatusCode();
+		var secondSlots = await secondSlotResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var secondTimeSlotId = secondSlots[0].GetProperty("id").GetString();
+
+		(await organizerHttp.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		// vera signs up for the *second* slot specifically, so the status card
+		// must show that slot's own date/time, not just any/the first one.
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var volunteerHttp = new HttpClient { BaseAddress = backend };
+		volunteerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+
+		var engagementResponse = await volunteerHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { type = "ScheduledSlots", timeSlotId = secondTimeSlotId, message = (string?)null });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		(await organizerHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var statusCard = Page.GetByTestId("application-status");
+		await Expect(statusCard).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(statusCard.GetByText("Your sign-up")).ToBeVisibleAsync();
+		await Expect(statusCard.GetByText("Confirmed")).ToBeVisibleAsync();
+		// The registered slot's own date/time next to the status Chip - previously
+		// missing entirely (#1938), matching what /my-signups already showed.
+		await Expect(statusCard.GetByText("Scheduled:")).ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -321,6 +321,13 @@ export default function VolunteerOpportunityDetailPage() {
 
 	const cue = opportunity.currentUserEngagement;
 
+	// The slot the signed-in volunteer registered for, so the status card
+	// below can show its date/time next to the status Chip - matching what
+	// /my-signups already shows for the same engagement (#1938).
+	const registeredTimeSlot = cue
+		? opportunity.timeSlots.find((ts) => ts.id === cue.timeSlotId)
+		: undefined;
+
 	// Folded down by the shared contract, with the same rule the list
 	// projection uses - so this page can no longer state a different capacity
 	// than the card the reader clicked to get here (#1777).
@@ -408,6 +415,16 @@ export default function VolunteerOpportunityDetailPage() {
 								>
 									{t(`myEngagements.status.${cue.status}`)}
 								</Chip>
+								{registeredTimeSlot && (
+									<p className="mt-1.5 flex items-center gap-1.5 text-xs font-medium text-gray-700">
+										<CalendarIcon className="h-3.5 w-3.5 shrink-0" />
+										<span>
+											{t("myEngagements.scheduledFor", {
+												range: `${formatDateTime(registeredTimeSlot.startDateTime as unknown as string, i18n.language)} - ${formatDateTime(registeredTimeSlot.endDateTime as unknown as string, i18n.language)}`,
+											})}
+										</span>
+									</p>
+								)}
 							</div>
 							<Button
 								type="button"


### PR DESCRIPTION
## What

On a volunteer opportunity's detail page, the sidebar's application-status card (`data-testid="application-status"`) now shows the registered time slot's date/time next to the status Chip, for offers with more than one time slot.

## Why

On `/volunteer-opportunities/{id}` for an offer with more than one time slot, the status card only rendered the `opportunities.yourApplication` label plus a status `Chip` - no date or time - even though `/my-signups` already showed the correct slot date/time for the same signup. A returning volunteer checking the offer page to remember when they signed up had to leave and go to "Meine Anmeldungen" to find out.

Fixed by resolving the signed-in user's `currentUserEngagement.timeSlotId` against the opportunity's own `timeSlots` array and rendering that slot's start/end next to the Chip, reusing the exact `myEngagements.scheduledFor` copy and `CalendarIcon` pattern `MyEngagementsPage/ActivitySection.tsx` already uses for the same data.

Closes #1938

## Testing

- `pnpm check` (tsc --noEmit), `pnpm lint`, `pnpm i18n:check`, `pnpm format:write` all pass locally - no new translation keys were needed (`myEngagements.scheduledFor` already exists in `en.json`/`de.json`).
- Added `backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs`: creates a two-slot opportunity, signs a volunteer up for the *second* slot specifically, confirms the engagement, then asserts the detail page's status card shows the "Scheduled:" date/time row (not just the status Chip).
- Added `AccessibilityTests.cs::VolunteerOpportunityDetailPage_ApplicationStatusWithTimeSlot_AsVera_HasNoSeriousA11yViolations`: an `a11y-check` subagent pass on this diff found that none of this file's existing detail-page axe scans ever reach the "signed-in volunteer with an existing engagement" render state the new content was added into (they all land on the sign-up-CTA/login-prompt/owner-draft states) - a pre-existing coverage gap that predates this change, but one this diff's new content now sits inside of. Closed it with a scan of that exact state.
- Could not run `dotnet build`/the VisualTests suite locally in this sandbox (outbound access to `builds.dotnet.microsoft.com` for the .NET SDK installer is blocked by the environment's network policy) - relying on CI's `dotnet.yml` to run the full suite, and will fix forward if it surfaces anything.

## Live verification

Skipped for this change at the requester's explicit instruction (no release candidate cut). The new `OpportunityDetailStatusCardTimeSlotTests` VisualTest is the durable, CI-run regression coverage for the fix in place of a live-staging check.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this card's contents)


---
_Generated by [Claude Code](https://claude.ai/code/session_015t5mMdYaiY6fjSsf9GMVH9)_