### PR TITLE
fix: widen org switcher pill and switch to middle-ellipsis truncation

### DIFF
--- a/backend/tests/VisualTests/OrganizationSwitcherTruncationTests.cs
+++ b/backend/tests/VisualTests/OrganizationSwitcherTruncationTests.cs
@@ -60,9 +60,16 @@ public class OrganizationSwitcherTruncationTests(AspireFixture fixture) : Visual
 		var tail = Page.GetByTestId("org-switcher-current-name-tail");
 		await Expect(nameSpan).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		var fullText = await nameSpan.InnerTextAsync();
-		var headText = await head.InnerTextAsync();
-		var tailText = await tail.InnerTextAsync();
+		// TextContentAsync, not InnerTextAsync: this assertion is about DOM text
+		// integrity (see the comment below), and InnerTextAsync is layout-aware -
+		// on a squeeze narrow enough to actually truncate the head, Chromium can
+		// report a "\n" at the flex-item boundary between the two spans even
+		// though nothing in the DOM or the rendered line itself contains one.
+		// TextContentAsync reads the raw text nodes React put there, unaffected
+		// by that rendering quirk.
+		var fullText = await nameSpan.TextContentAsync() ?? "";
+		var headText = await head.TextContentAsync() ?? "";
+		var tailText = await tail.TextContentAsync() ?? "";
 		(headText + tailText).Should().Be(fullText,
 			"the head/tail split must reconstruct the exact org name - only the rendering "
 			+ "may be clipped, the DOM text must never become a fixed-length approximation");

