### PR TITLE
fix(frontend): show ellipsis instead of hard-clipping agenda event titles

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -291,6 +291,22 @@ overflow-y-auto already handles vertical scrolling. */
 	border-bottom: 1px solid rgb(243 244 246);
 }
 
+/* Without this, the browser's auto table-layout algorithm sizes the EVENT
+column to its content's max-content width (the full, un-wrapped title),
+growing the whole table past its 30rem floor for every long title instead of
+truncating it - CalEventChip's own `truncate` span never gets a chance to
+show an ellipsis because it's never actually assigned a width narrower than
+its content. `width: 100%; max-width: 0` is the standard trick to make an
+auto-layout column take only the space left over by its neighbors instead of
+however much its content wants (confirmed empirically: DATE/TIME columns keep
+their natural width, EVENT is capped to what remains, and only then does the
+child truncate/ellipsis correctly) - verified this doesn't regress wider
+widgets, where EVENT still gets ample room and titles show in full (#1906). */
+.rbc-agenda-event-cell {
+	width: 100%;
+	max-width: 0;
+}
+
 /* Show more link */
 .rbc-show-more {
 	font-size: 0.75rem;


### PR DESCRIPTION
The Agenda view's EVENT column had no width constraint, so the browser's auto table-layout sized it to the full un-wrapped title on every row, growing the table (and requiring more horizontal scroll) instead of letting CalEventChip's truncate span ellipsize. Capping the column via width:100%/max-width:0 forces it to take only the leftover space, so long titles now truncate with a visible "..." instead of getting cut off mid-word with no signal.

Fixes #1906.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
