### PR TITLE
fix: interpolate opportunity title in OpportunityDeleted notification

### DIFF
--- a/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementCancellationHelper.cs
@@ -63,7 +63,8 @@ internal static class EngagementCancellationHelper
 		var notification = Notification.Create(
 			engagement.VolunteerId!.Value,
 			NotificationKind.EngagementCancelled,
-			engagement.Id.Value);
+			engagement.Id.Value,
+			opportunityTitle);
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		return true;

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -17,6 +17,9 @@ internal static class OpportunityNotificationHelper
 	/// has an active (pending or confirmed) engagement on the opportunity, or -
 	/// when <paramref name="timeSlotId"/> is given - only those engaged on that
 	/// specific time slot. The opportunity id is used as the related entity id.
+	/// <paramref name="opportunityTitle"/>, when given, is snapshotted onto each
+	/// created notification so its title can still be shown once the opportunity
+	/// itself is deleted and a live lookup would find nothing (einsatzbereit#2073).
 	/// When <paramref name="keycloakUserService"/>, <paramref name="emailService"/>,
 	/// <paramref name="emailTemplateRenderer"/> and <paramref name="opportunityTitle"/>
 	/// are all supplied, also emails every notified volunteer in a single batch
@@ -45,7 +48,8 @@ internal static class OpportunityNotificationHelper
 			var notification = Notification.Create(
 				UserId.Create(volunteerId).GetValueOrThrow(),
 				kind,
-				opportunityId.Value);
+				opportunityId.Value,
+				opportunityTitle);
 
 			await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		}

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityEngagementCascadeHelper.cs
@@ -43,7 +43,8 @@ internal static class VolunteerOpportunityEngagementCascadeHelper
 			engagementReadRepository,
 			opportunityId,
 			opportunityNotificationKind,
-			cancellationToken);
+			cancellationToken,
+			opportunityTitle: opportunityTitle);
 
 		// GetActiveEngagementsForOpportunityAsync already excludes anonymized
 		// engagements (einsatzbereit#1724), so CancelAsync's own guard below

--- a/backend/src/Domain/Notifications/Notification.cs
+++ b/backend/src/Domain/Notifications/Notification.cs
@@ -13,6 +13,16 @@ public sealed class Notification
 
 	public Guid RelatedEntityId { get; private set; }
 
+	// Captured at creation time so the notification text can still interpolate
+	// a title once the related opportunity is gone (hard-deleted, or
+	// shadow-deleted and filtered out by VolunteerOpportunityConfiguration's
+	// query filter) by the time this notification is read - a live join
+	// against the opportunity table alone finds nothing for either case
+	// (einsatzbereit#2073). Null for notification kinds that never pass a
+	// title through (e.g. invitation/feedback notifications resolve their
+	// display text from a live join elsewhere and never go stale the same way).
+	public string? TitleSnapshot { get; private set; }
+
 	public bool IsRead { get; private set; }
 
 	// Retention (NotificationRetentionJob) prunes read notifications relative to
@@ -33,24 +43,28 @@ public sealed class Notification
 		NotificationId id,
 		UserId recipientId,
 		NotificationKind kind,
