### PR TITLE
fix: add honest ARIA semantics to my-signups switcher, fix language selector label-in-name

### DIFF
--- a/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeToggleTests.cs
@@ -122,4 +122,34 @@ public class MyEngagementsScopeToggleTests(AspireFixture fixture) : VisualTestBa
 			+ $"upcoming={upcomingWidth:F1}x{upcomingHeight:F1}px, past={pastWidth:F1}x{pastHeight:F1}px, "
 			+ $"widthDelta={widthDelta:F1}px, heightDelta={heightDelta:F1}px, both must be <2px)");
 	}
+
+	[Test]
+	public async Task ScopeToggle_AnnouncesPressedState_ForTheActiveSegment()
+	{
+		// #2072: looks and behaves exactly like a tab set for a sighted mouse
+		// user - a DOM query for role="tablist"/"tab" finds nothing anywhere in
+		// the app - but neither segment implements arrow-key navigation between
+		// them, so the honest-semantics fix (same call LanguageSelector.tsx and
+		// RowActionsMenu.tsx make for their own controls, see NavigationTests'
+		// HomePage_LanguageSelector_AnnouncesDisclosureSemantics) is aria-pressed
+		// on a labelled group of toggle buttons, not the full ARIA tabs pattern
+		// that promises keyboard behaviour this doesn't implement.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var upcomingTab = Page.GetByTestId("engagements-scope-upcoming");
+		var pastTab = Page.GetByTestId("engagements-scope-past");
+		await Expect(upcomingTab).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(upcomingTab).ToHaveAttributeAsync("aria-pressed", "true");
+		await Expect(pastTab).ToHaveAttributeAsync("aria-pressed", "false");
+
+		await pastTab.ClickAsync();
+		await Expect(pastTab).ToHaveAttributeAsync("aria-pressed", "true");
+		await Expect(upcomingTab).ToHaveAttributeAsync("aria-pressed", "false");
+	}
 }

--- a/backend/tests/VisualTests/NavigationTests.cs
+++ b/backend/tests/VisualTests/NavigationTests.cs
@@ -357,6 +357,15 @@ public class NavigationTests(AspireFixture fixture) : VisualTestBase(fixture)
 			new Regex($".*{Regex.Escape(expectedLanguageName)}.*")
 		);
 
+		// #2072: the accessible name used to replace the visible "EN"/"DE" text
+		// outright rather than extend it - a WCAG 2.5.3 Label-in-Name violation,
+		// since it never contained the string a speech-input user would say
+		// ("Klick DE") to target this control. It must now lead with that code.
+		await Expect(langBtn).ToHaveAttributeAsync(
+			"aria-label",
+			new Regex($"^{Regex.Escape(activeCode)}\\b.*")
+		);
+
 		await langBtn.ClickAsync();
 
 		var dropdown = banner.GetByTestId("language-selector-menu");

--- a/frontend/src/components/Header/LanguageSelector.tsx
+++ b/frontend/src/components/Header/LanguageSelector.tsx
@@ -40,7 +40,13 @@ export default function LanguageSelector({
 				type="button"
 				onClick={() => setOpen((o) => !o)}
 				aria-expanded={open}
+				// #2072: the accessible name used to replace the visible "EN"/"DE"
+				// text outright instead of extending it, a WCAG 2.5.3 Label-in-Name
+				// violation - "Klick DE" (speech input) wouldn't have matched an
+				// accessible name that never contains "DE". Leading with the same
+				// code the button displays keeps the two in sync.
 				aria-label={t("language.switchLanguageCurrent", {
+					code: current.short,
 					language: t(`language.${currentCode}`),
 				})}
 				data-testid="language-selector-trigger"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -906,7 +906,7 @@
       "de": "Deutsch",
       "en": "English",
       "switchLanguage": "Sprache wechseln",
-      "switchLanguageCurrent": "Sprache wechseln, aktuell {{language}}",
+      "switchLanguageCurrent": "{{code}} - Sprache wechseln, aktuell {{language}}",
       "switchedFromAccount": "Zu {{language}} gewechselt, basierend auf deinem Konto"
     },
     "auth": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -906,7 +906,7 @@
       "de": "Deutsch",
       "en": "English",
       "switchLanguage": "Switch language",
-      "switchLanguageCurrent": "Switch language, currently {{language}}",
+      "switchLanguageCurrent": "{{code}} - Switch language, currently {{language}}",
       "switchedFromAccount": "Switched to {{language}} based on your account"
     },
     "auth": {

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -333,6 +333,13 @@ export default function ActivitySection() {
 			<div
 				role="group"
 				aria-label={t("myEngagements.scopeLabel")}
+				// #2072: looks and behaves like a tab set for a sighted mouse user,
+				// but there's no arrow-key navigation between the two segments - so
+				// the honest-semantics call (same one LanguageSelector.tsx and
+				// RowActionsMenu.tsx make for their own controls) is a labelled
+				// group of toggle buttons (aria-pressed), not the full ARIA tabs
+				// pattern (role="tablist"/"tab"/"tabpanel") that promises roving
+				// tabindex and arrow keys this doesn't implement.
 				// grid-cols-2 (not flex): an intrinsically-sized flex-1 track squeezes
 				// both segments to an equal share of the shrink-to-fit container width
 				// - which is sized to the *sum* of their natural widths - so the
@@ -353,7 +360,7 @@ export default function ActivitySection() {
 					data-testid="engagements-scope-upcoming"
 					onClick={() => switchEngagementsScope("upcoming")}
 					disabled={engagementsLoading}
-					aria-current={engagementsScope === "upcoming" ? "true" : undefined}
+					aria-pressed={engagementsScope === "upcoming"}
 					className={`rounded-md px-3 py-1.5 text-center text-sm font-medium whitespace-nowrap transition-colors ${
 						engagementsScope === "upcoming"
 							? "bg-white text-brand-700 shadow-sm"
@@ -367,7 +374,7 @@ export default function ActivitySection() {
 					data-testid="engagements-scope-past"
 					onClick={() => switchEngagementsScope("past")}
 					disabled={engagementsLoading}
-					aria-current={engagementsScope === "past" ? "true" : undefined}
+					aria-pressed={engagementsScope === "past"}
 					className={`rounded-md px-3 py-1.5 text-center text-sm font-medium whitespace-nowrap transition-colors ${
 						engagementsScope === "past"
 							? "bg-white text-brand-700 shadow-sm"


### PR DESCRIPTION
my-signups' Upcoming/Past switcher looked and behaved like a tab set but exposed no grouping, selected state, or keyboard model to assistive tech - add aria-pressed to the two toggle buttons instead of claiming a full ARIA tabs pattern (role="tablist"/"tab") whose arrow-key navigation isn't implemented, matching the repo's existing disclosure-over-unearned-widget convention (#1772).

The language switcher's aria-label replaced its visible "EN"/"DE" text outright instead of extending it, a WCAG 2.5.3 Label-in-Name violation speech-input users would hit directly. Lead the label with the same code.

Deliberately does not add aria-haspopup/role="menu" to the four popover triggers the issue also flagged (language switcher, notification bell, org switcher, opportunity row menu) - RowActionsMenu.tsx and LanguageSelector.tsx already document why that combination was removed (#1772: it promises a keyboard model none of them implement), and NavigationTests.cs has a standing regression test asserting the language switcher trigger has no aria-haspopup attribute at all.

Fixes #2072

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
