### PR TITLE
fix(frontend): show offline state for a not-yet-cached route instead of crashing

### DIFF
--- a/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
+++ b/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1955. Distinct from #1774's OfflineStateTests, which cover
+/// a route whose *data fetch* fails while offline - both there and here the
+/// route's own chunk was already warmed first. Every page is lazy-loaded
+/// (App.tsx's per-route <c>React.lazy</c>), so client-side navigation to a
+/// route whose JS chunk was never fetched fails its dynamic <c>import()</c>
+/// outright when offline: a plain <c>TypeError</c> caught only by the
+/// top-level ErrorBoundary, which used to render the generic "Something went
+/// wrong" screen - no acknowledgement the cause was connectivity, and no path
+/// back except a reload that would fail again while still offline.
+/// ErrorBoundary now recognizes that error shape (see
+/// <c>lib/dynamicImportError.ts</c>) and renders the same dedicated offline
+/// state every other offline-aware surface in the app already uses.
+///
+/// Deliberately does NOT warm the target route first - the opposite of
+/// <see cref="VisualTestBase.WarmOpportunitiesRouteThenLeaveAsync"/> - since
+/// the chunk must never have been fetched for its <c>import()</c> to fail at
+/// all. Reaches <c>/help</c> by clicking the header's nav link rather than
+/// <c>GotoAsync</c> while offline, for the same reason OfflineStateTests
+/// does: this suite blocks service workers (see
+/// <see cref="VisualTestBase.ContextOptions"/>), so an offline document
+/// navigation could not load the app shell in the first place.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class ErrorBoundaryOfflineTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task NavigatingToUncachedRouteWhileOffline_ShowsOfflineState_NotGenericErrorBoundary()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync(origin);
+		await Expect(Page.GetByTestId("nav-help")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Context.SetOfflineAsync(true);
+		try
+		{
+			await Page.GetByTestId("nav-help").ClickAsync();
+
+			await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+				.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+			// The two halves of the old behaviour, both gone: the generic crash
+			// screen, and a reload button that could not possibly succeed while
+			// still offline.
+			await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Something went wrong" }))
+				.Not.ToBeVisibleAsync();
+			await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reload" }))
+				.Not.ToBeVisibleAsync();
+		}
+		finally
+		{
+			await Context.SetOfflineAsync(false);
+		}
+	}
+
+	[Test]
+	public async Task UncachedRouteFailsWhileOffline_WhenTheConnectionReturns_LoadsWithoutBeingAsked()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync(origin);
+		await Expect(Page.GetByTestId("nav-help")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Context.SetOfflineAsync(true);
+		try
+		{
+			await Page.GetByTestId("nav-help").ClickAsync();
+			await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+				.ToBeVisibleAsync(new() { Timeout = 20_000 });
+		}
+		finally
+		{
+			await Context.SetOfflineAsync(false);
+		}
+
+		// No click needed: the `online` event alone drives the recovery - a real
+		// reload, not just clearing the caught error, since React.lazy() caches
+		// a rejected import() for the page's lifetime (see ErrorBoundary.tsx).
+		// Same edge-triggered pattern useLoadMore already relies on for a failed
+		// data fetch (see OfflineStateTests), just with a reload as the specific
+		// recovery action instead of a refetch.
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Help" }))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+	}
+}

--- a/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
+++ b/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
@@ -86,7 +86,9 @@ public class ErrorBoundaryOfflineTests(AspireFixture fixture) : VisualTestBase(f
 		// Same edge-triggered pattern useLoadMore already relies on for a failed
 		// data fetch (see OfflineStateTests), just with a reload as the specific
 		// recovery action instead of a refetch.
-		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Help" }))
+		// Exact: HelpPage's own "Still need help?" contact heading also matches
+		// a plain (substring) "Help" filter.
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Help", Exact = true }))
 			.ToBeVisibleAsync(new() { Timeout = 20_000 });
 	}
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,9 @@ import { Component, type ReactNode } from "react";
 import i18next from "i18next";
 import { statusTitleClass } from "../lib/headingClasses";
 import Button from "./Button";