-		Guid relatedEntityId)
+		Guid relatedEntityId,
+		string? titleSnapshot)
 		: base(id)
 	{
 		RecipientId = recipientId;
 		Kind = kind;
 		RelatedEntityId = relatedEntityId;
+		TitleSnapshot = titleSnapshot;
 		IsRead = false;
 	}
 
 	public static Notification Create(
 		UserId recipientId,
 		NotificationKind kind,
-		Guid relatedEntityId) =>
+		Guid relatedEntityId,
+		string? titleSnapshot = null) =>
 		new(
 			NotificationId.New(),
 			recipientId,
 			kind,
-			relatedEntityId);
+			relatedEntityId,
+			titleSnapshot);
 
 	public void MarkRead(DateTimeOffset readOn)
 	{

--- a/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Domain.Notifications;
 using Domain.Users;
+using Domain.VolunteerOpportunities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -38,6 +39,9 @@ internal sealed class NotificationConfiguration
 
 		builder.Property(n => n.RelatedEntityId)
 			.IsRequired();
+
+		builder.Property(n => n.TitleSnapshot)
+			.HasMaxLength(VolunteerOpportunity.MaxTitleLength);
 
 		builder.Property(n => n.IsRead)
 			.IsRequired();

--- a/backend/src/Infrastructure/Persistence/Migrations/20260818173514_AddNotificationTitleSnapshot.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260818173514_AddNotificationTitleSnapshot.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Persistence.Migrations
 {
 	[DbContext(typeof(ApplicationDbContext))]
-	partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+	[Migration("20260818173514_AddNotificationTitleSnapshot")]
+	partial class AddNotificationTitleSnapshot
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260818173514_AddNotificationTitleSnapshot.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260818173514_AddNotificationTitleSnapshot.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations
+{
+	/// <inheritdoc />
+	public partial class AddNotificationTitleSnapshot : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<string>(
+				name: "title_snapshot",
+				table: "notification",
+				type: "character varying(200)",
+				maxLength: 200,
+				nullable: true);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "title_snapshot",
+				table: "notification");
+		}
+	}
+}

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -185,6 +185,7 @@ internal sealed class NotificationReadRepository(
 				engagementToOpportunity.TryGetValue(n.RelatedEntityId, out var opportunityId))
 			{
 				opportunityTitles.TryGetValue(opportunityId, out relatedTitle);
+				relatedTitle ??= n.TitleSnapshot;
 
 				actionUrl = n.Kind is NotificationKind.EngagementCreated or NotificationKind.EngagementWithdrawn or NotificationKind.FeedbackSubmitted
 					? (opportunityOrganizations.TryGetValue(opportunityId, out var organizationId)
@@ -206,6 +207,7 @@ internal sealed class NotificationReadRepository(
 			else if (!EngagementKinds.Contains(n.Kind))
 			{
 				opportunityTitles.TryGetValue(n.RelatedEntityId, out relatedTitle);
+				relatedTitle ??= n.TitleSnapshot;
 
 				actionUrl = n.Kind == NotificationKind.OpportunityUpdated
 					? $"/volunteer-opportunities/{n.RelatedEntityId}"

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -134,11 +134,15 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		// Act
 		await _sut.Handle(new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
 
-		// Assert
+		// Assert - TitleSnapshot is captured here too (einsatzbereit#2073): a
+		// shadow-deleted opportunity is filtered out of every query by
+		// VolunteerOpportunityConfiguration's IsDeleted filter, so a later live
+		// lookup by relatedEntityId would find nothing to interpolate {{title}} with.
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n!.RecipientId == engagement.VolunteerId!.Value
 				&& n.Kind == NotificationKind.EngagementCancelled
-				&& n.RelatedEntityId == engagement.Id.Value),
+				&& n.RelatedEntityId == engagement.Id.Value
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 		engagement.Status.Should().Be(EngagementStatus.Cancelled);
 		engagement.Events.Should().ContainSingle(e => e is EngagementCancelledDomainEvent)

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/CancelVolunteerOpportunity/VolunteerOpportunityCancelledDomainEventHandlerTests.cs
@@ -66,9 +66,12 @@ public class VolunteerOpportunityCancelledDomainEventHandlerTests
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
+		// Assert - TitleSnapshot is captured here too (einsatzbereit#2073), so an
+		// opportunity later hard/shadow-deleted still shows a title on this notification.
 		await _notifRepo.Received(1).AddAsync(
-			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityCancelled && n.RelatedEntityId == opportunity.Id.Value),
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityCancelled
+				&& n.RelatedEntityId == opportunity.Id.Value
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -115,8 +115,13 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
 
 		// Assert - one OpportunityDeleted notification per active volunteer, none for cancelled.
+		// TitleSnapshot must be captured here since the opportunity row is hard-deleted
+		// right after, so a later live lookup by relatedEntityId would find nothing to
+		// interpolate {{title}} with (einsatzbereit#2073).
 		await _notifRepo.Received(2).AddAsync(
-			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityDeleted && n.RelatedEntityId == opportunityId),
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityDeleted
+				&& n.RelatedEntityId == opportunityId
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 	}
 
@@ -185,12 +190,14 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n!.RecipientId == pendingEngagement.VolunteerId!.Value
 				&& n.Kind == NotificationKind.EngagementCancelled
-				&& n.RelatedEntityId == pendingEngagement.Id.Value),
+				&& n.RelatedEntityId == pendingEngagement.Id.Value
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n!.RecipientId == confirmedEngagement.VolunteerId!.Value
 				&& n.Kind == NotificationKind.EngagementCancelled
-				&& n.RelatedEntityId == confirmedEngagement.Id.Value),
+				&& n.RelatedEntityId == confirmedEngagement.Id.Value
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 		pendingEngagement.Events.Should().ContainSingle(e => e is EngagementCancelledDomainEvent)
 			.Which.Should().BeOfType<EngagementCancelledDomainEvent>()

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UnpublishVolunteerOpportunity/VolunteerOpportunityUnpublishedDomainEventHandlerTests.cs
@@ -66,9 +66,12 @@ public class VolunteerOpportunityUnpublishedDomainEventHandlerTests
 		// Act
 		await _sut.Handle(domainEvent, cancellationToken);
 
-		// Assert
+		// Assert - TitleSnapshot is captured here too (einsatzbereit#2073), so an
+		// opportunity later hard/shadow-deleted still shows a title on this notification.
 		await _notifRepo.Received(1).AddAsync(
-			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUnpublished && n.RelatedEntityId == opportunity.Id.Value),
+			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUnpublished
+				&& n.RelatedEntityId == opportunity.Id.Value
+				&& n.TitleSnapshot == "Titel"),
 			cancellationToken);
 	}
 

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -12,6 +12,11 @@ namespace VisualTests;
 /// relatedTitle stays null forever, and its actionUrl 404s. Covers both the
 /// frontend fallback title text and EngagementManagementPage rendering the
 /// existing NotFoundPage instead of a raw error string on that 404.
