### PR TITLE
fix(frontend): distinguish login-streak icon from activity-streak icon on profile

### DIFF
--- a/frontend/src/pages/ProfileOverviewPage/index.tsx
+++ b/frontend/src/pages/ProfileOverviewPage/index.tsx
@@ -23,7 +23,7 @@ import ImageCropModal from "../../components/ImageCropModal";
 import FileUploadButton from "../../components/FileUploadButton";
 import Field from "../../components/Field";
 import Button from "../../components/Button";
-import { CheckIcon, PencilIcon } from "../../components/icons";
+import { CalendarIcon, CheckIcon, PencilIcon } from "../../components/icons";
 import AchievementsSection from "./AchievementsSection";
 import {
 	useProfileForm,
@@ -497,7 +497,7 @@ export default function ProfileOverviewPage() {
 															data-testid="profile-stat-login-streak"
 															className="flex items-center gap-1.5 text-xs text-brand-800"
 														>
-															<FireIcon className="h-3.5 w-3.5" />
+															<CalendarIcon className="h-3.5 w-3.5" />
 															{t("achievements.loginStreak", {
 																count: streaks.loginStreak,
 																badge: t(


### PR DESCRIPTION
Both streak stats used FireIcon, making the weekly activity streak and the daily login streak look like the same metric next to each other. Swap the login-streak caption to the existing CalendarIcon.

Fixes #1921

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1921

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
