### PR TITLE
docs(frontend): document intentional Zeitslot/Termin wording split

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -156,6 +156,19 @@ Shared UI primitives live in `src/components/` and `src/lib/` (no separate desig
 
 **Tokens:** the brand color scale (`brand-50`...`brand-900`) and `accent-400` are defined once in `src/styles/global.css`'s `@theme` block - use them instead of ad hoc hex values or arbitrary colors. `rounded-xl` is the default corner radius for interactive surfaces (buttons, inputs); cards, panels and modals use the separate `rounded-card` (16px) token instead - see `surfaceClasses.ts` and `Modal.tsx`. `rounded-md` is reserved for `Skeleton` loading blocks.
 
+## Copy Conventions
+
+- **"Zeitslot" vs "Termin"** (opportunity-detail page, `/my-signups`): both
+  words describe the same `TimeSlot` entity, but the split is a deliberate
+  register shift, not drift (#1920). "Zeitslot" (`opportunities.availableTimeSlots`,
+  `opportunities.joinWaitlist`, etc.) is used while a slot is still one of
+  several open options to choose from - an inventory listing. Once the
+  volunteer has committed to one, both the opportunity-detail page and
+  `/my-signups` switch to "Termin" (`myEngagements.scheduledFor`) - the
+  volunteer's own confirmed appointment. Keep this pairing when touching
+  either surface; don't rename one into the other to "fix" the apparent
+  inconsistency.
+
 ## Accessibility (a11y)
 
 `eslint-plugin-jsx-a11y` is enabled with the recommended ruleset. All violations are errors - CI will fail on any a11y lint issue.


### PR DESCRIPTION
Reviewed both surfaces: Zeitslot always labels an unpicked option (availableTimeSlots, joinWaitlist), Termin always labels the volunteer's own confirmed slot (scheduledFor) on opportunity-detail and /my-signups alike - consistent register shift, not drift. Records the decision so future contributors/reviewers stop flagging it.

Fixes #1920

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
