### PR TITLE
fix: make offline handling consistent across pages, add manual retry

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -2126,6 +2126,95 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		}
 	}
 
+	/// <summary>
+	/// #2065: the opportunity detail page's new full-page (non-`inline`) offline
+	/// branch - a different DOM/landmark shape than the `inline` case
+	/// <see cref="OpportunityListOffline_HasNoSeriousA11yViolations"/> above
+	/// covers (this one replaces <c>PageHeaderBand</c> and the rest of the page
+	/// too, the same way the page's existing not-found/generic-error branches
+	/// already do), and it also now carries a "Try again" button neither of
+	/// those two variants had axe coverage for on this page before.
+	///
+	/// Simulated by pinning <c>navigator.onLine</c> false and aborting just the
+	/// detail request, not <c>Context.SetOfflineAsync</c> - same technique
+	/// <c>OrgAppLayoutErrorStatesTests</c> uses for the org shell, and simpler
+	/// than the warm-then-navigate dance the test above needs, since this page
+	/// is reached with a normal document <c>GotoAsync</c> either way.
+	/// </summary>
+	[Test]
+	public async Task VolunteerOpportunityDetailPage_Offline_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var olafSession = await Fixture.SignInAsync("olaf", "olaf123");
+		using var olafHttp = new HttpClient { BaseAddress = backend };
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
+
+		var suffix = Guid.NewGuid().ToString("N");
+		var orgResponse = await olafHttp.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"DetailOfflineA11y Org {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = $"DetailOfflineA11y Opportunity {suffix}",
+			descriptionDe = "Created by AccessibilityTests",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
+	/// <summary>
+	/// #2065: the landing page's "These opportunities need people" preview
+	/// section used to remove itself on any failure, offline included, so its
+	/// new inline offline notice (plus the "Try again" button #2065 added to
+	/// the offline variant generally) had no axe coverage anywhere - the plain
+	/// <see cref="HomePage_HasNoSeriousA11yViolations"/> scan above never
+	/// simulates a failure.
+	/// </summary>
+	[Test]
+	public async Task HomePage_LatestOpportunitiesOffline_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+		await Page.RouteAsync("**/v1/volunteer-opportunities*", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync(origin);
+		await Expect(Page.GetByTestId("landing-latest-offline"))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
 	[Test]
 	public async Task OrgAppUnknownOrganization_HasNoSeriousA11yViolations()
 	{

--- a/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
+++ b/backend/tests/VisualTests/ErrorBoundaryOfflineTests.cs
@@ -46,12 +46,17 @@ public class ErrorBoundaryOfflineTests(AspireFixture fixture) : VisualTestBase(f
 				.ToBeVisibleAsync(new() { Timeout = 20_000 });
 
 			// The two halves of the old behaviour, both gone: the generic crash
-			// screen, and a reload button that could not possibly succeed while
-			// still offline.
+			// screen, and its "Reload" button (which offers no acknowledgement
+			// the cause was connectivity).
 			await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Something went wrong" }))
 				.Not.ToBeVisibleAsync();
 			await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Reload" }))
 				.Not.ToBeVisibleAsync();
+			// #2065: the offline state's own "Try again" button - a real reload
+			// (see ErrorBoundary.tsx's onRetry), for a connection that comes back
+			// without the browser ever firing an `online` event.
+			await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+				.ToBeVisibleAsync();
 		}
 		finally
 		{

--- a/backend/tests/VisualTests/HomePageOfflineTests.cs
+++ b/backend/tests/VisualTests/HomePageOfflineTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #2065 (finding 1): LatestOpportunitiesSection removed itself
+/// on any failure, offline included - reasonable for a generic error (arguing
+/// against the hero directly above it), but wrong for offline, where every
+/// other offline-aware surface in the app (starting with #1774's
+/// /opportunities list) says so instead of silently vanishing. A visitor
+/// reloading the landing page with no connection used to see the hero promise
+/// "find an opportunity that fits you" and then nothing backing it up at all.
+///
+/// Simulated by pinning <c>navigator.onLine</c> false and aborting just the
+/// list request rather than by <c>Context.SetOfflineAsync</c>, because this
+/// suite blocks service workers (see <see cref="VisualTestBase.ContextOptions"/>),
+/// so a genuinely offline document navigation could not load the app shell at
+/// all - the same technique <c>OrgAppLayoutErrorStatesTests</c> uses for the
+/// org shell.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class HomePageOfflineTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task HomePage_WhileOffline_ShowsOfflineNoticeInsteadOfHidingTheSection()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+		// Single asterisk deliberately: it does not cross a `/`, so this only
+		// matches the list endpoint's own query string, not
+		// /volunteer-opportunities/{id} (see OfflineStateTests for the same note).
+		await Page.RouteAsync("**/v1/volunteer-opportunities*", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync(origin);
+
+		// The section itself (heading + "Browse all opportunities" link) still
+		// renders - only the grid of cards is replaced by the offline notice.
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "These opportunities need people" }))
+			.ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		var offline = Page.GetByTestId("landing-latest-offline");
+		await Expect(offline).ToBeVisibleAsync();
+		await Expect(offline).ToContainTextAsync("You are offline");
+
+		// #2065 added a manual retry alongside the offline notice - the
+		// fallback for a connection that comes back without the browser ever
+		// firing an `online` event, same as every other offline surface now
+		// offers.
+		await Expect(offline.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+			.ToBeVisibleAsync();
+
+		// The section degrades in place - it does not take the rest of the
+		// landing page down with it, and the "no evidence there is anything to
+		// find" hole this regression closes is specifically about this
+		// section, not the whole page.
+		await Expect(Page.GetByTestId("hero-keyword-input")).ToBeVisibleAsync();
+	}
+
+	[Test]
+	public async Task HomePage_WhenNoOpportunitiesButOnline_StillHidesTheSection()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		// A generic (non-offline) failure is deliberately left alone by #2065 -
+		// only the offline branch changed. Aborting with a plain HTTP 500
+		// response (not a transport-level "internetdisconnected") keeps
+		// `navigator.onLine` true and gives the request a real HTTP status, so
+		// useLoadMore's errorIsOffline reads false and the section still
+		// removes itself rather than arguing against the hero above it.
+		await Page.RouteAsync("**/v1/volunteer-opportunities*", async route =>
+		{
+			await route.FulfillAsync(new()
+			{
+				Status = 500,
+				ContentType = "application/json",
+				Headers = new Dictionary<string, string> { ["Access-Control-Allow-Origin"] = "*" },
+				Body = "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.6.1\",\"status\":500}",
+			});
+		});
+
+		await Page.GotoAsync(origin);
+
+		await Expect(Page.GetByTestId("hero-keyword-input")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByTestId("landing-latest-offline")).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByText("These opportunities need people")).Not.ToBeVisibleAsync();
+	}
+}

