### PR TITLE
fix: hide Withdraw once checked in on opportunity detail page

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -7956,7 +7956,8 @@
         "required": [
           "id",
           "status",
-          "timeSlotId"
+          "timeSlotId",
+          "isCheckedIn"
         ],
         "type": "object",
         "properties": {
@@ -7973,6 +7974,9 @@
               "string"
             ],
             "format": "uuid"
+          },
+          "isCheckedIn": {
+            "type": "boolean"
           }
         }
       },

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDetails/v1/VolunteerOpportunityDetails.cs
@@ -41,4 +41,5 @@ public sealed record TimeSlotDetail(
 public sealed record CurrentUserEngagementInfo(
 	Guid Id,
 	string Status,
-	Guid? TimeSlotId);
+	Guid? TimeSlotId,
+	bool IsCheckedIn);

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -581,14 +581,15 @@ internal sealed class VolunteerOpportunityReadRepository(
 					e.VolunteerId == userId_ &&
 					(e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
 				.OrderByDescending(e => e.CreatedOn)
-				.Select(e => new { e.Id, e.Status, e.TimeSlotId })
+				.Select(e => new { e.Id, e.Status, e.TimeSlotId, e.IsCheckedIn })
 				.FirstOrDefaultAsync(cancellationToken);
 
 			if (engagement is not null)
 				currentUserEngagement = new CurrentUserEngagementInfo(
 					engagement.Id.Value,
 					engagement.Status.ToString(),
-					engagement.TimeSlotId?.Value);
+					engagement.TimeSlotId?.Value,
+					engagement.IsCheckedIn);
 		}
 
 		return new VolunteerOpportunityDetails(

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -12649,6 +12649,9 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("timeSlotId")]
         public System.Guid? TimeSlotId { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("isCheckedIn")]
+        public bool IsCheckedIn { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -877,6 +877,41 @@ public class EngagementTests(IntegrationTestFixture fixture)
 		details.Should().NotBeNull();
 	}
 
+	// Regression for #1893: the opportunity detail page's Withdraw action used
+	// to ignore check-in state entirely because CurrentUserEngagementInfo never
+	// carried IsCheckedIn, guaranteeing a 409 from Engagement.Withdraw's guard
+	// once a volunteer had checked in. This pins the field the frontend now
+	// gates on, mirroring GetMyEngagements' IsCheckedIn (already covered above).
+	[Test]
+	public async Task GetVolunteerOpportunityDetails_ShouldReflectCheckedInStatus_OnCurrentUserEngagement(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		var engagement = await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+		await olafClient.ConfirmEngagementAsync(engagement.Id, cancellationToken);
+
+		var beforeCheckIn = await veraClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+		beforeCheckIn.CurrentUserEngagement.Should().NotBeNull();
+		beforeCheckIn.CurrentUserEngagement!.IsCheckedIn.Should().BeFalse();
+
+		await olafClient.CheckInEngagementAsync(engagement.Id, cancellationToken);
+
+		var afterCheckIn = await veraClient.GetVolunteerOpportunityDetailsAsync(opportunity.Id, cancellationToken);
+		afterCheckIn.CurrentUserEngagement.Should().NotBeNull();
+		afterCheckIn.CurrentUserEngagement!.IsCheckedIn.Should().BeTrue();
+
+		var act = () => veraClient.WithdrawEngagementAsync(engagement.Id, cancellationToken);
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
 	[Test]
 	public async Task CheckInWithPin_ShouldReturn400_WhenVolunteerTriesToCheckInSomeoneElsesEngagement(
 		CancellationToken cancellationToken)

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -367,6 +367,42 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_ApplicationStatusCheckedIn_AsVera_HasNoSeriousA11yViolations()
+	{
+		// einsatzbereit#1893: once the volunteer's engagement is checked in, the
+		// application-status card swaps its Withdraw button out for a "Checked
+		// in" Chip (Engagement.Withdraw's IsCheckedIn guard would otherwise
+		// reject the withdrawal with a 409) - a render state none of this
+		// file's other detail-page scans reach, since none of them check
+		// anyone in.
+		var (_, opportunityId, engagementId) =
+			await SeedConfirmedEngagementAsync("Manual", "DetailCheckedInA11y");
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+		(await olafHttp.PostAsync($"/v1/engagements/{engagementId}/check-in", null)).EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync(
+			$"{frontend.GetLeftPart(UriPartial.Authority)}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Proves the scan below actually saw the checked-in state, rather than
+		// passing against a page where the Withdraw button just never rendered
+		// for an unrelated reason.
+		var statusCard = Page.GetByTestId("application-status");
+		await Expect(statusCard.GetByText("Checked in")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(statusCard.GetByRole(AriaRole.Button, new() { Name = "Withdraw" }))
+			.Not.ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task VolunteerOpportunityDetailPage_MapMarker_HasAccessibleName()
 	{
 		// #1681: SingleMarkerMap.tsx's Leaflet divIcon marker rendered an

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6516,6 +6516,7 @@ export interface CurrentUserEngagementInfo {
     id: string;
     status: string;
     timeSlotId: string | undefined;
+    isCheckedIn: boolean;
 
     [key: string]: any;
 }

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -43,6 +43,7 @@ import { signinLocaleArgs } from "../lib/authLocale";
 import { cardClass } from "../lib/surfaceClasses";
 import {
 	CalendarIcon,
+	CheckIconSolid,
 	EnvelopeIcon,
 	FlagIcon,
 	GlobeIcon,
@@ -438,17 +439,29 @@ export default function VolunteerOpportunityDetailPage() {
 										</span>
 									</p>
 								)}
+								{cue.isCheckedIn && (
+									<Chip tone="success" size="sm" className="mt-2">
+										<CheckIconSolid className="h-3 w-3" />
+										{t("checkIn.checkedInLabel")}
+									</Chip>
+								)}
 							</div>
-							<Button
-								type="button"
-								variant="dangerOutline"
-								size="sm"
-								className="shrink-0"
-								onClick={() => setShowWithdrawConfirm(true)}
-								disabled={withdrawing}
-							>
-								{t("myEngagements.withdraw")}
-							</Button>
+							{/* Withdrawing after check-in is rejected server-side (Engagement.Withdraw's
+							IsCheckedIn guard, #673) - hide the action rather than let a volunteer hit
+							that 409, matching the same isCheckedIn gate /my-signups already applies
+							(#1893). */}
+							{!cue.isCheckedIn && (
+								<Button
+									type="button"
+									variant="dangerOutline"
+									size="sm"
+									className="shrink-0"
+									onClick={() => setShowWithdrawConfirm(true)}
+									disabled={withdrawing}
+								>
+									{t("myEngagements.withdraw")}
+								</Button>
+							)}
 						</div>
 					</div>
 				)}


### PR DESCRIPTION
CurrentUserEngagementInfo never carried IsCheckedIn, so the detail page's Withdraw button stayed enabled after check-in and always hit the Engagement.Withdraw 409 guard from #673. Thread IsCheckedIn through the query the same way GetMyEngagements already does, and gate the button on it like /my-signups.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #1893

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
