### PR TITLE
fix: allow same-origin framing for silent SSO renewal

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -207,7 +207,20 @@ jobs:
           [ -n "$csp" ] || { echo "::error::No Content-Security-Policy header"; exit 1; }
           echo "$csp" | grep -q "${{ inputs.vite_api_url }}" || { echo "::error::CSP does not allow the runtime API origin (connect-src)"; exit 1; }
           echo "$csp" | grep -q "${{ inputs.keycloak_origin }}" || { echo "::error::CSP does not allow the runtime Keycloak origin (frame-src)"; exit 1; }
+          echo "$csp" | grep -qE "frame-src[^;]*'self'" || { echo "::error::CSP frame-src does not allow 'self' - automaticSilentRenew/signinSilent()'s same-origin hidden iframe (silent_redirect_uri) would be blocked in production (#2042)"; exit 1; }
           echo "$csp" | grep -q "${{ inputs.storage_public_url }}" || { echo "::error::CSP does not allow the runtime storage origin (img-src) - cross-origin images would be blocked"; exit 1; }
+
+      # frame-src 'self' above only controls what the *parent* page may embed -
+      # whether the browser actually renders silent-renew.html inside that
+      # hidden iframe is a separate check against this response's *own*
+      # X-Frame-Options/frame-ancestors (#2042). Both must be verified, or a
+      # regression in either one silently re-breaks automaticSilentRenew.
+      - name: silent-renew.html allows same-origin framing
+        run: |
+          headers=$(curl -fsSI http://localhost:8081/silent-renew.html | tr -d '\r')
+          echo "$headers"
+          echo "$headers" | grep -qi '^x-frame-options: SAMEORIGIN$' || { echo "::error::/silent-renew.html's X-Frame-Options is not SAMEORIGIN - the site-wide DENY would block automaticSilentRenew's hidden iframe (#2042)"; exit 1; }
+          echo "$headers" | grep -i '^content-security-policy:' | grep -qE "frame-ancestors[^;]*'self'" || { echo "::error::/silent-renew.html's CSP does not allow frame-ancestors 'self' (#2042)"; exit 1; }
 
       - name: gzip_static serves precompressed assets
         run: |

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -12,7 +12,19 @@ gzip_vary on;
 # location still has to re-emit this header, but from one definition
 # instead of four copies that can drift out of sync.
 map $host $csp_header {
-	default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: ${CSP_API_ORIGIN} ${CSP_STORAGE_ORIGIN}; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN}; frame-src ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
+	default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: ${CSP_API_ORIGIN} ${CSP_STORAGE_ORIGIN}; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_KEYCLOAK_ORIGIN}; frame-src 'self' ${CSP_KEYCLOAK_ORIGIN}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
+}
+
+# silent-renew.html's own policy (#2042) - frame-src 'self' above only governs
+# what the *parent* page is allowed to embed; whether the browser actually
+# renders silent-renew.html inside that hidden iframe is a separate check
+# against frame-ancestors on silent-renew.html's *own* response, enforced
+# independently of the parent's CSP. Every other page keeps frame-ancestors
+# 'none' (no exceptions to the site-wide anti-clickjacking policy above) -
+# this is scoped to the one route that legitimately needs to be framed, via
+# its own location block below rather than a blanket relaxation.
+map $host $csp_header_silent_renew {
+	default "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'self'";
 }
 
 # Recognizes social-preview and search-engine crawlers by User-Agent so a shared or
@@ -97,6 +109,25 @@ server {
 		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 		add_header Content-Security-Policy $csp_header always;
+	}
+
+	# main.tsx's silent_redirect_uri (#2042) - automaticSilentRenew/signinSilent()
+	# load this same-origin page inside a hidden iframe, which needs
+	# X-Frame-Options: SAMEORIGIN and frame-ancestors 'self' (via
+	# $csp_header_silent_renew above) instead of every other page's DENY/'none' -
+	# without both, the browser refuses to render it in that iframe regardless
+	# of frame-src on the parent. Cache-Control matches /index.html above for
+	# the same reason: this HTML references a content-hashed JS filename that
+	# changes on every deploy, so it must never be served stale from cache.
+	location = /silent-renew.html {
+		add_header Cache-Control "no-store" always;
+		add_header X-Content-Type-Options "nosniff" always;
+		add_header X-Frame-Options "SAMEORIGIN" always;
+		add_header X-XSS-Protection "1; mode=block" always;
+		add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+		add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(self), payment=()" always;
+		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+		add_header Content-Security-Policy $csp_header_silent_renew always;
 	}
 
 	# Shared/crawled deep links to a specific opportunity or organization