--- a/backend/tests/VisualTests/OfflineStateTests.cs
+++ b/backend/tests/VisualTests/OfflineStateTests.cs
@@ -13,8 +13,12 @@ namespace VisualTests;
 /// next to a "Retry" button that could not possibly succeed while the
 /// connection was down.
 ///
-/// The list now says it is offline, offers no action it cannot honour, and
-/// refetches by itself the moment the connection is back.
+/// The list now says it is offline and refetches by itself the moment the
+/// connection is back. #2065 added a manual "Try again" fallback on top of
+/// that: the automatic recovery depends on the browser firing an `online`
+/// event, which some captive portals and mobile networks never do even once
+/// the connection is genuinely back, and a manual retry that re-issues the
+/// same request can still succeed in exactly that case.
 ///
 /// Both tests reach <c>/opportunities</c> by clicking through the header nav
 /// rather than by <c>GotoAsync</c> while offline. That is deliberate on two
@@ -29,7 +33,7 @@ namespace VisualTests;
 public class OfflineStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	[Test]
-	public async Task OpportunityList_WhileOffline_SaysSoInsteadOfOfferingADeadRetry()
+	public async Task OpportunityList_WhileOffline_SaysSoAndOffersAManualRetryFallback()
 	{
 		var origin = await WarmOpportunitiesRouteThenLeaveAsync();
 
@@ -42,13 +46,16 @@ public class OfflineStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 			await Expect(offline).ToBeVisibleAsync(new() { Timeout = 20_000 });
 			await Expect(offline).ToContainTextAsync("You are offline");
 
-			// The two halves of the old behaviour, both gone: the generic
-			// server-error wording, and the retry that cannot succeed. The retry
-			// is asserted absent inside the offline block rather than page-wide,
-			// so this can't trip Playwright's strict mode on some unrelated
-			// control elsewhere in the chrome.
+			// The old generic server-error wording is gone. #2065: unlike the
+			// original #1774 design, a single "Try again" button is now offered
+			// alongside the offline notice - the fallback for a connection that
+			// came back without the browser ever firing an `online` event.
+			// Scoped to the offline block rather than page-wide, so this can't
+			// trip Playwright's strict mode on some unrelated control elsewhere
+			// in the chrome.
 			await Expect(Page.GetByTestId("opportunities-error")).Not.ToBeVisibleAsync();
-			await Expect(offline.GetByRole(AriaRole.Button)).ToHaveCountAsync(0);
+			await Expect(offline.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+				.ToHaveCountAsync(1);
 
 			// The announcement has to come from the list's own always-mounted
 			// sr-only region, not from a region inside the notice above: a
@@ -108,7 +115,46 @@ public class OfflineStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(offline).ToContainTextAsync("You are offline");
 
 		await Expect(Page.GetByTestId("opportunities-error")).Not.ToBeVisibleAsync();
-		await Expect(offline.GetByRole(AriaRole.Button)).ToHaveCountAsync(0);
+		await Expect(offline.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+			.ToHaveCountAsync(1);
+	}
+
+	/// <summary>
+	/// Regression for #2065's core scenario: a connection that came back
+	/// without the browser ever firing an <c>online</c> event (a captive
+	/// portal, some mobile networks). No <c>Context.SetOfflineAsync</c> and no
+	/// <c>online</c> DOM event anywhere in this test - recovery has to come
+	/// from the click alone, proving the manual retry does not depend on the
+	/// event-driven path the other tests in this class exercise.
+	/// </summary>
+	[Test]
+	public async Task OpportunityList_ManualRetry_SucceedsWithoutAnOnlineEvent()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		var shouldFail = true;
+		await Page.RouteAsync("**/v1/volunteer-opportunities*", async route =>
+		{
+			if (!shouldFail)
+			{
+				await route.ContinueAsync();
+				return;
+			}
+			await route.AbortAsync("internetdisconnected");
+		});
+
+		await Page.GotoAsync($"{origin}/opportunities");
+
+		var offline = Page.GetByTestId("opportunities-offline");
+		await Expect(offline).ToBeVisibleAsync(new() { Timeout = 20_000 });
+
+		shouldFail = false;
+		await offline.GetByRole(AriaRole.Button, new() { Name = "Try again" }).ClickAsync();
+
+		await Expect(offline).Not.ToBeVisibleAsync(new() { Timeout = 20_000 });
+		await Expect(Page.GetByTestId("opportunities-result-count"))
+			.ToHaveTextAsync(new Regex(@"opportunit(y|ies)"), new() { Timeout = 20_000 });
 	}
 
 	[Test]
@@ -128,8 +174,9 @@ public class OfflineStateTests(AspireFixture fixture) : VisualTestBase(fixture)
 			await Context.SetOfflineAsync(false);
 		}
 
