### PR TITLE
fix: collapse same-day time ranges, retire long-form date register

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -156,6 +156,25 @@ Shared UI primitives live in `src/components/` and `src/lib/` (no separate desig
 
 **Tokens:** the brand color scale (`brand-50`...`brand-900`) and `accent-400` are defined once in `src/styles/global.css`'s `@theme` block - use them instead of ad hoc hex values or arbitrary colors. `rounded-xl` is the default corner radius for interactive surfaces (buttons, inputs); cards, panels and modals use the separate `rounded-card` (16px) token instead - see `surfaceClasses.ts` and `Modal.tsx`. `rounded-md` is reserved for `Skeleton` loading blocks.
 
+## Date Formatting
+
+One numeric convention (`27.08.2026, 09:00`), plus one documented relative
+exception - no other date register (#2047). All helpers live in
+`lib/format.ts` and take `lng` as `i18n.language` ("de"/"en"), not an Intl
+locale (see `resolveDateLocale`):
+
+| Helper                | Use for                                                                                                             |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `formatDateTime`      | Any single point-in-time timestamp ("27.08.2026, 09:00") - the default                                             |
+| `formatDateTimeRange` | Any start/end range (time slots, calendar events) - collapses a same-day range to one date with a hyphen-joined time range ("27.08.2026, 09:00-17:00") instead of repeating the date on both ends; falls back to two full `formatDateTime`s joined by " - " once the range crosses a calendar day. Always use this for ranges instead of hand-joining two `formatDateTime` calls - that's the exact duplication #2047 was filed about |
+| `formatDate`          | Date-only, no time-of-day (deadlines like `ValidUntil`, "created on"/"sent on" timestamps)                          |
+| `formatPostedAgo`     | The one relative-date exception ("Vor 5 Tagen veroeffentlicht") - pair it with an `aria-label` (not just `title`, which browse-mode screen reader users and touch/mobile never see) on the wrapping element combining the relative text with the absolute `formatDateTime`, so the exact timestamp is still available to everyone; `title` alongside it is a harmless bonus for mouse users (see `VolunteerOpportunityDetailPage.tsx`'s posted-on span) |
+| `formatFullDate`      | Screen-reader-only accessible names for calendar day cells whose visible label is a bare number (`MiniCalendar`, `CalendarWidget`) - not a visible register, so it doesn't compete with the above |
+
+There is no long-form date helper (spelled-out month, e.g. "13. August
+2026") - it was retired as a third competing register; use `formatDate`
+even for lower-frequency "created on" timestamps.
+
 ## Copy Conventions
 
 - **"Zeitslot" vs "Termin"** (opportunity-detail page, `/my-signups`): both

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -6,7 +6,7 @@ import Dropdown from "../Dropdown";
 import TagsInput from "../TagsInput";
 import ErrorBanner from "../ErrorBanner";
 import Chip from "../Chip";
-import { formatDateTime } from "../../lib/format";
+import { formatDateTimeRange } from "../../lib/format";
 import { inputSurfaceClass, labelClass } from "../../lib/formClasses";
 import type { OpportunityFormValues } from "./schema";
 
@@ -356,8 +356,12 @@ export default function DetailsStep({
 										className="flex items-center justify-between rounded-lg bg-white px-3 py-2 text-sm shadow-sm"
 									>
 										<span className="text-gray-700">
-											{formatDateTime(slot.startDateTime, i18n.language)} -{" "}
-											{formatDateTime(slot.endDateTime, i18n.language)} (
+											{formatDateTimeRange(
+												slot.startDateTime,
+												slot.endDateTime,
+												i18n.language,
+											)}{" "}
+											(
 											{slot.maxParticipants === null
 												? t("timeSlots.unlimited")
 												: slot.maxParticipants}

--- a/frontend/src/components/SignUpModal.tsx
+++ b/frontend/src/components/SignUpModal.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TimeSlotDetail } from "../client/api-client";
 import { useApiClient } from "../hooks/useApiClient";
-import { computeSpotsLeft, formatDateTime, isSlotFull } from "../lib/format";
+import {
+	computeSpotsLeft,
+	formatDateTimeRange,
+	isSlotFull,
+} from "../lib/format";
 import { getApiErrorMessage } from "../lib/apiError";
 import { labelClass, textareaClass } from "../lib/formClasses";
 import Dropdown from "./Dropdown";
@@ -128,10 +132,8 @@ export default function SignUpModal({
 									return {
 										value: ts.id,
 										disabled: slotFull,
-										label: `${formatDateTime(
+										label: `${formatDateTimeRange(
 											ts.startDateTime as unknown as string,
-											i18n.language,
-										)} - ${formatDateTime(
 											ts.endDateTime as unknown as string,
 											i18n.language,
 										)} ${

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -5,8 +5,8 @@ import {
 	formatOccurrence,
 	formatParticipationType,
 	formatDate,
-	formatDateLong,
 	formatDateTime,
+	formatDateTimeRange,
 	formatPostedAgo,
 	isRecentlyCreatedOrganization,
 	isSlotFull,
@@ -184,32 +184,45 @@ describe("formatDate", () => {
 	});
 });
 
-describe("formatDateLong", () => {
-	// Compares against the identical Intl call rather than a hardcoded string
-	// so the assertion doesn't depend on the host's local timezone offset.
-	it("formats using en-GB style for en, spelling out the month", () => {
-		const iso = "2026-08-15T23:59:59.999Z";
-		const expected = new Date(iso).toLocaleDateString("en-GB", {
-			day: "2-digit",
-			month: "long",
-			year: "numeric",
-		});
-		expect(formatDateLong(iso, "en")).toBe(expected);
+describe("formatDateTimeRange", () => {
+	// Local Date constructors (not ISO "Z" strings) so same-day/cross-day
+	// boundaries are exact regardless of the test runner's local timezone -
+	// same reasoning as calendarRange.test.ts.
+	it("collapses a same-day range to one date with a hyphen-joined time range", () => {
+		const start = new Date(2026, 7, 27, 9, 0);
+		const end = new Date(2026, 7, 27, 17, 0);
+		const datePart = new Intl.DateTimeFormat("de-DE", {
+			dateStyle: "medium",
+		}).format(start);
+		const startTime = new Intl.DateTimeFormat("de-DE", {
+			timeStyle: "short",
+		}).format(start);
+		const endTime = new Intl.DateTimeFormat("de-DE", {
+			timeStyle: "short",
+		}).format(end);
+		expect(
+			formatDateTimeRange(start.toISOString(), end.toISOString(), "de"),
+		).toBe(`${datePart}, ${startTime}-${endTime}`);
 	});
 
-	it("formats using de-DE style when locale is de", () => {
-		const iso = "2026-08-15T23:59:59.999Z";
-		const expected = new Date(iso).toLocaleDateString("de-DE", {
-			day: "2-digit",
-			month: "long",
-			year: "numeric",
-		});
-		expect(formatDateLong(iso, "de")).toBe(expected);
+	it("falls back to two full formatDateTime calls once the range crosses a calendar day", () => {
+		const start = new Date(2026, 7, 27, 23, 0);
+		const end = new Date(2026, 7, 28, 1, 0);
+		const startIso = start.toISOString();
+		const endIso = end.toISOString();
+		expect(formatDateTimeRange(startIso, endIso, "de")).toBe(
+			`${formatDateTime(startIso, "de")} - ${formatDateTime(endIso, "de")}`,
+		);
 	});
 
-	it("differs from the compact formatDate style", () => {
-		const iso = "2026-08-15T23:59:59.999Z";
-		expect(formatDateLong(iso, "de")).not.toBe(formatDate(iso, "de"));
+	it("uses en-GB style time-of-day for en", () => {
+		const start = new Date(2026, 7, 27, 9, 0);
+		const end = new Date(2026, 7, 27, 17, 0);
+		expect(
+			formatDateTimeRange(start.toISOString(), end.toISOString(), "en"),
+		).not.toBe(
+			formatDateTimeRange(start.toISOString(), end.toISOString(), "de"),
+		);
 	});
 });
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from "i18next";
-import { differenceInCalendarDays } from "date-fns";
+import { differenceInCalendarDays, isSameDay } from "date-fns";
 import type { OpportunityCapacity } from "./opportunityCapacity";
 
 export function formatOccurrence(occurrence: string, t: TFunction): string {
@@ -118,6 +118,45 @@ export function formatDateTime(dt: string, lng: string): string {
 	return getDateTimeFormatter(lng).format(new Date(dt));
 }
 
+const timeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getTimeFormatter(lng: string): Intl.DateTimeFormat {
+	const resolvedLocale = resolveDateLocale(lng);
+	let formatter = timeFormatters.get(resolvedLocale);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(resolvedLocale, { timeStyle: "short" });
+		timeFormatters.set(resolvedLocale, formatter);
+	}
+	return formatter;
+}
+
+/**
+ * The product-wide time-range string ("27.08.2026, 09:00-17:00") - collapses
+ * the date to one side when `start`/`end` fall on the same calendar day
+ * (in the viewer's local time zone) instead of repeating it on both ends,
+ * since nearly every time slot is same-day and the doubled form was the
+ * string most likely to wrap onto three lines in narrow cards (#2047). Falls
+ * back to two full `formatDateTime` calls joined with " - " once the range
+ * crosses a day boundary, so the date is never dropped where it's actually
+ * needed. `lng` is i18n.language ("de"/"en"), not an Intl locale (see
+ * formatDateTime).
+ */
+export function formatDateTimeRange(
+	startDt: string,
+	endDt: string,
+	lng: string,
+): string {
+	const start = new Date(startDt);
+	const end = new Date(endDt);
+	if (!isSameDay(start, end)) {
+		return `${formatDateTime(startDt, lng)} - ${formatDateTime(endDt, lng)}`;
+	}
+	const datePart = getDateFormatter(lng).format(start);
+	const startTime = getTimeFormatter(lng).format(start);
+	const endTime = getTimeFormatter(lng).format(end);
+	return `${datePart}, ${startTime}-${endTime}`;
+}
+
 const dateFormatters = new Map<string, Intl.DateTimeFormat>();
 
 function getDateFormatter(lng: string): Intl.DateTimeFormat {
@@ -137,32 +176,6 @@ function getDateFormatter(lng: string): Intl.DateTimeFormat {
  * i18n.language ("de"/"en"), not an Intl locale (see formatDateTime). */
 export function formatDate(dt: string, lng: string): string {
 	return getDateFormatter(lng).format(new Date(dt));
-}
-
-const longDateFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getLongDateFormatter(lng: string): Intl.DateTimeFormat {
-	const resolvedLocale = resolveDateLocale(lng);
-	let formatter = longDateFormatters.get(resolvedLocale);
-	if (!formatter) {
-		formatter = new Intl.DateTimeFormat(resolvedLocale, {
-			day: "2-digit",
-			month: "long",
-			year: "numeric",
-		});
-		longDateFormatters.set(resolvedLocale, formatter);
-	}
-	return formatter;
-}
-
-/** Long-form date-only formatting (e.g. "25. Juli 2026") - for lower-frequency
- * "created on"/"sent on" timestamps where a spelled-out month reads better
- * than the compact numeric style `formatDate` uses. `lng` is i18n.language
- * ("de"/"en"), not an Intl locale (see formatDateTime). Centralized here so
- * call sites don't each re-derive their own `toLocaleDateString` options and
- * drift into a third date format alongside formatDate/formatDateTime (#986). */
-export function formatDateLong(dt: string, lng: string): string {
-	return getLongDateFormatter(lng).format(new Date(dt));
 }
 
 const fullDateFormatters = new Map<string, Intl.DateTimeFormat>();

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -14,7 +14,7 @@ import { dispatchToast } from "../lib/toastBus";
 import { inputClass, labelClass } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
 import {
-	formatDateLong,
+	formatDate,
 	formatDateTime,
 	isRecentlyCreatedOrganization,
 } from "../lib/format";
@@ -409,7 +409,7 @@ function OrganizationsSection() {
 												})}
 												{" · "}
 												{t("administration.organizations.createdOn", {
-													date: formatDateLong(row.createdOn, i18n.language),
+													date: formatDate(row.createdOn, i18n.language),
 												})}
 											</p>
 										</div>

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -20,7 +20,7 @@ import ModalLoadingFallback from "../components/ModalLoadingFallback";
 import NotFoundPage from "./NotFoundPage";
 import {
 	formatDate,
-	formatDateTime,
+	formatDateTimeRange,
 	pickLocalizedText,
 	resolveDateLocale,
 } from "../lib/format";
@@ -599,12 +599,8 @@ export default function EngagementManagementPage() {
 								</option>
 								{opportunity.timeSlots.map((slot) => (
 									<option key={slot.id} value={slot.id}>
-										{formatDateTime(
+										{formatDateTimeRange(
 											slot.startDateTime as unknown as string,
-											i18n.language,
-										)}{" "}
-										-{" "}
-										{formatDateTime(
 											slot.endDateTime as unknown as string,
 											i18n.language,
 										)}
@@ -800,7 +796,11 @@ export default function EngagementManagementPage() {
 												return (
 													<p className="mt-1 text-xs text-gray-500">
 														{slot
-															? `${formatDateTime(slot.startDateTime as unknown as string, i18n.language)} - ${formatDateTime(slot.endDateTime as unknown as string, i18n.language)}`
+															? formatDateTimeRange(
+																	slot.startDateTime as unknown as string,
+																	slot.endDateTime as unknown as string,
+																	i18n.language,
+																)
 															: e.timeSlotId.slice(0, 8) + "..."}
 													</p>
 												);

--- a/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
+++ b/frontend/src/pages/MyEngagementsPage/ActivitySection.tsx
@@ -10,7 +10,7 @@ import { useLoadMore } from "../../hooks/useLoadMore";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
 import { isFeedbackEditable } from "../../lib/feedback";
-import { formatDate, formatDateTime } from "../../lib/format";
+import { formatDate, formatDateTimeRange } from "../../lib/format";
 import { cardClass } from "../../lib/surfaceClasses";
 import AddToCalendarMenu from "../../components/AddToCalendarMenu";
 import Chip from "../../components/Chip";
@@ -476,7 +476,11 @@ export default function ActivitySection() {
 											<CalendarIcon className="h-3.5 w-3.5 shrink-0" />
 											<span>
 												{t("myEngagements.scheduledFor", {
-													range: `${formatDateTime(e.timeSlotStartDateTime as unknown as string, i18n.language)} - ${formatDateTime(e.timeSlotEndDateTime as unknown as string, i18n.language)}`,
+													range: formatDateTimeRange(
+														e.timeSlotStartDateTime as unknown as string,
+														e.timeSlotEndDateTime as unknown as string,
+														i18n.language,
+													),
 												})}
 											</span>
 										</p>

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 	computeSpotsLeft,
 	formatDate,
 	formatDateTime,
+	formatDateTimeRange,
 	formatOccurrence,
 	formatParticipationType,
 	formatPostedAgo,
@@ -356,6 +357,20 @@ export default function VolunteerOpportunityDetailPage() {
 		secondaryLabel: capacitySecondaryLabel,
 	} = describeCapacity(capacity, t);
 
+	// formatPostedAgo's relative text ("Vor 5 Tagen veroeffentlicht") is the
+	// one documented exception to the site's numeric date convention - it
+	// still needs the absolute date available to screen readers (`aria-label`,
+	// not just `title`, which browse-mode AT users and touch/mobile never see
+	// - #2047) and to sighted mouse users (`title`).
+	const postedOnRelative = formatPostedAgo(
+		opportunity.createdOn as unknown as string,
+		t,
+	);
+	const postedOnAbsolute = formatDateTime(
+		opportunity.createdOn as unknown as string,
+		i18n.language,
+	);
+
 	const otherOrgOpportunities =
 		orgProfile?.openOpportunities
 			.filter((opp) => opp.id !== opportunity.id)
@@ -434,7 +449,11 @@ export default function VolunteerOpportunityDetailPage() {
 										<CalendarIcon className="h-3.5 w-3.5 shrink-0" />
 										<span>
 											{t("myEngagements.scheduledFor", {
-												range: `${formatDateTime(registeredTimeSlot.startDateTime as unknown as string, i18n.language)} - ${formatDateTime(registeredTimeSlot.endDateTime as unknown as string, i18n.language)}`,
+												range: formatDateTimeRange(
+													registeredTimeSlot.startDateTime as unknown as string,
+													registeredTimeSlot.endDateTime as unknown as string,
+													i18n.language,
+												),
 											})}
 										</span>
 									</p>
@@ -737,11 +756,12 @@ export default function VolunteerOpportunityDetailPage() {
 										{capacitySecondaryLabel}
 									</span>
 								)}
-								<span className="text-xs text-gray-500">
-									{formatPostedAgo(
-										opportunity.createdOn as unknown as string,
-										t,
-									)}
+								<span
+									className="text-xs text-gray-500"
+									title={postedOnAbsolute}
+									aria-label={`${postedOnRelative} (${postedOnAbsolute})`}
+								>
+									{postedOnRelative}
 								</span>
 							</div>
 
@@ -809,12 +829,8 @@ export default function VolunteerOpportunityDetailPage() {
 												className={`flex items-center justify-between ${cardClass} text-sm text-gray-700`}
 											>
 												<span>
-													{formatDateTime(
+													{formatDateTimeRange(
 														ts.startDateTime as unknown as string,
-														i18n.language,
-													)}
-													{" - "}
-													{formatDateTime(
 														ts.endDateTime as unknown as string,
 														i18n.language,
 													)}

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -23,7 +23,7 @@ import { useSharedOrgFetch } from "../../../hooks/useSharedOrgFetch";
 import { visibleCalendarRange } from "../../../lib/calendarRange";
 import {
 	formatDate,
-	formatDateTime,
+	formatDateTimeRange,
 	formatFullDate,
 	pickLocalizedText,
 	resolveDateLocale,
@@ -93,7 +93,11 @@ function CalEventChip({
 }) {
 	const { t, i18n } = useTranslation();
 	const e = event as CalEvent;
-	const timeRange = `${formatDateTime(e.start.toISOString(), i18n.language)} - ${formatDateTime(e.end.toISOString(), i18n.language)}`;
+	const timeRange = formatDateTimeRange(
+		e.start.toISOString(),
+		e.end.toISOString(),
+		i18n.language,
+	);
 	const capacityLabel =
 		e.maxParticipants === null
 			? t("orgOverview.eventChipUnlimited", { booked: e.bookedCount })

--- a/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/SettingsWidget.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { OrganizationDetailsResponse } from "../../../client/api-client";
 import WidgetCard from "./WidgetCard";
 import type { WidgetSizeClass } from "./widgetCatalog";
-import { formatDateLong } from "../../../lib/format";
+import { formatDate } from "../../../lib/format";
 
 interface Props {
 	org: OrganizationDetailsResponse;
@@ -71,7 +71,7 @@ function SettingsWidget({ org, size }: Props) {
 							<>
 								<span className="mx-1.5">&middot;</span>
 								{t("orgSettings.createdOn", {
-									date: formatDateLong(
+									date: formatDate(
 										org.createdOn as unknown as string,
 										i18n.language,
 									),

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -19,7 +19,7 @@ import SectionHeading from "../../components/SectionHeading";
 import ErrorBanner from "../../components/ErrorBanner";
 import SuccessBanner from "../../components/SuccessBanner";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
-import { formatDateLong } from "../../lib/format";
+import { formatDate } from "../../lib/format";
 import { cardClass } from "../../lib/surfaceClasses";
 
 export default function OrgMembersPage() {
@@ -397,7 +397,7 @@ export default function OrgMembersPage() {
 											</p>
 											<p className="truncate text-xs text-gray-500">
 												{t("orgSettings.invitationSentOn", {
-													date: formatDateLong(
+													date: formatDate(
 														invitation.createdOn as unknown as string,
 														i18n.language,
 													),

--- a/frontend/src/pages/app/OrgSettingsPage.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.tsx
@@ -26,7 +26,7 @@ import FileUploadButton from "../../components/FileUploadButton";
 import Field from "../../components/Field";
 import { RequiredFieldsLegend } from "../../components/RequiredMark";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
-import { formatDateLong } from "../../lib/format";
+import { formatDate } from "../../lib/format";
 
 export default function OrgSettingsPage() {
 	const { org, reloadOrg, isOrganizer } = useOutletContext<OrgAppContext>();
@@ -276,7 +276,7 @@ export default function OrgSettingsPage() {
 						subtitle={
 							<p className="text-xs text-gray-500">
 								{t("orgSettings.createdOn", {
-									date: formatDateLong(
+									date: formatDate(
 										org.createdOn as unknown as string,
 										i18n.language,
 									),


### PR DESCRIPTION
Every date range on the platform doubled the date for same-day slots ("27.08.2026, 09:00 - 27.08.2026, 17:00") since it was built as two formatDateTime calls joined with " - " - the string most likely to wrap onto three lines in narrow cards, and the norm since nearly every shift is same-day. Adds a shared formatDateTimeRange helper that collapses to "27.08.2026, 09:00-17:00" on a shared day and falls back to the full form otherwise, wired into all six call sites. Also retires the long-form date register (formatDateLong, e.g. "13. August 2026") in favour of the existing numeric formatDate, and documents the resulting single date-format convention in frontend/AGENTS.md.

Closes #2047.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
