### PR TITLE
feat(frontend): serve locale-specific PWA manifests per active language

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -222,32 +222,42 @@ jobs:
       # instead of the application/manifest+json the W3C Web App Manifest spec
       # requires - a strict installability check (some Lighthouse
       # configurations, some non-Chromium engines) can refuse to treat a
-      # non-application/manifest+json response as a valid manifest.
-      - name: manifest.webmanifest is served with the correct Content-Type
+      # non-application/manifest+json response as a valid manifest. Checked
+      # for both locale manifests (#1923) since either can be the one
+      # index.html's <link rel="manifest"> currently points at.
+      - name: manifest.<locale>.webmanifest is served with the correct Content-Type
         run: |
-          content_type=$(curl -fsSI http://localhost:8081/manifest.webmanifest | tr -d '\r' | grep -i '^content-type:')
-          echo "$content_type"
-          echo "$content_type" | grep -qi "application/manifest+json" \
-            || { echo "::error::manifest.webmanifest was not served as application/manifest+json"; exit 1; }
+          for locale in de en; do
+            content_type=$(curl -fsSI "http://localhost:8081/manifest.${locale}.webmanifest" | tr -d '\r' | grep -i '^content-type:')
+            echo "$content_type"
+            echo "$content_type" | grep -qi "application/manifest+json" \
+              || { echo "::error::manifest.${locale}.webmanifest was not served as application/manifest+json"; exit 1; }
+          done
 
       # The lint job's check:pwa-manifest validates what vite.config.ts
       # declares against the PNGs in public/; this validates what the built
       # image actually serves. Between the two sits the build - an asset that
       # never made it into dist/, or a manifest field vite-plugin-pwa dropped,
-      # only shows up here (#1799).
+      # only shows up here (#1799). Both locale manifests are checked (#1923)
+      # so an English-speaking visitor gets the same richer install UI as the
+      # German default.
       - name: Web app manifest is served with a complete install listing
         run: |
-          manifest=$(curl -fsS http://localhost:8081/manifest.webmanifest)
-          echo "$manifest"
-          echo "$manifest" | jq -e '.id' > /dev/null || { echo "::error::manifest.webmanifest has no id"; exit 1; }
-          echo "$manifest" | jq -e '[.screenshots[] | select(.form_factor == "narrow")] | length > 0' > /dev/null \
-            || { echo "::error::manifest.webmanifest has no narrow screenshot - Chrome on Android needs one for the richer install UI"; exit 1; }
-          echo "$manifest" | jq -e '[.screenshots[] | select(.form_factor == "wide")] | length > 0' > /dev/null \
-            || { echo "::error::manifest.webmanifest has no wide screenshot"; exit 1; }
-          echo "$manifest" | jq -e '.shortcuts | length > 0' > /dev/null || { echo "::error::manifest.webmanifest has no shortcuts"; exit 1; }
-          for src in $(echo "$manifest" | jq -r '[.screenshots[].src] + [.shortcuts[].icons[].src] + [.icons[].src] | .[]' | sort -u); do
-            code=$(curl -fsS -o /dev/null -w "%{http_code}" "http://localhost:8081${src}" || echo 000)
-            [ "$code" = "200" ] || { echo "::error::manifest asset ${src} returned $code - the install prompt drops the whole listing over one missing file"; exit 1; }
+          for locale in de en; do
+            manifest=$(curl -fsS "http://localhost:8081/manifest.${locale}.webmanifest")
+            echo "$manifest"
+            echo "$manifest" | jq -e '.id' > /dev/null || { echo "::error::manifest.${locale}.webmanifest has no id"; exit 1; }
+            echo "$manifest" | jq -e ".lang == \"${locale}\"" > /dev/null \
+              || { echo "::error::manifest.${locale}.webmanifest has lang != \"${locale}\""; exit 1; }
+            echo "$manifest" | jq -e '[.screenshots[] | select(.form_factor == "narrow")] | length > 0' > /dev/null \
+              || { echo "::error::manifest.${locale}.webmanifest has no narrow screenshot - Chrome on Android needs one for the richer install UI"; exit 1; }
+            echo "$manifest" | jq -e '[.screenshots[] | select(.form_factor == "wide")] | length > 0' > /dev/null \
+              || { echo "::error::manifest.${locale}.webmanifest has no wide screenshot"; exit 1; }
+            echo "$manifest" | jq -e '.shortcuts | length > 0' > /dev/null || { echo "::error::manifest.${locale}.webmanifest has no shortcuts"; exit 1; }
+            for src in $(echo "$manifest" | jq -r '[.screenshots[].src] + [.shortcuts[].icons[].src] + [.icons[].src] | .[]' | sort -u); do
+              code=$(curl -fsS -o /dev/null -w "%{http_code}" "http://localhost:8081${src}" || echo 000)
+              [ "$code" = "200" ] || { echo "::error::manifest asset ${src} returned $code - the install prompt drops the whole listing over one missing file"; exit 1; }
+            done
           done
 
       - name: Stop container

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Every contribution counts - bug reports, ideas, documentation, or code.
 | UI source strings (i18n keys in `frontend/src/locales/en.json`) | English - add or edit new keys here first |
 | UI German translation (`frontend/src/locales/de.json`) | German - keep in parity with `en.json` via `pnpm i18n:check` |
 | End-user-facing app and documentation | German (Einsatzbereit's primary audience is German-speaking; the UI negotiates the visitor's browser language at runtime and falls back to German - `<html lang="de">` - only when that can't be detected, see `frontend/src/i18n.ts`) |
-| Installed-app metadata (the web app manifest in `frontend/vite.config.ts`) | German only, deliberately - `lang: "de"`, with German `name`/`description`/`shortcuts`. It is built once at build time and served as a single static file, so localising it would mean serving a different manifest per locale; that is not worth building for a German-first audience |
+| Installed-app metadata (the web app manifest in `frontend/vite.config.ts`) | Localized per active i18next language - a separate `manifest.de.webmanifest`/`manifest.en.webmanifest` is built at build time (`deManifest`/`enManifest`), and `frontend/src/i18n.ts` swaps `index.html`'s `<link rel="manifest">` between them as the visitor's language changes. German remains the default (`manifest.de.webmanifest`) for a visitor whose language hasn't resolved yet |
 | Code, commits, issues, pull requests | English |
 
 A PR that adds or changes UI text must update both `en.json` (the source) and `de.json` (the translation) - see `frontend/AGENTS.md`.

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -68,8 +68,11 @@ server {
 	# (einsatzbereit#1966) - most browsers are lenient about it, but a strict
 	# installability check (some Lighthouse configs, some non-Chromium engines)
 	# can refuse to treat a non-application/manifest+json response as a valid
-	# manifest.
-	location = /manifest.webmanifest {
+	# manifest. Matches both locale manifests (manifest.de.webmanifest,
+	# manifest.en.webmanifest, einsatzbereit#1923) rather than one exact
+	# filename, since index.html's <link rel="manifest"> is swapped between
+	# them at runtime (frontend/src/i18n.ts) as the visitor's language changes.
+	location ~ ^/manifest\.(de|en)\.webmanifest$ {
 		default_type application/manifest+json;
 	}
 

--- a/frontend/scripts/check-pwa-manifest.js
+++ b/frontend/scripts/check-pwa-manifest.js
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
-// Guards the web app manifest declared in vite.config.ts (issue #1799). The
-// manifest used to be the bare minimum - name, description, three icons -
-// with no `id`, no `screenshots` and no `shortcuts`, so Chrome on Android
-// fell back to its plain install prompt (name + icon only) instead of the
-// "richer install UI" listing, and the installed app's identity was derived
-// from `start_url`, meaning a future entry-point move would have installed a
-// second copy next to the first rather than updating it.
+// Guards the web app manifests declared in vite.config.ts (issue #1799,
+// localized per-locale in #1923). The manifest used to be the bare minimum -
+// name, description, three icons - with no `id`, no `screenshots` and no
+// `shortcuts`, so Chrome on Android fell back to its plain install prompt
+// (name + icon only) instead of the "richer install UI" listing, and the
+// installed app's identity was derived from `start_url`, meaning a future
+// entry-point move would have installed a second copy next to the first
+// rather than updating it. #1923 then split the single manifest into one
+// per supported i18next language (`deManifest`/`enManifest` in
+// vite.config.ts, served as manifest.de.webmanifest/manifest.en.webmanifest)
+// so an English-speaking visitor doesn't get German OS-level app metadata -
+// everything below runs once per locale.
 //
 // Screenshots are the fragile half: Chrome silently drops the richer install
 // UI - no console warning, no visible failure - if any single screenshot
@@ -92,191 +97,199 @@ function field(objectText, name) {
 	return match ? match[1] : null;
 }
 
-const manifestIndex = viteConfig.indexOf("manifest:");
-const manifest =
-	manifestIndex === -1
-		? null
-		: sliceBalanced(viteConfig, manifestIndex, "{", "}");
+// One manifest const per supported i18next language - keep in sync with
+// frontend/src/i18n.ts's supportedLngs and the manifestFilename/
+// emitLocaleManifest calls in vite.config.ts.
+const LOCALES = [
+	{ lang: "de", varName: "deManifest" },
+	{ lang: "en", varName: "enManifest" },
+];
 
-if (!manifest) {
-	fail("Could not find the VitePWA `manifest: { ... }` block in vite.config.ts.");
-	process.exit(1);
-}
+for (const { lang, varName } of LOCALES) {
+	const varIndex = viteConfig.indexOf(`const ${varName} =`);
+	const manifest =
+		varIndex === -1 ? null : sliceBalanced(viteConfig, varIndex, "{", "}");
 
-// 1. An explicit id, decoupled from start_url. Without it the browser
-// derives the app identity from start_url, so moving the entry point later
-// reads as a different app to every already-installed client.
-if (!/\bid:\s*"\/"/.test(manifest)) {
-	fail(
-		'The manifest in vite.config.ts has no `id: "/"` - without an explicit id the installed ' +
-			"app's identity is derived from start_url, so a later start_url change would install a " +
-			"second copy alongside the existing one instead of updating it (#1799).",
-	);
-}
-
-// 2. lang stays declared. The German-only manifest is a deliberate decision
-// (see the comment on it in vite.config.ts and CONTRIBUTING.md's Language
-// Convention) - dropping the field entirely would leave the language of the
-// name/description undeclared rather than merely non-localised.
-if (!/\blang:\s*"[a-z]{2}(-[A-Za-z0-9]+)*"/.test(manifest)) {
-	fail(
-		"The manifest in vite.config.ts has no `lang` - the name and description are written in " +
-			"one specific language and need to say which (see CONTRIBUTING.md's Language Convention " +
-			"for why that language is German).",
-	);
-}
-
-// 3. Screenshots: present, on disk, and within every constraint Chrome
-// enforces for the richer install UI.
-const screenshotsIndex = manifest.indexOf("screenshots:");
-const screenshotsBlock =
-	screenshotsIndex === -1
-		? null
-		: sliceBalanced(manifest, screenshotsIndex, "[", "]");
-
-if (!screenshotsBlock) {
-	fail(
-		"The manifest in vite.config.ts has no `screenshots` - without them Chrome on Android " +
-			"shows the minimal install prompt (name + icon) instead of a real listing (#1799).",
-	);
-} else {
-	const screenshots = topLevelObjects(screenshotsBlock);
-	if (screenshots.length === 0) {
-		fail("The manifest's `screenshots` array in vite.config.ts is empty.");
+	if (!manifest) {
+		fail(`Could not find "const ${varName} = { ... }" in vite.config.ts.`);
+		continue;
 	}
 
-	const aspectByFormFactor = new Map();
-
-	for (const entry of screenshots) {
-		const src = field(entry, "src");
-		const sizes = field(entry, "sizes");
-		const type = field(entry, "type");
-		const formFactor = field(entry, "form_factor");
-		const label = field(entry, "label");
-
-		if (!src || !sizes || !type || !formFactor) {
-			fail(
-				`A manifest screenshot entry in vite.config.ts is missing src/sizes/type/form_factor: ${entry.replace(/\s+/g, " ")}`,
-			);
-			continue;
-		}
-
-		// Screenshots are install-time artwork the browser fetches once, on
-		// demand - keeping them out of the directories workbox.globPatterns
-		// sweeps ("icons/*.png") is what stops half a megabyte of them being
-		// precached by the service worker for every visitor, installing or not.
-		if (!src.startsWith("/screenshots/")) {
-			fail(
-				`Manifest screenshot "${src}" is not under /screenshots/ - keep screenshots there so ` +
-					"workbox.globPatterns (which sweeps icons/*.png) doesn't precache install-prompt " +
-					"artwork into every visitor's service worker cache.",
-			);
-		}
-
-		if (!label) {
-			fail(
-				`Manifest screenshot "${src}" has no \`label\` - it is the accessible description shown ` +
-					"with the screenshot in the install prompt.",
-			);
-		}
-
-		const file = join(publicDir, src.replace(/^\//, ""));
-		if (!existsSync(file)) {
-			fail(
-				`Manifest screenshot "${src}" does not exist at public${src} - the install prompt would ` +
-					"drop the whole listing over one missing file.",
-			);
-			continue;
-		}
-
-		if (type !== "image/png" || !src.endsWith(".png")) {
-			fail(
-				`Manifest screenshot "${src}" is declared as "${type}" - this check reads PNG headers to ` +
-					"verify dimensions, so screenshots must be PNGs (or this script needs extending).",
-			);
-			continue;
-		}
-
-		const actual = pngDimensions(file);
-		if (!actual) {
-			fail(`Manifest screenshot "${src}" is not a readable PNG.`);
-			continue;
-		}
-
-		const declared = `${actual.width}x${actual.height}`;
-		if (sizes !== declared) {
-			fail(
-				`Manifest screenshot "${src}" declares sizes "${sizes}" but the file on disk is ` +
-					`${declared} - Chrome drops a screenshot whose declared size doesn't match.`,
-			);
-		}
-
-		const shorter = Math.min(actual.width, actual.height);
-		const longer = Math.max(actual.width, actual.height);
-		if (shorter < MIN_DIMENSION || longer > MAX_DIMENSION) {
-			fail(
-				`Manifest screenshot "${src}" is ${declared} - every dimension must be between ` +
-					`${MIN_DIMENSION} and ${MAX_DIMENSION} px for the richer install UI.`,
-			);
-		}
-		if (longer / shorter > MAX_ASPECT_RATIO) {
-			fail(
-				`Manifest screenshot "${src}" is ${declared}, an aspect ratio of ` +
-					`${(longer / shorter).toFixed(2)}:1 - the longer side may be at most ` +
-					`${MAX_ASPECT_RATIO}x the shorter one.`,
-			);
-		}
-
-		// All screenshots of one form factor must share a single aspect ratio,
-		// or Chrome shows none of them.
-		const aspect = actual.width / actual.height;
-		const seen = aspectByFormFactor.get(formFactor);
-		if (seen === undefined) {
-			aspectByFormFactor.set(formFactor, { aspect, src });
-		} else if (Math.abs(seen.aspect - aspect) > 0.01) {
-			fail(
-				`Manifest screenshot "${src}" (${declared}) has a different aspect ratio than ` +
-					`"${seen.src}", which is also form_factor "${formFactor}" - all screenshots of one ` +
-					"form factor must share one aspect ratio.",
-			);
-		}
-	}
-
-	// Chrome only qualifies for the richer install UI on Android when a narrow
-	// (mobile) screenshot exists, and only shows wide ones on desktop.
-	if (!aspectByFormFactor.has("narrow")) {
+	// 1. An explicit id, decoupled from start_url. Without it the browser
+	// derives the app identity from start_url, so moving the entry point later
+	// reads as a different app to every already-installed client.
+	if (!/\bid:\s*"\/"/.test(manifest)) {
 		fail(
-			'No manifest screenshot has form_factor "narrow" - Chrome on Android requires at least ' +
-				"one to show the richer install UI at all.",
+			`${varName} in vite.config.ts has no \`id: "/"\` - without an explicit id the installed ` +
+				"app's identity is derived from start_url, so a later start_url change would install a " +
+				"second copy alongside the existing one instead of updating it (#1799).",
 		);
 	}
-	if (!aspectByFormFactor.has("wide")) {
+
+	// 2. lang must be declared and match this manifest's own locale - a
+	// mismatch (e.g. enManifest declaring lang: "de") would silently serve the
+	// wrong language declaration alongside correctly-translated content.
+	if (!new RegExp(`\\blang:\\s*"${lang}"`).test(manifest)) {
 		fail(
-			'No manifest screenshot has form_factor "wide" - desktop install prompts only show wide ' +
-				"screenshots.",
+			`${varName} in vite.config.ts has no \`lang: "${lang}"\` - each locale manifest must ` +
+				"declare its own language (#1923), matching the manifest.<locale>.webmanifest file it " +
+				"is served as.",
 		);
 	}
-}
 
-// 4. Shortcuts: present, and every one of them points at a route that
-// actually exists. A renamed route would otherwise leave a long-press
-// shortcut on installed devices landing on NotFoundPage, with nothing in CI
-// noticing.
-const shortcutsIndex = manifest.indexOf("shortcuts:");
-const shortcutsBlock =
-	shortcutsIndex === -1
-		? null
-		: sliceBalanced(manifest, shortcutsIndex, "[", "]");
+	// 3. Screenshots: present, on disk, and within every constraint Chrome
+	// enforces for the richer install UI.
+	const screenshotsIndex = manifest.indexOf("screenshots:");
+	const screenshotsBlock =
+		screenshotsIndex === -1
+			? null
+			: sliceBalanced(manifest, screenshotsIndex, "[", "]");
 
-if (!shortcutsBlock) {
-	fail(
-		"The manifest in vite.config.ts has no `shortcuts` - the installed app's long-press menu " +
-			"then offers nothing beyond opening the app (#1799).",
-	);
-} else {
+	if (!screenshotsBlock) {
+		fail(
+			`${varName} in vite.config.ts has no \`screenshots\` - without them Chrome on Android ` +
+				"shows the minimal install prompt (name + icon) instead of a real listing (#1799).",
+		);
+	} else {
+		const screenshots = topLevelObjects(screenshotsBlock);
+		if (screenshots.length === 0) {
+			fail(`${varName}'s \`screenshots\` array in vite.config.ts is empty.`);
+		}
+
+		const aspectByFormFactor = new Map();
+
+		for (const entry of screenshots) {
+			const src = field(entry, "src");
+			const sizes = field(entry, "sizes");
+			const type = field(entry, "type");
+			const formFactor = field(entry, "form_factor");
+			const label = field(entry, "label");
+
+			if (!src || !sizes || !type || !formFactor) {
+				fail(
+					`A ${varName} screenshot entry in vite.config.ts is missing src/sizes/type/form_factor: ${entry.replace(/\s+/g, " ")}`,
+				);
+				continue;
+			}
+
+			// Screenshots are install-time artwork the browser fetches once, on
+			// demand - keeping them out of the directories workbox.globPatterns
+			// sweeps ("icons/*.png") is what stops half a megabyte of them being
+			// precached by the service worker for every visitor, installing or not.
+			if (!src.startsWith("/screenshots/")) {
+				fail(
+					`${varName} screenshot "${src}" is not under /screenshots/ - keep screenshots there so ` +
+						"workbox.globPatterns (which sweeps icons/*.png) doesn't precache install-prompt " +
+						"artwork into every visitor's service worker cache.",
+				);
+			}
+
+			if (!label) {
+				fail(
+					`${varName} screenshot "${src}" has no \`label\` - it is the accessible description shown ` +
+						"with the screenshot in the install prompt.",
+				);
+			}
+
+			const file = join(publicDir, src.replace(/^\//, ""));
+			if (!existsSync(file)) {
+				fail(
+					`${varName} screenshot "${src}" does not exist at public${src} - the install prompt would ` +
+						"drop the whole listing over one missing file.",
+				);
+				continue;
+			}
+
+			if (type !== "image/png" || !src.endsWith(".png")) {
+				fail(
+					`${varName} screenshot "${src}" is declared as "${type}" - this check reads PNG headers to ` +
+						"verify dimensions, so screenshots must be PNGs (or this script needs extending).",
+				);
+				continue;
+			}
+
+			const actual = pngDimensions(file);
+			if (!actual) {
+				fail(`${varName} screenshot "${src}" is not a readable PNG.`);
+				continue;
+			}
+
+			const declared = `${actual.width}x${actual.height}`;
+			if (sizes !== declared) {
+				fail(
+					`${varName} screenshot "${src}" declares sizes "${sizes}" but the file on disk is ` +
+						`${declared} - Chrome drops a screenshot whose declared size doesn't match.`,
+				);
+			}
+
+			const shorter = Math.min(actual.width, actual.height);
+			const longer = Math.max(actual.width, actual.height);
+			if (shorter < MIN_DIMENSION || longer > MAX_DIMENSION) {
+				fail(
+					`${varName} screenshot "${src}" is ${declared} - every dimension must be between ` +
+						`${MIN_DIMENSION} and ${MAX_DIMENSION} px for the richer install UI.`,
+				);
+			}
+			if (longer / shorter > MAX_ASPECT_RATIO) {
+				fail(
+					`${varName} screenshot "${src}" is ${declared}, an aspect ratio of ` +
+						`${(longer / shorter).toFixed(2)}:1 - the longer side may be at most ` +
+						`${MAX_ASPECT_RATIO}x the shorter one.`,
+				);
+			}
+
+			// All screenshots of one form factor must share a single aspect ratio,
+			// or Chrome shows none of them.
+			const aspect = actual.width / actual.height;
+			const seen = aspectByFormFactor.get(formFactor);
+			if (seen === undefined) {
+				aspectByFormFactor.set(formFactor, { aspect, src });
+			} else if (Math.abs(seen.aspect - aspect) > 0.01) {
+				fail(
+					`${varName} screenshot "${src}" (${declared}) has a different aspect ratio than ` +
+						`"${seen.src}", which is also form_factor "${formFactor}" - all screenshots of one ` +
+						"form factor must share one aspect ratio.",
+				);
+			}
+		}
+
+		// Chrome only qualifies for the richer install UI on Android when a narrow
+		// (mobile) screenshot exists, and only shows wide ones on desktop.
+		if (!aspectByFormFactor.has("narrow")) {
+			fail(
+				`No ${varName} screenshot has form_factor "narrow" - Chrome on Android requires at least ` +
+					"one to show the richer install UI at all.",
+			);
+		}
+		if (!aspectByFormFactor.has("wide")) {
+			fail(
+				`No ${varName} screenshot has form_factor "wide" - desktop install prompts only show wide ` +
+					"screenshots.",
+			);
+		}
+	}
+
+	// 4. Shortcuts: present, and every one of them points at a route that
+	// actually exists. A renamed route would otherwise leave a long-press
+	// shortcut on installed devices landing on NotFoundPage, with nothing in CI
+	// noticing.
+	const shortcutsIndex = manifest.indexOf("shortcuts:");
+	const shortcutsBlock =
+		shortcutsIndex === -1
+			? null
+			: sliceBalanced(manifest, shortcutsIndex, "[", "]");
+
+	if (!shortcutsBlock) {
+		fail(
+			`${varName} in vite.config.ts has no \`shortcuts\` - the installed app's long-press menu ` +
+				"then offers nothing beyond opening the app (#1799).",
+		);
+		continue;
+	}
+
 	const shortcuts = topLevelObjects(shortcutsBlock);
 	if (shortcuts.length === 0) {
-		fail("The manifest's `shortcuts` array in vite.config.ts is empty.");
+		fail(`${varName}'s \`shortcuts\` array in vite.config.ts is empty.`);
 	}
 
 	for (const entry of shortcuts) {
@@ -285,14 +298,14 @@ if (!shortcutsBlock) {
 
 		if (!name || !url) {
 			fail(
-				`A manifest shortcut entry in vite.config.ts is missing name/url: ${entry.replace(/\s+/g, " ")}`,
+				`A ${varName} shortcut entry in vite.config.ts is missing name/url: ${entry.replace(/\s+/g, " ")}`,
 			);
 			continue;
 		}
 
 		if (!appTsx.includes(`path="${url}"`)) {
 			fail(
-				`Manifest shortcut "${name}" points at "${url}", which is not a route declared in ` +
+				`${varName} shortcut "${name}" points at "${url}", which is not a route declared in ` +
 					"src/App.tsx - an installed app's shortcut would open NotFoundPage. Update the " +
 					"shortcut URL alongside the route rename.",
 			);
@@ -303,7 +316,7 @@ if (!shortcutsBlock) {
 			iconsIndex === -1 ? null : sliceBalanced(entry, iconsIndex, "[", "]");
 		if (!iconsBlock) {
 			fail(
-				`Manifest shortcut "${name}" has no icons - Android's long-press menu falls back to a ` +
+				`${varName} shortcut "${name}" has no icons - Android's long-press menu falls back to a ` +
 					"generic entry without one.",
 			);
 			continue;
@@ -313,25 +326,25 @@ if (!shortcutsBlock) {
 			const src = field(icon, "src");
 			const sizes = field(icon, "sizes");
 			if (!src || !sizes) {
-				fail(`An icon of manifest shortcut "${name}" is missing src/sizes.`);
+				fail(`An icon of ${varName} shortcut "${name}" is missing src/sizes.`);
 				continue;
 			}
 			const file = join(publicDir, src.replace(/^\//, ""));
 			if (!existsSync(file)) {
 				fail(
-					`Icon "${src}" of manifest shortcut "${name}" does not exist at public${src}.`,
+					`Icon "${src}" of ${varName} shortcut "${name}" does not exist at public${src}.`,
 				);
 				continue;
 			}
 			const actual = pngDimensions(file);
 			if (!actual) {
-				fail(`Icon "${src}" of manifest shortcut "${name}" is not a readable PNG.`);
+				fail(`Icon "${src}" of ${varName} shortcut "${name}" is not a readable PNG.`);
 				continue;
 			}
 			const declared = `${actual.width}x${actual.height}`;
 			if (sizes !== declared) {
 				fail(
-					`Icon "${src}" of manifest shortcut "${name}" declares sizes "${sizes}" but the file ` +
+					`Icon "${src}" of ${varName} shortcut "${name}" declares sizes "${sizes}" but the file ` +
 						`on disk is ${declared}.`,
 				);
 			}
@@ -339,10 +352,31 @@ if (!shortcutsBlock) {
 	}
 }
 
+// 5. VitePWA must actually build/serve one of these locale manifests as its
+// default (manifest.de.webmanifest, matching the German default everything
+// else end-user-facing serves) - and the other must be emitted somewhere in
+// the same config, or manifest.en.webmanifest is just dead code above that
+// nothing ever writes to dist/.
+if (!/manifestFilename:\s*"manifest\.de\.webmanifest"/.test(viteConfig)) {
+	fail(
+		'vite.config.ts does not set manifestFilename: "manifest.de.webmanifest" on the VitePWA ' +
+			"plugin - without it, VitePWA falls back to its default manifest.webmanifest filename, " +
+			"which the nginx location block and CI's live-served checks (frontend-checks.yml) no " +
+			"longer expect (#1923).",
+	);
+}
+if (!/manifest\.en\.webmanifest/.test(viteConfig.replace(/manifestFilename:\s*"manifest\.de\.webmanifest"/, ""))) {
+	fail(
+		'vite.config.ts never references "manifest.en.webmanifest" outside of manifestFilename - ' +
+			"enManifest is declared but nothing writes it into the build output (#1923).",
+	);
+}
+
 if (ok) {
 	console.log(
-		"Web app manifest declares id, screenshots and shortcuts; every referenced asset exists, " +
-			"matches its declared size and satisfies the install-prompt constraints.",
+		"Both locale web app manifests (de/en) declare id, lang, screenshots and shortcuts; every " +
+			"referenced asset exists, matches its declared size and satisfies the install-prompt " +
+			"constraints.",
 	);
 } else {
 	process.exit(1);

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -55,10 +55,25 @@ void i18next
 		returnNull: false,
 	});
 
+// The web app manifest is built per-locale (vite.config.ts's deManifest/
+// enManifest, #1923) since it's a static file with no per-request negotiation
+// - swapping this link's href is the only lever an SPA has over which one the
+// browser reads for the install prompt/OS app listing. Only "de"/"en" exist;
+// anything else (a future supportedLngs addition without a matching
+// manifest.<lng>.webmanifest) falls back to the German default rather than
+// pointing at a file that doesn't exist.
+function updateManifestLink(lang: string) {
+	const link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+	if (!link) return;
+	link.href = `/manifest.${lang === "en" ? "en" : "de"}.webmanifest`;
+}
+
 i18next.on("languageChanged", (lang: string) => {
 	document.documentElement.lang = lang;
 	localStorage.setItem("i18nextLng", lang);
+	updateManifestLink(lang);
 });
 document.documentElement.lang = i18next.language;
+updateManifestLink(i18next.language);
 
 export default i18next;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,250 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import svgr from "vite-plugin-svgr";
 import { VitePWA } from "vite-plugin-pwa";
 import { compression } from "vite-plugin-compression2";
+
+// Shared across every locale manifest below - the installed icon is the same
+// image regardless of the visitor's language.
+const manifestIcons = [
+	{
+		src: "/icons/icon-192.png",
+		sizes: "192x192",
+		type: "image/png",
+	},
+	{
+		src: "/icons/icon-512.png",
+		sizes: "512x512",
+		type: "image/png",
+	},
+	{
+		src: "/icons/icon-512.png",
+		sizes: "512x512",
+		type: "image/png",
+		purpose: "maskable",
+	},
+];
+
+// Two fully self-contained manifest objects rather than one base object with
+// locale overrides spread in - scripts/check-pwa-manifest.js validates each
+// locale by slicing its literal object text out of this file, which only
+// works if every field (screenshots/shortcuts included) is written out
+// in-place instead of inherited through a spread.
+const deManifest = {
+	// The installed app's identity, pinned independently of start_url
+	// (#1799). Without an explicit id, the browser derives one from
+	// start_url, so moving the entry point later would look like a
+	// brand new app to an already-installed client - it would install
+	// a second copy alongside the first rather than update it.
+	id: "/",
+	name: "Einsatzbereit",
+	short_name: "Einsatzbereit",
+	description:
+		"Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde.",
+	lang: "de",
+	start_url: "/",
+	display: "standalone",
+	background_color: "#ffffff",
+	theme_color: "#2d8a5e",
+	icons: manifestIcons,
+	// Captured from the real app so the Android install prompt shows
+	// an actual listing (Chrome's "richer install UI") instead of the
+	// bare name + icon it falls back to without screenshots. Chrome
+	// only qualifies for that UI when at least one narrow (mobile)
+	// screenshot is present, and only shows the wide ones on desktop,
+	// hence both form factors. Its other constraints, all enforced by
+	// scripts/check-pwa-manifest.js: every dimension between 320 and
+	// 3840 px, the longer side at most 2.3x the shorter, and one
+	// shared aspect ratio per form factor (16:9 wide, 9:16 narrow).
+	//
+	// These live in public/screenshots/ rather than public/icons/ so
+	// workbox.globPatterns above ("icons/*.png") does not sweep half a
+	// megabyte of install-prompt artwork into the service worker's
+	// precache - the browser fetches them at install time, and a
+	// visitor who never installs never needs them at all.
+	screenshots: [
+		{
+			src: "/screenshots/wide-home.png",
+			sizes: "1920x1080",
+			type: "image/png",
+			form_factor: "wide",
+			label: "Startseite mit Suche nach Einsätzen in deiner Nähe",
+		},
+		{
+			src: "/screenshots/wide-opportunities.png",
+			sizes: "1920x1080",
+			type: "image/png",
+			form_factor: "wide",
+			label: "Übersicht der gefundenen Einsätze mit Filtern",
+		},
+		{
+			src: "/screenshots/narrow-home.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "Startseite mit Suche nach Einsätzen in deiner Nähe",
+		},
+		{
+			src: "/screenshots/narrow-opportunities.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "Liste der gefundenen Einsätze",
+		},
+		{
+			src: "/screenshots/narrow-detail.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "Detailansicht eines Einsatzes mit Ort und Zeitraum",
+		},
+	],
+	// Long-press / jump-list entries on the installed app. Both point
+	// at static paths, which is all a build-time manifest can express:
+	// the organizer dashboard was considered too (#1799) and left out
+	// for exactly that reason - its URL is organization-scoped
+	// (/app/:organizationId/dashboard, resolved at runtime from the
+	// user's memberships and the active-org cookie, see
+	// lib/activeOrg.ts), so there is no single URL to bake in here.
+	// /my-signups is the member-facing shortcut instead; signed-out
+	// users hitting it land in Keycloak via ProtectedRoute and come
+	// back to it, which is the right behaviour for a shortcut only a
+	// signed-in member would tap.
+	shortcuts: [
+		{
+			name: "Einsätze finden",
+			short_name: "Einsätze",
+			description: "Freiwilligeneinsätze in deiner Nähe durchsuchen",
+			url: "/opportunities",
+			icons: [
+				{
+					src: "/icons/shortcut-search.png",
+					sizes: "96x96",
+					type: "image/png",
+				},
+			],
+		},
+		{
+			name: "Meine Anmeldungen",
+			short_name: "Anmeldungen",
+			description: "Deine Anmeldungen zu Einsätzen ansehen",
+			url: "/my-signups",
+			icons: [
+				{
+					src: "/icons/shortcut-signups.png",
+					sizes: "96x96",
+					type: "image/png",
+				},
+			],
+		},
+	],
+};
+
+// English counterpart of deManifest (#1923) - frontend/src/i18n.ts swaps the
+// <link rel="manifest"> href between the two manifestFilenames below as the
+// visitor's active i18next language changes, so an English-speaking visitor
+// installs an app whose OS-level name/description/shortcuts are in English
+// too instead of always getting the German one.
+const enManifest = {
+	id: "/",
+	name: "Einsatzbereit",
+	short_name: "Einsatzbereit",
+	description:
+		"Einsatzbereit connects committed volunteers with regional volunteer opportunities. Find local opportunities, help spontaneously, and make a difference in your community.",
+	lang: "en",
+	start_url: "/",
+	display: "standalone",
+	background_color: "#ffffff",
+	theme_color: "#2d8a5e",
+	icons: manifestIcons,
+	screenshots: [
+		{
+			src: "/screenshots/wide-home.png",
+			sizes: "1920x1080",
+			type: "image/png",
+			form_factor: "wide",
+			label: "Home page with search for opportunities near you",
+		},
+		{
+			src: "/screenshots/wide-opportunities.png",
+			sizes: "1920x1080",
+			type: "image/png",
+			form_factor: "wide",
+			label: "Overview of matching opportunities with filters",
+		},
+		{
+			src: "/screenshots/narrow-home.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "Home page with search for opportunities near you",
+		},
+		{
+			src: "/screenshots/narrow-opportunities.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "List of matching opportunities",
+		},
+		{
+			src: "/screenshots/narrow-detail.png",
+			sizes: "1080x1920",
+			type: "image/png",
+			form_factor: "narrow",
+			label: "Detail view of an opportunity with location and time period",
+		},
+	],
+	shortcuts: [
+		{
+			name: "Find opportunities",
+			short_name: "Opportunities",
+			description: "Search volunteer opportunities near you",
+			url: "/opportunities",
+			icons: [
+				{
+					src: "/icons/shortcut-search.png",
+					sizes: "96x96",
+					type: "image/png",
+				},
+			],
+		},
+		{
+			name: "My sign-ups",
+			short_name: "Sign-ups",
+			description: "View your volunteer opportunity sign-ups",
+			url: "/my-signups",
+			icons: [
+				{
+					src: "/icons/shortcut-signups.png",
+					sizes: "96x96",
+					type: "image/png",
+				},
+			],
+		},
+	],
+};
+
+// Emits an extra static *.webmanifest asset alongside the one VitePWA itself
+// generates from `manifest:`/`manifestFilename` below (#1923) - VitePWA only
+// manages a single manifest per plugin instance, so the second locale is
+// written directly into the bundle here instead. Runs in `generateBundle`
+// (before Rollup writes dist/ to disk), same phase VitePWA emits its own
+// manifest asset in, so by the time VitePWA's `closeBundle` hook globs
+// workbox.globPatterns against the files on disk (see below), this file is
+// already there too.
+function emitLocaleManifest(
+	fileName: string,
+	manifest: Record<string, unknown>,
+): Plugin {
+	const source = JSON.stringify(manifest, null, 2);
+	return {
+		name: `emit-${fileName}`,
+		generateBundle() {
+			this.emitFile({ type: "asset", fileName, source });
+		},
+	};
+}
 
 export default defineConfig({
 	plugins: [
@@ -39,7 +280,7 @@ export default defineConfig({
 				globPatterns: [
 					"index.html",
 					"favicon.svg",
-					"manifest.webmanifest",
+					"manifest.*.webmanifest",
 					"icons/*.png",
 					"assets/{index,vendor}-*.js",
 					"assets/*.css",
@@ -73,144 +314,17 @@ export default defineConfig({
 				navigateFallback: "/index.html",
 				navigateFallbackDenylist: [/^\/v1\//],
 			},
-			manifest: {
-				// The installed app's identity, pinned independently of start_url
-				// (#1799). Without an explicit id, the browser derives one from
-				// start_url, so moving the entry point later would look like a
-				// brand new app to an already-installed client - it would install
-				// a second copy alongside the first rather than update it.
-				id: "/",
-				name: "Einsatzbereit",
-				short_name: "Einsatzbereit",
-				description:
-					"Einsatzbereit verbindet engagierte Freiwillige mit regionalen Hilfsangeboten. Finde lokale Einsätze, hilf spontan und mach einen Unterschied in deiner Gemeinde.",
-				// Deliberately German-only, not localised per visitor (#1799).
-				// German is the default served locale for everything end-user-
-				// facing (index.html's <html lang="de">, the meta description and
-				// og: tags right next to it) - see CONTRIBUTING.md's Language
-				// Convention. A localised manifest would have to be served
-				// per-locale (a content-negotiated route, or a runtime
-				// <link rel="manifest"> swap), which this static nginx deployment
-				// has no mechanism for and which is not worth building for a
-				// German-first audience. English-locale visitors therefore install
-				// an app whose name and description are German, the same language
-				// the site itself serves them.
-				lang: "de",
-				start_url: "/",
-				display: "standalone",
-				background_color: "#ffffff",
-				theme_color: "#2d8a5e",
-				icons: [
-					{
-						src: "/icons/icon-192.png",
-						sizes: "192x192",
-						type: "image/png",
-					},
-					{
-						src: "/icons/icon-512.png",
-						sizes: "512x512",
-						type: "image/png",
-					},
-					{
-						src: "/icons/icon-512.png",
-						sizes: "512x512",
-						type: "image/png",
-						purpose: "maskable",
-					},
-				],
-				// Captured from the real app so the Android install prompt shows
-				// an actual listing (Chrome's "richer install UI") instead of the
-				// bare name + icon it falls back to without screenshots. Chrome
-				// only qualifies for that UI when at least one narrow (mobile)
-				// screenshot is present, and only shows the wide ones on desktop,
-				// hence both form factors. Its other constraints, all enforced by
-				// scripts/check-pwa-manifest.js: every dimension between 320 and
-				// 3840 px, the longer side at most 2.3x the shorter, and one
-				// shared aspect ratio per form factor (16:9 wide, 9:16 narrow).
-				//
-				// These live in public/screenshots/ rather than public/icons/ so
-				// workbox.globPatterns above ("icons/*.png") does not sweep half a
-				// megabyte of install-prompt artwork into the service worker's
-				// precache - the browser fetches them at install time, and a
-				// visitor who never installs never needs them at all.
-				screenshots: [
-					{
-						src: "/screenshots/wide-home.png",
-						sizes: "1920x1080",
-						type: "image/png",
-						form_factor: "wide",
-						label: "Startseite mit Suche nach Einsätzen in deiner Nähe",
-					},
-					{
-						src: "/screenshots/wide-opportunities.png",
-						sizes: "1920x1080",
-						type: "image/png",
-						form_factor: "wide",
-						label: "Übersicht der gefundenen Einsätze mit Filtern",
-					},
-					{
-						src: "/screenshots/narrow-home.png",
-						sizes: "1080x1920",
-						type: "image/png",
-						form_factor: "narrow",
-						label: "Startseite mit Suche nach Einsätzen in deiner Nähe",
-					},
-					{
-						src: "/screenshots/narrow-opportunities.png",
-						sizes: "1080x1920",
-						type: "image/png",
-						form_factor: "narrow",
-						label: "Liste der gefundenen Einsätze",
-					},
-					{
-						src: "/screenshots/narrow-detail.png",
-						sizes: "1080x1920",
-						type: "image/png",
-						form_factor: "narrow",
-						label: "Detailansicht eines Einsatzes mit Ort und Zeitraum",
-					},
-				],
-				// Long-press / jump-list entries on the installed app. Both point
-				// at static paths, which is all a build-time manifest can express:
-				// the organizer dashboard was considered too (#1799) and left out
-				// for exactly that reason - its URL is organization-scoped
-				// (/app/:organizationId/dashboard, resolved at runtime from the
-				// user's memberships and the active-org cookie, see
-				// lib/activeOrg.ts), so there is no single URL to bake in here.
-				// /my-signups is the member-facing shortcut instead; signed-out
-				// users hitting it land in Keycloak via ProtectedRoute and come
-				// back to it, which is the right behaviour for a shortcut only a
-				// signed-in member would tap.
-				shortcuts: [
-					{
-						name: "Einsätze finden",
-						short_name: "Einsätze",
-						description: "Freiwilligeneinsätze in deiner Nähe durchsuchen",
-						url: "/opportunities",
-						icons: [
-							{
-								src: "/icons/shortcut-search.png",
-								sizes: "96x96",
-								type: "image/png",
-							},
-						],
-					},
-					{
-						name: "Meine Anmeldungen",
-						short_name: "Anmeldungen",
-						description: "Deine Anmeldungen zu Einsätzen ansehen",
-						url: "/my-signups",
-						icons: [
-							{
-								src: "/icons/shortcut-signups.png",
-								sizes: "96x96",
-								type: "image/png",
-							},
-						],
-					},
-				],
-			},
+			// Default/fallback manifest (#1923) - served at manifest.de.webmanifest
+			// and injected into index.html's <link rel="manifest"> by VitePWA,
+			// matching the German default everything else end-user-facing serves
+			// (index.html's <html lang="de">, see CONTRIBUTING.md's Language
+			// Convention). frontend/src/i18n.ts swaps that link's href to
+			// manifest.en.webmanifest (emitted by emitLocaleManifest below) once
+			// the visitor's active i18next language resolves to English.
+			manifest: deManifest,
+			manifestFilename: "manifest.de.webmanifest",
 		}),
+		emitLocaleManifest("manifest.en.webmanifest", enManifest),
 	],
 	// react/react-dom and react-router are shared by (almost) every lazy
 	// route chunk - splitting them into their own stably-named vendor


### PR DESCRIPTION
Split the single German-only web app manifest into manifest.de.webmanifest/ manifest.en.webmanifest (vite.config.ts's deManifest/enManifest), swapped via index.html's <link rel="manifest"> in i18n.ts as the visitor's language changes, so an English-speaking installer no longer gets German name/ description/shortcuts. Updates nginx, the check:pwa-manifest CI script, and CONTRIBUTING.md's Language Convention to match.

Closes #1923

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
