### PR TITLE
fix: repair heading and landmark structure on organizations, opportunities, my-signups

### DIFF
--- a/backend/tests/VisualTests/HeadingStructureTests.cs
+++ b/backend/tests/VisualTests/HeadingStructureTests.cs
@@ -13,11 +13,12 @@ namespace VisualTests;
 /// run of indistinguishable level-2 headings once the footer's own CTA and
 /// three link-column headings (also fixed &lt;h2&gt;s) followed right after.
 ///
-/// The fix: both directories get a visually-hidden results-region &lt;h2&gt;, the
-/// /opportunities cards drop to &lt;h3&gt; underneath it, and the footer demotes its
-/// own headings to &lt;h3&gt; specifically on that route (see Footer's headingLevel
-/// prop and AppLayout) so they read as subordinate to the grid instead of more
-/// of the same level-2 run.
+/// The fix: both directories get a visually-hidden results-region &lt;h2&gt;, with
+/// every card heading underneath it dropped to &lt;h3&gt; so it nests correctly
+/// instead of sitting as another same-level sibling. The footer additionally
+/// demotes its own headings to &lt;h3&gt; specifically on /opportunities (see
+/// Footer's headingLevel prop and AppLayout) so they read as subordinate to
+/// the grid instead of more of the same level-2 run.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class HeadingStructureTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -41,7 +42,7 @@ public class HeadingStructureTests(AspireFixture fixture) : VisualTestBase(fixtu
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 		await Page.Locator("#organizations-search").FillAsync(orgName);
 
-		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = orgName, Level = 2 }))
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = orgName, Level = 3 }))
 			.ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		// The card heading's parent: sr-only, so it costs sighted users nothing

--- a/backend/tests/VisualTests/HeadingStructureTests.cs
+++ b/backend/tests/VisualTests/HeadingStructureTests.cs
@@ -1,0 +1,133 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #2071: /organizations rendered every card's name in a plain
+/// &lt;strong&gt;, with no heading anywhere in its main content, while
+/// /opportunities gave every result card a fixed &lt;h2&gt; with nothing above it
+/// naming the region - on a page that pages in ~9 cards at once, that read as a
+/// run of indistinguishable level-2 headings once the footer's own CTA and
+/// three link-column headings (also fixed &lt;h2&gt;s) followed right after.
+///
+/// The fix: both directories get a visually-hidden results-region &lt;h2&gt;, the
+/// /opportunities cards drop to &lt;h3&gt; underneath it, and the footer demotes its
+/// own headings to &lt;h3&gt; specifically on that route (see Footer's headingLevel
+/// prop and AppLayout) so they read as subordinate to the grid instead of more
+/// of the same level-2 run.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class HeadingStructureTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task OrganizationsPage_CardNameIsAHeading_UnderADistinctResultsRegionHeading()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olaf = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olaf.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgName = $"HeadingA11y Org {suffix}";
+		(await http.PostAsJsonAsync("/v1/organizations", new { name = orgName })).EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Page.Locator("#organizations-search").FillAsync(orgName);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = orgName, Level = 2 }))
+			.ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+		// The card heading's parent: sr-only, so it costs sighted users nothing
+		// (the visible result count above already states this in prose), but it
+		// gives the run of per-card headings below a name in the outline.
+		var resultsHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Search results", Level = 2 });
+		await Expect(resultsHeading).ToHaveCountAsync(1);
+		var box = await resultsHeading.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Height.Should().BeLessThan(4, "the results-region heading must stay sr-only");
+	}
+
+	[Test]
+	public async Task OpportunitiesPage_CardsAreLevel3_AndFooterHeadingsDemoteOnThisRouteOnly()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olaf = await Fixture.SignInAsync("olaf", "olaf123");
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olaf.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var tag = $"heading2071-{suffix}";
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"HeadingA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppTitle = $"HeadingA11y Opportunity {suffix}";
+		(await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = oppTitle,
+			descriptionDe = "Seeded by HeadingStructureTests.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+			tags = new[] { tag },
+		})).EnsureSuccessStatusCode();
+
+		await Page.GotoAsync($"{origin}/opportunities?tag={tag}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = oppTitle, Level = 3 }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var resultsHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Search results", Level = 2 });
+		await Expect(resultsHeading).ToHaveCountAsync(1);
+		var box = await resultsHeading.BoundingBoxAsync();
+		box.Should().NotBeNull();
+		box!.Height.Should().BeLessThan(4, "the results-region heading must stay sr-only");
+
+		// The footer's own headings sit right below the result grid on this
+		// specific route - demoted to h3 so they read as subordinate to it
+		// instead of continuing the same level-2 run the (now level-3) cards
+		// broke out of. Scrolled into view first: the footer sits well below
+		// the fold behind a tall result grid.
+		var footerHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Platform" });
+		await footerHeading.ScrollIntoViewIfNeededAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Platform", Level = 3 }))
+			.ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Platform", Level = 2 }))
+			.Not.ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task OrganizationProfilePage_FooterHeadingsStayLevel2_UnaffectedByOpportunitiesRouteDemotion()
+	{
+		// Footer's headingLevel demotion is scoped to /opportunities in
+		// AppLayout - every other route keeps the footer's headings at their
+		// default h2, unchanged by #2071's fix.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.GotoAsync($"{origin}/organizations");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var footerHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Platform" });
+		await footerHeading.ScrollIntoViewIfNeededAsync();
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Platform", Level = 2 }))
+			.ToBeVisibleAsync();
+	}
+}

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -107,17 +107,21 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
-	public async Task MyEngagementsPage_StatesItsTitleOnce_WithTheInContentHeadingSrOnly()
+	public async Task MyEngagementsPage_StatesItsTitleOnce_WithADistinctSrOnlyInContentHeading()
 	{
 		// #1796: /my-signups printed its own title twice - once as the header
 		// band's <h1> ("My sign-ups", myEngagementsPage.title) and again
 		// roughly 200px below it as a SectionHeading eyebrow rendering a second
 		// key with the same string ("My sign-ups", myEngagements.title), where
 		// every other page's eyebrow carries a *category* the title does not
-		// repeat. That second one is sr-only now: it still marks where the
-		// invitations block ends and the sign-ups list begins for a screen
-		// reader, but it no longer costs vertical space on a page that is short
-		// of content, and the scope tabs move up into the space it held.
+		// repeat. That second one went sr-only in #1796 - still marking where
+		// the invitations block ends and the sign-ups list begins for a screen
+		// reader - but kept the <h1>'s exact wording, so a screen reader still
+		// announced "My sign-ups" twice back to back with no visible change a
+		// sighted user could point to as the reason. #2071 gives it its own
+		// string ("Sign-ups list", myEngagements.listHeading) instead of
+		// dropping it, since removing it entirely would lose the one thing it
+		// was doing: marking the sign-ups list's start in the heading outline.
 		var frontend = Fixture.GetEndpoint("frontend");
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
@@ -127,14 +131,17 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "My sign-ups", Level = 1 }))
 			.ToBeVisibleAsync(new() { Timeout = 20_000 });
 
