### PR TITLE
feat: add per-locale German/English title and description to opportunities

### DIFF
--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityEndpoint.cs
@@ -129,8 +129,10 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 		}
 
 		var command = new CreateVolunteerOpportunityCommand(
-			request.Title ?? string.Empty,
-			request.Description ?? string.Empty,
+			request.TitleDe ?? string.Empty,
+			string.IsNullOrWhiteSpace(request.TitleEn) ? null : request.TitleEn,
+			request.DescriptionDe ?? string.Empty,
+			string.IsNullOrWhiteSpace(request.DescriptionEn) ? null : request.DescriptionEn,
 			OrganizationId.Create(request.OrganizationId).GetValueOrThrow(),
 			request.IsRemote,
 			address,
@@ -152,8 +154,10 @@ internal sealed class CreateVolunteerOpportunityEndpoint
 
 		var response = new CreateVolunteerOpportunityResponse(
 			opportunity.Id.Value,
-			opportunity.Title,
-			opportunity.Description,
+			opportunity.TitleDe,
+			opportunity.TitleEn,
+			opportunity.DescriptionDe,
+			opportunity.DescriptionEn,
 			opportunity.OrganizationId.Value,
 			opportunity.Address?.Street,
 			opportunity.Address?.HouseNumber,

--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityRequest.cs
@@ -3,8 +3,10 @@ using System.ComponentModel.DataAnnotations;
 namespace Api.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 
 public sealed record CreateVolunteerOpportunityRequest(
-	[MaxLength(200)] string? Title,
-	[MaxLength(5000)] string? Description,
+	[MaxLength(200)] string? TitleDe,
+	[MaxLength(200)] string? TitleEn,
+	[MaxLength(5000)] string? DescriptionDe,
+	[MaxLength(5000)] string? DescriptionEn,
 	Guid OrganizationId,
 	bool IsRemote,
 	[MaxLength(200)] string? Street,

--- a/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityResponse.cs
+++ b/backend/src/Api/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityResponse.cs
@@ -2,8 +2,10 @@ namespace Api.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 
 public sealed record CreateVolunteerOpportunityResponse(
 	Guid Id,
-	string Title,
-	string Description,
+	string TitleDe,
+	string? TitleEn,
+	string DescriptionDe,
+	string? DescriptionEn,
 	Guid OrganizationId,
 	string? Street,
 	string? HouseNumber,

--- a/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityEndpoint.cs
@@ -91,8 +91,10 @@ internal sealed class UpdateVolunteerOpportunityEndpoint
 
 		var command = new UpdateVolunteerOpportunityCommand(
 			opportunityId,
-			request.Title ?? string.Empty,
-			request.Description ?? string.Empty,
+			request.TitleDe ?? string.Empty,
+			string.IsNullOrWhiteSpace(request.TitleEn) ? null : request.TitleEn,
+			request.DescriptionDe ?? string.Empty,
+			string.IsNullOrWhiteSpace(request.DescriptionEn) ? null : request.DescriptionEn,
 			request.IsRemote,
 			address,
 			occurrence,

--- a/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityRequest.cs
@@ -3,8 +3,10 @@ using System.ComponentModel.DataAnnotations;
 namespace Api.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
 
 public sealed record UpdateVolunteerOpportunityRequest(
-	[MaxLength(200)] string? Title,
-	[MaxLength(5000)] string? Description,
+	[MaxLength(200)] string? TitleDe,
+	[MaxLength(200)] string? TitleEn,
+	[MaxLength(5000)] string? DescriptionDe,
+	[MaxLength(5000)] string? DescriptionEn,
 	bool IsRemote,
 	[MaxLength(200)] string? Street,
 	[MaxLength(20)] string? HouseNumber,

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7697,8 +7697,10 @@
       },
       "CreateVolunteerOpportunityRequest": {
         "required": [
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "organizationId",
           "isRemote",
           "street",
@@ -7716,13 +7718,25 @@
         ],
         "type": "object",
         "properties": {
-          "title": {
+          "titleDe": {
             "type": [
               "null",
               "string"
             ]
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionEn": {
             "type": [
               "null",
               "string"
@@ -7807,8 +7821,10 @@
       "CreateVolunteerOpportunityResponse": {
         "required": [
           "id",
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "organizationId",
           "street",
           "houseNumber",
@@ -7832,11 +7848,23 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "titleDe": {
             "type": "string"
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
             "type": "string"
+          },
+          "descriptionEn": {
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "organizationId": {
             "type": "string",
@@ -8665,7 +8693,8 @@
       "OrganizationCalendarEventDto": {
         "required": [
           "opportunityId",
-          "title",
+          "titleDe",
+          "titleEn",
           "color",
           "timeSlots"
         ],
@@ -8675,8 +8704,14 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "titleDe": {
             "type": "string"
+          },
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "color": {
             "type": [
@@ -9283,8 +9318,10 @@
       "PublicOpportunitySummaryDto": {
         "required": [
           "id",
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "street",
           "houseNumber",
           "zipCode",
@@ -9303,10 +9340,22 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "titleDe": {
             "type": "string"
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionEn": {
             "type": [
               "null",
               "string"
@@ -10063,8 +10112,10 @@
       },
       "UpdateVolunteerOpportunityRequest": {
         "required": [
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "isRemote",
           "street",
           "houseNumber",
@@ -10080,13 +10131,25 @@
         ],
         "type": "object",
         "properties": {
-          "title": {
+          "titleDe": {
             "type": [
               "null",
               "string"
             ]
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionEn": {
             "type": [
               "null",
               "string"
@@ -10181,8 +10244,10 @@
       "VolunteerOpportunityDetails": {
         "required": [
           "id",
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "organizationId",
           "organizationName",
           "street",
@@ -10210,10 +10275,22 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "titleDe": {
             "type": "string"
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionEn": {
             "type": [
               "null",
               "string"
@@ -10341,8 +10418,10 @@
       "VolunteerOpportunitySummary": {
         "required": [
           "id",
-          "title",
-          "description",
+          "titleDe",
+          "titleEn",
+          "descriptionDe",
+          "descriptionEn",
           "organizationId",
           "organizationName",
           "street",
@@ -10372,10 +10451,22 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "titleDe": {
             "type": "string"
           },
-          "description": {
+          "titleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionDe": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descriptionEn": {
             "type": [
               "null",
               "string"

--- a/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/CancelEngagementCommandHandler.cs
@@ -35,7 +35,7 @@ internal sealed class CancelEngagementCommandHandler(
 			dbContext,
 			engagement,
 			request.Reason,
-			opportunity.Title,
+			opportunity.TitleDe,
 			// The volunteer hears about this only here - no opportunity-level
 			// notification accompanies a single engagement cancellation.
 			notifyVolunteer: true,

--- a/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledNotificationHandler.cs
+++ b/backend/src/Application/Engagements/CancelEngagement/v1/EngagementCancelledNotificationHandler.cs
@@ -36,7 +36,7 @@ internal sealed class EngagementCancelledNotificationHandler(
 		// Falling back to a live lookup only covers callers that didn't have a title
 		// handy to pass into Cancel().
 		var opportunityTitle = notification.OpportunityTitle
-			?? (await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken))?.Title;
+			?? (await dbContext.VolunteerOpportunities.FindAsync(notification.OpportunityId, cancellationToken))?.TitleDe;
 
 		if (opportunityTitle is null)
 		{

--- a/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementOrganizerNotificationHelper.cs
@@ -112,7 +112,7 @@ internal static class EngagementOrganizerNotificationHelper
 				{
 					["OrganizerName"] = organizerName,
 					["VolunteerName"] = volunteerName,
-					["OpportunityTitle"] = opportunity.Title,
+					["OpportunityTitle"] = opportunity.TitleDe,
 				});
 
 			var unsubscribeUrl = unsubscribeLinkBuilder.Build(

--- a/backend/src/Application/Engagements/Common/EngagementVolunteerConfirmationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementVolunteerConfirmationHelper.cs
@@ -75,7 +75,7 @@ internal static class EngagementVolunteerConfirmationHelper
 			new Dictionary<string, string>
 			{
 				["VolunteerName"] = volunteerName,
-				["OpportunityTitle"] = opportunity.Title,
+				["OpportunityTitle"] = opportunity.TitleDe,
 			});
 
 		await emailService.SendAsync(

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/EngagementConfirmedNotificationHandler.cs
@@ -50,7 +50,7 @@ internal sealed class EngagementConfirmedNotificationHandler(
 			new Dictionary<string, string>
 			{
 				["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
-				["OpportunityTitle"] = opportunity.Title,
+				["OpportunityTitle"] = opportunity.TitleDe,
 			});
 
 		var unsubscribeUrl = unsubscribeLinkBuilder.Build(

--- a/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
+++ b/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
@@ -71,7 +71,7 @@ internal sealed class EngagementReminderDueHandler(
 			new Dictionary<string, string>
 			{
 				["DisplayName"] = displayName,
-				["OpportunityTitle"] = opportunity.Title,
+				["OpportunityTitle"] = opportunity.TitleDe,
 				["StartFormatted"] = startFormatted,
 			});
 

--- a/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQueryHandler.cs
+++ b/backend/src/Application/Meta/GetVolunteerOpportunityMeta/v1/GetVolunteerOpportunityMetaQueryHandler.cs
@@ -21,8 +21,8 @@ internal sealed class GetVolunteerOpportunityMetaQueryHandler(
 		var baseUrl = request.BaseUrl.TrimEnd('/');
 
 		return MetaHtmlBuilder.Build(
-			$"{opportunity.Title} - Einsatzbereit",
-			opportunity.Description,
+			$"{opportunity.TitleDe} - Einsatzbereit",
+			opportunity.DescriptionDe,
 			$"{baseUrl}/volunteer-opportunities/{opportunity.Id}",
 			opportunity.BannerImageUrl ?? $"{baseUrl}/og-image.png");
 	}

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
@@ -47,7 +47,7 @@ internal sealed class DeleteOrganizationCommandHandler(
 
 		if (blockingOpportunities.Count > 0)
 		{
-			var titles = string.Join(", ", blockingOpportunities.Select(o => $"'{o.Title}'"));
+			var titles = string.Join(", ", blockingOpportunities.Select(o => $"'{o.TitleDe}'"));
 			throw new ResultFailureException(Error.Conflict(
 				"Organization.HasBlockingOpportunities",
 				$"Conflict: cannot delete organization while it has opportunities with future time slots or active engagements: {titles}. Resolve or cancel these first."));

--- a/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/OrganizationCalendarEventDto.cs
+++ b/backend/src/Application/Organizations/GetOrganizationCalendarEvents/v1/OrganizationCalendarEventDto.cs
@@ -2,7 +2,8 @@ namespace Application.Organizations.GetOrganizationCalendarEvents.v1;
 
 public sealed record OrganizationCalendarEventDto(
 	Guid OpportunityId,
-	string Title,
+	string TitleDe,
+	string? TitleEn,
 	string? Color,
 	IReadOnlyList<CalendarTimeSlotDto> TimeSlots);
 

--- a/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQueryHandler.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/GetPublicOrganizationProfileQueryHandler.cs
@@ -39,8 +39,10 @@ internal sealed class GetPublicOrganizationProfileQueryHandler(
 		var openOpportunities = opportunities
 			.Select(o => new PublicOpportunitySummaryDto(
 				o.Id,
-				o.Title,
-				o.Description,
+				o.TitleDe,
+				o.TitleEn,
+				o.DescriptionDe,
+				o.DescriptionEn,
 				o.Street,
 				o.HouseNumber,
 				o.ZipCode,

--- a/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/PublicOrganizationProfileResponse.cs
+++ b/backend/src/Application/Organizations/GetPublicOrganizationProfile/v1/PublicOrganizationProfileResponse.cs
@@ -19,8 +19,10 @@ public sealed record PublicAddressDto(
 
 public sealed record PublicOpportunitySummaryDto(
 	Guid Id,
-	string Title,
-	string? Description,
+	string TitleDe,
+	string? TitleEn,
+	string? DescriptionDe,
+	string? DescriptionEn,
 	string? Street,
 	string? HouseNumber,
 	string? ZipCode,

--- a/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CancelVolunteerOpportunity/v1/VolunteerOpportunityCancelledDomainEventHandler.cs
@@ -57,7 +57,7 @@ internal sealed class VolunteerOpportunityCancelledDomainEventHandler(
 			dbContext,
 			engagementReadRepository,
 			notification.OpportunityId,
-			opportunity.Title,
+			opportunity.TitleDe,
 			NotificationKind.OpportunityCancelled,
 			engagementCancellationReason,
 			// The OpportunityCancelled notification above already tells the volunteer

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -70,7 +70,7 @@ internal static class VolunteerOpportunityDeletionHelper
 			dbContext,
 			engagementReadRepository,
 			opportunityId,
-			opportunity.Title,
+			opportunity.TitleDe,
 			NotificationKind.OpportunityDeleted,
 			"Opportunity was deleted.",
 			// Kept on: the OpportunityDeleted text says the opportunity was removed

--- a/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommand.cs
@@ -7,8 +7,10 @@ using Domain.VolunteerOpportunities;
 namespace Application.VolunteerOpportunities.CreateVolunteerOpportunity.v1;
 
 public sealed record CreateVolunteerOpportunityCommand(
-	string Title,
-	string Description,
+	string TitleDe,
+	string? TitleEn,
+	string DescriptionDe,
+	string? DescriptionEn,
 	OrganizationId OrganizationId,
 	bool IsRemote,
 	Address? Address,

--- a/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateVolunteerOpportunity/v1/CreateVolunteerOpportunityCommandHandler.cs
@@ -32,8 +32,10 @@ internal sealed class CreateVolunteerOpportunityCommandHandler(
 		// GeocodeVolunteerOpportunityAddressHandler retries it out of band.
 		var opportunity = VolunteerOpportunity.Create(
 			request.OrganizationId,
-			request.Title,
-			request.Description,
+			request.TitleDe,
+			request.TitleEn,
+			request.DescriptionDe,
+			request.DescriptionEn,
 			request.IsRemote,
 			request.Address,
 			request.Occurrence,

--- a/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteTimeSlot/v1/DeleteTimeSlotCommandHandler.cs
@@ -82,7 +82,7 @@ internal sealed class DeleteTimeSlotCommandHandler(
 				dbContext,
 				engagement,
 				"The recurring time slot series was cancelled.",
-				opportunity.Title,
+				opportunity.TitleDe,
 				// Deleting slots out of a series raises no opportunity-level
 				// notification, so this is the volunteer's only in-app signal.
 				notifyVolunteer: true,

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunities/v1/VolunteerOpportunitySummary.cs
@@ -2,8 +2,10 @@ namespace Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
 
 public sealed record VolunteerOpportunitySummary(
 	Guid Id,
-	string Title,
-	string? Description,
+	string TitleDe,
+	string? TitleEn,
+	string? DescriptionDe,
+	string? DescriptionEn,
 	Guid OrganizationId,
 	string OrganizationName,
 	string? Street,

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
@@ -2,8 +2,10 @@ namespace Application.VolunteerOpportunities.GetVolunteerOpportunityDetails.v1;
 
 public sealed record VolunteerOpportunityDetails(
 	Guid Id,
-	string Title,
-	string? Description,
+	string TitleDe,
+	string? TitleEn,
+	string? DescriptionDe,
+	string? DescriptionEn,
 	Guid OrganizationId,
 	string OrganizationName,
 	string? Street,

--- a/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UnpublishVolunteerOpportunity/v1/VolunteerOpportunityUnpublishedDomainEventHandler.cs
@@ -53,7 +53,7 @@ internal sealed class VolunteerOpportunityUnpublishedDomainEventHandler(
 			dbContext,
 			engagementReadRepository,
 			notification.OpportunityId,
-			opportunity.Title,
+			opportunity.TitleDe,
 			NotificationKind.OpportunityUnpublished,
 			"Opportunity was unpublished.",
 			notifyPerEngagement: true,

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -84,7 +84,7 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			keycloakUserService,
 			emailService,
 			emailTemplateRenderer,
-			opportunity.Title);
+			opportunity.TitleDe);
 
 		return new UpdateTimeSlotResult(1, []);
 	}

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommand.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommand.cs
@@ -7,8 +7,10 @@ namespace Application.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
 
 public sealed record UpdateVolunteerOpportunityCommand(
 	Guid OpportunityId,
-	string Title,
-	string Description,
+	string TitleDe,
+	string? TitleEn,
+	string DescriptionDe,
+	string? DescriptionEn,
 	bool IsRemote,
 	Address? Address,
 	Occurrence Occurrence,

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -59,8 +59,8 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 		var prevAddress = opportunity.Address;
 		var prevOccurrence = opportunity.Occurrence;
 
-		opportunity.Rename(request.Title).ThrowIfFailure();
-		opportunity.ChangeDescription(request.Description).ThrowIfFailure();
+		opportunity.Rename(request.TitleDe, request.TitleEn).ThrowIfFailure();
+		opportunity.ChangeDescription(request.DescriptionDe, request.DescriptionEn).ThrowIfFailure();
 
 		// Relocate raises VolunteerOpportunityGeocodingRequestedDomainEvent itself
 		// when the address text actually changed (or is newly added after
@@ -91,7 +91,7 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 				keycloakUserService: keycloakUserService,
 				emailService: emailService,
 				emailTemplateRenderer: emailTemplateRenderer,
-				opportunityTitle: opportunity.Title);
+				opportunityTitle: opportunity.TitleDe);
 
 		return true;
 	}

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -23,9 +23,21 @@ public sealed class VolunteerOpportunity
 
 	public OrganizationId OrganizationId { get; private set; }
 
-	public string Title { get; private set; }
+	public string TitleDe { get; private set; }
 
-	public string Description { get; private set; }
+	/// <summary>
+	/// Optional English translation of <see cref="TitleDe"/> (einsatzbereit#1946) -
+	/// German is the one locale every opportunity is guaranteed to carry (see
+	/// EnsurePublishable), English is an organizer-supplied addition. Callers that
+	/// need to display a title for a given viewer locale fall back to
+	/// <see cref="TitleDe"/> when this is null or blank rather than requiring it.
+	/// </summary>
+	public string? TitleEn { get; private set; }
+
+	public string DescriptionDe { get; private set; }
+
+	/// <summary>Optional English translation of <see cref="DescriptionDe"/> - see <see cref="TitleEn"/>.</summary>
+	public string? DescriptionEn { get; private set; }
 
 	public bool IsRemote { get; private set; }
 
@@ -82,8 +94,10 @@ public sealed class VolunteerOpportunity
 	private VolunteerOpportunity(
 		VolunteerOpportunityId id,
 		OrganizationId organizationId,
-		string title,
-		string description,
+		string titleDe,
+		string? titleEn,
+		string descriptionDe,
+		string? descriptionEn,
 		bool isRemote,
 		Address? address,
 		Occurrence occurrence,
@@ -99,8 +113,10 @@ public sealed class VolunteerOpportunity
 		: base(id)
 	{
 		OrganizationId = organizationId;
-		Title = title;
-		Description = description;
+		TitleDe = titleDe;
+		TitleEn = titleEn;
+		DescriptionDe = descriptionDe;
+		DescriptionEn = descriptionEn;
 		IsRemote = isRemote;
 		Address = address;
 		Occurrence = occurrence;
@@ -184,8 +200,10 @@ public sealed class VolunteerOpportunity
 
 	public static Result<VolunteerOpportunity> Create(
 		OrganizationId organizationId,
-		string title,
-		string description,
+		string titleDe,
+		string? titleEn,
+		string descriptionDe,
+		string? descriptionEn,
 		bool isRemote,
 		Address? address,
 		Occurrence occurrence,
@@ -199,13 +217,21 @@ public sealed class VolunteerOpportunity
 		DateTimeOffset? validUntil = null,
 		DateTimeOffset? now = null)
 	{
-		var validTitleLength = EnsureValidTitleLength(title);
-		if (validTitleLength.IsFailure)
-			return Result.Failure<VolunteerOpportunity>(validTitleLength.Error);
+		var validTitleDeLength = EnsureValidTitleLength(titleDe);
+		if (validTitleDeLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validTitleDeLength.Error);
 
-		var validDescriptionLength = EnsureValidDescriptionLength(description);
-		if (validDescriptionLength.IsFailure)
-			return Result.Failure<VolunteerOpportunity>(validDescriptionLength.Error);
+		var validTitleEnLength = EnsureValidTitleLength(titleEn);
+		if (validTitleEnLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validTitleEnLength.Error);
+
+		var validDescriptionDeLength = EnsureValidDescriptionLength(descriptionDe);
+		if (validDescriptionDeLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validDescriptionDeLength.Error);
+
+		var validDescriptionEnLength = EnsureValidDescriptionLength(descriptionEn);
+		if (validDescriptionEnLength.IsFailure)
+			return Result.Failure<VolunteerOpportunity>(validDescriptionEnLength.Error);
 
 		var validTags = EnsureValidTags(tags ?? []);
 		if (validTags.IsFailure)
@@ -224,7 +250,7 @@ public sealed class VolunteerOpportunity
 
 		if (status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(title, description, isRemote, address);
+			var publishable = EnsurePublishable(titleDe, descriptionDe, isRemote, address);
 			if (publishable.IsFailure)
 				return Result.Failure<VolunteerOpportunity>(publishable.Error);
 
@@ -245,8 +271,10 @@ public sealed class VolunteerOpportunity
 		var opportunity = new VolunteerOpportunity(
 			VolunteerOpportunityId.New(),
 			organizationId,
-			title,
-			description,
+			titleDe,
+			titleEn,
+			descriptionDe,
+			descriptionEn,
 			isRemote,
 			address,
 			occurrence,
@@ -272,15 +300,15 @@ public sealed class VolunteerOpportunity
 	}
 
 	private static Result EnsurePublishable(
-		string title,
-		string description,
+		string titleDe,
+		string descriptionDe,
 		bool isRemote,
 		Address? address)
 	{
-		if (string.IsNullOrWhiteSpace(title))
+		if (string.IsNullOrWhiteSpace(titleDe))
 			return Result.Failure(Error.Validation("VolunteerOpportunity.TitleRequired", "Title must not be empty."));
 
-		if (string.IsNullOrWhiteSpace(description))
+		if (string.IsNullOrWhiteSpace(descriptionDe))
 			return Result.Failure(Error.Validation("VolunteerOpportunity.DescriptionRequired", "Description must not be empty."));
 
 		if (!isRemote && address is null)
@@ -301,7 +329,7 @@ public sealed class VolunteerOpportunity
 		if (Status == OpportunityStatus.Cancelled)
 			return Result.Failure(Error.Conflict("VolunteerOpportunity.CannotPublishCancelled", "A cancelled opportunity cannot be published again."));
 
-		var publishable = EnsurePublishable(Title, Description, IsRemote, Address);
+		var publishable = EnsurePublishable(TitleDe, DescriptionDe, IsRemote, Address);
 		if (publishable.IsFailure)
 			return publishable;
 
@@ -385,37 +413,47 @@ public sealed class VolunteerOpportunity
 		return Result.Success();
 	}
 
-	public Result Rename(string title)
+	public Result Rename(string titleDe, string? titleEn)
 	{
-		var validTitleLength = EnsureValidTitleLength(title);
-		if (validTitleLength.IsFailure)
-			return validTitleLength;
+		var validTitleDeLength = EnsureValidTitleLength(titleDe);
+		if (validTitleDeLength.IsFailure)
+			return validTitleDeLength;
+
+		var validTitleEnLength = EnsureValidTitleLength(titleEn);
+		if (validTitleEnLength.IsFailure)
+			return validTitleEnLength;
 
 		if (Status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(title, Description, IsRemote, Address);
+			var publishable = EnsurePublishable(titleDe, DescriptionDe, IsRemote, Address);
 			if (publishable.IsFailure)
 				return publishable;
 		}
 
-		Title = title;
+		TitleDe = titleDe;
+		TitleEn = titleEn;
 		return Result.Success();
 	}
 
-	public Result ChangeDescription(string description)
+	public Result ChangeDescription(string descriptionDe, string? descriptionEn)
 	{
-		var validDescriptionLength = EnsureValidDescriptionLength(description);
-		if (validDescriptionLength.IsFailure)
-			return validDescriptionLength;
+		var validDescriptionDeLength = EnsureValidDescriptionLength(descriptionDe);
+		if (validDescriptionDeLength.IsFailure)
+			return validDescriptionDeLength;
+
+		var validDescriptionEnLength = EnsureValidDescriptionLength(descriptionEn);
+		if (validDescriptionEnLength.IsFailure)
+			return validDescriptionEnLength;
 
 		if (Status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(Title, description, IsRemote, Address);
+			var publishable = EnsurePublishable(TitleDe, descriptionDe, IsRemote, Address);
 			if (publishable.IsFailure)
 				return publishable;
 		}
 
-		Description = description;
+		DescriptionDe = descriptionDe;
+		DescriptionEn = descriptionEn;
 		return Result.Success();
 	}
 
@@ -423,7 +461,7 @@ public sealed class VolunteerOpportunity
 	{
 		if (Status == OpportunityStatus.Published)
 		{
-			var publishable = EnsurePublishable(Title, Description, isRemote, address);
+			var publishable = EnsurePublishable(TitleDe, DescriptionDe, isRemote, address);
 			if (publishable.IsFailure)
 				return publishable;
 		}

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -83,7 +83,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp1 = VolunteerOpportunity.Create(
 			org1Id,
 			"Erste-Hilfe-Kurs",
+			"First Aid Course",
 			"Lerne lebensrettende Sofortmaßnahmen in unserem eintägigen Praxiskurs.",
+			"Learn life-saving emergency techniques in our one-day hands-on course.",
 			isRemote: false,
 			Address.Create("Karl-Heine-Straße", "12", "04177", "Leipzig").GetValueOrThrow(),
 			Occurrence.OneTime,
@@ -110,7 +112,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp2 = VolunteerOpportunity.Create(
 			org1Id,
 			"Blutspendetermin begleiten",
+			"Support a Blood Donation Drive",
 			"Unterstütze unseren regelmäßigen Blutspendetermin und hilf mit, Leben zu retten.",
+			"Help out at our regular blood donation drive and help save lives.",
 			isRemote: false,
 			Address.Create("Rathausplatz", "1", "04416", "Markkleeberg").GetValueOrThrow(),
 			Occurrence.Recurring,
@@ -123,7 +127,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp2b = VolunteerOpportunity.Create(
 			org1Id,
 			"Sanitätsdienst beim Stadtteilfest",
+			"First Aid Team at the Neighborhood Festival",
 			"Verstärke unser Sanitätsteam beim Stadtteilfest und leiste Erste Hilfe vor Ort.",
+			"Join our first aid team at the neighborhood festival and provide on-site first aid.",
 			isRemote: false,
 			Address.Create("Lindenauer Markt", "5", "04177", "Leipzig").GetValueOrThrow(),
 			Occurrence.OneTime,
@@ -136,7 +142,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp2c = VolunteerOpportunity.Create(
 			org1Id,
 			"Kleiderausgabe für Bedürftige",
+			"Clothing Distribution for Those in Need",
 			"Hilf mit, gespendete Kleidung zu sortieren und an Menschen in der Region auszugeben.",
+			"Help sort donated clothing and hand it out to people in the region.",
 			isRemote: false,
 			Address.Create("Lagerstraße", "10", "06108", "Halle (Saale)").GetValueOrThrow(),
 			Occurrence.Recurring,
@@ -149,7 +157,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp2d = VolunteerOpportunity.Create(
 			org1Id,
 			"Erste-Hilfe-Schulung für Vereine",
+			"First Aid Training for Clubs",
 			"Vermittle Vereinen und Gruppen online die Grundlagen der Ersten Hilfe.",
+			"Teach clubs and groups the basics of first aid online.",
 			isRemote: true,
 			address: null,
 			Occurrence.Recurring,
@@ -162,7 +172,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp3 = VolunteerOpportunity.Create(
 			org2Id,
 			"Helfer:innen für das Tierheim",
+			"Volunteers for the Animal Shelter",
 			"Hilf uns dabei, die Tiere in unserem Tierheim zu versorgen und zu betreuen.",
+			"Help us care for and look after the animals in our shelter.",
 			isRemote: false,
 			Address.Create("Tierparkweg", "5", "04177", "Leipzig").GetValueOrThrow(),
 			Occurrence.Recurring,
@@ -179,7 +191,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp4 = VolunteerOpportunity.Create(
 			org2Id,
 			"Online-Fundraising unterstützen",
+			"Support Online Fundraising",
 			"Unterstütze unser Fundraising-Team bequem von zu Hause aus.",
+			"Support our fundraising team comfortably from home.",
 			isRemote: true,
 			address: null,
 			Occurrence.OneTime,
@@ -192,7 +206,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp4b = VolunteerOpportunity.Create(
 			org2Id,
 			"Gassi-Dienst für Tierheimhunde",
+			"Dog Walking for Shelter Dogs",
 			"Geh regelmäßig mit unseren Tierheimhunden spazieren und gib ihnen Auslauf.",
+			"Take our shelter dogs for regular walks and give them some exercise.",
 			isRemote: false,
 			Address.Create("Tierparkweg", "5", "04177", "Leipzig").GetValueOrThrow(),
 			Occurrence.Recurring,
@@ -205,7 +221,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp4c = VolunteerOpportunity.Create(
 			org2Id,
 			"Futterspenden-Sammlung",
+			"Pet Food Donation Drive",
 			"Sammle Futter- und Sachspenden für unsere Tiere bei einer Aktion vor Ort.",
+			"Collect food and supply donations for our animals at an on-site event.",
 			isRemote: false,
 			Address.Create("Rathausplatz", "3", "04416", "Markkleeberg").GetValueOrThrow(),
 			Occurrence.OneTime,
@@ -218,7 +236,9 @@ internal sealed class ApplicationDbContextInitializer(
 		var opp4d = VolunteerOpportunity.Create(
 			org2Id,
 			"Patenschaft für Pflegetiere",
+			"Foster Animal Sponsorship",
 			"Übernimm eine Patenschaft für ein Pflegetier und begleite es bis zur Vermittlung.",
+			"Sponsor a foster animal and support it until it finds a new home.",
 			isRemote: true,
 			address: null,
 			Occurrence.Recurring,

--- a/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/VolunteerOpportunityConfiguration.cs
@@ -48,13 +48,26 @@ internal sealed class VolunteerOpportunityConfiguration
 				guid => OrganizationId.Create(guid).GetValueOrThrow())
 			.IsRequired();
 
-		builder.Property(vo => vo.Title)
+		builder.Property(vo => vo.TitleDe)
 			.HasMaxLength(VolunteerOpportunity.MaxTitleLength)
 			.IsRequired();
 
-		builder.Property(vo => vo.Description)
+		// Organizer-supplied English translation (einsatzbereit#1946) - unlike
+		// TitleDe, left unrequired at every layer (domain's EnsurePublishable,
+		// here, and the API request DTO) so an opportunity can still be published
+		// without one; viewers fall back to TitleDe (see frontend's
+		// pickLocalizedText) instead of getting stuck mid-translation.
+		builder.Property(vo => vo.TitleEn)
+			.HasMaxLength(VolunteerOpportunity.MaxTitleLength)
+			.IsRequired(false);
+
+		builder.Property(vo => vo.DescriptionDe)
 			.HasMaxLength(VolunteerOpportunity.MaxDescriptionLength)
 			.IsRequired();
+
+		builder.Property(vo => vo.DescriptionEn)
+			.HasMaxLength(VolunteerOpportunity.MaxDescriptionLength)
+			.IsRequired(false);
 
 		builder.Property(vo => vo.IsRemote)
 			.IsRequired();

--- a/backend/src/Infrastructure/Persistence/Migrations/20260816123225_SplitVolunteerOpportunityTitleDescriptionByLocale.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260816123225_SplitVolunteerOpportunityTitleDescriptionByLocale.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260816123225_SplitVolunteerOpportunityTitleDescriptionByLocale")]
+	partial class SplitVolunteerOpportunityTitleDescriptionByLocale
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260816123225_SplitVolunteerOpportunityTitleDescriptionByLocale.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260816123225_SplitVolunteerOpportunityTitleDescriptionByLocale.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class SplitVolunteerOpportunityTitleDescriptionByLocale : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.RenameColumn(
+				name: "title",
+				table: "volunteer_opportunity",
+				newName: "title_de");
+
+			migrationBuilder.RenameColumn(
+				name: "description",
+				table: "volunteer_opportunity",
+				newName: "description_de");
+
+			migrationBuilder.AddColumn<string>(
+				name: "description_en",
+				table: "volunteer_opportunity",
+				type: "character varying(5000)",
+				maxLength: 5000,
+				nullable: true);
+
+			migrationBuilder.AddColumn<string>(
+				name: "title_en",
+				table: "volunteer_opportunity",
+				type: "character varying(200)",
+				maxLength: 200,
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "description_en",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.DropColumn(
+				name: "title_en",
+				table: "volunteer_opportunity");
+
+			migrationBuilder.RenameColumn(
+				name: "title_de",
+				table: "volunteer_opportunity",
+				newName: "title");
+
+			migrationBuilder.RenameColumn(
+				name: "description_de",
+				table: "volunteer_opportunity",
+				newName: "description");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminAuditLogReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminAuditLogReadRepository.cs
@@ -58,7 +58,7 @@ internal sealed class AdminAuditLogReadRepository(
 			? await dbContext.VolunteerOpportunitiesQuery
 				.IgnoreQueryFilters()
 				.Where(vo => opportunityIds.Contains(vo.Id))
-				.ToDictionaryAsync(vo => vo.Id.Value, vo => vo.Title, cancellationToken)
+				.ToDictionaryAsync(vo => vo.Id.Value, vo => vo.TitleDe, cancellationToken)
 			: new Dictionary<Guid, string>();
 
 		var organizationIds = page

--- a/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/AdminReportReadRepository.cs
@@ -56,7 +56,7 @@ internal sealed class AdminReportReadRepository(
 		var opportunities = await dbContext.VolunteerOpportunitiesQuery
 			.IgnoreQueryFilters()
 			.Where(vo => opportunityIdVOs.Contains(vo.Id))
-			.ToDictionaryAsync(vo => vo.Id.Value, vo => new { vo.Title, vo.IsDeleted }, cancellationToken);
+			.ToDictionaryAsync(vo => vo.Id.Value, vo => new { vo.TitleDe, vo.IsDeleted }, cancellationToken);
 
 		var organizations = await dbContext.OrganizationsQuery
 			.IgnoreQueryFilters()
@@ -79,7 +79,7 @@ internal sealed class AdminReportReadRepository(
 				g.TargetId,
 				g.TargetType switch
 				{
-					ReportTargetType.VolunteerOpportunity => opportunities.GetValueOrDefault(g.TargetId)?.Title ?? string.Empty,
+					ReportTargetType.VolunteerOpportunity => opportunities.GetValueOrDefault(g.TargetId)?.TitleDe ?? string.Empty,
 					ReportTargetType.Organization => organizations.GetValueOrDefault(g.TargetId)?.Name ?? string.Empty,
 					ReportTargetType.User => userDisplayNames.GetValueOrDefault(g.TargetId, string.Empty),
 					_ => string.Empty,

--- a/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/EngagementReadRepository.cs
@@ -21,14 +21,14 @@ internal sealed class EngagementReadRepository(
 		var raw = await dbContext.EngagementsQuery
 			.Where(e => e.OpportunityId == opportunityId)
 			.Join(
-				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId, o.CheckInMethod }),
+				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.TitleDe, o.OrganizationId, o.CheckInMethod }),
 				e => e.OpportunityId,
 				o => o.Id,
 				(e, o) => new
 				{
 					e.Id,
 					e.OpportunityId,
-					OpportunityTitle = o.Title,
+					OpportunityTitle = o.TitleDe,
 					o.OrganizationId,
 					o.CheckInMethod,
 					e.VolunteerId,
@@ -160,14 +160,14 @@ internal sealed class EngagementReadRepository(
 
 		var raw = await scopedQuery
 			.Join(
-				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.Title, o.OrganizationId, o.CheckInMethod }),
+				dbContext.VolunteerOpportunitiesQuery.Select(o => new { o.Id, o.TitleDe, o.OrganizationId, o.CheckInMethod }),
 				e => e.OpportunityId,
 				o => o.Id,
 				(e, o) => new
 				{
 					e.Id,
 					e.OpportunityId,
-					OpportunityTitle = o.Title,
+					OpportunityTitle = o.TitleDe,
 					o.OrganizationId,
 					o.CheckInMethod,
 					e.VolunteerId,
@@ -377,7 +377,7 @@ internal sealed class EngagementReadRepository(
 		var opportunityIds = engagements.Select(e => e.OpportunityId).Distinct().ToList();
 		var opportunities = await dbContext.VolunteerOpportunitiesQuery
 			.Where(o => opportunityIds.Contains(o.Id))
-			.Select(o => new { o.Id, o.Title, o.IsRemote, o.Address, o.OrganizationId, o.CheckInMethod, o.ValidUntil })
+			.Select(o => new { o.Id, o.TitleDe, o.IsRemote, o.Address, o.OrganizationId, o.CheckInMethod, o.ValidUntil })
 			.ToDictionaryAsync(o => o.Id, cancellationToken);
 
 		var organizationIds = opportunities.Values.Select(o => o.OrganizationId).Distinct().ToList();
@@ -420,7 +420,7 @@ internal sealed class EngagementReadRepository(
 			return new EngagementSummary(
 				e.Id.Value,
 				e.OpportunityId.Value,
-				opportunity?.Title,
+				opportunity?.TitleDe,
 				organization?.Id.Value,
 				organization?.Name,
 				e.VolunteerId?.Value,
@@ -481,7 +481,7 @@ internal sealed class EngagementReadRepository(
 		// refuses to show a non-organizer.
 		var opportunity = await dbContext.VolunteerOpportunitiesQuery
 			.Where(o => o.Id == engagement.OpportunityId && o.Status == OpportunityStatus.Published)
-			.Select(o => new { o.Id, o.Title, o.Description, o.IsRemote, o.Address })
+			.Select(o => new { o.Id, o.TitleDe, o.DescriptionDe, o.IsRemote, o.Address })
 			.FirstOrDefaultAsync(cancellationToken);
 
 		if (opportunity is null)
@@ -500,8 +500,8 @@ internal sealed class EngagementReadRepository(
 		return new EngagementCalendarInfo(
 			engagementId.Value,
 			opportunity.Id.Value,
-			opportunity.Title,
-			opportunity.Description,
+			opportunity.TitleDe,
+			opportunity.DescriptionDe,
 			location,
 			timeSlot.StartDateTime,
 			timeSlot.EndDateTime);

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -170,9 +170,9 @@ internal sealed class NotificationReadRepository(
 			var opportunityIdVOs = allOpportunityIds.Select(id => VolunteerOpportunityId.Create(id).GetValueOrThrow()).ToList();
 			var opportunityRows = await dbContext.VolunteerOpportunitiesQuery
 				.Where(o => opportunityIdVOs.Contains(o.Id))
-				.Select(o => new { o.Id, o.Title, o.OrganizationId })
+				.Select(o => new { o.Id, o.TitleDe, o.OrganizationId })
 				.ToListAsync(cancellationToken);
-			opportunityTitles = opportunityRows.ToDictionary(x => x.Id.Value, x => x.Title);
+			opportunityTitles = opportunityRows.ToDictionary(x => x.Id.Value, x => x.TitleDe);
 			opportunityOrganizations = opportunityRows.ToDictionary(x => x.Id.Value, x => x.OrganizationId.Value);
 		}
 

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -81,8 +81,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(vo => new
 			{
 				vo.Id,
-				vo.Title,
-				vo.Description,
+				vo.TitleDe,
+				vo.TitleEn,
+				vo.DescriptionDe,
+				vo.DescriptionEn,
 				OrganizationId = vo.OrganizationId.Value,
 				Street = vo.Address != null ? vo.Address.Street : null,
 				HouseNumber = vo.Address != null ? vo.Address.HouseNumber : null,
@@ -128,8 +130,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 				.Select(s => new
 				{
 					s.Id,
-					s.Title,
-					s.Description,
+					s.TitleDe,
+					s.TitleEn,
+					s.DescriptionDe,
+					s.DescriptionEn,
 					s.OrganizationId,
 					s.Street,
 					s.HouseNumber,
@@ -181,7 +185,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 				.Select(x =>
 				{
 					var (orgName, orgLogoUrl) = orgMap[x.OrganizationId];
-					return ToSummary(x.Id.Value, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
+					return ToSummary(x.Id.Value, x.TitleDe, x.TitleEn, x.DescriptionDe, x.DescriptionEn, x.OrganizationId, orgName, orgLogoUrl,
 						x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 						x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 						x.Status, x.BannerImageUrl,
@@ -211,7 +215,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(x =>
 			{
 				var (orgName, orgLogoUrl) = organizationSummaries[x.OrganizationId];
-				return ToSummary(x.Id.Value, x.Title, x.Description, x.OrganizationId, orgName, orgLogoUrl,
+				return ToSummary(x.Id.Value, x.TitleDe, x.TitleEn, x.DescriptionDe, x.DescriptionEn, x.OrganizationId, orgName, orgLogoUrl,
 					x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 					x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 					x.Status, x.BannerImageUrl,
@@ -364,12 +368,18 @@ internal sealed class VolunteerOpportunityReadRepository(
 		// bare VolunteerOpportunity) - a real Join would ripple into every
 		// vo.* reference in the caller's projection (see #869's comment) and
 		// the HasRadius branch's CountAsync(query)/baseQuery reuse.
+		//
+		// Matches across both locale variants of Title/Description (#1946) -
+		// TitleEn/DescriptionEn are optional, so a null check guards each before
+		// the ILike-style .Contains(...) call.
 		if (!string.IsNullOrWhiteSpace(keyword))
 		{
 			var loweredKeyword = keyword.ToLower();
 			query = query.Where(vo =>
-				vo.Title.ToLower().Contains(loweredKeyword) ||
-				vo.Description.ToLower().Contains(loweredKeyword) ||
+				vo.TitleDe.ToLower().Contains(loweredKeyword) ||
+				(vo.TitleEn != null && vo.TitleEn.ToLower().Contains(loweredKeyword)) ||
+				vo.DescriptionDe.ToLower().Contains(loweredKeyword) ||
+				(vo.DescriptionEn != null && vo.DescriptionEn.ToLower().Contains(loweredKeyword)) ||
 				dbContext.OrganizationsQuery.Any(o => o.Id == vo.OrganizationId && o.Name.ToLower().Contains(loweredKeyword)));
 		}
 
@@ -429,8 +439,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 	// entities and fully materializing them client-side) - see #869 follow-up.
 	private static VolunteerOpportunitySummary ToSummary(
 		Guid id,
-		string title,
-		string description,
+		string titleDe,
+		string? titleEn,
+		string? descriptionDe,
+		string? descriptionEn,
 		Guid organizationId,
 		string orgName,
 		string? orgLogoUrl,
@@ -456,8 +468,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 		int currentParticipantCount) =>
 		new(
 			id,
-			title,
-			description,
+			titleDe,
+			titleEn,
+			descriptionDe,
+			descriptionEn,
 			organizationId,
 			orgName,
 			street,
@@ -499,8 +513,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(x => new
 			{
 				x.vo.Id,
-				x.vo.Title,
-				x.vo.Description,
+				x.vo.TitleDe,
+				x.vo.TitleEn,
+				x.vo.DescriptionDe,
+				x.vo.DescriptionEn,
 				x.vo.OrganizationId,
 				x.org.Name,
 				x.vo.Address,
@@ -577,8 +593,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 		return new VolunteerOpportunityDetails(
 			result.Id.Value,
-			result.Title,
-			result.Description,
+			result.TitleDe,
+			result.TitleEn,
+			result.DescriptionDe,
+			result.DescriptionEn,
 			result.OrganizationId.Value,
 			result.Name,
 			result.Address?.Street,
@@ -626,8 +644,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(x => new
 			{
 				Id = x.vo.Id.Value,
-				x.vo.Title,
-				x.vo.Description,
+				x.vo.TitleDe,
+				x.vo.TitleEn,
+				x.vo.DescriptionDe,
+				x.vo.DescriptionEn,
 				OrganizationId = x.vo.OrganizationId.Value,
 				OrgName = x.org.Name,
 				OrgLogoUrl = x.org.LogoUrl,
@@ -667,7 +687,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 		var (maxParticipantsMap, participantCountMap) = await LoadParticipantStatsAsync(guids, cancellationToken);
 
 		return rows
-			.Select(x => ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, x.OrgName, x.OrgLogoUrl,
+			.Select(x => ToSummary(x.Id, x.TitleDe, x.TitleEn, x.DescriptionDe, x.DescriptionEn, x.OrganizationId, x.OrgName, x.OrgLogoUrl,
 				x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 				x.Status, x.BannerImageUrl,
@@ -703,8 +723,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(x => new
 			{
 				Id = x.vo.Id.Value,
-				x.vo.Title,
-				x.vo.Description,
+				x.vo.TitleDe,
+				x.vo.TitleEn,
+				x.vo.DescriptionDe,
+				x.vo.DescriptionEn,
 				OrganizationId = x.vo.OrganizationId.Value,
 				OrgName = x.org.Name,
 				OrgLogoUrl = x.org.LogoUrl,
@@ -744,7 +766,7 @@ internal sealed class VolunteerOpportunityReadRepository(
 		var (maxParticipantsMap, participantCountMap) = await LoadParticipantStatsAsync(guids, cancellationToken);
 
 		var items = rows
-			.Select(x => ToSummary(x.Id, x.Title, x.Description, x.OrganizationId, x.OrgName, x.OrgLogoUrl,
+			.Select(x => ToSummary(x.Id, x.TitleDe, x.TitleEn, x.DescriptionDe, x.DescriptionEn, x.OrganizationId, x.OrgName, x.OrgLogoUrl,
 				x.Street, x.HouseNumber, x.ZipCode, x.City, x.Latitude, x.Longitude, x.IsRemote, x.Occurrence,
 				x.ParticipationType, x.CheckInMethod, x.Category, x.Tags, x.CreatedOn, x.ValidUntil, x.NextTimeSlotStart, x.NextTimeSlotEnd,
 				x.Status, x.BannerImageUrl,
@@ -771,7 +793,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 			.Select(vo => new
 			{
 				Id = vo.Id.Value,
-				vo.Title,
+				vo.TitleDe,
+				vo.TitleEn,
 				vo.Color,
 				TimeSlots = vo.TimeSlots
 					.Where(ts => ts.StartDateTime >= from && ts.StartDateTime <= to)
@@ -810,7 +833,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 		return rows
 			.Select(r => new OrganizationCalendarEventDto(
 				r.Id,
-				r.Title,
+				r.TitleDe,
+				r.TitleEn,
 				r.Color,
 				r.TimeSlots
 					.Select(ts => new CalendarTimeSlotDto(

--- a/backend/tests/Application.UnitTests/Engagements/BulkCancelEngagements/BulkCancelEngagementsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/BulkCancelEngagements/BulkCancelEngagementsCommandHandlerTests.cs
@@ -44,7 +44,7 @@ public class BulkCancelEngagementsCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private static Engagement CreatePendingEngagement(VolunteerOpportunityId? opportunityId = null) =>
 		Engagement.CreateSlotSignUp(opportunityId ?? DefaultOpportunityId, UserId.New(), TimeSlotId.New());

--- a/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
@@ -44,7 +44,7 @@ public class BulkConfirmEngagementsCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private static Engagement CreateConfirmedEngagement(VolunteerOpportunityId? opportunityId = null)
 	{

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/CancelEngagementCommandHandlerTests.cs
@@ -48,7 +48,7 @@ public class CancelEngagementCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private static Engagement CreatePendingScheduledSlotsEngagement() =>
 		Engagement.CreateSlotSignUp(

--- a/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CancelEngagement/EngagementCancelledNotificationHandlerTests.cs
@@ -53,7 +53,7 @@ public class EngagementCancelledNotificationHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldEmailVolunteer_WhenEngagementCancelled(

--- a/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInEngagement/CheckInEngagementCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class CheckInEngagementCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
 	private static Engagement CreateConfirmedEngagement(VolunteerOpportunityId opportunityId)

--- a/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CheckInWithPin/CheckInWithPinCommandHandlerTests.cs
@@ -239,7 +239,9 @@ public class CheckInWithPinCommandHandlerTests
 		VolunteerOpportunity.Create(
 			DefaultOrgId,
 			"Test",
+			null,
 			"Test",
+			null,
 			false,
 			DefaultAddress,
 			Occurrence.OneTime,
@@ -252,7 +254,9 @@ public class CheckInWithPinCommandHandlerTests
 		VolunteerOpportunity.Create(
 			DefaultOrgId,
 			"Test",
+			null,
 			"Test",
+			null,
 			false,
 			DefaultAddress,
 			Occurrence.OneTime,

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -318,7 +318,7 @@ public class ConfirmEngagementCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private static UserStreak BuildStreakWithTotalConfirmedEngagementsOf(UserId userId, int count)
 	{

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/EngagementConfirmedNotificationHandlerTests.cs
@@ -53,7 +53,7 @@ public class EngagementConfirmedNotificationHandlerTests
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldRenderConfirmationEmail_InVolunteersPreferredLanguage(

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -40,7 +40,9 @@ public class CreateEngagementCommandHandlerTests
 		var opportunity = VolunteerOpportunity.Create(
 			OrganizationId.New(),
 			"Test Opportunity",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -95,7 +97,9 @@ public class CreateEngagementCommandHandlerTests
 		var opportunity = VolunteerOpportunity.Create(
 			OrganizationId.New(),
 			"Test Opportunity",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementCreatedDomainEventHandlerTests.cs
@@ -54,7 +54,7 @@ public class EngagementCreatedDomainEventHandlerTests
 
 	private static VolunteerOpportunity CreateOpportunity(OrganizationId organizationId) =>
 		VolunteerOpportunity.Create(
-			organizationId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			organizationId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/EngagementReactivatedDomainEventHandlerTests.cs
@@ -54,7 +54,7 @@ public class EngagementReactivatedDomainEventHandlerTests
 
 	private static VolunteerOpportunity CreateOpportunity(OrganizationId organizationId) =>
 		VolunteerOpportunity.Create(
-			organizationId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			organizationId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/Engagements/EngagementReminder/EngagementReminderDueHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementReminder/EngagementReminderDueHandlerTests.cs
@@ -44,7 +44,7 @@ public class EngagementReminderDueHandlerTests
 		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
 		// here since the handler doesn't look at Status at all.
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Beach Cleanup", "Help clean the beach", true, null,
+			DefaultOrgId, "Beach Cleanup", null, "Help clean the beach", null, true, null,
 			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
@@ -183,7 +183,7 @@ public class EngagementReminderDueHandlerTests
 		// winter instant is used so Europe/Berlin is deterministically UTC+1
 		// (CET, no DST) regardless of when this test runs.
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Beach Cleanup", "Help clean the beach", true, null,
+			DefaultOrgId, "Beach Cleanup", null, "Help clean the beach", null, true, null,
 			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		var artificialNow = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/GetEngagements/GetEngagementsQueryHandlerTests.cs
@@ -395,5 +395,5 @@ public class GetEngagementsQueryHandlerTests
 	}
 
 	private static VolunteerOpportunity CreateDefaultOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Test", "Test", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft).Value;
 }

--- a/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/EngagementFeedbackSubmittedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/SubmitFeedback/EngagementFeedbackSubmittedDomainEventHandlerTests.cs
@@ -39,7 +39,7 @@ public class EngagementFeedbackSubmittedDomainEventHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity(OrganizationId organizationId) =>
 		VolunteerOpportunity.Create(
-			organizationId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			organizationId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/Engagements/UndoCheckInEngagement/UndoCheckInEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/UndoCheckInEngagement/UndoCheckInEngagementCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class UndoCheckInEngagementCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
 	private static Engagement CreateCheckedInEngagement(VolunteerOpportunityId opportunityId)

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/EngagementWithdrawnDomainEventHandlerTests.cs
@@ -52,7 +52,7 @@ public class EngagementWithdrawnDomainEventHandlerTests
 
 	private static VolunteerOpportunity CreateOpportunity(OrganizationId organizationId) =>
 		VolunteerOpportunity.Create(
-			organizationId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			organizationId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/WithdrawEngagement/WithdrawEngagementCommandHandlerTests.cs
@@ -43,7 +43,7 @@ public class WithdrawEngagementCommandHandlerTests
 	private VolunteerOpportunity CreateOpportunityForOrganizerNotification(VolunteerOpportunityId opportunityId, out Guid organizerUserId)
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			OrganizationId.New(), "Test", "Test", false, DefaultAddress,
+			OrganizationId.New(), "Test", null, "Test", null, false, DefaultAddress,
 			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None,
 			_pinGenerator, status: OpportunityStatus.Draft).Value;
 		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns(opportunity);

--- a/backend/tests/Application.UnitTests/Meta/GetVolunteerOpportunityMeta/GetVolunteerOpportunityMetaQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Meta/GetVolunteerOpportunityMeta/GetVolunteerOpportunityMetaQueryHandlerTests.cs
@@ -25,7 +25,9 @@ public class GetVolunteerOpportunityMetaQueryHandlerTests
 		new(
 			id ?? Guid.NewGuid(),
 			title,
+			null,
 			description,
+			null,
 			Guid.NewGuid(),
 			"Küstenschutz e.V.",
 			"Strandweg",

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -65,7 +65,7 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		Organization.Create(OrganizationId.Create(id).GetValueOrThrow(), "Test Org").Value;
 
 	private VolunteerOpportunity CreateOpportunity(OrganizationId orgId) =>
-		VolunteerOpportunity.Create(orgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(orgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldShadowDeleteOrganization_EvenWithMultipleMembers(

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
@@ -79,7 +79,7 @@ public class DeleteOrganizationCommandHandlerTests
 	private VolunteerOpportunity CreateOpportunityWithFutureTimeSlot(OrganizationId orgId)
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			orgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+			orgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 		opportunity.AddTimeSlot(DateTimeOffset.UtcNow.AddDays(1), DateTimeOffset.UtcNow.AddDays(1).AddHours(2), 5, DateTimeOffset.UtcNow);
 		return opportunity;
 	}
@@ -212,7 +212,7 @@ public class DeleteOrganizationCommandHandlerTests
 		SetMembers(orgId, DefaultRequestingUserId.Value);
 		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
 		var finishedOpportunity = VolunteerOpportunity.Create(
-			organizationId, "Finished Opportunity", "Beschreibung", true, null, Occurrence.OneTime,
+			organizationId, "Finished Opportunity", null, "Beschreibung", null, true, null, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Published, validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 		_dbContext

--- a/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/GetOrganizationCalendarEvents/GetOrganizationCalendarEventsQueryHandlerTests.cs
@@ -36,7 +36,7 @@ public class GetOrganizationCalendarEventsQueryHandlerTests
 		// Arrange
 		var events = new List<OrganizationCalendarEventDto>
 		{
-			new(Guid.NewGuid(), "Title", "#ff0000", []),
+			new(Guid.NewGuid(), "Title", null, "#ff0000", []),
 		};
 		_readRepository.GetCalendarEventsAsync(DefaultOrgId, DefaultFrom, DefaultTo, cancellationToken).Returns(events);
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/AdminRestoreVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/AdminRestoreVolunteerOpportunityCommandHandlerTests.cs
@@ -31,7 +31,7 @@ public class AdminRestoreVolunteerOpportunityCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldRestoreOpportunity_AndWriteAuditLog(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -57,7 +57,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldShadowDeleteOpportunity_WithoutCheckingOwnership(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/CancelVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/CancelVolunteerOpportunityCommandHandlerTests.cs
@@ -35,7 +35,7 @@ public class CancelVolunteerOpportunityCommandHandlerTests
 	private static VolunteerOpportunity CreatePublishedOpportunity()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 		opportunity.Publish();
@@ -127,7 +127,7 @@ public class CancelVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 		SetupOpportunity(opportunityId, opportunity);
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
@@ -45,7 +45,7 @@ public class VolunteerOpportunityCancelledDomainEventHandlerTests
 
 	private static VolunteerOpportunity CreatePublishedOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class CreateTimeSlotCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress,
 			Occurrence.Recurring, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateVolunteerOpportunity/CreateVolunteerOpportunityCommandHandlerTests.cs
@@ -38,7 +38,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Helpers needed",
+			null,
 			"For moving",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -54,8 +56,8 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
-		result.Title.Should().Be("Helpers needed");
-		result.Description.Should().Be("For moving");
+		result.TitleDe.Should().Be("Helpers needed");
+		result.DescriptionDe.Should().Be("For moving");
 		result.OrganizationId.Should().Be(TestOrganizationId);
 		result.IsRemote.Should().BeFalse();
 		result.Address.Should().NotBeNull();
@@ -65,12 +67,14 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldPersistEmptyTitle_WhenDraftAndTitleOmitted(
+	public async Task Handle_ShouldPersistEnglishTitleAndDescription_WhenProvided(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
-			string.Empty,
+			"Helfer gesucht",
+			"Helpers needed",
+			"Zum Umzug",
 			"For moving",
 			TestOrganizationId,
 			false,
@@ -87,7 +91,38 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
-		result.Title.Should().Be(string.Empty);
+		result.TitleDe.Should().Be("Helfer gesucht");
+		result.TitleEn.Should().Be("Helpers needed");
+		result.DescriptionDe.Should().Be("Zum Umzug");
+		result.DescriptionEn.Should().Be("For moving");
+	}
+
+	[Test]
+	public async Task Handle_ShouldPersistEmptyTitle_WhenDraftAndTitleOmitted(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var command = new CreateVolunteerOpportunityCommand(
+			string.Empty,
+			null,
+			"For moving",
+			null,
+			TestOrganizationId,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			null,
+			[],
+			OpportunityStatus.Draft,
+			DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.TitleDe.Should().Be(string.Empty);
 	}
 
 	[Test]
@@ -97,7 +132,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Helpers needed",
+			null,
 			"For moving",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -124,7 +161,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -154,7 +193,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -186,7 +227,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		var validUntil = DateTimeOffset.UtcNow.AddDays(14);
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -213,7 +256,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -245,7 +290,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		var tooManyTags = Enumerable.Range(0, VolunteerOpportunity.MaxTagsCount + 1).Select(i => $"tag{i}").ToList();
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -276,7 +323,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,
@@ -308,7 +357,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// event that triggers GeocodeVolunteerOpportunityAddressHandler's
 		// out-of-band retry.
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
+			"Title", null, "Description", null, TestOrganizationId, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -330,7 +379,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 		// dispatching this command, so no out-of-band retry is needed (#1963).
 		var coordinatedAddress = TestAddress.WithCoordinates(52.52, 13.405).Value;
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, false, coordinatedAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
+			"Title", null, "Description", null, TestOrganizationId, false, coordinatedAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -347,7 +396,7 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 	{
 		// Arrange
 		var command = new CreateVolunteerOpportunityCommand(
-			"Title", "Description", TestOrganizationId, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
+			"Title", null, "Description", null, TestOrganizationId, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], OpportunityStatus.Draft, DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
@@ -367,7 +416,9 @@ public class CreateVolunteerOpportunityCommandHandlerTests
 
 		var command = new CreateVolunteerOpportunityCommand(
 			"Title",
+			null,
 			"Description",
+			null,
 			TestOrganizationId,
 			false,
 			TestAddress,

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteOpportunityBanner/DeleteOpportunityBannerCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class DeleteOpportunityBannerCommandHandlerTests
 	private VolunteerOpportunity CreateOpportunityWithBanner()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		opportunity.SetBannerImageUrl("https://example.com/banner.png");
 		return opportunity;

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteTimeSlot/DeleteTimeSlotCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public class DeleteTimeSlotCommandHandlerTests
 	private VolunteerOpportunity CreateOpportunityWithTimeSlot(out TimeSlot timeSlot)
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
 			Occurrence.Recurring, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		timeSlot = opportunity.AddTimeSlot(
@@ -104,7 +104,7 @@ public class DeleteTimeSlotCommandHandlerTests
 		out TimeSlot slot1, out TimeSlot slot2, out TimeSlot slot3)
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
 			Occurrence.Recurring, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
@@ -205,7 +205,7 @@ public class DeleteTimeSlotCommandHandlerTests
 		// Arrange: slot1 is a past occurrence (created as valid-at-the-time via an
 		// artificially-past `now`), slot2 is still upcoming.
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, Address.Create("Hauptstrasse", "1", "12345", "Berlin").Value,
 			Occurrence.Recurring, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		var seriesId = Guid.CreateVersion7();

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
-		VolunteerOpportunity.Create(DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldReturnTrue_WhenOpportunityExists(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/GeocodeVolunteerOpportunityAddressHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/GeocodeVolunteerOpportunityAddressHandlerTests.cs
@@ -35,7 +35,7 @@ public sealed class GeocodeVolunteerOpportunityAddressHandlerTests : IDisposable
 
 	private VolunteerOpportunity CreateNonRemoteOpportunity(Address? address = null) =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, address ?? DefaultAddress, Occurrence.OneTime,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, address ?? DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityCheckInPin/GetOpportunityCheckInPinQueryHandlerTests.cs
@@ -32,7 +32,7 @@ public class GetOpportunityCheckInPinQueryHandlerTests
 
 	private VolunteerOpportunity CreateOpportunityWithPin() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.PINCode, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.PINCode, _pinGenerator,
 			status: OpportunityStatus.Draft, checkInPin: "48213").Value;
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetOpportunityFeedback/GetOpportunityFeedbackQueryHandlerTests.cs
@@ -42,7 +42,7 @@ public class GetOpportunityFeedbackQueryHandlerTests
 
 	private static VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(),
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, Substitute.For<IPinGenerator>(),
 			status: OpportunityStatus.Draft).Value;
 
 	private async Task<(int PageNumber, int PageSize)> CapturedArgsAsync(int pageNumber, int pageSize)

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/PublishVolunteerOpportunity/PublishVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/PublishVolunteerOpportunity/PublishVolunteerOpportunityCommandHandlerTests.cs
@@ -37,7 +37,7 @@ public class PublishVolunteerOpportunityCommandHandlerTests
 		string description = "Beschreibung",
 		ParticipationType participationType = ParticipationType.IndividualContact) =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, participationType, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, title, null, description, null, false, DefaultAddress, Occurrence.OneTime, participationType, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft,
 			validUntil: participationType == ParticipationType.IndividualContact ? DateTimeOffset.UtcNow.AddDays(30) : null).Value;
 
@@ -237,7 +237,7 @@ public class PublishVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, address: null, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, address: null, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		SetupOpportunity(opportunityId, opportunity);
 
@@ -273,7 +273,7 @@ public class PublishVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		SetupOpportunity(opportunityId, opportunity);
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/ReportVolunteerOpportunity/ReportVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/ReportVolunteerOpportunity/ReportVolunteerOpportunityCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class ReportVolunteerOpportunityCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		Domain.VolunteerOpportunities.VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	[Test]
 	public async Task Handle_ShouldAddReport_WhenOpportunityExists(

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/SetOpportunityColor/SetOpportunityColorCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/SetOpportunityColor/SetOpportunityColorCommandHandlerTests.cs
@@ -32,7 +32,7 @@ public class SetOpportunityColorCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/UnpublishVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/UnpublishVolunteerOpportunityCommandHandlerTests.cs
@@ -35,7 +35,7 @@ public class UnpublishVolunteerOpportunityCommandHandlerTests
 	private static VolunteerOpportunity CreatePublishedOpportunity()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Draft,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 		opportunity.Publish();
@@ -89,7 +89,7 @@ public class UnpublishVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 		SetupOpportunity(opportunityId, opportunity);
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
@@ -45,7 +45,7 @@ public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
 
 	private static VolunteerOpportunity CreatePublishedOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, Substitute.For<IPinGenerator>(), status: OpportunityStatus.Published,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -65,7 +65,7 @@ public class UpdateTimeSlotCommandHandlerTests
 
 	private VolunteerOpportunity CreateScheduledSlotsOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", false, DefaultAddress,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, false, DefaultAddress,
 			Occurrence.Recurring, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -73,16 +73,16 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, title, null, description, null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
 
 	private VolunteerOpportunity CreateDraftOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
-		VolunteerOpportunity.Create(DefaultOrgId, title, description, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
+		VolunteerOpportunity.Create(DefaultOrgId, title, null, description, null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private VolunteerOpportunity CreatePublishedScheduledSlotsOpportunity()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Altes Thema", "Alte Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Altes Thema", null, "Alte Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 		opportunity.AddTimeSlot(DateTimeOffset.UtcNow.AddDays(7), DateTimeOffset.UtcNow.AddDays(7).AddHours(2), 10, DateTimeOffset.UtcNow);
 		opportunity.Publish();
@@ -102,7 +102,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.PINCode, null, [], DefaultRequestingUserId,
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.PINCode, null, [], DefaultRequestingUserId,
 			CheckInPin: "13579");
 
 		// Act
@@ -110,6 +110,31 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		// Assert
 		opportunity.CheckInPin.Should().Be("13579");
+	}
+
+	[Test]
+	public async Task Handle_ShouldUpdateTitleEnAndDescriptionEn(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).Value, cancellationToken)
+			.Returns(opportunity);
+
+		var command = new UpdateVolunteerOpportunityCommand(
+			opportunityId, "Neues Thema", "New topic", "Neue Beschreibung", "New description", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		opportunity.TitleDe.Should().Be("Neues Thema");
+		opportunity.TitleEn.Should().Be("New topic");
+		opportunity.DescriptionDe.Should().Be("Neue Beschreibung");
+		opportunity.DescriptionEn.Should().Be("New description");
 	}
 
 	[Test]
@@ -126,15 +151,15 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.Manual, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.Manual, null, [], DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
 		result.Should().BeTrue();
-		opportunity.Title.Should().Be("Neues Thema");
-		opportunity.Description.Should().Be("Neue Beschreibung");
+		opportunity.TitleDe.Should().Be("Neues Thema");
+		opportunity.DescriptionDe.Should().Be("Neue Beschreibung");
 		opportunity.Address.Should().Be(newAddress);
 	}
 
@@ -151,7 +176,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.Recurring, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.Recurring, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -175,7 +200,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId,
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId,
 			ValidUntil: validUntil);
 
 		// Act
@@ -199,7 +224,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -221,7 +246,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId,
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId,
 			ValidUntil: DateTimeOffset.UtcNow.AddDays(-1));
 
 		// Act
@@ -252,7 +277,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			]);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -285,7 +310,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			]);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -309,7 +334,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Remote", "Desc", true, Address: null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Remote", null, "Desc", null, true, Address: null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -331,7 +356,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns((VolunteerOpportunity?)null);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -354,7 +379,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "   ", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "   ", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -377,14 +402,14 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(command, cancellationToken);
 
 		// Assert
 		result.Should().BeTrue();
-		opportunity.Title.Should().Be(string.Empty);
+		opportunity.TitleDe.Should().Be(string.Empty);
 	}
 
 	[Test]
@@ -407,7 +432,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Material change: new address (city changed).
 		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -446,7 +471,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -477,7 +502,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		// Cosmetic change only: title and description change, address/remote/occurrence unchanged.
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -505,7 +530,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, tooManyTags, DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, tooManyTags, DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -541,7 +566,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -568,7 +593,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Titel", "Beschreibung", false, Address: null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Titel", null, "Beschreibung", null, false, Address: null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -594,7 +619,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(false);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
@@ -602,8 +627,8 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Assert
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
-		opportunity.Title.Should().Be("Altes Thema");
-		opportunity.Description.Should().Be("Alte Beschreibung");
+		opportunity.TitleDe.Should().Be("Altes Thema");
+		opportunity.DescriptionDe.Should().Be("Alte Beschreibung");
 	}
 
 	[Test]
@@ -617,7 +642,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		var opportunityId = Guid.CreateVersion7();
 		var geocodedAddress = DefaultAddress.WithCoordinates(52.52, 13.405).GetValueOrThrow();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Altes Thema", "Alte Beschreibung", false, geocodedAddress, Occurrence.OneTime,
+			DefaultOrgId, "Altes Thema", null, "Alte Beschreibung", null, false, geocodedAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 		opportunity.ClearEvents();
@@ -628,7 +653,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		var newAddress = Address.Create("Nirgendwostraße", "999", "99999", "Nirgendwo").Value;
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -649,7 +674,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		var opportunityId = Guid.CreateVersion7();
 		var geocodedAddress = DefaultAddress.WithCoordinates(52.52, 13.405).GetValueOrThrow();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Altes Thema", "Alte Beschreibung", false, geocodedAddress, Occurrence.OneTime,
+			DefaultOrgId, "Altes Thema", null, "Alte Beschreibung", null, false, geocodedAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 		opportunity.ClearEvents();
@@ -660,7 +685,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 
 		// Same street/house number/zip/city as geocodedAddress - only cosmetic fields change.
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);
@@ -678,7 +703,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Arrange
 		var opportunityId = Guid.CreateVersion7();
 		var opportunity = VolunteerOpportunity.Create(
-			DefaultOrgId, "Altes Thema", "Alte Beschreibung", true, null, Occurrence.OneTime,
+			DefaultOrgId, "Altes Thema", null, "Alte Beschreibung", null, true, null, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
 			validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 
@@ -687,7 +712,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 			.Returns(opportunity);
 
 		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", "Neue Beschreibung", false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
+			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
 
 		// Act
 		await _sut.Handle(command, cancellationToken);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
@@ -38,7 +38,7 @@ public class UploadOpportunityBannerCommandHandlerTests
 
 	private VolunteerOpportunity CreateOpportunity() =>
 		VolunteerOpportunity.Create(
-			DefaultOrgId, "Titel", "Beschreibung", true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
+			DefaultOrgId, "Titel", null, "Beschreibung", null, true, null, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator,
 			status: OpportunityStatus.Draft).Value;
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/VolunteerOpportunityTests.cs
@@ -22,7 +22,9 @@ public class VolunteerOpportunityTests
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Helpers needed",
+			null,
 			"We need helpers for moving",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -32,8 +34,8 @@ public class VolunteerOpportunityTests
 			status: OpportunityStatus.Draft).Value;
 
 		// Assert
-		opportunity.Title.Should().Be("Helpers needed");
-		opportunity.Description.Should().Be("We need helpers for moving");
+		opportunity.TitleDe.Should().Be("Helpers needed");
+		opportunity.DescriptionDe.Should().Be("We need helpers for moving");
 		opportunity.OrganizationId.Should().Be(TestOrganizationId);
 		opportunity.IsRemote.Should().BeFalse();
 		opportunity.Address.Should().Be(TestAddress);
@@ -48,7 +50,9 @@ public class VolunteerOpportunityTests
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Remote help",
+			null,
 			"Online volunteering",
+			null,
 			true,
 			null,
 			Occurrence.Recurring,
@@ -72,7 +76,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			title!,
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -95,7 +101,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			title!,
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -106,7 +114,7 @@ public class VolunteerOpportunityTests
 
 		// Assert
 		result.IsSuccess.Should().BeTrue();
-		result.Value.Title.Should().Be(title);
+		result.Value.TitleDe.Should().Be(title);
 	}
 
 	[Test]
@@ -119,7 +127,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			description!,
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -142,7 +152,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			title,
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -166,7 +178,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			title,
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -189,7 +203,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			description,
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -213,7 +229,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			description,
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -224,6 +242,192 @@ public class VolunteerOpportunityTests
 
 		// Assert
 		result.IsSuccess.Should().BeTrue();
+	}
+
+	// --- Per-locale title/description (#1946) ---
+
+	[Test]
+	public void Create_ShouldSetTitleEnAndDescriptionEn_WhenProvided()
+	{
+		// Act
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Helfer gesucht",
+			"Helpers needed",
+			"Wir brauchen Helfer beim Umzug",
+			"We need helpers for moving",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+		// Assert
+		opportunity.TitleDe.Should().Be("Helfer gesucht");
+		opportunity.TitleEn.Should().Be("Helpers needed");
+		opportunity.DescriptionDe.Should().Be("Wir brauchen Helfer beim Umzug");
+		opportunity.DescriptionEn.Should().Be("We need helpers for moving");
+	}
+
+	[Test]
+	public void Create_ShouldAllow_PublishingWithoutEnglishVariant()
+	{
+		// Only the German title/description is required to publish - English is
+		// an optional organizer-supplied translation (#1946).
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Titel",
+			null,
+			"Beschreibung",
+			null,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			PinGenerator,
+			validUntil: Now.AddDays(30),
+			status: OpportunityStatus.Published);
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		result.Value.TitleEn.Should().BeNull();
+		result.Value.DescriptionEn.Should().BeNull();
+	}
+
+	[Test]
+	public void Create_ShouldFail_WhenTitleEnExceedsMaxLength()
+	{
+		// Arrange
+		var titleEn = new string('a', VolunteerOpportunity.MaxTitleLength + 1);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			titleEn,
+			"Description",
+			null,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Title must not exceed {VolunteerOpportunity.MaxTitleLength} characters.");
+	}
+
+	[Test]
+	public void Create_ShouldFail_WhenDescriptionEnExceedsMaxLength()
+	{
+		// Arrange
+		var descriptionEn = new string('a', VolunteerOpportunity.MaxDescriptionLength + 1);
+
+		// Act
+		var result = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Title",
+			null,
+			"Description",
+			descriptionEn,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft);
+
+		// Assert
+		result.IsFailure.Should().BeTrue();
+		result.Error.Description.Should().Be($"Description must not exceed {VolunteerOpportunity.MaxDescriptionLength} characters.");
+	}
+
+	[Test]
+	public void Rename_ShouldUpdateBothTitleDeAndTitleEn()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Titel",
+			"Title",
+			"Beschreibung",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+		// Act
+		var result = opportunity.Rename("Neuer Titel", "New title");
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		opportunity.TitleDe.Should().Be("Neuer Titel");
+		opportunity.TitleEn.Should().Be("New title");
+	}
+
+	[Test]
+	public void Rename_ShouldClearTitleEn_WhenRenamedWithoutIt()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Titel",
+			"Title",
+			"Beschreibung",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+		// Act
+		opportunity.Rename("Neuer Titel", null);
+
+		// Assert
+		opportunity.TitleEn.Should().BeNull();
+	}
+
+	[Test]
+	public void ChangeDescription_ShouldUpdateBothDescriptionDeAndDescriptionEn()
+	{
+		// Arrange
+		var opportunity = VolunteerOpportunity.Create(
+			TestOrganizationId,
+			"Titel",
+			"Title",
+			"Beschreibung",
+			"Description",
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.ScheduledSlots,
+			CheckInMethod.None,
+			PinGenerator,
+			status: OpportunityStatus.Draft).Value;
+
+		// Act
+		var result = opportunity.ChangeDescription("Neue Beschreibung", "New description");
+
+		// Assert
+		result.IsSuccess.Should().BeTrue();
+		opportunity.DescriptionDe.Should().Be("Neue Beschreibung");
+		opportunity.DescriptionEn.Should().Be("New description");
 	}
 
 	// --- Tags (#1678) ---
@@ -238,7 +442,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -263,7 +469,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -288,7 +496,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -313,7 +523,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -380,7 +592,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			null,
 			Occurrence.OneTime,
@@ -400,7 +614,9 @@ public class VolunteerOpportunityTests
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Regular help",
+			null,
 			"Every Saturday",
+			null,
 			false,
 			TestAddress,
 			Occurrence.Recurring,
@@ -421,7 +637,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -442,7 +660,9 @@ public class VolunteerOpportunityTests
 		var opportunity = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -466,7 +686,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -487,7 +709,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -508,7 +732,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -532,7 +758,9 @@ public class VolunteerOpportunityTests
 		var result = VolunteerOpportunity.Create(
 			TestOrganizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			false,
 			TestAddress,
 			Occurrence.OneTime,
@@ -552,7 +780,7 @@ public class VolunteerOpportunityTests
 	public void Publish_ShouldFail_WhenIndividualContactHasNoValidUntil()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 		var result = opportunity.Publish();
@@ -566,7 +794,7 @@ public class VolunteerOpportunityTests
 	public void Publish_ShouldSucceed_WhenIndividualContactHasValidUntil()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 		opportunity.SetValidUntil(Now.AddDays(14), Now);
 
@@ -580,7 +808,7 @@ public class VolunteerOpportunityTests
 	public void SetValidUntil_ShouldSetValue_WhenIndividualContact()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 		var result = opportunity.SetValidUntil(Now.AddDays(14), Now);
@@ -593,7 +821,7 @@ public class VolunteerOpportunityTests
 	public void SetValidUntil_ShouldClearValue_WhenGivenNull()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft, validUntil: Now.AddDays(14)).Value;
 
 		var result = opportunity.SetValidUntil(null, Now);
@@ -617,7 +845,7 @@ public class VolunteerOpportunityTests
 	public void SetValidUntil_ShouldFail_WhenNotInFuture()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 		var result = opportunity.SetValidUntil(Now, Now);
@@ -630,7 +858,7 @@ public class VolunteerOpportunityTests
 	public void SwitchParticipationType_ShouldClearValidUntil_WhenSwitchingAwayFromIndividualContact()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft, validUntil: Now.AddDays(14)).Value;
 
 		opportunity.SwitchParticipationType(ParticipationType.ScheduledSlots);
@@ -642,7 +870,7 @@ public class VolunteerOpportunityTests
 	public void SwitchParticipationType_ShouldKeepValidUntil_WhenStayingIndividualContact()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft, validUntil: Now.AddDays(14)).Value;
 
 		opportunity.SwitchParticipationType(ParticipationType.IndividualContact);
@@ -777,15 +1005,15 @@ public class VolunteerOpportunityTests
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 		var newAddress = Address.Create("Neue Straße", "42", "10115", "Hamburg").Value;
 
-		opportunity.Rename("New title");
-		opportunity.ChangeDescription("New desc");
+		opportunity.Rename("New title", null);
+		opportunity.ChangeDescription("New desc", null);
 		opportunity.Relocate(false, newAddress);
 		opportunity.Reschedule(Occurrence.Recurring);
 		opportunity.SwitchParticipationType(ParticipationType.IndividualContact);
 		opportunity.ChangeCheckInMethod(CheckInMethod.Manual, PinGenerator);
 
-		opportunity.Title.Should().Be("New title");
-		opportunity.Description.Should().Be("New desc");
+		opportunity.TitleDe.Should().Be("New title");
+		opportunity.DescriptionDe.Should().Be("New desc");
 		opportunity.Address.Should().Be(newAddress);
 		opportunity.Occurrence.Should().Be(Occurrence.Recurring);
 		opportunity.ParticipationType.Should().Be(ParticipationType.IndividualContact);
@@ -829,7 +1057,7 @@ public class VolunteerOpportunityTests
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10, Now);
 
-		opportunity.Rename("New title");
+		opportunity.Rename("New title", null);
 		opportunity.SwitchParticipationType(ParticipationType.ScheduledSlots);
 
 		opportunity.TimeSlots.Should().HaveCount(1);
@@ -840,8 +1068,8 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 
-		opportunity.Rename("Remote title");
-		opportunity.ChangeDescription("Remote desc");
+		opportunity.Rename("Remote title", null);
+		opportunity.ChangeDescription("Remote desc", null);
 		opportunity.Relocate(true, null);
 
 		opportunity.IsRemote.Should().BeTrue();
@@ -856,10 +1084,10 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 
-		var result = opportunity.Rename(title!);
+		var result = opportunity.Rename(title!, null);
 
 		result.IsSuccess.Should().BeTrue();
-		opportunity.Title.Should().Be(title);
+		opportunity.TitleDe.Should().Be(title);
 	}
 
 	[Test]
@@ -870,7 +1098,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = CreatePublishedScheduledSlotsOpportunity();
 
-		var result = opportunity.Rename(title!);
+		var result = opportunity.Rename(title!, null);
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Be("Title must not be empty.");
@@ -884,7 +1112,7 @@ public class VolunteerOpportunityTests
 	{
 		var opportunity = CreatePublishedScheduledSlotsOpportunity();
 
-		var result = opportunity.ChangeDescription(description!);
+		var result = opportunity.ChangeDescription(description!, null);
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Be("Description must not be empty.");
@@ -896,7 +1124,7 @@ public class VolunteerOpportunityTests
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 		var title = new string('a', VolunteerOpportunity.MaxTitleLength + 1);
 
-		var result = opportunity.Rename(title);
+		var result = opportunity.Rename(title, null);
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Be($"Title must not exceed {VolunteerOpportunity.MaxTitleLength} characters.");
@@ -908,7 +1136,7 @@ public class VolunteerOpportunityTests
 		var opportunity = CreateDraftScheduledSlotsOpportunity();
 		var description = new string('a', VolunteerOpportunity.MaxDescriptionLength + 1);
 
-		var result = opportunity.ChangeDescription(description);
+		var result = opportunity.ChangeDescription(description, null);
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Description.Should().Be($"Description must not exceed {VolunteerOpportunity.MaxDescriptionLength} characters.");
@@ -1006,13 +1234,13 @@ public class VolunteerOpportunityTests
 
 	private static VolunteerOpportunity CreateDraftScheduledSlotsOpportunity() =>
 		VolunteerOpportunity.Create(
-			TestOrganizationId, "Old title", "Old desc", false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Old title", null, "Old desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 	private static VolunteerOpportunity CreatePublishedScheduledSlotsOpportunity()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10, Now);
 		opportunity.Publish();
@@ -1028,7 +1256,7 @@ public class VolunteerOpportunityTests
 		pinGenerator.GeneratePin().Returns("1234");
 
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, pinGenerator, validUntil: Now.AddDays(30)).Value;
 
 		opportunity.CheckInPin.Should().Be("1234");
@@ -1038,7 +1266,7 @@ public class VolunteerOpportunityTests
 	public void Create_ShouldUseGivenPin_WhenPINCodeAndPinGiven()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: "13579", validUntil: Now.AddDays(30)).Value;
 
 		opportunity.CheckInPin.Should().Be("13579");
@@ -1048,7 +1276,7 @@ public class VolunteerOpportunityTests
 	public void Create_ShouldNotSetPin_WhenCheckInMethodIsNotPINCode()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, checkInPin: "1234", validUntil: Now.AddDays(30)).Value;
 
 		opportunity.CheckInPin.Should().BeNull();
@@ -1061,7 +1289,7 @@ public class VolunteerOpportunityTests
 	public void Create_ShouldFail_WhenPinIsInvalidFormat(string pin)
 	{
 		var result = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: pin);
 
 		result.IsFailure.Should().BeTrue();
@@ -1087,7 +1315,7 @@ public class VolunteerOpportunityTests
 	public void Create_ShouldFail_WhenPinIsTrivial(string pin)
 	{
 		var result = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: pin);
 
 		result.IsFailure.Should().BeTrue();
@@ -1098,7 +1326,7 @@ public class VolunteerOpportunityTests
 	public void ChangeCheckInMethod_ShouldFail_WhenPinIsTrivial()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		var result = opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "1111");
@@ -1112,7 +1340,7 @@ public class VolunteerOpportunityTests
 	public void ChangeCheckInMethod_ShouldOverwritePin_WhenCustomPinGiven()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "6193");
@@ -1124,7 +1352,7 @@ public class VolunteerOpportunityTests
 	public void ChangeCheckInMethod_ShouldKeepExistingPin_WhenNoPinGiven()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator);
@@ -1139,7 +1367,7 @@ public class VolunteerOpportunityTests
 		pinGenerator.GeneratePin().Returns("5678");
 
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, pinGenerator, validUntil: Now.AddDays(30)).Value;
 
 		opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, pinGenerator);
@@ -1151,7 +1379,7 @@ public class VolunteerOpportunityTests
 	public void ChangeCheckInMethod_ShouldFail_WhenPinIsInvalidFormat()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.PINCode, PinGenerator, checkInPin: "4827", validUntil: Now.AddDays(30)).Value;
 
 		var result = opportunity.ChangeCheckInMethod(CheckInMethod.PINCode, PinGenerator, checkInPin: "abc");
@@ -1164,7 +1392,7 @@ public class VolunteerOpportunityTests
 	public void AddTimeSlot_ShouldAddSlot_WhenParticipationTypeIsScheduledSlots()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), maxParticipants: 20, Now);
@@ -1177,7 +1405,7 @@ public class VolunteerOpportunityTests
 	public void AddTimeSlot_ShouldFail_WhenParticipationTypeIsIndividualContact()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.IndividualContact,
 			CheckInMethod.None, PinGenerator, validUntil: Now.AddDays(30)).Value;
 
 		var result = opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), maxParticipants: 10, Now);
@@ -1190,7 +1418,7 @@ public class VolunteerOpportunityTests
 	public void AddTimeSlot_ShouldSupportMultipleSlots()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.Recurring, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.Recurring, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10, Now);
@@ -1205,7 +1433,7 @@ public class VolunteerOpportunityTests
 	public void RemoveTimeSlot_ShouldRemoveSlot_WhenSlotExists()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 10, Now);
 		var slotId = opportunity.TimeSlots.First().Id;
@@ -1219,7 +1447,7 @@ public class VolunteerOpportunityTests
 	public void RemoveTimeSlot_ShouldFail_WhenSlotNotFound()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 		var nonExistentId = TimeSlotId.New();
 
@@ -1233,7 +1461,7 @@ public class VolunteerOpportunityTests
 	public void RemoveTimeSlot_ShouldOnlyRemoveTargetSlot_WhenMultipleSlotsExist()
 	{
 		var opportunity = VolunteerOpportunity.Create(
-			TestOrganizationId, "Title", "Desc", false, TestAddress, Occurrence.Recurring, ParticipationType.ScheduledSlots,
+			TestOrganizationId, "Title", null, "Desc", null, false, TestAddress, Occurrence.Recurring, ParticipationType.ScheduledSlots,
 			CheckInMethod.None, PinGenerator, status: OpportunityStatus.Draft).Value;
 		opportunity.AddTimeSlot(FutureSlotStart, FutureSlotStart.AddHours(2), 5, Now);
 		opportunity.AddTimeSlot(FutureSlotStart.AddDays(7), FutureSlotStart.AddDays(7).AddHours(2), 5, Now);

--- a/backend/tests/IntegrationTests/AccountDeletionTests.cs
+++ b/backend/tests/IntegrationTests/AccountDeletionTests.cs
@@ -34,8 +34,8 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Account Deletion Test Opportunity",
-				Description = "Integration test opportunity for account deletion",
+				TitleDe = "Account Deletion Test Opportunity",
+				DescriptionDe = "Integration test opportunity for account deletion",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -279,8 +279,8 @@ public class AccountDeletionTests(IntegrationTestFixture fixture)
 		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Anonymized Checked-In Engagement Test Opportunity",
-				Description = "Integration test opportunity for #1724",
+				TitleDe = "Anonymized Checked-In Engagement Test Opportunity",
+				DescriptionDe = "Integration test opportunity for #1724",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/AdminShadowDeleteUserTests.cs
+++ b/backend/tests/IntegrationTests/AdminShadowDeleteUserTests.cs
@@ -72,8 +72,8 @@ public class AdminShadowDeleteUserTests(IntegrationTestFixture fixture)
 			opportunity.Id,
 			new UpdateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				IsRemote = false,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -114,8 +114,8 @@ public class AdminShadowDeleteUserTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12475,11 +12475,17 @@ namespace IntegrationTests
     public partial class CreateVolunteerOpportunityRequest
     {
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
-        public string? Title { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
+        public string? TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
-        public string? Description { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
+        public string? DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -12546,13 +12552,19 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid Id { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = default!;
+        public string TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Description { get; set; } = default!;
+        public string DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -13266,9 +13278,12 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid OpportunityId { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = default!;
+        public string TitleDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("color")]
         public string? Color { get; set; } = default!;
@@ -13818,12 +13833,18 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid Id { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = default!;
+        public string TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
-        public string? Description { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
+        public string? DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("street")]
         public string? Street { get; set; } = default!;
@@ -14489,11 +14510,17 @@ namespace IntegrationTests
     public partial class UpdateVolunteerOpportunityRequest
     {
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
-        public string? Title { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
+        public string? TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
-        public string? Description { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
+        public string? DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("isRemote")]
         public bool IsRemote { get; set; } = default!;
@@ -14577,12 +14604,18 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid Id { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = default!;
+        public string TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
-        public string? Description { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
+        public string? DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -14679,12 +14712,18 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.Guid Id { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("titleDe")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = default!;
+        public string TitleDe { get; set; } = default!;
 
-        [System.Text.Json.Serialization.JsonPropertyName("description")]
-        public string? Description { get; set; } = default!;
+        [System.Text.Json.Serialization.JsonPropertyName("titleEn")]
+        public string? TitleEn { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionDe")]
+        public string? DescriptionDe { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("descriptionEn")]
+        public string? DescriptionEn { get; set; } = default!;
 
         [System.Text.Json.Serialization.JsonPropertyName("organizationId")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]

--- a/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
+++ b/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
@@ -156,8 +156,8 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		// like "nachbarschaftshilfe-lindenau.example" is not prose and has no locale.
 		var prose = organizations.Select(o => o.Name)
 			.Concat(organizations.Select(o => o.Description ?? string.Empty))
-			.Concat(opportunities.Select(o => o.Title))
-			.Concat(opportunities.Select(o => o.Description))
+			.Concat(opportunities.Select(o => o.TitleDe))
+			.Concat(opportunities.Select(o => o.DescriptionDe))
 			.Where(text => !string.IsNullOrWhiteSpace(text))
 			.ToList();
 
@@ -201,7 +201,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		var slots = (await dbContext.Set<VolunteerOpportunity>()
 				.Include(o => o.TimeSlots)
 				.ToListAsync(cancellationToken))
-			.SelectMany(o => o.TimeSlots.Select(slot => (o.Title, slot.StartDateTime, slot.EndDateTime)))
+			.SelectMany(o => o.TimeSlots.Select(slot => (o.TitleDe, slot.StartDateTime, slot.EndDateTime)))
 			.ToList();
 
 		slots.Should().NotBeEmpty("the seed set publishes slot-based opportunities");
@@ -242,7 +242,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
 		var opportunity = await dbContext.Set<VolunteerOpportunity>()
 			.Include(o => o.TimeSlots)
-			.SingleAsync(o => o.Title == "Erste-Hilfe-Kurs", cancellationToken);
+			.SingleAsync(o => o.TitleDe == "Erste-Hilfe-Kurs", cancellationToken);
 
 		var engagements = await dbContext.Set<Engagement>()
 			.Where(e => e.VolunteerId == veraUserId && e.OpportunityId == opportunity.Id)

--- a/backend/tests/IntegrationTests/AuditLogTests.cs
+++ b/backend/tests/IntegrationTests/AuditLogTests.cs
@@ -76,8 +76,8 @@ public class AuditLogTests(
 		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = opportunityTitle,
-				Description = "Integration test opportunity",
+				TitleDe = opportunityTitle,
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = organization.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/AutomaticCheckInJobTests.cs
+++ b/backend/tests/IntegrationTests/AutomaticCheckInJobTests.cs
@@ -164,7 +164,7 @@ public class AutomaticCheckInJobTests(IntegrationTestFixture fixture)
 		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
 		// here since nothing in this test path depends on the opportunity being published.
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Beach Cleanup", "Help clean the beach", true, null,
+			organization.Id, "Beach Cleanup", null, "Help clean the beach", null, true, null,
 			Occurrence.OneTime, ParticipationType.ScheduledSlots, checkInMethod, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).Value;
 

--- a/backend/tests/IntegrationTests/CreateTimeSlotTests.cs
+++ b/backend/tests/IntegrationTests/CreateTimeSlotTests.cs
@@ -114,8 +114,8 @@ public class CreateTimeSlotTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReadRepositoryTests.cs
@@ -81,7 +81,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.Recurring,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.Recurring,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var slotA = opportunity.AddTimeSlot(
@@ -118,7 +118,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var slot = opportunity.AddTimeSlot(
@@ -147,7 +147,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var slot = opportunity.AddTimeSlot(
@@ -178,7 +178,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		dbContext.Set<VolunteerOpportunity>().Add(opportunity);
@@ -228,7 +228,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.Recurring,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.Recurring,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var slot = opportunity.AddTimeSlot(
@@ -373,7 +373,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.None, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
@@ -406,7 +406,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.QRCode, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
@@ -460,7 +460,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.PINCode, new RandomPinGenerator(),
 			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
@@ -494,7 +494,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var pastNow = DateTimeOffset.UtcNow.AddDays(-11);
@@ -528,7 +528,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var futureSlot = opportunity.AddTimeSlot(
@@ -567,7 +567,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.Manual, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var futureSlot = opportunity.AddTimeSlot(
@@ -605,7 +605,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.Manual, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var pastNow = DateTimeOffset.UtcNow.AddDays(-11);
@@ -644,7 +644,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.IndividualContact, CheckInMethod.Manual, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft, validUntil: DateTimeOffset.UtcNow.AddDays(30)).GetValueOrThrow();
 		await dbContext.VolunteerOpportunities.AddAsync(opportunity, cancellationToken);
@@ -678,7 +678,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Strandreinigung", "Beschreibung", false, DefaultAddress, Occurrence.Recurring,
+			organization.Id, "Strandreinigung", null, "Beschreibung", null, false, DefaultAddress, Occurrence.Recurring,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		var slot = opportunity.AddTimeSlot(
@@ -743,7 +743,7 @@ public class EngagementReadRepositoryTests(IntegrationTestFixture fixture)
 		dbContext.Set<DomainOrganization>().Add(organization);
 
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Titel", "Beschreibung", false, DefaultAddress, Occurrence.OneTime,
+			organization.Id, "Titel", null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
 			ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).GetValueOrThrow();
 		// Added out of chronological order - CreatedOn (sign-up order) must not

--- a/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
+++ b/backend/tests/IntegrationTests/EngagementReminderJobTests.cs
@@ -189,7 +189,7 @@ public class EngagementReminderJobTests(IntegrationTestFixture fixture)
 		// at least one time slot first - see VolunteerOpportunity.Create) - Draft is fine
 		// here since nothing in this test path depends on the opportunity being published.
 		var opportunity = VolunteerOpportunity.Create(
-			organization.Id, "Beach Cleanup", "Help clean the beach", true, null,
+			organization.Id, "Beach Cleanup", null, "Help clean the beach", null, true, null,
 			Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, new NoOpPinGenerator(),
 			status: OpportunityStatus.Draft).Value;
 

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -2051,8 +2051,8 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -2074,8 +2074,8 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "ScheduledSlots Opportunity",
-				Description = "Integration test ScheduledSlots opportunity",
+				TitleDe = "ScheduledSlots Opportunity",
+				DescriptionDe = "Integration test ScheduledSlots opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/EnumCheckConstraintTests.cs
+++ b/backend/tests/IntegrationTests/EnumCheckConstraintTests.cs
@@ -391,7 +391,9 @@ public class EnumCheckConstraintTests(IntegrationTestFixture fixture)
 		var opportunity = VolunteerOpportunity.Create(
 			organization.Id,
 			"Title",
+			null,
 			"Description",
+			null,
 			isRemote: true,
 			address: null,
 			Occurrence.OneTime,
@@ -497,7 +499,9 @@ public class EnumCheckConstraintTests(IntegrationTestFixture fixture)
 		VolunteerOpportunity.Create(
 			organizationId,
 			"Title",
+			null,
 			"Description",
+			null,
 			isRemote: true,
 			address: null,
 			Occurrence.OneTime,

--- a/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationDashboardTests.cs
@@ -195,8 +195,8 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -218,8 +218,8 @@ public class GetOrganizationDashboardTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "ScheduledSlots Opportunity",
-				Description = "Integration test ScheduledSlots opportunity",
+				TitleDe = "ScheduledSlots Opportunity",
+				DescriptionDe = "Integration test ScheduledSlots opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/GetOrganizationEngagementsTests.cs
+++ b/backend/tests/IntegrationTests/GetOrganizationEngagementsTests.cs
@@ -225,8 +225,8 @@ public class GetOrganizationEngagementsTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/GetSitemapTests.cs
+++ b/backend/tests/IntegrationTests/GetSitemapTests.cs
@@ -119,8 +119,8 @@ public class GetSitemapTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken) =>
 		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Published opportunity",
-			Description = "IndividualContact - no time slots required to publish",
+			TitleDe = "Published opportunity",
+			DescriptionDe = "IndividualContact - no time slots required to publish",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -136,8 +136,8 @@ public class GetSitemapTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, CancellationToken cancellationToken) =>
 		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Draft opportunity",
-			Description = "Never published",
+			TitleDe = "Draft opportunity",
+			DescriptionDe = "Never published",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -155,8 +155,8 @@ public class GetSitemapTests(IntegrationTestFixture fixture)
 	{
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Expired opportunity",
-			Description = "Only has a time slot that already ended",
+			TitleDe = "Expired opportunity",
+			DescriptionDe = "Only has a time slot that already ended",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -33,8 +33,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
 		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Draft - never published",
-			Description = "Exists only to force a fresh output-cache read; see comment above.",
+			TitleDe = "Draft - never published",
+			DescriptionDe = "Exists only to force a fresh output-cache read; see comment above.",
 			OrganizationId = orgId,
 			Occurrence = "OneTime",
 			ParticipationType = "IndividualContact",
@@ -182,8 +182,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Opportunity with a slot",
-			Description = "Description",
+			TitleDe = "Opportunity with a slot",
+			DescriptionDe = "Description",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -227,8 +227,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Opportunity with recurring slots",
-			Description = "Description",
+			TitleDe = "Opportunity with recurring slots",
+			DescriptionDe = "Description",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -271,8 +271,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Opportunity without slots",
-			Description = "Description",
+			TitleDe = "Opportunity without slots",
+			DescriptionDe = "Description",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -303,8 +303,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var future = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Future opportunity",
-			Description = "Has an upcoming slot",
+			TitleDe = "Future opportunity",
+			DescriptionDe = "Has an upcoming slot",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -329,8 +329,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var slotless = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Slotless opportunity",
-			Description = "Never has time slots",
+			TitleDe = "Slotless opportunity",
+			DescriptionDe = "Never has time slots",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -361,8 +361,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Mixed expiry opportunity",
-			Description = "One slot already ended, one is still upcoming",
+			TitleDe = "Mixed expiry opportunity",
+			DescriptionDe = "One slot already ended, one is still upcoming",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -486,8 +486,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var act = () => client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Not allowed",
-			Description = "Vera cannot create opportunities",
+			TitleDe = "Not allowed",
+			DescriptionDe = "Vera cannot create opportunities",
 			OrganizationId = Guid.NewGuid(),
 			Street = "Test Street",
 			HouseNumber = "1",
@@ -511,8 +511,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var result = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Opportunity with address",
-			Description = "Test",
+			TitleDe = "Opportunity with address",
+			DescriptionDe = "Test",
 			OrganizationId = orgId,
 			Street = "Main Street",
 			HouseNumber = "42a",
@@ -611,8 +611,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 
 		var opportunity = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Matching opportunity",
-			Description = "Description",
+			TitleDe = "Matching opportunity",
+			DescriptionDe = "Description",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -666,7 +666,7 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, tag: "environment", cancellationToken: cancellationToken);
 
 		result.TotalItems.Should().Be(1);
-		result.Items.Single().Title.Should().Be("Beach Cleanup");
+		result.Items.Single().TitleDe.Should().Be("Beach Cleanup");
 	}
 
 	[Test]
@@ -687,9 +687,9 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		var byDescription = await sut.GetVolunteerOpportunitiesAsync(1, 10, keyword: "shoreline", cancellationToken: cancellationToken);
 
 		byTitle.TotalItems.Should().Be(1);
-		byTitle.Items.Single().Title.Should().Be("Beach Cleanup");
+		byTitle.Items.Single().TitleDe.Should().Be("Beach Cleanup");
 		byDescription.TotalItems.Should().Be(1);
-		byDescription.Items.Single().Title.Should().Be("Beach Cleanup");
+		byDescription.Items.Single().TitleDe.Should().Be("Beach Cleanup");
 	}
 
 	[Test]
@@ -714,7 +714,7 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		var result = await sut.GetVolunteerOpportunitiesAsync(1, 10, keyword: "wildlife rescue", cancellationToken: cancellationToken);
 
 		result.TotalItems.Should().Be(1);
-		result.Items.Single().Title.Should().Be("Weekend Shift");
+		result.Items.Single().TitleDe.Should().Be("Weekend Shift");
 	}
 
 	[Test]
@@ -745,7 +745,7 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 			1, 10, centerLatitude: centerLat, centerLongitude: centerLon, radiusKm: 20, cancellationToken: cancellationToken);
 
 		result.TotalItems.Should().Be(2, "only the near and mid opportunities fall within the 20km radius");
-		result.Items.Select(i => i.Title).Should().Equal(
+		result.Items.Select(i => i.TitleDe).Should().Equal(
 			["Near Opportunity", "Mid Opportunity"],
 			"radius search results must be ordered by distance ascending");
 	}
@@ -780,8 +780,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		// slot, so create it as a draft, add a slot, then publish it.
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = description,
+			TitleDe = title,
+			DescriptionDe = description,
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -813,8 +813,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken) =>
 		await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "No time slots - IndividualContact",
+			TitleDe = title,
+			DescriptionDe = "No time slots - IndividualContact",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -831,8 +831,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	{
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "Scheduled slots opportunity with a single time slot",
+			TitleDe = title,
+			DescriptionDe = "Scheduled slots opportunity with a single time slot",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -872,8 +872,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	{
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Expired opportunity",
-			Description = "Only has a time slot that already ended",
+			TitleDe = "Expired opportunity",
+			DescriptionDe = "Only has a time slot that already ended",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -908,8 +908,8 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, string title, string[] tags, CancellationToken cancellationToken) =>
 		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "Description",
+			TitleDe = title,
+			DescriptionDe = "Description",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -935,7 +935,9 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 		var opportunity = VolunteerOpportunity.Create(
 			DomainOrganizationId.Create(orgId).GetValueOrThrow(),
 			title,
+			null,
 			"Description",
+			null,
 			isRemote: false,
 			address,
 			Occurrence.OneTime,

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
@@ -122,8 +122,8 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 
 		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Express interest opportunity",
-			Description = "No time slots - IndividualContact",
+			TitleDe = "Express interest opportunity",
+			DescriptionDe = "No time slots - IndividualContact",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -156,8 +156,8 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 		var slotStart = UtcDayAt(daysFromToday: 4, hour: 10);
 		var draft = await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Still a draft",
-			Description = "Never published",
+			TitleDe = "Still a draft",
+			DescriptionDe = "Never published",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -318,8 +318,8 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 		// created as a draft, given its slot, and only then published.
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "Scheduled slots opportunity seeded for the date-availability calendar",
+			TitleDe = title,
+			DescriptionDe = "Scheduled slots opportunity seeded for the date-availability calendar",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityDetailsTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityDetailsTests.cs
@@ -97,8 +97,8 @@ public class GetVolunteerOpportunityDetailsTests(IntegrationTestFixture fixture)
 		await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityMetaTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityMetaTests.cs
@@ -90,8 +90,8 @@ public class GetVolunteerOpportunityMetaTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, bool isDraft, CancellationToken cancellationToken) =>
 		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Strandreinigung Musterstadt",
-			Description = "Gemeinsam sammeln wir Müll am Strand ein.",
+			TitleDe = "Strandreinigung Musterstadt",
+			DescriptionDe = "Gemeinsam sammeln wir Müll am Strand ein.",
 			OrganizationId = orgId,
 			IsRemote = true,
 			Occurrence = "OneTime",

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -646,8 +646,8 @@ public class NotificationTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = title,
-				Description = "Integration test opportunity for notifications",
+				TitleDe = title,
+				DescriptionDe = "Integration test opportunity for notifications",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationCalendarEventsTests.cs
@@ -231,8 +231,8 @@ public class OrganizationCalendarEventsTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Calendar Events Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Calendar Events Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationOpportunitiesTests.cs
@@ -39,7 +39,7 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 		var result = await client.GetOrganizationOpportunitiesAsync(orgId, "Draft", 1, 10, cancellationToken);
 
 		result.TotalItems.Should().Be(1);
-		result.Items.Single().Title.Should().Be("Draft 1");
+		result.Items.Single().TitleDe.Should().Be("Draft 1");
 	}
 
 	[Test]
@@ -55,7 +55,7 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 		var result = await client.GetOrganizationOpportunitiesAsync(orgId, "Published", 1, 10, cancellationToken);
 
 		result.TotalItems.Should().Be(1);
-		result.Items.Single().Title.Should().Be("Published 1");
+		result.Items.Single().TitleDe.Should().Be("Published 1");
 	}
 
 	[Test]
@@ -187,7 +187,7 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 		var result = await veraClient.GetOrganizationOpportunitiesAsync(orgId, "Published", 1, 10, cancellationToken);
 
 		result.TotalItems.Should().Be(1);
-		result.Items.Single().Title.Should().Be("Published 1");
+		result.Items.Single().TitleDe.Should().Be("Published 1");
 	}
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(CancellationToken cancellationToken)
@@ -212,8 +212,8 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken) =>
 		client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "Integration test opportunity",
+			TitleDe = title,
+			DescriptionDe = "Integration test opportunity",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",
@@ -230,8 +230,8 @@ public class OrganizationOpportunitiesTests(IntegrationTestFixture fixture)
 	{
 		var opportunity = await client.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = title,
-			Description = "Integration test opportunity",
+			TitleDe = title,
+			DescriptionDe = "Integration test opportunity",
 			OrganizationId = orgId,
 			Street = "Sample Street",
 			HouseNumber = "1",

--- a/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationSettingsTests.cs
@@ -1007,8 +1007,8 @@ public class OrganizationSettingsTests(
 		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Blocking Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Blocking Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -1058,8 +1058,8 @@ public class OrganizationSettingsTests(
 		var opportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Expired Slot Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Expired Slot Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -1092,8 +1092,8 @@ public class OrganizationSettingsTests(
 		var blockingOpportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Future Slot Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Future Slot Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",
@@ -1120,8 +1120,8 @@ public class OrganizationSettingsTests(
 		var nonBlockingOpportunity = await olafClient.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Expired Slot Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Expired Slot Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = org.Id.Value,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/OutboxTests.cs
+++ b/backend/tests/IntegrationTests/OutboxTests.cs
@@ -104,8 +104,8 @@ public class OutboxTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/IntegrationTests/OutputCachingTests.cs
+++ b/backend/tests/IntegrationTests/OutputCachingTests.cs
@@ -85,8 +85,8 @@ public class OutputCachingTests(IntegrationTestFixture fixture)
 		// No IsDraft flag - published immediately, so it must appear on the very next read.
 		await authenticatedClient.CreateVolunteerOpportunityAsync(new CreateVolunteerOpportunityRequest
 		{
-			Title = "Freshly published opportunity",
-			Description = "Proves a create evicts the output cache (#1543)",
+			TitleDe = "Freshly published opportunity",
+			DescriptionDe = "Proves a create evicts the output cache (#1543)",
 			OrganizationId = orgId,
 			IsRemote = true,
 			Occurrence = "OneTime",

--- a/backend/tests/IntegrationTests/VolunteerOpportunityOwnershipTests.cs
+++ b/backend/tests/IntegrationTests/VolunteerOpportunityOwnershipTests.cs
@@ -117,8 +117,8 @@ public class VolunteerOpportunityOwnershipTests(IntegrationTestFixture fixture)
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
-				Title = "Test Opportunity",
-				Description = "Integration test opportunity",
+				TitleDe = "Test Opportunity",
+				DescriptionDe = "Integration test opportunity",
 				OrganizationId = orgId,
 				Street = "Test Street",
 				HouseNumber = "1",

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -205,8 +205,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"A11y Draft Test {suffix}",
-			description = "Seeded draft for the owner-affordances a11y scan.",
+			titleDe = $"A11y Draft Test {suffix}",
+			descriptionDe = "Seeded draft for the owner-affordances a11y scan.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -259,8 +259,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"A11y Mobile Rail Test {suffix}",
-			description = "Seeded for #1965 mobile action-rail a11y coverage.",
+			titleDe = $"A11y Mobile Rail Test {suffix}",
+			descriptionDe = "Seeded for #1965 mobile action-rail a11y coverage.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -397,8 +397,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var title = $"Marker A11y Test {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Seeded for the map marker accessible-name regression (#1681).",
+			titleDe = title,
+			descriptionDe = "Seeded for the map marker accessible-name regression (#1681).",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",
@@ -478,8 +478,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var title = $"No Map A11y Test {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Seeded for the map-unavailable placeholder a11y regression (#1963).",
+			titleDe = title,
+			descriptionDe = "Seeded for the map-unavailable placeholder a11y regression (#1963).",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",
@@ -1355,8 +1355,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"EngagementManagementA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"EngagementManagementA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -1422,8 +1422,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"OrgEngagementsA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"OrgEngagementsA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -1751,8 +1751,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"NotifA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"NotifA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2070,8 +2070,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CancelDialogA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"CancelDialogA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2130,8 +2130,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"OrgEngagementsCancelDialogA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"OrgEngagementsCancelDialogA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2194,8 +2194,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CancelOpportunityDialogA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"CancelOpportunityDialogA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2244,8 +2244,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"{label} Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2421,8 +2421,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"ToastA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"ToastA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -2501,8 +2501,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"MarkedDayA11y Opportunity {suffix}",
-			description = "Created by AccessibilityTests",
+			titleDe = $"MarkedDayA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -1832,7 +1832,20 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	// One case per administration section: they are separate routes behind a
 	// shared left rail now, not four stacked sections on one page, so a single
 	// scan of /administration would only ever cover the first of them.
+	//
+	// [Retry(2)]: this is the one AuthHelper.LoginAsync call site that reliably
+	// lands in the very first concurrently-started batch of tests (see the
+	// "organizations" case, which repeatedly logged as one of the first two
+	// "[slow] still running" entries across many unrelated PRs' CI runs). The
+	// real Keycloak round trip it drives occasionally exceeds even a generous
+	// fixed timeout while the Aspire stack is still warming up - raising
+	// AuthHelper's timeout from 30s to 90s across several rounds never
+	// eliminated it, it just kept landing a few seconds past whatever ceiling
+	// was set (63s at a 60s cap, ~93.5s at a 90s cap). A per-test retry costs
+	// nothing on the common case (a fast top-of-suite login) and absorbs the
+	// rare slow one without inflating every other LoginAsync caller's timeout.
 	[Test]
+	[Retry(2)]
 	[Arguments("organizations")]
 	[Arguments("users")]
 	[Arguments("reports")]

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -312,8 +312,8 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await organizerHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"A11y Status Slot Test {suffix}",
-			description = "Seeded for #1938 application-status time-slot a11y coverage.",
+			titleDe = $"A11y Status Slot Test {suffix}",
+			descriptionDe = "Seeded for #1938 application-status time-slot a11y coverage.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/AchievementCopyTests.cs
+++ b/backend/tests/VisualTests/AchievementCopyTests.cs
@@ -227,8 +227,8 @@ public class AchievementCopyTests(AspireFixture fixture) : VisualTestBase(fixtur
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"AchievementCopy Opportunity {suffix}",
-			description = "Created by AchievementCopyTests to give vera an activity streak.",
+			titleDe = $"AchievementCopy Opportunity {suffix}",
+			descriptionDe = "Created by AchievementCopyTests to give vera an activity streak.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -50,8 +50,8 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 			var oppResponse = await seedHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title = $"AchievementsSelfSeed Opportunity {suffix}",
-				description = "Created by AchievementsTests to guarantee olaf has an achievement.",
+				titleDe = $"AchievementsSelfSeed Opportunity {suffix}",
+				descriptionDe = "Created by AchievementsTests to guarantee olaf has an achievement.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",
@@ -101,8 +101,8 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 			var oppResponse = await setupHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title = $"AchievementSeed Opportunity {setupSuffix}",
-				description = "Created by AchievementsTests to guarantee a confirmed engagement",
+				titleDe = $"AchievementSeed Opportunity {setupSuffix}",
+				descriptionDe = "Created by AchievementsTests to guarantee a confirmed engagement",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/AdminReportsTests.cs
+++ b/backend/tests/VisualTests/AdminReportsTests.cs
@@ -43,8 +43,8 @@ public class AdminReportsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var title = $"Flagged Opportunity {suffix}";
 		var opportunityResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Regression coverage for the admin reports 500.",
+			titleDe = title,
+			descriptionDe = "Regression coverage for the admin reports 500.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/AuthHelper.cs
+++ b/backend/tests/VisualTests/AuthHelper.cs
@@ -41,7 +41,7 @@ public static class AuthHelper
 		// HasNoSeriousA11yViolations across otherwise-unrelated PRs). Waiting
 		// on the "User menu" button - the same authenticated-render signal
 		// FastSignInAsync already waits on - is independent of which frame
-		// navigation Playwright happens to observe. 60s, not 30s: this is the
+		// navigation Playwright happens to observe. 90s, not 30s: this is the
 		// only caller that drives the real Keycloak round trip (redirect,
 		// form submit, code exchange) rather than seeding a token, and the
 		// AdministrationPage_HasNoSeriousA11yViolations(organizations) case
@@ -49,11 +49,13 @@ public static class AuthHelper
 		// concurrently-started tests, while the Aspire stack (Postgres,
 		// Keycloak, backend API) is still warming up on top of the CPU
 		// contention AssemblyParallelLimit.cs already documents among
-		// concurrent Playwright sessions - both 30s and 45s were observed
-		// too tight for that specific cold-start window even after fixing
-		// the wait target above.
+		// concurrent Playwright sessions. 30s, 45s and 60s were each observed
+		// too tight for that cold-start window even after fixing the wait
+		// target above - the 60s failure clocked in at ~63s, right at the
+		// boundary rather than wildly over, so 90s gives real margin instead
+		// of chasing the timeout up in small increments again.
 		await page.GetByRole(AriaRole.Button, new() { Name = "User menu" })
-			.WaitForAsync(new() { Timeout = 60_000 });
+			.WaitForAsync(new() { Timeout = 90_000 });
 	}
 
 	/// <summary>

--- a/backend/tests/VisualTests/AuthHelper.cs
+++ b/backend/tests/VisualTests/AuthHelper.cs
@@ -41,21 +41,21 @@ public static class AuthHelper
 		// HasNoSeriousA11yViolations across otherwise-unrelated PRs). Waiting
 		// on the "User menu" button - the same authenticated-render signal
 		// FastSignInAsync already waits on - is independent of which frame
-		// navigation Playwright happens to observe. 90s, not 30s: this is the
-		// only caller that drives the real Keycloak round trip (redirect,
-		// form submit, code exchange) rather than seeding a token, and the
-		// AdministrationPage_HasNoSeriousA11yViolations(organizations) case
-		// that exercises it consistently lands in the very first batch of
-		// concurrently-started tests, while the Aspire stack (Postgres,
-		// Keycloak, backend API) is still warming up on top of the CPU
-		// contention AssemblyParallelLimit.cs already documents among
-		// concurrent Playwright sessions. 30s, 45s and 60s were each observed
-		// too tight for that cold-start window even after fixing the wait
-		// target above - the 60s failure clocked in at ~63s, right at the
-		// boundary rather than wildly over, so 90s gives real margin instead
-		// of chasing the timeout up in small increments again.
+		// navigation Playwright happens to observe. 45s, not 30s, to match
+		// GoToOrgAppDashboardViaCtaAsync below: this is the only caller that
+		// drives the real Keycloak round trip (redirect, form submit, code
+		// exchange) rather than seeding a token, so it is the most exposed to
+		// AssemblyParallelLimit.cs's documented CPU contention among
+		// concurrent Playwright sessions. Pushing this fixed timeout past 90s
+		// chasing AdministrationPage_HasNoSeriousA11yViolations(organizations) -
+		// the one caller that consistently lands in the earliest concurrent
+		// batch, while the Aspire stack is still warming up - never actually
+		// caught up: 30s, 45s, 60s and 90s were each observed too tight in
+		// turn, always failing a few seconds past whatever ceiling was set.
+		// That test now carries its own [Retry(2)] instead, so this timeout
+		// only needs to cover the common case, not the occasional outlier.
 		await page.GetByRole(AriaRole.Button, new() { Name = "User menu" })
-			.WaitForAsync(new() { Timeout = 90_000 });
+			.WaitForAsync(new() { Timeout = 45_000 });
 	}
 
 	/// <summary>

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -113,8 +113,8 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 		var oppTitle = $"VisualLogo Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by AvatarAndLogoDisplayTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by AvatarAndLogoDisplayTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -42,8 +42,8 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var oppTitle = $"CheckInNone Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInAndSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInAndSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -104,8 +104,8 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var oppTitle = $"CheckInManual Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInAndSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInAndSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -187,8 +187,8 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var oppTitle = $"CheckInPinSwitch Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInAndSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInAndSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -266,8 +266,8 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var oppTitle = $"SlotCounts Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInAndSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInAndSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -368,8 +368,8 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var oppTitle = $"Unlimited Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInAndSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInAndSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -34,8 +34,8 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		var oppTitle = $"CheckInModalDeleted Opportunity {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInModalDeletedOpportunityTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInModalDeletedOpportunityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
+++ b/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
@@ -94,8 +94,8 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 		var oppTitle = $"CheckInPinEdit Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CheckInPinOrganizerSetTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CheckInPinOrganizerSetTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
+++ b/backend/tests/VisualTests/CreateOpportunityRetryTests.cs
@@ -116,7 +116,7 @@ public class CreateOpportunityRetryTests(AspireFixture fixture) : VisualTestBase
 			response.EnsureSuccessStatusCode();
 			var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 			return body.GetProperty("items").EnumerateArray()
-				.Where(o => o.GetProperty("title").GetString() == uniqueTitle)
+				.Where(o => o.GetProperty("titleDe").GetString() == uniqueTitle)
 				.ToList();
 		}
 

--- a/backend/tests/VisualTests/DateFilterCalendarTests.cs
+++ b/backend/tests/VisualTests/DateFilterCalendarTests.cs
@@ -156,8 +156,8 @@ public class DateFilterCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 		// so it goes draft -> slot -> publish.
 		var createResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Seeded for #1779 date-filter availability marks.",
+			titleDe = title,
+			descriptionDe = "Seeded for #1779 date-filter availability marks.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EmailDeliveryTests.cs
+++ b/backend/tests/VisualTests/EmailDeliveryTests.cs
@@ -175,8 +175,8 @@ public class EmailDeliveryTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by EmailDeliveryTests",
+			titleDe = title,
+			descriptionDe = "Created by EmailDeliveryTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementBulkActionsTests.cs
+++ b/backend/tests/VisualTests/EngagementBulkActionsTests.cs
@@ -120,8 +120,8 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 		// Create rejects a non-null ValidUntil for any other participation type).
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by EngagementBulkActionsTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by EngagementBulkActionsTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementCalendarTests.cs
+++ b/backend/tests/VisualTests/EngagementCalendarTests.cs
@@ -49,8 +49,8 @@ public class EngagementCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 		var oppTitle = $"VisualCal Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by EngagementCalendarTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by EngagementCalendarTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
+++ b/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
@@ -145,8 +145,8 @@ public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTe
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by EngagementCancellationReasonTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by EngagementCancellationReasonTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
+++ b/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
@@ -33,8 +33,8 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CheckInStatusCode Opportunity {suffix}",
-			description = "Created by EngagementCheckInStatusCodeTests.",
+			titleDe = $"CheckInStatusCode Opportunity {suffix}",
+			descriptionDe = "Created by EngagementCheckInStatusCodeTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -81,8 +81,8 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		const string pin = "482170";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CheckInPinOwner Opportunity {suffix}",
-			description = "Created by EngagementCheckInStatusCodeTests.",
+			titleDe = $"CheckInPinOwner Opportunity {suffix}",
+			descriptionDe = "Created by EngagementCheckInStatusCodeTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -139,8 +139,8 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		const string pin = "482170";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CheckInPinOracle Opportunity {suffix}",
-			description = "Created by EngagementCheckInStatusCodeTests.",
+			titleDe = $"CheckInPinOracle Opportunity {suffix}",
+			descriptionDe = "Created by EngagementCheckInStatusCodeTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -201,8 +201,8 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		const string pin = "482170";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CheckInPinLockout Opportunity {suffix}",
-			description = "Created by EngagementCheckInStatusCodeTests.",
+			titleDe = $"CheckInPinLockout Opportunity {suffix}",
+			descriptionDe = "Created by EngagementCheckInStatusCodeTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
+++ b/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
@@ -151,8 +151,8 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by EngagementCoreJourneysTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by EngagementCoreJourneysTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
@@ -177,8 +177,8 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"EngHistDeletedOpp {label} {suffix}",
-			description = "Created by EngagementHistoryForDeletedOpportunityTests",
+			titleDe = $"EngHistDeletedOpp {label} {suffix}",
+			descriptionDe = "Created by EngagementHistoryForDeletedOpportunityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
@@ -109,8 +109,8 @@ public class EngagementManagementCheckInPinTests(AspireFixture fixture) : Visual
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"CheckInPin {label} {suffix}",
-			description = "Created by EngagementManagementCheckInPinTests",
+			titleDe = $"CheckInPin {label} {suffix}",
+			descriptionDe = "Created by EngagementManagementCheckInPinTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
@@ -99,8 +99,8 @@ public class EngagementManagementFeedbackSectionTests(AspireFixture fixture) : V
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"FeedbackSection {label} Opportunity {suffix}",
-			description = "Created by EngagementManagementFeedbackSectionTests",
+			titleDe = $"FeedbackSection {label} Opportunity {suffix}",
+			descriptionDe = "Created by EngagementManagementFeedbackSectionTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
@@ -78,8 +78,8 @@ public class EngagementManagementFiltersTests(AspireFixture fixture) : VisualTes
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by EngagementManagementFiltersTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by EngagementManagementFiltersTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementReactivationTests.cs
+++ b/backend/tests/VisualTests/EngagementReactivationTests.cs
@@ -142,8 +142,8 @@ public class EngagementReactivationTests(AspireFixture fixture) : VisualTestBase
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"EngagementReactivation {label} {suffix}",
-			description = "Created by EngagementReactivationTests",
+			titleDe = $"EngagementReactivation {label} {suffix}",
+			descriptionDe = "Created by EngagementReactivationTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementStatusContrastTests.cs
+++ b/backend/tests/VisualTests/EngagementStatusContrastTests.cs
@@ -103,8 +103,8 @@ public class EngagementStatusContrastTests(AspireFixture fixture) : VisualTestBa
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"EngagementStatusContrast {suffix}",
-			description = "Created by EngagementStatusContrastTests",
+			titleDe = $"EngagementStatusContrast {suffix}",
+			descriptionDe = "Created by EngagementStatusContrastTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
+++ b/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
@@ -198,8 +198,8 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by EngagementUndoCheckInTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by EngagementUndoCheckInTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
+++ b/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
@@ -108,8 +108,8 @@ public class LandingOpportunityPreviewTests(AspireFixture fixture) : VisualTestB
 		{
 			var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = "Seeded for #1914 landing tablet grid visual test.",
+				titleDe = title,
+				descriptionDe = "Seeded for #1914 landing tablet grid visual test.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/ListLayoutGridTests.cs
+++ b/backend/tests/VisualTests/ListLayoutGridTests.cs
@@ -55,8 +55,8 @@ public class ListLayoutGridTests(AspireFixture fixture) : VisualTestBase(fixture
 	{
 		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Seeded for #977 list-layout-grid visual test.",
+			titleDe = title,
+			descriptionDe = "Seeded for #977 list-layout-grid visual test.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -250,8 +250,8 @@ public class ListLayoutGridTests(AspireFixture fixture) : VisualTestBase(fixture
 		{
 			var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = "Seeded for #977 list-layout-grid visual test.",
+				titleDe = title,
+				descriptionDe = "Seeded for #977 list-layout-grid visual test.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/LoadMoreErrorPreservesItemsTests.cs
+++ b/backend/tests/VisualTests/LoadMoreErrorPreservesItemsTests.cs
@@ -60,8 +60,8 @@ public class LoadMoreErrorPreservesItemsTests(AspireFixture fixture) : VisualTes
 		{
 			var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title = $"LoadMoreError Opportunity {suffix}-{i}",
-				description = "Seeded by LoadMoreErrorPreservesItemsTests.",
+				titleDe = $"LoadMoreError Opportunity {suffix}-{i}",
+				descriptionDe = "Seeded by LoadMoreErrorPreservesItemsTests.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/LoadingStateTests.cs
+++ b/backend/tests/VisualTests/LoadingStateTests.cs
@@ -150,8 +150,8 @@ public class LoadingStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"LoadingState {label} {suffix}",
-			description = "Created by LoadingStateTests",
+			titleDe = $"LoadingState {label} {suffix}",
+			descriptionDe = "Created by LoadingStateTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
+++ b/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
@@ -41,8 +41,8 @@ public class LocalizedCheckInPinErrorTests(AspireFixture fixture) : VisualTestBa
 		var oppTitle = $"LocalizedPinError Opportunity {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by LocalizedCheckInPinErrorTests.",
+			titleDe = oppTitle,
+			descriptionDe = "Created by LocalizedCheckInPinErrorTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/MapUnavailablePlaceholderTests.cs
+++ b/backend/tests/VisualTests/MapUnavailablePlaceholderTests.cs
@@ -37,8 +37,8 @@ public class MapUnavailablePlaceholderTests(AspireFixture fixture) : VisualTestB
 		// as it would be while geocoding is still pending in production.
 		var oppResponse = await PostJsonWithRetryAsync(http, "/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by OpportunityDetailPage_ShowsMapUnavailableNote_WhenCoordinatesAreMissing",
+			titleDe = title,
+			descriptionDe = "Created by OpportunityDetailPage_ShowsMapUnavailableNote_WhenCoordinatesAreMissing",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",

--- a/backend/tests/VisualTests/MilestoneAchievementTests.cs
+++ b/backend/tests/VisualTests/MilestoneAchievementTests.cs
@@ -102,8 +102,8 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"Milestone668 {label} {suffix}",
-			description = "Created by MilestoneAchievementTests",
+			titleDe = $"Milestone668 {label} {suffix}",
+			descriptionDe = "Created by MilestoneAchievementTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -98,8 +98,8 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		var oppTitle = $"CheckedInFuture Opportunity {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by MyEngagementsScopeTabsTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by MyEngagementsScopeTabsTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -215,8 +215,8 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by MyEngagementsScopeTabsTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by MyEngagementsScopeTabsTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -44,8 +44,8 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"MyEngagements Opportunity {suffix}",
-			description = "Created by MyEngagementsTests.",
+			titleDe = $"MyEngagements Opportunity {suffix}",
+			descriptionDe = "Created by MyEngagementsTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
@@ -48,8 +48,8 @@ public class MyEngagementsTimeSlotTests(AspireFixture fixture) : VisualTestBase(
 		var oppTitle = $"VisualSlot Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by MyEngagementsTimeSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by MyEngagementsTimeSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
@@ -44,8 +44,8 @@ public class MyEngagementsWithdrawErrorMessageTests(AspireFixture fixture) : Vis
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"MyEngagementsWithdrawErrorMessage Opportunity {suffix}",
-			description = "Created by MyEngagementsWithdrawErrorMessageTests.",
+			titleDe = $"MyEngagementsWithdrawErrorMessage Opportunity {suffix}",
+			descriptionDe = "Created by MyEngagementsWithdrawErrorMessageTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -130,8 +130,8 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"NotifDeletedOpp {label} {suffix}",
-			description = "Created by NotificationForDeletedOpportunityTests",
+			titleDe = $"NotifDeletedOpp {label} {suffix}",
+			descriptionDe = "Created by NotificationForDeletedOpportunityTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -60,8 +60,8 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var oppTitle = $"NotifDeepLink Opportunity {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by NotificationTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by NotificationTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -206,8 +206,8 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var oppTitle = $"NotifMarkReadFail Opportunity {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by NotificationTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by NotificationTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
+++ b/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
@@ -102,8 +102,8 @@ public class NotificationUnreadMarkerTests(AspireFixture fixture) : VisualTestBa
 	{
 		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by NotificationUnreadMarkerTests",
+			titleDe = title,
+			descriptionDe = "Created by NotificationUnreadMarkerTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
+++ b/backend/tests/VisualTests/OpportunityApplicationStateTests.cs
@@ -179,8 +179,8 @@ public class OpportunityApplicationStateTests(AspireFixture fixture) : VisualTes
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"OpportunityApplicationState {label} {suffix}",
-			description = "Created by OpportunityApplicationStateTests",
+			titleDe = $"OpportunityApplicationState {label} {suffix}",
+			descriptionDe = "Created by OpportunityApplicationStateTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -516,8 +516,8 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	{
 		var response = await organizer.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by OpportunityCardContractTests",
+			titleDe = title,
+			descriptionDe = "Created by OpportunityCardContractTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -562,8 +562,8 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	{
 		var response = await organizer.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by OpportunityCardContractTests",
+			titleDe = title,
+			descriptionDe = "Created by OpportunityCardContractTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "Recurring",

--- a/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
@@ -104,8 +104,8 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 		// deadline on anything but IndividualContact, so sending one here 400s.
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"Measure1794 {suffix}",
-			description = "Seeded for #1794 detail-page measure regression coverage.",
+			titleDe = $"Measure1794 {suffix}",
+			descriptionDe = "Seeded for #1794 detail-page measure regression coverage.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
@@ -60,8 +60,8 @@ public class OpportunityDetailPageMobileActionRailTests(AspireFixture fixture) :
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"MobileRail1965 {label} {suffix}",
-			description = "Seeded for #1965 mobile action-rail regression coverage.",
+			titleDe = $"MobileRail1965 {label} {suffix}",
+			descriptionDe = "Seeded for #1965 mobile action-rail regression coverage.",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",

--- a/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
@@ -96,8 +96,8 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"Spacing1111 {label} {suffix}",
-			description = "Seeded for #1111 detail-page spacing regression coverage.",
+			titleDe = $"Spacing1111 {label} {suffix}",
+			descriptionDe = "Seeded for #1111 detail-page spacing regression coverage.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
@@ -36,8 +36,8 @@ public class OpportunityDetailStatusCardTimeSlotTests(AspireFixture fixture) : V
 		var oppTitle = $"StatusCardSlot Opportunity {suffix}";
 		var oppResponse = await organizerHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by OpportunityDetailStatusCardTimeSlotTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by OpportunityDetailStatusCardTimeSlotTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityFilterRowAlignmentTests.cs
+++ b/backend/tests/VisualTests/OpportunityFilterRowAlignmentTests.cs
@@ -64,8 +64,8 @@ public class OpportunityFilterRowAlignmentTests(AspireFixture fixture) : VisualT
 		{
 			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = "Seeded for #1798 filter-row alignment visual test.",
+				titleDe = title,
+				descriptionDe = "Seeded for #1798 filter-row alignment visual test.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityResultCountTests.cs
+++ b/backend/tests/VisualTests/OpportunityResultCountTests.cs
@@ -52,8 +52,8 @@ public class OpportunityResultCountTests(AspireFixture fixture) : VisualTestBase
 		{
 			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = "Seeded by OpportunityResultCountTests.",
+				titleDe = title,
+				descriptionDe = "Seeded by OpportunityResultCountTests.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
+++ b/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
@@ -128,8 +128,8 @@ public class OpportunityUnpublishCancelTests(AspireFixture fixture) : VisualTest
 		var title = $"{label} {suffix}";
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = $"Created by {nameof(OpportunityUnpublishCancelTests)}",
+			titleDe = title,
+			descriptionDe = $"Created by {nameof(OpportunityUnpublishCancelTests)}",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCustomizeTests.cs
@@ -932,8 +932,8 @@ public class OrgDashboardCustomizeTests(AspireFixture fixture) : VisualTestBase(
 		{
 			var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title = $"Row Height Opportunity {i} {suffix}",
-				description = "Created by WidgetContentOverflow_DoesNotStretchTheSharedGridRow",
+				titleDe = $"Row Height Opportunity {i} {suffix}",
+				descriptionDe = "Created by WidgetContentOverflow_DoesNotStretchTheSharedGridRow",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -165,8 +165,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		// up for, left unconfirmed so it stays Pending.
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"Pending Queue Opportunity {suffix}",
-			description = "Created by ToDoWidget_ReadsAsResolvedAndOffersNoCta_UntilASignUpIsActuallyWaiting",
+			titleDe = $"Pending Queue Opportunity {suffix}",
+			descriptionDe = "Created by ToDoWidget_ReadsAsResolvedAndOffersNoCta_UntilASignUpIsActuallyWaiting",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -412,8 +412,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		var oppTitle = $"Visual1254 Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CalendarWidget agenda-header i18n test",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CalendarWidget agenda-header i18n test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -512,8 +512,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		// few lines below it).
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"Visual1959 Opportunity {suffix}",
-			description = "Created by CalendarWidget toolbar date-format test",
+			titleDe = $"Visual1959 Opportunity {suffix}",
+			descriptionDe = "Created by CalendarWidget toolbar date-format test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -628,8 +628,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		var oppTitle = $"Visual812 Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CalendarWidget mobile overflow test",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CalendarWidget mobile overflow test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -752,8 +752,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		var oppTitle = $"Visual1397 Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by CalendarWidget color-save test",
+			titleDe = oppTitle,
+			descriptionDe = "Created by CalendarWidget color-save test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -860,8 +860,8 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		var oppTitle = $"Visual Upcoming Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by the Upcoming Opportunities widget test",
+			titleDe = oppTitle,
+			descriptionDe = "Created by the Upcoming Opportunities widget test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
+++ b/backend/tests/VisualTests/OrganizationEngagementsTabTests.cs
@@ -57,8 +57,8 @@ public class OrganizationEngagementsTabTests(AspireFixture fixture) : VisualTest
 		var oppTitle = $"VisualEngTab Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Created by OrganizationEngagementsTabTests",
+			titleDe = oppTitle,
+			descriptionDe = "Created by OrganizationEngagementsTabTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -394,8 +394,8 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"FeedbackEdit Opportunity {suffix}",
-			description = "Created by ProfileOverviewTests",
+			titleDe = $"FeedbackEdit Opportunity {suffix}",
+			descriptionDe = "Created by ProfileOverviewTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/QRScannerModalTests.cs
+++ b/backend/tests/VisualTests/QRScannerModalTests.cs
@@ -303,8 +303,8 @@ public class QRScannerModalTests(AspireFixture fixture) : VisualTestBase(fixture
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"QRScanner {label} Opportunity {suffix}",
-			description = "Created by QRScannerModalTests.",
+			titleDe = $"QRScanner {label} Opportunity {suffix}",
+			descriptionDe = "Created by QRScannerModalTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/QuickCheckInWidgetTests.cs
+++ b/backend/tests/VisualTests/QuickCheckInWidgetTests.cs
@@ -150,8 +150,8 @@ public class QuickCheckInWidgetTests(AspireFixture fixture) : VisualTestBase(fix
 	{
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by QuickCheckInWidgetTests.",
+			titleDe = title,
+			descriptionDe = "Created by QuickCheckInWidgetTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -145,8 +145,8 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var oppTitle = $"Stale Session Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = oppTitle,
-			description = "Seeded for the stale-session regression coverage.",
+			titleDe = oppTitle,
+			descriptionDe = "Seeded for the stale-session regression coverage.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
+++ b/backend/tests/VisualTests/SignUpModalMessageFieldTests.cs
@@ -145,8 +145,8 @@ public class SignUpModalMessageFieldTests(AspireFixture fixture) : VisualTestBas
 
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"SignUpModalMessageField {label} {suffix}",
-			description = "Created by SignUpModalMessageFieldTests",
+			titleDe = $"SignUpModalMessageField {label} {suffix}",
+			descriptionDe = "Created by SignUpModalMessageFieldTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/SignUpModalPreselectTests.cs
+++ b/backend/tests/VisualTests/SignUpModalPreselectTests.cs
@@ -106,8 +106,8 @@ public class SignUpModalPreselectTests(AspireFixture fixture) : VisualTestBase(f
 
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"SignUpModalPreselect {label} {suffix}",
-			description = "Created by SignUpModalPreselectTests",
+			titleDe = $"SignUpModalPreselect {label} {suffix}",
+			descriptionDe = "Created by SignUpModalPreselectTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/SignUpVocabularyTests.cs
+++ b/backend/tests/VisualTests/SignUpVocabularyTests.cs
@@ -182,8 +182,8 @@ public class SignUpVocabularyTests(AspireFixture fixture) : VisualTestBase(fixtu
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"{label} {suffix}",
-			description = "Created by SignUpVocabularyTests",
+			titleDe = $"{label} {suffix}",
+			descriptionDe = "Created by SignUpVocabularyTests",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/backend/tests/VisualTests/SingleMarkerMapStaticTests.cs
+++ b/backend/tests/VisualTests/SingleMarkerMapStaticTests.cs
@@ -38,8 +38,8 @@ public class SingleMarkerMapStaticTests(AspireFixture fixture) : VisualTestBase(
 		var title = $"Static Map Test {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by SingleMarkerMap_OnDesktop_DoesNotPanWhenDragged",
+			titleDe = title,
+			descriptionDe = "Created by SingleMarkerMap_OnDesktop_DoesNotPanWhenDragged",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",

--- a/backend/tests/VisualTests/SingleMarkerMapTouchScrollTests.cs
+++ b/backend/tests/VisualTests/SingleMarkerMapTouchScrollTests.cs
@@ -61,8 +61,8 @@ public class SingleMarkerMapTouchScrollTests(AspireFixture fixture) : VisualTest
 		var title = $"Touch Scroll Test {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by SingleMarkerMap_OnMobile_DisablesTouchDragSoPageStillScrolls",
+			titleDe = title,
+			descriptionDe = "Created by SingleMarkerMap_OnMobile_DisablesTouchDragSoPageStillScrolls",
 			organizationId,
 			isRemote = false,
 			street = "Teststrasse",

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -366,8 +366,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 			var title = $"{label} {suffix}";
 			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = $"{label} opportunity for detail enrichment coverage.",
+				titleDe = title,
+				descriptionDe = $"{label} opportunity for detail enrichment coverage.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",
@@ -668,8 +668,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = draftTitle,
-			description = "Seeded draft for OpportunitiesHub test",
+			titleDe = draftTitle,
+			descriptionDe = "Seeded draft for OpportunitiesHub test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -682,8 +682,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 
 		var publishedResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = publishedTitle,
-			description = "Seeded published for OpportunitiesHub test",
+			titleDe = publishedTitle,
+			descriptionDe = "Seeded published for OpportunitiesHub test",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -828,8 +828,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 			var title = $"{label} {suffix}";
 			var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 			{
-				title,
-				description = $"{label} opportunity for issue 1223 stale-error coverage.",
+				titleDe = title,
+				descriptionDe = $"{label} opportunity for issue 1223 stale-error coverage.",
 				organizationId,
 				isRemote = true,
 				occurrence = "OneTime",
@@ -928,8 +928,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var draftTitle = $"Detail Draft Test {suffix}";
 		var draftResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = draftTitle,
-			description = "Seeded draft for the detail-page owner-affordances regression test.",
+			titleDe = draftTitle,
+			descriptionDe = "Seeded draft for the detail-page owner-affordances regression test.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -993,8 +993,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var publishedTitle = $"Detail Published Test {suffix}";
 		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = publishedTitle,
-			description = "Seeded published opportunity for the detail-page owner-affordances edge case.",
+			titleDe = publishedTitle,
+			descriptionDe = "Seeded published opportunity for the detail-page owner-affordances edge case.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -1042,8 +1042,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var title = $"Tag Chip Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by DetailPage_TagChip_IsClickableLink_FiltersBrowseList",
+			titleDe = title,
+			descriptionDe = "Created by DetailPage_TagChip_IsClickableLink_FiltersBrowseList",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -1107,8 +1107,8 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		var title = $"List Tag Chip Opportunity {suffix}";
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title,
-			description = "Created by ListCard_TagChips_AreClickableLinks_SwitchTagFilterAndSurviveSpecialCharacters",
+			titleDe = title,
+			descriptionDe = "Created by ListCard_TagChips_AreClickableLinks_SwitchTagFilterAndSurviveSpecialCharacters",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",
@@ -1147,5 +1147,116 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 			new Regex($"^{Regex.Escape($"{origin}/opportunities?tag={Uri.EscapeDataString(tagB)}")}$"),
 			new() { Timeout = 15_000 });
 		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+	}
+
+	[Test]
+	public async Task OpportunityDetailPage_TitleAndDescription_FollowTheLanguageSwitch()
+	{
+		// Regression for #1946: organizer-authored title/description used to
+		// stay in whichever language they were entered in regardless of the
+		// site's language switcher - only UI chrome (badges, dates) actually
+		// translated. Opportunities now carry a required German variant and an
+		// optional English one; the detail page must pick the variant matching
+		// the active UI language.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Bilingual Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var titleDe = $"Deutscher Titel {suffix}";
+		var titleEn = $"English Title {suffix}";
+		var descriptionDe = $"Deutsche Beschreibung fuer Ausgabe 1946 Abdeckung {suffix}.";
+		var descriptionEn = $"English description for issue 1946 coverage {suffix}.";
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe,
+			titleEn,
+			descriptionDe,
+			descriptionEn,
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var body = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = body.GetProperty("id").GetString();
+
+		// This suite's default browser context resolves to English with no
+		// stored language choice (see InitialLocaleResolutionTests).
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(Page.Locator("h1")).ToContainTextAsync(titleEn, new() { Timeout = 15_000 });
+		await Expect(Page.GetByText(descriptionEn)).ToBeVisibleAsync();
+		await Expect(Page.Locator("h1")).Not.ToContainTextAsync(titleDe);
+
+		// Switching to German follows through to the German variant on the
+		// same page, without a reload.
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch language" }).ClickAsync();
+		await Page.GetByTestId("language-selector-menu")
+			.GetByRole(AriaRole.Button, new() { Name = "Deutsch" }).ClickAsync();
+		await Expect(Page.Locator("h1")).ToContainTextAsync(titleDe, new() { Timeout = 15_000 });
+		await Expect(Page.GetByText(descriptionDe)).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task OpportunityDetailPage_FallsBackToGermanTitle_WhenNoEnglishTranslationProvided()
+	{
+		// Companion to OpportunityDetailPage_TitleAndDescription_FollowTheLanguageSwitch:
+		// English is optional (#1946) - an opportunity without a translation must
+		// still show its German content when viewed in English, rather than a
+		// blank title/description.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"German Only Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var titleDe = $"Nur Deutscher Titel {suffix}";
+		var descriptionDe = $"Nur eine deutsche Beschreibung {suffix}.";
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe,
+			descriptionDe,
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var body = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = body.GetProperty("id").GetString();
+
+		// Default English context (see InitialLocaleResolutionTests) - still
+		// falls back to the German content rather than rendering blank.
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Expect(Page.Locator("h1")).ToContainTextAsync(titleDe, new() { Timeout = 15_000 });
+		await Expect(Page.GetByText(descriptionDe)).ToBeVisibleAsync();
 	}
 }

--- a/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
+++ b/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
@@ -53,8 +53,8 @@ public class WithdrawEngagementErrorMessageTests(AspireFixture fixture) : Visual
 
 		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			title = $"WithdrawErrorMessage Opportunity {suffix}",
-			description = "Created by WithdrawEngagementErrorMessageTests.",
+			titleDe = $"WithdrawErrorMessage Opportunity {suffix}",
+			descriptionDe = "Created by WithdrawEngagementErrorMessageTests.",
 			organizationId,
 			isRemote = true,
 			occurrence = "OneTime",

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6464,8 +6464,10 @@ export interface CreateTimeSlotResponse {
 }
 
 export interface CreateVolunteerOpportunityRequest {
-    title: string | undefined;
-    description: string | undefined;
+    titleDe: string | undefined;
+    titleEn: string | undefined;
+    descriptionDe: string | undefined;
+    descriptionEn: string | undefined;
     organizationId: string;
     isRemote: boolean;
     street: string | undefined;
@@ -6486,8 +6488,10 @@ export interface CreateVolunteerOpportunityRequest {
 
 export interface CreateVolunteerOpportunityResponse {
     id: string;
-    title: string;
-    description: string;
+    titleDe: string;
+    titleEn: string | undefined;
+    descriptionDe: string;
+    descriptionEn: string | undefined;
     organizationId: string;
     street: string | undefined;
     houseNumber: string | undefined;
@@ -6702,7 +6706,8 @@ export interface Organization {
 
 export interface OrganizationCalendarEventDto {
     opportunityId: string;
-    title: string;
+    titleDe: string;
+    titleEn: string | undefined;
     color: string | undefined;
     timeSlots: CalendarTimeSlotDto[];
 
@@ -6863,8 +6868,10 @@ export interface PublicAddressDto {
 
 export interface PublicOpportunitySummaryDto {
     id: string;
-    title: string;
-    description: string | undefined;
+    titleDe: string;
+    titleEn: string | undefined;
+    descriptionDe: string | undefined;
+    descriptionEn: string | undefined;
     street: string | undefined;
     houseNumber: string | undefined;
     zipCode: string | undefined;
@@ -7069,8 +7076,10 @@ export interface UpdateUserProfileRequest {
 }
 
 export interface UpdateVolunteerOpportunityRequest {
-    title: string | undefined;
-    description: string | undefined;
+    titleDe: string | undefined;
+    titleEn: string | undefined;
+    descriptionDe: string | undefined;
+    descriptionEn: string | undefined;
     isRemote: boolean;
     street: string | undefined;
     houseNumber: string | undefined;
@@ -7096,8 +7105,10 @@ export interface VolunteerOpportunityAvailableDate {
 
 export interface VolunteerOpportunityDetails {
     id: string;
-    title: string;
-    description: string | undefined;
+    titleDe: string;
+    titleEn: string | undefined;
+    descriptionDe: string | undefined;
+    descriptionEn: string | undefined;
     organizationId: string;
     organizationName: string;
     street: string | undefined;
@@ -7125,8 +7136,10 @@ export interface VolunteerOpportunityDetails {
 
 export interface VolunteerOpportunitySummary {
     id: string;
-    title: string;
-    description: string | undefined;
+    titleDe: string;
+    titleEn: string | undefined;
+    descriptionDe: string | undefined;
+    descriptionEn: string | undefined;
     organizationId: string;
     organizationName: string;
     street: string | undefined;

--- a/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { UseFormRegister, UseFormWatch } from "react-hook-form";
@@ -9,51 +10,146 @@ import { IMAGE_UPLOAD_ACCEPT, getImageUploadHint } from "../../lib/imageUpload";
 interface Props {
 	register: UseFormRegister<OpportunityFormValues>;
 	watch: UseFormWatch<OpportunityFormValues>;
-	titleError?: string;
-	descriptionError?: string;
+	titleDeError?: string;
+	titleEnError?: string;
+	descriptionDeError?: string;
+	descriptionEnError?: string;
 	bannerPreview: string | null;
 	bannerError: string | null;
 	onBannerChange: (e: ChangeEvent<HTMLInputElement>) => void;
 	onBannerRemove: () => void;
 }
 
+const CONTENT_LANGUAGES = ["de", "en"] as const;
+type ContentLanguage = (typeof CONTENT_LANGUAGES)[number];
+
 export default function BasicsStep({
 	register,
 	watch,
-	titleError,
-	descriptionError,
+	titleDeError,
+	titleEnError,
+	descriptionDeError,
+	descriptionEnError,
 	bannerPreview,
 	bannerError,
 	onBannerChange,
 	onBannerRemove,
 }: Props) {
 	const { t, i18n } = useTranslation();
-	const title = watch("title");
-	const description = watch("description");
+	const [activeLanguage, setActiveLanguage] = useState<ContentLanguage>("de");
+	const titleDe = watch("titleDe");
+	const titleEn = watch("titleEn");
+	const descriptionDe = watch("descriptionDe");
+	const descriptionEn = watch("descriptionEn");
+	const hasError = {
+		de: Boolean(titleDeError || descriptionDeError),
+		en: Boolean(titleEnError || descriptionEnError),
+	};
+
+	// German is required, so an error there always blocks moving on. Without
+	// this, an error raised while the English tab is active (e.g. clicking
+	// Next with the German title still blank) left the German fields - and
+	// their inline role="alert" text - hidden behind display:none, with
+	// nothing else surfacing the failure: the button just appeared to do
+	// nothing, for sighted and screen-reader users alike. Switching the tab
+	// back un-hides the existing FloatingField error text, the same way it
+	// already surfaces for every other step in this wizard - no separate
+	// live-region banner needed on top of that.
+	useEffect(() => {
+		if (titleDeError || descriptionDeError) setActiveLanguage("de");
+	}, [titleDeError, descriptionDeError]);
 
 	return (
 		<div className="space-y-4" data-testid="wizard-step-1">
-			<FloatingField
-				id="opportunity-title"
-				label={t("createOpportunity.fieldTitle")}
-				registration={register("title")}
-				required
-				error={titleError}
-				maxLength={150}
-				showCount
-				displayValue={title}
-			/>
-			<FloatingField
-				id="opportunity-description"
-				label={t("createOpportunity.fieldDescription")}
-				registration={register("description")}
-				required
-				error={descriptionError}
-				maxLength={2000}
-				multiline
-				showCount
-				displayValue={description}
-			/>
+			{/* Plain toggle buttons, not an ARIA tablist - this repo's convention
+			(see LanguageSelector.tsx, Stepper in ./shared.tsx) is to only claim a
+			widget role when the matching keyboard model (arrow keys) is actually
+			implemented; a labelled pair of buttons with aria-current for the
+			active one needs none of that. Both languages' values stay in the form
+			regardless of which is showing - switching tabs never loses data,
+			since only German is required to publish (einsatzbereit#1946). */}
+			<div
+				role="group"
+				aria-label={t("createOpportunity.contentLanguageGroup")}
+				className="inline-flex rounded-lg border border-gray-200 p-0.5"
+			>
+				{CONTENT_LANGUAGES.map((lang) => (
+					<button
+						key={lang}
+						type="button"
+						aria-current={activeLanguage === lang ? "true" : undefined}
+						data-testid={`opportunity-content-language-${lang}`}
+						onClick={() => setActiveLanguage(lang)}
+						className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+							activeLanguage === lang
+								? "bg-brand-600 text-white"
+								: "text-gray-600 hover:bg-gray-50"
+						}`}
+					>
+						{t(`language.${lang}`)}
+						{hasError[lang] && (
+							<span
+								aria-hidden="true"
+								className={`h-1.5 w-1.5 rounded-full ${
+									activeLanguage === lang ? "bg-white" : "bg-red-500"
+								}`}
+							/>
+						)}
+					</button>
+				))}
+			</div>
+
+			<div className={activeLanguage === "de" ? "space-y-4" : "hidden"}>
+				{/* Keeps the original "opportunity-title"/"opportunity-description"
+				ids (no "-de" suffix) - this is the direct successor of the single
+				title/description field that existed before #1946, and a wide range
+				of VisualTests locators already target these exact ids. */}
+				<FloatingField
+					id="opportunity-title"
+					label={t("createOpportunity.fieldTitle")}
+					registration={register("titleDe")}
+					required
+					error={titleDeError}
+					maxLength={150}
+					showCount
+					displayValue={titleDe}
+				/>
+				<FloatingField
+					id="opportunity-description"
+					label={t("createOpportunity.fieldDescription")}
+					registration={register("descriptionDe")}
+					required
+					error={descriptionDeError}
+					maxLength={2000}
+					multiline
+					showCount
+					displayValue={descriptionDe}
+				/>
+			</div>
+			<div className={activeLanguage === "en" ? "space-y-4" : "hidden"}>
+				<p className="text-xs text-gray-500">
+					{t("createOpportunity.contentLanguageEnglishHint")}
+				</p>
+				<FloatingField
+					id="opportunity-title-en"
+					label={t("createOpportunity.fieldTitle")}
+					registration={register("titleEn")}
+					error={titleEnError}
+					maxLength={150}
+					showCount
+					displayValue={titleEn}
+				/>
+				<FloatingField
+					id="opportunity-description-en"
+					label={t("createOpportunity.fieldDescription")}
+					registration={register("descriptionEn")}
+					error={descriptionEnError}
+					maxLength={2000}
+					multiline
+					showCount
+					displayValue={descriptionEn}
+				/>
+			</div>
 
 			<div>
 				<p className="mb-1.5 text-sm font-semibold text-gray-800">

--- a/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
@@ -79,10 +79,15 @@ export default function BasicsStep({
 						type="button"
 						aria-current={activeLanguage === lang ? "true" : undefined}
 						data-testid={`opportunity-content-language-${lang}`}
+						// Sits before the title field in the DOM but must not steal the
+						// modal's initial focus from it (see Modal.tsx) - a keyboard user
+						// opening this dialog wants to start typing the title, not land
+						// on a language toggle first.
+						data-skip-initial-focus
 						onClick={() => setActiveLanguage(lang)}
 						className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
 							activeLanguage === lang
-								? "bg-brand-600 text-white"
+								? "bg-brand-50 text-brand-700"
 								: "text-gray-600 hover:bg-gray-50"
 						}`}
 					>
@@ -90,9 +95,7 @@ export default function BasicsStep({
 						{hasError[lang] && (
 							<span
 								aria-hidden="true"
-								className={`h-1.5 w-1.5 rounded-full ${
-									activeLanguage === lang ? "bg-white" : "bg-red-500"
-								}`}
+								className="h-1.5 w-1.5 rounded-full bg-red-500"
 							/>
 						)}
 					</button>

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -137,8 +137,10 @@ function endOfDayFromDateInput(value: string): Date {
 }
 
 const DEFAULT_VALUES: OpportunityFormValues = {
-	title: "",
-	description: "",
+	titleDe: "",
+	titleEn: "",
+	descriptionDe: "",
+	descriptionEn: "",
 	isRemote: false,
 	street: "",
 	houseNumber: "",
@@ -157,8 +159,10 @@ function formFromOpportunity(
 	opp: VolunteerOpportunityDetails,
 ): OpportunityFormValues {
 	return {
-		title: opp.title ?? "",
-		description: opp.description ?? "",
+		titleDe: opp.titleDe ?? "",
+		titleEn: opp.titleEn ?? "",
+		descriptionDe: opp.descriptionDe ?? "",
+		descriptionEn: opp.descriptionEn ?? "",
 		isRemote: opp.isRemote,
 		street: opp.street ?? "",
 		houseNumber: opp.houseNumber ?? "",
@@ -728,8 +732,10 @@ export default function CreateVolunteerOpportunityModal({
 		try {
 			if (isEditMode && initialOpportunity) {
 				await api.updateVolunteerOpportunity(initialOpportunity.id, {
-					title: values.title,
-					description: values.description,
+					titleDe: values.titleDe,
+					titleEn: values.titleEn || undefined,
+					descriptionDe: values.descriptionDe,
+					descriptionEn: values.descriptionEn || undefined,
 					isRemote: values.isRemote,
 					street: values.isRemote ? undefined : values.street,
 					houseNumber: values.isRemote ? undefined : values.houseNumber,
@@ -773,8 +779,10 @@ export default function CreateVolunteerOpportunityModal({
 				let opportunityId = createdOpportunityIdRef.current;
 				if (opportunityId) {
 					await api.updateVolunteerOpportunity(opportunityId, {
-						title: values.title,
-						description: values.description,
+						titleDe: values.titleDe,
+						titleEn: values.titleEn || undefined,
+						descriptionDe: values.descriptionDe,
+						descriptionEn: values.descriptionEn || undefined,
 						isRemote: values.isRemote,
 						street: values.isRemote ? undefined : values.street,
 						houseNumber: values.isRemote ? undefined : values.houseNumber,
@@ -792,8 +800,10 @@ export default function CreateVolunteerOpportunityModal({
 					});
 				} else {
 					const opportunity = await api.createVolunteerOpportunity({
-						title: values.title,
-						description: values.description,
+						titleDe: values.titleDe,
+						titleEn: values.titleEn || undefined,
+						descriptionDe: values.descriptionDe,
+						descriptionEn: values.descriptionEn || undefined,
 						organizationId,
 						isRemote: values.isRemote,
 						street: values.isRemote ? undefined : values.street,
@@ -1079,8 +1089,10 @@ export default function CreateVolunteerOpportunityModal({
 						<BasicsStep
 							register={registerWithRevalidate}
 							watch={watch}
-							titleError={errors.title?.message}
-							descriptionError={errors.description?.message}
+							titleDeError={errors.titleDe?.message}
+							titleEnError={errors.titleEn?.message}
+							descriptionDeError={errors.descriptionDe?.message}
+							descriptionEnError={errors.descriptionEn?.message}
 							bannerPreview={bannerPreview}
 							bannerError={bannerError}
 							onBannerChange={handleBannerChange}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/schema.ts
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/schema.ts
@@ -18,8 +18,10 @@ export function buildOpportunityFormSchema(t: TFunction) {
 
 	return z
 		.object({
-			title: z.string().max(150, tooLong(150)),
-			description: z.string().max(2000, tooLong(2000)),
+			titleDe: z.string().max(150, tooLong(150)),
+			titleEn: z.string().max(150, tooLong(150)),
+			descriptionDe: z.string().max(2000, tooLong(2000)),
+			descriptionEn: z.string().max(2000, tooLong(2000)),
 			isRemote: z.boolean(),
 			street: z.string().max(100, tooLong(100)),
 			houseNumber: z.string().max(10, tooLong(10)),
@@ -34,12 +36,15 @@ export function buildOpportunityFormSchema(t: TFunction) {
 			validUntil: z.string(),
 		})
 		.superRefine((data, ctx) => {
-			if (!data.title.trim())
-				ctx.addIssue({ code: "custom", path: ["title"], message: required });
-			if (!data.description.trim())
+			// Only the German variant is required to publish (matches the
+			// backend's EnsurePublishable) - the English one is an optional
+			// translation an organizer can add later (einsatzbereit#1946).
+			if (!data.titleDe.trim())
+				ctx.addIssue({ code: "custom", path: ["titleDe"], message: required });
+			if (!data.descriptionDe.trim())
 				ctx.addIssue({
 					code: "custom",
-					path: ["description"],
+					path: ["descriptionDe"],
 					message: required,
 				});
 			if (!data.isRemote) {
@@ -83,7 +88,7 @@ export type OpportunityFormValues = z.infer<
 
 /** Which fields belong to each wizard step, for per-step "Next" validation. */
 export const STEP_FIELDS: Record<number, (keyof OpportunityFormValues)[]> = {
-	1: ["title", "description"],
+	1: ["titleDe", "titleEn", "descriptionDe", "descriptionEn"],
 	2: ["street", "houseNumber", "zipCode", "city"],
 	3: ["checkInPin"],
 	4: [],

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -71,7 +71,14 @@ export default function Modal({
 		if (hasFocusedRef.current) return;
 		hasFocusedRef.current = true;
 		const scope = initialFocusRef?.current ?? dialogRef.current;
-		scope?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+		// Skips anything opted out via data-skip-initial-focus (e.g. a toggle
+		// that happens to sit before the dialog's actual first field) rather
+		// than the true first focusable child - still fully Tab-reachable via
+		// FOCUSABLE_SELECTOR below, just not where focus lands on open.
+		const candidate = Array.from(
+			scope?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+		).find((el) => !el.hasAttribute("data-skip-initial-focus"));
+		candidate?.focus();
 	}, [initialFocusRef]);
 
 	useEffect(() => {

--- a/frontend/src/components/PublicOpportunityCard.tsx
+++ b/frontend/src/components/PublicOpportunityCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { PublicOpportunitySummaryDto } from "../client/api-client";
-import { formatOccurrence } from "../lib/format";
+import { formatOccurrence, pickLocalizedText } from "../lib/format";
 import { getOpportunityCapacity } from "../lib/opportunityCapacity";
 import Chip from "./Chip";
 import { CalendarIcon, GlobeIcon, MapPinIcon } from "./icons";
@@ -36,15 +36,25 @@ export default function PublicOpportunityCard({
 }: {
 	opportunity: PublicOpportunitySummaryDto;
 }) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const capacity = capacityChip(getOpportunityCapacity(opportunity), t);
+	const title = pickLocalizedText(
+		opportunity.titleDe,
+		opportunity.titleEn,
+		i18n.language,
+	);
+	const description = pickLocalizedText(
+		opportunity.descriptionDe,
+		opportunity.descriptionEn,
+		i18n.language,
+	);
 
 	return (
 		<li className="group relative flex h-full flex-col rounded-card border border-gray-100 bg-white p-5 shadow-resting transition-shadow hover:shadow-raised">
 			<Link
 				to={`/volunteer-opportunities/${opportunity.id}`}
 				className="absolute inset-0 rounded-card"
-				aria-label={opportunity.title}
+				aria-label={title}
 			/>
 
 			{/* Category left, capacity top-right - the same chip row
@@ -79,12 +89,12 @@ export default function PublicOpportunityCard({
 			</p>
 
 			<h3 className="mt-2 font-display text-xl font-bold text-gray-900 group-hover:text-brand-800">
-				{opportunity.title}
+				{title}
 			</h3>
 
-			{opportunity.description && (
+			{description && (
 				<p className="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-600">
-					{opportunity.description}
+					{description}
 				</p>
 			)}
 

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -2,7 +2,12 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
-import { formatDate, formatDateTime, formatOccurrence } from "../../lib/format";
+import {
+	formatDate,
+	formatDateTime,
+	formatOccurrence,
+	pickLocalizedText,
+} from "../../lib/format";
 import Chip, { type ChipTone } from "../Chip";
 import { getInitials } from "../../lib/initials";
 import {
@@ -137,6 +142,12 @@ export default function OpportunityListItem({
 	const capacity = capacityChip(getOpportunityCapacity(item), t);
 	const date = dateLine(item, t, i18n.language);
 	const DateIcon = date.Icon;
+	const title = pickLocalizedText(item.titleDe, item.titleEn, i18n.language);
+	const description = pickLocalizedText(
+		item.descriptionDe,
+		item.descriptionEn,
+		i18n.language,
+	);
 
 	// No overflow-hidden on the card any more. The stretched link below is what
 	// a keyboard user actually lands on (the title is inside it, not focusable
@@ -151,7 +162,7 @@ export default function OpportunityListItem({
 			<Link
 				to={`/volunteer-opportunities/${item.id}`}
 				className="absolute inset-0 z-10 rounded-card"
-				aria-label={item.title}
+				aria-label={title}
 			/>
 			<div className="flex h-full flex-col">
 				{/* Banner, only when the organization actually uploaded a photo.
@@ -212,7 +223,7 @@ export default function OpportunityListItem({
 					landing page has a section heading over these cards again, hence
 					a prop rather than a second fixed level. */}
 					<Heading className="text-base leading-snug font-semibold text-gray-900 underline-offset-2 transition-colors group-hover:text-brand-700 group-hover:underline sm:text-lg">
-						{item.title}
+						{title}
 					</Heading>
 					{/* See dateLine() above for the three kinds this slot can state and
 					why each one carries its own glyph and tone. */}
@@ -224,9 +235,9 @@ export default function OpportunityListItem({
 						<DateIcon className="h-4 w-4 shrink-0" />
 						<span>{date.label}</span>
 					</p>
-					{item.description && (
+					{description && (
 						<p className="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-500">
-							{item.description}
+							{description}
 						</p>
 					)}
 					{item.tags.length > 0 && (

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -11,6 +11,7 @@ import {
 	isRecentlyCreatedOrganization,
 	isSlotFull,
 	NEW_ORGANIZATION_THRESHOLD_DAYS,
+	pickLocalizedText,
 	resolveDateLocale,
 } from "./format";
 
@@ -85,6 +86,35 @@ describe("isSlotFull", () => {
 
 	it("is full when bookings exceed capacity", () => {
 		expect(isSlotFull(5, 6)).toBe(true);
+	});
+});
+
+describe("pickLocalizedText", () => {
+	it("returns the German text when the viewer's language is German", () => {
+		expect(pickLocalizedText("Deutscher Titel", "English Title", "de")).toBe(
+			"Deutscher Titel",
+		);
+	});
+
+	it("returns the English text when the viewer's language is English", () => {
+		expect(pickLocalizedText("Deutscher Titel", "English Title", "en")).toBe(
+			"English Title",
+		);
+	});
+
+	it("falls back to German when no English variant was provided", () => {
+		expect(pickLocalizedText("Deutscher Titel", undefined, "en")).toBe(
+			"Deutscher Titel",
+		);
+		expect(pickLocalizedText("Deutscher Titel", null, "en")).toBe(
+			"Deutscher Titel",
+		);
+	});
+
+	it("falls back to German when the English variant is blank", () => {
+		expect(pickLocalizedText("Deutscher Titel", "   ", "en")).toBe(
+			"Deutscher Titel",
+		);
 	});
 });
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -59,6 +59,34 @@ export function formatSignUpCount(
 	}
 }
 
+/**
+ * Organizer-authored opportunity title/description carry a required German
+ * variant and an optional English one (einsatzbereit#1946) - this picks
+ * whichever matches the viewer's active UI language, falling back to German
+ * when English wasn't provided (or is blank) rather than showing nothing.
+ * Single source of truth so every card/list/detail surface that renders an
+ * opportunity's title or description resolves the same way instead of each
+ * re-deriving its own fallback.
+ */
+export function pickLocalizedText(
+	textDe: string,
+	textEn: string | null | undefined,
+	lng: string,
+): string;
+export function pickLocalizedText(
+	textDe: string | null | undefined,
+	textEn: string | null | undefined,
+	lng: string,
+): string | undefined;
+export function pickLocalizedText(
+	textDe: string | null | undefined,
+	textEn: string | null | undefined,
+	lng: string,
+): string | undefined {
+	if (lng === "en" && textEn && textEn.trim().length > 0) return textEn;
+	return textDe ?? undefined;
+}
+
 /** i18n's UI language ("de"/"en") -> the Intl/date-fns locale used for date
  * formatting. The app only ever runs with i18n.language "de" or "en" (see
  * i18n.ts's supportedLngs), so this always maps to a fixed regional variant

--- a/frontend/src/lib/quickCheckIn.test.ts
+++ b/frontend/src/lib/quickCheckIn.test.ts
@@ -7,8 +7,10 @@ function makeOpportunity(
 ): VolunteerOpportunitySummary {
 	return {
 		id: "opp-1",
-		title: "Opportunity",
-		description: undefined,
+		titleDe: "Opportunity",
+		titleEn: undefined,
+		descriptionDe: undefined,
+		descriptionEn: undefined,
 		organizationId: "org-1",
 		organizationName: "Org",
 		street: undefined,

--- a/frontend/src/lib/upcomingOpportunities.test.ts
+++ b/frontend/src/lib/upcomingOpportunities.test.ts
@@ -15,8 +15,10 @@ function makeOpportunity(
 ): VolunteerOpportunitySummary {
 	return {
 		id: "opp-1",
-		title: "Opportunity",
-		description: undefined,
+		titleDe: "Opportunity",
+		titleEn: undefined,
+		descriptionDe: undefined,
+		descriptionEn: undefined,
 		organizationId: "org-1",
 		organizationName: "Org",
 		street: undefined,
@@ -55,6 +57,7 @@ describe("selectUpcomingOpportunities", () => {
 		const items = selectUpcomingOpportunities(
 			[upcoming("a", "2026-08-15T09:00:00Z")],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items).toHaveLength(1);
@@ -71,6 +74,7 @@ describe("selectUpcomingOpportunities", () => {
 				makeOpportunity({ id: "interest-based" }),
 			],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items.map((i) => i.id)).toEqual(["has-slot"]);
@@ -80,6 +84,7 @@ describe("selectUpcomingOpportunities", () => {
 		const items = selectUpcomingOpportunities(
 			[upcoming("broken", "not-a-date")],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items).toEqual([]);
@@ -93,6 +98,7 @@ describe("selectUpcomingOpportunities", () => {
 				upcoming("middle", "2026-08-15T09:00:00Z"),
 			],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items.map((i) => i.id)).toEqual(["soonest", "middle", "later"]);
@@ -109,7 +115,7 @@ describe("selectUpcomingOpportunities", () => {
 		);
 
 		expect(
-			selectUpcomingOpportunities(opportunities, "Untitled draft"),
+			selectUpcomingOpportunities(opportunities, "Untitled draft", "de"),
 		).toHaveLength(MAX_UPCOMING_ITEMS);
 	});
 
@@ -117,11 +123,12 @@ describe("selectUpcomingOpportunities", () => {
 		const items = selectUpcomingOpportunities(
 			[
 				makeOpportunity({
-					title: "",
+					titleDe: "",
 					nextTimeSlotStart: "2026-08-15T09:00:00Z" as unknown as Date,
 				}),
 			],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items[0].title).toBe("Untitled draft");
@@ -144,6 +151,7 @@ describe("selectUpcomingOpportunities", () => {
 				}),
 			],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items.map((i) => [i.id, i.bookedCount, i.maxParticipants])).toEqual([
@@ -165,12 +173,45 @@ describe("selectUpcomingOpportunities", () => {
 				}),
 			],
 			"Untitled draft",
+			"de",
 		);
 
 		expect(items[0].participationType).toBe("ScheduledSlots");
 	});
 
 	it("returns an empty array for an empty input", () => {
-		expect(selectUpcomingOpportunities([], "Untitled draft")).toEqual([]);
+		expect(selectUpcomingOpportunities([], "Untitled draft", "de")).toEqual([]);
+	});
+
+	it("prefers the English title when the viewer's language is English", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				makeOpportunity({
+					titleDe: "Deutscher Titel",
+					titleEn: "English Title",
+					nextTimeSlotStart: "2026-08-15T09:00:00Z" as unknown as Date,
+				}),
+			],
+			"Untitled draft",
+			"en",
+		);
+
+		expect(items[0].title).toBe("English Title");
+	});
+
+	it("falls back to the German title when English wasn't provided", () => {
+		const items = selectUpcomingOpportunities(
+			[
+				makeOpportunity({
+					titleDe: "Deutscher Titel",
+					titleEn: undefined,
+					nextTimeSlotStart: "2026-08-15T09:00:00Z" as unknown as Date,
+				}),
+			],
+			"Untitled draft",
+			"en",
+		);
+
+		expect(items[0].title).toBe("Deutscher Titel");
 	});
 });

--- a/frontend/src/lib/upcomingOpportunities.ts
+++ b/frontend/src/lib/upcomingOpportunities.ts
@@ -1,4 +1,5 @@
 import type { VolunteerOpportunitySummary } from "../client/api-client";
+import { pickLocalizedText } from "./format";
 
 export const MAX_UPCOMING_ITEMS = 5;
 
@@ -40,10 +41,13 @@ export interface UpcomingItem {
  *
  * `unnamedTitle` is the caller's translated fallback for an untitled draft -
  * passed in rather than translated here so this stays a pure function.
+ * `lang` is i18n.language ("de"/"en"), used to pick the matching title
+ * variant (einsatzbereit#1946) - same reasoning as `unnamedTitle`.
  */
 export function selectUpcomingOpportunities(
 	opportunities: VolunteerOpportunitySummary[],
 	unnamedTitle: string,
+	lang: string,
 ): UpcomingItem[] {
 	return opportunities
 		.flatMap((o): UpcomingItem[] => {
@@ -57,7 +61,7 @@ export function selectUpcomingOpportunities(
 			return [
 				{
 					id: o.id,
-					title: o.title || unnamedTitle,
+					title: pickLocalizedText(o.titleDe, o.titleEn, lang) || unnamedTitle,
 					nextStart,
 					nextStartMs,
 					bookedCount: o.currentParticipantCount,

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -257,6 +257,8 @@
       "next": "Weiter",
       "fieldTitle": "Titel",
       "fieldDescription": "Beschreibung",
+      "contentLanguageGroup": "Inhaltssprache",
+      "contentLanguageEnglishHint": "Optional. Freiwillige, die die Seite auf Englisch anzeigen, sehen diesen Text anstelle der deutschen Version unten - lass das Feld leer, um allen den deutschen Text zu zeigen.",
       "fieldStreet": "Straße",
       "fieldNumber": "Hausnummer",
       "fieldZip": "PLZ",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -257,6 +257,8 @@
       "next": "Next",
       "fieldTitle": "Title",
       "fieldDescription": "Description",
+      "contentLanguageGroup": "Content language",
+      "contentLanguageEnglishHint": "Optional. Volunteers viewing the site in English see this instead of the German version below - leave it blank to show the German text to everyone.",
       "fieldStreet": "Street",
       "fieldNumber": "House number",
       "fieldZip": "ZIP",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -18,7 +18,12 @@ import LoadMoreError from "../components/LoadMoreError";
 import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import NotFoundPage from "./NotFoundPage";
-import { formatDate, formatDateTime, resolveDateLocale } from "../lib/format";
+import {
+	formatDate,
+	formatDateTime,
+	pickLocalizedText,
+	resolveDateLocale,
+} from "../lib/format";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { useSetOrgBreadcrumbExtra } from "../contexts/OrgBreadcrumbContext";
 import { dispatchToast } from "../lib/toastBus";
@@ -50,12 +55,15 @@ export default function EngagementManagementPage() {
 		useState<VolunteerOpportunityDetails | null>(null);
 	const [opportunityError, setOpportunityError] = useState<string | null>(null);
 	const [retryingOpportunity, setRetryingOpportunity] = useState(false);
+	const opportunityTitle =
+		opportunity &&
+		pickLocalizedText(opportunity.titleDe, opportunity.titleEn, i18n.language);
 	usePageTitle(
-		opportunity?.title
-			? `${t("engagementManagement.title")} - ${opportunity.title}`
+		opportunityTitle
+			? `${t("engagementManagement.title")} - ${opportunityTitle}`
 			: t("engagementManagement.title"),
 	);
-	useSetOrgBreadcrumbExtra(opportunity?.title);
+	useSetOrgBreadcrumbExtra(opportunityTitle);
 
 	const STATUS_LABELS: Record<string, string> = {
 		Pending: t("engagementManagement.status.Pending"),

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -16,6 +16,7 @@ import {
 	formatParticipationType,
 	formatPostedAgo,
 	isSlotFull,
+	pickLocalizedText,
 } from "../lib/format";
 import {
 	FEW_SPOTS_THRESHOLD,
@@ -129,7 +130,14 @@ export default function VolunteerOpportunityDetailPage() {
 
 	const [opportunity, setOpportunity] =
 		useState<VolunteerOpportunityDetails | null>(null);
-	usePageTitle(opportunity?.title);
+	usePageTitle(
+		opportunity &&
+			pickLocalizedText(
+				opportunity.titleDe,
+				opportunity.titleEn,
+				i18n.language,
+			),
+	);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [showSignUp, setShowSignUp] = useState(false);
@@ -517,8 +525,16 @@ export default function VolunteerOpportunityDetailPage() {
 						{opportunity.organizationName}
 					</Link>
 				}
-				title={opportunity.title}
-				lead={opportunity.description ?? undefined}
+				title={pickLocalizedText(
+					opportunity.titleDe,
+					opportunity.titleEn,
+					i18n.language,
+				)}
+				lead={pickLocalizedText(
+					opportunity.descriptionDe,
+					opportunity.descriptionEn,
+					i18n.language,
+				)}
 			/>
 
 			<div data-content-wrapper className="mx-auto max-w-6xl">
@@ -945,7 +961,11 @@ export default function VolunteerOpportunityDetailPage() {
 
 				{showReport && (
 					<ReportContentModal
-						targetLabel={opportunity.title}
+						targetLabel={pickLocalizedText(
+							opportunity.titleDe,
+							opportunity.titleEn,
+							i18n.language,
+						)}
 						onSubmit={handleReportSubmit}
 						onClose={() => setShowReport(false)}
 					/>

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -24,6 +24,7 @@ import { visibleCalendarRange } from "../../../lib/calendarRange";
 import {
 	formatDate,
 	formatDateTime,
+	pickLocalizedText,
 	resolveDateLocale,
 } from "../../../lib/format";
 import { brandColor } from "../../../lib/brandColor";
@@ -284,7 +285,7 @@ function CalendarWidget({
 			(displayedCalData ?? []).flatMap((opp) =>
 				opp.timeSlots.map((slot) => ({
 					id: slot.timeSlotId,
-					title: opp.title,
+					title: pickLocalizedText(opp.titleDe, opp.titleEn, i18n.language),
 					start: new Date(slot.startDateTime),
 					end: new Date(slot.endDateTime),
 					opportunityId: opp.opportunityId,
@@ -293,7 +294,7 @@ function CalendarWidget({
 					maxParticipants: slot.maxParticipants ?? null,
 				})),
 			),
-		[displayedCalData],
+		[displayedCalData, i18n.language],
 	);
 
 	// #983: opening on the current month whenever the organizer happens to

--- a/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/QuickCheckInWidget.tsx
@@ -5,6 +5,7 @@ import { useApiClient } from "../../../hooks/useApiClient";
 import { dispatchToast } from "../../../lib/toastBus";
 import { inputSurfaceClass } from "../../../lib/formClasses";
 import { filterQrCheckInOpportunities } from "../../../lib/quickCheckIn";
+import { pickLocalizedText } from "../../../lib/format";
 import Skeleton from "../../../components/Skeleton";
 import Button from "../../../components/Button";
 import Dropdown from "../../../components/Dropdown";
@@ -38,7 +39,7 @@ function QuickCheckInWidget({
 	size,
 	onOpportunityCreated,
 }: Props) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 
 	// Shared with UpcomingOpportunitiesWidget, which fetches the same
@@ -134,7 +135,9 @@ function QuickCheckInWidget({
 							className={inputSurfaceClass}
 							options={qrOpportunities.map((o) => ({
 								value: o.id,
-								label: o.title || t("orgDashboard.unnamedDraft"),
+								label:
+									pickLocalizedText(o.titleDe, o.titleEn, i18n.language) ||
+									t("orgDashboard.unnamedDraft"),
 							}))}
 						/>
 					</div>

--- a/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/UpcomingOpportunitiesWidget.tsx
@@ -71,9 +71,10 @@ function UpcomingOpportunitiesWidget({
 				? selectUpcomingOpportunities(
 						opportunities,
 						t("orgDashboard.unnamedDraft"),
+						i18n.language,
 					)
 				: null,
-		[opportunities, t],
+		[opportunities, t, i18n.language],
 	);
 
 	return (

--- a/frontend/src/pages/app/OrgOpportunitiesPage.tsx
+++ b/frontend/src/pages/app/OrgOpportunitiesPage.tsx
@@ -13,7 +13,7 @@ import { getApiErrorMessage } from "../../lib/apiError";
 import { labelClass, textareaClass } from "../../lib/formClasses";
 import { cardClass } from "../../lib/surfaceClasses";
 import { getOpportunityCapacity } from "../../lib/opportunityCapacity";
-import { formatSignUpCount } from "../../lib/format";
+import { formatSignUpCount, pickLocalizedText } from "../../lib/format";
 import Chip, { type ChipTone } from "../../components/Chip";
 import CreateVolunteerOpportunityModal from "../../components/CreateVolunteerOpportunityModal";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -40,7 +40,7 @@ const STATUS_BADGE_TONE: Record<string, ChipTone> = {
 
 export default function OrgOpportunitiesPage() {
 	const { org, isOrganizer } = useOutletContext<OrgAppContext>();
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const api = useApiClient();
 	const organizationId = org.id;
 	usePageTitle(`${t("orgOverview.tabOpportunities")} - ${org.name}`);
@@ -327,6 +327,12 @@ export default function OrgOpportunitiesPage() {
 	) {
 		const status = item.status;
 		const isHighlighted = item.id === highlightedId;
+		const title = pickLocalizedText(item.titleDe, item.titleEn, i18n.language);
+		const description = pickLocalizedText(
+			item.descriptionDe,
+			item.descriptionEn,
+			i18n.language,
+		);
 		const badgeLabel =
 			status === "Draft"
 				? t("opportunities.draftBadge")
@@ -355,7 +361,7 @@ export default function OrgOpportunitiesPage() {
 							to={`/volunteer-opportunities/${item.id}`}
 							className="truncate text-sm font-semibold text-gray-900 hover:text-brand-700 hover:underline"
 						>
-							{item.title || t("orgDashboard.unnamedDraft")}
+							{title || t("orgDashboard.unnamedDraft")}
 						</Link>
 						{showStatusBadge && (
 							<Chip
@@ -368,9 +374,9 @@ export default function OrgOpportunitiesPage() {
 							</Chip>
 						)}
 					</div>
-					{item.description && (
+					{description && (
 						<p className="mt-0.5 line-clamp-1 text-xs text-gray-500">
-							{item.description}
+							{description}
 						</p>
 					)}
 					{/* Unconditional: this is the number an organizer opens the page
@@ -419,7 +425,7 @@ export default function OrgOpportunitiesPage() {
 						<div className="ml-auto">
 							<RowActionsMenu
 								label={t("orgOpportunities.moreActionsFor", {
-									title: item.title || t("orgDashboard.unnamedDraft"),
+									title: title || t("orgDashboard.unnamedDraft"),
 								})}
 								actions={[
 									...(status !== "Cancelled"


### PR DESCRIPTION
## What

Organizer-authored opportunity title and description now carry a required German variant plus an optional English translation. A volunteer viewing the site in English sees the English variant when the organizer supplied one, falling back to German otherwise - the mixed-language read from #1946 is gone rather than signposted.

## Why

Switching the site language to English correctly translated all UI chrome on `/opportunities` (category badges, dates, frequency tags), but every opportunity's title/description stayed in German, since there was no separate English field for it. The issue asked for a decision between a frontend-only "originally posted in German" signpost or a real per-locale content model; given the choice, this PR implements the real fix.

Closes #1946

## Implementation

**Backend** - `VolunteerOpportunity.TitleDe`/`TitleEn`/`DescriptionDe`/`DescriptionEn` replace the old single `Title`/`Description` (German required, matching the previous requirement; English optional, so an opportunity can still be published without a translation). EF Core migration renames the existing columns to the `_de` variants (data-preserving `RenameColumn`, no backfill needed) and adds nullable `_en` columns. Every command/query/DTO/read-repository projection touching these fields was updated accordingly, and the demo seed data now includes real English translations for all 10 seeded opportunities.

**Frontend** - a new `pickLocalizedText(textDe, textEn, lng)` helper (`lib/format.ts`) picks the viewer's active-language variant, falling back to German. Every surface that renders an opportunity's title/description now goes through it: the public card, the browse-list card, the detail page, and the organizer dashboard's calendar/upcoming/quick-check-in widgets and opportunities list. The organizer create/edit wizard's first step gets a German/English content-language toggle (plain labelled buttons, not an ARIA tablist, matching this repo's existing `LanguageSelector`/`Stepper` convention) so organizers can enter both; the toggle auto-switches back to German if a validation error lands on a hidden German field, so a blocked "Next"/"Publish" is never silent.

**Notification/email scope note** - in-app notifications and transactional emails (engagement confirmations, reminders, cancellations) keep interpolating the German title only, even though several of those code paths already resolve the recipient's preferred language for the surrounding email copy. This isn't a regression (there was only ever one German title before this PR), but it is a real inconsistency a reviewer flagged during self-review. Deliberately left out of this PR's scope to keep the diff to the browsing-page fix the issue actually asked for - worth a small follow-up PR to thread `TitleEn` through `OpportunityNotificationHelper` and pick per-recipient.

## Testing

- `dotnet run --project backend/tests/Application.UnitTests` - 1016/1016 passed (9 new tests covering the German/English split: required-German/optional-English validation, publish without an English variant, `Rename`/`ChangeDescription` round-trips, and handler-level persistence)
- `dotnet run --project backend/tests/ArchitectureTests` - 417/417 passed
- `dotnet build backend/Einsatzbereit.slnx` - clean across the whole solution (Application.UnitTests, IntegrationTests, ArchitectureTests, VisualTests all compile with 0 `error CS`); NSwag-generated clients (`frontend/src/client/api-client.ts`, `backend/tests/IntegrationTests/ApiClient.cs`, `backend/src/Api/wwwroot/openapi-v1.json`) regenerated and verified in sync
- Added two new `backend/tests/VisualTests/VolunteerOpportunityTests.cs` cases: one creates a bilingual opportunity and asserts the detail page's title/description follow the language switcher end-to-end, the other asserts an opportunity with only German content still renders correctly when viewed in English (fallback, not a blank page)
- `pnpm check` / `pnpm lint` / `pnpm test` (270/270) / `pnpm i18n:check` / `pnpm build` - all clean
- `/self-review` run: 5 parallel domain-checks (`nswag-check`, `ef-migration-check`, `architecture-check`, `a11y-check`, `i18n-check`) - all findings addressed: a German grammar fix in the new locale string, and a real accessibility trap in the language-toggle (a validation error on a hidden German field produced no perceivable feedback) fixed by auto-switching the toggle back to German when that happens

## Live verification

Skipped for this PR at the user's explicit request (no release candidate cut). CI's `VisualTests` job runs the two new end-to-end assertions above against the full Aspire stack on every push, which is the durable, reviewable record of the fix per this repo's own convention - the throwaway staging-verification script this repo's deploy flow normally requires isn't applicable here since no RC/staging deploy happens as part of this PR.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - no user-facing docs reference the old single-locale behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhwjKLBS4y94Wn86hVaXgB)_