### PR TITLE
fix(frontend): stop org dashboard defaulting to an empty, mostly-blank layout

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
@@ -21,6 +21,11 @@ namespace VisualTests;
 /// page falls back to DEFAULT_LAYOUT solely when the API reports
 /// hasCustomLayout=false, and nothing migrates a stored layout - the second
 /// test here is the guard on that.
+///
+/// #2045 stopped forcing every widget in a shared row to one uniform,
+/// square-derived height outside edit mode - see the third test here for the
+/// week-view/empty-grid half of that fix, and .dashboard-widget-grid--editing
+/// in global.css for the CSS itself.
 /// </summary>
 [ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
 public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualTestBase(fixture)
@@ -54,16 +59,22 @@ public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualT
 			.Should().Be("8 / span 1",
 				"shrinking the Calendar must pull Settings up with it, not leave three empty rows");
 
-		// UpcomingOpportunities is 2 rows tall, so a 4-row Calendar renders
-		// roughly twice its height (rows plus one extra gap). Expressed as a
-		// ratio rather than a pixel count because the row height is a container
-		// query on the grid's own rendered width - at 6 rows this was ~3.1.
-		var upcomingBox = await Page.GetByTestId("widget-tile-UpcomingOpportunities").BoundingBoxAsync();
+		// #2045 stopped forcing every row in a shared band to one uniform,
+		// container-query-derived square height outside edit mode (see
+		// .dashboard-widget-grid--editing in global.css) - a fresh org's empty
+		// UpcomingOpportunities and empty-Agenda Calendar now each size to
+		// their own short content instead of both being stretched to the same
+		// multi-row square, so comparing the two against each other no longer
+		// says anything about whether the Calendar itself is bloated. What
+		// still catches a real regression (back toward the ~900px, 6-row
+		// footprint #1795 fixed) is the Calendar's own absolute height,
+		// bounded well above its 400px internal floor (CALENDAR_MIN_HEIGHT_PX)
+		// but nowhere near that old size.
 		var calendarBox = await calendar.BoundingBoxAsync();
-		upcomingBox.Should().NotBeNull();
 		calendarBox.Should().NotBeNull();
-		((double)calendarBox!.Height / upcomingBox!.Height).Should().BeLessThan(2.5,
-			"the Calendar's height must stay proportionate to the widgets around it");
+		calendarBox!.Height.Should().BeLessThan(700,
+			"the Calendar must stay close to its own content/floor height, not balloon back toward the "
+				+ "~900px footprint #1795 fixed");
 
 		// Acceptance criterion: the widgets carrying actionable information are
 		// on the first screen of a 900px-tall viewport.
@@ -132,6 +143,63 @@ public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualT
 			return gridRow == "4 / span 5";
 		}, () => "a saved layout must keep its own Calendar height rather than being reset to the "
 			+ $"default 4 rows (last observed: \"{gridRow}\")", timeoutMs: 10_000);
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	[Test]
+	public async Task CustomizedMediumWidthCalendar_WithNoEventsInTheDefaultWeek_FallsBackToAgenda()
+	{
+		// #2045: a medium-width placement (classifyWidth in widgetCatalog.ts)
+		// defaults CalendarWidget to week view (defaultViewForSize), which -
+		// before this fix - stayed on whatever week `new Date()` fell in even
+		// when that week held nothing at all, rendering a completely empty
+		// grid scrolled to midnight. This was the exact bug reported: "the
+		// org's only upcoming opportunity falls outside the displayed week".
+		// The fix generalizes the existing month-only empty-view fallback
+		// (#983) to any grid view, so an empty week now lands on Agenda
+		// instead - which has no "which week" problem since it just lists
+		// whatever is actually upcoming, however far out that is.
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await Page.SetViewportSizeAsync(1440, 900);
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual CalEmptyWeek {Guid.NewGuid():N}");
+
+		// Saves a layout with just a medium-width (5 columns, classifyWidth's
+		// own <=5 threshold) Calendar directly through the API, rather than
+		// driving the corner-to-corner resize UI in the browser just to reach
+		// the same placement - this org has no events at all, so which exact
+		// week `new Date()` lands in doesn't matter.
+		using (var http = await CreateAuthenticatedHttpClientAsync(backend))
+		{
+			var response = await http.PutAsJsonAsync(
+				$"/v1/organizations/{organizationId}/dashboard/layout",
+				new
+				{
+					widgets = new[]
+					{
+						new { widgetKey = "Calendar", x = 1, y = 1, width = 5, height = 4 },
+					},
+				});
+			response.EnsureSuccessStatusCode();
+		}
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		var calendarWidget = Page.GetByTestId("widget-tile-Calendar");
+		await Expect(calendarWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// Never sits on the empty time-grid view it defaulted to. Agenda's own
+		// empty state (Agenda.js) renders a bare "no events" span with no
+		// .rbc-agenda-table at all - .rbc-agenda-view is the wrapper present
+		// either way, so that's what confirms the view itself switched.
+		await Expect(calendarWidget.Locator(".rbc-time-view")).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(calendarWidget.Locator(".rbc-agenda-view")).ToBeVisibleAsync();
+		await Expect(calendarWidget.GetByText("No events in this range.")).ToBeVisibleAsync();
 
 		await DeleteOrganizationAsync(backend, organizationId);
 	}

--- a/backend/tests/VisualTests/OrgDashboardSettingsIconWidgetTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardSettingsIconWidgetTests.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Visual tests for the SettingsIcon widget's label (#2045). At its own
+/// catalog default (compact, 2x1 - see widgetCatalog.ts), the icon+label row
+/// used to hide the text span entirely and rely on WidgetCard's own title
+/// bar alone - leaving a sighted organizer looking at a bare gear icon with
+/// no visible caption on the tile itself, even though the stretched Link
+/// already carried an accessible name for assistive tech. The label is now
+/// always rendered, regardless of size.
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class OrgDashboardSettingsIconWidgetTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	public async Task CompactDefaultPlacement_ShowsTheSettingsLabel_NotJustTheGearIcon()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var backend = Fixture.GetEndpoint("backend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		var organizationId = await CreateOrganizationAsync($"Visual SettingsIcon {Guid.NewGuid():N}");
+
+		// Saves a layout with just the SettingsIcon widget at its own catalog
+		// default (2x1, classifyWidth's own compact threshold) directly
+		// through the API, rather than driving the "Add Widget" picker in the
+		// browser just to reach the same placement.
+		using (var http = await CreateAuthenticatedHttpClientAsync(backend))
+		{
+			var response = await http.PutAsJsonAsync(
+				$"/v1/organizations/{organizationId}/dashboard/layout",
+				new
+				{
+					widgets = new[]
+					{
+						new { widgetKey = "SettingsIcon", x = 1, y = 1, width = 2, height = 1 },
+					},
+				});
+			response.EnsureSuccessStatusCode();
+		}
+
+		await Page.GotoAsync($"{origin}/app/{organizationId}/dashboard");
+		var settingsIconWidget = Page.GetByTestId("widget-tile-SettingsIcon");
+		await Expect(settingsIconWidget).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		// The decorative icon+label group (aria-hidden - the accessible name
+		// comes from the stretched Link) must show the label text on screen,
+		// not just carry it as an accessible name nobody sighted can see.
+		// Scoped to the <span> tag specifically - WidgetCard's own <h2> title
+		// carries the same "Settings" text, and a plain GetByText would match
+		// both, which Playwright's strict mode rejects as ambiguous.
+		await Expect(settingsIconWidget.Locator("span", new() { HasText = "Settings" }))
+			.ToBeVisibleAsync();
+
+		await DeleteOrganizationAsync(backend, organizationId);
+	}
+
+	private async Task<string> CreateOrganizationAsync(string name)
+	{
+		var backend = Fixture.GetEndpoint("backend");
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		response.EnsureSuccessStatusCode();
+		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return org.GetProperty("id").GetProperty("value").GetString()!;
+	}
+
+	private async Task DeleteOrganizationAsync(Uri backend, string organizationId)
+	{
+		using var http = await CreateAuthenticatedHttpClientAsync(backend);
+		await http.DeleteAsync($"/v1/organizations/{organizationId}");
+	}
+
+	private async Task<HttpClient> CreateAuthenticatedHttpClientAsync(Uri backend)
+	{
+		var token = await Page.EvaluateAsync<string?>(@"() => {
+			for (let i = 0; i < sessionStorage.length; i++) {
+				const key = sessionStorage.key(i);
+				if (key && key.includes('oidc.user')) {
+					const entry = JSON.parse(sessionStorage.getItem(key) ?? 'null');
+					if (entry?.access_token) return entry.access_token;
+				}
+			}
+			return null;
+		}");
+		token.Should().NotBeNull("OIDC access token must be available in sessionStorage after login");
+
+		var http = new HttpClient { BaseAddress = backend };
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+		return http;
+	}
+}