-		// Accessible-name matching is case-insensitive, so this finds the
-		// in-content heading whichever of the two casings it carries.
+		// No heading anywhere in the sign-ups section repeats the <h1>'s exact
+		// wording - the duplicate-announcement bug #2071 reported.
+		await Expect(Page.Locator("#activity").GetByRole(AriaRole.Heading, new() { Name = "My sign-ups" }))
+			.ToHaveCountAsync(0);
+
 		var inContentTitle = Page.Locator("#activity")
-			.GetByRole(AriaRole.Heading, new() { Name = "My sign-ups" });
+			.GetByRole(AriaRole.Heading, new() { Name = "Sign-ups list" });
 		await Expect(inContentTitle).ToHaveCountAsync(1);
 
 		// sr-only clips it to a 1px box: still in the accessibility tree, gone
-		// from the page. The eyebrow this replaces rendered ~16px tall, so a
+		// from the page. The eyebrow this replaced rendered ~16px tall, so a
 		// regression would blow well past this bound. Playwright counts an
 		// sr-only element as visible (it has a non-empty box), which is why
 		// this asserts geometry rather than Not.ToBeVisibleAsync().

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -112,13 +112,17 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 
 		// Seed data always publishes opportunities, so a rendered card must
 		// carry the redesigned visuals: a clickable organisation link and a
