### PR TITLE
fix: close accessibility and consistency gaps in the Keycloak login theme

### DIFF
--- a/backend/tests/VisualTests/KeycloakThemeTests.cs
+++ b/backend/tests/VisualTests/KeycloakThemeTests.cs
@@ -111,6 +111,10 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(Page.Locator(".card-eyebrow")).ToHaveTextAsync("Sign in");
 		await Expect(Page.Locator("#password")).ToBeVisibleAsync();
 		await Expect(Page.Locator("#kc-login")).ToBeVisibleAsync();
+		// #2063: stock Keycloak's doLogIn is Title Case ("Sign In"), which read
+		// inconsistently against the sentence-case eyebrow right above it and
+		// the rest of the app.
+		await Expect(Page.Locator("#kc-login")).ToHaveAttributeAsync("value", "Sign in");
 	}
 
 	[Test]
@@ -151,6 +155,79 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var background = await Page.Locator("#kc-login")
 			.EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor");
 		background.Should().Be("rgb(34, 105, 71)", "the primary button should use brand-700");
+	}
+
+	[Test]
+	public async Task Login_ForgotPasswordLink_MatchesRegisterLinkTreatment()
+	{
+		// #2063: "Forgot password?" used to render in the same muted grey as
+		// the static "Remember me" label beside it, with no underline and
+		// nothing marking it as interactive - while the less critical
+		// "Register" link in the card footer got full brand-700 treatment.
+		// Also pins the sentence-case wording (stock Keycloak's doForgotPassword
+		// is Title Case: "Forgot Password?").
+		await Page.GotoAsync(AuthUrl(locale: "en"));
+		var forgotPassword = Page.GetByRole(AriaRole.Link, new() { Name = "Forgot password?", Exact = true });
+		await Expect(forgotPassword).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		var color = await forgotPassword.EvaluateAsync<string>("el => getComputedStyle(el).color");
+		color.Should().Be("rgb(34, 105, 71)",
+			"login: \"Forgot password?\" should get the same brand-700 treatment as \"Register\"");
+	}
+
+	[Test]
+	public async Task Login_FailedAttempt_AssociatesErrorWithBothFieldsAndRecolorsFocusRing()
+	{
+		// #2063: both fields got aria-invalid="true" after a failed attempt,
+		// but neither pointed aria-describedby at the error message span - a
+		// screen-reader user tabbing back into them heard "invalid" with no
+		// explanation why. Separately, the theme's global brand-green
+		// :focus-visible ring was drawn on top of the red error border, so the
+		// field the user is actually looking at looked the least like it had
+		// a problem - the ring should turn red to match instead.
+		await Page.GotoAsync(AuthUrl(locale: "en"));
+		await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+		await Page.Locator("#username").FillAsync($"no-such-user-{Guid.NewGuid():N}");
+		await Page.Locator("#password").FillAsync("wrong-password");
+		await Page.Locator("#kc-login").ClickAsync();
+
+		await Expect(Page.Locator("#input-error")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+		await Expect(Page.Locator("#username")).ToHaveAttributeAsync("aria-invalid", "true");
+		await Expect(Page.Locator("#username")).ToHaveAttributeAsync("aria-describedby", "input-error");
+		await Expect(Page.Locator("#password")).ToHaveAttributeAsync("aria-invalid", "true");
+		await Expect(Page.Locator("#password")).ToHaveAttributeAsync("aria-describedby", "input-error");
+
+		await Page.Locator("#username").FocusAsync();
+		var outlineColor = await Page.Locator("#username")
+			.EvaluateAsync<string>("el => getComputedStyle(el).outlineColor");
+		outlineColor.Should().Be("rgb(220, 38, 38)",
+			"login: the focus ring on an invalid, focused field should turn red, not stay the brand green");
+	}
+
+	[Test]
+	public async Task Login_LanguageMenu_LabelsAreEndonymsRegardlessOfCurrentLocale()
+	{
+		// #2063: stock Keycloak's messages_de.properties lists "Deutsch" for
+		// German but "Englisch (English)" for English - translating the other
+		// locale's name into the current one, with the endonym only in
+		// brackets. The in-app switcher (Header/LanguageSelector.tsx) uses
+		// endonyms for both languages regardless of which one is currently
+		// active; the theme's menu should match.
+		foreach (var locale in new[] { "en", "de" })
+		{
+			await Page.GotoAsync(AuthUrl(locale: locale));
+			await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+			await Page.Locator(".lang-trigger").ClickAsync();
+			var items = Page.Locator(".lang-menu .lang-item");
+			await Expect(items).ToHaveCountAsync(2);
+
+			var labels = (await items.AllTextContentsAsync()).Select(l => l.Trim());
+			labels.Should().BeEquivalentTo(["Deutsch", "English"],
+				$"locale={locale}: the language menu should list endonyms for both languages");
+		}
 	}
 
 	[Test]
@@ -225,7 +302,7 @@ public class KeycloakThemeTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Page.GotoAsync(AuthUrl(locale: "en"));
 		await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 30_000 });
 
