### PR TITLE
fix: treat network-level fetch failures as offline, not a stale browser flag

### DIFF
--- a/backend/tests/VisualTests/OfflineStateTests.cs
+++ b/backend/tests/VisualTests/OfflineStateTests.cs
@@ -70,6 +70,47 @@ public class OfflineStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 		}
 	}
 
+	/// <summary>
+	/// Regression for #1901: OpportunityResultsList used to decide offline-vs-
+	/// generic-error purely from <c>useOnlineStatus()</c> (<c>navigator.onLine</c>).
+	/// That flag is only reliable when it reads false - true only means the
+	/// browser has a network interface up, and a well-documented cross-browser
+	/// quirk lets it keep reading true across a hard reload or cold PWA launch
+	/// even while genuinely offline. A visitor in that state used to see the
+	/// generic "An unexpected error occurred" screen with a "Retry" button that
+	/// could not possibly succeed, instead of the dedicated offline state.
+	///
+	/// Reproduced with a real document navigation (<c>GotoAsync</c>, not the
+	/// header-nav click <see cref="WarmOpportunitiesRouteThenLeaveAsync"/> uses)
+	/// since only the one list request is aborted here, not the whole context
+	/// (<c>Context.SetOfflineAsync</c>) - the app shell's own JS/CSS still load
+	/// over the network same as a real hard reload, with no service worker
+	/// needed to bring back a precached shell.
+	/// </summary>
+	[Test]
+	public async Task OpportunityList_HardReloadWhileNavigatorOnLineMisreportsTrue_StillShowsOfflineState()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => true });");
+		// Single asterisk deliberately: it does not cross a `/`, so this only
+		// matches the list endpoint's own query string, not
+		// /volunteer-opportunities/{id} or /volunteer-opportunities/date-availability.
+		await Page.RouteAsync("**/v1/volunteer-opportunities*", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync($"{origin}/opportunities");
+
+		var offline = Page.GetByTestId("opportunities-offline");
+		await Expect(offline).ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(offline).ToContainTextAsync("You are offline");
+
+		await Expect(Page.GetByTestId("opportunities-error")).Not.ToBeVisibleAsync();
+		await Expect(offline.GetByRole(AriaRole.Button)).ToHaveCountAsync(0);
+	}
+
 	[Test]
 	public async Task OpportunityList_WhenTheConnectionReturns_RefetchesWithoutBeingAsked()
 	{

--- a/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
+++ b/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
@@ -139,6 +139,40 @@ public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBas
 			.Not.ToBeVisibleAsync();
 	}
 