+///
+/// Also covers #2073: the volunteer-facing OpportunityDeleted notification
+/// must keep its title after the same deletion, unlike the organizer-facing
+/// EngagementCreated notification above - see
+/// Notification_KeepsRelatedTitle_ForOpportunityDeletedKind_AfterOpportunityDeleted.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -22,7 +27,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		var backend = Fixture.GetEndpoint("backend");
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
-		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedTitle");
+		var (opportunityId, _, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedTitle");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
@@ -44,6 +49,37 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 	}
 
 	[Test]
+	public async Task Notification_KeepsRelatedTitle_ForOpportunityDeletedKind_AfterOpportunityDeleted()
+	{
+		// Regression for #2073: unlike EngagementCreated above, the volunteer's
+		// own OpportunityDeleted notification is the only way they learn which
+		// sign-up was affected, so it must not go the same route and lose its
+		// title once the opportunity row is gone. Notification.TitleSnapshot is
+		// captured when this notification is created - before the delete
+		// removes the opportunity row - and NotificationReadRepository falls
+		// back to it once the live title join finds nothing.
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+
+		var (opportunityId, _, title) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedKeepsTitle");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
+
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+
+		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
+		deleteResponse.EnsureSuccessStatusCode();
+
+		var notification = await GetNotificationByKindAsync(veraHttp, "OpportunityDeleted");
+
+		notification.GetProperty("relatedTitle").GetString().Should().Be(title,
+			"the title was snapshotted onto the notification when it was created, before the opportunity row disappeared");
+	}
+
+	[Test]
 	public async Task EngagementManagementPage_RendersNotFoundPage_ForDeletedOpportunity()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