--- a/frontend/scripts/check-nginx-csp.js
+++ b/frontend/scripts/check-nginx-csp.js
@@ -53,11 +53,36 @@ if (!mapMatch) {
 				"URL.createObjectURL() before upload and will be blocked by the browser without it.",
 		);
 	}
+
+	// Regression for #2042: frame-src without 'self' blocks the hidden iframe
+	// automaticSilentRenew/signinSilent() load for silent_redirect_uri
+	// (src/main.tsx, same-origin - see src/silentRenew.ts), breaking silent SSO
+	// and automatic token renewal in production while looking fine locally
+	// (the dev server sends no CSP header at all).
+	const frameSrcMatch = policy.match(/frame-src ([^;]+);/);
+	if (!frameSrcMatch || !frameSrcMatch[1].split(" ").includes("'self'")) {
+		fail(
+			"frame-src directive is missing 'self' - the hidden iframe automaticSilentRenew/signinSilent() " +
+				"loads for silent_redirect_uri is same-origin and will be blocked by the browser without it (#2042).",
+		);
+	}
+	if (!frameSrcMatch || !frameSrcMatch[1].includes("${CSP_KEYCLOAK_ORIGIN}")) {
+		fail(
+			"frame-src directive is missing ${CSP_KEYCLOAK_ORIGIN} - Keycloak's own iframes (e.g. its check-session " +
+				"iframe) will be blocked by the browser without it.",
+		);
+	}
 }
 
-// 2. Every add_header Content-Security-Policy line must reference the
-// shared $csp_header variable - none may hardcode the policy inline, which
-// is exactly how the four copies drifted out of sync before.
+// 2. Every add_header Content-Security-Policy line must reference a shared
+// $csp_header* variable - none may hardcode the policy inline, which is
+// exactly how the four copies drifted out of sync before. $csp_header_silent_renew
+// (#2042) is a second, deliberate exception to "exactly one policy" - see
+// check 5 below - so both are allowed here, just not a third ad hoc one.
+const allowedCspHeaderLines = new Set([
+	"add_header Content-Security-Policy $csp_header always;",
+	"add_header Content-Security-Policy $csp_header_silent_renew always;",
+]);
 const cspHeaderLines = template
 	.split("\n")
 	.map((line) => line.trim())
