### PR TITLE
fix: distinguish cancel action from cancelled status pill in engagement rows

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -963,7 +963,7 @@
       },
       "cancel": {
         "title": "Anmeldung absagen?",
-        "message": "Möchtest du diese Anmeldung wirklich absagen? Die freiwillige Person wird informiert.",
+        "message": "Möchtest du die Anmeldung von {{name}} für {{opportunity}} wirklich absagen? Die freiwillige Person wird informiert.",
         "confirm": "Ja, absagen",
         "reasonLabel": "Grund (optional)",
         "reasonPlaceholder": "Teile der freiwilligen Person den Grund mit…"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -963,7 +963,7 @@
       },
       "cancel": {
         "title": "Cancel sign-up?",
-        "message": "Are you sure you want to cancel this sign-up? The volunteer will be informed.",
+        "message": "Are you sure you want to cancel {{name}}'s sign-up for {{opportunity}}? They will be informed.",
         "confirm": "Yes, cancel",
         "reasonLabel": "Reason (optional)",
         "reasonPlaceholder": "Let the volunteer know why…"

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -36,7 +36,12 @@ import {
 	selectClass,
 } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
-import { CheckIconSolid, QrCodeIcon, StarIcon } from "../components/icons";
+import {
+	CheckIconSolid,
+	QrCodeIcon,
+	StarIcon,
+	TrashIcon,
+} from "../components/icons";
 import type { OrgAppContext } from "../layouts/OrgAppLayout";
 
 const STATUS_COLORS = ENGAGEMENT_STATUS_COLORS;
@@ -507,6 +512,8 @@ export default function EngagementManagementPage() {
 		setCancelError(null);
 	}
 
+	const cancelTarget = engagements.find((e) => e.id === confirmCancelId);
+
 	if (notFound) {
 		return <NotFoundPage />;
 	}
@@ -851,6 +858,7 @@ export default function EngagementManagementPage() {
 														name: volunteerDisplayName(e),
 													})}
 												>
+													<TrashIcon className="h-3.5 w-3.5" />
 													{t("engagementManagement.cancel")}
 												</Button>
 											</div>
@@ -890,6 +898,7 @@ export default function EngagementManagementPage() {
 														name: volunteerDisplayName(e),
 													})}
 												>
+													<TrashIcon className="h-3.5 w-3.5" />
 													{t("engagementManagement.cancel")}
 												</Button>
 											</div>
@@ -945,7 +954,12 @@ export default function EngagementManagementPage() {
 			{confirmCancelId && (
 				<ConfirmDialog
 					title={t("confirmDialog.cancel.title")}
-					message={t("confirmDialog.cancel.message")}
+					message={t("confirmDialog.cancel.message", {
+						name: cancelTarget
+							? volunteerDisplayName(cancelTarget)
+							: t("engagementManagement.anonymizedVolunteer"),
+						opportunity: opportunityTitle ?? t("engagementManagement.title"),
+					})}
 					confirmLabel={t("confirmDialog.cancel.confirm")}
 					onConfirm={handleCancelConfirm}
 					onClose={handleCancelClose}

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -17,6 +17,7 @@ import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
 import LoadMoreError from "../../components/LoadMoreError";
 import LoadMoreButton from "../../components/LoadMoreButton";
+import { TrashIcon } from "../../components/icons";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
 const ENGAGEMENTS_PAGE_SIZE = 10;
@@ -134,6 +135,8 @@ export default function OrgEngagementsPage() {
 		setCancelReason("");
 		setCancelError(null);
 	}
+
+	const cancelTarget = engagements.find((e) => e.id === confirmCancelId);
 
 	async function handleCancelConfirm() {
 		if (!confirmCancelId) return;
@@ -352,6 +355,7 @@ export default function OrgEngagementsPage() {
 													name: volunteerDisplayName(e),
 												})}
 											>
+												<TrashIcon className="h-3.5 w-3.5" />
 												{t("orgEngagements.cancel")}
 											</Button>
 										</div>
@@ -367,6 +371,7 @@ export default function OrgEngagementsPage() {
 												name: volunteerDisplayName(e),
 											})}
 										>
+											<TrashIcon className="h-3.5 w-3.5" />
 											{t("orgEngagements.cancel")}
 										</Button>
 									)}
@@ -399,7 +404,13 @@ export default function OrgEngagementsPage() {
 			{confirmCancelId && (
 				<ConfirmDialog
 					title={t("confirmDialog.cancel.title")}
-					message={t("confirmDialog.cancel.message")}
+					message={t("confirmDialog.cancel.message", {
+						name: cancelTarget
+							? volunteerDisplayName(cancelTarget)
+							: t("orgEngagements.anonymizedVolunteer"),
+						opportunity:
+							cancelTarget?.opportunityTitle ?? t("orgDashboard.unnamedDraft"),
+					})}
 					confirmLabel={t("confirmDialog.cancel.confirm")}
 					onConfirm={handleCancelConfirm}
 					onClose={handleCancelClose}


### PR DESCRIPTION
The dangerOutline "Cancel"/"Absagen" button next to a Pending/Confirmed engagement rendered as a red-outlined pill visually near-identical to the red "Abgesagt" status chip on other rows, risking accidental cancellation - the action notifies the volunteer and can't be undone from either screen. Add a leading icon to the cancel button so it reads as an action rather than a label, and name the volunteer and opportunity in the confirmation dialog before it executes.

Fixes #2082

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
