### PR TITLE
fix: make deadline chip amber conditional on proximity, use brand tone for admin badge

### DIFF
--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -61,8 +61,17 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 
 			await row.GetByRole(AriaRole.Button, new() { Name = $"Promote {username} to admin" }).ClickAsync();
 			await ConfirmDialogAsync("Yes, promote");
-			await Expect(row.GetByText("Admin", new() { Exact = true })).ToBeVisibleAsync();
+			var adminBadge = row.GetByText("Admin", new() { Exact = true });
+			await Expect(adminBadge).ToBeVisibleAsync();
 			await Expect(row.GetByRole(AriaRole.Button, new() { Name = $"Remove admin from {username}" })).ToBeVisibleAsync();
+
+			// #2088: the badge used to share the amber warning tone with actual
+			// status indicators (e.g. a flagged organization), which read as a
+			// warning rather than a role designation. It now uses the same
+			// brand-tinted tone as other role badges (e.g. the Organizer chip).
+			var badgeBackground = await adminBadge.EvaluateAsync<string>(
+				"el => getComputedStyle(el).backgroundColor");
+			badgeBackground.Should().Be("rgb(240, 250, 245)", "the admin badge should use the brand tone, not amber");
 		}
 		finally
 		{

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -80,7 +80,9 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	/// The acceptance criterion the previous code deliberately failed: a
 	/// deadline card and a start-date card have to be distinguishable without
 	/// reading the label. Asserted on the rendered colour and glyph rather than
-	/// on class names - what matters is that the eye can separate them.
+	/// on class names - what matters is that the eye can separate them. Uses a
+	/// deadline inside the imminent window (#2088's amber only applies there -
+	/// see the next test for a deadline outside it).
 	/// </summary>
 	[Test]
 	public async Task PublicGrid_ADeadlineCard_LooksDifferentFromAStartDateCard()
@@ -95,7 +97,8 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 		var organizationId = await CreateOrganizationAsync(organizer, keyword);
 
 		await PublishSlotBasedOpportunityAsync(organizer, organizationId, $"{keyword} with a slot");
-		await PublishInterestBasedOpportunityAsync(organizer, organizationId, $"{keyword} with a deadline");
+		await PublishInterestBasedOpportunityAsync(
+			organizer, organizationId, $"{keyword} with a deadline", TimeSpan.FromDays(3));
 
 		await Page.GotoAsync($"{origin}/opportunities?q={keyword}");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -111,13 +114,52 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 		var startColor = await startLine.EvaluateAsync<string>("el => getComputedStyle(el).color");
 		var deadlineColor = await deadlineLine.EvaluateAsync<string>("el => getComputedStyle(el).color");
 		deadlineColor.Should().NotBe(startColor,
-			"a start date and an application deadline are different kinds of fact in the same slot");
+			"a start date and an imminent application deadline are different kinds of fact in the same slot");
 
 		// A different glyph too, so the distinction survives for a reader who
 		// cannot separate the two tones.
 		var startGlyph = await startLine.Locator("svg path").First.GetAttributeAsync("d");
 		var deadlineGlyph = await deadlineLine.Locator("svg path").First.GetAttributeAsync("d");
 		deadlineGlyph.Should().NotBe(startGlyph);
+	}
+
+	/// <summary>
+	/// #2088: every deadline used to render in the same amber warning tone
+	/// regardless of how far away it was, including ones months out - which
+	/// diluted the warning for a deadline that was actually close. A deadline
+	/// outside the imminent window now falls back to the same neutral tone a
+	/// start date uses.
+	/// </summary>
+	[Test]
+	public async Task PublicGrid_ADistantDeadlineCard_UsesTheSameNeutralToneAsAStartDateCard()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var keyword = $"CardDistantDeadline{Guid.NewGuid():N}";
+		using var organizer = await CreateOrganizerClientAsync(keycloak, backend);
+		var organizationId = await CreateOrganizationAsync(organizer, keyword);
+
+		await PublishSlotBasedOpportunityAsync(organizer, organizationId, $"{keyword} with a slot");
+		await PublishInterestBasedOpportunityAsync(
+			organizer, organizationId, $"{keyword} with a distant deadline", TimeSpan.FromDays(90));
+
+		await Page.GotoAsync($"{origin}/opportunities?q={keyword}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var startLine = Page.Locator("[data-testid='opportunity-date-line'][data-date-kind='start']").First;
+		var deadlineLine = Page.Locator("[data-testid='opportunity-date-line'][data-date-kind='deadline']").First;
+
+		await Expect(startLine).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(deadlineLine).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(deadlineLine).ToContainTextAsync("Express interest by");
+
+		var startColor = await startLine.EvaluateAsync<string>("el => getComputedStyle(el).color");
+		var deadlineColor = await deadlineLine.EvaluateAsync<string>("el => getComputedStyle(el).color");
+		deadlineColor.Should().Be(startColor,
+			"a deadline months away should not carry the same urgent tone as one about to close");
 	}
 
 	/// <summary>
