### PR TITLE
fix: give each administration sub-page its own title and h1

### DIFF
--- a/backend/tests/VisualTests/AdministrationNavLinkTests.cs
+++ b/backend/tests/VisualTests/AdministrationNavLinkTests.cs
@@ -25,10 +25,12 @@ public class AdministrationNavLinkTests(AspireFixture fixture) : VisualTestBase(
 		await Expect(link).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
 		await link.ClickAsync();
-		// /administration is a shell that redirects to its first section.
+		// /administration is a shell that redirects to its first section - the
+		// h1 names that section, not the shell itself (#2052).
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/administration/organizations");
-		await Expect(Page.Locator("h1")).ToHaveTextAsync("Administration");
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Organizations");
+		await Expect(Page).ToHaveTitleAsync("Organizations - Administration | Einsatzbereit");
 	}
 
 	[Test]
@@ -50,10 +52,10 @@ public class AdministrationNavLinkTests(AspireFixture fixture) : VisualTestBase(
 	// Regression for #1026: the nav link was already hidden for non-admins
 	// (see the test above), but /administration itself had no role check -
 	// a non-admin who typed the URL directly still got the page shell (the
-	// "Administration" heading) with every section immediately failing its
-	// API call and rendering an error banner, instead of being kept off the
-	// page entirely. ProtectedRoute's requiredRole="admin" now keeps such
-	// visitors out before AdministrationPage ever mounts.
+	// section h1, e.g. "Organizations") with every section immediately
+	// failing its API call and rendering an error banner, instead of being
+	// kept off the page entirely. ProtectedRoute's requiredRole="admin" now
+	// keeps such visitors out before AdministrationPage ever mounts.
 	//
 	// Amended by #1774: keeping them out used to mean <Navigate to="/" />,
 	// which silently dumped anyone following a bookmarked or shared admin link
@@ -77,7 +79,7 @@ public class AdministrationNavLinkTests(AspireFixture fixture) : VisualTestBase(
 		await Expect(Page.GetByText("Your account does not have admin rights", new() { Exact = false }))
 			.ToBeVisibleAsync();
 		// The page itself still never mounts - the point of #1026 stands.
-		await Expect(Page.Locator("h1")).Not.ToHaveTextAsync("Administration");
+		await Expect(Page.Locator("h1")).Not.ToHaveTextAsync("Organizations");
 		// ...and the URL is still the one that was asked for, rather than "/".
 		await Expect(Page).ToHaveURLAsync($"{origin}/administration");
 		// AdministrationPage is what would normally set the tab title, and it is
@@ -101,6 +103,6 @@ public class AdministrationNavLinkTests(AspireFixture fixture) : VisualTestBase(
 		await Page.GotoAsync($"{origin}/administration");
 
 		await Page.WaitForURLAsync($"{origin}/administration/organizations", new() { Timeout = 15_000 });
-		await Expect(Page.Locator("h1")).ToHaveTextAsync("Administration");
+		await Expect(Page.Locator("h1")).ToHaveTextAsync("Organizations");
 	}
 }

--- a/backend/tests/VisualTests/AdministrationPageTitleTests.cs
+++ b/backend/tests/VisualTests/AdministrationPageTitleTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Playwright;
+
+namespace VisualTests;
+
+/// <summary>
+/// Regression for #2052: /administration/organizations, /users, /reports and
+/// /audit-log all rendered the same document title and h1 ("Administration"),
+/// with the section name only appearing as an h2 further down. Each route now
+/// gets its own distinct title/h1 pair, matching the pattern already used
+/// elsewhere (e.g. AuthGuardTests/NavigationTests' org-scoped pages).
+/// </summary>
+[ClassDataSource<AspireFixture>(Shared = SharedType.PerTestSession)]
+public class AdministrationPageTitleTests(AspireFixture fixture) : VisualTestBase(fixture)
+{
+	[Test]
+	[Arguments("organizations", "Organizations")]
+	[Arguments("users", "Users")]
+	[Arguments("reports", "Reports")]
+	[Arguments("audit-log", "Audit log")]
+	public async Task AdministrationPage_EachSection_HasItsOwnDistinctTitleAndHeading(
+		string section,
+		string sectionName)
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		var origin = frontend.GetLeftPart(UriPartial.Authority);
+
+		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "admin", "admin123");
+		await Expect(Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Page.GotoAsync($"{origin}/administration/{section}");
+
+		await Expect(Page.Locator("h1")).ToHaveTextAsync(sectionName, new() { Timeout = 15_000 });
+		await Expect(Page).ToHaveTitleAsync($"{sectionName} - Administration | Einsatzbereit");
+	}
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1249,7 +1249,6 @@
     },
     "administration": {
       "title": "Administration",
-      "eyebrow": "Plattform",
       "subNavLabel": "Administrationsbereiche",
       "organizationsHeading": "Organisationen",
       "usersHeading": "Nutzer:innen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1249,7 +1249,6 @@
     },
     "administration": {
       "title": "Administration",
-      "eyebrow": "Platform",
       "subNavLabel": "Administration sections",
       "organizationsHeading": "Organizations",
       "usersHeading": "Users",

--- a/frontend/src/pages/AdministrationPage.tsx
+++ b/frontend/src/pages/AdministrationPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import type { ReactNode } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { Link, Outlet, useLocation } from "react-router";
@@ -22,7 +21,6 @@ import { avatarColorClasses } from "../lib/avatarColor";
 import { usePageTitle } from "../hooks/usePageTitle";
 import Chip from "../components/Chip";
 import PageHeaderBand from "../components/PageHeaderBand";
-import PageSectionHeading from "../components/PageSectionHeading";
 import SubNavRail from "../components/SubNavRail";
 import Skeleton from "../components/Skeleton";
 import EmptyState from "../components/EmptyState";
@@ -79,17 +77,21 @@ export const ADMIN_TABS = [
 export default function AdministrationPage() {
 	const { t } = useTranslation();
 	const { pathname } = useLocation();
-	usePageTitle(t("administration.title"));
 
-	const active =
-		ADMIN_TABS.find((tab) => pathname.startsWith(tab.href))?.key ??
-		"organizations";
+	// The active tab drives the page title/h1 below, not just the rail's
+	// highlighted item - each of the four routes needs its own distinct pair
+	// (#2052), where the shell used to render the fixed "Administration" for
+	// all of them and left the section name in an h2 further down.
+	const activeTab =
+		ADMIN_TABS.find((tab) => pathname.startsWith(tab.href)) ?? ADMIN_TABS[0];
+	const sectionTitle = t(activeTab.labelKey);
+	usePageTitle(`${sectionTitle} - ${t("administration.title")}`);
 
 	return (
 		<>
 			<PageHeaderBand
-				eyebrow={t("administration.eyebrow")}
-				title={t("administration.title")}
+				eyebrow={t("administration.title")}
+				title={sectionTitle}
 			/>
 
 			<div
@@ -98,7 +100,7 @@ export default function AdministrationPage() {
 			>
 				<SubNavRail
 					ariaLabel={t("administration.subNavLabel")}
-					active={active}
+					active={activeTab.key}
 					items={ADMIN_TABS.map((tab) => ({
 						key: tab.key,
 						href: tab.href,
@@ -113,60 +115,30 @@ export default function AdministrationPage() {
 	);
 }
 
-function AdminSection({
-	headingKey,
-	descriptionKey,
-	children,
-}: {
-	headingKey: string;
-	descriptionKey?: string;
-	children: ReactNode;
-}) {
-	const { t } = useTranslation();
-	return (
-		<section>
-			<PageSectionHeading
-				description={descriptionKey ? t(descriptionKey) : undefined}
-			>
-				{t(headingKey)}
-			</PageSectionHeading>
-			{children}
-		</section>
-	);
-}
-
 export function AdminOrganizationsPage() {
-	return (
-		<AdminSection headingKey="administration.organizationsHeading">
-			<OrganizationsSection />
-		</AdminSection>
-	);
+	return <OrganizationsSection />;
 }
 
 export function AdminUsersPage() {
-	return (
-		<AdminSection headingKey="administration.usersHeading">
-			<UsersSection />
-		</AdminSection>
-	);
+	return <UsersSection />;
 }
 
 export function AdminReportsPage() {
-	return (
-		<AdminSection headingKey="administration.reportsHeading">
-			<ReportsSection />
-		</AdminSection>
-	);
+	return <ReportsSection />;
 }
 
 export function AdminAuditLogPage() {
+	const { t } = useTranslation();
 	return (
-		<AdminSection
-			headingKey="administration.auditLogHeading"
-			descriptionKey="administration.auditLog.scopeDescription"
-		>
+		<>
+			{/* No repeated "Audit log" heading here - the band's h1 above already
+			says that (#2052). Only the scope note, which the old h2 pairing used
+			to carry as PageSectionHeading's description, still earns its keep. */}
+			<p className="mb-4 text-sm text-gray-500">
+				{t("administration.auditLog.scopeDescription")}
+			</p>
 			<AuditLogSection />
-		</AdminSection>
+		</>
 	);
 }
 


### PR DESCRIPTION
## What

Each `/administration/*` sub-page (organizations, users, reports, audit log) now gets its own document title and `<h1>` instead of all four sharing the fixed "Administration" title/heading.

## Why

`AdministrationPage` always rendered `usePageTitle(t("administration.title"))` and `PageHeaderBand`'s `title="Administration"`, regardless of which sub-route was active - the actual section name only showed up as an `<h2>` further down via a now-removed `AdminSection`/`PageSectionHeading` wrapper. Every other area of the app titles its sub-pages correctly (e.g. via `usePageTitle` combined with the active section/entity name), so this was the one inconsistent spot, flagged independently in 4 separate reviews.

Closes #2052

## Testing

- `AdministrationPage` now derives the active tab from the URL and uses its label for both the document title (`"{Section} - Administration | Einsatzbereit"`, matching the `usePageTitle` pattern used elsewhere, e.g. `OrgMembersPage`) and the `<h1>` (via `PageHeaderBand`'s `title`), demoting "Administration" into the band's `eyebrow`.
- The old `AdminSection` wrapper (which rendered a redundant `<h2>` with the same section name) is removed, since it would now literally duplicate the promoted `<h1>` text; the audit log's scope-description note is kept as a plain paragraph.
- Removed the now-unused `administration.eyebrow` locale key ("Platform"/"Plattform") from both `en.json` and `de.json`.
- Updated the two existing `h1` assertions in `AdministrationNavLinkTests.cs` that expected the old fixed "Administration" text.
- Added `AdministrationPageTitleTests.cs` (TUnit/Playwright), asserting the correct `<h1>` text and document title for all four sub-routes.
- Ran locally: `pnpm check` (tsc), `pnpm lint`, `pnpm i18n:check`, `pnpm format:write` (no changes), `dotnet build` for `Api`, `VisualTests`, and `ArchitectureTests` - all green. `/self-review` run, plus the `a11y-check` and `i18n-check` subagents on this diff - both passed with no findings.
- `VisualTests` itself needs real container networking (Aspire/Testcontainers), which isn't available in this sandboxed session - see root `AGENTS.md`'s Sandbox Limitations. CI's `dotnet.yml` will run the full suite including the new test.

## Live verification

Per the requester's explicit instructions for this task, no release candidate was cut and no live-staging verification was performed here - they will handle deploy/verification themselves.

## Checklist

- [x] `/self-review` run and findings addressed (no findings survived review)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this page's title/heading behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhkwhHRcqNFFQVVN665u6)_