### PR TITLE
fix: focus the first invalid field when the create-opportunity wizard blocks navigation

### DIFF
--- a/backend/tests/VisualTests/WizardFocusFirstInvalidFieldTests.cs
+++ b/backend/tests/VisualTests/WizardFocusFirstInvalidFieldTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #2077: the create-opportunity wizard marks required fields
+/// with an asterisk and wires up aria-required (see RequiredFieldMarkerTests,
+/// #1797), but never called react-hook-form's own <c>handleSubmit()</c> -
+/// "Next", a blocked stepper jump and the final submit all call
+/// <c>trigger()</c> directly instead (see WizardLiveRevalidationTests, #1928),
+/// so <c>shouldFocusError</c>'s automatic focus-the-first-invalid-field never
+/// ran. A blocked step advance left every screen-reader and keyboard user to
+/// hunt for whichever field had turned red, with no signal of where focus
+/// should go. Focus must now move to the first field that is actually
+/// invalid, not always the first field in the step.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class WizardFocusFirstInvalidFieldTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task Next_WithBothRequiredFieldsBlank_FocusesTheTitleField()
+	{
+		await OpenCreateWizardAsync();
+
+		// Title and description both empty - title comes first in the step's
+		// field order, so it is the one that should receive focus.
+		await Page.GetByTestId("modal-next").ClickAsync();
+
+		await Expect(Page.Locator("#opportunity-title-error")).ToHaveTextAsync("Please fill this in.");
+		await Expect(Page.Locator("#opportunity-title")).ToBeFocusedAsync();
+	}
+
+	[Test]
+	public async Task Next_WithOnlyDescriptionBlank_FocusesTheDescriptionFieldNotTheTitle()
+	{
+		await OpenCreateWizardAsync();
+
+		// Title is already valid - the first *invalid* field is the
+		// description, not simply the first field in the step.
+		await Page.Locator("#opportunity-title").FillAsync("Focus regression test");
+		await Page.GetByTestId("modal-next").ClickAsync();
+
+		await Expect(Page.Locator("#opportunity-description-error")).ToHaveTextAsync("Please fill this in.");
+		await Expect(Page.Locator("#opportunity-description")).ToBeFocusedAsync();
+		await Expect(Page.Locator("#opportunity-title-error")).Not.ToBeAttachedAsync();
+	}
+
+	[Test]
+	public async Task StepperJump_BlockedByTheCurrentStep_AlsoFocusesItsFirstInvalidField()
+	{
+		await OpenCreateWizardAsync();
+
+		// Step 1 is untouched (both fields required) - jumping to step 4
+		// must be refused and land focus back on the field standing in the way.
+		await Page.GetByTestId("wizard-stepper-4").ClickAsync();
+
+		await Expect(Page.Locator("#create-opportunity-step-blocked")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync();
+		await Expect(Page.Locator("#opportunity-title")).ToBeFocusedAsync();
+	}
+
+	private async Task OpenCreateWizardAsync()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var pinnedOrgId = await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await AuthHelper.GoToOrgAppDashboardAsync(Page, frontend, pinnedOrgId!.Value);
+
+		var createBtn = Page.GetByRole(AriaRole.Button, new() { Name = "Create opportunity" });
+		await Expect(createBtn.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await createBtn.First.ClickAsync();
+		await Expect(Page.GetByTestId("wizard-step-1")).ToBeVisibleAsync(new() { Timeout = 5_000 });
+	}
+}

--- a/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/BasicsStep.tsx
@@ -14,6 +14,11 @@ interface Props {
 	titleEnError?: string;
 	descriptionDeError?: string;
 	descriptionEnError?: string;
+	/** Bumped on every "Next"/stepper-jump/submit validation attempt for this
+	 * step, even when it produces the same error message as last time - see
+	 * the tab-switch effect below for why the message strings alone aren't
+	 * enough (einsatzbereit#2077). */
+	revalidationAttempt: number;
 	bannerPreview: string | null;
 	bannerError: string | null;
 	onBannerChange: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -30,6 +35,7 @@ export default function BasicsStep({
 	titleEnError,
 	descriptionDeError,
 	descriptionEnError,
+	revalidationAttempt,
 	bannerPreview,
 	bannerError,
 	onBannerChange,
@@ -55,9 +61,17 @@ export default function BasicsStep({
 	// back un-hides the existing FloatingField error text, the same way it
 	// already surfaces for every other step in this wizard - no separate
 	// live-region banner needed on top of that.
+	//
+	// `revalidationAttempt` is in the dependency list alongside the error
+	// messages themselves, not instead of them: a user can switch to the
+	// English tab *while* a German error is still outstanding (nothing stops
+	// that), and a second failed attempt then produces the exact same message
+	// string as the first - message-only deps would see no change and skip
+	// the switch, leaving the newly-focused German field hidden behind
+	// display:none (einsatzbereit#2077).
 	useEffect(() => {
 		if (titleDeError || descriptionDeError) setActiveLanguage("de");
-	}, [titleDeError, descriptionDeError]);
+	}, [titleDeError, descriptionDeError, revalidationAttempt]);
 
 	return (
 		<div className="space-y-4" data-testid="wizard-step-1">

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -209,6 +209,8 @@ export default function CreateVolunteerOpportunityModal({
 		getValues,
 		trigger,
 		clearErrors,
+		setFocus,
+		getFieldState,
 		formState: { errors, isDirty },
 	} = useForm<OpportunityFormValues>({
 		resolver: zodResolver(schema),
@@ -302,6 +304,17 @@ export default function CreateVolunteerOpportunityModal({
 
 	const bodyRef = useRef<HTMLDivElement>(null);
 
+	// This wizard never calls react-hook-form's own `handleSubmit()` - "Next",
+	// a blocked stepper jump and the final submit all call `trigger()`
+	// directly instead (see the revalidation comment on `registerWithRevalidate`
+	// below) - so `shouldFocusError`'s automatic focus-the-first-invalid-field
+	// never runs (mirrors the gap SignUpModal.tsx's message field closed by
+	// hand). `focusFieldsRef` carries the field list to check once the
+	// relevant step is on screen; `focusAttempt` is the trigger for the effect
+	// below, bumped even when the target step doesn't change (einsatzbereit#2077).
+	const focusFieldsRef = useRef<(keyof OpportunityFormValues)[] | null>(null);
+	const [focusAttempt, setFocusAttempt] = useState(0);
+
 	const occurrence = watch("occurrence");
 	const participationType = watch("participationType");
 	const isRemote = watch("isRemote");
@@ -368,6 +381,29 @@ export default function CreateVolunteerOpportunityModal({
 		setBlockedJump(null);
 	}, [step]);
 
+	// Runs after the step named in `focusFieldsRef` has actually committed to
+	// the DOM (a failed "Next" leaves the step unchanged; a failed final
+	// submit or blocked stepper jump may have just switched to it via
+	// `setStep`), so the field it focuses is guaranteed to be mounted -
+	// including BasicsStep's German/English toggle, whose own effect (keyed
+	// on `revalidationAttempt` as well as the error messages themselves, see
+	// its comment) un-hides the German tab first if needed. react-hook-form's
+	// own `setFocus` does not call the DOM `.focus()` synchronously - it
+	// defers by a tick - which is what actually closes this race rather than
+	// React's own effect-ordering: BasicsStep's cascading tab-switch render
+	// settles well within that tick.
+	useEffect(() => {
+		if (focusAttempt === 0 || !focusFieldsRef.current) return;
+		for (const field of focusFieldsRef.current) {
+			if (getFieldState(field).invalid) {
+				setFocus(field);
+				break;
+			}
+		}
+		focusFieldsRef.current = null;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [focusAttempt]);
+
 	function requestClose() {
 		// isDirty only tracks react-hook-form's own fields - time slots, the
 		// banner file and its removal all live in separate useState outside the
@@ -401,6 +437,13 @@ export default function CreateVolunteerOpportunityModal({
 			},
 		});
 
+	/** Queued for the effect above - see its comment for why this can't just
+	 * call `setFocus` inline. */
+	function requestFocusFirstInvalid(fields: (keyof OpportunityFormValues)[]) {
+		focusFieldsRef.current = fields;
+		setFocusAttempt((n) => n + 1);
+	}
+
 	function applyOrgAddress() {
 		if (!orgAddress) return;
 		setValue("street", orgAddress.street);
@@ -421,7 +464,10 @@ export default function CreateVolunteerOpportunityModal({
 	async function handleNext() {
 		const fields = STEP_FIELDS[step];
 		const valid = fields.length === 0 || (await trigger(fields));
-		if (!valid) return;
+		if (!valid) {
+			requestFocusFirstInvalid(fields);
+			return;
+		}
 		setStep((s) => Math.min(TOTAL_STEPS, s + 1));
 	}
 
@@ -455,6 +501,10 @@ export default function CreateVolunteerOpportunityModal({
 				blocking: blockingStep,
 				attempt: (prev?.attempt ?? 0) + 1,
 			}));
+			// Only the current step's own fields are on screen to focus - a
+			// blocking step further along stays unreached, and the live region
+			// above already names it.
+			if (blockingStep === step) requestFocusFirstInvalid(STEP_FIELDS[step]);
 			return;
 		}
 		setStep(n);
@@ -704,6 +754,7 @@ export default function CreateVolunteerOpportunityModal({
 				const stepValid = await trigger(fields);
 				if (!stepValid) {
 					setStep(s);
+					requestFocusFirstInvalid(fields);
 					return;
 				}
 			}
@@ -1098,6 +1149,7 @@ export default function CreateVolunteerOpportunityModal({
 							titleEnError={errors.titleEn?.message}
 							descriptionDeError={errors.descriptionDe?.message}
 							descriptionEnError={errors.descriptionEn?.message}
+							revalidationAttempt={focusAttempt}
 							bannerPreview={bannerPreview}
 							bannerError={bannerError}
 							onBannerChange={handleBannerChange}


### PR DESCRIPTION
Required fields already carried an aria-hidden asterisk and aria-required (#1819), but the wizard never calls react-hook-form's own handleSubmit() - "Next", a blocked stepper jump and the final submit all call trigger() directly instead, so shouldFocusError's automatic focus-the-first-invalid- field never ran. A blocked step advance left keyboard and screen-reader users with no signal of which field to fix beyond a field turning red.

Add a small focus-request mechanism (a field list ref plus an attempt counter, mirroring the existing blockedJump/errorToken pattern in this file) that focuses the first field actually reported invalid by getFieldState, once the relevant step has committed to the DOM.

Also close a related race in BasicsStep's German/English tab-switch effect: it was keyed only on the error message strings, so a second failed attempt producing the same message (after the user manually switched tabs without fixing the German field) was silently skipped, leaving the field to focus hidden behind display:none.

Fixes #2077

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
