### PR TITLE
fix: use two-letter monogram in organization directory

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -760,6 +760,48 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task Directory_ShowsTwoLetterMonogram_MatchingEveryOtherSurface()
+	{
+		// Regression for #1916: OrganizationsPage rendered org.name.charAt(0) - a
+		// single letter, indistinguishable between organizations that share a
+		// first word - while every other surface (header org switcher,
+		// opportunity cards, org profile page) already renders getInitials' two-
+		// letter monogram. Reuses the exact two organization names the issue
+		// itself cited, already covered by initials.test.ts's assertions that
+		// "Lindenauer Nachbarschaftshilfe e.V." -> "LN" and
+		// "Lindenauer Tierschutzverein e.V." -> "LT" - the random suffix below is
+		// appended to "Lindenauer" itself (no new word) so those two-letter
+		// results still hold.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olaf = await Fixture.SignInAsync("olaf", "olaf123");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olaf.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var neighborhoodName = $"Lindenauer{suffix} Nachbarschaftshilfe e.V.";
+		var animalShelterName = $"Lindenauer{suffix} Tierschutzverein e.V.";
+
+		foreach (var name in new[] { neighborhoodName, animalShelterName })
+			(await http.PostAsJsonAsync("/v1/organizations", new { name })).EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.Locator("#organizations-search").FillAsync($"Lindenauer{suffix}");
+
+		var neighborhoodCard = Page.Locator("li").Filter(new() { HasTextString = neighborhoodName });
+		var animalShelterCard = Page.Locator("li").Filter(new() { HasTextString = animalShelterName });
+		await Expect(neighborhoodCard).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(animalShelterCard).ToBeVisibleAsync();
+
+		(await neighborhoodCard.Locator("span").First.TextContentAsync()).Should().Be("LN");
+		(await animalShelterCard.Locator("span").First.TextContentAsync()).Should().Be("LT");
+	}
+
+	[Test]
 	public async Task PublicProfilePage_ContentIsLeftAlignedUnderHeading()
 	{
 		// Regression for #766: OrganizationProfileView's content wrapper had

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -9,6 +9,7 @@ import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { getApiErrorMessage } from "../lib/apiError";
 import { avatarColorClasses } from "../lib/avatarColor";
+import { getInitials } from "../lib/initials";
 import { cardClass } from "../lib/surfaceClasses";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
@@ -241,7 +242,7 @@ export default function OrganizationsPage() {
 												<span
 													className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-semibold ${avatarColor.bg} ${avatarColor.text}`}
 												>
-													{org.name.charAt(0).toUpperCase()}
+													{getInitials(org.name)}
 												</span>
 											)}
 											<div className="flex min-w-0 flex-1 items-center gap-2">


### PR DESCRIPTION
## What

`/organizations` now renders the same two-letter monogram (via the shared `getInitials()` helper) as every other surface in the app, instead of a bare single-letter initial for organizations without a logo.

## Why

The public organization directory rendered `org.name.charAt(0).toUpperCase()` - a single letter that's indistinguishable between two organizations sharing a first word (e.g. "Lindenauer Nachbarschaftshilfe e.V." and "Lindenauer Tierschutzverein e.V." both showed a plain "L"). Every other surface - the header org switcher, opportunity cards, and the org profile page - already renders the shared `getInitials()` two-letter monogram ("LN"/"LT"), and the organization directory is the one page whose entire purpose is telling organizations apart.

Closes #1916

## Testing

- `pnpm lint`, `pnpm check`, `pnpm format:check`, `pnpm test` (264 tests) all pass locally.
- Added `Directory_ShowsTwoLetterMonogram_MatchingEveryOtherSurface` to `backend/tests/VisualTests/OrganizationTests.cs` - creates two organizations sharing the "Lindenauer" first word (the exact example names from the issue) and asserts the directory renders distinguishable "LN"/"LT" monograms instead of an ambiguous "L" for both. Runs as part of `dotnet.yml`'s CI suite; could not be run locally in this sandbox (no Docker/Aspire orchestration available in this session - see root `AGENTS.md`'s Sandbox Limitations).

## Live verification

Skipped for this PR at the requester's explicit instruction (no release candidate was cut). The durable regression test above is the reviewable proof of the fix instead, and will run against the local Aspire stack in CI.

## Checklist

- [x] `/self-review` run and findings addressed (diff also checked against the `a11y-check` subagent - no issues, the two-letter change doesn't alter the span's accessibility semantics)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this avatar behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Lwif1j98eDTEGQ7y7X3TY)_