### PR TITLE
fix(frontend): probe for a live Keycloak SSO session on a fresh tab

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/PageHealthTests.cs
+++ b/backend/tests/VisualTests/PageHealthTests.cs
@@ -18,6 +18,16 @@ public class PageHealthTests(AspireFixture fixture) : VisualTestBase(fixture)
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 
+		// #1929: the home page now probes for a live Keycloak SSO session on
+		// mount even when anonymous (useSilentSsoProbe) - it genuinely crosses
+		// into Keycloak now, same as the anonymous-redirect tests in
+		// AuthGuardTests/HomePageOrgCtaTests, so it needs the same
+		// X-Forwarded-For strip (see AllowKeycloakCrossOriginRequestsAsync's
+		// own doc comment) or the probe's discovery fetch trips Keycloak's
+		// CORS preflight and this test's own console-error assertion below
+		// fails on that, not on a real regression.
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+
 		var consoleErrors = new List<string>();
 		var failedResponses = new List<string>();
 

--- a/backend/tests/VisualTests/SilentSsoProbeTests.cs
+++ b/backend/tests/VisualTests/SilentSsoProbeTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class SilentSsoProbeTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	// Regression for #1929: a second tab's sessionStorage starts out empty -
+	// main.tsx's OIDC userStore is intentionally sessionStorage-backed, scoped
+	// per top-level browsing context rather than shared context-wide (see
+	// OpportunityApplicationStateTests' Context.NewPageAsync precedent, which
+	// documents the same per-tab scoping for a different reason). A public
+	// page's header used to render "logged out" - "Anmelden"/"Registrieren" -
+	// on a fresh tab regardless of whether the underlying Keycloak SSO session
+	// (a real browser cookie, shared context-wide) was still live, since
+	// automaticSilentRenew only ever renews an *already-known* session and
+	// never discovers one. useSilentSsoProbe now probes once via
+	// signinSilent() on mount, picking the live session back up without a
+	// full page reload.
+	[Test]
+	public async Task FreshTab_WithLiveSsoSession_HeaderShowsLoggedIn()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		// A real login, not AuthHelper.FastSignInAsync - the fix specifically
+		// depends on a live Keycloak SSO session *cookie*, which only a real
+		// login through Keycloak's UI sets. FastSignInAsync only ever seeds a
+		// token straight into sessionStorage and never visits Keycloak at all.
+		await AuthHelper.LoginAsync(Page, frontend, "vera", "vera123");
+
+		// A second tab in the same browser context: shares vera's Keycloak
+		// session cookie, but starts with none of Page's sessionStorage.
+		var freshTab = await Context.NewPageAsync();
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(freshTab);
+		await freshTab.GotoAsync(origin);
+
+		// The probe's hidden-iframe round trip to Keycloak takes a moment -
+		// the header is expected to catch up shortly after first paint, not
+		// necessarily be correct on the very first frame.
+		await Expect(freshTab.GetByRole(AriaRole.Button, new() { Name = "User menu" }))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(freshTab.GetByRole(AriaRole.Button, new() { Name = "Sign in" }))
+			.Not.ToBeVisibleAsync();
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useSessionExpiryHandler } from "./hooks/useSessionExpiryHandler";
+import { useSilentSsoProbe } from "./hooks/useSilentSsoProbe";
 import { signinLocaleArgs } from "./lib/authLocale";
 import ErrorBanner from "./components/ErrorBanner";
 import Button from "./components/Button";
