### PR TITLE
fix: show explanatory card instead of empty rail for owners on their own opportunity

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -235,6 +235,53 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_OwnerNotice_AsOlaf_HasNoSeriousA11yViolations()
+	{
+		// #2081: an owner viewing their own already-published (non-draft)
+		// opportunity now renders a new "owner notice" card with a link to
+		// the engagement-management view, in place of the sign-up CTA/login
+		// blocks. VolunteerOpportunityDetailPage_OwnerDraft_AsOlaf above only
+		// ever seeds isDraft: true, so it never reaches this !isDraft branch -
+		// same rationale as that test's own comment.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Owner Notice Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = $"A11y Owner Notice Test {suffix}",
+			descriptionDe = "Seeded published opportunity for the owner-notice a11y scan.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		response.EnsureSuccessStatusCode();
+		var opportunity = await response.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.GetByTestId("opportunity-owner-notice")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	[Test]
 	public async Task VolunteerOpportunityDetailPage_MobileActionRail_AsVera_HasNoSeriousA11yViolations()
 	{
 		// #1965: the sign-up CTA (and its deadline/status/login-prompt

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -1017,6 +1017,68 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task DetailPage_OwnerViewingOwnPublishedOpportunity_ShowsNoticeInsteadOfEmptyRail()
+	{
+		// Regression for #2081: an organizer viewing their own org's already-
+		// published opportunity gets none of the sign-up CTA/status/login
+		// blocks (each requires !isOwner), so the entire right-hand rail used
+		// to render as nothing at all - indistinguishable from a rendering
+		// failure, with no way back to the management view. A notice card
+		// must replace it, explaining why and linking to the engagement-
+		// management page for this exact opportunity.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Owner Notice Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var publishedTitle = $"Detail Owner Notice Test {suffix}";
+		var response = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = publishedTitle,
+			descriptionDe = "Seeded published opportunity for the owner-notice regression test.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		response.EnsureSuccessStatusCode();
+		var opportunity = await response.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.Locator("h1").First).ToHaveTextAsync(publishedTitle, new() { Timeout = 15_000 });
+
+		await Expect(Page.GetByTestId("signup-cta")).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByTestId("login-prompt")).Not.ToBeVisibleAsync();
+
+		var notice = Page.GetByTestId("opportunity-owner-notice");
+		await Expect(notice).ToBeVisibleAsync();
+		await Expect(notice).ToContainTextAsync("your organization's opportunity", new() { IgnoreCase = true });
+
+		var manageLink = notice.GetByRole(AriaRole.Link);
+		await Expect(manageLink).ToHaveAttributeAsync(
+			"href",
+			$"/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements");
+
+		await manageLink.ClickAsync();
+		await Expect(Page).ToHaveURLAsync(
+			new Regex($@"/app/{Regex.Escape(organizationId ?? "")}/dashboard/opportunities/{Regex.Escape(opportunityId ?? "")}/engagements$"));
+	}
+
+	[Test]
 	public async Task DetailPage_TagChip_IsClickableLink_FiltersBrowseList()
 	{
 		// Regression for #1021: tag chips used to render as plain,

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -222,6 +222,8 @@
       "cancel": "Absagen",
       "cancelSuccess": "Einsatz abgesagt.",
       "loginPrompt": "Melde dich an, um mitzumachen.",
+      "ownOpportunityNoticeTitle": "Einsatz deiner Organisation",
+      "ownOpportunityNoticeMessage": "Das ist ein Einsatz deiner Organisation. Du kannst dich nicht selbst anmelden.",
       "yourApplication": "Deine Anmeldung",
       "aboutOrganization": "Über diese Organisation",
       "aboutOrganizationLoadError": "Die Kontaktdaten dieser Organisation konnten nicht geladen werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -222,6 +222,8 @@
       "cancel": "Cancel",
       "cancelSuccess": "Opportunity cancelled.",
       "loginPrompt": "Sign in to sign up for this opportunity.",
+      "ownOpportunityNoticeTitle": "Your organization's opportunity",
+      "ownOpportunityNoticeMessage": "This is your organization's opportunity - you can't sign up for it yourself.",
       "yourApplication": "Your sign-up",
       "aboutOrganization": "About this organization",
       "aboutOrganizationLoadError": "Couldn't load this organization's contact details.",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -36,6 +36,7 @@ import LoadMoreError from "../components/LoadMoreError";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import PageHeaderBand from "../components/PageHeaderBand";
 import PublicOpportunityCard from "../components/PublicOpportunityCard";
+import RouteState from "../components/RouteState";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage } from "../lib/apiError";
@@ -372,11 +373,20 @@ export default function VolunteerOpportunityDetailPage() {
 		isAuthenticated && !isOwner && !!cue && !isDraft;
 	const showSignUpCta = isAuthenticated && !isOwner && !cue && !isDraft;
 	const showLoginPrompt = !isAuthenticated && !isDraft;
+	// An owner viewing their own published opportunity gets none of the three
+	// blocks above (each requires !isOwner) - without this, the rail is just
+	// silently empty, indistinguishable from a rendering failure, and offers
+	// no way back to the management view (#2081). Excluded for isDraft: the
+	// action row already shows the draft badge plus Edit/Publish there, and an
+	// unpublished draft has no engagements yet for the linked management page
+	// to show.
+	const showOwnerNotice = isOwner && !isDraft;
 	const hasActionRail =
 		showDeadlineCard ||
 		showApplicationStatus ||
 		showSignUpCta ||
-		showLoginPrompt;
+		showLoginPrompt ||
+		showOwnerNotice;
 
 	// The sticky rail's content, rendered once for the lg+ sidebar and once
 	// more (testIdSuffix "-mobile") right above the map for narrow viewports -
@@ -398,6 +408,20 @@ export default function VolunteerOpportunityDetailPage() {
 	) {
 		return (
 			<>
+				{showOwnerNotice && (
+					<RouteState
+						inline
+						variant="forbidden"
+						title={t("opportunities.ownOpportunityNoticeTitle")}
+						message={t("opportunities.ownOpportunityNoticeMessage")}
+						action={{
+							label: t("engagementManagement.title"),
+							to: `/app/${opp.organizationId}/dashboard/opportunities/${opp.id}/engagements`,
+						}}
+						data-testid={`opportunity-owner-notice${testIdSuffix}`}
+					/>
+				)}
+
 				{showDeadlineCard && (
 					<div
 						className={`flex items-center gap-1.5 text-sm font-medium text-gray-700 ${cardClass}`}


### PR DESCRIPTION
An organizer viewing their own org's already-published opportunity got none of the sign-up CTA/status/login-prompt blocks (each requires !isOwner), so the right-hand action rail rendered as nothing at all - indistinguishable from a rendering failure, with no way back to the management view.

Adds a notice card in that state instead, explaining why and linking to the engagement-management page for that opportunity.

Fixes #2081

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
