### PR TITLE
fix: require a title before saving an opportunity as a draft

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -630,6 +630,44 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
+	public async Task SaveDraft_DisabledUntilTitled_EnablesOnceTitleFilled()
+	{
+		// Regression for #2076: submitting a completely empty form via "Save
+		// as draft" used to succeed silently and produce an unnamed,
+		// indistinguishable record. The button must stay disabled until the
+		// (German) title is filled in, mirroring the same field "Publish"
+		// already requires.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+
+		await Page.WaitForSelectorAsync("[role='dialog']", new() { Timeout = 5000 });
+
+		var saveDraftBtn = Page.GetByTestId("modal-save-draft");
+		await Expect(saveDraftBtn).ToBeVisibleAsync();
+		await Expect(saveDraftBtn).ToBeDisabledAsync();
+
+		// Whitespace-only must not count as a title either.
+		await Page.Locator("#opportunity-title").FillAsync("   ");
+		await Expect(saveDraftBtn).ToBeDisabledAsync();
+
+		var uniqueTitle = $"Draft Gate Visual Test {Guid.NewGuid().ToString("N")[..8]}";
+		await Page.Locator("#opportunity-title").FillAsync(uniqueTitle);
+		await Expect(saveDraftBtn).ToBeEnabledAsync();
+
+		await saveDraftBtn.ClickAsync();
+		await Expect(Page).ToHaveURLAsync(new Regex(@"/opportunities"), new() { Timeout = 30_000 });
+
+		var draftsSection = Page.GetByTestId("drafts-section");
+		await Expect(draftsSection).ToBeVisibleAsync();
+		await Expect(draftsSection.GetByText(uniqueTitle)).ToBeVisibleAsync();
+	}
+
+	[Test]
 	public async Task OpportunitiesHub_ShowsDraftAndPublished_AndPublishesDraftInline()
 	{
 		// The org "Engagements" tab is now the unified "Opportunities" hub: it

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -305,7 +305,12 @@ export default function CreateVolunteerOpportunityModal({
 	const occurrence = watch("occurrence");
 	const participationType = watch("participationType");
 	const isRemote = watch("isRemote");
+	const titleDe = watch("titleDe");
 	const isScheduledSlots = participationType === "ScheduledSlots";
+	// A title-less draft renders as an unnamed, indistinguishable row wherever
+	// drafts are listed (see "unnamedDraft" fallback) - block the save instead
+	// of letting an empty form through silently (#2076).
+	const draftTitleMissing = !titleDe.trim();
 
 	useEffect(() => {
 		if (isEditMode) return;
@@ -1159,56 +1164,79 @@ export default function CreateVolunteerOpportunityModal({
 					)}
 				</div>
 
-				<div className="flex items-center justify-between gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4">
-					<Button
-						type="button"
-						variant="secondary"
-						data-testid="modal-cancel"
-						onClick={() => (step > 1 ? setStep((s) => s - 1) : requestClose())}
-					>
-						{step === 1
-							? t("createOpportunity.cancel")
-							: t("createOpportunity.back")}
-					</Button>
+				<div className="border-t border-gray-100 bg-gray-50">
+					{/* Visible, not sr-only: native `disabled` drops "Save as draft"
+					from the tab order, so a keyboard-only user can never focus it to
+					hear its aria-describedby, and never hovers it to see its `title`
+					tooltip either (same gap OrgMembersPage's leave-organization hint
+					documents, #1926) - the on-page text is the only channel that
+					reaches them. */}
+					{canSaveDraft && draftTitleMissing && (
+						<p id="save-draft-hint" className="px-6 pt-3 text-xs text-gray-500">
+							{t("createOpportunity.saveDraftRequiresTitle")}
+						</p>
+					)}
+					<div className="flex items-center justify-between gap-3 px-6 py-4">
+						<Button
+							type="button"
+							variant="secondary"
+							data-testid="modal-cancel"
+							onClick={() =>
+								step > 1 ? setStep((s) => s - 1) : requestClose()
+							}
+						>
+							{step === 1
+								? t("createOpportunity.cancel")
+								: t("createOpportunity.back")}
+						</Button>
 
-					<div className="flex items-center gap-2">
-						{canSaveDraft && (
-							<Button
-								type="button"
-								variant="tertiary"
-								data-testid="modal-save-draft"
-								disabled={submitting !== null}
-								onClick={() => void submit(true)}
-							>
-								{submitting === "draft"
-									? t("createOpportunity.savingDraft")
-									: t("createOpportunity.saveDraft")}
-							</Button>
-						)}
-						{step < TOTAL_STEPS ? (
-							<Button
-								type="button"
-								data-testid="modal-next"
-								onClick={() => void handleNext()}
-							>
-								{t("createOpportunity.next")}
-							</Button>
-						) : (
-							<Button
-								type="button"
-								disabled={submitting !== null}
-								data-testid="modal-submit"
-								onClick={() => void submit(false)}
-							>
-								{submitting === "publish"
-									? isEditMode
-										? t("createOpportunity.saving")
-										: t("createOpportunity.creating")
-									: isEditMode
-										? t("createOpportunity.save")
-										: t("createOpportunity.publish")}
-							</Button>
-						)}
+						<div className="flex items-center gap-2">
+							{canSaveDraft && (
+								<Button
+									type="button"
+									variant="outline"
+									data-testid="modal-save-draft"
+									disabled={submitting !== null || draftTitleMissing}
+									aria-describedby={
+										draftTitleMissing ? "save-draft-hint" : undefined
+									}
+									title={
+										draftTitleMissing
+											? t("createOpportunity.saveDraftRequiresTitle")
+											: undefined
+									}
+									onClick={() => void submit(true)}
+								>
+									{submitting === "draft"
+										? t("createOpportunity.savingDraft")
+										: t("createOpportunity.saveDraft")}
+								</Button>
+							)}
+							{step < TOTAL_STEPS ? (
+								<Button
+									type="button"
+									data-testid="modal-next"
+									onClick={() => void handleNext()}
+								>
+									{t("createOpportunity.next")}
+								</Button>
+							) : (
+								<Button
+									type="button"
+									disabled={submitting !== null}
+									data-testid="modal-submit"
+									onClick={() => void submit(false)}
+								>
+									{submitting === "publish"
+										? isEditMode
+											? t("createOpportunity.saving")
+											: t("createOpportunity.creating")
+										: isEditMode
+											? t("createOpportunity.save")
+											: t("createOpportunity.publish")}
+								</Button>
+							)}
+						</div>
 					</div>
 				</div>
 			</Modal>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -297,6 +297,7 @@
       "publish": "Veröffentlichen",
       "saveDraft": "Als Entwurf speichern",
       "savingDraft": "Wird gespeichert…",
+      "saveDraftRequiresTitle": "Gib im Schritt \"Grunddaten\" einen Titel ein, bevor du als Entwurf speicherst.",
       "draftSavedToast": "Entwurf gespeichert. Du findest ihn im Tab \"Einsätze\".",
       "fieldBanner": "Bannerbild (optional)",
       "bannerUpload": "Bild hochladen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -297,6 +297,7 @@
       "publish": "Publish",
       "saveDraft": "Save as draft",
       "savingDraft": "Saving…",
+      "saveDraftRequiresTitle": "Add a title on the Basics step before saving as a draft.",
       "draftSavedToast": "Draft saved. Find it under the Opportunities tab.",
       "fieldBanner": "Banner image (optional)",
       "bannerUpload": "Upload image",


### PR DESCRIPTION
An empty create-opportunity form could be saved as a draft with one click, producing an unnamed, indistinguishable record - and the action looked like plain text next to Cancel, with no visual weight of its own. Disable "Save as draft" until the German title is filled in (same field Publish already requires) and give it an outlined style distinct from Cancel and Publish/Next.

Fixes #2076.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