@@ -68,10 +93,10 @@ if (cspHeaderLines.length === 0) {
 }
 
 for (const line of cspHeaderLines) {
-	if (line !== "add_header Content-Security-Policy $csp_header always;") {
+	if (!allowedCspHeaderLines.has(line)) {
 		fail(
-			`Found a Content-Security-Policy header not referencing the shared $csp_header variable: "${line}". ` +
-				"Every location must emit the header via $csp_header, not a hardcoded policy string.",
+			`Found a Content-Security-Policy header not referencing a shared $csp_header* variable: "${line}". ` +
+				"Every location must emit the header via $csp_header or $csp_header_silent_renew, not a hardcoded policy string.",
 		);
 	}
 }
@@ -118,6 +143,50 @@ if (!/CSP_STORAGE_ORIGIN="\$\(url_origin "\$STORAGE_PUBLIC_URL"\)"/.test(entrypo
 
 if (!/export\s+.*\bCSP_STORAGE_ORIGIN\b/.test(entrypoint)) {
 	fail("99-runtime-config.sh computes CSP_STORAGE_ORIGIN but never exports it.");
+}
+
+// 5. silent-renew.html (#2042) needs frame-ancestors 'self' (and a matching
+// X-Frame-Options: SAMEORIGIN) to actually render inside the hidden iframe
+// automaticSilentRenew/signinSilent() loads it in - frame-src 'self' on the
+// *parent* (checked in 1 above) only governs what the parent may embed;
+// whether the embed is actually allowed to render is a separate check
+// against frame-ancestors/X-Frame-Options on silent-renew.html's *own*
+// response, so both are required and neither is sufficient alone.
+const silentRenewMapMatch = template.match(
+	/map\s+\$host\s+\$csp_header_silent_renew\s*\{\s*default\s+"([^"]+)";\s*\}/,
+);
+if (!silentRenewMapMatch) {
+	fail(
+		'Could not find a `map $host $csp_header_silent_renew { default "..."; }` block in nginx.conf.template - ' +
+			"silent-renew.html (#2042) needs its own policy with frame-ancestors 'self', distinct from every " +
+			"other page's frame-ancestors 'none'.",
+	);
+} else if (!silentRenewMapMatch[1].includes("frame-ancestors 'self'")) {
+	fail(
+		"$csp_header_silent_renew's policy does not include frame-ancestors 'self' - without it, the browser " +
+			"still refuses to render silent-renew.html inside the hidden iframe regardless of frame-src (#2042).",
+	);
+}
+
+const silentRenewLocationMatch = template.match(
+	/location\s*=\s*\/silent-renew\.html\s*\{([\s\S]*?)\n\t\}/,
+);
+if (!silentRenewLocationMatch) {
+	fail("Could not find a `location = /silent-renew.html { ... }` block in nginx.conf.template.");
+} else {
+	const locationBlock = silentRenewLocationMatch[1];
+	if (!/add_header X-Frame-Options "SAMEORIGIN" always;/.test(locationBlock)) {
+		fail(
+			"The /silent-renew.html location does not set X-Frame-Options: SAMEORIGIN - the site-wide DENY " +
+				"(used everywhere else) independently blocks the hidden iframe this page exists for, regardless " +
+				"of frame-ancestors/frame-src (#2042).",
+		);
+	}
+	if (!/add_header Content-Security-Policy \$csp_header_silent_renew always;/.test(locationBlock)) {
+		fail(
+			"The /silent-renew.html location does not emit Content-Security-Policy via $csp_header_silent_renew.",
+		);
+	}
 }
 
 if (ok) {

--- a/frontend/silent-renew.html
+++ b/frontend/silent-renew.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Signing in...</title>
+		<script src="/config.js" defer></script>
+	</head>
+	<body>
+		<script type="module" src="/src/silentRenew.ts"></script>
+	</body>
+</html>

--- a/frontend/src/hooks/useSilentSsoProbe.ts
+++ b/frontend/src/hooks/useSilentSsoProbe.ts
@@ -22,11 +22,14 @@ export function useSilentSsoProbe() {
 	const attemptedRef = useRef(false);
 
 	useEffect(() => {
-		// signinSilent() itself loads this same app in a hidden iframe to
-		// complete the round trip (oidc-client-ts's silent_redirect_uri
-		// defaults to redirect_uri, i.e. /callback - see main.tsx). Without this
-		// guard, that inner mount would see itself as logged out too and fire
-		// its own nested probe, recursing iframes-in-iframes indefinitely.
+		// signinSilent() loads main.tsx's silent_redirect_uri - a dedicated,
+		// minimal page (src/silentRenew.ts), not this app - in a hidden iframe
+		// to complete the round trip, so this hook can no longer actually mount
+		// inside that iframe (#2042). Guard kept anyway as a defense-in-depth
+		// backstop: frame-ancestors 'none' (nginx.conf.template) already blocks
+		// this app from being framed by anything, itself included, but a future
+		// CSP/config mistake shouldn't be able to bring back the
+		// iframes-in-iframes recursion this used to guard against directly.
 		if (window.self !== window.top) return;
 		// /callback is mid-flow (a real signin or an automatic silent renewal)
 		// handling its own auth resolution - a probe here would be redundant at

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -34,6 +34,12 @@ const oidcConfig = {
 	post_logout_redirect_uri: window.location.origin,
 	scope: "openid profile email",
 	automaticSilentRenew: true,
+	// A dedicated, minimal page (src/silentRenew.ts) rather than defaulting to
+	// /callback (#2042) - oidc-client-ts's hidden iframe for automaticSilentRenew/
+	// signinSilent() would otherwise boot the full SPA every renewal cycle, and
+	// the CSP's frame-src has to allow 'self' for this origin's own iframe to
+	// load at all (see frontend/nginx.conf.template).
+	silent_redirect_uri: window.location.origin + "/silent-renew.html",
 	// sessionStorage, not localStorage: tokens (incl. refresh_token, since the
 	// realm has "rememberMe": true) must not survive tab close or browser
 	// restart on a shared/kiosk machine - a realistic setting for a

--- a/frontend/src/silentRenew.ts
+++ b/frontend/src/silentRenew.ts
@@ -1,0 +1,20 @@
+import { UserManager } from "oidc-client-ts";
+import { runtimeConfig } from "./lib/runtimeConfig";
+
+// main.tsx's silent_redirect_uri (#2042) - loaded in a hidden iframe by
+// automaticSilentRenew/signinSilent() every renewal cycle. Deliberately not
+// /callback: that would boot the entire SPA (React, i18n, fonts, the whole
+// route tree) inside the iframe just to relay one URL back to the parent
+// window. signinSilentCallback() below only forwards the callback URL via
+// postMessage to window.parent - the actual token exchange and storage
+// happens in the parent window's own UserManager instance (main.tsx), not
+// here, so this page needs nothing else.
+new UserManager({
+	authority: runtimeConfig.keycloakAuthorityUrl,
+	client_id: runtimeConfig.keycloakClientId,
+	redirect_uri: window.location.origin + "/callback",
+})
+	.signinSilentCallback()
+	.catch((error: unknown) => {
+		console.error("[silent-renew]", error);
+	});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,13 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import svgr from "vite-plugin-svgr";
 import { VitePWA } from "vite-plugin-pwa";
 import { compression } from "vite-plugin-compression2";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Shared across every locale manifest below - the installed icon is the same
 // image regardless of the visitor's language.
@@ -246,6 +250,40 @@ function emitLocaleManifest(
 	};
 }
 
+// silent-renew.html (#2042) is a second HTML entry alongside index.html (see
+// build.rollupOptions.input below), so VitePWA's registerSW/manifest-link
+// injection and the single-CSS-bundle build (cssCodeSplit: false above) both
+// attach to it the same as they do to index.html - a PWA install manifest
+// link, a service-worker registration script, and the entire app's
+// stylesheet, none of which this page (renders nothing, exists purely to
+// relay a URL back to its opener) needs. Left in place, that's dead weight
+// re-fetched on every automaticSilentRenew hidden-iframe cycle (every ~4
+// minutes) - stripped here instead, after VitePWA's own transform has run.
+function stripPwaChromeFromSilentRenew(): Plugin {
+	return {
+		name: "strip-pwa-chrome-from-silent-renew",
+		// VitePWA's own html injection runs as an `enforce: "post"` plugin, not
+		// just a `transformIndexHtml` `order: "post"` hook - Vite buckets hooks
+		// by their enclosing plugin's `enforce` first, so without this too, our
+		// (merely order:"post") hook would run in the earlier "normal" bucket,
+		// before VitePWA has injected anything to strip.
+		enforce: "post",
+		transformIndexHtml: {
+			order: "post",
+			handler(html, ctx) {
+				if (!ctx.filename.endsWith("silent-renew.html")) return html;
+				return html
+					.replace(/\s*<link rel="manifest"[^>]*>/, "")
+					.replace(
+						/\s*<script id="vite-plugin-pwa:register-sw"[^>]*><\/script>/,
+						"",
+					)
+					.replace(/\s*<link rel="stylesheet"[^>]*>/, "");
+			},
+		},
+	};
+}
+
 export default defineConfig({
 	plugins: [
 		react(),
@@ -312,7 +350,12 @@ export default defineConfig({
 					},
 				],
 				navigateFallback: "/index.html",
-				navigateFallbackDenylist: [/^\/v1\//],
+				// /silent-renew.html (#2042) is a real static file, not a client
+				// route - without this, the service worker's SPA-shell fallback
+				// would intercept the hidden iframe's navigation to it and serve
+				// index.html instead, booting the full app right back into the
+				// iframe it exists to avoid.
+				navigateFallbackDenylist: [/^\/v1\//, /^\/silent-renew\.html$/],
 			},
 			// Default/fallback manifest (#1923) - served at manifest.de.webmanifest
 			// and injected into index.html's <link rel="manifest"> by VitePWA,
@@ -325,6 +368,7 @@ export default defineConfig({
 			manifestFilename: "manifest.de.webmanifest",
 		}),
 		emitLocaleManifest("manifest.en.webmanifest", enManifest),
+		stripPwaChromeFromSilentRenew(),
 	],
 	// react/react-dom and react-router are shared by (almost) every lazy
 	// route chunk - splitting them into their own stably-named vendor
@@ -348,6 +392,17 @@ export default defineConfig({
 		// were code-split.
 		cssCodeSplit: false,
 		rollupOptions: {
+			// silent-renew.html (#2042) is a second, standalone entry point -
+			// deliberately outside globPatterns/navigateFallback above, so it's
+			// fetched from the network like any other static file rather than
+			// precached or served the SPA shell. "index" is named explicitly to
+			// keep the main entry's chunk name unchanged (globPatterns'
+			// "assets/{index,vendor}-*.js" and the frontend-checks.yml smoke test
+			// both still expect "assets/index-*.js").
+			input: {
+				index: resolve(__dirname, "index.html"),
+				silentRenew: resolve(__dirname, "silent-renew.html"),
+			},
 			output: {
 				manualChunks(id) {
 					if (


### PR DESCRIPTION
CSP frame-src lacked 'self', so automaticSilentRenew/signinSilent()'s hidden iframe was blocked in production, breaking silent SSO and automatic token renewal. Point silent_redirect_uri at a dedicated minimal page (silent-renew.html) instead of /callback, so the renewal iframe no longer boots the whole SPA - and give that page its own frame-ancestors 'self'/X-Frame-Options: SAMEORIGIN, since the site-wide DENY/'none' would otherwise still block it regardless of frame-src.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #2042

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
