### PR TITLE
fix: register silent-renew redirect URI for the frontend Keycloak client

### DIFF
--- a/.github/workflows/keycloak-realm-import.yml
+++ b/.github/workflows/keycloak-realm-import.yml
@@ -41,6 +41,7 @@ jobs:
           KC_VERSION: ${{ steps.kc.outputs.version }}
         run: |
           set -u
+          KC_FRONTEND_URL="https://app.example.test"
           IMPORT_DIR="$RUNNER_TEMP/kc-import"
           mkdir -p "$IMPORT_DIR"
           cp keycloak/realms/*-realm.json "$IMPORT_DIR/"
@@ -48,7 +49,7 @@ jobs:
           docker run -d --name kc-import-check -p 8080:8080 \
             -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
             -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
-            -e KC_FRONTEND_URL=https://app.example.test \
+            -e "KC_FRONTEND_URL=$KC_FRONTEND_URL" \
             -e KEYCLOAK_BACKEND_SECRET=dummy-not-a-real-secret \
             -e KC_SMTP_HOST=localhost \
             -e KC_SMTP_PORT=1025 \
@@ -107,4 +108,17 @@ jobs:
             exit 1
           fi
 
-          echo "Realm 'einsatzbereit' imported and served successfully on Keycloak $KC_VERSION, with all client placeholders resolved."
+          frontend_redirect_uris=$(printf '%s' "$clients" | jq -r '.[] | select(.clientId == "frontend") | .redirectUris[]')
+          missing=""
+          for path in /callback /silent-renew.html; do
+            if ! printf '%s\n' "$frontend_redirect_uris" | grep -qF "$KC_FRONTEND_URL$path"; then
+              missing="$missing $KC_FRONTEND_URL$path"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::The imported 'frontend' client's redirectUris are missing:$missing - frontend/src/main.tsx sends these as redirect_uri/silent_redirect_uri, so Keycloak would reject the authorization request with invalid_redirect_uri."
+            exit 1
+          fi
+
+          echo "Realm 'einsatzbereit' imported and served successfully on Keycloak $KC_VERSION, with all client placeholders resolved and the 'frontend' client's redirectUris covering every URI main.tsx can send."

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -85,7 +85,8 @@
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
       "redirectUris": [
-        "${KC_FRONTEND_URL}/callback"
+        "${KC_FRONTEND_URL}/callback",
+        "${KC_FRONTEND_URL}/silent-renew.html"
       ],
       "webOrigins": [
         "${KC_FRONTEND_URL}"


### PR DESCRIPTION
## What

Adds `${KC_FRONTEND_URL}/silent-renew.html` to the `frontend` client's `redirectUris` in `keycloak/realms/einsatzbereit-realm.json`, alongside the existing `/callback` entry. Also extends `keycloak-realm-import.yml` to assert that the imported `frontend` client's `redirectUris` cover every redirect URI `frontend/src/main.tsx` can send.

## Why

`main.tsx` configures `automaticSilentRenew: true` with `silent_redirect_uri: window.location.origin + "/silent-renew.html"`. Keycloak validates `redirect_uri` on a `prompt=none` authorization request the same way it does on an interactive login, and the committed realm only ever registered `/callback`. The hidden renewal iframe's request was rejected with `invalid_redirect_uri`, so sessions died at the realm's access-token lifetime instead of renewing, bouncing users to login mid-session - anywhere the released Keycloak image runs.

This wasn't caught locally or in CI because `AppHost.cs` overlays a `http://localhost:*` wildcard onto the `frontend` client's `redirectUris` for local Aspire/Playwright runs, which happens to also match `/silent-renew.html`. Only the committed realm's exact-match entries, exercised by the released image, were affected.

Closes #2166

## Testing

- Validated `keycloak/realms/einsatzbereit-realm.json` and `.github/workflows/keycloak-realm-import.yml` for syntax (JSON/YAML parse cleanly).
- Extended `keycloak-realm-import.yml`'s existing "Import realm and verify it is served" step (which already reads the imported `frontend` client back through the Keycloak admin API to check for unresolved `${...}` placeholders) to additionally assert its `redirectUris` contain both `$KC_FRONTEND_URL/callback` and `$KC_FRONTEND_URL/silent-renew.html`, failing the check with a clear error if either is missing. This exercises the exact-match realm shape the released image ships, not just the wildcard-patched local dev copy, so this class of gap fails CI going forward.
- Confirmed in CI: all 14 checks passed, including "Import realm on the released Keycloak version" (the check this PR extends).

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no docs described the previous single-entry `redirectUris` shape as intentional)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjEX6NuCLkttzwZQLcJ6Cv)_