### PR TITLE
fix: stop apiError strings leaking backend field names and shadow-delete jargon

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1397,49 +1397,49 @@
     },
     "apiError": {
       "AchievementId": {
-        "Empty": "AchievementId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "NotificationId": {
-        "Empty": "NotificationId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "EngagementId": {
-        "Empty": "EngagementId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "VolunteerOpportunityId": {
-        "Empty": "VolunteerOpportunityId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "OrganizationId": {
-        "Empty": "OrganizationId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "OrganizationInvitationId": {
-        "Empty": "OrganizationInvitationId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "OrganizationMembershipId": {
-        "Empty": "OrganizationMembershipId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "OrganizationDashboardLayoutId": {
-        "Empty": "OrganizationDashboardLayoutId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "TimeSlotId": {
-        "Empty": "TimeSlotId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "UserId": {
-        "Empty": "UserId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "UserStreakId": {
-        "Empty": "UserStreakId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "ReportId": {
-        "Empty": "ReportId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "AuditLogId": {
-        "Empty": "AuditLogId darf nicht leer sein."
+        "Empty": "Diese Anfrage war unvollständig. Lade die Seite neu und versuche es erneut."
       },
       "User": {
         "InvalidId": "Ungültige:r Nutzer:in.",
         "NotFound": "Nutzer:in nicht gefunden.",
-        "AlreadyDeleted": "Nutzer:in ist bereits schattengelöscht.",
-        "NotDeleted": "Nutzer:in ist nicht schattengelöscht.",
+        "AlreadyDeleted": "Nutzer:in ist bereits ausgeblendet.",
+        "NotDeleted": "Nutzer:in ist nicht ausgeblendet.",
         "InvalidUnsubscribeToken": "Der Abmelde-Link ist ungültig oder wurde bereits mit einem anderen Token verwendet.",
         "SoleOrganizerOfOrganizations": "Du bist die:der einzige Organisator:in mindestens einer Organisation. Übertrage die Leitung an eine andere Person oder lösche diese Organisationen, bevor du dein Konto löschst."
       },
@@ -1471,8 +1471,8 @@
         "NotMember": "Du hast keine Berechtigung, diese Ressource einzusehen.",
         "WebsiteInvalid": "Die Website muss eine gültige http- oder https-URL sein.",
         "WebsiteTooLong": "Die Website darf 500 Zeichen nicht überschreiten.",
-        "AlreadyDeleted": "Organisation ist bereits schattengelöscht.",
-        "NotDeleted": "Organisation ist nicht schattengelöscht."
+        "AlreadyDeleted": "Organisation ist bereits ausgeblendet.",
+        "NotDeleted": "Organisation ist nicht ausgeblendet."
       },
       "OrganizationInvitation": {
         "NotPending": "Die Einladung ist nicht mehr ausstehend.",
@@ -1518,8 +1518,8 @@
         "CannotCancelDraft": "Ein Entwurf kann nicht abgesagt werden - lösche ihn stattdessen.",
         "CannotPublishCancelled": "Ein abgesagter Einsatz kann nicht erneut veröffentlicht werden.",
         "NotPublished": "Nur ein veröffentlichter Einsatz kann depubliziert werden.",
-        "AlreadyDeleted": "Der Einsatz ist bereits schattengelöscht.",
-        "NotDeleted": "Der Einsatz ist nicht schattengelöscht.",
+        "AlreadyDeleted": "Der Einsatz ist bereits ausgeblendet.",
+        "NotDeleted": "Der Einsatz ist nicht ausgeblendet.",
         "ValidUntilMustBeFuture": "Die Frist muss in der Zukunft liegen.",
         "ValidUntilNotAllowed": "Eine Frist kann nur bei Einsätzen mit Teilnahmeart „Einzelkontakt“ gesetzt werden.",
         "IndividualContactRequiresValidUntil": "Ein Einsatz mit Teilnahmeart „Einzelkontakt“ benötigt eine Frist, bevor er veröffentlicht werden kann.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1397,49 +1397,49 @@
     },
     "apiError": {
       "AchievementId": {
-        "Empty": "AchievementId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "NotificationId": {
-        "Empty": "NotificationId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "EngagementId": {
-        "Empty": "EngagementId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "VolunteerOpportunityId": {
-        "Empty": "VolunteerOpportunityId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "OrganizationId": {
-        "Empty": "OrganizationId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "OrganizationInvitationId": {
-        "Empty": "OrganizationInvitationId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "OrganizationMembershipId": {
-        "Empty": "OrganizationMembershipId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "OrganizationDashboardLayoutId": {
-        "Empty": "OrganizationDashboardLayoutId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "TimeSlotId": {
-        "Empty": "TimeSlotId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "UserId": {
-        "Empty": "UserId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "UserStreakId": {
-        "Empty": "UserStreakId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "ReportId": {
-        "Empty": "ReportId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "AuditLogId": {
-        "Empty": "AuditLogId must not be empty."
+        "Empty": "This request was incomplete. Reload the page and try again."
       },
       "User": {
         "InvalidId": "Invalid user.",
         "NotFound": "User not found.",
-        "AlreadyDeleted": "User is already shadow-deleted.",
-        "NotDeleted": "User is not shadow-deleted.",
+        "AlreadyDeleted": "User is already hidden.",
+        "NotDeleted": "User is not hidden.",
         "InvalidUnsubscribeToken": "The unsubscribe link is invalid or has already been used with a different token.",
         "SoleOrganizerOfOrganizations": "You are the sole organizer of one or more organizations. Transfer ownership to another organizer or delete these organizations before deleting your account."
       },
@@ -1471,8 +1471,8 @@
         "NotMember": "You do not have permission to view this resource.",
         "WebsiteInvalid": "Website must be a valid http or https URL.",
         "WebsiteTooLong": "Website must not exceed 500 characters.",
-        "AlreadyDeleted": "Organization is already shadow-deleted.",
-        "NotDeleted": "Organization is not shadow-deleted."
+        "AlreadyDeleted": "Organization is already hidden.",
+        "NotDeleted": "Organization is not hidden."
       },
       "OrganizationInvitation": {
         "NotPending": "Invitation is not pending.",
@@ -1518,8 +1518,8 @@
         "CannotCancelDraft": "A draft opportunity cannot be cancelled - delete it instead.",
         "CannotPublishCancelled": "A cancelled opportunity cannot be published again.",
         "NotPublished": "Only a published opportunity can be unpublished.",
-        "AlreadyDeleted": "Opportunity is already shadow-deleted.",
-        "NotDeleted": "Opportunity is not shadow-deleted.",
+        "AlreadyDeleted": "Opportunity is already hidden.",
+        "NotDeleted": "Opportunity is not hidden.",
         "ValidUntilMustBeFuture": "Deadline must be in the future.",
         "ValidUntilNotAllowed": "A deadline can only be set for Individual contact opportunities.",
         "IndividualContactRequiresValidUntil": "An Individual contact opportunity must have a deadline before it can be published.",


### PR DESCRIPTION
Collapse the thirteen *Id.Empty validation guards into one shared, actionable message per locale, and replace the "shadow-deleted"/ "schattengeloescht" wording in the User/Organization/VolunteerOpportunity AlreadyDeleted/NotDeleted errors with plain "hidden"/"ausgeblendet", matching the terminology already used for the same action elsewhere in the UI (shadowDelete: "Hide"/"Verbergen").

Fixes #2085

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
