### PR TITLE
fix(frontend): drop redundant noun in English notification bell label

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -875,8 +875,8 @@
     },
     "notifications": {
       "bellLabel": "Notifications",
-      "bellLabelWithCount_one": "Notifications, {{count}} unread notification",
-      "bellLabelWithCount_other": "Notifications, {{count}} unread notifications",
+      "bellLabelWithCount_one": "Notifications, {{count}} unread",
+      "bellLabelWithCount_other": "Notifications, {{count}} unread",
       "markAllRead": "Mark all as read",
       "clearRead": "Clear read",
       "clearReadError": "Failed to clear read notifications.",


### PR DESCRIPTION
en.json's bellLabelWithCount repeated "notifications" on every focus ("Notifications, 10 unread notifications"). Match the German string's pattern (no repeated noun) for both plural forms.

Closes #2087

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
