### PR TITLE
chore(ci): record a Stryker.NET mutation-score baseline on Domain + Application

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -12,6 +12,7 @@
 ├── publish.yml                 Tag-triggered: build + push backend/frontend/keycloak to GHCR, create a GitHub Release, then deploy-staging (RC tags) or deploy-production (stable tags)
 ├── release-rc.yml              Promotes a release/v* branch into a real tag (used by Claude Code on the web)
 ├── reset-staging.yml           Manual (workflow_dispatch): wipes staging Postgres + MinIO data, restarts with same images
+├── mutation-tests.yml          Manual (workflow_dispatch): Stryker.NET over Domain + Application, report-only
 ├── lint.yml                    Ban em/en dashes + EditorConfig check
 └── pr-title.yml                Validate PR title against Conventional Commits
 ```
@@ -119,6 +120,18 @@ Rotating the staging host's SSH host key (a fresh box, a reinstall) requires upd
 **Required `staging` Environment secrets:** `MINIO_APP_ACCESS_KEY` / `MINIO_APP_SECRET_KEY` - a generated (not MinIO root) credential pair the `minio-init` compose service provisions on first deploy, scoped to only the `einsatzbereit` bucket. The backend authenticates with these instead of `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` (#1353) - a leaked value can then only read/write that one bucket, not administer the whole MinIO instance.
 
 **Required `staging`/`production` Environment secrets:** `OFFSITE_S3_ENDPOINT` / `OFFSITE_S3_ACCESS_KEY` / `OFFSITE_S3_SECRET_KEY` - point `minio-backup`'s offsite leg (#1087) at the `einsatzbereit-backups` S3-compatible Object Storage bucket, mirroring `postgres_backups`/`minio_backups` off the host daily. A distinct bucket/credential pair from anything MinIO-related above - this is a backup destination, not application storage. Shared across both Environments since staging and production are the same host today (see "`deploy-staging` vs `deploy-production`" above).
+
+## Mutation Testing Workflow (manual)
+
+`mutation-tests.yml` runs Stryker.NET over the two layers that `Application.UnitTests` can drive without Docker.
+
+- **Trigger:** `workflow_dispatch` only - never on push or pull request, so it can never gate a merge
+- **Jobs:** one `mutation-tests` job, a `fail-fast: false` matrix over `project: [Domain, Application]`, so it reports as two checks. Each leg installs `dotnet-stryker` (pinned to 4.16.0) and runs it from `backend/tests/Application.UnitTests/`, mutating one source project while `Application.UnitTests` (1017 tests, no Docker) does the killing. Measured ~4 min (`Domain`) and ~8 min (`Application`)
+- **Report-only (#2147), by two independent mechanisms:** the workflow is manual so it is never a required check, and `stryker-config.json` pins `thresholds.break` to `0` so a low score exits 0 anyway. Same posture as the coverage summary in `fast-tests` (#1327). **Do not add a break threshold** - the whole point of the number is that it is allowed to move
+- **Why manual and not on the PR path:** it is roughly two orders of magnitude more expensive than the `fast-tests` job whose test suite it reuses. It exists as the guardrail for the E2E rebalance (#2148) - record the score, migrate a wave of end-to-end tests down the pyramid, re-run, and if the score held, the removed coverage was redundant. See `docs/TDRs/2_slow_ci_pipeline.adoc` for the recorded baseline, the wall-clock, and how to read the number
+- **Run it from `backend/tests/Application.UnitTests/`, never from `backend/`** - from `backend/` Stryker finds `Einsatzbereit.slnx`, switches to solution mode, and builds the whole solution including `VisualTests` and its ~290 MiB Playwright download, for a run that never opens a browser
+- **`concurrency: 1` in `stryker-config.json` is load-bearing, not a performance knob (#2147).** Stryker's Microsoft.Testing.Platform runner is preview, and above concurrency 1 it reports kills that never happened: 30-73 extra kills per run, never a lost one, and a different subset every time (across four `Domain` runs the spurious sets intersected in zero mutants). That inflates the score by ~5 points and jitters it by ~1. At concurrency 1 two runs at the same commit are bit-for-bit identical. Raising it to use the runner's spare cores destroys the only property that makes the number worth recording
+- **`Application.UnitTests.csproj` references `Domain.csproj` directly** even though Application already pulls it in transitively. That reference exists only so Stryker can resolve `--project Domain.csproj`; see the comment in the csproj before removing it as redundant
 
 ## Reset Workflow (manual)
 

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,0 +1,144 @@
+name: Mutation Testing
+
+# Report-only, and deliberately not wired into the PR gate (#2147).
+#
+# Two reasons it is manual rather than automatic:
+#
+#   1. Cost. A full pass over Domain + Application takes ~12 minutes against a
+#      test suite that runs in 3 seconds - every mutant re-runs the tests that
+#      cover it, one mutant at a time (see the concurrency note below). The
+#      measured numbers live in docs/TDRs/2_slow_ci_pipeline.adoc; they are far
+#      outside what belongs on the critical path #773/#2145 spent their effort
+#      cutting.
+#   2. Purpose. This number exists as the guardrail for the E2E rebalance
+#      (#2148): record it before a migration wave, re-run it after, and if the
+#      score did not drop, the removed end-to-end coverage was redundant. That
+#      is a per-wave question, not a per-commit one.
+#
+# There is deliberately NO score threshold that can block a merge - the config
+# (backend/tests/Application.UnitTests/stryker-config.json) pins
+# `thresholds.break` to 0 so Stryker always exits 0 on a low score. This job
+# only fails if Stryker itself fails, which is a tooling break worth seeing.
+# Same posture as the coverage summary in `fast-tests` (#1327): visibility is
+# the point, gating is not.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # One runner per mutated project, because they are independent runs against
+  # the same test project and the wall-clock is dominated by the larger one.
+  # fail-fast: false - a Stryker failure on one project says nothing about the
+  # other, and losing the half that would have completed wastes the whole run.
+  mutation-tests:
+    runs-on: ubuntu-latest
+    # Hang guard, not a target: the measured legs are ~4 min (Domain) and ~8 min
+    # (Application). Stryker has no overall timeout of its own, so without this a
+    # wedged test session would sit on the default 360 minutes.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [Domain, Application]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          global-json-file: backend/global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('backend/Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      # Pinned for the same reason dotnet-ef is pinned in dotnet.yml: the score
+      # is only comparable across runs if the mutant set is, and a new Stryker
+      # version can add or drop mutators. Bumping this is a deliberate act that
+      # invalidates the recorded baseline - re-record it in the TDR when you do.
+      - name: Install Stryker.NET
+        run: dotnet tool install --global dotnet-stryker --version 4.16.0
+
+      # Run from the test project directory on purpose. Stryker picks up
+      # stryker-config.json from the working directory, and - more importantly -
+      # from backend/ it would find Einsatzbereit.slnx, switch to solution mode,
+      # and try to build the whole solution, which drags in VisualTests and its
+      # ~290 MiB Playwright browser download for a run that never opens a
+      # browser. From here it builds Application.UnitTests.csproj and nothing
+      # else.
+      #
+      # `--project` selects which of the test project's referenced projects gets
+      # mutated; the tests driving it are Application.UnitTests either way.
+      #
+      # `concurrency: 1` in stryker-config.json is load-bearing and must not be
+      # raised to "use the runner's other cores" - see #2147. At concurrency 2
+      # the preview MTP runner reports 30-73 kills per run that concurrency 1
+      # does not, never the reverse, and a different subset every time: across
+      # four Domain runs the spurious sets intersected in zero mutants. That
+      # inflates the score by ~5 points and jitters it by ~1, which would make
+      # this number useless for the one job it has (deciding whether an E2E
+      # migration wave lost real coverage). At concurrency 1 two runs at the
+      # same commit are bit-for-bit identical, so any movement is real.
+      - name: Run Stryker.NET - ${{ matrix.project }}
+        working-directory: backend/tests/Application.UnitTests
+        run: |
+          start=$(date +%s)
+          dotnet-stryker --project ${{ matrix.project }}.csproj --output "$RUNNER_TEMP/stryker-${{ matrix.project }}"
+          echo "STRYKER_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      # Report-only summary, written straight to the job's step summary rather
+      # than via a third-party action - same reasoning as the coverage summary
+      # in dotnet.yml's fast-tests job. Killed + Timeout over
+      # Killed + Timeout + Survived + NoCoverage is Stryker's own score
+      # definition: CompileError and Ignored mutants are excluded from the
+      # denominator, so they neither help nor hurt the number.
+      - name: Publish mutation score summary
+        if: always()
+        run: |
+          report="$RUNNER_TEMP/stryker-${{ matrix.project }}/reports/mutation-report.json"
+          if [ ! -f "$report" ]; then
+            echo "### Mutation score - ${{ matrix.project }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "_No report produced - the Stryker run did not complete._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          jq -r --arg project "${{ matrix.project }}" --arg seconds "${STRYKER_SECONDS:-unknown}" '
+            [.files[].mutants[].status] as $all
+            | (($all | map(select(. == "Killed" or . == "Timeout")) | length)) as $killed
+            | (($all | map(select(. == "Survived")) | length)) as $survived
+            | (($all | map(select(. == "NoCoverage")) | length)) as $uncovered
+            | ($killed + $survived + $uncovered) as $scored
+            | "### Mutation score - \($project)",
+              "",
+              "| Metric | Value |",
+              "| --- | --- |",
+              "| Score | \(if $scored == 0 then "n/a" else ((10000 * $killed / $scored | round) / 100 | tostring) + " %" end) |",
+              "| Killed (incl. timeout) | \($killed) |",
+              "| Survived | \($survived) |",
+              "| Not covered | \($uncovered) |",
+              "| Mutants scored | \($scored) |",
+              "| Mutants generated | \($all | length) |",
+              "| Wall-clock | \($seconds) s |",
+              "",
+              "_Report-only (#2147). No threshold gates this workflow._"
+          ' "$report" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-report-${{ matrix.project }}
+          path: ${{ runner.temp }}/stryker-${{ matrix.project }}/reports/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -171,6 +171,23 @@ Because dispatch now happens in a fresh scope after commit (not inline inside th
 - `AuthHelper.cs` - `LoginAsync` drives the real Keycloak login UI; `FastSignInAsync` seeds a minted token straight into `localStorage` to skip the redirect round trip for tests that only need an authenticated session as a precondition
 - Root `AGENTS.md`'s "Mandatory: Deploy and verify" flow requires a matching assertion here for every bug fix/feature - see step 6
 
+### Mutation testing (`Stryker.NET`, manual)
+
+Report-only, never a merge gate (#2147). Exists as the falsifiable guardrail for the E2E rebalance (#2148): record the score, move a wave of `VisualTests` cases down the pyramid, re-run - if the score held, the coverage that was removed was redundant. Line coverage cannot answer that question, because a deleted redundant test and a deleted load-bearing one look identical to it.
+
+```bash
+dotnet tool install --global dotnet-stryker --version 4.16.0
+cd backend/tests/Application.UnitTests
+dotnet-stryker --project Domain.csproj
+dotnet-stryker --project Application.csproj
+```
+
+- **Run from `tests/Application.UnitTests/`, not from `backend/`.** Stryker picks up `stryker-config.json` from the working directory, and from `backend/` it finds `Einsatzbereit.slnx`, switches to solution mode, and tries to build the whole solution - which drags in `VisualTests` and its ~290 MiB Playwright browser download for a run that never opens a browser.
+- **`test-runner: mtp` is mandatory** and is set in `stryker-config.json`. Stryker's default VSTest runner discovers zero tests against TUnit (Microsoft.Testing.Platform only, no VSTest adapter) and reports a vacuous pass. The MTP runner is still marked preview by Stryker and says so on every run.
+- **`concurrency: 1` is load-bearing, not a performance setting.** That preview MTP runner miscounts above concurrency 1: 30-73 kills per run that concurrency 1 does not report, never the reverse, and a different subset each time. The score comes out ~5 points high and moves ~1 point between identical runs, which makes it useless as a before/after guardrail. At concurrency 1 two runs at the same commit are bit-for-bit identical. Do not raise it.
+- **`Application.UnitTests.csproj` references `Domain.csproj` directly** purely so `--project Domain.csproj` resolves - Stryker only matches the project to mutate against the *direct* ProjectReference list. It is redundant to the compiler; see the comment in the csproj.
+- Recorded baseline (`Domain` 66.75 %, `Application` 68.49 %, combined 67.89 % at commit `c4a143b`), wall-clock (~4 min + ~8 min), and how to read the number: `docs/TDRs/2_slow_ci_pipeline.adoc`. CI equivalent: `.github/workflows/mutation-tests.yml` (`workflow_dispatch` only).
+
 ### Run all tests
 TUnit uses Microsoft.Testing.Platform, not the `dotnet test` new testing
 experience - run each project directly, the same way CI does:

--- a/backend/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/backend/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -15,6 +15,15 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Application\Application.csproj" />
+		<!--
+			Domain already arrives transitively through Application, so this reference adds
+			nothing to the compilation. It is here because Stryker.NET resolves the project it
+			mutates (its `project` option) from the *direct* ProjectReference list of the test
+			project that drives it. A transitively referenced project is invisible to that
+			lookup and fails with "Could not find an assembly reference to a mutable assembly",
+			so without this line the Domain half of the mutation run cannot start at all.
+		-->
+		<ProjectReference Include="..\..\src\Domain\Domain.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/backend/tests/Application.UnitTests/stryker-config.json
+++ b/backend/tests/Application.UnitTests/stryker-config.json
@@ -1,0 +1,8 @@
+{
+  "stryker-config": {
+    "test-runner": "mtp",
+    "reporters": ["json", "html"],
+    "concurrency": 1,
+    "thresholds": { "high": 80, "low": 60, "break": 0 }
+  }
+}

--- a/backend/tests/VisualTests/AchievementsTests.cs
+++ b/backend/tests/VisualTests/AchievementsTests.cs
@@ -40,7 +40,7 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		using (var seedHttp = new HttpClient { BaseAddress = backend })
 		{
 			seedHttp.DefaultRequestHeaders.Add(
-				"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+				"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 			var orgResponse = await PostJsonWithRetryAsync(seedHttp,
 				"/v1/organizations", new { name = $"AchievementsSelfSeed Org {suffix}" });
@@ -196,21 +196,4 @@ public class AchievementsTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(badgeToast).ToHaveCountAsync(0);
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/AdminUserManagementTests.cs
+++ b/backend/tests/VisualTests/AdminUserManagementTests.cs
@@ -249,7 +249,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 
 	private static async Task<bool> IsUserEnabledAsync(Uri keycloak, string userId)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
@@ -262,7 +262,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 
 	private static async Task<bool> HasAdminRealmRoleAsync(Uri keycloak, string userId)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
@@ -276,7 +276,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 
 	private static async Task<(string Username, string UserId)> CreateDisposableUserAsync(Uri keycloak)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 		// Not "admintest760-..." (deliberately doesn't contain "admin" as a
 		// substring): Keycloak's search= does infix matching, so a name
 		// containing "admin" would also match AdministrationPage_OwnRow_
@@ -314,7 +314,7 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 
 	private static async Task DeleteKeycloakUserAsync(Uri keycloak, string userId)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
@@ -323,19 +323,4 @@ public class AdminUserManagementTests(AspireFixture fixture) : VisualTestBase(fi
 		response.EnsureSuccessStatusCode();
 	}
 
-	private static async Task<string> GetAdminTokenAsync(Uri keycloak)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "client_credentials",
-				["client_id"] = "backend",
-				["client_secret"] = "backend-secret",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/AspireFixture.cs
+++ b/backend/tests/VisualTests/AspireFixture.cs
@@ -322,31 +322,14 @@ public class AspireFixture : IAsyncInitializer, IAsyncDisposable
 		return token.AccessToken;
 	}
 
-	// Every sign-in and every admin-token mint hits Keycloak's token endpoint,
-	// hundreds of times per run, and under that load it occasionally answers
-	// with a transient 500 no request here caused. Retries a 5xx a few times
-	// with a short backoff so one blip does not fail an unrelated test. Never
-	// retries a 4xx (wrong credentials, bad client config) - that's a real
-	// failure, not a blip.
-	private static async Task<HttpResponseMessage> PostTokenRequestWithRetryAsync(
+	// Delegates to AuthHelper so the whole suite shares one retry policy rather
+	// than this copy plus the ~29 hand-rolled ones the test classes carried
+	// (einsatzbereit#2147). Kept as a thin local name so the call sites above
+	// read the same as before.
+	private static Task<HttpResponseMessage> PostTokenRequestWithRetryAsync(
 		HttpClient client, string requestUri, Func<FormUrlEncodedContent> contentFactory,
 		CancellationToken cancellationToken = default)
-	{
-		const int maxAttempts = 3;
-		HttpResponseMessage response;
-		for (var attempt = 1; ; attempt++)
-		{
-			using var content = contentFactory();
-			response = await client.PostAsync(requestUri, content, cancellationToken);
-			if (response.StatusCode < HttpStatusCode.InternalServerError || attempt >= maxAttempts)
-				break;
-
-			response.Dispose();
-			await Task.Delay(TimeSpan.FromMilliseconds(500 * attempt), cancellationToken);
-		}
-
-		return response;
-	}
+		=> AuthHelper.PostTokenRequestWithRetryAsync(client, requestUri, contentFactory, cancellationToken);
 
 	private static async Task EnsureSuccessAsync(HttpResponseMessage response)
 	{

--- a/backend/tests/VisualTests/AuthHelper.cs
+++ b/backend/tests/VisualTests/AuthHelper.cs
@@ -1,7 +1,12 @@
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Playwright;
+
+// Aliased rather than a plain `using System.Net`, which would make Cookie
+// ambiguous against Microsoft.Playwright.Cookie further down this file.
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace VisualTests;
 
@@ -12,6 +17,104 @@ public static class AuthHelper
 	// mint the token in FastSignInAsync. This is what oidc-client-ts's storage
 	// key is keyed on, regardless of which client actually issued the token.
 	private const string FrontendClientId = "frontend";
+
+	// The realm and the two clients every direct token request in this suite uses.
+	// These were duplicated as private consts across ~25 test classes, each with
+	// its own copy of the token request below - which is exactly how those copies
+	// ended up bypassing the retry AspireFixture already had (einsatzbereit#2147).
+	private const string Realm = "einsatzbereit";
+	private const string FrontendTestClientId = "frontend-test";
+	private const string BackendClientId = "backend";
+	private const string BackendClientSecret = "backend-secret";
+
+	/// <summary>
+	/// Mints a user access token straight from Keycloak, no browser involved.
+	///
+	/// This is the single implementation for the whole suite. Every test class
+	/// that needs one used to carry its own private copy - 25 of them, all
+	/// semantically identical, none retrying - so a transient 500 from Keycloak's
+	/// token endpoint failed an unrelated test outright. AspireFixture had solved
+	/// this for its own sign-ins already; the copies simply never went through it.
+	/// </summary>
+	public static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		using var response = await PostTokenRequestWithRetryAsync(
+			http,
+			$"/realms/{Realm}/protocol/openid-connect/token",
+			() => new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "password",
+				["client_id"] = FrontendTestClientId,
+				["username"] = username,
+				["password"] = password,
+				["scope"] = "openid",
+			}));
+		response.EnsureSuccessStatusCode();
+
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()
+			?? throw new InvalidOperationException("Keycloak returned no access_token.");
+	}
+
+	/// <summary>
+	/// Mints a service-account token for the <c>backend</c> client, for tests that
+	/// drive Keycloak's admin API directly. Same retry story as
+	/// <see cref="GetTokenAsync"/> - four classes carried their own unprotected copy.
+	/// </summary>
+	public static async Task<string> GetAdminTokenAsync(Uri keycloak)
+	{
+		using var http = new HttpClient { BaseAddress = keycloak };
+		using var response = await PostTokenRequestWithRetryAsync(
+			http,
+			$"/realms/{Realm}/protocol/openid-connect/token",
+			() => new FormUrlEncodedContent(new Dictionary<string, string>
+			{
+				["grant_type"] = "client_credentials",
+				["client_id"] = BackendClientId,
+				["client_secret"] = BackendClientSecret,
+			}));
+		response.EnsureSuccessStatusCode();
+
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+		return body.GetProperty("access_token").GetString()
+			?? throw new InvalidOperationException("Keycloak returned no access_token.");
+	}
+
+	/// <summary>
+	/// The one retry policy for every Keycloak token request the suite makes.
+	/// AspireFixture delegates to this too, so widening the budget here widens it
+	/// everywhere rather than in one of several near-identical copies.
+	///
+	/// Every sign-in and every admin-token mint hits the token endpoint, hundreds
+	/// of times per run, and under that load it occasionally answers with a
+	/// transient 500 no request here caused. Never retries a 4xx (wrong
+	/// credentials, bad client config) - that is a real failure, not a blip.
+	///
+	/// The budget is four attempts over ~3.5 s (0.5 s, 1 s, 2 s). Three attempts
+	/// over ~1.5 s was not enough: einsatzbereit#2147 observed a run exhaust the
+	/// old budget against a shard's cold stack, and sharding (#2145) means every
+	/// shard now has its own cold window instead of one per suite.
+	/// </summary>
+	public static async Task<HttpResponseMessage> PostTokenRequestWithRetryAsync(
+		HttpClient client, string requestUri, Func<FormUrlEncodedContent> contentFactory,
+		CancellationToken cancellationToken = default)
+	{
+		const int maxAttempts = 4;
+		HttpResponseMessage response;
+		for (var attempt = 1; ; attempt++)
+		{
+			using var content = contentFactory();
+			response = await client.PostAsync(requestUri, content, cancellationToken);
+			if (response.StatusCode < HttpStatusCode.InternalServerError || attempt >= maxAttempts)
+				break;
+
+			response.Dispose();
+			await Task.Delay(TimeSpan.FromMilliseconds(500 * Math.Pow(2, attempt - 1)), cancellationToken);
+		}
+
+		return response;
+	}
 
 	/// <summary>
 	/// Drives the real Keycloak login UI, retrying the round trip once.

--- a/backend/tests/VisualTests/CheckInAndSlotTests.cs
+++ b/backend/tests/VisualTests/CheckInAndSlotTests.cs
@@ -33,7 +33,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInNone Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -100,7 +100,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInManual Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -146,24 +146,6 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		await Expect(row.GetByRole(AriaRole.Button, new() { Name = "Check in" })).Not.ToBeVisibleAsync();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	[Test]
 	public async Task EditOpportunity_SwitchToPINCode_ShowsSetPinOnManagePage()
 	{
@@ -183,7 +165,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		const string pin = "4821";
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInPinSwitch Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -262,7 +244,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"SlotCounts Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -372,7 +354,7 @@ public class CheckInAndSlotTests(AspireFixture fixture) : VisualTestBase(fixture
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"Unlimited Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/CheckInModalDeletedOpportunityTests.cs
@@ -24,7 +24,7 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInModalDeleted Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -52,7 +52,7 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		var opportunityId = opportunity.GetProperty("id").GetString();
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementResponse = await veraHttp.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message = "Applying via CheckInModalDeletedOpportunityTests." });
@@ -102,21 +102,4 @@ public class CheckInModalDeletedOpportunityTests(AspireFixture fixture) : Visual
 		await Expect(dialog.GetByText("Loading…")).Not.ToBeVisibleAsync();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/CheckInModalQrFallbackCodeTests.cs
+++ b/backend/tests/VisualTests/CheckInModalQrFallbackCodeTests.cs
@@ -22,7 +22,7 @@ public class CheckInModalQrFallbackCodeTests(AspireFixture fixture) : VisualTest
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await olafHttp.PostAsJsonAsync("/v1/organizations", new { name = $"CheckInQrFallback Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -47,7 +47,7 @@ public class CheckInModalQrFallbackCodeTests(AspireFixture fixture) : VisualTest
 		var opportunityId = opportunity.GetProperty("id").GetString();
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementResponse = await veraHttp.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message = "Applying via CheckInModalQrFallbackCodeTests." });
@@ -94,21 +94,4 @@ public class CheckInModalQrFallbackCodeTests(AspireFixture fixture) : VisualTest
 		await Expect(dialog.GetByText(engagementId, new() { Exact = true })).Not.ToBeVisibleAsync();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
+++ b/backend/tests/VisualTests/CheckInPinOrganizerSetTests.cs
@@ -67,7 +67,7 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 		await Expect(Page.Locator("[role='dialog']")).Not.ToBeVisibleAsync(new() { Timeout = 15_000 });
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var pinResponse = await http.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/check-in-pin");
 		pinResponse.EnsureSuccessStatusCode();
 		var persistedPin = await pinResponse.Content.ReadFromJsonAsync<string>();
@@ -84,7 +84,7 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(http, "/v1/organizations", new { name = $"CheckInPinEdit Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -139,21 +139,4 @@ public class CheckInPinOrganizerSetTests(AspireFixture fixture) : VisualTestBase
 		persistedPin.Should().Be(generatedPin);
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/EmailDeliveryTests.cs
+++ b/backend/tests/VisualTests/EmailDeliveryTests.cs
@@ -27,7 +27,7 @@ public class EmailDeliveryTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var mailpit = Fixture.GetEndpoint("mailpit", "webui");
 		var email = $"emaildelivery-{Guid.NewGuid():N}@example.test";
 
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
 
@@ -128,22 +128,6 @@ public class EmailDeliveryTests(AspireFixture fixture) : VisualTestBase(fixture)
 			$"Mailpit did not receive a message to '{recipientEmail}'"
 			+ (subjectContains is null ? "" : $" with subject containing '{subjectContains}'")
 			+ " within 30s.");
-	}
-
-	private static async Task<string> GetAdminTokenAsync(Uri keycloak)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "client_credentials",
-				["client_id"] = "backend",
-				["client_secret"] = "backend-secret",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
 	}
 
 	private async Task<string> CreateIndividualContactOpportunityAsync(string title)

--- a/backend/tests/VisualTests/EngagementBulkActionsTests.cs
+++ b/backend/tests/VisualTests/EngagementBulkActionsTests.cs
@@ -26,12 +26,12 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 		var keycloak = Fixture.GetEndpoint("keycloak");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
-		var olafToken = await GetTokenAsync(keycloak, "olaf", "olaf123");
+		var olafToken = await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123");
 		var (opportunityId, organizationId, firstSlotId, secondSlotId) =
 			await CreateScheduledSlotsOpportunityWithTwoSlotsAsync(keycloak, backend, olafToken, "BulkConfirmPartial");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var firstEngagementId = await ApplyForSlotAsync(veraHttp, opportunityId, firstSlotId);
 		var secondEngagementId = await ApplyForSlotAsync(veraHttp, opportunityId, secondSlotId);
 
@@ -77,24 +77,6 @@ public class EngagementBulkActionsTests(AspireFixture fixture) : VisualTestBase(
 		response.EnsureSuccessStatusCode();
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 		return body.GetProperty("id").GetString()!;
-	}
-
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
 	}
 
 	private static async Task<(string OpportunityId, string OrganizationId, string FirstSlotId, string SecondSlotId)>

--- a/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
+++ b/backend/tests/VisualTests/EngagementCancellationReasonTests.cs
@@ -27,7 +27,7 @@ public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTe
 		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CancelReasonOrganizer");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		IResponse? cancelResponse = null;
@@ -66,11 +66,11 @@ public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTe
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "CancelReasonVolunteer");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var engagementsResponse = await olafHttp.GetAsync($"/v1/volunteer-opportunities/{opportunityId}/engagements?pageNumber=1&pageSize=10");
 		engagementsResponse.EnsureSuccessStatusCode();
@@ -102,31 +102,13 @@ public class EngagementCancellationReasonTests(AspireFixture fixture) : VisualTe
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
 		Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
+++ b/backend/tests/VisualTests/EngagementCheckInStatusCodeTests.cs
@@ -21,9 +21,9 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInStatusCode Org {suffix}" });
@@ -68,9 +68,9 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinOwner Org {suffix}" });
@@ -126,9 +126,9 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinOracle Org {suffix}" });
@@ -188,9 +188,9 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var suffix = Guid.NewGuid().ToString("N");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckInPinLockout Org {suffix}" });
@@ -243,21 +243,4 @@ public class EngagementCheckInStatusCodeTests(AspireFixture fixture) : VisualTes
 			"the correct PIN must still be rejected once the per-engagement lockout has tripped");
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
+++ b/backend/tests/VisualTests/EngagementCoreJourneysTests.cs
@@ -30,7 +30,7 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "ConfirmJourney");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		await AuthHelper.FastSignInAsync(Page, Fixture, frontend, "olaf", "olaf123");
@@ -57,11 +57,11 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "WithdrawJourney");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
 		confirmResponse.EnsureSuccessStatusCode();
 
@@ -113,31 +113,13 @@ public class EngagementCoreJourneysTests(AspireFixture fixture) : VisualTestBase
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
 		Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/EngagementHistoryForDeletedOpportunityTests.cs
@@ -26,11 +26,11 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistDeleted");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
 		confirmResponse.EnsureSuccessStatusCode();
@@ -63,11 +63,11 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistDeletedUi");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
 		deleteResponse.EnsureSuccessStatusCode();
 
@@ -105,7 +105,7 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "EngHistOrphanedUi");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		await Fixture.DeleteOpportunityRowDirectlyAsync(Guid.Parse(opportunityId));
@@ -135,30 +135,12 @@ public class EngagementHistoryForDeletedOpportunityTests(AspireFixture fixture) 
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementCheckInPinTests.cs
@@ -66,31 +66,13 @@ public class EngagementManagementCheckInPinTests(AspireFixture fixture) : Visual
 		pinResponseStatuses.Should().ContainSingle().Which.Should().Be(200);
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
 		Uri keycloak, Uri backend, string label, string checkInMethod)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
+++ b/backend/tests/VisualTests/EngagementManagementFiltersTests.cs
@@ -41,31 +41,13 @@ public class EngagementManagementFiltersTests(AspireFixture fixture) : VisualTes
 		await Expect(Page.GetByText("Vera Volunteer")).ToBeVisibleAsync();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
 		Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Fresh organization rather than olaf's shared seed org - see the
 		// identical note in EngagementManagementCheckInPinTests.
@@ -96,7 +78,7 @@ public class EngagementManagementFiltersTests(AspireFixture fixture) : VisualTes
 	private static async Task CreateAndConfirmVeraEngagementAsync(Uri keycloak, Uri backend, string opportunityId)
 	{
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementResponse = await veraHttp.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message = "Filter test signup" });
@@ -105,7 +87,7 @@ public class EngagementManagementFiltersTests(AspireFixture fixture) : VisualTes
 		var engagementId = engagement.GetProperty("id").GetString()!;
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var confirmResponse = await olafHttp.PostAsync($"/v1/engagements/{engagementId}/confirm", content: null);
 		confirmResponse.EnsureSuccessStatusCode();
 	}

--- a/backend/tests/VisualTests/EngagementReactivationTests.cs
+++ b/backend/tests/VisualTests/EngagementReactivationTests.cs
@@ -27,7 +27,7 @@ public class EngagementReactivationTests(AspireFixture fixture) : VisualTestBase
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "Reactivation");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var firstEngagement = await ApplyAsync(http, opportunityId, "Original application.");
 		var firstCreatedOn = await GetCreatedOnAsync(http, opportunityId);
@@ -70,7 +70,7 @@ public class EngagementReactivationTests(AspireFixture fixture) : VisualTestBase
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "ReactivationUi");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var engagementId = await ApplyAsync(http, opportunityId, "Original application.");
 		var withdrawResponse = await http.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
@@ -109,30 +109,12 @@ public class EngagementReactivationTests(AspireFixture fixture) : VisualTestBase
 		return match.GetProperty("createdOn").GetDateTimeOffset();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementStatusContrastTests.cs
+++ b/backend/tests/VisualTests/EngagementStatusContrastTests.cs
@@ -28,7 +28,7 @@ public class EngagementStatusContrastTests(AspireFixture fixture) : VisualTestBa
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend);
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var applyResponse = await http.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
@@ -66,30 +66,12 @@ public class EngagementStatusContrastTests(AspireFixture fixture) : VisualTestBa
 		}
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
+++ b/backend/tests/VisualTests/EngagementUndoCheckInTests.cs
@@ -24,9 +24,9 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(olafHttp, "UndoCheckInHappyPath");
 		var engagementId = await CreateAndConfirmEngagementAsync(veraHttp, olafHttp, opportunityId);
@@ -53,9 +53,9 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(olafHttp, "UndoCheckInNotCheckedIn");
 		var engagementId = await CreateAndConfirmEngagementAsync(veraHttp, olafHttp, opportunityId);
@@ -78,9 +78,9 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(olafHttp, "UndoCheckInTerminated");
 		var engagementId = await CreateAndConfirmEngagementAsync(veraHttp, olafHttp, opportunityId);
@@ -104,11 +104,11 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		var keycloak = Fixture.GetEndpoint("keycloak");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		using var adminHttp = new HttpClient { BaseAddress = backend };
-		adminHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "admin", "admin123")}");
+		adminHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "admin", "admin123")}");
 
 		var (opportunityId, _) = await CreateIndividualContactOpportunityAsync(olafHttp, "UndoCheckInForbidden");
 		var engagementId = await CreateAndConfirmEngagementAsync(veraHttp, olafHttp, opportunityId);
@@ -135,9 +135,9 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var (opportunityId, organizationId) = await CreateIndividualContactOpportunityAsync(olafHttp, "UndoCheckInUi", checkInMethod: "Manual");
 		await CreateAndConfirmEngagementAsync(veraHttp, olafHttp, opportunityId);
@@ -164,24 +164,6 @@ public class EngagementUndoCheckInTests(AspireFixture fixture) : VisualTestBase(
 		await Expect(checkedInBadge).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
 		await Expect(row.GetByRole(AriaRole.Button, new() { Name = "Mark as checked in" }))
 			.ToBeVisibleAsync(new() { Timeout = 10_000 });
-	}
-
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
 	}
 
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(

--- a/backend/tests/VisualTests/JwtAudienceTests.cs
+++ b/backend/tests/VisualTests/JwtAudienceTests.cs
@@ -79,7 +79,7 @@ public class JwtAudienceTests(AspireFixture fixture) : VisualTestBase(fixture)
 
 		using var olafHttp = new HttpClient { BaseAddress = backendOrigin };
 		olafHttp.DefaultRequestHeaders.Add(
-			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+			"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = orgName });
 		orgResponse.EnsureSuccessStatusCode();
 
@@ -110,7 +110,7 @@ public class JwtAudienceTests(AspireFixture fixture) : VisualTestBase(fixture)
 		// organizations exist or what order this test runs in.
 		using var adminHttp = new HttpClient { BaseAddress = backendOrigin };
 		adminHttp.DefaultRequestHeaders.Add(
-			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "admin", "admin123")}");
+			"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "admin", "admin123")}");
 
 		var found = false;
 		for (var page = 1; !found; page++)
@@ -139,21 +139,4 @@ public class JwtAudienceTests(AspireFixture fixture) : VisualTestBase(fixture)
 				+ string.Join(", ", authErrors));
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/MilestoneAchievementTests.cs
+++ b/backend/tests/VisualTests/MilestoneAchievementTests.cs
@@ -29,9 +29,6 @@ namespace VisualTests;
 public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(fixture)
 {
 	private const string Realm = "einsatzbereit";
-	private const string BackendClientId = "backend";
-	private const string BackendClientSecret = "backend-secret";
-	private const string FrontendClientId = "frontend-test";
 
 	[Test]
 	public async Task DedicatedBadge_IsAwarded_OnFifthConfirmation_EvenAfterAnEarlierConfirmedOpportunityWasDeleted()
@@ -44,11 +41,11 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 		{
 			using var olafHttp = new HttpClient { BaseAddress = backend };
 			olafHttp.DefaultRequestHeaders.Authorization =
-				new AuthenticationHeaderValue("Bearer", await GetTokenAsync(keycloak, "olaf", "olaf123"));
+				new AuthenticationHeaderValue("Bearer", await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123"));
 
 			using var volunteerHttp = new HttpClient { BaseAddress = backend };
 			volunteerHttp.DefaultRequestHeaders.Authorization =
-				new AuthenticationHeaderValue("Bearer", await GetTokenAsync(keycloak, volunteerUsername, volunteerPassword));
+				new AuthenticationHeaderValue("Bearer", await AuthHelper.GetTokenAsync(keycloak, volunteerUsername, volunteerPassword));
 
 			var engagementIds = new List<string>();
 			var opportunityIds = new List<string>();
@@ -135,7 +132,7 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 
 	private static async Task<(string Username, string Password, string UserId)> CreateDisposableVolunteerAsync(Uri keycloak)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 		var username = $"milestone668-{Guid.NewGuid():N}";
 		var password = $"Milestone668!{Guid.NewGuid():N}";
 
@@ -167,7 +164,7 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 
 	private static async Task DeleteKeycloakUserAsync(Uri keycloak, string userId)
 	{
-		var adminToken = await GetAdminTokenAsync(keycloak);
+		var adminToken = await AuthHelper.GetAdminTokenAsync(keycloak);
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
 		adminHttp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
@@ -176,37 +173,4 @@ public class MilestoneAchievementTests(AspireFixture fixture) : VisualTestBase(f
 		response.EnsureSuccessStatusCode();
 	}
 
-	private static async Task<string> GetAdminTokenAsync(Uri keycloak)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "client_credentials",
-				["client_id"] = BackendClientId,
-				["client_secret"] = BackendClientSecret,
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = FrontendClientId,
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
+++ b/backend/tests/VisualTests/MyEngagementsScopeTabsTests.cs
@@ -25,7 +25,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		var pastOpportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "ScopeTabsPast");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var upcomingEngagementId = await ApplyAsync(veraHttp, upcomingOpportunityId, "Still pending.");
 		var pastEngagementId = await ApplyAsync(veraHttp, pastOpportunityId, "About to withdraw.");
@@ -87,7 +87,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		var opportunityId = await CreateIndividualContactOpportunityAsync(keycloak, backend, "ScopeTabsWithdrawnFuture");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Withdrawing right away.");
 		var withdrawResponse = await veraHttp.PostAsync($"/v1/engagements/{engagementId}/withdraw", content: null);
@@ -133,7 +133,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"CheckedInFuture Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -170,7 +170,7 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 			.EnsureSuccessStatusCode();
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var engagementResponse = await veraHttp.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
@@ -223,30 +223,12 @@ public class MyEngagementsScopeTabsTests(AspireFixture fixture) : VisualTestBase
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<string> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
+++ b/backend/tests/VisualTests/NotificationForDeletedOpportunityTests.cs
@@ -30,11 +30,11 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		var (opportunityId, _, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedTitle");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
 		deleteResponse.EnsureSuccessStatusCode();
@@ -64,11 +64,11 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		var (opportunityId, _, title) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedKeepsTitle");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
 		deleteResponse.EnsureSuccessStatusCode();
@@ -90,7 +90,7 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 		var (opportunityId, organizationId, _) = await CreateIndividualContactOpportunityAsync(keycloak, backend, "NotifDeletedUi");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var deleteResponse = await olafHttp.DeleteAsync($"/v1/volunteer-opportunities/{opportunityId}");
 		deleteResponse.EnsureSuccessStatusCode();
@@ -127,31 +127,13 @@ public class NotificationForDeletedOpportunityTests(AspireFixture fixture) : Vis
 			.First(n => n.GetProperty("kind").GetString() == kind);
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId, string Title)> CreateIndividualContactOpportunityAsync(Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 		var title = $"NotifDeletedOpp {label} {suffix}";
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Create a fresh organization rather than reusing olaf's shared seed
 		// org - other VisualTests running concurrently in this shared Aspire

--- a/backend/tests/VisualTests/OpportunityCardContractTests.cs
+++ b/backend/tests/VisualTests/OpportunityCardContractTests.cs
@@ -615,7 +615,7 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 		string username,
 		string password)
 	{
-		var token = await GetTokenAsync(keycloak, username, password);
+		var token = await AuthHelper.GetTokenAsync(keycloak, username, password);
 		var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 		return http;
@@ -700,22 +700,4 @@ public class OpportunityCardContractTests(AspireFixture fixture) : VisualTestBas
 			?? throw new InvalidOperationException("opportunity id missing");
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()
-			?? throw new InvalidOperationException("no access_token in the token response");
-	}
 }

--- a/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardWidgetsTests.cs
@@ -135,7 +135,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		var suffix = Guid.NewGuid().ToString("N");
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add(
-			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+			"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"Visual1780 {suffix}" });
@@ -176,7 +176,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
 		veraHttp.DefaultRequestHeaders.Add(
-			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+			"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		(await veraHttp.PostAsJsonAsync(
 			$"/v1/volunteer-opportunities/{opportunityId}/engagements",
 			new { message = "Sign-up for the #1780 pending queue" }))
@@ -213,7 +213,7 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
 		olafHttp.DefaultRequestHeaders.Add(
-			"Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+			"Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp,
 			"/v1/organizations", new { name = $"Visual1780 Error {Guid.NewGuid():N}" });
 		orgResponse.EnsureSuccessStatusCode();
@@ -908,26 +908,4 @@ public class OrgDashboardWidgetsTests(AspireFixture fixture) : VisualTestBase(fi
 		await Page.WaitForURLAsync(new Regex(@"/app/[^/]+/dashboard"), new() { Timeout = 15_000 });
 	}
 
-	/// <summary>
-	/// Mints a token straight from Keycloak's password grant, for the
-	/// second actor in a test (vera signing up while the browser stays
-	/// logged in as olaf) - same helper as EngagementManagementFiltersTests.
-	/// </summary>
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/QRScannerModalTests.cs
+++ b/backend/tests/VisualTests/QRScannerModalTests.cs
@@ -260,24 +260,6 @@ public class QRScannerModalTests(AspireFixture fixture) : VisualTestBase(fixture
 			""");
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	/// <summary>
 	/// Creates a fresh organization + QRCode-check-in opportunity, has vera
 	/// apply, and has olaf confirm the application - the precondition for a
@@ -292,9 +274,9 @@ public class QRScannerModalTests(AspireFixture fixture) : VisualTestBase(fixture
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 
 		var orgResponse = await PostJsonWithRetryAsync(olafHttp, "/v1/organizations", new { name = $"QRScanner {label} Org {suffix}" });
 		orgResponse.EnsureSuccessStatusCode();

--- a/backend/tests/VisualTests/ReducedMotionTransformTests.cs
+++ b/backend/tests/VisualTests/ReducedMotionTransformTests.cs
@@ -35,7 +35,7 @@ public class ReducedMotionTransformTests(AspireFixture fixture) : VisualTestBase
 		var keycloak = Fixture.GetEndpoint("keycloak");
 		var origin = frontend.GetLeftPart(UriPartial.Authority);
 
-		var token = await GetTokenAsync(keycloak, "olaf", "olaf123");
+		var token = await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123");
 		using var http = new HttpClient { BaseAddress = backend };
 		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
@@ -122,22 +122,4 @@ public class ReducedMotionTransformTests(AspireFixture fixture) : VisualTestBase
 			"the shared ChevronDownIcon's open-state rotate is a transform transition too, per #2068's audit");
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()
-			?? throw new InvalidOperationException("no access_token in the token response");
-	}
 }

--- a/backend/tests/VisualTests/SelfRegistrationDefaultRoleTests.cs
+++ b/backend/tests/VisualTests/SelfRegistrationDefaultRoleTests.cs
@@ -69,7 +69,7 @@ public class SelfRegistrationDefaultRoleTests(AspireFixture fixture) : VisualTes
 		await Expect(Page.Locator("#kc-register-form")).Not.ToBeVisibleAsync(new() { Timeout = 30_000 });
 
 		using var adminHttp = new HttpClient { BaseAddress = keycloak };
-		adminHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetAdminTokenAsync(adminHttp)}");
+		adminHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetAdminTokenAsync(keycloak)}");
 
 		var userId = await FindUserIdAsync(adminHttp, username);
 		try
@@ -80,7 +80,7 @@ public class SelfRegistrationDefaultRoleTests(AspireFixture fixture) : VisualTes
 			// registration just created and call the baseline authenticated
 			// endpoint directly. Before the fix, "user" was missing from the
 			// token's roles claim and this returned 403.
-			var accessToken = await GetTokenAsync(keycloak, username, password);
+			var accessToken = await AuthHelper.GetTokenAsync(keycloak, username, password);
 
 			using var http = new HttpClient { BaseAddress = backend };
 			http.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
@@ -95,21 +95,6 @@ public class SelfRegistrationDefaultRoleTests(AspireFixture fixture) : VisualTes
 		{
 			await adminHttp.DeleteAsync($"/admin/realms/{Realm}/users/{userId}");
 		}
-	}
-
-	private static async Task<string> GetAdminTokenAsync(HttpClient keycloakHttp)
-	{
-		var response = await keycloakHttp.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "client_credentials",
-				["client_id"] = "backend",
-				["client_secret"] = "backend-secret",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
 	}
 
 	private static async Task<string> FindUserIdAsync(HttpClient adminHttp, string username)
@@ -140,21 +125,4 @@ public class SelfRegistrationDefaultRoleTests(AspireFixture fixture) : VisualTes
 		resetPasswordResponse.EnsureSuccessStatusCode();
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			$"/realms/{Realm}/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
 }

--- a/backend/tests/VisualTests/SignUpVocabularyTests.cs
+++ b/backend/tests/VisualTests/SignUpVocabularyTests.cs
@@ -93,11 +93,11 @@ public class SignUpVocabularyTests(AspireFixture fixture) : VisualTestBase(fixtu
 			await CreateIndividualContactOpportunityAsync(keycloak, backend, "VocabularyOrganizer");
 
 		using var veraHttp = new HttpClient { BaseAddress = backend };
-		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "vera", "vera123")}");
+		veraHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "vera", "vera123")}");
 		var engagementId = await ApplyAsync(veraHttp, opportunityId, "Please let me help.");
 
 		using var olafHttp = new HttpClient { BaseAddress = backend };
-		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		olafHttp.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// Confirmed, not Pending - the confirmed row is the one that used to
 		// carry the odd verb out ("Stornieren").
@@ -144,31 +144,13 @@ public class SignUpVocabularyTests(AspireFixture fixture) : VisualTestBase(fixtu
 		return body.GetProperty("id").GetString()!;
 	}
 
-	private static async Task<string> GetTokenAsync(Uri keycloak, string username, string password)
-	{
-		using var http = new HttpClient { BaseAddress = keycloak };
-		var response = await http.PostAsync(
-			"/realms/einsatzbereit/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "frontend-test",
-				["username"] = username,
-				["password"] = password,
-				["scope"] = "openid",
-			}));
-		response.EnsureSuccessStatusCode();
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-		return body.GetProperty("access_token").GetString()!;
-	}
-
 	private static async Task<(string OpportunityId, string OrganizationId)> CreateIndividualContactOpportunityAsync(
 		Uri keycloak, Uri backend, string label)
 	{
 		var suffix = Guid.NewGuid().ToString("N");
 
 		using var http = new HttpClient { BaseAddress = backend };
-		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await GetTokenAsync(keycloak, "olaf", "olaf123")}");
+		http.DefaultRequestHeaders.Add("Authorization", $"Bearer {await AuthHelper.GetTokenAsync(keycloak, "olaf", "olaf123")}");
 
 		// A fresh organization per test rather than olaf's shared seed org -
 		// other tests in this shared Aspire session mutate the seed orgs (see

--- a/backend/tests/VisualTests/VisualTestBase.cs
+++ b/backend/tests/VisualTests/VisualTestBase.cs
@@ -126,7 +126,13 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 	protected static async Task<HttpResponseMessage> PostJsonWithRetryAsync(
 		HttpClient client, string requestUri, object body, CancellationToken cancellationToken = default)
 	{
-		const int maxAttempts = 3;
+		// Four attempts over ~3.5 s (0.5 s, 1 s, 2 s), matching
+		// AuthHelper.PostTokenRequestWithRetryAsync. Three attempts over ~1.5 s with
+		// a linear backoff was not enough: einsatzbereit#2147 observed an
+		// organization-creation POST exhaust the old budget outright against a
+		// shard's cold stack, and #2145's sharding gives every shard its own cold
+		// window instead of one per suite.
+		const int maxAttempts = 4;
 		HttpResponseMessage response;
 		for (var attempt = 1; ; attempt++)
 		{
@@ -135,7 +141,7 @@ public abstract class VisualTestBase(AspireFixture fixture) : PageTest
 				break;
 
 			response.Dispose();
-			await Task.Delay(TimeSpan.FromMilliseconds(500 * attempt), cancellationToken);
+			await Task.Delay(TimeSpan.FromMilliseconds(500 * Math.Pow(2, attempt - 1)), cancellationToken);
 		}
 
 		return response;

--- a/docs/TDRs/2_slow_ci_pipeline.adoc
+++ b/docs/TDRs/2_slow_ci_pipeline.adoc
@@ -281,7 +281,7 @@ Strategic (larger change, defer until justified):
 
 *The concurrency trap - the most important finding here, because it decides whether the number is usable at all.* The first pass ran at Stryker's suggested `concurrency: 2` and produced 71.60 % / 73.47 %. Repeating it at the same commit produced 70.68 % / 72.85 %. The mutant *sets* were identical both times, but individual verdicts churned: 47 of 872 Domain mutants and 99 of 1818 Application mutants changed status between two runs of unchanged code. Disabling Stryker's `bail` and `mix-mutants` optimisations did not help (34 flips remained, at no cost in runtime), which ruled out mutant batching as the cause.
 
-Dropping to `concurrency: 1` did. Two runs per project at concurrency 1 were *bit-for-bit identical* - zero flips out of 872 and out of 1818. Comparing the concurrency-2 runs against that deterministic baseline shows the error is one-directional:
+Dropping to `concurrency: 1` did. Two runs per project at concurrency 1 were *bit-for-bit identical* - zero flips out of 872 and out of 1818. The determinism survives a dependency change too: re-running both projects after merging `main`'s TUnit 1.65.31 -> 1.65.38 bump (#2144) reproduced every single verdict, 0 flips out of 2690 mutants and the same 66.75 % / 68.49 %. So the number tracks the test suite, not the machine or the engine underneath it. Comparing the concurrency-2 runs against that deterministic baseline shows the error is one-directional:
 
 [cols="3,1,1" options="header"]
 |===

--- a/docs/TDRs/2_slow_ci_pipeline.adoc
+++ b/docs/TDRs/2_slow_ci_pipeline.adoc
@@ -2,7 +2,7 @@
 
 - *Author:* @maik-hasler
 - *Version:* identified in v1.0.0
-- *Date:* 2026-07-18 (last re-measured 2026-08-20, issue #2145)
+- *Date:* 2026-07-18 (last re-measured 2026-08-20, issues #2145 and #2147)
 - *Status:* In Progress
 
 === Description
@@ -234,6 +234,140 @@ Wall-clock is therefore just over the < 10 min target rather than under it, and 
 Strategic (larger change, defer until justified):
 
 - *Move end-to-end tests off the per-PR critical path:* Keep build, unit, architecture, and integration tests on every pull request (fast and deterministic) and run the full `VisualTests` suite on a merge queue or nightly schedule instead of every push. This is the largest feedback-time win and best fits the Maintainability goal, at the cost of slightly later end-to-end signal.
+- *Rebalance the test pyramid (issue #2148):* Move the bulk of the `VisualTests` suite down into `IntegrationTests` and `Application.UnitTests`, keeping end-to-end coverage only for what genuinely needs a browser. 542 end-to-end tests is roughly 24 % of the whole suite sitting in the slowest and most fragile layer, and sharding only divides that cost rather than removing it. The risk is deleting real coverage along with redundant coverage, which is why the guardrail below had to be recorded first.
++
+[NOTE]
+====
+*Mutation-score baseline recorded (issue #2147, 2026-08-20).* Deliberately scoped to producing the number: no test changes, no threshold gate.
+
+*Why this and not line coverage.* Line coverage cannot answer the question #2148 raises. A redundant end-to-end test and a load-bearing one look identical to it: delete either, and the lines they touched are still executed by something else, so the percentage barely moves. Mutation testing gives a falsifiable condition instead - record the score now, re-run it after each migration wave, and *if the score does not drop, the coverage that was removed was redundant.* Without a recorded number first, #2148 is unfalsifiable and should not start.
+
+*What was measured.* Stryker.NET 4.16.0 mutating `backend/src/Domain` and `backend/src/Application`, one run per source project, both driven by `Application.UnitTests` (1017 tests, no Docker). .NET SDK 10.0.400, `mutation-level: Standard`, `concurrency: 1` (see "The concurrency trap" below), on a 4-vCPU machine. Measured at commit `c4a143b` (`ci: shard visual-tests across four runners and cut fixed waits (#2146)`). The configuration is checked in at `backend/tests/Application.UnitTests/stryker-config.json`, so the run is reproducible by anyone.
+
+.Mutation-score baseline, commit `c4a143b`, Stryker.NET 4.16.0, concurrency 1
+[cols="2,1,1,1,1,1,1,1" options="header"]
+|===
+|Project |Generated |Scored |Killed |Survived |No coverage |Score |Wall-clock
+
+|`Domain`
+|872
+|764
+|510
+|173
+|81
+|*66.75 %*
+|3 min 58 s
+
+|`Application`
+|1818
+|1466
+|1004
+|343
+|119
+|*68.49 %*
+|7 min 42 s
+
+|*Combined*
+|2690
+|2230
+|1514
+|516
+|200
+|*67.89 %*
+|11 min 40 s
+|===
+
+"Generated" minus "scored" is 460 mutants Stryker excludes from the score itself: 333 ignored (blocks already covered), 126 that did not compile, 1 runtime error. The score is `(killed + timeout) / (killed + timeout + survived + no coverage)`; there was exactly one timeout across both runs.
+
+*The concurrency trap - the most important finding here, because it decides whether the number is usable at all.* The first pass ran at Stryker's suggested `concurrency: 2` and produced 71.60 % / 73.47 %. Repeating it at the same commit produced 70.68 % / 72.85 %. The mutant *sets* were identical both times, but individual verdicts churned: 47 of 872 Domain mutants and 99 of 1818 Application mutants changed status between two runs of unchanged code. Disabling Stryker's `bail` and `mix-mutants` optimisations did not help (34 flips remained, at no cost in runtime), which ruled out mutant batching as the cause.
+
+Dropping to `concurrency: 1` did. Two runs per project at concurrency 1 were *bit-for-bit identical* - zero flips out of 872 and out of 1818. Comparing the concurrency-2 runs against that deterministic baseline shows the error is one-directional:
+
+[cols="3,1,1" options="header"]
+|===
+|Run |Kills concurrency 1 does not report |Kills concurrency 1 reports that it misses
+
+|`Domain`, four separate concurrency-2 runs
+|+37 / +30 / +40 / +38
+|0 / 0 / 0 / 0
+
+|`Application`, two separate concurrency-2 runs
+|+73 / +64
+|0 / 0
+|===
+
+Every parallel run invents kills and never loses one, and it invents a *different* set each time: across the four Domain runs the four spurious sets intersected in exactly zero mutants (75 distinct mutants were spuriously killed at least once). So concurrency inflates the score by roughly 5 points and jitters it by roughly 1. Stryker's Microsoft.Testing.Platform runner is marked preview and warns as much on every run; this looks like its per-mutant attribution losing track of which test host reported which failure. *`concurrency: 1` is therefore load-bearing, not a performance setting* - the whole value of this number is that a movement in it means something, and at concurrency 2 a 1-point drop is indistinguishable from running the tool twice.
+
+*Wall-clock: cheap enough to run per migration wave.* 11 min 40 s for both projects sequentially, and the two projects are independent, so `.github/workflows/mutation-tests.yml` runs them as a matrix on separate runners - CI wall-clock is the longer leg (~8 min) plus job setup, not the sum. That is affordable several times per wave. It is still ~150x the `fast-tests` job whose 1017 tests it reuses (3 s), which is why it stays off the per-PR path.
+
+*Decided: it runs in CI, but manually and report-only.* `mutation-tests.yml` is `workflow_dispatch` only, so it is never a required check and cannot block a merge, and `thresholds.break` is pinned to `0` so a low score exits 0 regardless. Same posture as the report-only coverage summary added to `fast-tests` in #1327: visibility is the point. *Do not add a break threshold* - a number whose whole purpose is to be free to move cannot double as a gate.
+
+*What 67.89 % is actually made of,* because the headline is misleading read alone:
+
+[cols="3,1,3" options="header"]
+|===
+|Slice |Score |What it says
+
+|Headline (everything scored)
+|67.89 %
+|The number to track across #2148's waves. Compare like with like: only against another concurrency-1 run of Stryker 4.16.0.
+
+|Excluding the string mutator
+|81.13 %
+|330 of the 516 survivors (64 %) are string-literal mutations. Nothing else is close - statement removal is 10.9 %, equality 8.3 %, and every remaining mutator is under 6 %.
+
+|Covered code only
+|74.58 %
+|Drops the 200 mutants no unit test reaches at all. That is a coverage gap rather than a test-quality one, and much of it is `Api`/`Infrastructure`-facing plumbing that `IntegrationTests` exercises instead.
+
+|Both adjustments
+|86.86 %
+|Mutants that are both reachable and not a bare string swap are killed at roughly 87 %.
+|===
+
+Domain and Application land within two points of each other on every one of those four slices (66.75/68.49, 80.39/81.52, 74.67/74.54, 85.89/87.37), which is a good sign the number measures a property of the test suite rather than of one layer.
+
+*The string survivors are not noise, and this is the single most actionable thing the run surfaced.* Splitting the string-literal mutants by what the literal actually is:
+
+[cols="3,1,1,1,1" options="header"]
+|===
+|Literal kind |Killed |Survived |No coverage |Kill rate
+
+|`Error` code (`"Engagement.NotPending"`)
+|6
+|174
+|44
+|*3 %*
+
+|Prose description (`"Only pending engagements can be confirmed."`)
+|132
+|84
+|51
+|49 %
+
+|Other short literals
+|146
+|72
+|5
+|65 %
+|===
+
+Error codes are essentially unasserted: 6 kills out of 224. The cause is `ResultFailureException(Error error) : Exception(error.Description)` - assertions written as `ThrowAsync<ResultFailureException>().WithMessage("*not found*")` pin the human-readable prose and leave `Error.Code` untouched, even though `Error.Code` is what `ResultFailureExceptionHandler` puts on the wire as `errorCode` and what the frontend branches on. The contract that can be reworded freely is tested; the contract that cannot be changed without breaking clients is not. Those 174 survivors are 34 % of every survivor in both projects, so closing that one pattern alone would move the combined score from 67.9 % to roughly 75.7 %. Out of scope for #2147 (no test changes), worth its own issue.
+
+*How to read the number, and what a "good" score here would be.* Stryker's own built-in thresholds (high 80, low 60) are generic defaults, and a single global target is the wrong instrument for this codebase - 64 % of the surviving mutants are string swaps, whose kill rate says more about assertion style than about test quality. Useful expectations, in the order they should be reached for:
+
+. *For #2148, the only threshold that matters is "did it drop".* The run is deterministic, so any drop at all is real. Treat a drop of more than ~0.5 points (~11 mutants) after a migration wave as coverage that was actually load-bearing, and go find which mutants stopped dying - the JSON report names them. A wave that holds the score flat has proven its case.
+. *As a standing target, 75 % combined is the realistic next rung* and is reachable without writing a single new test scenario - it is what asserting `Error.Code` instead of (or alongside) exception message text would produce on its own.
+. *Above that, judge the adjusted slices, not the headline.* "Reachable, non-string" mutants are already killed at 87 %, which is genuinely healthy; the headline is held down by literal mutations and by unreachable code, and neither is fixed by writing more of the same tests.
+. *80 % headline is a reasonable long-run ambition and a bad short-run gate.* Getting there means both fixing the error-code assertions and covering the 200 currently unreachable mutants, most of which belong to `IntegrationTests`' territory rather than to the unit suite.
+
+*Caveats on the number.*
+
+- Stryker's Microsoft.Testing.Platform runner is preview and prints a warning saying so on every run. It is not optional here: TUnit has no VSTest adapter, so Stryker's default VSTest runner discovers zero tests and reports a vacuous pass rather than an error. `test-runner: mtp` is pinned in the config for that reason, and the concurrency finding above is a concrete symptom of the runner's preview status.
+- The Stryker version is pinned (4.16.0) in the workflow and in the documented local command. A different version can add or drop mutators, which changes the denominator and makes the score incomparable with this baseline. Bumping it means re-recording this table.
+- `Application.UnitTests.csproj` gained a direct `ProjectReference` to `Domain.csproj`. It is redundant to the compiler (Application already pulls Domain in) and exists only because Stryker resolves the project it mutates from the test project's *direct* reference list; without it the Domain half cannot run at all.
+- Wall-clock was measured on a 4-vCPU sandbox, not a GitHub runner. Same core count as `ubuntu-latest`, so it should transfer, but treat it as an estimate until `mutation-tests.yml` has run for real.
+====
 - *Larger or self-hosted runners:* GitHub-hosted larger runners are paid (conflicts with the minimal-budget constraint); a self-hosted runner fits the self-hosting principle (ADR-3 rationale) but adds operational burden that the single-maintainer constraint discourages. Revisit only if the suite outgrows the hosted two-core runner.
 
 === Consequences of Delay


### PR DESCRIPTION
## What

Two things, the second added after CI surfaced it on this PR's own runs:

1. **Records a Stryker.NET mutation-score baseline** over `backend/src/Domain` and `backend/src/Application`, driven by `Application.UnitTests`, plus a manual, report-only CI workflow to reproduce it. No test changes to the mutated layers, no threshold gate.
2. **Consolidates every `VisualTests` Keycloak token request behind one retrying helper**, closing the gap that made `visual-tests (2)` fail twice here. Shard 2 is green on the current head.

| Project | Generated | Scored | Killed | Survived | No coverage | Score | Wall-clock |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `Domain` | 872 | 764 | 510 | 173 | 81 | **66.75 %** | 3 min 58 s |
| `Application` | 1818 | 1466 | 1004 | 343 | 119 | **68.49 %** | 7 min 42 s |
| **Combined** | 2690 | 2230 | 1514 | 516 | 200 | **67.89 %** | 11 min 40 s |

Stryker.NET 4.16.0, .NET SDK 10.0.400, `mutation-level: Standard`, `concurrency: 1`, measured at `c4a143b` and re-confirmed unchanged on the merged head.

Files:

- `backend/tests/Application.UnitTests/stryker-config.json` - checked-in config so the run is reproducible.
- `.github/workflows/mutation-tests.yml` - `workflow_dispatch` only, matrix over the two projects, score to the job summary, HTML/JSON report as an artifact.
- `docs/TDRs/2_slow_ci_pipeline.adoc` - the durable record, under a new "Rebalance the test pyramid (#2148)" bullet alongside the #2145 measurements.
- `backend/AGENTS.md`, `.github/AGENTS.md` - how to run it and the traps below.
- `backend/tests/Application.UnitTests/Application.UnitTests.csproj` - direct `ProjectReference` to `Domain.csproj`.
- `backend/tests/VisualTests/**` (30 files) - the retry consolidation, see below.

## Why

Split out of #2145. #2148 wants to move most of the 542 end-to-end tests down the pyramid, and the risk is deleting real coverage along with redundant coverage. Line coverage cannot distinguish the two - delete either kind of test and the lines are still executed by something else. A mutation score can, provided it is recorded before the migration starts. Without this number, #2148 is unfalsifiable.

Closes #2147

## Three findings the mutation setup depends on

**1. Stryker's default runner silently reports a vacuous pass.** TUnit is Microsoft.Testing.Platform only and ships no VSTest adapter, so Stryker's default VSTest runner discovers 0 tests, skips every mutant, and exits 0 - it does not error. `test-runner: mtp` is pinned in the config for that reason.

**2. `concurrency: 1` is load-bearing, not a performance setting.** The first pass at Stryker's suggested concurrency 2 gave 71.60 % / 73.47 %; a repeat at the same commit gave 70.68 % / 72.85 %. Mutant sets identical, but 47 of 872 and 99 of 1818 individual verdicts changed. Disabling `bail` and `mix-mutants` did not help (34 flips remained). Dropping to `concurrency: 1` did - two runs per project came out bit-for-bit identical. Measured against that deterministic baseline the error is one-directional:

| Run | Kills concurrency 1 does not report | Kills it reports that concurrency 2 misses |
| --- | --- | --- |
| `Domain`, four concurrency-2 runs | +37 / +30 / +40 / +38 | 0 / 0 / 0 / 0 |
| `Application`, two concurrency-2 runs | +73 / +64 | 0 / 0 |

Every parallel run invents kills, never loses one, and invents a different subset each time - across the four `Domain` runs the spurious sets intersected in **zero** mutants. Net effect: score ~5 points high, ~1 point of jitter, which is exactly the magnitude #2148 needs to detect.

**3. Stryker resolves the project it mutates from the test project's *direct* `ProjectReference` list.** `Domain` arrives transitively via `Application`, so `--project Domain.csproj` failed with "Could not find an assembly reference to a mutable assembly". The added reference is redundant to the compiler and exists purely for that lookup; the csproj carries a comment saying so.

**Determinism, independently confirmed.** `main` moved four commits ahead mid-PR, one being the TUnit 1.65.31 -> 1.65.38 bump (#2144) - a change to the engine that does the killing. Re-running both projects on the merged head reproduced **every single verdict: 0 flips out of 2690 mutants**, same 66.75 % / 68.49 %. The number tracks the test suite, not the machine or the engine under it.

## The `visual-tests (2)` failures, and the fix

This PR's own CI failed shard 2 twice, each time on a **different test hitting a different service**, both a transient 500 during setup:

| Head | Test | Failing call | Service |
| --- | --- | --- | --- |
| `f73fe6c` | `MissingCoordinatesFallbackTests` | `POST /v1/organizations` | backend API |
| `a7330e0` | `SignUpVocabularyTests.GetTokenAsync` | `POST /realms/.../token` | Keycloak |

The second is the same gap #2141 closed for opportunity/engagement POSTs, one layer down. `AspireFixture` already had `PostTokenRequestWithRetryAsync`, with a comment naming exactly this failure mode. But **29 test classes carried their own private copy of the token request instead of going through it** - 25 `GetTokenAsync` and 4 `GetAdminTokenAsync`, all semantically identical, **not one of them retrying**. A blip on any of them failed an unrelated test outright.

Consolidated into `AuthHelper.GetTokenAsync` / `GetAdminTokenAsync`, both built on a single `AuthHelper.PostTokenRequestWithRetryAsync` that `AspireFixture` now delegates to as well. One retry policy for the suite instead of one protected copy and 29 unprotected ones. **Net -419 lines.**

Both retry budgets also widen from 3 attempts over ~1.5 s (linear) to 4 over ~3.5 s (exponential: 0.5 s, 1 s, 2 s), in `AuthHelper` and in `VisualTestBase.PostJsonWithRetryAsync`. The first failure exhausted the old budget on a call that *was* already retrying, and #2145's sharding means every shard now hits a cold stack rather than one cold window amortised across a 542-test session.

This does not touch the mutation baseline: Stryker mutates `Domain` + `Application` driven by `Application.UnitTests`, and `VisualTests` is in neither graph.

## Decision on CI: manual, report-only, no gate

`mutation-tests.yml` is `workflow_dispatch` only, so it is never a required check, and `thresholds.break` is pinned to `0` so a low score exits 0 regardless. Two independent mechanisms, both deliberate. Same posture as the report-only coverage summary in `fast-tests` (#1327). The job only fails if Stryker itself fails.

It is off the PR path on cost: ~8 min for the longer leg against a test suite that runs in 3 s. The two projects run as a matrix, so CI wall-clock is the longer leg rather than the sum - affordable several times per migration wave, which is the cadence this number is for.

## What the score is made of

| Slice | Combined | What it says |
| --- | --- | --- |
| Headline | 67.89 % | The number to track across #2148's waves |
| Excluding the string mutator | 81.13 % | 330 of 516 survivors (64 %) are string-literal mutations |
| Covered code only | 74.58 % | Drops 200 mutants no unit test reaches |
| Both | 86.86 % | Reachable, non-string mutants are killed at ~87 % |

`Domain` and `Application` land within two points of each other on all four, which suggests the number measures the test suite rather than one layer.

**One thing worth its own issue** (out of scope here - no changes to the mutated layers): the string survivors are not equivalent mutants. Split by what the literal is, `Error` codes are killed 6 times out of 224 (**3 %**) while prose descriptions are killed 49 % of the time. `ResultFailureException(Error error) : Exception(error.Description)` means assertions written as `ThrowAsync().WithMessage("*not found*")` pin the human-readable prose and leave `Error.Code` unasserted - even though `Error.Code` is what `ResultFailureExceptionHandler` puts on the wire as `errorCode` and what the frontend branches on. Those 174 survivors are 34 % of every survivor in both projects; closing that one pattern would move the combined score from 67.9 % to roughly 75.7 %.

## Testing

- **CI is fully green on `8dfac0b`: all 16 checks, including all four `visual-tests` shards.** Shard 2, which failed on both earlier heads, passes.
- `dotnet build` clean for `VisualTests`, `Application.UnitTests`, `ArchitectureTests`: **0 warnings, 0 `error CS`**.
- `Application.UnitTests` 1017/1017 and `ArchitectureTests` 417/417 pass locally.
- `dotnet format --verify-no-changes` exits 0.
- `lint.yml`'s typographic-dash check run over all tracked files; `visual-test-shard-partition`'s guard re-run locally (138 classes, partition intact).
- Nine full Stryker runs across the concurrency / `bail` / `mix-mutants` matrix; the two backing the baseline were each repeated byte-identical, plus a third `Domain` run through the committed config, plus a full re-run on the merged head after the TUnit bump.
- The `jq` summary expression validated against both real reports (emits 66.75 % / 68.49 %, matching Stryker's own reported score).
- `VisualTests` could not be run locally (needs Docker and a Playwright browser; `cdn.playwright.dev` is blocked in the authoring session), so the retry consolidation was verified by compilation and review locally and by the green CI run above.

## Live verification

Not applicable - CI configuration, documentation, and test-infrastructure only. No production code changed, so no release candidate was cut (per this template's docs/CI exemption).

## Checklist

- [x] `/self-review` run and findings addressed - reviewed the diff directly rather than fanning out to the `.claude/agents/` checks: no endpoint, DTO, entity, `.tsx` component, or locale key changes, so `nswag-check`, `ef-migration-check`, `architecture-check`, `a11y-check`, and `i18n-check` have nothing in scope
- [x] CI is green
- [x] Documentation updated if this change affects behavior