### PR TITLE
fix: attach returnTo state to Header's sign-in/register redirects

### DIFF
--- a/backend/tests/VisualTests/AuthGuardTests.cs
+++ b/backend/tests/VisualTests/AuthGuardTests.cs
@@ -52,6 +52,35 @@ public class AuthGuardTests(AspireFixture fixture) : VisualTestBase(fixture)
 			.Not.ToBeVisibleAsync();
 	}
 
+	// Regression for #2049: Header's own "Sign in" button used to call
+	// signinRedirect() with no `state`, unlike ProtectedRoute and
+	// useSessionExpiryHandler - so a visitor who signed in from anywhere other
+	// than "/" was always bounced back to the home page instead of where they
+	// started (main.tsx's onSigninCallback falls back to "/" when
+	// user.state.returnTo is absent).
+	[Test]
+	public async Task Header_SignIn_FromNonHomePage_ReturnsToOriginatingPage()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+
+		await AuthHelper.AllowKeycloakCrossOriginRequestsAsync(Page);
+
+		await Page.GotoAsync($"{frontend}opportunities");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "Sign in" }).First.ClickAsync();
+
+		await Page.Locator("#username").WaitForAsync(new() { Timeout = 30_000 });
+		await Page.Locator("#username").FillAsync("vera");
+		await Page.Locator("#password").FillAsync("vera123");
+		await Page.Locator("#kc-login").ClickAsync();
+
+		await Page.GetByRole(AriaRole.Button, new() { Name = "User menu" })
+			.WaitForAsync(new() { Timeout = 45_000 });
+
+		await Expect(Page).ToHaveURLAsync(new Regex(@"/opportunities$"));
+	}
+
 	[Test]
 	public async Task Header_Anonymous_ShowsSignInButton()
 	{

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
-import { useNavigate, Link } from "react-router";
+import { useLocation, useNavigate, Link } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
 import { useMyOrganizations } from "../../hooks/useMyOrganizations";
@@ -31,6 +31,7 @@ export default function Header({
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const isLoggedIn = auth.isAuthenticated;
 	const user = auth.user?.profile;
 	const displayName = (user?.name ??
@@ -100,11 +101,17 @@ export default function Header({
 	}
 
 	function handleSignIn() {
-		auth.signinRedirect(signinLocaleArgs());
+		auth.signinRedirect({
+			...signinLocaleArgs(),
+			state: { returnTo: location.pathname + location.search },
+		});
 	}
 
 	function handleRegister() {
-		void signinRedirectForRegistration(signinLocaleArgs());
+		void signinRedirectForRegistration({
+			...signinLocaleArgs(),
+			state: { returnTo: location.pathname + location.search },
+		});
 	}
 
 	function handleSignOut() {


### PR DESCRIPTION
Header's own signinRedirect/signinRedirectForRegistration calls omitted the state param that ProtectedRoute and useSessionExpiryHandler already pass, so a login started from the header always landed on / regardless of where the visitor was.

Fixes #2049.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2049

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