--- a/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/CalendarWidget.tsx
@@ -345,21 +345,40 @@ function CalendarWidget({
 		[displayedCalData, i18n.language],
 	);
 
-	// #983: opening on the current month whenever the organizer happens to
-	// have no events scheduled in it wastes ~800px on an empty grid and,
-	// since `calDate` also starts on today, defaults to showing exactly
-	// nothing. The one-shot flag is consumed on the *first* load to
-	// complete, regardless of which view that happens to be (medium/compact
-	// widgets default to week/agenda, not month) - gating it behind
-	// `calView === "month"` instead would leave the flag unconsumed for
-	// those sizes and keep re-firing on every later view change, silently
-	// overriding a month view the organizer switched to deliberately.
+	// #983/#2045: opening on the current month (or week) whenever the
+	// organizer happens to have no events scheduled in it wastes hundreds of
+	// px on an empty grid and, since `calDate` also starts on today, defaults
+	// to showing exactly nothing - including week view, which #2045 reported
+	// scrolled to a completely empty night-hours grid because the org's only
+	// opportunity fell outside that week. Agenda has no such "which
+	// week/month" problem - it just lists whatever's actually upcoming - so
+	// any grid view that opens empty falls back to it. The one-shot flag is
+	// consumed on the *first* load to complete, regardless of which view
+	// that happens to be (medium/compact widgets default to week/agenda, not
+	// month) - gating it behind a specific view instead would leave the flag
+	// unconsumed for those sizes and keep re-firing on every later view
+	// change, silently overriding a view the organizer switched to
+	// deliberately.
 	const [hasCheckedInitialView, setHasCheckedInitialView] = useState(false);
 	useEffect(() => {
 		if (hasCheckedInitialView || calLoading) return;
 		setHasCheckedInitialView(true);
-		if (calView === "month" && calEvents.length === 0) setCalView("agenda");
+		if (calView !== "agenda" && calEvents.length === 0) setCalView("agenda");
 	}, [calLoading, calView, calEvents, hasCheckedInitialView]);
+
+	// react-big-calendar defaults an unset scrollToTime to midnight for week/
+	// day views (confirmed in node_modules/react-big-calendar/lib/{Week,Day}.js)
+	// - opening scrolled to a wall of empty night hours instead of the day's
+	// actual business hours is exactly #2045's reported bug. Falls back to
+	// the earliest event actually on screen when there is one, so a shift
+	// starting before 8am is still visible without an extra scroll.
+	const scrollToTime = useMemo(() => {
+		const eventHours = calEvents.map((e) => e.start.getHours());
+		const startHour = eventHours.length > 0 ? Math.min(8, ...eventHours) : 8;
+		const scrollDate = new Date(calDate);
+		scrollDate.setHours(startHour, 0, 0, 0);
+		return scrollDate;
+	}, [calEvents, calDate]);
 
 	const calendarMessages = useMemo(
 		() => ({
@@ -480,9 +499,30 @@ function CalendarWidget({
 							<Skeleton className="h-6 w-32" />
 							<Skeleton className="h-6 w-24" />
 						</div>
-						{Array.from({ length: 3 }).map((_, i) => (
-							<Skeleton key={i} className="h-10 w-full" />
-						))}
+						{/* #2045: matches the shape of whatever view is actually about
+						to render instead of always the same short list - agenda really
+						is a handful of rows, but week/month resolve to a real day/week
+						grid, and a short-list skeleton for those swapped for a much
+						taller grid the instant data arrived, jumping the page under the
+						organizer. */}
+						{calView === "agenda" ? (
+							<div aria-hidden="true" className="space-y-2">
+								{Array.from({ length: 3 }).map((_, i) => (
+									<Skeleton key={i} className="h-10 w-full" />
+								))}
+							</div>
+						) : (
+							<div
+								aria-hidden="true"
+								className={`grid gap-1 ${calView === "month" ? "grid-cols-7" : "grid-cols-1"}`}
+							>
+								{Array.from({
+									length: calView === "month" ? 35 : calView === "week" ? 7 : 1,
+								}).map((_, i) => (
+									<Skeleton key={i} className="h-16 w-full" />
+								))}
+							</div>
+						)}
 					</div>
 				)}
 				{calError && (
@@ -507,6 +547,7 @@ function CalendarWidget({
 							date={calDate}
 							onNavigate={(d: Date) => setCalDate(d)}
 							views={["month", "week", "day", "agenda"]}
+							scrollToTime={scrollToTime}
 							style={{ height: "100%", minHeight: CALENDAR_MIN_HEIGHT_PX }}
 							components={calendarComponents}
 							eventPropGetter={calendarEventPropGetter}

--- a/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
@@ -96,7 +96,7 @@ export default function EditableWidgetTile({
 					? onGripPointerDown
 					: undefined
 			}
-			className={`relative h-full ${
+			className={`relative ${editing ? "h-full" : "h-full lg:h-auto"} ${
 				editing && showPlacementControls && !isPlacing && !placingDisabled
 					? "cursor-grab touch-none active:cursor-grabbing"
 					: editing
@@ -104,7 +104,16 @@ export default function EditableWidgetTile({
 						: ""
 			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
 		>
-			<div inert={editing} className={`h-full ${editing ? "opacity-60" : ""}`}>
+			<div
+				inert={editing}
+				className={`h-full ${editing ? "opacity-60" : ""} ${
+					// Reserves room for the grip button below (absolutely positioned,
+					// centered at the tile's top edge) instead of letting it sit on
+					// top of WidgetCard's own title - on a narrow tile the two used to
+					// overlap directly (#2045, PR #2038 F12).
+					editing && showPlacementControls ? "pt-10" : ""
+				}`}
+			>
 				{/* A crash inside a single widget shouldn't blank the whole dashboard
 				(#1243) - the default full-page ErrorBoundary fallback would break
 				this tile's grid layout, so a small inline one is used instead. It

--- a/frontend/src/pages/app/OrgDashboardPage/SettingsIconWidget.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/SettingsIconWidget.tsx
@@ -12,9 +12,11 @@ interface Props {
 
 // A minimal shortcut tile to the settings page - distinct from
 // SettingsWidget's full organization summary card, for organizers who just
-// want a quick link rather than a preview. Icon-only at its default compact
-// footprint; a wider placement (#15) has room to also spell out the label
-// instead of just growing empty whitespace around the icon.
+// want a quick link rather than a preview. #2045: the label is always
+// visible, even at this widget's own tiny default compact footprint - a
+// bare gear icon with no on-screen text gave a sighted organizer no clue
+// what it was or that it was clickable, even though the link already had an
+// accessible name (aria-label below) for assistive tech.
 function SettingsIconWidget({ organizationId, size }: Props) {
 	const { t } = useTranslation();
 	const title = t("orgDashboard.settingsIconWidgetTitle");
@@ -32,12 +34,10 @@ function SettingsIconWidget({ organizationId, size }: Props) {
 			/>
 			<div
 				aria-hidden="true"
-				className={`flex items-center justify-center py-2 text-brand-700 ${size === "compact" ? "flex-col" : "flex-row gap-3"}`}
+				className={`flex items-center justify-center py-2 text-brand-700 ${size === "compact" ? "flex-col gap-1" : "flex-row gap-3"}`}
 			>
 				<Cog6ToothIcon className="h-8 w-8" />
-				{size !== "compact" && (
-					<span className="text-sm font-medium">{title}</span>
-				)}
+				<span className="text-sm font-medium">{title}</span>
 			</div>
 		</WidgetCard>
 	);

--- a/frontend/src/pages/app/OrgDashboardPage/WidgetCard.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/WidgetCard.tsx
@@ -27,11 +27,13 @@ export default function WidgetCard({
 				</h2>
 				{action}
 			</div>
-			{/* The grid row height dashboard-wide is now fixed (see
-			OrgDashboardPage's grid className), so a widget whose content is
-			taller than its allotted rows scrolls within itself here instead of
-			growing the shared row band and throwing off every other tile's
-			height. overflow-x-auto is the same idea sideways: html sets
+			{/* The grid row height is fixed only while editing (see
+			OrgDashboardPage's grid className and EditableWidgetTile's h-full -
+			#2045 stopped forcing that outside edit mode so a card sizes to its
+			own content instead of stretching into empty whitespace), so a widget
+			whose content is taller than its allotted rows scrolls within itself
+			here instead of growing the shared row band and throwing off every
+			other tile's height. overflow-x-auto is the same idea sideways: html sets
 			overflow-x: clip page-wide (see global.css), so a widget whose
 			content is wider than its rendered width - e.g. the Calendar
 			widget's toolbar/agenda table on a narrow viewport - would

--- a/frontend/src/pages/app/OrgDashboardPage/index.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/index.tsx
@@ -631,22 +631,29 @@ export default function OrgDashboardPage() {
 	) : (
 		<div
 			data-testid="dashboard-widget-grid"
-			// Uniform (not minmax(64px, auto)) row height: CSS Grid auto-rows
-			// apply to the whole row band across every column, not just the cell
-			// whose content demanded the extra height - a minmax row would let a
-			// single tall widget stretch its entire row, including the backdrop
-			// guide cells and any other widget sharing that row. A widget whose
-			// content exceeds its allotted rows scrolls internally instead (see
-			// WidgetCard).
+			// Uniform (not minmax(64px, auto)) row height while editing: CSS Grid
+			// auto-rows apply to the whole row band across every column, not just
+			// the cell whose content demanded the extra height - a minmax row
+			// would let a single tall widget stretch its entire row, including the
+			// backdrop guide cells and any other widget sharing that row. A widget
+			// whose content exceeds its allotted rows scrolls internally instead
+			// (see WidgetCard).
 			//
-			// The row height itself (see .dashboard-widget-grid in global.css)
-			// tracks the actual rendered column width via a container query,
-			// rather than a flat pixel constant - width already scales with the
-			// viewport (grid-cols-8's 1fr tracks), and matching row height to it
-			// keeps a widget's on-screen proportions (short-and-wide vs.
-			// tall-and-narrow) consistent across screen sizes instead of warping
-			// while its stored cell width/height stays the same.
-			className="dashboard-widget-grid grid grid-cols-1 gap-4 lg:grid-cols-8"
+			// The row height itself (see .dashboard-widget-grid[--editing] in
+			// global.css) tracks the actual rendered column width via a container
+			// query, rather than a flat pixel constant - width already scales
+			// with the viewport (grid-cols-8's 1fr tracks), and matching row
+			// height to it keeps a widget's on-screen proportions (short-and-wide
+			// vs. tall-and-narrow) consistent across screen sizes instead of
+			// warping while its stored cell width/height stays the same.
+			//
+			// #2045: outside edit mode there's no backdrop/resize affordance to
+			// keep uniform for, so the modifier class is dropped and rows size to
+			// their own content instead (align-items: start in global.css keeps a
+			// short card from being stretched to match a taller sibling in the
+			// same row) - a card holding one line of real content no longer
+			// claims a full square cell's worth of empty white space.
+			className={`dashboard-widget-grid grid grid-cols-1 gap-4 lg:grid-cols-8 ${editing ? "dashboard-widget-grid--editing" : ""}`}
 			// role="presentation": this delegated onClick/onPointerOver only ever
 			// acts on a bubbled event that actually originated on one of the
 			// aria-hidden guide cells above (see guideCellFromEvent) - the

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -367,14 +367,28 @@ widgets, where EVENT still gets ample room and titles show in full (#1906). */
  * widgetCatalog.ts and OrgDashboardPage/index.tsx) overrides it inline so
  * its own row height still tracks its own (narrower) rendered width the
  * same way the full-width grid already does, instead of assuming 8
- * columns' worth of gaps that aren't actually there. */
+ * columns' worth of gaps that aren't actually there.
+ *
+ * The uniform square row height only actually matters while editing (see
+ * the --editing modifier below) - that's what keeps the placement backdrop's
+ * guide cells and the drag/resize affordance predictable. Outside edit mode
+ * there's no backdrop to keep in sync, so rows are left at their initial
+ * (content-sized) height and align-items: start stops a short widget from
+ * being stretched to match a taller sibling in the same row - a card with
+ * one line of real content no longer claims a full square cell of empty
+ * white space (#2045). EditableWidgetTile/WidgetCard still opt into h-full
+ * while editing so the uniform cell continues to render as one full tile.
+ * align-items is scoped to :not(--editing) specifically because the
+ * placement backdrop's own guide cells (OrgDashboardPage's guideCells) have
+ * no explicit height of their own and depend on the default stretch to fill
+ * their cell while editing - align-items: start would collapse them. */
 .dashboard-widget-grid {
 	container-type: inline-size;
 	--dashboard-grid-columns: 8;
 }
 
 @media (min-width: 1024px) {
-	.dashboard-widget-grid {
+	.dashboard-widget-grid.dashboard-widget-grid--editing {
 		grid-auto-rows: max(
 			64px,
 			calc(
@@ -382,6 +396,10 @@ widgets, where EVENT still gets ample room and titles show in full (#1906). */
 					var(--dashboard-grid-columns)
 			)
 		);
+	}
+
+	.dashboard-widget-grid:not(.dashboard-widget-grid--editing) {
+		align-items: start;
 	}
 }
 


### PR DESCRIPTION
Fixes #2045. The organizer dashboard's calendar widget opened scrolled to midnight and, for a view with nothing scheduled, silently sat on an empty grid rather than the org's actual next event; widget cards were force- stretched to a fixed square row height regardless of content, wasting hundreds of px on short-content widgets; and the SettingsIcon widget's gear icon had no visible label at its own default compact size.

- CalendarWidget: pass scrollToTime (business hours, or the earliest event on screen) instead of react-big-calendar's midnight default, and generalize the existing month-only empty-view fallback to any grid view so an empty week/day lands on Agenda too. Loading skeletons now match the shape of the view about to render instead of always a short list.
- Dashboard grid: the uniform, container-query-derived square row height now applies only while editing (needed for the placement backdrop and resize affordance) - outside edit mode, rows size to their own content (align-items: start) instead of stretching every card to match.
- EditableWidgetTile: reserve space for the drag handle above the title in edit mode instead of letting it overlay a narrow widget's heading.
- SettingsIconWidget: always show the visible label, not just at non-compact sizes.

## What

<!-- Summarize the change in one or two sentences. -->

## Why

<!-- Explain the motivation. Link the issue this addresses. -->

Closes #

## Testing

<!-- Which tests were added/updated, and how were they run? -->

## Live verification

<!-- Required for bug fixes and features (see root AGENTS.md "Mandatory: Deploy and verify").
Document what was observed on the release-candidate / live-staging check, or state why this
change doesn't need one (e.g. docs-only, CI config). -->

## Checklist

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior
