### PR TITLE
fix(frontend): replace native required-field tooltip on sign-up message with translated inline error

### DIFF
--- a/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
+++ b/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
@@ -10,6 +10,12 @@ namespace VisualTests;
 /// Regression for #679: the "Message" textarea on a non-ScheduledSlots (Express
 /// interest) sign-up was silently HTML-required with no visible/accessible
 /// indication, so its markup had never been exercised by AccessibilityTests.
+///
+/// Regression for #1908: that same HTML `required` attribute made an empty
+/// submit fall back to the browser's own native constraint-validation
+/// tooltip, which follows the browser/OS UI language rather than the page's
+/// chosen language. The field is validated in script now, surfacing a
+/// translated inline message instead.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class SignUpModalMessageFieldTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -58,11 +64,54 @@ public class SignUpModalMessageFieldTests(AspireFixture fixture) : VisualTestBas
 
 		// The accessible name is the field name alone since #1797 unified the
 		// required marker: the visible marker is an aria-hidden asterisk and
-		// the native `required` below is what announces the field as required.
+		// `aria-required` below is what announces the field as required. Not
+		// the native `required` attribute (#1908) - that also runs the
+		// browser's own constraint validation, which pops a native tooltip in
+		// the browser/OS UI language rather than the page's chosen language.
 		var messageField = Page.GetByRole(AriaRole.Textbox, new() { Name = "Message", Exact = true });
 		await Expect(messageField).ToBeVisibleAsync();
-		await Expect(messageField).ToHaveAttributeAsync("required", "");
+		await Expect(messageField).Not.ToHaveAttributeAsync("required", "");
+		await Expect(messageField).ToHaveAttributeAsync("aria-required", "true");
 		await Expect(Page.Locator("label[for='sign-up-message']")).ToHaveTextAsync("Message*");
