### PR TITLE
fix(frontend): guide organizers to sign-up when invite search matches an email with no account

### DIFF
--- a/backend/tests/VisualTests/MemberSearchEmailGuidanceTests.cs
+++ b/backend/tests/VisualTests/MemberSearchEmailGuidanceTests.cs
@@ -1,0 +1,153 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression coverage for #1894: OrgMembersPage's "Invite member" search
+/// showed the same generic "No users found." empty state for a typo'd query
+/// and for a syntactically valid but unregistered email, even though the
+/// field's placeholder implies email-based invites work. An email-shaped
+/// query with zero results now gets dedicated guidance pointing the
+/// organizer at signing the person up first, while a non-email query with
+/// zero results still shows the generic message.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class MemberSearchEmailGuidanceTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task MemberSearch_UnregisteredEmail_ShowsSignUpGuidance_NotGenericNoResults()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual1894 EmailGuidance {Guid.NewGuid():N}");
+
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}/members/search**", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 200,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "[]",
+			});
+		});
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/members");
+		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.Locator("#member-search").FillAsync("brandnewperson@example.com");
+
+		var emailGuidance = Page.GetByText(
+			"No account exists for this email yet - ask the person to sign up first, then you can invite them here.");
+		await Expect(emailGuidance).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByText("No users found.", new() { Exact = true })).Not.ToBeVisibleAsync();
+
+		var axe = await Page.RunAxe();
+		axe.Violations.Where(v => v.Impact is "serious" or "critical").Should().BeEmpty();
+
+		await Page.UnrouteAsync($"**/v1/organizations/{organizationId}/members/search**");
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	[Test]
+	public async Task MemberSearch_NonEmailQueryWithNoResults_ShowsGenericNoResults()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual1894 GenericNoResults {Guid.NewGuid():N}");
+
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}/members/search**", async route =>
+		{
+			if (route.Request.Method != "GET")
+			{
+				await route.ContinueAsync();
+				return;
+			}
+
+			await route.FulfillAsync(new()
+			{
+				Status = 200,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "[]",
+			});
+		});
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard/members");
+		await Expect(Page.Locator("#member-search")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.Locator("#member-search").FillAsync("nosuchuser");
+
+		await Expect(Page.GetByText("No users found.", new() { Exact = true }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByText("ask the person to sign up", new() { Exact = false }))
+			.Not.ToBeVisibleAsync();
+
+		await Page.UnrouteAsync($"**/v1/organizations/{organizationId}/members/search**");
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	/// <summary>
+	/// Creates an organization through the API with the signed-in user's own
+	/// token - same approach as MemberSearchErrorTests.
+	/// </summary>
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	/// <summary>
+	/// The shared olaf account accumulates test debris across this suite's
+	/// session (see the root AGENTS.md note about live staging) - clean up the
+	/// organizations this test creates.
+	/// </summary>
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/frontend/src/lib/emailLike.test.ts
+++ b/frontend/src/lib/emailLike.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { looksLikeEmail } from "./emailLike";
+
+describe("looksLikeEmail", () => {
+	it("matches a syntactically valid email", () => {
+		expect(looksLikeEmail("brandnewperson@example.com")).toBe(true);
+	});
+
+	it("ignores surrounding whitespace", () => {
+		expect(looksLikeEmail("  person@example.com  ")).toBe(true);
+	});
+
+	it("rejects a plain username", () => {
+		expect(looksLikeEmail("brandnewperson")).toBe(false);
+	});
+
+	it("rejects a query containing a space", () => {
+		expect(looksLikeEmail("brand newperson@example.com")).toBe(false);
+	});
+
+	it("rejects an @ with no domain suffix", () => {
+		expect(looksLikeEmail("person@example")).toBe(false);
+	});
+
+	it("rejects an empty string", () => {
+		expect(looksLikeEmail("")).toBe(false);
+	});
+});

--- a/frontend/src/lib/emailLike.ts
+++ b/frontend/src/lib/emailLike.ts
@@ -1,0 +1,9 @@
+// A syntactically-plausible email shape (local@domain.tld) - not full RFC
+// 5322 validation, just enough to tell an organizer's member-search query
+// "person@example.com" apart from a name/username query for OrgMembersPage's
+// no-results guidance (#1894).
+const EMAIL_LIKE_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function looksLikeEmail(value: string): boolean {
+	return EMAIL_LIKE_PATTERN.test(value.trim());
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -546,6 +546,7 @@
       "leaveOrganizationLastOrganizerHint": "Du bist der:die einzige Organisator:in dieser Organisation - lösche stattdessen die Organisation, wenn du sie schließen möchtest.",
       "searching": "Suche läuft…",
       "noSearchResults": "Keine Nutzer:innen gefunden.",
+      "noSearchResultsEmail": "Für diese E-Mail-Adresse existiert noch kein Konto - bitte die Person, sich zuerst zu registrieren, dann kannst du sie hier einladen.",
       "memberSearchError": "Nutzer:innen konnten nicht gesucht werden.",
       "inviteLabel": "Mitglied einladen",
       "invitePlaceholder": "Nach Benutzername oder E-Mail suchen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -546,6 +546,7 @@
       "leaveOrganizationLastOrganizerHint": "You're the only organizer of this organization - delete the organization instead if you want to close it.",
       "searching": "Searching…",
       "noSearchResults": "No users found.",
+      "noSearchResultsEmail": "No account exists for this email yet - ask the person to sign up first, then you can invite them here.",
       "memberSearchError": "Could not search for users.",
       "inviteLabel": "Invite member",
       "invitePlaceholder": "Search by username or email…",

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -9,6 +9,7 @@ import type {
 import { useApiClient } from "../../hooks/useApiClient";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { getApiErrorMessage } from "../../lib/apiError";
+import { looksLikeEmail } from "../../lib/emailLike";
 import { inputClass, labelClass, selectClass } from "../../lib/formClasses";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -364,7 +365,9 @@ export default function OrgMembersPage() {
 							!memberSearchError &&
 							memberCandidates.length === 0 && (
 								<p role="status" className="mt-1 text-xs text-gray-500">
-									{t("orgSettings.noSearchResults")}
+									{looksLikeEmail(memberSearch)
+										? t("orgSettings.noSearchResultsEmail")
+										: t("orgSettings.noSearchResults")}
 								</p>
 							)}
 					</div>


### PR DESCRIPTION
Searching "Invite member" for a syntactically valid but unregistered email showed the same generic "No users found." as a typo, even though the field's placeholder implies email invites work. Detect an email-shaped query with zero results and show guidance pointing the organizer at getting the person signed up first, instead.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1894

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
