### PR TITLE
test: cover the InvitationReceived notification -> /my-signups journey

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2567,6 +2567,13 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
+		// Scoped to the filter bar: an unscoped "Reset" also matches the
+		// results list's own empty-state reset CTA (opportunities.clearFilters
+		// - the same label) whenever the "One-time" filter happens to catch
+		// zero opportunities in the shared VisualTests database at the moment
+		// this runs, which depends on what other concurrently-running test
+		// classes have created - a strict-mode violation unrelated to this
+		// test's own subject.
 		await Expect(
 			Page.GetByTestId("opportunities-filter-bar")
 				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -109,6 +109,76 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	/// <summary>
+	/// Regression for #1927: a real, unread InvitationReceived notification
+	/// navigated to /my-signups when clicked, but nothing there read as
+	/// related to the invitation - no dedicated acceptance surface was found
+	/// after checking notifications, profile, settings, and the
+	/// organizations directory. The routing itself
+	/// (NotificationReadRepository -> "/my-signups", einsatzbereit#1684) was
+	/// only ever asserted at the API level
+	/// (IntegrationTests.NotificationTests), never that the destination page
+	/// actually renders anything invitation-related - exactly the gap the
+	/// report fell into. Drives the whole journey: notification click ->
+	/// /my-signups -> the "Open invitations" card -> Accept, proving the
+	/// in-app acceptance surface the notification implies really exists and
+	/// really works.
+	/// </summary>
+	[Test]
+	public async Task InvitationReceivedNotification_NavigatesToMySignups_WhereTheInviteeCanAcceptIt()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgName = $"NotifInvite Org {suffix}";
+		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var veraSession = await Fixture.SignInAsync("vera", "vera123");
+
+		var inviteResponse = await olafHttp.PostAsJsonAsync(
+			$"/v1/organizations/{organizationId}/invitations",
+			new { inviteeId = veraSession.UserId, role = "Member" });
+		inviteResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+
+		var bell = Page.GetByTestId("notification-bell");
+		await Expect(bell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await bell.ClickAsync();
+
+		var panel = Page.GetByTestId("notification-panel");
+		await Expect(panel).ToBeVisibleAsync(new() { Timeout = 5_000 });
+
+		var notificationItem = panel.Locator("li", new() { HasText = orgName }).First;
+		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		// .First: the row's own select button is always the first interactive
+		// element (before the conditional mark-unread/delete action buttons
+		// added by #1061), but it has no aria-label of its own to filter by.
+		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
+
+		await Page.WaitForURLAsync(
+			$"{frontend.GetLeftPart(UriPartial.Authority)}/my-signups",
+			new() { Timeout = 15_000 });
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Open invitations" }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		var invitationCard = Page.Locator("li", new() { HasText = orgName });
+		await Expect(invitationCard).ToBeVisibleAsync();
+
+		await invitationCard.GetByRole(AriaRole.Button, new() { Name = "Accept" }).ClickAsync();
+
+		await Expect(invitationCard).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+	}
+
+	/// <summary>
 	/// Regression for #1222: clicking a notification awaited markOneRead()
 	/// with no error handling, so a failed mark-as-read call left an
 	/// unhandled rejection that silently swallowed the subsequent


### PR DESCRIPTION
## What

Adds an end-to-end VisualTests case proving that clicking an organization-invitation notification lands the volunteer on a page where they can actually act on it - invite, notification click, land on `/my-signups`, accept.

## Why

#1927 reported that clicking an organization-invitation notification ("Du wurdest eingeladen, [Org] beizutreten") navigated to `/my-signups`, which read as unrelated to invitations, with no dedicated acceptance surface found anywhere in the app. It asked for a decision: does invitation acceptance happen entirely through an external, emailed Keycloak Organizations link, or should there be an in-app acceptance surface?

Investigation found the in-app acceptance surface already exists, and the notification already routes there:

- `NotificationReadRepository.cs` maps `NotificationKind.InvitationReceived` to `actionUrl = "/my-signups"`, with a comment tying it to `einsatzbereit#1684` ("invitations moved off /profile onto their own page at /my-signups").
- `/my-signups` (`MyEngagementsPage` -> `ActivitySection.tsx`) renders an "Open invitations" card at the top of the page whenever `GetMyInvitations` returns pending invitations, with working Accept/Decline buttons wired to `AcceptInvitationEndpoint`/`DeclineInvitationEndpoint`.
- The whole invite -> notify -> accept/decline flow is einsatzbereit's own (`OrganizationInvitation` aggregate, own 14-day expiry/state machine, own email). Keycloak Organizations is only touched at acceptance time (`AddMemberAsync`) - there's no separate Keycloak-native invite-by-email-link flow in play.
- I pulled `NotificationReadRepository.cs` at `8546263d` - the exact commit the issue says it was reproduced against - via the GitHub API. The `/my-signups` routing and its `einsatzbereit#1684` comment were already present there, byte-for-byte identical to `main`.

So the routing decision this issue asked for is already made and already correct in code, and has been since before the report was filed. What was missing was proof: `IntegrationTests.NotificationTests` only asserted the `ActionUrl` *string* equals `/my-signups` - nothing ever drove the actual UI journey (notification click -> land on the page -> see an Accept/Decline card -> use it), which is exactly the gap the original report fell into. No VisualTests coverage of this flow existed at all (`OrganizationTests.cs` only covers the organizer/inviter side - sending, dismissing, resending invitations - never the invitee's `/my-signups` acceptance UI).

This PR closes that coverage gap rather than re-doing a routing fix that's already shipped, so a future regression here gets caught by CI instead of by another live-staging bug report.

Closes #1927

## Testing

Added `NotificationTests.InvitationReceivedNotification_NavigatesToMySignups_WhereTheInviteeCanAcceptIt` (`backend/tests/VisualTests/NotificationTests.cs`):

1. Olaf creates a throwaway org and invites Vera via the API (`POST /v1/organizations/{id}/invitations`).
2. Vera signs in, opens the notification bell, and clicks the resulting "You've been invited to join ..." notification.
3. Asserts the app lands on `/my-signups`.
4. Asserts the "Open invitations" card is visible with the invited org listed.
5. Clicks Accept and asserts the card disappears.

This runs as part of `dotnet.yml`'s `visual-tests` job (Aspire + Playwright) - I could not run it locally in this sandbox (no Docker/Aspire orchestration, and this session's network policy blocks the .NET SDK installer domains too, so I couldn't even compile-check it with `dotnet build`), so I've watched it closely against CI instead; see below.

## Live verification

Not performed for this PR - the change is test-only (no application behavior changed, since the routing/UI it covers was already correct and unchanged), and I was asked not to cut a release candidate for this task. This session's network egress is also blocked to the staging domain, so a live-staging check wasn't reachable from here regardless.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - test-only diff, closely mirrors existing patterns in the same file)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_015nymeW4LF3XKvGB7MNuGJT)_