-		await Page.GetByRole(AriaRole.Link, new() { Name = "Forgot Password?" }).ClickAsync();
+		await Page.GetByRole(AriaRole.Link, new() { Name = "Forgot password?" }).ClickAsync();
 		await Expect(Page.Locator("#username")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		await AssertThemeShellAsync("reset-password");

--- a/keycloak/themes/einsatzbereit/login/login.ftl
+++ b/keycloak/themes/einsatzbereit/login/login.ftl
@@ -26,6 +26,7 @@
 							value="${(login.username!'')}"
 							type="text"
 							aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+							<#if messagesPerField.existsError('username','password')>aria-describedby="input-error"</#if>
 							autocomplete="username"
 							autofocus
 							required
@@ -61,6 +62,7 @@
 							name="password"
 							type="password"
 							aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+							<#if messagesPerField.existsError('username','password')>aria-describedby="input-error"</#if>
 							autocomplete="current-password"
 							required
 							placeholder=" "
@@ -94,7 +96,7 @@
 						</#if>
 					</div>
 					<#if realm.resetPasswordAllowed>
-						<a href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a>
+						<a href="${url.loginResetCredentialsUrl}" class="link-accent">${msg("doForgotPassword")}</a>
 					</#if>
 				</div>
 

--- a/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_de.properties
@@ -9,6 +9,11 @@ backToLogin=Zurück zur Anmeldung
 backToSite=Zurück zu Einsatzbereit
 switchLanguage=Sprache wechseln
 
+# Endonyms in both directions - see the English bundle's locale_de/locale_en
+# for why (#2063).
+locale_de=Deutsch
+locale_en=English
+
 # Benennt den Schritt, zu dem die jeweilige Seite gehört. Die Registrierung
 # läuft über drei aufeinanderfolgende Keycloak-Seiten - Konto anlegen,
 # Adresse bestätigen, Passwort setzen - und auf keiner stand, dass sie

--- a/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
+++ b/keycloak/themes/einsatzbereit/login/messages/messages_en.properties
@@ -1,13 +1,27 @@
-loginTitle=Sign In
-registerTitle=Create Account
-emailForgotTitle=Reset Password
+loginTitle=Sign in
+registerTitle=Create account
+emailForgotTitle=Reset password
 emailForgotIntro=Enter your username or email address. We''ll send you a link to set a new password.
 doSubmitResetPassword=Send reset link
 noAccount=Don''t have an account yet?
 alreadyHaveAccount=Already have an account?
-backToLogin=Back to Sign In
+backToLogin=Back to sign in
 backToSite=Back to Einsatzbereit
 switchLanguage=Switch language
+
+# Kept in stock Title Case in base Keycloak ("Sign In", "Forgot Password?");
+# overridden here so the login form matches sentence case everywhere else in
+# the theme and in the app itself (#2063).
+doLogIn=Sign in
+doForgotPassword=Forgot password?
+
+# Endonyms in both directions, so "English" and "Deutsch" read the same
+# regardless of which language the page is currently in - stock Keycloak
+# instead translates the *other* locale's name into the current one
+# ("Englisch (English)" from German), unlike the in-app switcher, which
+# already uses endonyms for both (#2063).
+locale_de=Deutsch
+locale_en=English
 
 # Names the step of the funnel each page belongs to. Signing up runs across
 # three consecutive Keycloak screens - create account, confirm your address,

--- a/keycloak/themes/einsatzbereit/login/resources/css/einsatzbereit.css
+++ b/keycloak/themes/einsatzbereit/login/resources/css/einsatzbereit.css
@@ -393,6 +393,12 @@ a { color: inherit; }
 
 .form-input[aria-invalid="true"] { border-color: var(--destructive); }
 
+/* The global :focus-visible ring above is brand-700 (green) - on a field
+ * that also has a red error border, that made the one field the user is
+ * actually looking at look the least like it had a problem (#2063). Recolor
+ * the ring to match the error instead of overriding it away. */
+.form-input[aria-invalid="true"]:focus-visible { outline-color: var(--destructive); }
+
 .form-input:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
@@ -522,6 +528,16 @@ a { color: inherit; }
 .form-options-wrapper a:hover {
 	color: var(--foreground);
 	text-decoration: underline;
+}
+
+/* "Forgot password?" sat in the same muted grey as the static "Remember me"
+ * label beside it, with nothing marking it as interactive, while the
+ * .card-footer "Register" link on the same card got full brand treatment
+ * (#2063). Same color/weight here, resting and hovered alike. */
+.form-options a.link-accent,
+.form-options a.link-accent:hover {
+	color: var(--brand-700);
+	font-weight: 600;
 }
 
 /* One checkbox treatment for the whole theme. Previously "remember me" was


### PR DESCRIPTION
## What

Fixes five co-located accessibility/consistency gaps in the Keycloak FTL login theme (`keycloak/themes/einsatzbereit/login/`):

1. Associates the combined username/password error message with both fields via `aria-describedby="input-error"` (only rendered when the error actually exists, mirroring the existing `aria-invalid` conditional).
2. Gives "Forgot password?" the same brand-700, semibold link treatment as "Register" (new `.link-accent` class), instead of blending into the muted "Remember me" label beside it.
3. Recolors the `:focus-visible` ring to red (`var(--destructive)`) when a field is both `aria-invalid="true"` and focused, so the ring reinforces the error border instead of visually overpowering it with brand green.
4. Aligns the language menu to endonyms in both locales (`locale_de=Deutsch`, `locale_en=English` added to both message bundles), matching the in-app `LanguageSelector.tsx` convention - stock Keycloak instead translates the *other* locale's name into the current one (`Englisch (English)` from German).
5. Switches English strings to sentence case: the theme's own `loginTitle`/`registerTitle`/`emailForgotTitle`/`backToLogin` overrides, plus new overrides for stock Keycloak's Title Case `doLogIn` ("Sign In" -> "Sign in") and `doForgotPassword` ("Forgot Password?" -> "Forgot password?"), which weren't previously overridden by this theme.

German copy is unchanged - the issue's own text already quotes the current German rendering ("Passwort vergessen?") as correct, and the affected stock German strings don't carry a Sie/du distinction.

## Why

Closes #2063

## Testing

- `dotnet build tests/VisualTests` - compiles clean, 0 warnings/errors.
- `dotnet format --verify-no-changes` on the changed test file - no formatting violations.
- Added/extended TUnit + Playwright coverage in `backend/tests/VisualTests/KeycloakThemeTests.cs`:
  - `Login_RendersThemeShellWithBackLinkBelowCard` - extended to assert the primary button's value is "Sign in".
  - `Login_ForgotPasswordLink_MatchesRegisterLinkTreatment` (new) - asserts computed color matches brand-700 and the exact sentence-case wording.
  - `Login_FailedAttempt_AssociatesErrorWithBothFieldsAndRecolorsFocusRing` (new) - submits a bad login, asserts `aria-describedby` on both fields and that the focused/invalid field's outline color turns red.
  - `Login_LanguageMenu_LabelsAreEndonymsRegardlessOfCurrentLocale` (new) - opens the language menu under both `en` and `de` locales, asserts both items always read "Deutsch"/"English".
  - `ResetPassword_IsThemed` - updated the "Forgot Password?" locator literal to match the new copy (case-insensitive `GetByRole` matching means this wasn't a required change, just kept accurate).

Per this repo's [Sandbox Limitations](../blob/main/AGENTS.md#sandbox-limitations-claude-code-on-the-web), `VisualTests` needs real container networking (Aspire/Testcontainers) that isn't available in this session, so these were verified by compilation/format only, not by running the Playwright suite locally. CI's `dotnet.yml` runs the full suite including `VisualTests` on a real runner.

## Live verification

Per the request that opened this task, no release candidate was cut and no live-staging verification was performed here - the repo owner asked to manage the deploy/verify step themselves. `dotnet.yml`'s `visual-tests` job (VisualTests, real Aspire stack) will still exercise the new assertions above on this PR.

## Checklist

- [x] `/self-review` run and findings addressed (no findings - diff reviewed clean)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - theme-internal fix, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqqkD9ce3W3FBDk8fzrPVs)_