-		// No click, no reload: the `online` event alone has to drive the
-		// recovery, because the offline state deliberately offers no action.
+		// No click, no reload: the `online` event alone drives the recovery here
+		// - the manual "Try again" button #2065 added is a fallback for when
+		// that event never fires, not a replacement for it.
 		await Expect(Page.GetByTestId("opportunities-offline"))
 			.Not.ToBeVisibleAsync(new() { Timeout = 20_000 });
 		await Expect(Page.GetByTestId("opportunities-error"))

--- a/backend/tests/VisualTests/OpportunityDetailOfflineTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailOfflineTests.cs
@@ -1,0 +1,119 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #2065 (finding 4): the opportunity detail page had no
+/// offline handling at all - a dropped connection fell into the same generic
+/// <c>LoadMoreError</c> branch as any other server failure, complete with a
+/// retry button that could not possibly succeed while the connection was
+/// down. It now renders the same dedicated offline <c>RouteState</c> every
+/// other offline-aware surface in the app already uses (#1774), plus the
+/// manual retry fallback #2065 added there too.
+///
+/// Simulated by pinning <c>navigator.onLine</c> false and aborting the detail
+/// request rather than by <c>Context.SetOfflineAsync</c>, because this suite
+/// blocks service workers (see <see cref="VisualTestBase.ContextOptions"/>),
+/// so a genuinely offline document navigation could not load the app shell at
+/// all - the same technique <c>OrgAppLayoutErrorStatesTests</c> uses for the
+/// org shell.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OpportunityDetailOfflineTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	private async Task<string> CreatePublishedOpportunityAsync(string label)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync(
+			"/v1/organizations", new { name = $"DetailOffline2065 {label} {suffix}" });
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = $"DetailOffline2065 {label} {suffix}",
+			descriptionDe = "Seeded for #2065 detail-page offline-state regression coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "IndividualContact",
+			checkInMethod = "None",
+			validUntil = DateTimeOffset.UtcNow.AddDays(30),
+			isDraft = false,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		return opportunity.GetProperty("id").GetString()!;
+	}
+
+	[Test]
+	public async Task OpportunityDetail_WhileOffline_ShowsOfflineState_NotAGenericError()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var opportunityId = await CreatePublishedOpportunityAsync("Generic");
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", route =>
+			route.AbortAsync("internetdisconnected"));
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByText("Error:", new() { Exact = false })).Not.ToBeVisibleAsync();
+		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" })).ToBeVisibleAsync();
+	}
+
+	/// <summary>
+	/// #2065's core scenario: a connection that came back without the browser
+	/// ever firing an <c>online</c> event. <c>navigator.onLine</c> stays pinned
+	/// false for the whole test - clicking "Try again" is the only thing that
+	/// can recover, proving the manual retry does not depend on that event.
+	/// </summary>
+	[Test]
+	public async Task OpportunityDetail_ManualRetry_SucceedsWithoutAnOnlineEvent()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var opportunityId = await CreatePublishedOpportunityAsync("ManualRetry");
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+
+		var shouldFail = true;
+		await Page.RouteAsync($"**/v1/volunteer-opportunities/{opportunityId}", async route =>
+		{
+			if (!shouldFail)
+			{
+				await route.ContinueAsync();
+				return;
+			}
+			await route.AbortAsync("internetdisconnected");
+		});
+
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+
+		var retryButton = Page.GetByRole(AriaRole.Button, new() { Name = "Try again" });
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(retryButton).ToBeVisibleAsync();
+
+		shouldFail = false;
+		await retryButton.ClickAsync();
+
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByTestId("opportunity-at-a-glance")).ToBeVisibleAsync();
+	}
+}

