### PR TITLE
fix(backend): remove InvitationReceived notification when its invitation resolves

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -196,6 +196,17 @@ public interface IApplicationDbContext
 		UserId recipientId,
 		CancellationToken cancellationToken = default);
 
+	// Deletes any InvitationReceived notification(s) still pointing at this
+	// invitation (einsatzbereit#1919) - called wherever an invitation stops
+	// being actionable (accepted/declined/expired/dismissed) so a stale
+	// notification never survives to be clicked into a /my-signups page with
+	// no trace of what it was about. Scoped to a set rather than a single row
+	// as a defensive match for RelatedEntityId, not because callers expect
+	// more than one.
+	Task DeleteInvitationReceivedNotificationsAsync(
+		Guid invitationId,
+		CancellationToken cancellationToken = default);
+
 	Task<List<Engagement>> GetEngagementsForVolunteerTrackingAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
+++ b/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
@@ -40,6 +40,13 @@ internal sealed class AcceptInvitationCommandHandler(
 
 		invitation.Accept().ThrowIfFailure();
 
+		// #1919: the InvitationReceived notification's job is done the moment
+		// this invitation stops being actionable - leaving it in place meant
+		// clicking it later (from the bell's recent-notifications list, still
+		// unread or not) landed on /my-signups with no trace of what it was
+		// about.
+		await dbContext.DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
+
 		await keycloakOrganizationService.AddMemberAsync(
 			invitation.OrganizationId.Value,
 			invitation.InviteeId.Value,

--- a/backend/src/Application/Invitations/DeclineInvitation/v1/DeclineInvitationCommandHandler.cs
+++ b/backend/src/Application/Invitations/DeclineInvitation/v1/DeclineInvitationCommandHandler.cs
@@ -21,6 +21,12 @@ internal sealed class DeclineInvitationCommandHandler(
 			throw new ResultFailureException(Error.Forbidden("OrganizationInvitation.NotRecipient", "You are not the recipient of this invitation."));
 
 		invitation.Decline().ThrowIfFailure();
+
+		// #1919: see AcceptInvitationCommandHandler - a declined invitation is
+		// just as resolved as an accepted one, and its InvitationReceived
+		// notification would otherwise dead-end the same way.
+		await dbContext.DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return true;

--- a/backend/src/Application/Organizations/DismissInvitation/v1/DismissInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DismissInvitation/v1/DismissInvitationCommandHandler.cs
@@ -36,6 +36,11 @@ internal sealed class DismissInvitationCommandHandler(
 		if (invitation.Status == InvitationStatus.Accepted)
 			throw new ResultFailureException(Error.Conflict("OrganizationInvitation.AlreadyAccepted", "Accepted invitations cannot be dismissed."));
 
+		// #1919: an organizer dismissing (revoking) an invitation deletes the
+		// row outright, so the invitee's InvitationReceived notification would
+		// otherwise point at an invitation that no longer exists at all.
+		await dbContext.DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
+
 		dbContext.OrganizationInvitations.Delete(invitation);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
+++ b/backend/src/Application/Organizations/ResendInvitation/v1/ResendInvitationCommandHandler.cs
@@ -41,9 +41,10 @@ internal sealed class ResendInvitationCommandHandler(
 
 		invitation.Resend(DateTimeOffset.UtcNow).ThrowIfFailure();
 
-		// A fresh, unread notification - the original one (if still unread) stays
-		// as-is, but the invitee should see this bump in their bell dropdown the
-		// same way they would for a brand new invitation.
+		// A fresh, unread notification. Resend only reaches an Expired invitation
+		// (guard above), and InvitationExpiryJob now deletes the InvitationReceived
+		// notification from that same expiry (#1919), so there is never a stale
+		// original left behind here for the invitee to see twice.
 		var notification = Notification.Create(
 			invitation.InviteeId,
 			NotificationKind.InvitationReceived,

--- a/backend/src/Infrastructure/BackgroundJobs/InvitationExpiryJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/InvitationExpiryJob.cs
@@ -102,7 +102,16 @@ internal sealed class InvitationExpiryJob(
 			return 0;
 
 		foreach (var invitation in dueInvitations)
+		{
 			invitation.Expire(now).ThrowIfFailure();
+
+			// #1919: an expired invitation is just as resolved as an
+			// accepted/declined one - without this, its InvitationReceived
+			// notification stuck around indefinitely (it's never marked read
+			// automatically), pointing the invitee at a /my-signups page with
+			// nothing left to show for it.
+			await dbContext.DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
+		}
 
 		await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -383,6 +383,13 @@ internal sealed class ApplicationDbContext(
 			.Where(n => n.RecipientId == recipientId && n.IsRead)
 			.ExecuteDeleteAsync(cancellationToken);
 
+	public async Task DeleteInvitationReceivedNotificationsAsync(
+		Guid invitationId,
+		CancellationToken cancellationToken = default) =>
+		await Set<Notification>()
+			.Where(n => n.Kind == NotificationKind.InvitationReceived && n.RelatedEntityId == invitationId)
+			.ExecuteDeleteAsync(cancellationToken);
+
 	public async Task<List<Engagement>> GetEngagementsForVolunteerTrackingAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default) =>

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
@@ -122,6 +122,7 @@ public class AcceptInvitationCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>();
 		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -141,6 +142,26 @@ public class AcceptInvitationCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>();
 		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteInvitationReceivedNotification_OnAccept(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1919: an accepted invitation is resolved, so its
+		// InvitationReceived notification must not survive to be clicked into a
+		// /my-signups page with nothing left to show for it.
+		// Arrange
+		var invitation = CreatePendingInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new AcceptInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _dbContext.Received(1).DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
 	}
 
 	[Test]
@@ -166,5 +187,6 @@ public class AcceptInvitationCommandHandlerTests
 		result.Should().BeTrue();
 		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/DeclineInvitation/DeclineInvitationCommandHandlerTests.cs
@@ -45,6 +45,7 @@ public class DeclineInvitationCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		invitation.Status.Should().Be(InvitationStatus.Declined);
+		await _dbContext.Received(1).DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}
 
@@ -64,6 +65,7 @@ public class DeclineInvitationCommandHandlerTests
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.NotFound);
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -84,6 +86,7 @@ public class DeclineInvitationCommandHandlerTests
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
 		invitation.Status.Should().Be(InvitationStatus.Pending);
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -103,6 +106,7 @@ public class DeclineInvitationCommandHandlerTests
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Conflict);
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -122,5 +126,6 @@ public class DeclineInvitationCommandHandlerTests
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Conflict);
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DismissInvitation/DismissInvitationCommandHandlerTests.cs
@@ -85,6 +85,7 @@ public class DismissInvitationCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		_invitationRepo.Received(1).Delete(invitation);
+		await _dbContext.Received(1).DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}
 
@@ -103,6 +104,7 @@ public class DismissInvitationCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		_invitationRepo.Received(1).Delete(invitation);
+		await _dbContext.Received(1).DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}
 
@@ -124,6 +126,7 @@ public class DismissInvitationCommandHandlerTests
 		// Assert
 		result.Should().BeTrue();
 		_invitationRepo.Received(1).Delete(invitation);
+		await _dbContext.Received(1).DeleteInvitationReceivedNotificationsAsync(invitation.Id.Value, cancellationToken);
 		await _unitOfWork.Received(1).SaveChangesAsync(cancellationToken);
 	}
 
