### PR TITLE
fix(frontend): let org-switcher dropdown wrap long names instead of truncating

### DIFF
--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -125,7 +125,10 @@ export default function OrganizationSwitcher({
 										}`}
 									>
 										<OrgAvatar name={org.name} logoUrl={org.logoUrl} lazy />
-										<span className="truncate">{org.name}</span>
+										{/* No truncate here (unlike the collapsed trigger above) -
+										the panel already has the width to spare, so a long name
+										wraps onto a second line instead of being cut off (#1907). */}
+										<span className="min-w-0 flex-1">{org.name}</span>
 									</button>
 								</li>
 							))}


### PR DESCRIPTION
The open panel inherited a fixed w-64 with a truncating span for each row, so a long organization name got cut off even though the row had room to wrap. Drop the truncate class so the name flows onto a second line instead (#1907).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1907

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