--- a/backend/tests/VisualTests/OrganizationSwitcherTruncationTests.cs
+++ b/backend/tests/VisualTests/OrganizationSwitcherTruncationTests.cs
@@ -1,0 +1,124 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// #2080: the org switcher pill truncated a long organization name from the
+/// end at a fixed ~200px width. Olaf organizes "Lindenauer
+/// Nachbarschaftshilfe e.V." and "Lindenauer Tierschutzverein e.V." - names
+/// sharing both a leading word and a trailing "e.V." - so the old
+/// end-truncation could cut both down to the same visible "Lindenauer...",
+/// with nothing telling them apart even though everything an organizer does
+/// is attributed to whichever org this pill names.
+///
+/// Fixed in OrganizationSwitcher.tsx by widening the pill to ~340px
+/// (`max-w-85`) and replacing the single CSS `truncate` span with a
+/// head/tail split (`splitForMiddleTruncation` in middleTruncateSplit.ts):
+/// the head can grow the browser's own end-ellipsis when squeezed, the tail
+/// never does. That keeps the org name's DOM text exactly the real name at
+/// all times (a screen reader or a `.textContent()` read still gets the
+/// whole thing) while only the *rendered* width adapts - and puts the word
+/// that actually differs, right after the shared "Lindenauer " prefix, in
+/// the half of the string that survives however much of the head an actual
+/// render can show.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrganizationSwitcherTruncationTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Switcher_NamePillIsWidenedTo340px()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var nameSpan = Page.GetByTestId("org-switcher-current-name");
+		await Expect(nameSpan).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var maxWidth = await nameSpan.EvaluateAsync<string>("el => getComputedStyle(el).maxWidth");
+		maxWidth.Should().Be("340px",
+			"the pill was widened from its old 200px ceiling so a realistic org name has "
+			+ "room to show before anything needs to truncate at all");
+	}
+
+	[Test]
+	public async Task Switcher_HeadAndTailReconstructTheExactOrgName()
+	{
+		// Narrowed to mobile width, where the name span has the least room -
+		// the case most likely to force the head span into actually
+		// truncating (see AuthHelper/OrgAppMobileResponsiveTests for why this
+		// viewport is the tight one).
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+		await Page.SetViewportSizeAsync(375, 812);
+
+		var nameSpan = Page.GetByTestId("org-switcher-current-name");
+		var head = Page.GetByTestId("org-switcher-current-name-head");
+		var tail = Page.GetByTestId("org-switcher-current-name-tail");
+		await Expect(nameSpan).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var fullText = await nameSpan.InnerTextAsync();
+		var headText = await head.InnerTextAsync();
+		var tailText = await tail.InnerTextAsync();
+		(headText + tailText).Should().Be(fullText,
+			"the head/tail split must reconstruct the exact org name - only the rendering "
+			+ "may be clipped, the DOM text must never become a fixed-length approximation");
+
+		// Only the head is allowed to grow the browser's own ellipsis - if the
+		// tail carried it too, this would just be the old end-truncation
+		// moved one span over rather than an actual middle-ellipsis.
+		var tailTextOverflow = await tail.EvaluateAsync<string>("el => getComputedStyle(el).textOverflow");
+		tailTextOverflow.Should().NotBe("ellipsis");
+	}
+
+	[Test]
+	public async Task Switcher_DivergingWordSurvivesInTheHeadForOrgsSharingAPrefix()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+		await Page.SetViewportSizeAsync(375, 812);
+
+		var head = Page.GetByTestId("org-switcher-current-name-head");
+		await Expect(head).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var nameSpan = Page.GetByTestId("org-switcher-current-name");
+		var startingName = await nameSpan.InnerTextAsync();
+		if (startingName != "Lindenauer Nachbarschaftshilfe e.V."
+			&& startingName != "Lindenauer Tierschutzverein e.V.")
+		{
+			Skip.Test("seed data changed - nothing to compare against");
+		}
+		var headForStartingOrg = await head.InnerTextAsync();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Switch organization" }).ClickAsync();
+		var otherOrgName = startingName == "Lindenauer Nachbarschaftshilfe e.V."
+			? "Lindenauer Tierschutzverein e.V."
+			: "Lindenauer Nachbarschaftshilfe e.V.";
+		var otherOrgRow = Page.GetByTestId("org-switch-row").Filter(new() { HasText = otherOrgName });
+
+		// #1708: the switcher panel's rows can render a beat after the click
+		// that opens it - wait for the row itself rather than racing its mount.
+		try
+		{
+			await otherOrgRow.WaitForAsync(new() { Timeout = 10_000 });
+		}
+		catch (TimeoutException)
+		{
+			Skip.Test("seed data changed - nothing to compare against");
+		}
+		await otherOrgRow.ClickAsync();
+		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
+
+		await Expect(nameSpan).ToHaveTextAsync(otherOrgName, new() { Timeout = 15_000 });
+		var headForOtherOrg = await head.InnerTextAsync();
+
+		headForOtherOrg.Should().NotBe(headForStartingOrg,
+			"the two org names share both a leading word and a trailing \"e.V.\" - if the "
+			+ "head rendered identically for both, the fix regressed back to showing only "
+			+ "the shared prefix (#2080)");
+	}
+}

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -6,6 +6,7 @@ import type {
 	OrganizationSummaryDto,
 } from "../../client/api-client";
 import { orgTabPath } from "../../lib/orgTabs";
+import { splitForMiddleTruncation } from "../../lib/middleTruncateSplit";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
 import OrgAvatar from "./OrgAvatar";
 import ModalLoadingFallback from "../ModalLoadingFallback";
