### PR TITLE
fix(tests): retry transient 500s on opportunity/engagement POSTs in VisualTests

### DIFF
--- a/backend/tests/VisualTests/MilestoneAchievementTests.cs
+++ b/backend/tests/VisualTests/MilestoneAchievementTests.cs
@@ -100,7 +100,7 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 		var org = await createOrgResponse.Content.ReadFromJsonAsync<JsonElement>();
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString();
 
-		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		var oppResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/volunteer-opportunities", new
 		{
 			titleDe = $"Milestone668 {label} {suffix}",
 			descriptionDe = "Created by MilestoneAchievementTests",
@@ -119,7 +119,7 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 
 	private static async Task<string> ApplyAsync(HttpClient volunteerHttp, string opportunityId, string message)
 	{
-		var response = await volunteerHttp.PostAsJsonAsync(
+		var response = await PostJsonWithRetryAsync(volunteerHttp,
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message });
 		response.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/ProfileOverviewTests.cs
+++ b/backend/tests/VisualTests/ProfileOverviewTests.cs
@@ -398,7 +398,7 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		var organizationId = org.GetProperty("id").GetProperty("value").GetString()
 			?? throw new InvalidOperationException("Created organization had no id.");
 
-		var oppResponse = await olafHttp.PostAsJsonAsync("/v1/volunteer-opportunities", new
+		var oppResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/volunteer-opportunities", new
 		{
 			titleDe = $"FeedbackEdit Opportunity {suffix}",
 			descriptionDe = "Created by ProfileOverviewTests",
@@ -418,7 +418,7 @@ public class ProfileOverviewTests(AspireFixture fixture) : VisualTestBase(fixtur
 		var veraSession = await Fixture.SignInAsync("vera", "vera123");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
 		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {veraSession.AccessToken}");
-		var applyResponse = await veraHttp.PostAsJsonAsync(
+		var applyResponse = await PostJsonWithRetryAsync(veraHttp,
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message = "FeedbackEdit application." });
 		applyResponse.EnsureSuccessStatusCode();


### PR DESCRIPTION
## What

`MilestoneAchievementTests.CreateIndividualContactOpportunityAsync`/`ApplyAsync` and `ProfileOverviewTests.SeedCheckedInEngagementWithFeedbackAsync` now use `VisualTestBase.PostJsonWithRetryAsync` for their opportunity-creation and engagement-application POSTs, matching the retry treatment their own organization-creation calls (right next to them in the same methods) already had.

## Why

This session audited the 5 open non-Renovate PRs' CI (see #2140 for the `dotnet.yml` build-hang root cause fixed first). Once `build` actually completed, `visual-tests` still failed intermittently across 4 separate CI runs on 3 different PRs, always the same shape: `HttpRequestException: 500 (Internal Server Error)` on an opportunity-creation or engagement-application POST, in test classes completely unrelated to whichever PR's diff was running:

- `MilestoneAchievementTests.DedicatedBadge_IsAwarded_OnFifthConfirmation_EvenAfterAnEarlierConfirmedOpportunityWasDeleted` - failed at `CreateIndividualContactOpportunityAsync` on one PR's run, then again at `ApplyAsync` on a different PR's run
- `ProfileOverviewTests.ActivitySection_EditFeedback_PersistsUpdatedRatingAndComment` - failed at `SeedCheckedInEngagementWithFeedbackAsync`'s opportunity-creation call on a third PR's run

`VisualTestBase.PostJsonWithRetryAsync` (3 attempts, exponential-ish backoff, only for `>= 500` responses) already exists in this codebase specifically to absorb this class of transient failure under the suite's real concurrent load (~530 test classes against one shared Aspire-hosted backend/Postgres/Keycloak) - it's used in 68 test files already, including both files above, but only for their *organization*-creation call. The very next call in the same helper method (creating the opportunity, or applying to it) used a bare `PostAsJsonAsync`, leaving it exposed to exactly the failure mode the org-creation call next to it was already guarded against. This closes that specific gap for the two call sites this session actually observed failing in CI - not a repo-wide sweep of all 68 files, since I don't have evidence the other unguarded call sites (if any) have hit this in practice.

## Testing

- `dotnet build tests/VisualTests` - 0 warnings, 0 errors
- No behavior change outside test code - this only affects how the test helpers retry against transient backend errors, not application code

## Live verification

Not applicable - test-only change, no application behavior affected.

## Checklist

- [x] `/self-review` run and findings addressed (n/a - mechanical test-helper change matching an existing, already-reviewed pattern in the same files)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbCv7QgjS8XGZJ4FycGUn)_