### PR TITLE
fix(frontend): drop misleading no-account claim from landing mission text

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -67,7 +67,7 @@
       "latestLink": "Alle Einsätze ansehen",
       "missionLabel": "Vom Gründer",
       "missionTitle": "Warum ich Einsatzbereit gebaut habe",
-      "missionText": "Ehrenamt sollte nicht an Papierkram scheitern. Ich habe immer wieder erlebt, wie Leute helfen wollten und an Anmeldeformularen, Wartelisten oder schlicht fehlenden Einstiegspunkten gescheitert sind. Einsatzbereit nimmt jede dieser Hürden weg: Mikro-Ehrenamt, das in eine echte Woche passt - kostenlos, ohne Konto, komplett open source.",
+      "missionText": "Ehrenamt sollte nicht an Papierkram scheitern. Ich habe immer wieder erlebt, wie Leute helfen wollten und an Anmeldeformularen, Wartelisten oder schlicht fehlenden Einstiegspunkten gescheitert sind. Einsatzbereit nimmt jede dieser Hürden weg: Mikro-Ehrenamt, das in eine echte Woche passt - kostenlos, ohne Wartelisten, komplett open source.",
       "missionAuthor": "Maik Hasler, Gründer von Einsatzbereit",
       "missionCta": "Einsätze finden",
       "orgCtaLabel": "Für Organisationen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -67,7 +67,7 @@
       "latestLink": "Browse all opportunities",
       "missionLabel": "From the founder",
       "missionTitle": "Why I built Einsatzbereit",
-      "missionText": "Volunteering shouldn't require paperwork. I kept watching people who wanted to help get stuck on registration forms, waitlists, or simply not knowing where to start. Einsatzbereit removes every one of those barriers: micro-volunteering that fits into a real week - free, no account required, and fully open source.",
+      "missionText": "Volunteering shouldn't require paperwork. I kept watching people who wanted to help get stuck on registration forms, waitlists, or simply not knowing where to start. Einsatzbereit removes every one of those barriers: micro-volunteering that fits into a real week - free, no waiting lists, and fully open source.",
       "missionAuthor": "Maik Hasler, Founder of Einsatzbereit",
       "missionCta": "Find opportunities",
       "orgCtaLabel": "For organizations",


### PR DESCRIPTION
The mission statement promised "free, no account" while the FAQ correctly states a free account is required to join an opportunity. Replace the contradictory claim with "no waiting lists" so the FAQ remains the authoritative source on account requirements.

Fixes #2078

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