@@ -49,6 +50,9 @@ export default function OrganizationSwitcher({
 	);
 
 	const currentOrg = orgs.find((o) => o.id === currentOrgId) ?? null;
+	const [currentOrgNameHead, currentOrgNameTail] = currentOrg
+		? splitForMiddleTruncation(currentOrg.name)
+		: ["", ""];
 
 	function orgPath(org: OrganizationSummaryDto) {
 		return orgTabPath(org.id, currentTab);
@@ -90,17 +94,40 @@ export default function OrganizationSwitcher({
 							logoUrl={currentOrg?.logoUrl}
 						/>
 					)}
-					{/* title so a truncated name is still readable on hover - two
-					seeded orgs share a leading word, so the visible text can be
-					identical for both once cut. */}
+					{/* Middle-ellipsis, not end-truncation: two names sharing a
+					leading word (e.g. two seeded orgs both starting "Lindenauer")
+					used to become indistinguishable once cut. Split into a
+					`truncate` head (grows the browser's own end-ellipsis when
+					squeezed) and a `shrink-0` tail (never truncated) rather than
+					doing this in JS, so the DOM text stays the exact, full org
+					name - only the *rendered* width adapts - and a title
+					attribute still covers hover regardless of how much is
+					visible (#2080). */}
 					<span
 						data-testid="org-switcher-current-name"
 						title={error ? undefined : currentOrg?.name}
-						className="max-w-50 flex-1 truncate sm:min-w-24"
+						className="flex max-w-85 min-w-0 flex-1 overflow-hidden sm:min-w-24"
 					>
-						{error
-							? t("organization.loadError")
-							: (currentOrg?.name ?? t("organization.selectPlaceholder"))}
+						{error ? (
+							t("organization.loadError")
+						) : currentOrg ? (
+							<>
+								<span
+									data-testid="org-switcher-current-name-head"
+									className="min-w-0 truncate"
+								>
+									{currentOrgNameHead}
+								</span>
+								<span
+									data-testid="org-switcher-current-name-tail"
+									className="shrink-0 whitespace-nowrap"
+								>
+									{currentOrgNameTail}
+								</span>
+							</>
+						) : (
+							t("organization.selectPlaceholder")
+						)}
 					</span>
 					<ChevronDownIcon
 						open={open}

--- a/frontend/src/lib/middleTruncateSplit.test.ts
+++ b/frontend/src/lib/middleTruncateSplit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { splitForMiddleTruncation } from "./middleTruncateSplit";
+
+describe("splitForMiddleTruncation", () => {
+	it("always concatenates back to the original text", () => {
+		for (const text of [
+			"",
+			"A",
+			"Lindenauer Nachbarschaftshilfe e.V.",
+			"Lindenauer Tierschutzverein e.V.",
+		]) {
+			const [head, tail] = splitForMiddleTruncation(text);
+			expect(head + tail).toBe(text);
+		}
+	});
+
+	it("splits evenly, rounding the head up on an odd length", () => {
+		expect(splitForMiddleTruncation("ABCDE")).toEqual(["ABC", "DE"]);
+		expect(splitForMiddleTruncation("ABCD")).toEqual(["AB", "CD"]);
+	});
+
+	it("keeps the diverging word out of the shared head for two similar org names", () => {
+		const [headA] = splitForMiddleTruncation(
+			"Lindenauer Nachbarschaftshilfe e.V.",
+		);
+		const [headB] = splitForMiddleTruncation(
+			"Lindenauer Tierschutzverein e.V.",
+		);
+		expect(headA).not.toBe(headB);
+	});
+});

--- a/frontend/src/lib/middleTruncateSplit.ts
+++ b/frontend/src/lib/middleTruncateSplit.ts
@@ -1,0 +1,18 @@
+/** Splits a string into a head/tail pair for CSS-driven middle-ellipsis
+ * truncation (see OrganizationSwitcher.tsx): the head is rendered in a
+ * `truncate` span that shrinks and grows the browser's own end-ellipsis, the
+ * tail in a `shrink-0` span that never does. Deliberately not a JS
+ * character-count truncation (like `truncateFileName` in imageUpload.ts) -
+ * that would replace the DOM text with a fixed-length approximation, but
+ * this switcher's name has to stay the full, real org name in the DOM (a
+ * screen reader or a Playwright `.textContent()` reads the concatenation of
+ * both spans, which must equal the original string exactly) while only its
+ * *rendered* width adapts to whatever room the header actually has. An even
+ * split keeps a shared prefix (e.g. two orgs both starting "Lindenauer ")
+ * from swallowing the entire visible head, and lets a shared suffix (e.g.
+ * "e.V.") stay visible in the tail without crowding out the differentiator
+ * in between (#2080). */
+export function splitForMiddleTruncation(text: string): [string, string] {
+	const headLength = Math.ceil(text.length / 2);
+	return [text.slice(0, headLength), text.slice(headLength)];
+}


### PR DESCRIPTION
Two orgs sharing a leading word (e.g. two seeded "Lindenauer..." orgs) could end-truncate to the same visible text, with nothing telling an organizer which one they're acting in. Widen the pill from 200px to ~340px and split the name into a shrinking head plus a fixed tail so the differentiator that sits right after a shared prefix stays visible, while the DOM text stays the exact org name throughout (#2080).

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2080

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
