### PR TITLE
fix(frontend): match /opportunities' 768px grid breakpoint on the landing preview

### DIFF
--- a/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
+++ b/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Playwright;
 
@@ -75,6 +77,72 @@ public class LandingOpportunityPreviewTests(AspireFixture fixture) : VisualTestB
 		await link.ClickAsync();
 		await Page.WaitForURLAsync($"{origin}/opportunities", new() { Timeout = 15_000 });
 		await Expect(Page.Locator("h1")).ToHaveTextAsync("Find opportunities");
+	}
+
+	/// <summary>
+	/// #1914: at 768px the landing preview stayed single-column
+	/// (grid-cols-1 until lg) while /opportunities, rendering the same
+	/// OpportunityListItem card, already showed a two-column grid at that
+	/// width (sm:grid-cols-2). Seeds two fresh published opportunities so the
+	/// newest-first preview deterministically has at least two cards, then
+	/// checks they land side by side rather than stacked - the same
+	/// side-by-side check ListLayoutGridTests uses for /opportunities itself.
+	/// </summary>
+	[Test]
+	public async Task LandingPreview_AtTabletViewport_IsTwoColumnGridLikeOpportunitiesList()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"Visual1914 LandingGrid {Guid.NewGuid():N}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		foreach (var title in new[] { "Tablet Grid Card A", "Tablet Grid Card B" })
+		{
+			var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+			{
+				title,
+				description = "Seeded for #1914 landing tablet grid visual test.",
+				organizationId,
+				isRemote = true,
+				occurrence = "OneTime",
+				participationType = "IndividualContact",
+				checkInMethod = "None",
+				validUntil = DateTimeOffset.UtcNow.AddDays(30),
+				isDraft = false,
+			});
+			oppResponse.EnsureSuccessStatusCode();
+		}
+
+		await Page.SetViewportSizeAsync(768, 1024);
+		await Page.GotoAsync(frontend.GetLeftPart(UriPartial.Authority));
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var preview = Page.GetByTestId("landing-latest-opportunities");
+		await Expect(preview).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var display = await preview.EvaluateAsync<string>("el => getComputedStyle(el).display");
+		display.Should().Be("grid", "the preview must render as a CSS grid at 768px, not a single-column stack");
+
+		var items = preview.Locator("> li");
+		(await items.CountAsync()).Should().BeGreaterThanOrEqualTo(2,
+			"two opportunities were just seeded and the preview sorts newest first, so both must appear");
+
+		var firstBox = await items.Nth(0).BoundingBoxAsync();
+		var secondBox = await items.Nth(1).BoundingBoxAsync();
+		firstBox.Should().NotBeNull();
+		secondBox.Should().NotBeNull();
+
+		Math.Abs(firstBox!.Y - secondBox!.Y).Should().BeLessThan(2,
+			"at 768px the preview must show two columns like /opportunities does at the same viewport, "
+			+ "rather than the oversized single column #1914 reported");
 	}
 
 	[Test]

--- a/frontend/src/components/LatestOpportunitiesSection.tsx
+++ b/frontend/src/components/LatestOpportunitiesSection.tsx
@@ -23,12 +23,15 @@ import { ArrowRightIcon } from "./icons";
 // representations.
 const PREVIEW_COUNT = 3;
 
-// One column until lg, capped at a readable measure, three across above it.
-// Shared verbatim by the skeletons so the layout doesn't shift when the fetch
-// settles. sm:grid-cols-2 (what /opportunities uses) is wrong at this count:
-// three cards in a two-column grid leaves an orphan on every tablet.
+// One column until sm, capped at a readable measure; two from sm to match
+// /opportunities' grid at the same breakpoint (both render the same
+// OpportunityListItem, so the two surfaces should look alike at 768px);
+// three across from lg. Shared verbatim by the skeletons so the layout
+// doesn't shift when the fetch settles. Three items in a two-column grid
+// leaves the third sitting alone in the first column on tablet - preferred
+// over stretching a single card to the full section width.
 const GRID_CLASS =
-	"mx-auto mt-10 grid max-w-2xl grid-cols-1 gap-4 lg:max-w-none lg:grid-cols-3";
+	"mx-auto mt-10 grid max-w-2xl grid-cols-1 gap-4 sm:max-w-none sm:grid-cols-2 lg:grid-cols-3";
 
 export default function LatestOpportunitiesSection() {
 	const { t } = useTranslation();


### PR DESCRIPTION
## What

`LatestOpportunitiesSection` (the homepage's "Diese Einsätze suchen Leute" preview) now switches to a 2-column grid at the same `sm` (640px) breakpoint `/opportunities` uses, instead of staying single-column until `lg` (1024px).

## Why

Both surfaces render the same `OpportunityListItem` card, so they should look alike at the same viewport. At 768px, `/opportunities` already showed a clean 2-column grid (`sm:grid-cols-2`) while the landing preview rendered a single, oversized full-width card - the visual inconsistency reported in the issue.

Closes #1914

The previous `GRID_CLASS` comment explained a deliberate reason for *not* adding `sm:grid-cols-2`: with exactly 3 preview cards, a 2-column grid leaves the third card alone in the first column on tablet widths. That trade-off is accepted here (an odd card sitting in one half-width column) as clearly preferable to the reported bug (a single card stretched to the full section width) and to the tablet-width inconsistency with `/opportunities`. The code comment was updated to document this new reasoning rather than leaving the old (now inaccurate) rationale in place.

## Testing

- `pnpm lint`, `pnpm check`, `pnpm test` (264/264 passing) - all green
- Added `LandingPreview_AtTabletViewport_IsTwoColumnGridLikeOpportunitiesList` to `backend/tests/VisualTests/LandingOpportunityPreviewTests.cs`: seeds two fresh published opportunities and asserts, at a 768px viewport, the preview's `display: grid` and that the first two cards land side by side (same row) rather than stacked - the same side-by-side check `ListLayoutGridTests` uses for `/opportunities` itself. This runs against the local Aspire stack in CI (`dotnet.yml`).
- `a11y-check` subagent reviewed the diff: no a11y impact (pure CSS breakpoint change, DOM/focus order unaffected).
- Could not run `dotnet build`/the VisualTests suite locally in this sandbox (no `dotnet` reachable - outbound access to `builds.dotnet.microsoft.com` is blocked by this session's network policy); relying on CI (`dotnet.yml`) to compile and run the new test, and will fix anything it flags.

## Live verification

Skipped per explicit instruction for this task not to cut a release candidate. This is a pure Tailwind breakpoint change on an existing component with a dedicated VisualTests regression covering the fixed behavior (see Testing above), so CI's `dotnet.yml` run against the local Aspire stack is the verification for this PR.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (updated the stale `GRID_CLASS` comment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHepmJyJjbPmN4tmVQoF7N)_