### PR TITLE
fix(frontend): shrink hero card mobile bottom padding to remove dead space

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -278,7 +278,7 @@ export default function HomePage() {
 						/>
 					</div>
 
-					<div className="relative px-4 pt-24 pb-32 text-center sm:px-8 sm:pt-28 sm:pb-32 lg:px-10 lg:py-28">
+					<div className="relative px-4 pt-24 pb-12 text-center sm:px-8 sm:pt-28 sm:pb-32 lg:px-10 lg:py-28">
 						<h1
 							id={heroTitleId}
 							className="animate-fade-up-d1 mx-auto max-w-3xl font-display text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl xl:text-8xl"


### PR DESCRIPTION
The hero card's dark-green background extended ~130px below the search button on mobile, since pb-32 was carried over from the sm/lg layout where photo "stones" fill that area - stones stay hidden below sm.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2086

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