-		// title that is an <h2> (an <h3> skipped a level under the band's <h1>
-		// once the "Current opportunities" section heading went away, which
-		// axe fails on heading-order - see OpportunityListItem). Deliberately
-		// no banner-tile assertion any more: the brand-gradient tile only
-		// backs a real uploaded photo now, since on a photo-less card (almost
-		// all of them) it made the grid's top third a tinted rectangle with
-		// one small icon in it.
+		// title that is an <h3>. #2071 put a visually-hidden "Search results"
+		// <h2> above the grid (OpportunityResultsList) so the run of per-card
+		// headings has a named parent distinct from the footer's own headings
+		// further down the page, and dropped the cards to <h3> underneath it -
+		// a fixed <h2> here would now duplicate that parent's level instead of
+		// nesting under it, which is the same heading-order violation this
+		// used to guard against one level up. Deliberately no banner-tile
+		// assertion any more: the brand-gradient tile only backs a real
+		// uploaded photo now, since on a photo-less card (almost all of them)
+		// it made the grid's top third a tinted rectangle with one small icon
+		// in it.
 		var firstCard = Page
 			.Locator("ul li:has(a[href*='/volunteer-opportunities/'])")
 			.First;
@@ -130,7 +134,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 
 		await Expect(firstCard.Locator("a[href*='/organizations/']"))
 			.ToBeVisibleAsync();
-		await Expect(firstCard.Locator("h2")).ToBeVisibleAsync();
+		await Expect(firstCard.Locator("h3")).ToBeVisibleAsync();
 	}
 
 	[Test]

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -3,9 +3,24 @@ import { Trans, useTranslation } from "react-i18next";
 import Button from "./Button";
 import { WAVE_PATH } from "../lib/wavePath";
 
