### PR TITLE
fix(ci): harden apt against mirror stalls in dotnet.yml build job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,9 +63,24 @@ jobs:
   # standalone, now behind this job's setup+build time.
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # VisualTests.csproj's InstallPlaywrightBrowsers target (below, via
+      # `dotnet build`) shells out to `playwright install --with-deps
+      # chromium`, which runs its own `apt-get update`/`install` on every
+      # Playwright-cache miss. apt has no default network timeout, so a
+      # stalled connection to the runner's mirror hangs silently instead of
+      # failing - observed burning this job's entire timeout with zero
+      # output partway through `apt-get update` (einsatzbereit#2139-2138
+      # CI). Retries + a bounded per-request timeout turn that hang into a
+      # fast retry/failure instead.
+      - name: Harden apt against CI mirror stalls
+        run: |
+          echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
+          echo 'Acquire::http::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/80-retries
+          echo 'Acquire::https::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/80-retries
 
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -82,6 +82,27 @@ jobs:
           echo 'Acquire::http::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/80-retries
           echo 'Acquire::https::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/80-retries
 
+      # Reproduced locally: a concurrent `apt-get install` (this repo's own
+      # sandbox ran several `dotnet build` invocations in parallel) fails
+      # this same Playwright `--with-deps` install immediately with "E:
+      # Could not get lock /var/lib/dpkg/lock-frontend" instead of hanging -
+      # a different symptom from the mirror stall above, but the same
+      # command is exposed to it. GitHub-hosted runners run apt-daily.timer/
+      # apt-daily-upgrade.timer shortly after boot, which can hold this same
+      # lock for a few minutes; waiting it out here is cheap insurance
+      # against that immediate failure mode landing on this step instead.
+      - name: Wait for background apt/dpkg locks to clear
+        run: |
+          for i in $(seq 1 60); do
+            if sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1; then
+              echo "apt/dpkg lock held (attempt $i/60) - waiting..."
+              sleep 5
+            else
+              exit 0
+            fi
+          done
+          echo "::warning::apt/dpkg lock still held after 5 minutes - proceeding anyway"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:


### PR DESCRIPTION
## What

Adds an `Acquire::Retries`/`Acquire::http::Timeout`/`Acquire::https::Timeout` apt hardening step to `dotnet.yml`'s `build` job, and bumps its `timeout-minutes` from 15 to 20.

## Why

Auditing the 5 open non-renovate PRs (#2139, #2138, #2136, #2127, #2123), 4 of them had a `build` job stuck at `cancelled` after running for almost exactly 15 minutes with no test jobs able to run downstream (they all `needs: build`). Pulling the job logs for two of them (job 96122221079 on #2139, job 96125851621 on #2136) showed the exact same pattern: `dotnet build` reaches `VisualTests.csproj`'s `InstallPlaywrightBrowsers` target (`playwright install --with-deps chromium`), which shells out to its own `apt-get update`. That fetches InRelease files for a few mirrors and then goes completely silent - zero log output - for the rest of the job, until the 15-minute job timeout kills it (`##[error]The operation was canceled.`).

The one PR that *did* build successfully (#2127) got a `Cache hit occurred on the primary key playwright-Linux-...` for the Playwright browser cache, which apparently short-circuits this `apt-get` path entirely. So this only bites on a Playwright-cache miss (a new/rarely-touched branch, or once the cache entry expires) - explaining why it wasn't caught before: whichever PR happens to run first each day warms the cache for everyone else that day.

apt has no default network timeout, so a single stalled connection to the runner's mirror (`azure.archive.ubuntu.com` and friends are known to be flaky on GitHub-hosted runners) hangs indefinitely instead of failing fast and retrying. Pinning explicit retry/timeout values turns that indefinite hang into a bounded retry-or-fail, and the small timeout bump gives legitimate cold-cache work (the ~290 MiB browser download plus OS dependency install) a bit more headroom.

This is the CI-side root cause fix; the same change is being backported directly onto each of the 5 open PR branches (rather than waiting on this PR to merge first) so their own `pull_request`-triggered CI - which runs off each branch's own copy of this workflow file - picks it up immediately.

Closes: (no linked issue - found via this session's PR CI audit)

## Testing

- This PR's own `build` job is the test: if the fix works, it (and the downstream `format-check`/`fast-tests`/`integration-tests`/`visual-tests` jobs) should complete well within the new 20-minute budget instead of hanging to a cancelled timeout.
- No application code changed - CI workflow config only.

## Live verification

Not applicable - CI/workflow configuration change only, no user-facing behavior.

## Checklist

- [x] `/self-review` run and findings addressed (n/a - workflow YAML only, no code to review against backend/frontend conventions)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - `.github/AGENTS.md`'s `dotnet.yml` section describes job-level behavior, not individual steps; no behavior change from a contributor's perspective)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbCv7QgjS8XGZJ4FycGUn)_