### PR TITLE
fix: show specific withdraw error on /my-signups instead of generic retry loop

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2487,7 +2487,9 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GetByTestId("filter-frequency").ClickAsync();
 		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
 
-		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
+		await Expect(
+			Page.GetByTestId("opportunities-filter-bar")
+				.GetByRole(AriaRole.Button, new() { Name = "Reset" }))
 			.ToBeVisibleAsync();
 
 		var result = await Page.RunAxe();

--- a/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
@@ -1,0 +1,106 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #1918: WithdrawEngagementErrorMessageTests already covers
+/// VolunteerOpportunityDetailPage.tsx's withdraw dialog reacting to the
+/// server's specific errorCode (fixed under #1849), but
+/// MyEngagementsPage/ActivitySection.tsx's own handleWithdrawConfirm - the
+/// /my-signups page's withdraw flow the bug was actually filed against - was
+/// never switched over to getApiErrorMessage() at the same time, and kept
+/// checking `err instanceof Error`. That is never true for the parsed
+/// ProblemDetails object the NSwag client throws, so every withdrawal
+/// failure on this page, regardless of cause, fell back to the generic
+/// "Could not withdraw your sign-up. Please try again." - looping the same
+/// unhelpful message on a retry that could only ever fail the same way.
+///
+/// Reproduced here the same way as WithdrawEngagementErrorMessageTests: the
+/// engagement is withdrawn out-of-band while the confirm dialog is open, so
+/// confirming it hits Engagement.AlreadyTerminated (409 Conflict).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MyEngagementsWithdrawErrorMessageTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task MySignupsPage_ShowsSpecificTerminatedMessage_NotGenericWithdrawFallback()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N");
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"MyEngagementsWithdrawErrorMessage Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"MyEngagementsWithdrawErrorMessage Opportunity {suffix}",
+			description = "Created by MyEngagementsWithdrawErrorMessageTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var veraToken = (await Fixture.SignInAsync("vera", "vera123")).AccessToken;
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraToken}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Ready to help with MyEngagementsWithdrawErrorMessageTests." });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Pending engagements already show the Withdraw button on this page
+		// (unlike the detail page's application-status card, which only shows
+		// it once Confirmed), so no confirm step is needed here.
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+
+		// This is a shared Aspire session (~50 VisualTests classes running
+		// concurrently) - vera can have other no-time-slot engagements ahead of
+		// this one on the "Current & upcoming" scope's page-1, so page through
+		// to it the same way MyEngagementsTests does rather than assuming it
+		// lands on the first page.
+		await Expect(Page.Locator("#activity [data-testid='engagement-card']").First)
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await LoadMoreUntilVisibleAsync(card);
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await card.GetByRole(AriaRole.Button, new() { Name = "Withdraw" }).ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Expect(dialog).ToBeVisibleAsync();
+
+		// Withdraw out-of-band while the dialog sits open - the page's own list
+		// state still shows the sign-up as active, so confirming below sends a
+		// withdraw request the server can no longer honour.
+		(await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null))
+			.EnsureSuccessStatusCode();
+
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Yes, withdraw" }).ClickAsync();
+
+		var errorBanner = dialog.GetByRole(AriaRole.Alert);
+		await Expect(errorBanner).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(errorBanner).ToHaveTextAsync("Sign-up is already terminated.");
+	}
+}

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -139,7 +139,7 @@ export default function ActivitySection() {
 			setConfirmWithdrawId(null);
 		} catch (err) {
 			setWithdrawError(
-				err instanceof Error ? err.message : t("myEngagements.withdrawError"),
+				getApiErrorMessage(err, t("myEngagements.withdrawError")),
 			);
 		} finally {
 			setWithdrawing(false);


### PR DESCRIPTION
## What

`/my-signups` (`MyEngagementsPage/ActivitySection.tsx`) now shows the server's specific, actionable reason when a withdraw fails (e.g. "Sign-up is already terminated.") instead of always showing the generic "Could not withdraw your sign-up. Please try again." message.

## Why

Closes #1918

The backend's `WithdrawEngagementCommandHandler`/`Engagement.Withdraw()` already return a specific `errorCode` (e.g. `Engagement.AlreadyTerminated`, `Engagement.NotOwner`, `Engagement.CheckedIn`) with the correct HTTP status for every distinguishable failure, and both locales already have a translated message for every one of those codes under `apiError.Engagement.*`. The bug was purely on the frontend: `handleWithdrawConfirm`'s catch block in `ActivitySection.tsx` checked `err instanceof Error`, which is never true for the parsed `ProblemDetails` object the NSwag-generated client throws on every API failure - so the specific message was silently discarded and the generic fallback shown every time, regardless of cause. This is exactly what #1849 already fixed on the sibling withdraw flow in `VolunteerOpportunityDetailPage.tsx` (switching to the existing `getApiErrorMessage()` helper, which was already imported in this file for other error handlers) - that fix just never made it to this page's own withdraw handler.

This also explains the reproduction in the issue: the volunteer's stuck sign-up had already been withdrawn/removed server-side (evidenced by the organizer's mismatched "0 Anmeldungen" count), so every retry legitimately hit `Engagement.AlreadyTerminated` (409) and the UI discarded that specific reason every time, looping the same unhelpful message forever. The underlying stuck staging record itself is a data issue (per the issue's own text, a candidate for `reset-staging.yml` or a manual fix), not something this code change addresses.

## Testing

- Added `backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs`, a Playwright regression test for the `/my-signups` page mirroring the existing `WithdrawEngagementErrorMessageTests.cs` (which covers the already-fixed detail-page flow): it withdraws an engagement out-of-band while the confirm dialog is open, so confirming the withdraw hits `Engagement.AlreadyTerminated` (409), and asserts the dialog's alert banner shows the specific "Sign-up is already terminated." message rather than the generic fallback.
- `pnpm check` (tsc), `pnpm lint`, `pnpm format:check`, and `pnpm test` (vitest, 264 tests) all pass locally.
- Backend build/tests could not be run in this sandbox (`dotnet` SDK install is blocked by the session's egress policy - `builds.dotnet.microsoft.com` returns 403) - relying on CI's `dotnet.yml` to run `Application.UnitTests`/`ArchitectureTests`/`IntegrationTests`/`VisualTests`, including the new test above.

## Live verification

Skipped per explicit instruction for this task (no release candidate cut). The fix is a one-line frontend change reusing an existing, already-verified helper (`getApiErrorMessage`) and existing, already-translated error strings - the same mechanism #1849's live-verified fix used for the sibling page - plus the new `VisualTests` regression case above, which CI will run against the local Aspire stack.

## Checklist

- [x] `/self-review` run and findings addressed (clean - no P1-P4 findings; `a11y-check` subagent confirmed no markup/ARIA/focus impact and no new page requiring an `AccessibilityTests.cs` case)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (no docs impact - internal error-handling fix, no new locale keys, no behavior change beyond which existing string is shown)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TG7uxgcAhuoSvtvgvgRz4e)_