### PR TITLE
fix(frontend): re-validate create-opportunity wizard fields live on change

### DIFF
--- a/backend/tests/VisualTests/WizardLiveRevalidationTests.cs
+++ b/backend/tests/VisualTests/WizardLiveRevalidationTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1928: react-hook-form only re-validates an
+/// already-errored field on every keystroke once the form has gone through a
+/// <c>handleSubmit()</c> call - its <c>reValidateMode</c> default of
+/// "onChange" only takes effect after <c>isSubmitted</c> flips. This wizard
+/// never calls <c>handleSubmit</c>; both "Next" and the final submit call
+/// <c>trigger()</c> directly instead. A field marked invalid by "Next" used
+/// to keep showing "Please fill this in." and <c>aria-invalid="true"</c>
+/// even after the user had already typed a valid value, until "Next" was
+/// clicked a second time. The field's own validation now re-runs on every
+/// keystroke once it already has an error, so the message clears the moment
+/// the value becomes valid - no second "Next" click required.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class WizardLiveRevalidationTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task InvalidTitleField_FixedWithoutClickingNextAgain_ClearsItsErrorLive()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		// Title and description both empty - "Next" must mark both invalid.
+		await Page.GetByTestId("modal-next").ClickAsync();
+
+		var titleInput = Page.Locator("#opportunity-title");
+		var titleError = Page.Locator("#opportunity-title-error");
+		var descriptionError = Page.Locator("#opportunity-description-error");
+		await Expect(titleError).ToHaveTextAsync("Please fill this in.");
+		await Expect(descriptionError).ToHaveTextAsync("Please fill this in.");
+		await Expect(titleInput).ToHaveAttributeAsync("aria-invalid", "true");
+
+		// Real keystrokes into the now-invalid title field - deliberately not
+		// clicking "Next" again - matching how the bug was originally caught.
+		await titleInput.PressSequentiallyAsync("Erste-Hilfe-Kurs fuer Anfaenger");
+		await Expect(titleError).Not.ToBeAttachedAsync(new() { Timeout = 5_000 });
+		await Expect(titleInput).Not.ToHaveAttributeAsync("aria-invalid", "true");
+
+		// Description is untouched and must stay marked invalid - the fix is
+		// per-field, not a blanket clear of every error on the step.
+		await Expect(descriptionError).ToHaveTextAsync("Please fill this in.");
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -374,6 +374,24 @@ export default function CreateVolunteerOpportunityModal({
 		else onClose();
 	}
 
+	// react-hook-form only re-validates an already-errored field on every
+	// keystroke once the form has been through a handleSubmit() call
+	// (isSubmitted flips reValidateMode's default of "onChange" into effect) -
+	// this wizard never calls handleSubmit, each step and the final submit
+	// call trigger() directly instead, so a field marked invalid by "Next"
+	// kept showing its error, aria-invalid included, until "Next" was clicked
+	// again even after the user had already fixed it (#1928). Re-running that
+	// one field's own validation on change once it has an error closes the
+	// gap without waiting for another step advance.
+	const registerWithRevalidate: typeof register = (name, options) =>
+		register(name, {
+			...options,
+			onChange: async (event) => {
+				await options?.onChange?.(event);
+				if (errors[name as keyof OpportunityFormValues]) await trigger(name);
+			},
+		});
+
 	function applyOrgAddress() {
 		if (!orgAddress) return;
 		setValue("street", orgAddress.street);
@@ -1059,7 +1077,7 @@ export default function CreateVolunteerOpportunityModal({
 
 					{step === 1 && (
 						<BasicsStep
-							register={register}
+							register={registerWithRevalidate}
 							watch={watch}
 							titleError={errors.title?.message}
 							descriptionError={errors.description?.message}
@@ -1072,7 +1090,7 @@ export default function CreateVolunteerOpportunityModal({
 
 					{step === 2 && (
 						<LocationStep
-							register={register}
+							register={registerWithRevalidate}
 							watch={watch}
 							onRemoteToggle={handleRemoteToggle}
 							errors={{
@@ -1090,7 +1108,7 @@ export default function CreateVolunteerOpportunityModal({
 
 					{step === 3 && (
 						<FormatStep
-							register={register}
+							register={registerWithRevalidate}
 							watch={watch}
 							setCheckInPin={setCheckInPin}
 							checkInPinError={errors.checkInPin?.message}


### PR DESCRIPTION
## What

Once a field in the "Einsatz erstellen" wizard was marked invalid by clicking "Next", fixing its value while typing no longer clears the error text and `aria-invalid` immediately - it now clears live, the moment the value becomes valid, instead of requiring another "Next" click.

## Why

`useForm` is configured with `mode: "onBlur"` and relies on react-hook-form's documented `reValidateMode: "onChange"` default to live-clear an already-errored field as the user types. That default only takes effect once the form has gone through a `handleSubmit()` call (`isSubmitted` flips). This wizard never calls `handleSubmit` - `handleNext`/`handleStepClick`/`submit` all call `trigger(fields)` directly instead - so `isSubmitted` never flips, and RHF kept using `mode: "onBlur"` for revalidation instead of the live-clearing `reValidateMode`. The result: a field marked invalid by "Next" stayed invalid (error text + `aria-invalid="true"`) even after being fixed, until "Next" was clicked a second time.

Fix: wrap `register()` (`registerWithRevalidate` in `index.tsx`) so that once a field already has an error, its own validation re-runs via an explicit `trigger(name)` on every keystroke - independent of RHF's internal mode/reValidateMode decision - clearing the error the instant the value becomes valid. Applied to all three steps that render validated text/radio fields (Basics, Location, Format); composes with each field's existing custom `onChange` (e.g. the check-in PIN sanitizer) rather than replacing it.

Closes #1928

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm format:check`, `pnpm test` (264 tests) - all green.
- Added `backend/tests/VisualTests/WizardLiveRevalidationTests.cs`: opens the create-opportunity wizard, clicks "Next" with Title/Description empty to mark both invalid, then types a valid title with real Playwright keystrokes (`PressSequentiallyAsync`, no further "Next" click) and asserts the title's error/`aria-invalid` clear on their own while Description's error - still empty - stays put. Runs in CI's `dotnet.yml` (`visual-tests` job).
- Delegated a11y review to the `a11y-check` subagent: no regression - `aria-invalid`, `aria-describedby`, and the `role="alert"` error text all still flip together off the same `errors` state, and clearing an error as soon as it's fixed matches WCAG's error-suggestion guidance rather than working against it.

## Live verification

Not run for this change, per explicit instruction not to cut a release candidate for this task. In its place, `WizardLiveRevalidationTests.cs` (above) drives the exact repro from the issue - real keystrokes, no extra "Next" click - as an automated regression test that CI runs against the full Aspire stack on every build.

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 issues; a11y-check subagent confirmed no regression)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - internal validation-timing fix, no user-facing docs to update)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz4UwL8pyqSZBxA9XwGYBo)_