### PR TITLE
fix(frontend): clarify audit log's moderation-only scope

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1332,6 +1332,7 @@
         }
       },
       "auditLog": {
+        "scopeDescription": "Erfasst nur privilegierte Administrationsaktionen: Rollenänderungen, Sperren, Schattenlöschungen und Wiederherstellungen sowie von Admins abgesagte Anmeldungen. Übliche Selbstbedienungsaktionen wie Anmelden, Abmelden oder das Versenden von Einladungen werden hier nicht erfasst.",
         "loading": "Audit-Log wird geladen…",
         "error": "Audit-Log konnte nicht geladen werden.",
         "noEntries": "Noch keine privilegierten Aktionen erfasst.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1332,6 +1332,7 @@
         }
       },
       "auditLog": {
+        "scopeDescription": "Records privileged administrative actions only: role changes, blocks, shadow-deletes and restores, and admin-cancelled sign-ups. Routine self-service actions like signing up, withdrawing, or sending invitations aren't recorded here.",
         "loading": "Loading audit log…",
         "error": "Failed to load the audit log.",
         "noEntries": "No privileged actions recorded yet.",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -115,15 +115,21 @@ export default function AdministrationPage() {
 
 function AdminSection({
 	headingKey,
+	descriptionKey,
 	children,
 }: {
 	headingKey: string;
+	descriptionKey?: string;
 	children: ReactNode;
 }) {
 	const { t } = useTranslation();
 	return (
 		<section>
-			<PageSectionHeading>{t(headingKey)}</PageSectionHeading>
+			<PageSectionHeading
+				description={descriptionKey ? t(descriptionKey) : undefined}
+			>
+				{t(headingKey)}
+			</PageSectionHeading>
 			{children}
 		</section>
 	);
@@ -155,7 +161,10 @@ export function AdminReportsPage() {
 
 export function AdminAuditLogPage() {
 	return (
-		<AdminSection headingKey="administration.auditLogHeading">
+		<AdminSection
+			headingKey="administration.auditLogHeading"
+			descriptionKey="administration.auditLog.scopeDescription"
+		>
 			<AuditLogSection />
 		</AdminSection>
 	);


### PR DESCRIPTION
The audit log page implied comprehensive coverage under its "Administration" label, but only ever records privileged moderation actions (role changes, blocks, shadow-deletes/restores, admin-cancelled sign-ups) - routine self-service actions like sign-ups, withdrawals, and invitations never appear there, which read as broken rather than as intended scope.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1904

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