--- a/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
+++ b/backend/tests/VisualTests/OrgAppLayoutErrorStatesTests.cs
@@ -107,16 +107,21 @@ public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBas
 
 	/// <summary>
 	/// #1774 F33, org-shell half: with no connection the org request fails like
-	/// any other transport error, but calling that "an unexpected error" and
-	/// offering a retry is a lie - the retry cannot succeed until the connection
-	/// is back. Simulated by pinning <c>navigator.onLine</c> false and aborting
-	/// the org request rather than by <c>Context.SetOfflineAsync</c>, because
-	/// this suite blocks service workers (see VisualTestBase.ContextOptions), so
-	/// a genuinely offline document navigation could not load the app shell at
-	/// all - the very thing the precache makes work in production.
+	/// any other transport error, but calling that "an unexpected error" is a
+	/// lie regardless. Simulated by pinning <c>navigator.onLine</c> false and
+	/// aborting the org request rather than by <c>Context.SetOfflineAsync</c>,
+	/// because this suite blocks service workers (see
+	/// VisualTestBase.ContextOptions), so a genuinely offline document
+	/// navigation could not load the app shell at all - the very thing the
+	/// precache makes work in production.
+	///
+	/// #2065 added a "Try again" button to this screen on top of the existing
+	/// automatic <c>online</c>-event recovery (see the misreport variant below,
+	/// which stays event-driven) - a fallback for a connection that comes back
+	/// without the browser ever firing that event.
 	/// </summary>
 	[Test]
-	public async Task OrgShellWhileOffline_ShowsOfflineState_WithoutARetryThatCannotWork()
+	public async Task OrgShellWhileOffline_ShowsOfflineState_WithAManualRetryFallback()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
@@ -136,7 +141,7 @@ public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBas
 		await Expect(Page.GetByText("An unexpected error occurred", new() { Exact = false }))
 			.Not.ToBeVisibleAsync();
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
-			.Not.ToBeVisibleAsync();
+			.ToBeVisibleAsync();
 	}
 
 	/// <summary>
@@ -169,7 +174,55 @@ public class OrgAppLayoutErrorStatesTests(AspireFixture fixture) : VisualTestBas
 			.ToBeVisibleAsync(new() { Timeout = 15_000 });
 		await Expect(Page.GetByText("An unexpected error occurred", new() { Exact = false }))
 			.Not.ToBeVisibleAsync();
+		// #2065: the offline screen's manual retry fallback renders regardless
+		// of which signal decided the state was offline.
 		await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Try again" }))
+			.ToBeVisibleAsync();
+	}
+
+	/// <summary>
+	/// #2065's core scenario: a connection that came back without the browser
+	/// ever firing an <c>online</c> event. <c>navigator.onLine</c> stays pinned
+	/// false for the whole test (unlike the other offline tests above, nothing
+	/// here ever flips it or fires the event) - clicking "Try again" is the
+	/// only thing that can recover, proving the manual fallback works
+	/// independently of the event-driven path.
+	/// </summary>
+	[Test]
+	public async Task OrgShellWhileOffline_ManualRetry_SucceedsWithoutAnOnlineEvent()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var organizationId = await CreateOrganizationAsync("OrgOfflineManualRetry");
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+
+		await Page.AddInitScriptAsync(
+			"Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });");
+
+		var shouldFail = true;
+		await Page.RouteAsync($"**/v1/organizations/{organizationId}", async route =>
+		{
+			if (route.Request.Method != "GET" || !shouldFail)
+			{
+				await route.ContinueAsync();
+				return;
+			}
+			await route.AbortAsync("internetdisconnected");
+		});
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+
+		var retryButton = Page.GetByRole(AriaRole.Button, new() { Name = "Try again" });
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
+			.ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(retryButton).ToBeVisibleAsync();
+
+		shouldFail = false;
+		await retryButton.ClickAsync();
+
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "You are offline" }))
 			.Not.ToBeVisibleAsync();
 	}
 

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -91,6 +91,11 @@ export default class ErrorBoundary extends Component<Props, State> {
 						variant="offline"
 						title={t("routeState.offline.title")}
 						message={t("routeState.offline.message")}
+						// A real reload, not a state reset (#2065's fallback for a
+						// connection that came back without the browser firing
+						// `online`) - see componentDidMount for why React.lazy()'s
+						// cached rejection needs exactly that.
+						onRetry={() => window.location.reload()}
 					/>
 				);
 			}

