### PR TITLE
fix: scope Nominatim city search to Germany, drop non-place matches

### DIFF
--- a/backend/src/Infrastructure/Geocoding/GeocodingOptions.cs
+++ b/backend/src/Infrastructure/Geocoding/GeocodingOptions.cs
@@ -11,4 +11,12 @@ internal sealed class GeocodingOptions
 	public int TimeoutSeconds { get; set; } = 5;
 
 	public string DefaultCountry { get; set; } = "Deutschland";
+
+	// ISO 3166-1 alpha-2, lowercase - Nominatim's `countrycodes` free-text search
+	// param (unlike the structured `country` field above, which accepts a name).
+	// Restricts city-name/postal-code search to Germany so an ambiguous or
+	// short query never ranks an international namesake (e.g. Seoul/Bucksport
+	// for the "04416"/"04177" postal codes, or Polish villages for "Leip")
+	// ahead of - or instead of - the intended German city (#1900).
+	public string CitySearchCountryCode { get; set; } = "de";
 }

--- a/backend/src/Infrastructure/Geocoding/NominatimGeocodingService.cs
+++ b/backend/src/Infrastructure/Geocoding/NominatimGeocodingService.cs
@@ -130,6 +130,18 @@ internal sealed class NominatimGeocodingService(
 		}
 	}
 
