### PR TITLE
fix: size card grids to their container instead of the viewport

### DIFF
--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -256,7 +256,14 @@ export default function ActivitySection() {
 	}
 
 	return (
-		<section id="activity" className="mb-6">
+		// @container (#2044): this section's own width is capped by the
+		// [11rem_minmax(0,1fr)] sidebar layout in MyEngagementsPage/index.tsx to
+		// ~800px regardless of viewport, but the card grids below used to key
+		// their column count off the viewport (`xl:grid-cols-3` at 1280px) - so a
+		// wide-viewport visitor got 3 columns squeezed into that fixed 800px,
+		// wrapping card titles and dates that fit fine at 2 columns. `@container`
+		// variants below key off this element's actual width instead.
+		<section id="activity" className="@container mb-6">
 			{invitationsError && (
 				<ErrorBanner message={invitationsError} className="mb-4" />
 			)}
@@ -268,7 +275,7 @@ export default function ActivitySection() {
 					<SectionHeading>
 						{t("profileOverview.invitationsHeading")}
 					</SectionHeading>
-					<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					<ul className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:grid-cols-3">
 						{invitations.map((inv) => (
 							<li
 								key={inv.id}
@@ -388,7 +395,7 @@ export default function ActivitySection() {
 			{engagementsLoading && (
 				<div
 					role="status"
-					className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+					className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:grid-cols-3"
 				>
 					<span className="sr-only">{t("myEngagements.loading")}</span>
 					{Array.from({ length: 3 }).map((_, i) => (
@@ -428,7 +435,7 @@ export default function ActivitySection() {
 				))}
 
 			{!engagementsLoading && !engagementsError && engagements.length > 0 && (
-				<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				<ul className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:grid-cols-3">
 					{engagements.map((e) => (
 						<li
 							key={e.id}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -975,15 +975,20 @@ export default function VolunteerOpportunityDetailPage() {
 					</div>
 				</div>
 
-				{/* More from this organization - a wider grid than the reading
-			column above so a third card doesn't orphan onto its own row on
-			desktop (#1727). */}
+				{/* More from this organization - held to the same max-w-2xl measure
+			as the reading column above (#2044). #1727 had let this section span
+			the full outer wrapper so a third card wouldn't orphan onto its own
+			row, but that put a 1152px-wide block directly below a 672px-wide
+			column on the same scroll, reading as two different pages stacked.
+			One measure for the whole page wins over the marginally roomier grid -
+			dropping the xl:grid-cols-3 step rather than keeping a column count
+			this measure can no longer fit without squeezing each card. */}
 				{otherOrgOpportunities.length > 0 && (
-					<div className="mb-6" data-testid="more-from-organization">
+					<div className="mb-6 max-w-2xl" data-testid="more-from-organization">
 						<SectionHeading>
 							{t("opportunities.moreFromOrganization")}
 						</SectionHeading>
-						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 							{otherOrgOpportunities.map((opp) => (
 								<PublicOpportunityCard key={opp.id} opportunity={opp} />
 							))}


### PR DESCRIPTION
xl:grid-cols-3 fired at 1280px viewport width regardless of the actual container width. On /my-signups the sidebar layout caps the content column to ~800px, so wide-viewport visitors got 3 columns squeezed into that fixed width and card text wrapped. Switch ActivitySection's three grids to Tailwind 4 container queries (@container/@sm/@4xl) so column count follows the column's real width.

Also caps the opportunity detail page's "more from this organization" section to the same max-w-2xl measure as the reading column above it, instead of the wider outer wrapper - the page previously flipped between two different content widths (672px vs 1152px) on one scroll.

Fixes #2044

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