+	}
+
+	[Test]
+	public async Task SignUpModal_ExpressInterest_EmptyMessage_ShowsLocalizedInlineError()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync("MessageFieldInlineError");
+		var detailUrl = $"{origin}/volunteer-opportunities/{opportunityId}";
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync(detailUrl);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+		var dialog = Page.Locator("[role='dialog']");
+		await Page.WaitForSelectorAsync("[role='dialog']");
+
+		// Submit with the "Message" field left empty - scoped to the dialog
+		// since the submit button shares its label with the trigger behind it
+		// ("Express interest" end to end, #1775).
+		await dialog.GetByRole(AriaRole.Button, new() { Name = "Express interest" }).ClickAsync();
+
+		// The dialog must stay open (no submit went out) and show the
+		// translated inline message rather than a native browser tooltip,
+		// which this test's Chromium instance would render in English
+		// regardless of the page's language.
+		await Expect(dialog).ToBeVisibleAsync();
+		var messageField = Page.GetByRole(AriaRole.Textbox, new() { Name = "Message", Exact = true });
+		await Expect(messageField).ToHaveAttributeAsync("aria-invalid", "true");
+		await Expect(messageField).ToHaveAttributeAsync("aria-describedby", "sign-up-message-error");
+		await Expect(Page.Locator("#sign-up-message-error")).ToHaveTextAsync("Please enter a message.");
+
+		// Typing clears the error instead of leaving stale, now-wrong text
+		// under a field the volunteer has already fixed.
+		await messageField.FillAsync("Applying via VisualTests regression check.");
+		await Expect(Page.Locator("#sign-up-message-error")).Not.ToBeVisibleAsync();
+		await Expect(messageField).Not.ToHaveAttributeAsync("aria-invalid", "true");
 	}
 
 	private async Task<string> CreateIndividualContactOpportunityAsync(string label)

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
@@ -37,17 +37,34 @@ export default function SignUpModal({
 	const [message, setMessage] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [messageError, setMessageError] = useState<string | null>(null);
+	const messageFieldRef = useRef<HTMLTextAreaElement>(null);
 
 	const isScheduledSlots = participationType === "ScheduledSlots";
 
+	// Native `required` used to move focus to the invalid field for free as
+	// part of the browser's own constraint validation - #1908 replaced that
+	// validation with a translated inline message, so focus has to be sent
+	// there by hand (mirrors DetailsStep.tsx's error-focus effect, whose
+	// equivalent is react-hook-form's default `shouldFocusError` elsewhere).
+	useEffect(() => {
+		if (!messageError) return;
+		messageFieldRef.current?.focus();
+	}, [messageError]);
+
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
+		setError(null);
 		if (isScheduledSlots && timeSlots.length > 0 && !selectedTimeSlotId) {
 			setError(t("signUp.selectTimeSlotRequired"));
 			return;
 		}
+		if (!isScheduledSlots && !message.trim()) {
+			setMessageError(t("signUp.messageRequired"));
+			return;
+		}
+		setMessageError(null);
 		setSubmitting(true);
-		setError(null);
 
 		try {
 			await api.createEngagement(opportunityId, {
@@ -142,13 +159,30 @@ export default function SignUpModal({
 						</label>
 						<textarea
 							id="sign-up-message"
+							ref={messageFieldRef}
 							value={message}
-							onChange={(e) => setMessage(e.target.value)}
-							required
+							onChange={(e) => {
+								setMessage(e.target.value);
+								if (messageError) setMessageError(null);
+							}}
+							aria-required="true"
+							aria-invalid={messageError ? true : undefined}
+							aria-describedby={
+								messageError ? "sign-up-message-error" : undefined
+							}
 							rows={4}
 							placeholder={t("signUp.messagePlaceholder")}
 							className={textareaClass}
 						/>
+						{messageError && (
+							<p
+								id="sign-up-message-error"
+								className="mt-1 text-xs text-red-600"
+								role="alert"
+							>
+								{messageError}
+							</p>
+						)}
 					</div>
 				)}
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -380,7 +380,8 @@
       "submitInterest": "Interesse bekunden",
       "cancel": "Abbrechen",
       "unknownError": "Unbekannter Fehler",
-      "selectTimeSlotRequired": "Bitte wähle einen Zeitslot aus."
+      "selectTimeSlotRequired": "Bitte wähle einen Zeitslot aus.",
+      "messageRequired": "Bitte gib eine Nachricht ein."
     },
     "organization": {
       "create": "Organisation erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -380,7 +380,8 @@
       "submitInterest": "Express interest",
       "cancel": "Cancel",
       "unknownError": "Unknown error",
-      "selectTimeSlotRequired": "Please select a time slot."
+      "selectTimeSlotRequired": "Please select a time slot.",
+      "messageRequired": "Please enter a message."
     },
     "organization": {
       "create": "Create organization",


### PR DESCRIPTION
## What

The "Message" field on the "Interesse bekunden" (express interest) sign-up modal now validates in script and shows a translated inline error instead of relying on the browser's native `required`-field constraint validation.

## Why

The textarea used the native HTML `required` attribute, so submitting the sign-up modal with an empty "Nachricht" field popped the browser's own constraint-validation tooltip ("Please fill out this field.") in the browser/OS UI language, regardless of the page's chosen language (e.g. English tooltip on an otherwise entirely German modal).

Removed the native `required` attribute and replaced it with manual validation in `handleSubmit`: an empty message now sets a `messageError` state, sourced from the same i18n strings as the rest of the form (`signUp.messageRequired`), rendered as an inline message below the field - mirroring the existing `FloatingField` error pattern used in `CreateVolunteerOpportunityModal`. `aria-required`/`aria-invalid`/`aria-describedby` keep the field's accessible semantics, and focus is sent to the field on error (native `required` used to do this for free as part of the browser's own validation).

Closes #1908

## Testing

- `pnpm check` (tsc), `pnpm lint` (eslint), `pnpm test` (vitest, 264 tests), `pnpm format:check` (Prettier), `pnpm i18n:check` (locale key parity) - all pass locally.
- `/self-review` run: `a11y-check` and `i18n-check` subagents both reviewed the diff. `a11y-check` flagged that removing native `required` also silently dropped the browser's automatic focus-to-invalid-field behavior - fixed by adding a `useEffect` that focuses the message field when `messageError` is set (mirrors `DetailsStep.tsx`'s existing error-focus pattern / react-hook-form's `shouldFocusError` used elsewhere in the app). Self-review also caught that the early return for an empty message left a previous top-level API error banner stale on screen alongside the new inline error - fixed by clearing it at the top of `handleSubmit`.
- Updated `backend/tests/VisualTests/SignUpModalMessageFieldTests.cs`: the existing `SignUpModal_MessageField_IsLabelledAndMarkedRequired` test asserted the native `required` attribute existed - updated to assert it's absent and `aria-required="true"` is present instead. Added a new test, `SignUpModal_ExpressInterest_EmptyMessage_ShowsLocalizedInlineError`, that submits with an empty message and asserts the dialog stays open, `aria-invalid`/`aria-describedby` are wired up, the translated inline text renders, and typing clears the error again.
- Could not run the backend build/VisualTests locally in this sandbox (`builds.dotnet.microsoft.com` is blocked by this session's network egress policy, so the .NET SDK could not be installed) - CI's `dotnet.yml` will run the full suite including the new/updated `VisualTests` assertions on a real runner.

## Live verification

Per explicit instruction for this task, no release candidate was cut and no live-staging verification was performed. The fix is instead covered by the updated/added assertions in `backend/tests/VisualTests/SignUpModalMessageFieldTests.cs`, which CI's `dotnet.yml` runs against a real Aspire-orchestrated stack (Postgres, Keycloak, backend, frontend) via Playwright - the same mechanism the mandatory deploy-and-verify flow's step 6 requires as the durable, reviewable record of the fix.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal validation UX detail, not a documented behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QybWfURQYyh9QruWTAGu5y)_