### PR TITLE
fix(frontend): hide moot apply-by deadline on withdrawn/cancelled sign-ups

### DIFF
--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -67,6 +67,47 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 	}
 
 	/// <summary>
+	/// Regression for #2070: a Withdrawn engagement whose opportunity still has
+	/// a future "express interest by" deadline (the common shape for an
+	/// IndividualContact opportunity - it stays open for other volunteers long
+	/// after this one withdrew) used to keep showing that future-dated deadline
+	/// on its card in the "Past" scope, contradicting the scope's own label.
+	/// Once terminal (Cancelled/Withdrawn), the deadline is no longer
+	/// actionable for this engagement, so the card should drop it and rely on
+	/// the status chip instead.
+	/// </summary>
+	[Test]
+	public async Task EngagementsTab_PastScope_HidesFutureApplyByDeadline_ForWithdrawnEngagement()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var keycloak = Fixture.GetEndpoint("keycloak");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "ScopeTabsWithdrawnFuture");
+
+		using var veraHttp = new HttpClient { BaseAddress = backend };
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+
+		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Withdrawing right away.");
+		var withdrawResponse = await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
+		withdrawResponse.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/my-signups");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.Locator("[data-testid='engagements-scope-past']").ClickAsync();
+
+		var card = Page.Locator($"[data-engagement-id='{engagementId}']");
+		await LoadMoreUntilVisibleAsync(card);
+		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(card.GetByText("Withdrawn")).ToBeVisibleAsync();
+		await Expect(card.GetByText("Express interest by")).Not.ToBeVisibleAsync();
+	}
+
+	/// <summary>
 	/// Regression for #1855: Engagement.CheckIn() has no time-based guard, so an
 	/// organizer can check a volunteer in as soon as an engagement is Confirmed -
 	/// e.g. at arrival for a still-ongoing multi-hour shift, or (as filed) for a

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -103,7 +103,11 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		await LoadMoreUntilVisibleAsync(card);
 		await Expect(card).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await Expect(card.GetByText("Withdrawn")).ToBeVisibleAsync();
+		// Exact match: the opportunity's own fixture title ("ScopeTabsWithdrawnFuture")
+		// contains "Withdrawn" as a substring too, so a non-exact GetByText here
+		// is a strict-mode violation - it resolves to both the title link and
+		// the actual "Withdrawn" status badge this assertion means to check.
+		await Expect(card.GetByText("Withdrawn", new() { Exact = true })).ToBeVisibleAsync();
 		await Expect(card.GetByText("Express interest by")).Not.ToBeVisibleAsync();
 	}
 

--- a/frontend/src/lib/engagementStatus.test.ts
+++ b/frontend/src/lib/engagementStatus.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalEngagementStatus } from "./engagementStatus";
+
+describe("isTerminalEngagementStatus", () => {
+	it("returns true for Cancelled and Withdrawn", () => {
+		expect(isTerminalEngagementStatus("Cancelled")).toBe(true);
+		expect(isTerminalEngagementStatus("Withdrawn")).toBe(true);
+	});
+
+	it("returns false for Pending and Confirmed", () => {
+		expect(isTerminalEngagementStatus("Pending")).toBe(false);
+		expect(isTerminalEngagementStatus("Confirmed")).toBe(false);
+	});
+});

--- a/frontend/src/lib/engagementStatus.ts
+++ b/frontend/src/lib/engagementStatus.ts
@@ -4,3 +4,11 @@ export const ENGAGEMENT_STATUS_COLORS: Record<string, string> = {
 	Cancelled: "bg-red-50 text-red-700 border-red-100",
 	Withdrawn: "bg-gray-100 text-gray-700 border-gray-200",
 };
+
+// Cancelled/Withdrawn are terminal (#2070) - the opportunity's own
+// "express interest by" deadline is no longer actionable for an engagement
+// that already ended this way, so surfaces showing that deadline alongside
+// the engagement should gate on this rather than display it unconditionally.
+export function isTerminalEngagementStatus(status: string): boolean {
+	return status === "Cancelled" || status === "Withdrawn";
+}

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -8,7 +8,10 @@ import type {
 import { useApiClient } from "../../hooks/useApiClient";
 import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
-import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
+import {
+	ENGAGEMENT_STATUS_COLORS,
+	isTerminalEngagementStatus,
+} from "../../lib/engagementStatus";
 import { isFeedbackEditable } from "../../lib/feedback";
 import { formatDate, formatDateTimeRange } from "../../lib/format";
 import { cardClass } from "../../lib/surfaceClasses";
@@ -501,19 +504,26 @@ export default function ActivitySection() {
 												<ArrowsRightLeftIcon className="h-3.5 w-3.5 shrink-0" />
 												<span>{t("myEngagements.noFixedDate")}</span>
 											</p>
-											{e.opportunityValidUntil && (
-												<p className="mt-1 flex items-center gap-1.5 text-xs font-medium text-amber-700">
-													<ClockIcon className="h-3.5 w-3.5 shrink-0" />
-													<span>
-														{t("opportunities.applyBy", {
-															date: formatDate(
-																e.opportunityValidUntil as unknown as string,
-																i18n.language,
-															),
-														})}
-													</span>
-												</p>
-											)}
+											{/* Cancelled/Withdrawn is terminal - the opportunity's own
+											application deadline is no longer actionable for this
+											engagement, so showing it read as a future-looking date on a
+											card that is otherwise done (#2070). The status chip at the
+											top of the card is the one piece of temporal-status
+											information that still applies. */}
+											{!isTerminalEngagementStatus(e.status) &&
+												e.opportunityValidUntil && (
+													<p className="mt-1 flex items-center gap-1.5 text-xs font-medium text-amber-700">
+														<ClockIcon className="h-3.5 w-3.5 shrink-0" />
+														<span>
+															{t("opportunities.applyBy", {
+																date: formatDate(
+																	e.opportunityValidUntil as unknown as string,
+																	i18n.language,
+																),
+															})}
+														</span>
+													</p>
+												)}
 										</>
 									)}
 									{e.status === "Cancelled" && e.cancellationReason && (


### PR DESCRIPTION
Cancelled/Withdrawn engagements kept showing their opportunity's future "express interest by" deadline on the sign-up card, which read as contradictory under the "Past" scope on /my-signups.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2070

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
