### PR TITLE
fix: place new dashboard widgets into first available empty cell

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.test.ts
@@ -3,11 +3,23 @@ import {
 	DEFAULT_LAYOUT,
 	GRID_COLUMNS,
 	WIDGET_CATALOG,
+	compactLayout,
 	groupIntoRowBands,
 	isValidPlacement,
+	placeNewWidget,
 	sortByPosition,
 	type PlacedWidget,
+	type WidgetKey,
 } from "./widgetCatalog";
+
+function rectsOverlap(a: PlacedWidget, b: PlacedWidget): boolean {
+	return (
+		a.x < b.x + b.width &&
+		b.x < a.x + a.width &&
+		a.y < b.y + b.height &&
+		b.y < a.y + a.height
+	);
+}
 
 // #1795: the Calendar shipped at 6 rows tall, which at 1440px is ~900px of
 // the first screen an organizer opens handed to a month grid that usually
@@ -195,5 +207,107 @@ describe("groupIntoRowBands", () => {
 
 	it("returns no bands for an empty layout", () => {
 		expect(groupIntoRowBands([])).toEqual([]);
+	});
+});
+
+// #1917: newly-added widgets used to always append below every existing
+// widget at x=1, ignoring empty cells elsewhere in the grid - these guard the
+// first-available-empty-cell scan that replaced it.
+describe("placeNewWidget", () => {
+	it("places into an empty grid at the top-left corner", () => {
+		expect(placeNewWidget("SettingsIcon", [])).toEqual({
+			widgetKey: "SettingsIcon",
+			x: 1,
+			y: 1,
+			width: WIDGET_CATALOG.SettingsIcon.defaultWidth,
+			height: WIDGET_CATALOG.SettingsIcon.defaultHeight,
+		});
+	});
+
+	it("fills open space beside existing widgets instead of stacking below them", () => {
+		// The exact shape from the bug report: only "Einsatz erstellen"
+		// (CreateOpportunity) and "Einstellungen" (Settings) remain, both
+		// narrow and confined to the left columns - a wide swath of the grid
+		// to their right sits empty.
+		const existing: PlacedWidget[] = [
+			{ widgetKey: "CreateOpportunity", x: 1, y: 1, width: 2, height: 1 },
+			{ widgetKey: "Settings", x: 1, y: 2, width: 3, height: 1 },
+		];
+
+		const placed = placeNewWidget("ToDo", existing);
+
+		// ToDo's default footprint (4x1) fits beside CreateOpportunity in row 1
+		// (columns 3-6) - that's the first free cell the scan reaches, well
+		// above the old append target of row 3.
+		expect(placed).toEqual({
+			widgetKey: "ToDo",
+			x: 3,
+			y: 1,
+			width: 4,
+			height: 1,
+		});
+	});
+
+	it("places three widgets added in sequence into separate open cells rather than one shared column", () => {
+		// Mirrors the issue's repro: add three widgets one after another,
+		// compacting after each exactly like OrgDashboardPage's
+		// handleAddWidget does.
+		let layout: PlacedWidget[] = [
+			{ widgetKey: "CreateOpportunity", x: 1, y: 1, width: 2, height: 1 },
+			{ widgetKey: "Settings", x: 1, y: 2, width: 8, height: 1 },
+		];
+		const added: WidgetKey[] = [];
+		for (const key of [
+			"UpcomingOpportunities",
+			"VolunteerStats",
+			"ToDo",
+		] as const) {
+			layout = compactLayout([...layout, placeNewWidget(key, layout)]);
+			added.push(key);
+		}
+
+		const newWidgets = layout.filter((w) => added.includes(w.widgetKey));
+		// None of the newly-placed widgets overlap each other or the pre-
+		// existing widgets.
+		for (let i = 0; i < layout.length; i++) {
+			for (let j = i + 1; j < layout.length; j++) {
+				expect(rectsOverlap(layout[i], layout[j])).toBe(false);
+			}
+		}
+		// They don't all collapse into the same single column the way the
+		// append-only bug produced.
+		const distinctColumns = new Set(newWidgets.map((w) => w.x));
+		expect(distinctColumns.size).toBeGreaterThan(1);
+	});
+
+	it("falls back to appending below everything once no gap fits", () => {
+		// DEFAULT_LAYOUT is packed edge-to-edge on every row - no gap exists
+		// anywhere for a new widget to slot into.
+		const placed = placeNewWidget("QuickCheckIn", DEFAULT_LAYOUT);
+		const bottom = DEFAULT_LAYOUT.reduce(
+			(max, w) => Math.max(max, w.y + w.height),
+			1,
+		);
+
+		expect(placed).toEqual({
+			widgetKey: "QuickCheckIn",
+			x: 1,
+			y: bottom,
+			width: WIDGET_CATALOG.QuickCheckIn.defaultWidth,
+			height: WIDGET_CATALOG.QuickCheckIn.defaultHeight,
+		});
+	});
+
+	it("never places a widget overlapping an existing one", () => {
+		const existing: PlacedWidget[] = [
+			{ widgetKey: "Calendar", x: 1, y: 1, width: 8, height: 4 },
+			{ widgetKey: "VolunteerStats", x: 1, y: 5, width: 2, height: 1 },
+		];
+
+		const placed = placeNewWidget("ToDo", existing);
+
+		for (const widget of existing) {
+			expect(rectsOverlap(placed, widget)).toBe(false);
+		}
 	});
 });