+	// Nominatim's own `addresstype` for the *matched* result - not to be confused
+	// with which fields are present in its address breakdown (every result, even
+	// a street or lake, carries the containing city/town in `address`). Gating on
+	// this instead is what actually restricts suggestions to places, since
+	// `featuretype=city` turned out to be a no-op for free-text `q=` searches
+	// (verified against the live API while investigating #1900) - it let a
+	// street or POI that merely happens to be named after the query (e.g.
+	// "Hans-Leip-Straße") through, which then got mislabeled with its
+	// containing city ("Hamburg") as if that were the actual match.
+	private static readonly HashSet<string> PlaceAddressTypes =
+		new(StringComparer.OrdinalIgnoreCase) { "city", "town", "village", "municipality", "postcode" };
+
 	private static IReadOnlyList<CitySuggestion> ToSuggestions(IReadOnlyList<NominatimCityResult>? results)
 	{
 		var suggestions = new List<CitySuggestion>();
@@ -138,6 +150,9 @@ internal sealed class NominatimGeocodingService(
 
 		foreach (var result in results)
 		{
+			if (result.AddressType is null || !PlaceAddressTypes.Contains(result.AddressType))
+				continue;
+
 			var label = result.Address?.City ?? result.Address?.Town ?? result.Address?.Village ?? result.Address?.Municipality;
 			if (string.IsNullOrEmpty(label))
 				continue;
@@ -160,13 +175,13 @@ internal sealed class NominatimGeocodingService(
 		return suggestions;
 	}
 
-	private static string BuildCitySearchRequestUri(string query)
+	private string BuildCitySearchRequestUri(string query)
 	{
 		var queryString = string.Join(
 			'&',
 			"format=json",
 			"addressdetails=1",
-			"featuretype=city",
+			$"countrycodes={Uri.EscapeDataString(_options.CitySearchCountryCode)}",
 			$"q={Uri.EscapeDataString(query.Trim())}",
 			$"limit={MaxCitySuggestions}");
 
@@ -199,6 +214,7 @@ internal sealed class NominatimGeocodingService(
 	private sealed record NominatimCityResult(
 		[property: JsonPropertyName("lat")] string? Lat,
 		[property: JsonPropertyName("lon")] string? Lon,
+		[property: JsonPropertyName("addresstype")] string? AddressType,
 		[property: JsonPropertyName("address")] NominatimAddress? Address);
 
 	private sealed record NominatimAddress(

--- a/backend/tests/IntegrationTests/NominatimGeocodingServiceTests.cs
+++ b/backend/tests/IntegrationTests/NominatimGeocodingServiceTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Text;
+using Application.Common.Geocoding;
+using AwesomeAssertions;
+using Infrastructure.Geocoding;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace IntegrationTests;
+
+// Exercises Infrastructure.Geocoding.NominatimGeocodingService directly
+// (InternalsVisibleTo, see Infrastructure.csproj) against a stubbed HttpClient
+// instead of the real Nominatim API - like SmtpEmailServiceTests, it needs no
+// Aspire/Testcontainers fixture.
+//
+// Regression coverage for #1900: searching "04416" (Markkleeberg's real
+// postal code) used to rank Bucksport (Maine, USA) and Seoul above the
+// correct German city, and "Leip" surfaced a Hamburg street literally named
+// "Hans-Leip-Straße" mislabeled as a "Hamburg" suggestion via its address
+// breakdown. Both fixtures below are trimmed from real Nominatim responses
+// captured live while investigating the bug. The two root causes fixed here:
+// `countrycodes=de` now scopes the request to Germany, and results are kept
+// only when Nominatim's own `addresstype` marks them as an actual place/
+// postcode - `featuretype=city` looked like it did this but is a no-op for
+// free-text `q=` searches, verified against the live API.
+public class NominatimGeocodingServiceTests
+{
+	[Test]
+	public async Task SearchCitiesAsync_AnyQuery_RestrictsTheRequestToGermany()
+	{
+		var handler = new StubHandler(_ => JsonResponse("[]"));
+		var sut = CreateService(handler);
+
+		await sut.SearchCitiesAsync("Leipzig", "de");
+
+		handler.LastRequest.Should().NotBeNull();
+		handler.LastRequest!.RequestUri!.Query.Should().Contain("countrycodes=de");
+	}
+
+	[Test]
+	public async Task SearchCitiesAsync_PostalCodeMatch_KeepsTheGermanCityAndDropsInternationalNoise()
+	{
+		// Trimmed from the live, unfiltered response for q=04416 - #1900.
+		const string response = """
+			[
+				{"lat":"44.5834","lon":"-68.7873","addresstype":"postcode","address":{"city":"Bucksport"}},
+				{"lat":"37.5384","lon":"127.0016","addresstype":"postcode","address":{"city":"Seoul"}},
+				{"lat":"51.2833","lon":"12.3500","addresstype":"postcode","address":{"town":"Markkleeberg"}}
+			]
+			""";
+		var sut = CreateService(new StubHandler(_ => JsonResponse(response)));
+
+		var results = await sut.SearchCitiesAsync("04416", "de");
+
+		// A live call would never even receive the Bucksport/Seoul entries once
+		// countrycodes=de is applied - this fixture instead locks down that a
+		// postcode-type match (as opposed to a city-type match) still resolves
+		// to the correct label via its address breakdown.
+		results.Should().ContainSingle(r => r.Label == "Markkleeberg");
+	}
+
+	[Test]
+	public async Task SearchCitiesAsync_StreetNamedAfterTheQuery_IsNotMislabeledWithItsContainingCity()
+	{
+		// Trimmed from the live response for q=Leip, countrycodes=de - #1900.
+		// Hans-Leip-Straße is a real Hamburg street, not a match for a city
+		// named "Leip"; its address breakdown still carries "Hamburg" as the
+		// containing city, which the old (silently ignored) featuretype=city
+		// param never filtered out.
+		const string response = """
+			[
+				{"lat":"52.4333","lon":"14.0333","addresstype":"water","address":{"city":"Beeskow"}},
+				{"lat":"53.55","lon":"9.9500","addresstype":"road","address":{"city":"Hamburg"}}
+			]
+			""";
+		var sut = CreateService(new StubHandler(_ => JsonResponse(response)));
+
+		var results = await sut.SearchCitiesAsync("Leip", "de");
+
+		results.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task SearchCitiesAsync_GenuineCityMatch_IsReturned()
+	{
+		const string response = """
+			[
+				{"lat":"51.3397","lon":"12.3731","addresstype":"city","address":{"city":"Leipzig"}}
+			]
+			""";
+		var sut = CreateService(new StubHandler(_ => JsonResponse(response)));
+
+		var results = await sut.SearchCitiesAsync("Leipzig", "de");
+
+		results.Should().ContainSingle(r =>
+			r.Label == "Leipzig" && r.Latitude == 51.3397 && r.Longitude == 12.3731);
+	}
+
+	private static NominatimGeocodingService CreateService(HttpMessageHandler handler) =>
+		new(
+			new HttpClient(handler) { BaseAddress = new Uri("https://nominatim.example/") },
+			Options.Create(new GeocodingOptions { MinRequestIntervalMilliseconds = 0 }),
+			NullLogger<NominatimGeocodingService>.Instance);
+
+	private static HttpResponseMessage JsonResponse(string json) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+	{
+		public HttpRequestMessage? LastRequest { get; private set; }
+
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			LastRequest = request;
+			return Task.FromResult(respond(request));
+		}
+	}
+}


### PR DESCRIPTION
/v1/maps/cities was ranking international namesakes above (or instead of) the correct German city: postal codes 04416/04177 surfaced Bucksport (Maine) and Seoul ahead of Markkleeberg/Leipzig, and "Leip" returned unrelated Polish villages. Verified live against Nominatim: countrycodes wasn't set, so results weren't scoped to Germany at all, and the existing featuretype=city param turned out to be a silent no-op for free-text q= searches - it let a Hamburg street literally named "Hans-Leip-Strasse" through, which then got mislabeled with its containing city ("Hamburg") via its address breakdown.

Add countrycodes=de to the request, and replace the dead featuretype filter with a real post-response filter on Nominatim's own addresstype field, keeping only genuine city/town/village/municipality/postcode matches.

Partial-word queries like "Leipz"/"Leipzi" still return nothing - confirmed live that the public Nominatim API does not support prefix/ autocomplete-style matching at all, regardless of query parameters, so that part of the report is an upstream limitation rather than a bug in this backend's request or ranking logic.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1900

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
