### PR TITLE
fix(backend,tests): stop VisualTests flaking on Keycloak resilience-pipeline rejections

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -37,11 +37,27 @@ internal sealed class KeycloakOrganizationService(
 		var alias = GenerateAlias(name);
 		var request = new { name, alias };
 
-		var response = await httpClient.PostAsJsonAsync(
-			$"/admin/realms/{_options.Realm}/organizations",
-			request,
-			JsonOptions,
-			cancellationToken);
+		HttpResponseMessage response;
+		try
+		{
+			response = await httpClient.PostAsJsonAsync(
+				$"/admin/realms/{_options.Realm}/organizations",
+				request,
+				JsonOptions,
+				cancellationToken);
+		}
+		catch (ExecutionRejectedException ex)
+		{
+			// Same normalization as GetMembersAsync above: this is the single
+			// most-called Keycloak write in the app (every organization creation
+			// goes through it), so it is also the most likely to observe
+			// AddStandardResilienceHandler's circuit breaker/timeout/rate limiter
+			// rejecting the call outright under sustained load, before it ever
+			// reaches EnsureSuccessAsync below.
+			throw new HttpRequestException(
+				$"Keycloak organization creation for '{name}' was rejected by the resilience pipeline: {ex.Message}",
+				ex);
+		}
 
 		await EnsureSuccessAsync(response, cancellationToken);
 

--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -183,7 +183,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new
 		{
 			name = $"A11y Focus Order Org {suffix}",
 			contactEmail = "contact@example.org",
@@ -280,7 +280,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Draft Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"A11y Draft Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -334,7 +334,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Owner Notice Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"A11y Owner Notice Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -381,7 +381,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Mobile Rail Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"A11y Mobile Rail Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -434,7 +434,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var organizerHttp = new HttpClient { BaseAddress = backend };
 		organizerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await organizerHttp.PostAsJsonAsync("/v1/organizations", new { name = $"A11y Status Slot Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(organizerHttp, "/v1/organizations", new { name = $"A11y Status Slot Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -548,7 +548,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Marker A11y Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Marker A11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -625,7 +625,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"No Map A11y Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"No Map A11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1222,7 +1222,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"A11yLogo {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"A11yLogo {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1424,7 +1424,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"EmptyDashA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -1503,7 +1503,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"EngagementManagementA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -1570,7 +1570,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"OrgEngagementsA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -1894,7 +1894,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"NotifA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2075,7 +2075,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"DetailOfflineA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2271,7 +2271,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name = $"{label} {suffix}" });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"{label} {suffix}" });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()
@@ -2295,7 +2295,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"CancelDialogA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2355,7 +2355,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"OrgEngagementsCancelDialogA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2415,7 +2415,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"CancelOpportunityDialogA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2463,7 +2463,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"{label} Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2636,7 +2636,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"ToastA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -2715,7 +2715,7 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"MarkedDayA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -42,7 +42,7 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 			seedHttp.DefaultRequestHeaders.Add(
 				"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-			var orgResponse = await seedHttp.PostAsJsonAsync(
+			var orgResponse = await PostJsonWithRetryAsync(seedHttp,
 				"/v1/organizations", new { name = $"AchievementsSelfSeed Org {suffix}" });
 			orgResponse.EnsureSuccessStatusCode();
 			var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -93,7 +93,7 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 			setupHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {setupSession.AccessToken}");
 
 			var setupSuffix = Guid.NewGuid().ToString("N");
-			var orgResponse = await setupHttp.PostAsJsonAsync(
+			var orgResponse = await PostJsonWithRetryAsync(setupHttp,
 				"/v1/organizations", new { name = $"AchievementSeed Org {setupSuffix}" });
 			orgResponse.EnsureSuccessStatusCode();
 			var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/AdminReportsTests.cs
+++ b/backend/tests/VisualTests/AdminReportsTests.cs
@@ -33,7 +33,7 @@ public class AdminReportsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations",
 			new { name = $"Admin Reports Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
+++ b/backend/tests/VisualTests/AvatarAndLogoDisplayTests.cs
@@ -97,7 +97,7 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualLogo {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"VisualLogo {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -168,7 +168,7 @@ public class AvatarAndLogoDisplayTests(AspireFixture fixture) : VisualTestBase(f
 
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"LogoRemoval {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"LogoRemoval {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -34,7 +34,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInNone Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInNone Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -96,7 +96,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInManual Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInManual Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -179,7 +179,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinSwitch Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInPinSwitch Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -258,7 +258,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"SlotCounts Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"SlotCounts Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -360,7 +360,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Unlimited Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Unlimited Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -26,7 +26,7 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInModalDeleted Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInModalDeleted Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
+++ b/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
@@ -86,7 +86,7 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinEdit Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInPinEdit Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/DateFilterCalendarTests.cs
+++ b/backend/tests/VisualTests/DateFilterCalendarTests.cs
@@ -143,7 +143,7 @@ public class DateFilterCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 	private static async Task<string> CreateOrganizationAsync(HttpClient http, string namePrefix)
 	{
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name = $"{namePrefix} {suffix}" });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"{namePrefix} {suffix}" });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/EngagementBulkActionsTests.cs
+++ b/backend/tests/VisualTests/EngagementBulkActionsTests.cs
@@ -107,7 +107,7 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 
 		// Fresh organization rather than olaf's shared seed org - see the
 		// identical note in EngagementManagementFiltersTests.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementCalendarTests.cs
+++ b/backend/tests/VisualTests/EngagementCalendarTests.cs
@@ -41,7 +41,7 @@ public class EngagementCalendarTests(AspireFixture fixture) : VisualTestBase(fix
 
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualCal {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"VisualCal {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
+++ b/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
@@ -132,7 +132,7 @@ public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTe
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs, which made GET
 		// /v1/organizations intermittently race to an empty list here.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
+++ b/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
@@ -26,7 +26,7 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInStatusCode Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInStatusCode Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -73,7 +73,7 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinOwner Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinOwner Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -131,7 +131,7 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinOracle Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinOracle Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -193,7 +193,7 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInPinLockout Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinLockout Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
+++ b/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
@@ -142,7 +142,7 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs (see EngagementCancellationReasonTests.cs).
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
@@ -164,7 +164,7 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs, which made GET
 		// /v1/organizations intermittently race to an empty list here.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"EngHistDeletedOpp Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
@@ -96,7 +96,7 @@ public class EngagementManagementCheckInPinTests(AspireFixture fixture) : Visual
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs, which made GET
 		// /v1/organizations intermittently race to an empty list here.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"CheckInPin Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFeedbackSectionTests.cs
@@ -91,7 +91,7 @@ public class EngagementManagementFeedbackSectionTests(AspireFixture fixture) : V
 		// Fresh organization rather than olaf's shared seed org - other
 		// VisualTests running concurrently in this shared Aspire session can
 		// mutate/delete shared orgs (see EngagementManagementCheckInPinTests).
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"FeedbackSection {label} Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
@@ -69,7 +69,7 @@ public class EngagementManagementFiltersTests(AspireFixture fixture) : VisualTes
 
 		// Fresh organization rather than olaf's shared seed org - see the
 		// identical note in EngagementManagementCheckInPinTests.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementReactivationTests.cs
+++ b/backend/tests/VisualTests/EngagementReactivationTests.cs
@@ -129,7 +129,7 @@ public class EngagementReactivationTests(AspireFixture fixture) : VisualTestBase
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs, which made GET
 		// /v1/organizations intermittently race to an empty list here.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"EngagementReactivation Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementStatusContrastTests.cs
+++ b/backend/tests/VisualTests/EngagementStatusContrastTests.cs
@@ -94,7 +94,7 @@ public class EngagementStatusContrastTests(AspireFixture fixture) : VisualTestBa
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs (see EngagementReactivationTests).
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"EngagementStatusContrast Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
+++ b/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
@@ -189,7 +189,7 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var createOrgResponse = await olafHttp.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/HeadingStructureTests.cs
+++ b/backend/tests/VisualTests/HeadingStructureTests.cs
@@ -36,7 +36,7 @@ public class HeadingStructureTests(AspireFixture fixture) : VisualTestBase(fixtu
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgName = $"HeadingA11y Org {suffix}";
-		(await http.PostAsJsonAsync("/v1/organizations", new { name = orgName })).EnsureSuccessStatusCode();
+		(await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = orgName })).EnsureSuccessStatusCode();
 
 		await Page.GotoAsync($"{origin}/organizations");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -69,7 +69,7 @@ public class HeadingStructureTests(AspireFixture fixture) : VisualTestBase(fixtu
 		var suffix = Guid.NewGuid().ToString("N");
 		var tag = $"heading2071-{suffix}";
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"HeadingA11y Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"HeadingA11y Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/JwtAudienceTests.cs
+++ b/backend/tests/VisualTests/JwtAudienceTests.cs
@@ -80,7 +80,7 @@ public class JwtAudienceTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var olafHttp = new HttpClient { BaseAddress = backendOrigin };
 		olafHttp.DefaultRequestHeaders.Add(
 			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 
 		var authErrors = new List<string>();

--- a/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
+++ b/backend/tests/VisualTests/LandingOpportunityPreviewTests.cs
@@ -98,7 +98,7 @@ public class LandingOpportunityPreviewTests(AspireFixture fixture) : VisualTestB
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations", new { name = $"Visual1914 LandingGrid {Guid.NewGuid():N}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/ListLayoutGridTests.cs
+++ b/backend/tests/VisualTests/ListLayoutGridTests.cs
@@ -44,7 +44,7 @@ public class ListLayoutGridTests(AspireFixture fixture) : VisualTestBase(fixture
 	private static async Task<string> CreateOrganizationAsync(HttpClient http, string namePrefix)
 	{
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name = $"{namePrefix} {suffix}" });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"{namePrefix} {suffix}" });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/LoadMoreErrorPreservesItemsTests.cs
+++ b/backend/tests/VisualTests/LoadMoreErrorPreservesItemsTests.cs
@@ -48,7 +48,7 @@ public class LoadMoreErrorPreservesItemsTests(AspireFixture fixture) : VisualTes
 		// and ListLayoutGridTests for the same tag-scoping pattern).
 		var tag = $"loadmore1226-{suffix}";
 
-		var orgResponse = await http.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations", new { name = $"LoadMoreError {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
+++ b/backend/tests/VisualTests/LocalizedCheckInPinErrorTests.cs
@@ -31,7 +31,7 @@ public class LocalizedCheckInPinErrorTests(AspireFixture fixture) : VisualTestBa
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"LocalizedPinError Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/LogoUploadRejectionMessageTests.cs
+++ b/backend/tests/VisualTests/LogoUploadRejectionMessageTests.cs
@@ -50,7 +50,7 @@ public class LogoUploadRejectionMessageTests(AspireFixture fixture) : VisualTest
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"LogoReject {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"LogoReject {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/MilestoneAchievementTests.cs
+++ b/backend/tests/VisualTests/MilestoneAchievementTests.cs
@@ -93,7 +93,7 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var createOrgResponse = await olafHttp.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations",
 			new { name = $"Milestone668 Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -135,7 +135,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckedInFuture Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckedInFuture Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -251,7 +251,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs (see EngagementReactivationTests).
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"MyEngagementsScopeTabs Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/MyEngagementsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTests.cs
@@ -34,7 +34,7 @@ public class MyEngagementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var orgName = $"MyEngagements Org {suffix}";
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		// CreateOrganizationEndpoint returns the raw domain Organization

--- a/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsTimeSlotTests.cs
@@ -40,7 +40,7 @@ public class MyEngagementsTimeSlotTests(AspireFixture fixture) : VisualTestBase(
 
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualSlot {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"VisualSlot {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsWithdrawErrorMessageTests.cs
@@ -36,7 +36,7 @@ public class MyEngagementsWithdrawErrorMessageTests(AspireFixture fixture) : Vis
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"MyEngagementsWithdrawErrorMessage Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -157,7 +157,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		// org - other VisualTests running concurrently in this shared Aspire
 		// session can mutate/delete shared orgs, which made GET
 		// /v1/organizations intermittently race to an empty list here.
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"NotifDeletedOpp Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -51,7 +51,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"NotifDeepLink Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -135,7 +135,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgName = $"NotifInvite Org {suffix}";
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -197,7 +197,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"NotifMarkReadFail Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
+++ b/backend/tests/VisualTests/NotificationUnreadMarkerTests.cs
@@ -39,7 +39,7 @@ public class NotificationUnreadMarkerTests(AspireFixture fixture) : VisualTestBa
 
 		// A fresh org rather than olaf's shared seed org - other VisualTests in
 		// this shared Aspire session mutate/delete shared orgs concurrently.
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"NotifUnreadMarker Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -543,7 +543,7 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 
 	private static async Task<string> CreateOrganizationAsync(HttpClient organizer, string keyword)
 	{
-		var response = await organizer.PostAsJsonAsync("/v1/organizations", new { name = $"Org {keyword}" });
+		var response = await PostJsonWithRetryAsync(organizer, "/v1/organizations", new { name = $"Org {keyword}" });
 		response.EnsureSuccessStatusCode();
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return body.GetProperty("id").GetProperty("value").GetString()

--- a/backend/tests/VisualTests/OpportunityDetailOfflineTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailOfflineTests.cs
@@ -32,7 +32,7 @@ public class OpportunityDetailOfflineTests(AspireFixture fixture) : VisualTestBa
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations", new { name = $"DetailOffline2065 {label} {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMeasureTests.cs
@@ -80,7 +80,7 @@ public class OpportunityDetailPageMeasureTests(AspireFixture fixture) : VisualTe
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var orgName = $"Measure1794 {suffix}";
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageMobileActionRailTests.cs
@@ -53,7 +53,7 @@ public class OpportunityDetailPageMobileActionRailTests(AspireFixture fixture) :
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"MobileRail1965 {label} {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"MobileRail1965 {label} {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailPageSpacingTests.cs
@@ -75,7 +75,7 @@ public class OpportunityDetailPageSpacingTests(AspireFixture fixture) : VisualTe
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var orgName = $"Spacing1111 {label} {suffix}";
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
+++ b/backend/tests/VisualTests/OpportunityDetailStatusCardTimeSlotTests.cs
@@ -28,7 +28,7 @@ public class OpportunityDetailStatusCardTimeSlotTests(AspireFixture fixture) : V
 		using var organizerHttp = new HttpClient { BaseAddress = backend };
 		organizerHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await organizerHttp.PostAsJsonAsync("/v1/organizations", new { name = $"StatusCardSlot Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(organizerHttp, "/v1/organizations", new { name = $"StatusCardSlot Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/OpportunityFilterRowAlignmentTests.cs
+++ b/backend/tests/VisualTests/OpportunityFilterRowAlignmentTests.cs
@@ -55,7 +55,7 @@ public class OpportunityFilterRowAlignmentTests(AspireFixture fixture) : VisualT
 	private static async Task SeedPublishedOpportunitiesAsync(HttpClient http)
 	{
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1798 FilterRow {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual1798 FilterRow {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/OpportunityResultCountTests.cs
+++ b/backend/tests/VisualTests/OpportunityResultCountTests.cs
@@ -43,7 +43,7 @@ public class OpportunityResultCountTests(AspireFixture fixture) : VisualTestBase
 	private static async Task SeedTaggedOpportunitiesAsync(
 		HttpClient http, string tag, IReadOnlyList<string> titles)
 	{
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"ResultCount {tag}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"ResultCount {tag}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
+++ b/backend/tests/VisualTests/OpportunityUnpublishCancelTests.cs
@@ -120,7 +120,7 @@ public class OpportunityUnpublishCancelTests(AspireFixture fixture) : VisualTest
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"{label} Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"{label} Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OrgAppCompactHeaderTests.cs
+++ b/backend/tests/VisualTests/OrgAppCompactHeaderTests.cs
@@ -128,7 +128,7 @@ public class OrgAppCompactHeaderTests(AspireFixture fixture) : VisualTestBase(fi
 	{
 		var backend = Fixture.GetEndpoint("backend");
 		using var http = await CreateAuthenticatedHttpClientAsync(backend);
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
@@ -214,7 +214,7 @@ public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualT
 	{
 		var backend = Fixture.GetEndpoint("backend");
 		using var http = await CreateAuthenticatedHttpClientAsync(backend);
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OrgDashboardSettingsIconWidgetTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardSettingsIconWidgetTests.cs
@@ -67,7 +67,7 @@ public class OrgDashboardSettingsIconWidgetTests(AspireFixture fixture) : Visual
 	{
 		var backend = Fixture.GetEndpoint("backend");
 		using var http = await CreateAuthenticatedHttpClientAsync(backend);
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -137,7 +137,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		olafHttp.DefaultRequestHeaders.Add(
 			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"Visual1780 {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -214,7 +214,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add(
 			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"Visual1780 Error {Guid.NewGuid():N}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -387,7 +387,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		// full run, and this test only cares about a lone Calendar widget in
 		// its default (compact) placement.
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1254 {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual1254 {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -488,7 +488,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1959 {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual1959 {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -603,7 +603,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual812 {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual812 {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -730,7 +730,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual1397 {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual1397 {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -838,7 +838,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Visual Upcoming {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Visual Upcoming {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/OrganizationTests.cs
+++ b/backend/tests/VisualTests/OrganizationTests.cs
@@ -753,7 +753,7 @@ public class OrganizationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var animalShelterName = $"Lindenauer{suffix} Tierschutzverein e.V.";
 
 		foreach (var name in new[] { neighborhoodName, animalShelterName })
-			(await http.PostAsJsonAsync("/v1/organizations", new { name })).EnsureSuccessStatusCode();
+			(await PostJsonWithRetryAsync(http, "/v1/organizations", new { name })).EnsureSuccessStatusCode();
 
 		await Page.GotoAsync($"{origin}/organizations");
 		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -385,7 +385,7 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafSession.AccessToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"FeedbackEdit Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/QRScannerModalTests.cs
+++ b/backend/tests/VisualTests/QRScannerModalTests.cs
@@ -296,7 +296,7 @@ public class QRScannerModalTests(AspireFixture fixture) : VisualTestBase(fixture
 		using var veraHttp = new HttpClient { BaseAddress = backend };
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"QRScanner {label} Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"QRScanner {label} Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/QuickCheckInWidgetTests.cs
+++ b/backend/tests/VisualTests/QuickCheckInWidgetTests.cs
@@ -139,7 +139,7 @@ public class QuickCheckInWidgetTests(AspireFixture fixture) : VisualTestBase(fix
 
 	private static async Task<string> CreateOrganizationAsync(HttpClient http, string name)
 	{
-		var response = await http.PostAsJsonAsync("/v1/organizations", new { name });
+		var response = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name });
 		response.EnsureSuccessStatusCode();
 		var org = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return org.GetProperty("id").GetProperty("value").GetString()!;

--- a/backend/tests/VisualTests/ReducedMotionTransformTests.cs
+++ b/backend/tests/VisualTests/ReducedMotionTransformTests.cs
@@ -40,7 +40,7 @@ public class ReducedMotionTransformTests(AspireFixture fixture) : VisualTestBase
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"ReducedMotion {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"ReducedMotion {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/SessionExpiryTests.cs
+++ b/backend/tests/VisualTests/SessionExpiryTests.cs
@@ -136,7 +136,7 @@ public class SessionExpiryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations", new { name = $"Stale Session Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend/tests/VisualTests/SignUpVocabularyTests.cs
+++ b/backend/tests/VisualTests/SignUpVocabularyTests.cs
@@ -173,7 +173,7 @@ public class SignUpVocabularyTests(AspireFixture fixture) : VisualTestBase(fixtu
 		// A fresh organization per test rather than olaf's shared seed org -
 		// other tests in this shared Aspire session mutate the seed orgs (see
 		// EngagementCancellationReasonTests for the same reasoning).
-		var createOrgResponse = await http.PostAsJsonAsync(
+		var createOrgResponse = await PostJsonWithRetryAsync(http,
 			"/v1/organizations",
 			new { name = $"{label} Org {suffix}" });
 		createOrgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/SingleMarkerMapStaticTests.cs
+++ b/backend/tests/VisualTests/SingleMarkerMapStaticTests.cs
@@ -30,7 +30,7 @@ public class SingleMarkerMapStaticTests(AspireFixture fixture) : VisualTestBase(
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Static Map Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Static Map Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/SingleMarkerMapTouchScrollTests.cs
+++ b/backend/tests/VisualTests/SingleMarkerMapTouchScrollTests.cs
@@ -53,7 +53,7 @@ public class SingleMarkerMapTouchScrollTests(AspireFixture fixture) : VisualTest
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Touch Scroll Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Touch Scroll Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -342,7 +342,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var orgName = $"Detail Enrichment Org {suffix}";
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = orgName });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -694,7 +694,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N");
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"VisualOppHub {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"VisualOppHub {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -854,7 +854,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Stale Error Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Stale Error Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -956,7 +956,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Draft Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Detail Draft Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1020,7 +1020,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Published Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Detail Published Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1070,7 +1070,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
 		var suffix = Guid.NewGuid().ToString("N")[..8];
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Detail Owner Notice Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Detail Owner Notice Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1130,7 +1130,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Tag Chip Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Tag Chip Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1194,7 +1194,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"List Tag Chip Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"List Tag Chip Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1264,7 +1264,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"Bilingual Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Bilingual Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
@@ -1325,7 +1325,7 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await http.PostAsJsonAsync("/v1/organizations", new { name = $"German Only Org {suffix}" });
+		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"German Only Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();

--- a/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
+++ b/backend/tests/VisualTests/WithdrawEngagementErrorMessageTests.cs
@@ -45,7 +45,7 @@ public class WithdrawEngagementErrorMessageTests(AspireFixture fixture) : Visual
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {olafToken}");
 
-		var orgResponse = await olafHttp.PostAsJsonAsync(
+		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"WithdrawErrorMessage Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
 		var org = await orgResponse.Content.ReadFromJsonAsync<JsonElement>();


### PR DESCRIPTION
## What

Apply the suite's existing `PostJsonWithRetryAsync` retry helper to every `VisualTests` call site that creates an organization over HTTP (~106 call sites across 59 files), and mirror `KeycloakOrganizationService.GetMembersAsync`'s existing resilience-pipeline-rejection handling onto `CreateOrganizationAsync`.

## Why

Analyzed the reoccurring `visual-tests` CI failures on #2097: that PR (a single-file, purely cosmetic `MiniCalendar.tsx` change) was retriggered 6 times, and each retrigger failed on a **different, unrelated test** - `OrgDashboardWidgetsTests`, `MemberSearchMinCharsHintTests`, `MilestoneAchievementTests`, `NotificationForDeletedOpportunityTests`, `OrgAppLayoutErrorStatesTests` - all with a backend 500 or a Keycloak-token 500 during setup.

Pulled the actual job logs for one of those runs: the failure is `OrgAppLayoutErrorStatesTests.OrgShellWhileOffline_ShowsOfflineState_WithAManualRetryFallback` throwing `HttpRequestException: 500` out of its `CreateOrganizationAsync` helper (`POST /v1/organizations`). Traced that to the backend: `POST /v1/organizations` calls Keycloak's admin API server-side (`KeycloakOrganizationService.CreateOrganizationAsync`), and every HTTP client in this app gets `AddStandardResilienceHandler()` applied by default (`ServiceDefaults.AddServiceDefaults`). Under `VisualTests`' concurrent load, that handler's circuit breaker/timeout/rate limiter occasionally rejects the Keycloak call outright, which - uncaught - surfaces as a plain unhandled 500 to whichever test's org-creation call happens to land during that window. That explains the "different test every time" pattern exactly: it's whichever of the suite's ~512 tests is creating an organization when the breaker is open.

The suite already has the correct fix for this (`VisualTestBase.PostJsonWithRetryAsync`, added for #1890, and `KeycloakOrganizationService.GetMembersAsync`'s `ExecutionRejectedException` -> `HttpRequestException` normalization, added for #1709) - it had just only been rolled out to 3 of the ~60 files whose tests create an organization directly over HTTP. Every other call site was still a bare `PostAsJsonAsync` with no retry, each one a landmine that fires whenever the circuit breaker happens to be open at that moment. This change closes that gap comprehensively rather than patching one more file at a time as the next unrelated test happens to flake.

`CreateOrganizationAsync` in `KeycloakOrganizationService` is also the single most-called Keycloak write in the app (every test, and every real organizer, creates an org through it) but was the one write path that still let a resilience-pipeline rejection propagate as a raw, unlogged exception instead of the normalized, logged `HttpRequestException` every sibling method (`GetMembersAsync`) already produces - fixed for consistency and diagnosability.

Out of scope: 3 files (`OrganizationTests.cs`, `OrgDashboardWidgetsTests.cs`, `OrgDashboardCustomizeTests.cs`) also create organizations through the UI dialog (click "Create organization" -> submit) rather than a direct HTTP call the test itself can retry. Those hit the same backend risk but would need a UI-level retry-on-error-banner instead of an HTTP retry - no concrete evidence tied a specific observed failure to that path, so left as a follow-up rather than speculatively reworked here.

## Testing

- `dotnet build` (full solution): 0 warnings, 0 errors.
- `dotnet format --verify-no-changes`: clean.
- `dotnet run --project tests/Application.UnitTests`: 1017/1017 passed.
- `dotnet run --project tests/ArchitectureTests`: 417/417 passed.
- `tests/VisualTests`/`tests/IntegrationTests` need real container networking (Aspire/Testcontainers) that isn't available in this sandbox - verified via the release-candidate CI run instead (see Live verification).

## Live verification

This is a CI-reliability fix with no user-visible behavior change (the backend change only alters what gets logged when a resilience-pipeline rejection happens - the HTTP response was, and still is, an unlogged/logged 500 either way), so the live-staging Playwright script from `/live-verify` doesn't apply here - there's no new UI behavior to click through. The meaningful verification for this PR is the `visual-tests` CI job itself passing reliably, which is what was broken.

Cut `vX.Y.Z-rc.N` from this branch and will report the `backend-visual-tests` job result from `publish.yml`'s run once it completes.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no behavior change - N/A)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KvuL7ZKtetQLd9WjXASDmA)_