+import RouteState from "./RouteState";
+import { isDynamicImportError } from "../lib/dynamicImportError";
+import { getOnlineStatus, subscribeOnlineStatus } from "../lib/onlineStatus";
 
 interface Props {
 	children: ReactNode;
@@ -14,16 +17,54 @@ interface Props {
 interface State {
 	hasError: boolean;
 	error: Error | null;
+	online: boolean;
 }
 
 export default class ErrorBoundary extends Component<Props, State> {
+	private unsubscribeOnlineStatus: (() => void) | null = null;
+
 	constructor(props: Props) {
 		super(props);
-		this.state = { hasError: false, error: null };
+		this.state = { hasError: false, error: null, online: getOnlineStatus() };
 	}
 
-	static getDerivedStateFromError(error: Error): State {
+	static getDerivedStateFromError(
+		error: Error,
+	): Pick<State, "hasError" | "error"> {
 		return { hasError: true, error };
+	}
+
+	componentDidMount() {
+		// #1955: every route is lazy-loaded (App.tsx), so navigating to one
+		// whose chunk was never fetched throws a plain TypeError straight out of
+		// the dynamic import() - not routed through useOnlineStatus/RouteState at
+		// all, unlike every other offline-aware surface in the app.
+		this.unsubscribeOnlineStatus = subscribeOnlineStatus(() => {
+			const online = getOnlineStatus();
+			const cameBackOnline = online && !this.state.online;
+			// React.lazy() caches its import() promise - and a rejection - for
+			// the lifetime of the page (App.tsx's lazy() calls are module-level
+			// constants shared by every render), so clearing `hasError` here
+			// would just re-render straight into the exact same cached rejection
+			// and re-throw it instantly. Only a real reload re-fetches the chunk
+			// from scratch, mirroring what a visitor who reloads by hand already
+			// gets once back online - and matching what routeState.offline's
+			// reused copy ("we load the page again - you do not have to do
+			// anything") promises.
+			if (
+				cameBackOnline &&
+				this.state.hasError &&
+				isDynamicImportError(this.state.error)
+			) {
+				window.location.reload();
+				return;
+			}
+			this.setState({ online });
+		});
+	}
+
+	componentWillUnmount() {
+		this.unsubscribeOnlineStatus?.();
 	}
 
 	componentDidCatch(error: Error, info: React.ErrorInfo) {
@@ -43,6 +84,17 @@ export default class ErrorBoundary extends Component<Props, State> {
 		if (this.state.hasError) {
 			if (this.props.fallback) return this.props.fallback;
 			const t = i18next.t.bind(i18next);
+
+			if (!this.state.online && isDynamicImportError(this.state.error)) {
+				return (
+					<RouteState
+						variant="offline"
+						title={t("routeState.offline.title")}
+						message={t("routeState.offline.message")}
+					/>
+				);
+			}
+
 			return (
 				<div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
 					<h1 className={`text-brand-700 ${statusTitleClass}`}>

--- a/frontend/src/lib/dynamicImportError.test.ts
+++ b/frontend/src/lib/dynamicImportError.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isDynamicImportError } from "./dynamicImportError";
+
+describe("isDynamicImportError", () => {
+	it("recognizes Chromium's dynamic import fetch failure", () => {
+		const error = new TypeError(
+			"Failed to fetch dynamically imported module: https://example.com/assets/HelpPage-abc123.js",
+		);
+		expect(isDynamicImportError(error)).toBe(true);
+	});
+
+	it("recognizes Firefox's dynamic import fetch failure", () => {
+		const error = new TypeError(
+			"error loading dynamically imported module: https://example.com/assets/HelpPage-abc123.js",
+		);
+		expect(isDynamicImportError(error)).toBe(true);
+	});
+
+	it("recognizes Safari's module script failure", () => {
+		const error = new TypeError("Importing a module script failed");
+		expect(isDynamicImportError(error)).toBe(true);
+	});
+
+	it("is false for an unrelated TypeError", () => {
+		expect(isDynamicImportError(new TypeError("Failed to fetch"))).toBe(false);
+	});
+
+	it("is false for a non-Error value", () => {
+		expect(
+			isDynamicImportError("Failed to fetch dynamically imported module"),
+		).toBe(false);
+	});
+
+	it("is false for null/undefined", () => {
+		expect(isDynamicImportError(null)).toBe(false);
+		expect(isDynamicImportError(undefined)).toBe(false);
+	});
+});

--- a/frontend/src/lib/dynamicImportError.ts
+++ b/frontend/src/lib/dynamicImportError.ts
@@ -1,0 +1,17 @@
+/**
+ * True for the error a lazy route's `import()` (see App.tsx's per-route
+ * `React.lazy`) throws when its JS chunk cannot be fetched - offline, most
+ * commonly (#1955), but the same shape also covers a stale chunk URL evicted
+ * by a newer deploy. This is what lets ErrorBoundary tell that case apart
+ * from a real render crash. Wording is browser-specific and carries no
+ * machine-readable error code, so this matches on the message text: Chromium
+ * says "Failed to fetch dynamically imported module", Firefox says "error
+ * loading dynamically imported module", Safari says "Importing a module
+ * script failed" with no module URL at all.
+ */
+export function isDynamicImportError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /dynamically imported module|importing a module script failed/i.test(
+		error.message,
+	);
+}


### PR DESCRIPTION
## What

`ErrorBoundary` now recognizes when a caught error is a lazy-route dynamic-`import()` failure (a not-yet-visited route's JS chunk failing to fetch) while the browser is offline, and renders the same shared `RouteState` "offline" state every other offline-aware surface in the app already uses, instead of the generic "Something went wrong" screen.

## Why

Every route is lazy-loaded (`App.tsx`'s per-route `React.lazy`), so client-side navigation to a route whose chunk was never fetched throws a plain `TypeError` straight out of the dynamic `import()` when offline. That failure wasn't routed through `useOnlineStatus`/`RouteState` at all - it just hit the generic top-level `ErrorBoundary`, with no acknowledgement the cause was connectivity and no working path back (its own "Reload" button would fail the same way while still offline).

Closes #1955

## Testing

- New `frontend/src/lib/dynamicImportError.ts` (+ `dynamicImportError.test.ts`): matches the browser-specific wording of a failed dynamic import (Chromium, Firefox, Safari) against the caught error's message.
- `ErrorBoundary.tsx`: tracks live online status (`lib/onlineStatus.ts`, the same store `useOnlineStatus` uses) and, when `hasError && offline && isDynamicImportError(error)`, renders `RouteState` with the reused `routeState.offline.title`/`.message` copy instead of the generic fallback markup. On reconnect it triggers a real `window.location.reload()` rather than just clearing the caught error - `React.lazy()` caches a rejected `import()` for the page's lifetime (the `lazy()` calls in `App.tsx` are module-level constants), so clearing `hasError` alone would just re-render straight into the same cached rejection and throw again immediately.
- New `backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs` (2 tests): deliberately does *not* warm the `/help` route first (the chunk must never have been fetched for its `import()` to fail), goes offline, clicks the header's nav link, and asserts the offline state renders instead of the generic crash screen with no dead "Reload" button; the second test asserts the page recovers on its own once the connection returns, no click needed.
- Ran locally: `pnpm check` / `pnpm lint` / `pnpm test` (270 tests) / `pnpm format:write` / `pnpm i18n:check` - all clean. `dotnet build` on `VisualTests.csproj` isn't runnable end-to-end in this sandbox (no Docker/Aspire orchestration, and the pinned SDK/Playwright browser downloads are blocked by this environment's network policy - see root `AGENTS.md`'s Sandbox Limitations) - the new C# file was still confirmed to compile with zero compiler errors against an installed .NET 10 SDK before the post-build Playwright browser-install step (the actual network-blocked part) failed. `a11y-check` subagent reviewed the `.tsx` change: clean, no new page/route so no `AccessibilityTests.cs` entry needed.

## Live verification

Skipped per explicit instruction for this change - no release candidate was cut. `ErrorBoundaryOfflineTests.cs` (above) is the durable, CI-run regression coverage for this fix (`dotnet.yml`'s `visual-tests` job runs it against the local Aspire stack); it has not yet been observed passing against a real deployed build.

## Checklist

- [x] `/self-review` run and findings addressed (caught and fixed a real bug during review: the original reconnect handling cleared React state instead of reloading, which doesn't work with `React.lazy()`'s promise caching and would have shown the *wrong* fallback on reconnect)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal error-handling wiring, no user-facing docs to update)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MYXsJ9KFab7CEgDukixy9f)_