+	/// <summary>
+	/// Regression for #1901, org-shell half: the branch above proves the
+	/// offline state still works when <c>navigator.onLine</c> correctly reads
+	/// false. This proves the fix for the actual bug report - the flag can
+	/// misreport true across a hard reload/cold PWA launch while genuinely
+	/// offline (well-documented cross-browser quirk, since true only ever
+	/// means "the browser has a network interface up"), and the org request
+	/// failing with no HTTP response at all is now trusted over that stale
+	/// flag.
+	/// </summary>
+	[Test]
+	public async Task OrgShellWhileOffline_NavigatorOnLineMisreportsTrue_StillShowsOfflineState()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var organizationId = await CreateOrganizationAsync("OrgOfflineStaleFlag");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => true });");
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByText("An unexpected error occurred", new() { Exact = false }))
+			.Not.ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+			.Not.ToBeVisibleAsync();
+	}
+
 	[Test]
 	public async Task ServerError_ShowsRecoverableStateWithRetry_AndRetrySucceeds()
 	{

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../../client/api-client";
-import { useOnlineStatus } from "../../hooks/useOnlineStatus";
 import EmptyState from "../EmptyState";
 import Skeleton from "../Skeleton";
 import LoadMoreError from "../LoadMoreError";
@@ -11,6 +10,7 @@ import OpportunityListItem from "./OpportunityListItem";
 export default function OpportunityResultsList({
 	loading,
 	error,
+	errorIsOffline,
 	items,
 	hasFilters,
 	onClearFilters,
@@ -18,10 +18,12 @@ export default function OpportunityResultsList({
 	loadingMore,
 	onLoadMore,
 	loadMoreError,
+	loadMoreErrorIsOffline,
 	onRetryLoadMore,
 }: {
 	loading: boolean;
 	error: string | null;
+	errorIsOffline: boolean;
 	items: VolunteerOpportunitySummary[];
 	hasFilters: boolean;
 	onClearFilters: () => void;
@@ -29,10 +31,10 @@ export default function OpportunityResultsList({
 	loadingMore: boolean;
 	onLoadMore: () => void;
 	loadMoreError: string | null;
+	loadMoreErrorIsOffline: boolean;
 	onRetryLoadMore: () => void;
 }) {
 	const { t } = useTranslation();
-	const online = useOnlineStatus();
 	const isInitialLoad = loading && items.length === 0;
 	const countMessage =
 		!error && !isInitialLoad
@@ -49,7 +51,7 @@ export default function OpportunityResultsList({
 	// writing into it does. An *online* failure stays silent here: it renders
 	// LoadMoreError, whose ErrorBanner is already role="alert".
 	const liveMessage =
-		error && !online ? t("opportunities.offline") : countMessage;
+		error && errorIsOffline ? t("opportunities.offline") : countMessage;
 
 	return (
 		<>
@@ -118,20 +120,20 @@ export default function OpportunityResultsList({
 			while the connection was down. useLoadMore refetches on its own once
 			the connection returns, so this state needs no action at all. */}
 			{error &&
-				(online ? (
-					<LoadMoreError
-						message={t("opportunities.error", { message: error })}
-						retrying={loading}
-						onRetry={onRetryLoadMore}
-						data-testid="opportunities-error"
-					/>
-				) : (
+				(errorIsOffline ? (
 					<RouteState
 						inline
 						variant="offline"
 						title={t("routeState.offline.title")}
 						message={t("opportunities.offline")}
 						data-testid="opportunities-offline"
+					/>
+				) : (
+					<LoadMoreError
+						message={t("opportunities.error", { message: error })}
+						retrying={loading}
+						onRetry={onRetryLoadMore}
+						data-testid="opportunities-error"
 					/>
 				))}
 
@@ -165,19 +167,19 @@ export default function OpportunityResultsList({
 						(loadMoreError ? (
 							// Same offline split as the initial-load branch above, with
 							// wording for the case where rows are already on screen.
-							online ? (
-								<LoadMoreError
-									message={t("opportunities.error", { message: loadMoreError })}
-									retrying={loadingMore}
-									onRetry={onRetryLoadMore}
-								/>
-							) : (
+							loadMoreErrorIsOffline ? (
 								<RouteState
 									inline
 									variant="offline"
 									title={t("routeState.offline.title")}
 									message={t("opportunities.offlineLoadMore")}
 									data-testid="opportunities-offline-load-more"
+								/>
+							) : (
+								<LoadMoreError
+									message={t("opportunities.error", { message: loadMoreError })}
+									retrying={loadingMore}
+									onRetry={onRetryLoadMore}
 								/>
 							)
 						) : (

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -169,9 +169,11 @@ export default function VolunteerOpportunitiesList() {
 		loading,
 		loadingMore,
 		error,
+		errorIsOffline,
 		hasMore,
 		loadMore,
 		loadMoreError,
+		loadMoreErrorIsOffline,
 		retryLoadMore,
 	} = useVolunteerOpportunitiesData({
 		occurrence,
@@ -676,6 +678,7 @@ export default function VolunteerOpportunitiesList() {
 			<OpportunityResultsList
 				loading={loading}
 				error={error}
+				errorIsOffline={errorIsOffline}
 				items={items}
 				hasFilters={hasFilters}
 				onClearFilters={clearFilters}
@@ -683,6 +686,7 @@ export default function VolunteerOpportunitiesList() {
 				loadingMore={loadingMore}
 				onLoadMore={loadMore}
 				loadMoreError={loadMoreError}
+				loadMoreErrorIsOffline={loadMoreErrorIsOffline}
 				onRetryLoadMore={retryLoadMore}
 			/>
 		</div>

--- a/frontend/src/hooks/useLoadMore.ts
+++ b/frontend/src/hooks/useLoadMore.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useOnlineStatus } from "./useOnlineStatus";
+import { isNetworkError } from "../lib/apiError";
 
 export interface LoadMorePage<T> {
 	items: T[];
@@ -30,11 +31,23 @@ export interface UseLoadMoreResult<T> {
 	/** Set only when the page-1 (initial) fetch fails - items is empty whenever this is set. */
 	error: string | null;
 	/**
+	 * Whether `error` should be presented as an offline state instead of a
+	 * generic retryable error - true when the browser reports itself offline,
+	 * or when the fetch that produced `error` never got an HTTP response at
+	 * all (see isNetworkError). The latter is what makes a hard reload/cold
+	 * PWA launch while genuinely offline show the offline state too, since
+	 * `navigator.onLine` alone can misreport `true` in exactly that situation
+	 * (#1901) - the failed request itself is the more reliable signal.
+	 */
+	errorIsOffline: boolean;
+	/**
 	 * Set only when a page>1 (load-more) fetch fails - items keeps whatever was
 	 * already loaded (einsatzbereit#1226: a failed load-more used to wipe the
 	 * already-loaded rows because both cases shared a single `error`).
 	 */
 	loadMoreError: string | null;
+	/** Same offline/generic split as errorIsOffline, for loadMoreError. */
+	loadMoreErrorIsOffline: boolean;
 	hasMore: boolean;
 	loadMore: () => void;
 	/** Re-attempts the page that produced `loadMoreError`, without advancing further. */
@@ -87,7 +100,10 @@ export function useLoadMore<T>(
 	const [loading, setLoading] = useState(true);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [errorIsNetworkFailure, setErrorIsNetworkFailure] = useState(false);
 	const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+	const [loadMoreErrorIsNetworkFailure, setLoadMoreErrorIsNetworkFailure] =
+		useState(false);
 	const [resetToken, setResetToken] = useState(0);
 	const [retryToken, setRetryToken] = useState(0);
 
@@ -112,10 +128,12 @@ export function useLoadMore<T>(
 		if (isInitialLoad) {
 			setLoading(true);
 			setError(null);
+			setErrorIsNetworkFailure(false);
 		} else {
 			setLoadingMore(true);
 		}
 		setLoadMoreError(null);
+		setLoadMoreErrorIsNetworkFailure(false);
 
 		fetchPageRef
 			.current(page)
@@ -135,8 +153,13 @@ export function useLoadMore<T>(
 			})
 			.catch((err) => {
 				if (cancelled) return;
-				if (isInitialLoad) setError(getErrorMessage(err));
-				else setLoadMoreError(getErrorMessage(err));
+				if (isInitialLoad) {
+					setError(getErrorMessage(err));
+					setErrorIsNetworkFailure(isNetworkError(err));
+				} else {
+					setLoadMoreError(getErrorMessage(err));
+					setLoadMoreErrorIsNetworkFailure(isNetworkError(err));
+				}
 			})
 			.finally(() => {
 				if (cancelled) return;
@@ -166,6 +189,17 @@ export function useLoadMore<T>(
 		if (cameBackOnline && hasFailure) setRetryToken((n) => n + 1);
 	}, [online, hasFailure]);
 
+	// #1901: `online` alone flags a hard reload/cold PWA launch while
+	// genuinely offline as a generic error rather than the offline state,
+	// since navigator.onLine can misreport `true` in exactly that situation
+	// (see useOnlineStatus.ts). Whichever fetch actually failed is the more
+	// reliable witness - a failure with no HTTP response at all could only
+	// have happened with no working connection to the API, regardless of
+	// what the browser flag claims.
+	const errorIsOffline = error !== null && (!online || errorIsNetworkFailure);
+	const loadMoreErrorIsOffline =
+		loadMoreError !== null && (!online || loadMoreErrorIsNetworkFailure);
+
 	const loadMore = useCallback(() => {
 		setPage((p) => p + 1);
 	}, []);
@@ -177,7 +211,9 @@ export function useLoadMore<T>(
 	const reset = useCallback(() => {
 		setItems([]);
 		setError(null);
+		setErrorIsNetworkFailure(false);
 		setLoadMoreError(null);
+		setLoadMoreErrorIsNetworkFailure(false);
 		setPage(1);
 		setHasMore(false);
 		setResetToken((n) => n + 1);
@@ -191,7 +227,9 @@ export function useLoadMore<T>(
 		loading,
 		loadingMore,
 		error,
+		errorIsOffline,
 		loadMoreError,
+		loadMoreErrorIsOffline,
 		hasMore,
 		loadMore,
 		retryLoadMore,

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -8,7 +8,11 @@ import { useAchievementNotifier } from "../hooks/useAchievementNotifier";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import { setActiveOrgId } from "../lib/activeOrg";
 import { ORG_TABS, orgTabPath } from "../lib/orgTabs";
-import { getApiErrorMessage, getApiErrorStatus } from "../lib/apiError";
+import {
+	getApiErrorMessage,
+	getApiErrorStatus,
+	isNetworkError,
+} from "../lib/apiError";
 import {
 	OrgBreadcrumbProvider,
 	useOrgBreadcrumbExtra,
@@ -175,6 +179,11 @@ export default function OrgAppLayout() {
 	const [org, setOrg] = useState<OrganizationDetailsResponse | null>(null);
 	const [status, setStatus] = useState<LoadStatus>("loading");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// #1901: whether the failure behind status "error" never got an HTTP
+	// response at all - a stronger, cold-reload-safe offline signal than
+	// `online` alone, which can misreport `true` right after a hard reload
+	// while genuinely offline (see useOnlineStatus.ts).
+	const [errorIsNetworkFailure, setErrorIsNetworkFailure] = useState(false);
 	// Guards against a fast org switch (or a manual retry) racing its own
 	// previous request: only the response for the most recently issued
 	// request is allowed to update state, same pattern as
@@ -219,6 +228,7 @@ export default function OrgAppLayout() {
 					// decided at render time from the live connection status: while
 					// the browser reports itself offline, retrying cannot work.
 					setErrorMessage(getApiErrorMessage(err, t("error.serverError")));
+					setErrorIsNetworkFailure(isNetworkError(err));
 					setStatus("error");
 				}
 			});
@@ -295,8 +305,12 @@ export default function OrgAppLayout() {
 		// Offline is a distinct, self-clearing situation, not a server fault -
 		// and while it lasts, the retry button the error state offers is a lie
 		// (#1774). The effect above reloads as soon as the connection is back.
+		// #1901: `online` alone misses a hard reload/cold PWA launch while
+		// genuinely offline (navigator.onLine can misreport `true` there) - a
+		// failure that never got an HTTP response at all is trusted just as
+		// much, since that could only happen with no working connection.
 		return stateScreen(
-			online ? (
+			online && !errorIsNetworkFailure ? (
 				<RouteState
 					variant="error"
 					title={t("error.boundaryTitle")}

--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -18,6 +18,7 @@ import {
 	isApiErrorCode,
 	isApiForbiddenError,
 	isApiNotFoundError,
+	isNetworkError,
 } from "./apiError";
 
 describe("getApiErrorMessage", () => {
@@ -119,6 +120,31 @@ describe("getApiErrorStatus", () => {
 
 	it("returns null for a non-object value", () => {
 		expect(getApiErrorStatus("500")).toBeNull();
+	});
+});
+
+describe("isNetworkError", () => {
+	// #1901: a fetch that never reached the server (dropped connection, DNS
+	// failure) is the one case getApiErrorStatus itself cannot distinguish
+	// from "an error response happened to omit its status" - this makes that
+	// distinction available under its own name for callers that specifically
+	// want to treat "no HTTP response at all" as an offline signal.
+	it("returns true for a rejection with no status (e.g. a network failure)", () => {
+		expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+	});
+
+	it("returns true for null", () => {
+		expect(isNetworkError(null)).toBe(true);
+	});
+
+	it("returns false for a ProblemDetails-shaped rejection carrying a status", () => {
+		expect(isNetworkError({ status: 500, errorCode: "Server.Error" })).toBe(
+			false,
+		);
+	});
+
+	it("returns false for an ApiException-shaped rejection carrying a status", () => {
+		expect(isNetworkError({ status: 403, response: "{}" })).toBe(false);
 	});
 });
 

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -52,6 +52,20 @@ export function isApiNotFoundError(err: unknown): boolean {
 }
 
 /**
+ * Detects a rejected API call that never got an HTTP response at all - the
+ * fetch itself failed (dropped connection, DNS failure, CORS) as opposed to
+ * an error response the server actually sent, which always carries a numeric
+ * status (see getApiErrorStatus). This is a stronger, cold-reload-safe
+ * offline signal than `navigator.onLine`, which can misreport `true` right
+ * after a hard reload or cold PWA launch while genuinely offline - a
+ * well-documented cross-browser limitation (#1901) - since it reflects what
+ * the request that just ran actually did, rather than a cached browser flag.
+ */
+export function isNetworkError(err: unknown): boolean {
+	return getApiErrorStatus(err) === null;
+}
+
+/**
  * Detects a specific Result-pattern `errorCode` on a rejected API call (see
  * `getApiErrorMessage` for the shape). Used to treat one particular failure
  * as a benign no-op rather than surfacing it - e.g. a retried publish call

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -5,7 +5,6 @@ import { useAuth } from "react-oidc-context";
 import type { PublicOrganizationSummary } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
-import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { getApiErrorMessage } from "../lib/apiError";
 import { avatarColorClasses } from "../lib/avatarColor";
@@ -33,7 +32,6 @@ export default function OrganizationsPage() {
 	const api = useApiClient();
 	const { t } = useTranslation();
 	const auth = useAuth();
-	const online = useOnlineStatus();
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const search = searchParams.get("search") ?? "";
@@ -55,9 +53,11 @@ export default function OrganizationsPage() {
 		loading,
 		loadingMore,
 		error,
+		errorIsOffline,
 		hasMore,
 		loadMore,
 		loadMoreError,
+		loadMoreErrorIsOffline,
 		retryLoadMore,
 	} = useLoadMore<PublicOrganizationSummary>(
 		(pageNumber) =>
@@ -105,11 +105,11 @@ export default function OrganizationsPage() {
 				: t("organizationsPage.resultCount", { count: items.length })
 			: "";
 
-	// Same online-vs-offline split as OpportunityResultsList (#1774): while
-	// offline, this one live region carries the offline announcement instead
-	// of a result count.
+	// Same online-vs-offline split as OpportunityResultsList (#1774/#1901):
+	// while offline, this one live region carries the offline announcement
+	// instead of a result count.
 	const liveMessage =
-		error && !online ? t("organizationsPage.offline") : countMessage;
+		error && errorIsOffline ? t("organizationsPage.offline") : countMessage;
 
 	return (
 		<>
@@ -179,20 +179,20 @@ export default function OrganizationsPage() {
 			)}
 
 			{error &&
-				(online ? (
-					<LoadMoreError
-						message={t("organizationsPage.error", { message: error })}
-						retrying={loading}
-						onRetry={retryLoadMore}
-						data-testid="organizations-error"
-					/>
-				) : (
+				(errorIsOffline ? (
 					<RouteState
 						inline
 						variant="offline"
 						title={t("routeState.offline.title")}
 						message={t("organizationsPage.offline")}
 						data-testid="organizations-offline"
+					/>
+				) : (
+					<LoadMoreError
+						message={t("organizationsPage.error", { message: error })}
+						retrying={loading}
+						onRetry={retryLoadMore}
+						data-testid="organizations-error"
 					/>
 				))}
 
@@ -289,21 +289,21 @@ export default function OrganizationsPage() {
 					{items.length > 0 &&
 						hasMore &&
 						(loadMoreError ? (
-							online ? (
-								<LoadMoreError
-									message={t("organizationsPage.error", {
-										message: loadMoreError,
-									})}
-									retrying={loadingMore}
-									onRetry={retryLoadMore}
-								/>
-							) : (
+							loadMoreErrorIsOffline ? (
 								<RouteState
 									inline
 									variant="offline"
 									title={t("routeState.offline.title")}
 									message={t("organizationsPage.offlineLoadMore")}
 									data-testid="organizations-offline-load-more"
+								/>
+							) : (
+								<LoadMoreError
+									message={t("organizationsPage.error", {
+										message: loadMoreError,
+									})}
+									retrying={loadingMore}
+									onRetry={retryLoadMore}
 								/>
 							)
 						) : (


### PR DESCRIPTION
navigator.onLine can misreport true across a hard reload or cold PWA launch while genuinely offline (well-documented cross-browser quirk), which left OpportunityResultsList, OrganizationsPage and OrgAppLayout showing a generic error with a non-functional Retry button instead of the dedicated offline state. A fetch that never got an HTTP response at all is now treated as offline too, regardless of what navigator.onLine claims.

Fixes #1901.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
