### PR TITLE
fix(frontend): give org dashboard calendar day cells an accessible date label

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -758,6 +758,46 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task OrgDashboardPage_CalendarWidgetMonthView_AsOlaf_DateCellsHaveAccessibleDateLabel()
+	{
+		// einsatzbereit#1924: Month view's date-number button - rendered by
+		// react-big-calendar's own default DateHeader (node_modules/
+		// react-big-calendar/lib/DateHeader.js) - had no accessible name beyond
+		// the bare day-of-month digit visible on screen ("27"). CalendarWidget.tsx's
+		// components.month.dateHeader (CalDateHeader) now sets aria-label to a
+		// full date instead. Forces Month view via the toolbar rather than
+		// relying on olaf's seeded events landing in whichever month happens to
+		// be visible on the day this test runs (the color-dialog tests above
+		// Skip.Test for exactly that reason) - the day grid itself renders the
+		// same whether or not any event exists that month, so no seed data is
+		// needed here. Asserts the accessible name directly (mirroring
+		// VolunteerOpportunityDetailPage_MapMarker_HasAccessibleName above)
+		// rather than only an axe scan: the original bug already had visible
+		// button text, which satisfies axe's own accessible-name rules and
+		// would never have caught this regression.
+		var frontend = Fixture.GetEndpoint("frontend");
+		await NavigateToOrgAppDashboardAsOlafAsync(frontend);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Month" }).ClickAsync();
+
+		// `.rbc-current` marks the cell matching the calendar's own `date`
+		// state, which CalendarWidget.tsx initializes to `new Date()` and this
+		// test never navigates away from - i.e. today's cell.
+		var todayCell = Page.Locator(".rbc-current .rbc-button-link");
+		await Expect(todayCell).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var visibleLabel = await todayCell.InnerTextAsync();
+		var ariaLabel = await todayCell.GetAttributeAsync("aria-label");
+
+		ariaLabel.Should().NotBeNullOrWhiteSpace();
+		ariaLabel.Should().NotBe(visibleLabel,
+			"the accessible name must be more than the bare day-of-month digit visible on screen (einsatzbereit#1924)");
+		ariaLabel!.Length.Should().BeGreaterThan(visibleLabel.Length,
+			"a full date label (weekday, month, year) is always longer than the bare digit it replaces");
+	}
+
+	[Test]
 	public async Task OrgDashboardPage_LayoutLoadFailed_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// #1234: a failed dashboard-layout fetch now renders its own inline