@@ -129,6 +130,7 @@ function CallbackPage() {
 
 export default function App() {
 	useSessionExpiryHandler();
+	useSilentSsoProbe();
 	return (
 		<Routes>
 			<Route path="/callback" element={<CallbackPage />} />

--- a/frontend/src/hooks/useSilentSsoProbe.ts
+++ b/frontend/src/hooks/useSilentSsoProbe.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react";
+import { useAuth } from "react-oidc-context";
+import { useLocation } from "react-router";
+
+/**
+ * A fresh tab's sessionStorage carries no stored OIDC user (main.tsx's
+ * userStore is intentionally sessionStorage-backed, per-tab) even when the
+ * browser still holds a live Keycloak SSO session cookie from another tab -
+ * automaticSilentRenew only renews an *already-known* session, it never
+ * discovers one, so a public page's header rendered "logged out" regardless
+ * of the real session state (#1929). Probing once via signinSilent() closes
+ * that gap: on success it's the same USER_LOADED event automaticSilentRenew
+ * already relies on, so every consumer (Header, ProtectedRoute, ...) picks
+ * up the real state with no page reload. A rejection (no live session - the
+ * ordinary logged-out case) is expected and silently ignored, not surfaced
+ * as an error the way a renewal failure on an already-known session is
+ * (useSessionExpiryHandler).
+ */
+export function useSilentSsoProbe() {
+	const auth = useAuth();
+	const location = useLocation();
+	const attemptedRef = useRef(false);
+
+	useEffect(() => {
+		// signinSilent() itself loads this same app in a hidden iframe to
+		// complete the round trip (oidc-client-ts's silent_redirect_uri
+		// defaults to redirect_uri, i.e. /callback - see main.tsx). Without this
+		// guard, that inner mount would see itself as logged out too and fire
+		// its own nested probe, recursing iframes-in-iframes indefinitely.
+		if (window.self !== window.top) return;
+		// /callback is mid-flow (a real signin or an automatic silent renewal)
+		// handling its own auth resolution - a probe here would be redundant at
+		// best and, on a failed real callback, an extra pointless hidden-iframe
+		// round trip.
+		if (location.pathname === "/callback") return;
+		if (auth.isLoading || auth.isAuthenticated || attemptedRef.current) return;
+		attemptedRef.current = true;
+		auth.signinSilent().catch(() => {
+			// No live Keycloak SSO session behind this tab - the ordinary
+			// logged-out case, nothing to react to.
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [auth.isLoading, auth.isAuthenticated, location.pathname]);
+}


### PR DESCRIPTION
## What

A public page's header now attempts a lightweight silent-SSO check on mount, instead of only trusting whatever OIDC user object happens to already be in the current tab's `sessionStorage`.

## Why

A logged-in user opening a public route (`/`, `/opportunities`, `/volunteer-opportunities/:id`, ...) in a **new browser tab** saw the header render "logged out" ("Anmelden"/"Registrieren"), even though their Keycloak SSO session was still fully live. `sessionStorage` is per-tab (deliberately, `frontend/src/main.tsx`), so a fresh tab starts with no stored OIDC user - and `automaticSilentRenew: true` only renews an *already-known* session, it never discovers one. Clicking "Anmelden" in that state silently signed the user back in with zero credential prompt, proving the session was live the whole time.

`useSilentSsoProbe` (`frontend/src/hooks/useSilentSsoProbe.ts`), wired in at the top of `App.tsx`, attempts a single `signinSilent()` call once per tab when the app doesn't already know about a session. On success, the same `USER_LOADED` event `automaticSilentRenew` already relies on flips `auth.isAuthenticated` for every consumer (Header, `ProtectedRoute`, ...) with no page reload. A rejection (no live session - the ordinary logged-out case) is silently ignored, not surfaced as an error.

Guarded against the one real hazard this introduces: `signinSilent()` loads the same SPA in a hidden iframe (`oidc-client-ts`'s `silent_redirect_uri` defaults to `redirect_uri`, i.e. `/callback`) to complete the round trip - without a `window.self !== window.top` guard, that inner mount would see itself as logged out too and recurse into nested iframes.

Closes #1929

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm format:write`, `pnpm test` (264 tests) - all green locally.
- Added `backend/tests/VisualTests/SilentSsoProbeTests.cs`: logs in for real on one tab (`AuthHelper.LoginAsync`, so a genuine Keycloak SSO session cookie is set), opens a second tab in the same browser context via `Context.NewPageAsync()` (same precedent as `OpportunityApplicationStateTests`' per-tab `sessionStorage` scoping), navigates it to the home page, and asserts the header settles on "User menu" (logged in) rather than "Sign in", without a reload.
- Could not run `dotnet build`/the backend suites locally in this sandbox - outbound access to `builds.dotnet.microsoft.com` (the .NET SDK installer) is blocked by this environment's egress policy, so the .NET SDK itself couldn't be installed. The new test project change is straightforward and mirrors existing, working test patterns closely (`AuthHelper`, `VisualTestBase`, `OpportunityApplicationStateTests`'s `NewPageAsync` usage) - CI's `dotnet.yml` will run it for real.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. The new `SilentSsoProbeTests` C# test is the durable, reviewable regression coverage for this fix and will run against the local Aspire stack in CI (`dotnet.yml`).

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 findings; see PR discussion if asked)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01681k7M1xwqCTJUTcEbwaCR)_