### PR TITLE
fix: backfill membership rows for all org members, not just organizers

### DIFF
--- a/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
+++ b/backend/src/Infrastructure/BackgroundJobs/OrganizationMembershipBackfillJob.cs
@@ -13,9 +13,11 @@ namespace Infrastructure.BackgroundJobs;
 
 // One-shot compensator for pre-existing organizations that predate the
 // organization_membership table (migration AddOrganizationMembership). Without it,
-// every organizer of an org created before that migration has zero membership rows
-// and gets 403'd out of their own org, since OwnershipGuard.EnsureIsOrganizerAsync
-// has no Keycloak fallback at request time.
+// every member of an org created before that migration has zero membership rows:
+// organizers get 403'd out of their own org, since OwnershipGuard.EnsureIsOrganizerAsync
+// (and EnsureIsMemberAsync for plain members) has no Keycloak fallback at request time,
+// and the admin org list's member count - which reads this table directly - undercounts
+// against the org's own Keycloak-sourced members page (#1895).
 // Organizations created after that migration always get their founding organizer's
 // membership row written synchronously by CreateOrganizationCommandHandler, so once
 // this has run once against every organization that existed before the table did,
@@ -106,13 +108,19 @@ internal sealed class OrganizationMembershipBackfillJob(
 					var members = await keycloakOrganizationService.GetMembersAsync(
 						organizationId.Value, cancellationToken);
 
-					foreach (var member in members
-						.Where(m => realmOrganizerIds.Contains(m.UserId))
-						.DistinctBy(m => m.UserId))
+					// Every Keycloak member gets a row here, not just organizers - a plain
+					// member left out would have no way to ever get one afterwards (nothing else
+					// backfills), which under-counted this organization's membership everywhere
+					// that reads organization_membership instead of calling Keycloak directly (#1895).
+					foreach (var member in members.DistinctBy(m => m.UserId))
 					{
+						var role = realmOrganizerIds.Contains(member.UserId)
+							? OrganizationMemberRole.Organizer
+							: OrganizationMemberRole.Member;
+
 						dbContext.Set<OrganizationMembership>().Add(
 							OrganizationMembership.Create(
-								organizationId, UserId.Create(member.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer));
+								organizationId, UserId.Create(member.UserId).GetValueOrThrow(), role));
 					}
 				}
 			}

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -33,13 +33,14 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 	public Task ResetAsync() => fixture.ResetAsync();
 
 	[Test]
-	public async Task BackfillAsync_PreExistingOrganizationWithoutMembershipRows_InsertsRowPerDistinctOrganizer(
+	public async Task BackfillAsync_PreExistingOrganizationWithoutMembershipRows_InsertsRowPerDistinctMember(
 		CancellationToken cancellationToken)
 	{
 		await using var dbContext = fixture.CreateApplicationDbContext();
 		var organizationId = await SeedOrganizationWithoutMembershipRowsAsync(dbContext, cancellationToken);
 
 		var organizerId = Guid.NewGuid();
+		var memberId = Guid.NewGuid();
 		var keycloak = new FakeKeycloakOrganizationService
 		{
 			MembersToReturn =
@@ -48,8 +49,10 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 				// Same organizer reported twice (e.g. multiple Keycloak group mappings) - must
 				// not produce two rows and violate the unique (organization_id, user_id) index.
 				new KeycloakOrganizationMember(organizerId, "olaf", "Olaf", "O.", "olaf@example.com", IsOrganisator: true),
-				// Plain member, not an organizer - must not get a membership row at all.
-				new KeycloakOrganizationMember(Guid.NewGuid(), "vera", "Vera", "V.", "vera@example.com", IsOrganisator: false),
+				// Plain member, not an organizer - must still get a membership row (#1895: a
+				// skipped plain member undercounts this organization everywhere that reads
+				// organization_membership instead of Keycloak directly).
+				new KeycloakOrganizationMember(memberId, "vera", "Vera", "V.", "vera@example.com", IsOrganisator: false),
 			],
 		};
 
@@ -60,9 +63,15 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 			.Where(m => m.OrganizationId == organizationId)
 			.ToListAsync(cancellationToken);
 
-		memberships.Should().ContainSingle();
-		memberships[0].UserId.Should().Be(UserId.Create(organizerId).GetValueOrThrow());
-		memberships[0].Role.Should().Be(OrganizationMemberRole.Organizer);
+		memberships.Should().HaveCount(2);
+
+		var organizerMembership = memberships.Should().ContainSingle(m => m.UserId == UserId.Create(organizerId).GetValueOrThrow())
+			.Subject;
+		organizerMembership.Role.Should().Be(OrganizationMemberRole.Organizer);
+
+		var memberMembership = memberships.Should().ContainSingle(m => m.UserId == UserId.Create(memberId).GetValueOrThrow())
+			.Subject;
+		memberMembership.Role.Should().Be(OrganizationMemberRole.Member);
 
 		var marker = await dbContext.Set<OrganizationMembershipBackfillState>().SingleOrDefaultAsync(cancellationToken);
 		marker.Should().NotBeNull("a completed run must leave the one-shot marker behind");


### PR DESCRIPTION
The one-shot backfill job for pre-existing organizations only ever wrote organization_membership rows for organizers, so a plain member of such an org had no local row. That undercounted the admin org list's member count (reads organization_membership directly) against the org's own members page (reads the full roster from Keycloak), and silently blocked those members from OwnershipGuard.EnsureIsMemberAsync-gated views of their own organization.

Fixes #1895

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