--- a/frontend/src/components/LatestOpportunitiesSection.tsx
+++ b/frontend/src/components/LatestOpportunitiesSection.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { VolunteerOpportunitySummary } from "../client/api-client";
 import OpportunityListItem from "./VolunteerOpportunitiesList/OpportunityListItem";
+import RouteState from "./RouteState";
 import Skeleton from "./Skeleton";
 import { useApiClient } from "../hooks/useApiClient";
 import { useLoadMore } from "../hooks/useLoadMore";
@@ -42,21 +43,24 @@ export default function LatestOpportunitiesSection() {
 	// (VolunteerOpportunityReadRepository sorts on CreatedOn descending), so
 	// the heading says "just published" rather than claiming these are the
 	// soonest or the nearest.
-	// No getErrorMessage override: nothing here renders the message. A failure
-	// removes the section (see below), so translating the error would produce a
-	// string with nowhere to go.
-	const { items, loading, error } = useLoadMore<VolunteerOpportunitySummary>(
-		(pageNumber) =>
+	// No getErrorMessage override: nothing here renders a generic error message
+	// (see below, a non-offline failure removes the section entirely), so
+	// translating one would produce a string with nowhere to go.
+	const { items, loading, error, errorIsOffline, retryLoadMore } =
+		useLoadMore<VolunteerOpportunitySummary>((pageNumber) =>
 			fetchVolunteerOpportunities(api, { pageNumber, pageSize: PREVIEW_COUNT }),
-	);
+		);
 
-	// The section removes itself rather than rendering an empty state or an
-	// error box. Both would argue against the hero directly above them - a
-	// landing page that opens with "find an opportunity" and immediately
-	// reports that there are none, or that something broke, is worse than one
-	// that simply doesn't raise the subject. /opportunities is where a visitor
-	// gets the real empty state and a retry.
-	if (error || (!loading && items.length === 0)) return null;
+	// A generic failure still removes the section rather than rendering an
+	// error box - that would argue against the hero directly above it, and
+	// /opportunities is where a visitor gets the real error state and a retry.
+	// Offline is different (#2065): the section used to vanish then too, which
+	// on a reload with no connection threw away the one piece of evidence this
+	// page gives that there is anything to find, with no explanation - unlike
+	// /opportunities, which has said so since #1774. An empty result (no error,
+	// zero items) still removes the section either way.
+	if ((error && !errorIsOffline) || (!loading && items.length === 0))
+		return null;
 
 	return (
 		<section aria-labelledby={titleId} className="mb-20">
@@ -85,7 +89,29 @@ export default function LatestOpportunitiesSection() {
 				</Link>
 			</div>
 
-			{loading && items.length === 0 ? (
+			{/* Always mounted, not conditional on the message - registered before
+			the connection ever drops so writing into it on the offline transition
+			actually announces (a role="status" node inserted into the DOM already
+			populated does not reliably announce; see RouteState's own comment on
+			this and OpportunityResultsList's identical pattern for the
+			/opportunities list, #2065). RouteState's offline variant carries no
+			live region of its own by design - announcing the transition is left
+			to the caller, and unlike the list this section previously had
+			nothing else nearby that could double as one. */}
+			<p role="status" className="sr-only">
+				{error && errorIsOffline ? t("landing.offline") : ""}
+			</p>
+
+			{error && errorIsOffline ? (
+				<RouteState
+					inline
+					variant="offline"
+					title={t("routeState.offline.title")}
+					message={t("landing.offline")}
+					onRetry={retryLoadMore}
+					data-testid="landing-latest-offline"
+				/>
+			) : loading && items.length === 0 ? (
 				<div className={GRID_CLASS}>
 					{Array.from({ length: PREVIEW_COUNT }).map((_, i) => (
 						<div

--- a/frontend/src/components/LatestOpportunitiesSection.tsx
+++ b/frontend/src/components/LatestOpportunitiesSection.tsx
@@ -58,8 +58,12 @@ export default function LatestOpportunitiesSection() {
 	// on a reload with no connection threw away the one piece of evidence this
 	// page gives that there is anything to find, with no explanation - unlike
 	// /opportunities, which has said so since #1774. An empty result (no error,
-	// zero items) still removes the section either way.
-	if ((error && !errorIsOffline) || (!loading && items.length === 0))
+	// zero items) still removes the section either way - the `!error` here is
+	// deliberate: useLoadMore's own contract is "items is empty whenever error
+	// is set" (see UseLoadMoreResult.error), so without it this branch would
+	// fire for the offline case too (items is empty then as well) and hide the
+	// offline notice this whole guard exists to keep visible.
+	if ((error && !errorIsOffline) || (!loading && !error && items.length === 0))
 		return null;
 
 	return (
@@ -99,7 +103,9 @@ export default function LatestOpportunitiesSection() {
 			to the caller, and unlike the list this section previously had
 			nothing else nearby that could double as one. */}
 			<p role="status" className="sr-only">
-				{error && errorIsOffline ? t("landing.offline") : ""}
+				{error && errorIsOffline
+					? `${t("routeState.offline.title")}. ${t("landing.offline")}`
+					: ""}
 			</p>
 
 			{error && errorIsOffline ? (

--- a/frontend/src/components/RouteState.tsx
+++ b/frontend/src/components/RouteState.tsx
@@ -44,11 +44,14 @@ interface Props {
 	title: string;
 	message: string;
 	/**
-	 * Honoured for `error` only - the one variant where trying the same thing
-	 * again can actually work. A 403/404 is permanent, and retrying while
-	 * offline is guaranteed to fail, so those two recover by other means (see
-	 * the `online`-event refetches in OrgAppLayout and useLoadMore) rather
-	 * than by handing the user a button that does nothing.
+	 * Honoured for `error` and `offline` - not `notFound`/`forbidden`, which
+	 * name a permanent fact about the request that retrying cannot change.
+	 * `offline` already recovers on its own via the `online`-event refetches
+	 * in OrgAppLayout and useLoadMore, but that path depends on the browser
+	 * actually firing the event - which some captive portals and mobile
+	 * networks never do even once the connection is genuinely back (#2065).
+	 * This is the manual fallback for exactly that case, so callers should
+	 * still pass it for `offline` rather than relying on the event alone.
 	 */
 	onRetry?: () => void;
 	/** Escape hatch out of a dead end - rendered as a real link, not a button. */
@@ -73,7 +76,7 @@ export default function RouteState({
 }: Props) {
 	const { t } = useTranslation();
 	const Icon = VARIANT_ICONS[variant];
-	const canRetry = variant === "error" && !!onRetry;
+	const canRetry = (variant === "error" || variant === "offline") && !!onRetry;
 	// A route-level state is the page, so it owns the tab title - the
 	// unknown-organization branch used to get this for free from NotFoundPage,
 	// and /administration as a non-admin never had it at all (the page whose

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -118,7 +118,9 @@ export default function OpportunityResultsList({
 			and then used to throw all of that away by reporting "an unexpected
 			error occurred" here, next to a retry button that could not succeed
 			while the connection was down. useLoadMore refetches on its own once
-			the connection returns, so this state needs no action at all. */}
+			the connection returns, so this state needs no action - the retry
+			button below is only a fallback for a connection that came back
+			without the browser ever firing an `online` event (#2065). */}
 			{error &&
 				(errorIsOffline ? (
 					<RouteState
@@ -126,6 +128,7 @@ export default function OpportunityResultsList({
 						variant="offline"
 						title={t("routeState.offline.title")}
 						message={t("opportunities.offline")}
+						onRetry={onRetryLoadMore}
 						data-testid="opportunities-offline"
 					/>
 				) : (
@@ -173,6 +176,7 @@ export default function OpportunityResultsList({
 									variant="offline"
 									title={t("routeState.offline.title")}
 									message={t("opportunities.offlineLoadMore")}
+									onRetry={onRetryLoadMore}
 									data-testid="opportunities-offline-load-more"
 								/>
 							) : (

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -50,8 +50,17 @@ export default function OpportunityResultsList({
 	// This one was mounted and empty long before the connection dropped, so
 	// writing into it does. An *online* failure stays silent here: it renders
 	// LoadMoreError, whose ErrorBanner is already role="alert".
+	//
+	// Prefixed with routeState.offline.title rather than just
+	// opportunities.offline (#2065 trimmed that string's own "You are
+	// offline." lead-in, since the visible RouteState notice already carries
+	// it as its own heading) - this node has no heading next to it, so the
+	// announcement needs to say so itself or a screen reader hears only "we
+	// will load the opportunities..." with no indication why.
 	const liveMessage =
-		error && errorIsOffline ? t("opportunities.offline") : countMessage;
+		error && errorIsOffline
+			? `${t("routeState.offline.title")}. ${t("opportunities.offline")}`
+			: countMessage;
 
 	return (
 		<>

--- a/frontend/src/layouts/OrgAppLayout.tsx
+++ b/frontend/src/layouts/OrgAppLayout.tsx
@@ -239,10 +239,11 @@ export default function OrgAppLayout() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [organizationId]);
 
-	// The offline state deliberately has no retry button, so regaining the
-	// connection is what has to drive the recovery (#1774). Scoped to a failed
-	// load: a shell that is already showing an organization is never refetched
-	// out from under the user just because a tunnel ended.
+	// The primary recovery path stays the `online` event, not the offline
+	// state's manual retry button (#2065) - it needs no click and covers the
+	// common case. Scoped to a failed load: a shell that is already showing an
+	// organization is never refetched out from under the user just because a
+	// tunnel ended.
 	useEffect(() => {
 		if (online && status === "error") load();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -323,6 +324,7 @@ export default function OrgAppLayout() {
 					variant="offline"
 					title={t("routeState.offline.title")}
 					message={t("routeState.offline.message")}
+					onRetry={load}
 					action={backToSite}
 				/>
 			),

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -65,6 +65,7 @@
       "latestLabel": "Gerade veröffentlicht",
       "latestTitle": "Diese Einsätze suchen Leute",
       "latestLink": "Alle Einsätze ansehen",
+      "offline": "Sobald deine Verbindung zurück ist, zeigen wir diese Einsätze wieder.",
       "missionLabel": "Vom Gründer",
       "missionTitle": "Warum ich Einsatzbereit gebaut habe",
       "missionText": "Ehrenamt sollte nicht an Papierkram scheitern. Ich habe immer wieder erlebt, wie Leute helfen wollten und an Anmeldeformularen, Wartelisten oder schlicht fehlenden Einstiegspunkten gescheitert sind. Einsatzbereit nimmt jede dieser Hürden weg: Mikro-Ehrenamt, das in eine echte Woche passt - kostenlos, ohne Wartelisten, komplett open source.",
@@ -104,8 +105,8 @@
       "searchPlaceholder": "Organisationen nach Namen suchen…",
       "loading": "Organisationen werden geladen…",
       "error": "Fehler: {{message}}",
-      "offline": "Du bist offline. Sobald deine Verbindung zurück ist, laden wir die Organisationen.",
-      "offlineLoadMore": "Du bist offline. Das sind die Organisationen, die vor dem Verbindungsabbruch geladen wurden - den Rest holen wir, sobald du wieder online bist.",
+      "offline": "Sobald deine Verbindung zurück ist, laden wir die Organisationen.",
+      "offlineLoadMore": "Das sind die Organisationen, die vor dem Verbindungsabbruch geladen wurden - den Rest holen wir, sobald du wieder online bist.",
       "noResults": "Keine Organisationen gefunden.",
       "noResultsWithSearch": "Keine Organisationen gefunden für \"{{search}}\".",
       "clearSearch": "Suche zurücksetzen",
@@ -238,8 +239,9 @@
       "factWhen": "Wann",
       "factFormat": "Ablauf",
       "factWhere": "Wo",
-      "offline": "Du bist offline. Sobald deine Verbindung zurück ist, laden wir die Einsätze.",
-      "offlineLoadMore": "Du bist offline. Das sind die Einsätze, die vor dem Verbindungsabbruch geladen wurden - den Rest holen wir, sobald du wieder online bist."
+      "offline": "Sobald deine Verbindung zurück ist, laden wir die Einsätze.",
+      "offlineLoadMore": "Das sind die Einsätze, die vor dem Verbindungsabbruch geladen wurden - den Rest holen wir, sobald du wieder online bist.",
+      "offlineDetail": "Sobald deine Verbindung zurück ist, laden wir diese Seite erneut."
     },
     "createOpportunity": {
       "title": "Einsatz erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -65,6 +65,7 @@
       "latestLabel": "Just published",
       "latestTitle": "These opportunities need people",
       "latestLink": "Browse all opportunities",
+      "offline": "We will show these opportunities again as soon as your connection is back.",
       "missionLabel": "From the founder",
       "missionTitle": "Why I built Einsatzbereit",
       "missionText": "Volunteering shouldn't require paperwork. I kept watching people who wanted to help get stuck on registration forms, waitlists, or simply not knowing where to start. Einsatzbereit removes every one of those barriers: micro-volunteering that fits into a real week - free, no waiting lists, and fully open source.",
@@ -104,8 +105,8 @@
       "searchPlaceholder": "Search organizations by name…",
       "loading": "Loading organizations…",
       "error": "Error: {{message}}",
-      "offline": "You are offline. We will load the organizations as soon as your connection is back.",
-      "offlineLoadMore": "You are offline. These are the organizations that loaded before the connection dropped - we will fetch the rest as soon as you are back online.",
+      "offline": "We will load the organizations as soon as your connection is back.",
+      "offlineLoadMore": "These are the organizations that loaded before the connection dropped - we will fetch the rest as soon as you are back online.",
       "noResults": "No organizations found.",
       "noResultsWithSearch": "No organizations match \"{{search}}\".",
       "clearSearch": "Clear search",
@@ -238,8 +239,9 @@
       "factWhen": "When",
       "factFormat": "How it works",
       "factWhere": "Where",
-      "offline": "You are offline. We will load the opportunities as soon as your connection is back.",
-      "offlineLoadMore": "You are offline. These are the opportunities that loaded before the connection dropped - we will fetch the rest as soon as you are back online."
+      "offline": "We will load the opportunities as soon as your connection is back.",
+      "offlineLoadMore": "These are the opportunities that loaded before the connection dropped - we will fetch the rest as soon as you are back online.",
+      "offlineDetail": "We will load this page again as soon as your connection is back."
     },
     "createOpportunity": {
       "title": "Create opportunity",

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -185,6 +185,7 @@ export default function OrganizationsPage() {
 						variant="offline"
 						title={t("routeState.offline.title")}
 						message={t("organizationsPage.offline")}
+						onRetry={retryLoadMore}
 						data-testid="organizations-offline"
 					/>
 				) : (
@@ -295,6 +296,7 @@ export default function OrganizationsPage() {
 									variant="offline"
 									title={t("routeState.offline.title")}
 									message={t("organizationsPage.offlineLoadMore")}
+									onRetry={retryLoadMore}
 									data-testid="organizations-offline-load-more"
 								/>
 							) : (

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -8,6 +8,7 @@ import type {
 	VolunteerOpportunityDetails,
 } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
+import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import {
 	computeSpotsLeft,
 	formatDate,
@@ -40,7 +41,7 @@ import PublicOpportunityCard from "../components/PublicOpportunityCard";
 import RouteState from "../components/RouteState";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { dispatchToast } from "../lib/toastBus";
-import { getApiErrorMessage } from "../lib/apiError";
+import { getApiErrorMessage, isNetworkError } from "../lib/apiError";
 import { signinLocaleArgs } from "../lib/authLocale";
 import { cardClass } from "../lib/surfaceClasses";
 import {
@@ -143,6 +144,13 @@ export default function VolunteerOpportunityDetailPage() {
 	);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	// #2065: whether `error` came from a request that never got an HTTP
+	// response at all - the same offline signal useLoadMore/OrgAppLayout use,
+	// since `navigator.onLine` alone can misreport `true` right after a hard
+	// reload while genuinely offline (#1901).
+	const [errorIsNetworkFailure, setErrorIsNetworkFailure] = useState(false);
+	const online = useOnlineStatus();
+	const errorIsOffline = error !== null && (!online || errorIsNetworkFailure);
 	const [showSignUp, setShowSignUp] = useState(false);
 	const [showReport, setShowReport] = useState(false);
 	const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
@@ -233,6 +241,7 @@ export default function VolunteerOpportunityDetailPage() {
 		const requestId = ++latestRequestRef.current;
 		setLoading(true);
 		setError(null);
+		setErrorIsNetworkFailure(false);
 		api
 			.getVolunteerOpportunityDetails(opportunityId)
 			.then((details) => {
@@ -242,6 +251,7 @@ export default function VolunteerOpportunityDetailPage() {
 			.catch((err) => {
 				if (requestId !== latestRequestRef.current) return;
 				setError(getApiErrorMessage(err, t("error.serverError")));
+				setErrorIsNetworkFailure(isNetworkError(err));
 			})
 			.finally(() => {
 				if (requestId !== latestRequestRef.current) return;
@@ -309,7 +319,20 @@ export default function VolunteerOpportunityDetailPage() {
 			</div>
 		);
 	if (error)
-		return (
+		return errorIsOffline ? (
+			// #2065: this page had no offline handling at all - a dropped
+			// connection fell into the generic error branch below, with a retry
+			// button that could not succeed while the connection was down. Not
+			// `inline`: unlike OpportunityResultsList's offline notice, this
+			// replaces the whole route rather than one section of a page that
+			// already owns an <h1>.
+			<RouteState
+				variant="offline"
+				title={t("routeState.offline.title")}
+				message={t("opportunities.offlineDetail")}
+				onRetry={load}
+			/>
+		) : (
 			<LoadMoreError
 				message={t("opportunities.error", { message: error })}
 				// load() unconditionally flips `loading` back to true, so the


### PR DESCRIPTION
- Homepage's "latest opportunities" section now shows the shared offline state instead of silently disappearing, matching /opportunities.
- Dropped a redundant "You are offline" prefix that repeated the RouteState title verbatim in several offline messages.
- RouteState's offline variant now honours a manual retry action too, so a connection that comes back without the browser firing an `online` event (captive portals, some mobile networks) isn't a dead end.
- Opportunity detail page shows the offline state instead of a generic error when the connection drops.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2065

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
