### PR TITLE
fix(backend): stop CreateTimeSlot recurrence tests flaking around DST transitions

### DIFF
--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CreateTimeSlot/CreateTimeSlotCommandHandlerTests.cs
@@ -99,6 +99,16 @@ public class CreateTimeSlotCommandHandlerTests
 		result.Should().OnlyContain(ts => ts.RecurrenceFrequency == "Weekly" && ts.RecurrenceCount == 8);
 	}
 
+	// BaseStart/BaseEnd are pinned to "now" and drift day by day, so a recurrence
+	// window that happens to straddle the Europe/Berlin DST transition (last
+	// Sunday of March/October) makes Advance()'s DST-safe local-time
+	// re-resolution (see CreateTimeSlotCommandHandler.Advance, #1160) disagree
+	// with a naive AddDays/AddMonths on the origin's fixed UTC offset by an hour.
+	// These two tests aren't exercising DST behaviour (Handle_ShouldKeepLocalWallClockTime_AcrossADstTransition
+	// already does), so they use a fixed start deep in a DST-transition-free
+	// window instead of the shared, "now"-derived BaseStart/BaseEnd.
+	private static readonly DateTimeOffset FixedRecurrenceStart = new(2027, 1, 5, 9, 0, 0, TimeSpan.Zero);
+
 	[Test]
 	public async Task Handle_ShouldCreate8WeeklySlots_WithWeeklyFrequency(
 		CancellationToken cancellationToken)
@@ -109,15 +119,17 @@ public class CreateTimeSlotCommandHandlerTests
 			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
 			.Returns(opportunity);
 
+		var start = FixedRecurrenceStart;
+		var end = start.AddHours(2);
 		var command = new CreateTimeSlotCommand(
-			opportunityId, BaseStart, BaseEnd, 5, DefaultRequestingUserId,
+			opportunityId, start, end, 5, DefaultRequestingUserId,
 			RecurrenceFrequency: "Weekly", RecurrenceCount: 8);
 
 		var result = await _sut.Handle(command, cancellationToken);
 
 		result.Should().HaveCount(8);
 		for (var i = 0; i < 8; i++)
-			result[i].StartDateTime.Should().Be(BaseStart.AddDays(7 * i));
+			result[i].StartDateTime.Should().Be(start.AddDays(7 * i));
 	}
 
 	[Test]
@@ -130,16 +142,18 @@ public class CreateTimeSlotCommandHandlerTests
 			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
 			.Returns(opportunity);
 
+		var start = FixedRecurrenceStart;
+		var end = start.AddHours(2);
 		var command = new CreateTimeSlotCommand(
-			opportunityId, BaseStart, BaseEnd, 20, DefaultRequestingUserId,
+			opportunityId, start, end, 20, DefaultRequestingUserId,
 			RecurrenceFrequency: "Monthly", RecurrenceCount: 3);
 
 		var result = await _sut.Handle(command, cancellationToken);
 
 		result.Should().HaveCount(3);
-		result[0].StartDateTime.Should().Be(BaseStart);
-		result[1].StartDateTime.Should().Be(BaseStart.AddMonths(1));
-		result[2].StartDateTime.Should().Be(BaseStart.AddMonths(2));
+		result[0].StartDateTime.Should().Be(start);
+		result[1].StartDateTime.Should().Be(start.AddMonths(1));
+		result[2].StartDateTime.Should().Be(start.AddMonths(2));
 	}
 
 	[Test]


### PR DESCRIPTION
## What

Fixes the failing `Build and Test Backend` job on `main` (`fast-tests`): `Handle_ShouldCreate3MonthlySlots_WithMonthlyFrequency` failed with `Expected result[2].StartDateTime to represent the same point in time as <2026-10-25 04:07:57 +0h>, but <2026-10-25 05:07:57 +0h> does not`.

## Why

`Handle_ShouldCreate8WeeklySlots_WithWeeklyFrequency` and `Handle_ShouldCreate3MonthlySlots_WithMonthlyFrequency` derive their start time from the shared `BaseStart = DateTimeOffset.UtcNow.AddDays(7)` field, then assert against a naive `BaseStart.AddDays(...)`/`AddMonths(...)` (fixed UTC offset, no timezone awareness).

`CreateTimeSlotCommandHandler.Advance()` was made DST-safe for issue #1160: it converts to the organizer's local time (Europe/Berlin by default), advances the wall-clock date, then re-resolves the UTC offset that applies *at the advanced date* - so an occurrence correctly shifts from CEST (+02:00) to CET (+01:00) across the last-Sunday-of-October transition.

Because `BaseStart` is derived from `UtcNow`, these two tests' recurrence window drifts forward one day at a time. Whenever that window happens to straddle the DST transition, the naive UTC-offset-preserving assertion and the DST-aware handler output legitimately disagree by an hour - which is exactly what happened on `main`, since `2026-10-25` is Germany's fall-back date this year and `UtcNow.AddDays(7)` (run on 2026-08-18) plus two months lands exactly on it. This is a ticking time bomb: the tests pass most of the year and fail specifically in the ~2-month window before each of the two annual DST transitions, whenever CI happens to run then.

Neither test is meant to exercise DST behavior - `Handle_ShouldKeepLocalWallClockTime_AcrossADstTransition` already covers that explicitly with fixed dates. So both tests now use a fixed start (`2027-01-05`) deep in a DST-transition-free window instead of the shared, `UtcNow`-derived `BaseStart`/`BaseEnd`, restoring deterministic pass/fail regardless of what day CI runs on.

## Testing

- Independently verified the fix's date arithmetic in Python (`zoneinfo`, mirroring `Advance()`'s local-time-then-reresolve-offset logic) against both the old (`UtcNow`-derived, DST-crossing) and new (fixed, DST-transition-free) start dates - confirmed the old dates mismatch by exactly one hour at the point the real CI failure hit, and the new fixed dates match for every assertion in both tests.
- Could not run `dotnet run --project tests/Application.UnitTests` locally in this sandbox: the .NET SDK install is blocked by this session's egress policy (`builds.dotnet.microsoft.com` returned 403 via the proxy). CI (which has full network access) will be the first real execution of this fix - watching it after this PR opens.

## Live verification

Not applicable - this is a test-only fix to a flaky assertion in `Application.UnitTests`. No production/runtime code changed, so there is nothing new to observe on staging.

## Checklist

- [x] `/self-review` run and findings addressed (diff is minimal and clean - no findings)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - test-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyf6uPKabVkgXxhhNH4ssQ)_