@@ -558,7 +600,8 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 	private static async Task<string> PublishInterestBasedOpportunityAsync(
 		HttpClient organizer,
 		string organizationId,
-		string title)
+		string title,
+		TimeSpan? validUntilOffset = null)
 	{
 		var response = await organizer.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
@@ -569,7 +612,7 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 			occurrence = "Recurring",
 			participationType = "IndividualContact",
 			checkInMethod = "None",
-			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			validUntil = DateTimeOffset.UtcNow.Add(validUntilOffset ?? TimeSpan.FromDays(30)),
 		});
 		response.EnsureSuccessStatusCode();
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>();

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityListItem.tsx
@@ -6,6 +6,7 @@ import {
 	formatDate,
 	formatDateTime,
 	formatOccurrence,
+	isDeadlineImminent,
 	pickLocalizedText,
 } from "../../lib/format";
 import Chip, { type ChipTone } from "../Chip";
@@ -80,6 +81,11 @@ export function capacityChip(
  * clock/amber for a deadline running down, arrows/muted for no fixed date)
  * makes the kind legible at a glance without going back to an unlabelled
  * slot. Deliberate reversal of the previous decision, per #1777.
+ *
+ * The deadline's amber only applies within isDeadlineImminent's window - a
+ * deadline months out used the same warning tone as one closing tomorrow,
+ * which drowned out the actually-urgent ones (#2088). Outside that window it
+ * falls back to the same neutral tone as a set start date.
  */
 function dateLine(
 	item: VolunteerOpportunitySummary,
@@ -106,12 +112,13 @@ function dateLine(
 	}
 
 	if (item.validUntil) {
+		const validUntil = item.validUntil as unknown as string;
 		return {
 			kind: "deadline",
 			Icon: ClockIcon,
-			tone: "text-amber-700",
+			tone: isDeadlineImminent(validUntil) ? "text-amber-700" : "text-gray-700",
 			label: t("opportunities.applyBy", {
-				date: formatDate(item.validUntil as unknown as string, language),
+				date: formatDate(validUntil, language),
 			}),
 		};
 	}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -206,3 +206,14 @@ export function isRecentlyCreatedOrganization(createdOn: string): boolean {
 	const days = differenceInCalendarDays(new Date(), new Date(createdOn));
 	return days <= NEW_ORGANIZATION_THRESHOLD_DAYS;
 }
+
+/** Window (in days) within which an application deadline is flagged with the
+ * amber warning tone. Applying that tone to every deadline regardless of
+ * distance - including ones months out - diluted the warning for one that is
+ * actually close (#2088). */
+export const DEADLINE_IMMINENT_THRESHOLD_DAYS = 7;
+
+export function isDeadlineImminent(validUntil: string): boolean {
+	const days = differenceInCalendarDays(new Date(validUntil), new Date());
+	return days <= DEADLINE_IMMINENT_THRESHOLD_DAYS;
+}

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -699,7 +699,7 @@ function UsersSection() {
 										<p className="truncate font-medium text-gray-900">
 											{displayName}
 											{isAdmin && (
-												<Chip tone="warning" size="sm" className="ml-2">
+												<Chip tone="brand" size="sm" className="ml-2">
 													{t("administration.users.adminBadge")}
 												</Chip>
 											)}


### PR DESCRIPTION
Deadline chips rendered amber unconditionally regardless of how far away the deadline was, diluting the warning for one that was actually close. The admin role badge shared that same amber tone with real warning states (e.g. a flagged organization), reading as a status warning rather than a role designation.

Fixes #2088.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
