### PR TITLE
fix: move sticky sign-up rail earlier in DOM so it isn't the 8th tab stop

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -168,6 +168,97 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 	}
 
 	[Test]
+	public async Task VolunteerOpportunityDetailPage_SignUpCta_IsReachableBeforeReportButton()
+	{
+		// #2050: the desktop sticky rail holding the primary sign-up CTA was the
+		// last child of its two-column grid (put there for #1755's layout), even
+		// though CSS placed it visually in the right-hand column - so a keyboard
+		// user had to tab through the report button, the map, its Leaflet
+		// attribution links and the organization's contact links (7 stops) before
+		// ever reaching the CTA. Fixed by making the <aside> the *first* child of
+		// the grid and pinning both children back to their original visual
+		// column/row with explicit grid placement (lg:col-start-*/lg:row-start-*),
+		// decoupling DOM/focus order from visual order. Axe has no rule for a
+		// DOM-order-vs-visual-order mismatch (WCAG 2.4.3 Focus Order is exactly
+		// the kind of thing axe-core documents as untestable), so this asserts
+		// the fact directly the same way HomePage_SkipLink_MovesFocusToMainContent
+		// above does for the skip link.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var olafToken = (await Fixture.SignInAsync("olaf", "olaf123")).AccessToken;
+		using var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
+
+		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new
+		{
+			name = $"A11y Focus Order Org {suffix}",
+			contactEmail = "contact@example.org",
+			contactPhone = "+49 30 1234567",
+			website = "https://example.org",
+		});
+		orgResponse.EnsureSuccessStatusCode();
+		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
+
+		var oppResponse = await http.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		{
+			titleDe = $"A11y Focus Order Test {suffix}",
+			descriptionDe = "Seeded for #2050 focus-order coverage.",
+			organizationId,
+			isRemote = true,
+			occurrence = "OneTime",
+			participationType = "ScheduledSlots",
+			checkInMethod = "None",
+			isDraft = true,
+		});
+		oppResponse.EnsureSuccessStatusCode();
+		var opportunity = await oppResponse.Content.ReadFromJsonAsync<JsonElement>();
+		var opportunityId = opportunity.GetProperty("id").GetString();
+
+		var start = DateTimeOffset.UtcNow.AddDays(5);
+		(await http.PostAsJsonAsync($"/v1/volunteer-opportunities/{opportunityId}/time-slots", new
+		{
+			startDateTime = start,
+			endDateTime = start.AddHours(2),
+			maxParticipants = 5,
+			recurrenceCount = 1,
+		})).EnsureSuccessStatusCode();
+
+		(await http.PostAsync($"/v1/volunteer-opportunities/{opportunityId}/publish", content: null))
+			.EnsureSuccessStatusCode();
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "vera", "vera123");
+		await Page.GotoAsync($"{origin}/volunteer-opportunities/{opportunityId}");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		// Proves the states this regression depends on actually rendered: the
+		// report button (Vera is signed in and not the owner) and the sign-up CTA.
+		await Expect(Page.GetByTestId("report-opportunity")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		var ctaButton = Page.GetByTestId("signup-cta").GetByRole(AriaRole.Button);
+		await Expect(ctaButton).ToBeVisibleAsync();
+
+		// Same skip-link jump as HomePage_SkipLink_MovesFocusToMainContent, so
+		// the count below starts from <main> rather than depending on how many
+		// links the Header itself happens to have.
+		await Page.Keyboard.PressAsync("Tab");
+		var skipLink = Page.GetByRole(AriaRole.Link, new() { Name = "Skip to content" });
+		await Expect(skipLink).ToBeFocusedAsync();
+		await Page.Keyboard.PressAsync("Enter");
+		await Expect(Page.Locator("#main-content")).ToBeFocusedAsync();
+
+		// First stop inside <main> is the organization link in the page's
+		// eyebrow; the second must be the sign-up CTA now that the rail is the
+		// grid's first child - not the report button, which sits later in the
+		// reading column.
+		await Page.Keyboard.PressAsync("Tab");
+		await Page.Keyboard.PressAsync("Tab");
+		await Expect(ctaButton).ToBeFocusedAsync();
+	}
+
+	[Test]
 	public async Task VolunteerOpportunityDetailPage_OwnerDraft_AsOlaf_HasNoSeriousA11yViolations()
 	{
 		// #1027: the draftBadge chip plus owner-only Edit/Publish actions

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -380,13 +380,13 @@ export default function VolunteerOpportunityDetailPage() {
 
 	// The sticky rail's content, rendered once for the lg+ sidebar and once
 	// more (testIdSuffix "-mobile") right above the map for narrow viewports -
-	// on desktop the CTA sits at the top of the page next to the reading
-	// column, but below lg the rail drops to the DOM's end, after the at-a-
-	// glance summary, the map and the organisation contact card add up to
-	// ~700px of scrolling before the page's one conversion point is reachable
-	// (#1965). Only one instance is ever visible at a given viewport (the
-	// aside hides below lg, this copy hides at lg+), so duplicated ids don't
-	// collide and duplicated buttons are never both reachable at once.
+	// the aside is invisible below lg (`hidden` until `lg:block`) since sticky
+	// positioning and the grid column it's pinned to (#2050) only exist at
+	// that breakpoint, so without this second copy a mobile visitor would
+	// have no way to reach the CTA at all (#1965). Only one instance is ever
+	// visible at a given viewport (the aside hides below lg, this copy hides
+	// at lg+), so duplicated ids don't collide and duplicated buttons are
+	// never both reachable at once.
 	// Takes the already-null-checked opportunity as a parameter rather than
 	// closing over the outer `opportunity` state directly - TS control-flow
 	// narrowing doesn't carry a `const`'s narrowed type into a nested function
@@ -571,9 +571,24 @@ export default function VolunteerOpportunityDetailPage() {
 			time-slot list, which on a long opportunity put the page's only
 			conversion point below the fold while ~500px of page sat empty next to
 			it. One column below lg, where a 20rem rail would just be a narrow box
-			and the CTA is better off in reading order anyway. */}
+			and the CTA is better off in reading order anyway. The rail is the
+			first child below (not the reading column) with explicit grid
+			placement pinning each side back to its visual column/row (#2050) -
+			DOM order used to match visual order by accident, which put the rail
+			last in both and made the CTA the 8th focusable element on the page,
+			after the report button, the map and the organization's contact
+			links. */}
 				<div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start lg:gap-10">
-					<div className="min-w-0">
+					{/* Hidden below lg: the mobile-only copy right above the map (#1965)
+				carries the same content there instead. sticky needs a scroll
+				container that is not the grid item itself; lg:items-start on the
+				grid keeps this from stretching to full row height, which would
+				make top-24 have nothing left to stick against. */}
+					<aside className="hidden lg:sticky lg:top-24 lg:col-start-2 lg:row-start-1 lg:block">
+						<div className="space-y-6">{renderActionRail("", opportunity)}</div>
+					</aside>
+
+					<div className="min-w-0 lg:col-start-1 lg:row-start-1">
 						{/* Flush left inside the outer wrapper, not centred within it.
 			#1727 deliberately let the banner span the full wrapper while prose
 			stayed at a reading measure - but centring the prose meant the page
@@ -918,15 +933,6 @@ export default function VolunteerOpportunityDetailPage() {
 								)}
 						</div>
 					</div>
-
-					{/* Hidden below lg: the mobile-only copy right above the map (#1965)
-				carries the same content there instead. sticky needs a scroll
-				container that is not the grid item itself; lg:items-start on the
-				grid keeps this from stretching to full row height, which would
-				make top-24 have nothing left to stick against. */}
-					<aside className="hidden lg:sticky lg:top-24 lg:block">
-						<div className="space-y-6">{renderActionRail("", opportunity)}</div>
-					</aside>
 				</div>
 
 				{/* More from this organization - a wider grid than the reading


### PR DESCRIPTION
Keyboard/screen-reader users had to tab through the report button, map, Leaflet attribution links and organization contact links before reaching the primary CTA, because the desktop sticky rail sat last in the DOM (placed there for #1755's layout) even though it renders in the right column. Reorders the rail to be the grid's first child and pins both children back to their original visual column/row with explicit grid placement, decoupling focus order from visual order.

Adds a regression test asserting the CTA is one of the first Tab stops, since axe-core has no rule for a DOM-order-vs-visual-order mismatch.

Fixes #2050

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