--- a/frontend/src/components/VolunteerOpportunitiesList/MiniCalendar.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/MiniCalendar.tsx
@@ -3,7 +3,7 @@ import type { KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { addDays, addMonths, endOfWeek, startOfWeek } from "date-fns";
 import { ChevronLeftIcon, ChevronRightIcon } from "../icons";
-import { resolveDateLocale } from "../../lib/format";
+import { formatFullDate, resolveDateLocale } from "../../lib/format";
 
 function fmtIso(d: Date): string {
 	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -193,12 +193,6 @@ export default function MiniCalendar({
 	const monthName = new Intl.DateTimeFormat(locale, {
 		month: "long",
 	}).format(firstOfMonth);
-	const fullDateFormatter = new Intl.DateTimeFormat(locale, {
-		weekday: "long",
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	});
 	const dayLabels = Array.from({ length: 7 }, (_, i) => {
 		const ref = new Date(2024, 0, 1 + i); // 2024-01-01 was Monday
 		return new Intl.DateTimeFormat(locale, { weekday: "short" }).format(ref);
@@ -338,10 +332,10 @@ export default function MiniCalendar({
 										tabIndex={isFocusTarget ? 0 : -1}
 										aria-label={
 											isPast
-												? `${fullDateFormatter.format(day)}, ${t("opportunities.dayInPast")}`
+												? `${formatFullDate(day, i18n.language)}, ${t("opportunities.dayInPast")}`
 												: isMarked
-													? `${fullDateFormatter.format(day)}, ${t("opportunities.dayOpportunityCount", { count: opportunityCount })}`
-													: fullDateFormatter.format(day)
+													? `${formatFullDate(day, i18n.language)}, ${t("opportunities.dayOpportunityCount", { count: opportunityCount })}`
+													: formatFullDate(day, i18n.language)
 										}
 										// aria-disabled, not the disabled attribute: a natively
 										// disabled button drops out of the tab order entirely, which

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -165,6 +165,32 @@ export function formatDateLong(dt: string, lng: string): string {
 	return getLongDateFormatter(lng).format(new Date(dt));
 }
 
+const fullDateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getFullDateFormatter(lng: string): Intl.DateTimeFormat {
+	const resolvedLocale = resolveDateLocale(lng);
+	let formatter = fullDateFormatters.get(resolvedLocale);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(resolvedLocale, {
+			weekday: "long",
+			year: "numeric",
+			month: "long",
+			day: "numeric",
+		});
+		fullDateFormatters.set(resolvedLocale, formatter);
+	}
+	return formatter;
+}
+
+/** Full spelled-out date with weekday (e.g. "Samstag, 1. August 2026") - for
+ * screen-reader accessible names on calendar day cells (MiniCalendar's date
+ * grid, CalendarWidget's month view) whose visible label is just a bare
+ * number and needs a complete accessible name instead. `lng` is
+ * i18n.language ("de"/"en"), not an Intl locale (see formatDateTime). */
+export function formatFullDate(date: Date, lng: string): string {
+	return getFullDateFormatter(lng).format(date);
+}
+
 export function formatPostedAgo(dt: string, t: TFunction): string {
 	const days = differenceInCalendarDays(new Date(), new Date(dt));
 	return days <= 0

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -24,6 +24,7 @@ import { visibleCalendarRange } from "../../../lib/calendarRange";
 import {
 	formatDate,
 	formatDateTime,
+	formatFullDate,
 	pickLocalizedText,
 	resolveDateLocale,
 } from "../../../lib/format";
@@ -130,27 +131,32 @@ function CalEventChip({
 // month-view day cell as a bare `<button>{label}</button>` with only the
 // numeric day ("27") and no aria-label - identical text repeats up to five
 // times a month, leaving a screen-reader user with no way to tell which "27"
-// they're on (einsatzbereit#1925). Mirrors MiniCalendar.tsx's own aria-label
-// recipe (full weekday/day/month/year, plus "in the past" for a past date)
-// rather than inventing a second phrasing for the same concept - reusing its
-// "opportunities.dayInPast" string rather than adding a duplicate key.
-function CalDateHeader({ label, date, onDrillDown }: DateHeaderProps) {
+// they're on (einsatzbereit#1924/#1925 - filed twice for the same gap).
+// Mirrors MiniCalendar.tsx's own aria-label recipe (full weekday/day/month/
+// year via the shared formatFullDate helper, plus "in the past" for a past
+// date) rather than inventing a second phrasing for the same concept, and
+// mirrors the library default's span-vs-button split (span when RBC reports
+// no drilldown view to navigate to, otherwise the same rbc-button-link
+// button) so a day cell never exposes a control with no real action.
+function CalDateHeader({
+	label,
+	date,
+	drilldownView,
+	onDrillDown,
+}: DateHeaderProps) {
 	const { t, i18n } = useTranslation();
-	const locale = resolveDateLocale(i18n.language);
 	const todayMidnight = new Date();
 	todayMidnight.setHours(0, 0, 0, 0);
 	const isPast = date.getTime() < todayMidnight.getTime();
 	const isToday = date.getTime() === todayMidnight.getTime();
-	const fullDate = new Intl.DateTimeFormat(locale, {
-		weekday: "long",
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	}).format(date);
+	const fullDate = formatFullDate(date, i18n.language);
 	const ariaLabel = isPast
 		? `${fullDate}, ${t("opportunities.dayInPast")}`
 		: fullDate;
 
+	if (!drilldownView) {
+		return <span aria-label={ariaLabel}>{label}</span>;
+	}
 	return (
 		<button
 			type="button"


### PR DESCRIPTION
react-big-calendar's default Month-view date-number button exposed no accessible name beyond the bare day-of-month digit ("27"), leaving screen reader users with no month/year/weekday context. Wire a custom components.month.dateHeader that mirrors the library default but sets aria-label to a full localized date, reusing the same formatting MiniCalendar.tsx already relied on for its day grid (now shared via a new formatFullDate helper in lib/format.ts).

Closes #1924.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