--- a/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
+++ b/frontend/src/pages/app/OrgDashboardPage/widgetCatalog.ts
@@ -385,21 +385,32 @@ export function groupIntoRowBands(widgets: PlacedWidget[]): LayoutRowBand[] {
 	}));
 }
 
-// Appends a newly added widget directly below every widget currently on the
-// grid, at its catalog default size - always non-overlapping since nothing
-// occupies the grid below the current bottom edge. The organizer then drags
-// it into its intended spot via corner-to-corner placement.
+// Places a newly added widget into the first available empty cell(s) on the
+// grid, at its catalog default size (#1917), instead of always appending
+// below every existing widget in column 1 - that ignored gaps elsewhere on
+// the grid, so a partially-filled layout with open columns beside its
+// existing widgets still had every new addition stack underneath column 1,
+// one on top of the next. Scans row-major (top-to-bottom, then left-to-right
+// within a row) for the first position the widget's footprint fits without
+// overlapping anything already placed.
 export function placeNewWidget(
 	widgetKey: WidgetKey,
 	existing: PlacedWidget[],
 ): PlacedWidget {
-	const entry = WIDGET_CATALOG[widgetKey];
+	const { defaultWidth: width, defaultHeight: height } =
+		WIDGET_CATALOG[widgetKey];
 	const bottom = existing.reduce((max, w) => Math.max(max, w.y + w.height), 1);
-	return {
-		widgetKey,
-		x: 1,
-		y: bottom,
-		width: entry.defaultWidth,
-		height: entry.defaultHeight,
-	};
+	for (let y = 1; y <= bottom; y++) {
+		for (let x = 1; x + width - 1 <= GRID_COLUMNS; x++) {
+			const candidate: PlacedWidget = { widgetKey, x, y, width, height };
+			if (!existing.some((w) => rectsOverlap(candidate, w))) {
+				return candidate;
+			}
+		}
+	}
+	// Unreachable: row `bottom` (by definition) has nothing occupying it or
+	// any row below, so the y === bottom, x === 1 candidate above always
+	// matches before the loop runs out - this return only exists to give
+	// every code path a value for the type checker.
+	return { widgetKey, x: 1, y: bottom, width, height };
 }


### PR DESCRIPTION
## What

`placeNewWidget` (Organizer dashboard, `Widget hinzufügen`) now scans the grid row-major (top-to-bottom, then left-to-right) for the first empty cell(s) a newly-added widget's default footprint fits into, instead of always appending it below every existing widget at column 1.

## Why

Per the issue's proposed fix: appending always to column 1 ignored empty space elsewhere in the grid. On a partially-filled layout (e.g. only "Einsatz erstellen"/"Einstellungen" left after removing other widgets), adding several widgets in sequence via "Widget hinzufügen" stacked all of them vertically in the left column, leaving the columns to the right untouched even though they had room. The grid stayed drag-and-drop rearrangeable, but the default placement wasn't using the space it had.

Closes #1917

## Testing

Added `describe("placeNewWidget", ...)` in `widgetCatalog.test.ts`:
- places into the top-left corner of an empty grid
- fills an open cell beside existing widgets instead of appending below them
- three widgets added in sequence (compacting after each, same as `OrgDashboardPage`'s `handleAddWidget`) land in distinct columns rather than stacking in one
- falls back to appending below everything once `DEFAULT_LAYOUT` (packed edge-to-edge) leaves no gap
- never places a widget overlapping an existing one

Ran locally: `pnpm test`, `pnpm check`, `pnpm lint`, `pnpm format:check` - all pass.

## Live verification

Not performed for this change - the task explicitly asked not to cut a release candidate. This is a pure frontend placement-algorithm change covered by the added unit tests above; no backend/API surface changed.

## Checklist

- [x] `/self-review` run and findings addressed (caught and fixed a misleading comment on an unreachable fallback branch before committing)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - behavior documented in code comments; no user-facing docs describe the old append behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TDQqgccUXJr7toVCzMqeUk)_