### PR TITLE
fix(frontend): percent-encode spaces in select chevron data URI

### DIFF
--- a/frontend/src/lib/formClasses.test.ts
+++ b/frontend/src/lib/formClasses.test.ts
@@ -4,6 +4,7 @@ import {
 	inputClass,
 	textareaClass,
 	labelClass,
+	selectClass,
 } from "./formClasses";
 
 describe("formClasses", () => {
@@ -41,5 +42,27 @@ describe("formClasses", () => {
 	it("keeps labelClass a small muted label style", () => {
 		expect(labelClass).toContain("text-xs");
 		expect(labelClass).toContain("text-gray-600");
+	});
+
+	it("keeps the select chevron's data URI free of raw whitespace Tailwind can't parse (#2051)", () => {
+		// Tailwind splits utility candidates on whitespace, so a raw space
+		// inside this arbitrary value silently drops the whole bg-[url(...)]
+		// class from the generated CSS - the chevron then never renders.
+		const urlToken = selectClass.match(/bg-\[url\('([^']+)'\)\]/);
+		expect(urlToken).not.toBeNull();
+		const dataUri = urlToken?.[1] ?? "";
+		expect(dataUri).not.toBe("");
+		expect(/\s/.test(dataUri)).toBe(false);
+
+		// Guard against swapping in underscores instead: Tailwind detects
+		// url(...) arbitrary values and, unlike other arbitrary values,
+		// leaves underscores as literal underscores rather than converting
+		// them to spaces - which would corrupt the SVG markup below.
+		const svgMarkup = decodeURIComponent(
+			dataUri.slice(dataUri.indexOf(",") + 1),
+		);
+		const doc = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
+		expect(doc.querySelector("parsererror")).toBeNull();
+		expect(doc.querySelector("svg")).not.toBeNull();
 	});
 });

--- a/frontend/src/lib/formClasses.ts
+++ b/frontend/src/lib/formClasses.ts
@@ -25,6 +25,6 @@ export const textareaClass = `${inputClass} resize-y`;
 // styled inputs. appearance-none plus an inline chevron gives them the same
 // surface as everything else; bg-position keeps the chevron clear of the
 // text on both paddings.
-export const selectClass = `${inputClass} appearance-none bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat pr-9 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 fill=%22none%22 viewBox=%220 0 24 24%22 stroke-width=%221.5%22 stroke=%22%236b7280%22%3E%3Cpath stroke-linecap=%22round%22 stroke-linejoin=%22round%22 d=%22m19.5 8.25-7.5 7.5-7.5-7.5%22/%3E%3C/svg%3E')]`;
+export const selectClass = `${inputClass} appearance-none bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat pr-9 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20fill=%22none%22%20viewBox=%220%200%2024%2024%22%20stroke-width=%221.5%22%20stroke=%22%236b7280%22%3E%3Cpath%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20d=%22m19.5%208.25-7.5%207.5-7.5-7.5%22/%3E%3C/svg%3E')]`;
 
 export const labelClass = "block text-xs font-medium text-gray-600";


### PR DESCRIPTION
Raw unescaped spaces inside the bg-[url(...)] arbitrary value broke Tailwind's whitespace-delimited class-candidate scanner, so the chevron utility never made it into the generated CSS - native <select> elements rendered with no dropdown arrow. Underscores (the usual Tailwind escape for spaces in arbitrary values) don't work here either, since Tailwind leaves underscores literal inside url(...) values to avoid mangling real URLs. Percent-encoding the spaces as %20 keeps the token whitespace-free and decodes back to valid SVG.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2051

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