@@ -51,7 +87,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		var keycloak = Fixture.GetEndpoint("keycloak");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
-		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedUi");
+		var (opportunityId, organizationId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedUi");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
@@ -77,7 +113,10 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<JsonElement> GetEngagementCreatedNotificationAsync(HttpClient http)
+	private static async Task<JsonElement> GetEngagementCreatedNotificationAsync(HttpClient http) =>
+		await GetNotificationByKindAsync(http, "EngagementCreated");
+
+	private static async Task<JsonElement> GetNotificationByKindAsync(HttpClient http, string kind)
 	{
 		var response = await http.GetAsync("/v1/notifications");
 		response.EnsureSuccessStatusCode();
@@ -85,7 +124,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		// GetMyNotifications returns a NotificationsPage ({ items, hasMore }),
 		// not a bare array, since einsatzbereit#1384 added cursor pagination.
 		return page.GetProperty("items").EnumerateArray()
-			.First(n => n.GetProperty("kind").GetString() == "EngagementCreated");
+			.First(n => n.GetProperty("kind").GetString() == kind);
 	}
 
 	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
@@ -106,9 +145,10 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		return body.GetProperty("access_token").GetString()!;
 	}
 
-	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
+	private static async Task<(string OpportunityId, string OrganizationId, string Title)> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
+		var title = $"NotifDeletedOpp {label} {suffix}";
 
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
@@ -130,7 +170,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 
 		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
 		{
-			titleDe = $"NotifDeletedOpp {label} {suffix}",
+			titleDe = title,
 			descriptionDe = "Created by NotificationForDeletedOpportunityTests",
 			organizationId,
 			isRemote = true,
@@ -142,6 +182,6 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		});
 		oppResponse.EnsureSuccessStatusCode();
 		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
-		return (opportunity.GetProperty("id").GetString()!, organizationId);
+		return (opportunity.GetProperty("id").GetString()!, organizationId, title);
 	}
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -893,7 +893,7 @@
         "EngagementCancelled": "Deine Anmeldung für {{title}} wurde abgesagt",
         "EngagementWithdrawn": "Eine Anmeldung für {{title}} wurde zurückgezogen",
         "OpportunityUpdated": "{{title}} wurde aktualisiert",
-        "OpportunityDeleted": "Ein Einsatz, für den du dich angemeldet hast, wurde entfernt",
+        "OpportunityDeleted": "{{title}} wurde entfernt",
         "OpportunityUnpublished": "{{title}} wurde zurückgezogen und deine Anmeldung wurde abgesagt",
         "OpportunityCancelled": "Der Einsatz {{title}} wurde abgesagt - deine Anmeldung ist damit hinfällig",
         "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -893,7 +893,7 @@
         "EngagementCancelled": "Your sign-up for {{title}} was cancelled",
         "EngagementWithdrawn": "A sign-up for {{title}} was withdrawn",
         "OpportunityUpdated": "{{title}} was updated",
-        "OpportunityDeleted": "An opportunity you signed up for was removed",
+        "OpportunityDeleted": "{{title}} was removed",
         "OpportunityUnpublished": "{{title}} was taken down and your sign-up was cancelled",
         "OpportunityCancelled": "The opportunity {{title}} was cancelled - your sign-up no longer stands",
         "InvitationReceived": "You've been invited to join {{title}}",


### PR DESCRIPTION
Snapshot the opportunity title onto a notification at creation time (Notification.TitleSnapshot) so it survives the opportunity being hard-deleted or shadow-deleted, since a live title lookup finds nothing in either case. Falls back to it in NotificationReadRepository only when the live join is empty, so unaffected notification kinds keep showing the current title.

Closes #2073.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