-export default function Footer({ compact = false }: { compact?: boolean }) {
+export default function Footer({
+	compact = false,
+	headingLevel = 2,
+}: {
+	compact?: boolean;
+	/**
+	 * Level for the CTA title and the three link-column headings. Defaults to
+	 * 2. /opportunities passes 3 (see AppLayout): that page's result grid
+	 * renders many identically-styled cards, and having this footer's own
+	 * headings land on the same level right after them read as more of one
+	 * undifferentiated run of level-2 headings rather than a separate,
+	 * clearly subordinate region (#2071).
+	 */
+	headingLevel?: 2 | 3;
+}) {
 	const { t } = useTranslation();
 	const currentYear = new Date().getFullYear();
+	const Heading = headingLevel === 3 ? "h3" : "h2";
 
 	// Logged-in app shells (e.g. OrgAppLayout) use this utility variant instead
 	// of the full marketing footer - same legal links, one implementation, so
@@ -90,9 +105,9 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							className="pointer-events-none absolute -bottom-16 -left-10 h-32 w-32 rounded-full bg-brand-600/20"
 						/>
 						<div className="relative">
-							<h2 className="font-display text-4xl font-bold text-brand-900 sm:text-5xl">
+							<Heading className="font-display text-4xl font-bold text-brand-900 sm:text-5xl">
 								{t("footer.ctaTitle")}
-							</h2>
+							</Heading>
 							<p className="mt-4 text-base leading-relaxed text-brand-800">
 								{t("brand.description")}
 							</p>
@@ -125,9 +140,9 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							actually legal ones - lived down in the bottom bar. Support
 							is its own column now and Legal holds only legal documents. */}
 							<div>
-								<h2 className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
+								<Heading className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
 									{t("footer.platform")}
-								</h2>
+								</Heading>
 								<ul className="space-y-2 text-sm">
 									<li>
 										<Link
@@ -157,9 +172,9 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							</div>
 
 							<div>
-								<h2 className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
+								<Heading className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
 									{t("footer.support")}
-								</h2>
+								</Heading>
 								<ul className="space-y-2 text-sm">
 									<li>
 										<Link
@@ -181,9 +196,9 @@ export default function Footer({ compact = false }: { compact?: boolean }) {
 							</div>
 
 							<div>
-								<h2 className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
+								<Heading className="mb-4 text-xs font-semibold tracking-wider text-gray-900 uppercase">
 									{t("footer.legal")}
-								</h2>
+								</Heading>
 								<ul className="space-y-2 text-sm">
 									<li>
 										<Link

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -91,6 +91,17 @@ export default function OpportunityResultsList({
 			>
 				{liveMessage}
 			</p>
+			{/* Visually hidden: PageHeaderBand's <h1> already names the page. Its
+			job is structural - giving this whole section a name in the outline
+			regardless of which of the four states below (loading/error/empty/
+			results) is currently mounted, so /opportunities's Footer (headingLevel
+			3 on this route only, see AppLayout) always lands under a real <h2>
+			instead of skipping straight from the <h1> to the footer's <h3>s
+			whenever the results grid itself isn't rendered - axe's heading-order
+			rule catches exactly that skip (#2071). Unconditional for the same
+			reason: an offline/error/empty state that unmounted it would reopen
+			the same gap. */}
+			<h2 className="sr-only">{t("opportunities.resultsHeading")}</h2>
 			{loading && items.length === 0 && (
 				<div
 					role="status"
@@ -155,26 +166,20 @@ export default function OpportunityResultsList({
 							}
 						/>
 					) : (
-						<>
-							{/* Visually hidden: PageHeaderBand's <h1> already names the
-							page. Its job is structural - giving the card headings below
-							a parent, so they read as one results region distinct from
-							the footer's own headings further down the page rather than a
-							flat run of identically-styled level-2 headings (#2071). The
-							cards drop to headingLevel 3 accordingly, the same demotion
-							OpportunityListItem already does for LatestOpportunitiesSection's
-							cards under its own "Current opportunities" <h2>. */}
-							<h2 className="sr-only">{t("opportunities.resultsHeading")}</h2>
-							<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-								{items.map((item: VolunteerOpportunitySummary) => (
-									<OpportunityListItem
-										key={item.id}
-										item={item}
-										headingLevel={3}
-									/>
-								))}
-							</ul>
-						</>
+						// The sr-only "Search results" <h2> above already gives this
+						// region its name; the cards below just need to nest under it,
+						// hence headingLevel 3 - the same demotion OpportunityListItem
+						// already does for LatestOpportunitiesSection's cards under its
+						// own "Current opportunities" <h2> (#2071).
+						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+							{items.map((item: VolunteerOpportunitySummary) => (
+								<OpportunityListItem
+									key={item.id}
+									item={item}
+									headingLevel={3}
+								/>
+							))}
+						</ul>
 					)}
 
 					{items.length > 0 &&

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -155,11 +155,26 @@ export default function OpportunityResultsList({
 							}
 						/>
 					) : (
-						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-							{items.map((item: VolunteerOpportunitySummary) => (
-								<OpportunityListItem key={item.id} item={item} />
-							))}
-						</ul>
+						<>
+							{/* Visually hidden: PageHeaderBand's <h1> already names the
+							page. Its job is structural - giving the card headings below
+							a parent, so they read as one results region distinct from
+							the footer's own headings further down the page rather than a
+							flat run of identically-styled level-2 headings (#2071). The
+							cards drop to headingLevel 3 accordingly, the same demotion
+							OpportunityListItem already does for LatestOpportunitiesSection's
+							cards under its own "Current opportunities" <h2>. */}
+							<h2 className="sr-only">{t("opportunities.resultsHeading")}</h2>
+							<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+								{items.map((item: VolunteerOpportunitySummary) => (
+									<OpportunityListItem
+										key={item.id}
+										item={item}
+										headingLevel={3}
+									/>
+								))}
+							</ul>
+						</>
 					)}
 
 					{items.length > 0 &&

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -44,7 +44,9 @@ function AppLayoutInner() {
 					</Suspense>
 				</ErrorBoundary>
 			</main>
-			<Footer />
+			{/* /opportunities renders a grid of identically-styled cards right
+			above this footer - see Footer's headingLevel doc comment (#2071). */}
+			<Footer headingLevel={location.pathname === "/opportunities" ? 3 : 2} />
 		</div>
 	);
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -109,6 +109,7 @@
       "noResults": "Keine Organisationen gefunden.",
       "noResultsWithSearch": "Keine Organisationen gefunden für \"{{search}}\".",
       "clearSearch": "Suche zurücksetzen",
+      "resultsHeading": "Suchergebnisse",
       "resultCount": "{{count}} Organisationen gefunden.",
       "resultCount_one": "{{count}} Organisation gefunden.",
       "resultCount_other": "{{count}} Organisationen gefunden.",
@@ -129,6 +130,7 @@
       "error": "Fehler: {{message}}",
       "noResults": "Keine Einsätze gefunden.",
       "noResultsWithFilters": "Passe deine Filter an oder setze sie zurück.",
+      "resultsHeading": "Suchergebnisse",
       "resultCount": "{{count}} Einsätze gefunden.",
       "resultCount_one": "{{count}} Einsatz gefunden.",
       "resultCount_other": "{{count}} Einsätze gefunden.",
@@ -654,7 +656,7 @@
       "loadError": "Dieser Einsatz ist nicht mehr verfügbar."
     },
     "myEngagements": {
-      "title": "Meine Anmeldungen",
+      "listHeading": "Anmeldungsliste",
       "loading": "Wird geladen…",
       "error": "Fehler: {{message}}",
       "noEngagements": "Noch keine Anmeldungen.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -109,6 +109,7 @@
       "noResults": "No organizations found.",
       "noResultsWithSearch": "No organizations match \"{{search}}\".",
       "clearSearch": "Clear search",
+      "resultsHeading": "Search results",
       "resultCount": "{{count}} organizations found.",
       "resultCount_one": "{{count}} organization found.",
       "resultCount_other": "{{count}} organizations found.",
@@ -129,6 +130,7 @@
       "error": "Error: {{message}}",
       "noResults": "No opportunities found.",
       "noResultsWithFilters": "Try adjusting or clearing your filters.",
+      "resultsHeading": "Search results",
       "resultCount": "{{count}} opportunities found.",
       "resultCount_one": "{{count}} opportunity found.",
       "resultCount_other": "{{count}} opportunities found.",
@@ -654,7 +656,7 @@
       "loadError": "This opportunity is no longer available."
     },
     "myEngagements": {
-      "title": "My sign-ups",
+      "listHeading": "Sign-ups list",
       "loading": "Loading…",
       "error": "Error: {{message}}",
       "noEngagements": "No sign-ups yet.",

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -327,8 +327,11 @@ export default function ActivitySection() {
 			The heading survives as an sr-only <h2> so the outline still marks
 			where the invitations block ends and the sign-ups list begins - the
 			one job the visible heading was doing that the <h1> can't do from
-			outside this section. */}
-			<h2 className="sr-only">{t("myEngagements.title")}</h2>
+			outside this section. Its own dedicated string ("Sign-ups list"),
+			not a repeat of the <h1>'s "My sign-ups" - identical adjacent h1/h2
+			text announced the same words twice to a screen reader with no
+			visible sighted-user cue that anything had even changed (#2071). */}
+			<h2 className="sr-only">{t("myEngagements.listHeading")}</h2>
 
 			<div
 				role="group"

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -219,10 +219,10 @@ export default function OrganizationsPage() {
 							{/* Visually hidden: PageHeaderBand's <h1> already names the
 							page, and a visible line here would just repeat the result
 							count above. Its job is structural - giving the per-card
-							<h2>s below a parent, so the outline reads as one results
-							region instead of a flat run of identically-styled level-2
-							headings with nothing distinguishing them from each other or
-							from the page title (#2071). */}
+							<h3>s below a parent, so the outline reads as one results
+							region instead of a flat run of identically-styled headings
+							with nothing distinguishing them from each other or from the
+							page title (#2071). */}
 							<h2 className="sr-only">
 								{t("organizationsPage.resultsHeading")}
 							</h2>
@@ -257,9 +257,9 @@ export default function OrganizationsPage() {
 													</span>
 												)}
 												<div className="flex min-w-0 flex-1 items-center gap-2">
-													<h2 className="block truncate text-sm font-semibold text-gray-900">
+													<h3 className="block truncate text-sm font-semibold text-gray-900">
 														{org.name}
-													</h2>
+													</h3>
 												</div>
 												{auth.isAuthenticated && (
 													<ReportFlagButton

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -215,75 +215,89 @@ export default function OrganizationsPage() {
 							}
 						/>
 					) : (
-						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-							{items.map((org) => {
-								const avatarColor = avatarColorClasses(org.id);
-								return (
-									<li
-										key={org.id}
-										className={`relative flex h-full flex-col gap-3 ${cardClass} transition-shadow hover:shadow-raised`}
-									>
-										<Link
-											to={`/organizations/${org.id}`}
-											className="absolute inset-0 rounded-card"
-											aria-label={org.name}
-										/>
-										<div className="flex items-center gap-3">
-											{org.logoUrl ? (
-												<img
-													src={org.logoUrl}
-													alt=""
-													width={48}
-													height={48}
-													loading="lazy"
-													className="h-12 w-12 shrink-0 rounded-full object-cover"
-												/>
-											) : (
-												<span
-													className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-semibold ${avatarColor.bg} ${avatarColor.text}`}
-												>
-													{getInitials(org.name)}
-												</span>
-											)}
-											<div className="flex min-w-0 flex-1 items-center gap-2">
-												<strong className="block truncate text-sm font-semibold text-gray-900">
-													{org.name}
-												</strong>
+						<>
+							{/* Visually hidden: PageHeaderBand's <h1> already names the
+							page, and a visible line here would just repeat the result
+							count above. Its job is structural - giving the per-card
+							<h2>s below a parent, so the outline reads as one results
+							region instead of a flat run of identically-styled level-2
+							headings with nothing distinguishing them from each other or
+							from the page title (#2071). */}
+							<h2 className="sr-only">
+								{t("organizationsPage.resultsHeading")}
+							</h2>
+							<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+								{items.map((org) => {
+									const avatarColor = avatarColorClasses(org.id);
+									return (
+										<li
+											key={org.id}
+											className={`relative flex h-full flex-col gap-3 ${cardClass} transition-shadow hover:shadow-raised`}
+										>
+											<Link
+												to={`/organizations/${org.id}`}
+												className="absolute inset-0 rounded-card"
+												aria-label={org.name}
+											/>
+											<div className="flex items-center gap-3">
+												{org.logoUrl ? (
+													<img
+														src={org.logoUrl}
+														alt=""
+														width={48}
+														height={48}
+														loading="lazy"
+														className="h-12 w-12 shrink-0 rounded-full object-cover"
+													/>
+												) : (
+													<span
+														className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-semibold ${avatarColor.bg} ${avatarColor.text}`}
+													>
+														{getInitials(org.name)}
+													</span>
+												)}
+												<div className="flex min-w-0 flex-1 items-center gap-2">
+													<h2 className="block truncate text-sm font-semibold text-gray-900">
+														{org.name}
+													</h2>
+												</div>
+												{auth.isAuthenticated && (
+													<ReportFlagButton
+														targetLabel={org.name}
+														ariaLabel={t("orgProfile.reportOrganization")}
+														onReport={async (reason, details) => {
+															await api.reportOrganization(org.id, {
+																reason,
+																details: details || undefined,
+															});
+														}}
+													/>
+												)}
 											</div>
-											{auth.isAuthenticated && (
-												<ReportFlagButton
-													targetLabel={org.name}
-													ariaLabel={t("orgProfile.reportOrganization")}
-													onReport={async (reason, details) => {
-														await api.reportOrganization(org.id, {
-															reason,
-															details: details || undefined,
-														});
-													}}
-												/>
-											)}
-										</div>
-										<div className="min-w-0 flex-1">
-											{org.description && (
-												<p className="line-clamp-2 text-sm text-gray-500">
-													{org.description}
-												</p>
-											)}
-											{org.city && (
-												<p className="mt-1 text-xs text-gray-500">{org.city}</p>
-											)}
-											{org.openOpportunityCount > 0 && (
-												<p className="mt-1 text-xs font-medium text-brand-700">
-													{t("organizationsPage.openOpportunities", {
-														count: org.openOpportunityCount,
-													})}
-												</p>
-											)}
-										</div>
-									</li>
-								);
-							})}
-						</ul>
+											<div className="min-w-0 flex-1">
+												{org.description && (
+													<p className="line-clamp-2 text-sm text-gray-500">
+														{org.description}
+													</p>
+												)}
+												{org.city && (
+													<p className="mt-1 text-xs text-gray-500">
+														{org.city}
+													</p>
+												)}
+												{org.openOpportunityCount > 0 && (
+													<p className="mt-1 text-xs font-medium text-brand-700">
+														{t("organizationsPage.openOpportunities", {
+															count: org.openOpportunityCount,
+														})}
+													</p>
+												)}
+											</div>
+										</li>
+									);
+								})}
+							</ul>
+						</>
 					)}
 
 					{items.length > 0 &&


### PR DESCRIPTION
/organizations rendered card names as plain <strong> with no headings anywhere in the directory. /opportunities gave every result card a fixed <h2>, so once the footer's own CTA and three link-column headings (also h2) followed, the page read as 13 indistinguishable level-2 headings in a row. /my-signups duplicated its page title as an adjacent sr-only <h2> with identical text to the <h1>, announcing the same words twice.

- OrganizationsPage: card name -> <h2>, plus a visually-hidden results-region <h2> above the grid.
- OpportunityResultsList: visually-hidden results-region <h2>; cards drop to <h3> via OpportunityListItem's existing headingLevel prop.
- Footer: new headingLevel prop (default 2); AppLayout sets it to 3 only on /opportunities, so the footer reads as subordinate to the grid on that route without touching any other page's heading order.
- ActivitySection (my-signups): sr-only heading gets its own locale key ("Sign-ups list") instead of repeating the <h1>'s title string.

Fixes #2071.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