@@ -144,6 +147,7 @@ public class DismissInvitationCommandHandlerTests
 		await act.Should().ThrowAsync<ResultFailureException>()
 			.WithMessage("*Accepted invitations*");
 		_invitationRepo.DidNotReceive().Delete(Arg.Any<OrganizationInvitation>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 		await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/IntegrationTests/InvitationExpiryJobTests.cs
+++ b/backend/tests/IntegrationTests/InvitationExpiryJobTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using AwesomeAssertions;
+using Domain.Notifications;
 using Domain.Organizations;
 using Domain.Users;
 using Infrastructure.BackgroundJobs;
@@ -65,6 +66,34 @@ public class InvitationExpiryJobTests(IntegrationTestFixture fixture)
 			.Select(i => i.Status)
 			.SingleAsync(cancellationToken);
 		status.Should().Be(InvitationStatus.Pending);
+	}
+
+	[Test]
+	public async Task ExpireDueInvitationsAsync_PendingInvitationPastItsWindow_DeletesItsInvitationReceivedNotification(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1919: an expired invitation's InvitationReceived
+		// notification is never marked read automatically, so without this it
+		// stuck around forever, pointing the invitee at a /my-signups page with
+		// nothing left to show for it.
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var createdAt = DateTimeOffset.UtcNow.AddDays(-(OrganizationInvitation.ExpiryWindowDays + 1));
+		var invitationId = await SeedInvitationAsync(dbContext, createdAt, cancellationToken);
+
+		var notification = Notification.Create(UserId.New(), NotificationKind.InvitationReceived, invitationId.Value);
+		dbContext.Set<Notification>().Add(notification);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var expired = await InvitationExpiryJob.ExpireDueInvitationsAsync(
+			dbContext, DateTimeOffset.UtcNow, cancellationToken);
+
+		expired.Should().Be(1);
+
+		var remainingNotification = await dbContext.Set<Notification>()
+			.AsNoTracking()
+			.Where(n => n.Id == notification.Id)
+			.SingleOrDefaultAsync(cancellationToken);
+		remainingNotification.Should().BeNull();
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -242,6 +242,84 @@ public class NotificationTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetMyNotifications_InvitationReceived_IsRemoved_WhenInvitationIsAccepted(
+		CancellationToken cancellationToken)
+	{
+		// Regression for #1919: an accepted invitation is resolved, so its
+		// InvitationReceived notification must not survive to be clicked into a
+		// /my-signups page with nothing left to show for it.
+		const string organizationName = "Invitation Accept Cleanup Test Org";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		var beforeAccept = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		beforeAccept.Items.Should().Contain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+
+		await veraClient.AcceptInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var afterAccept = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		afterAccept.Items.Should().NotContain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+	}
+
+	[Test]
+	public async Task GetMyNotifications_InvitationReceived_IsRemoved_WhenInvitationIsDeclined(
+		CancellationToken cancellationToken)
+	{
+		const string organizationName = "Invitation Decline Cleanup Test Org";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		var beforeDecline = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		beforeDecline.Items.Should().Contain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+
+		await veraClient.DeclineInvitationAsync(invitation.InvitationId, cancellationToken);
+
+		var afterDecline = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		afterDecline.Items.Should().NotContain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+	}
+
+	[Test]
+	public async Task GetMyNotifications_InvitationReceived_IsRemoved_WhenOrganizerDismissesInvitation(
+		CancellationToken cancellationToken)
+	{
+		// An organizer revoking a still-Pending invitation (#1040) deletes the
+		// invitation row outright - the invitee's InvitationReceived notification
+		// would otherwise point at an invitation that no longer exists at all.
+		const string organizationName = "Invitation Dismiss Cleanup Test Org";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var org = await olafClient.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = organizationName }, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var vera = await veraClient.GetUserProfileAsync(cancellationToken);
+		var invitation = await olafClient.CreateInvitationAsync(
+			org.Id.Value, new CreateInvitationRequest { InviteeId = vera.Id, Role = "Member" }, cancellationToken);
+
+		var beforeDismiss = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		beforeDismiss.Items.Should().Contain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+
+		await olafClient.DismissInvitationAsync(org.Id.Value, invitation.InvitationId, cancellationToken);
+
+		var afterDismiss = await veraClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+		afterDismiss.Items.Should().NotContain(n => n.Kind == "InvitationReceived" && n.RelatedTitle == organizationName);
+	}
+
+	[Test]
 	public async Task GetMyNotifications_FeedbackSubmitted_HasRelatedTitleAndOrganizerDashboardUrl(
 		CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
## What

When an organization invitation is accepted, declined, expires, or is dismissed (revoked) by an organizer, its `InvitationReceived` notification is now deleted along with it.

## Why

Clicking an org-invitation notification always navigates to `/my-signups` by design. But the notification's lifecycle was never tied to the underlying invitation's resolution state - once the invitation was accepted/declined/expired/dismissed, the notification stuck around (it's never marked read automatically), so clicking it later landed on `/my-signups` with no trace of the invitation and no explanation of why nothing was there.

This adds `IApplicationDbContext.DeleteInvitationReceivedNotificationsAsync(invitationId, ct)` and calls it from every place an invitation stops being actionable:
- `AcceptInvitationCommandHandler`
- `DeclineInvitationCommandHandler`
- `DismissInvitationCommandHandler` (organizer revokes - deletes the invitation row outright)
- `InvitationExpiryJob` (background expiry sweep)

All four already run inside `TransactionPipelineBehavior`'s ambient DB transaction (or, for the job, a single `SaveChangesAsync`), so the notification delete is atomic with the state change that makes it stale - no window where a resolved invitation still has a live notification.

`ResendInvitationCommandHandler`'s comment was updated to reflect that a stale original can no longer exist by the time a resend is even possible (resend only reaches an `Expired` invitation, and expiry now clears its notification in the same step).

Closes #1919

## Testing

- `Application.UnitTests`: added/extended coverage in `AcceptInvitationCommandHandlerTests`, `DeclineInvitationCommandHandlerTests`, and `DismissInvitationCommandHandlerTests` asserting the notification-cleanup call fires on the success path and does *not* fire on every failure path (not found / forbidden / conflict / idempotent no-op).
- `IntegrationTests`: added `NotificationTests` cases exercising the real accept/decline/dismiss flows end-to-end against a live Postgres, asserting the `InvitationReceived` notification is present before and gone after. Added an `InvitationExpiryJobTests` case seeding a notification and asserting it's deleted once its invitation expires.

I could not run `dotnet build`/the test suites locally in this sandbox - the .NET SDK installer (`builds.dotnet.microsoft.com`) is blocked by this session's egress policy (403), and per this repo's `AGENTS.md` the `IntegrationTests`/`VisualTests` projects need real container networking unavailable here regardless. CI's `dotnet.yml` will run the full suite (`Application.UnitTests`, `ArchitectureTests`, `IntegrationTests`, `VisualTests`) on push.

## Live verification

Not performed for this PR - no release candidate was cut (explicitly out of scope for this change per instruction). No EF model/schema change is involved (confirmed via this repo's `ef-migration-check` subagent - the fix is a new query method against the existing `Notification` table, no new entity/migration needed), so there's no deploy-time risk beyond what the automated test suites above already cover.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (in-code comments only; no user-facing docs affected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVrV1wdirt8gPuWFGSsaxp)_