### PR TITLE
chore: remove the dead Zzztestdorf exact-match fixture from FakeGeocodingService

### DIFF
--- a/backend/src/Infrastructure/Geocoding/FakeGeocodingService.cs
+++ b/backend/src/Infrastructure/Geocoding/FakeGeocodingService.cs
@@ -4,9 +4,6 @@ namespace Infrastructure.Geocoding;
 
 internal sealed class FakeGeocodingService : IGeocodingService
 {
-	internal const string ExactMatchFixtureQuery = "Zzztestdorf";
-	internal const string ExactMatchFixtureOtherResult = "Neu-Zzztestdorf";
-
 	public Task<GeocodingResult> GeocodeAsync(
 		string street,
 		string houseNumber,
@@ -18,16 +15,6 @@ internal sealed class FakeGeocodingService : IGeocodingService
 	public Task<IReadOnlyList<CitySuggestion>> SearchCitiesAsync(
 		string query,
 		string language,
-		CancellationToken cancellationToken = default)
-	{
-		if (string.Equals(query.Trim(), ExactMatchFixtureQuery, StringComparison.OrdinalIgnoreCase))
-		{
-			return Task.FromResult<IReadOnlyList<CitySuggestion>>([
-				new CitySuggestion(ExactMatchFixtureQuery, 51.0, 10.0),
-				new CitySuggestion(ExactMatchFixtureOtherResult, 51.1, 10.1),
-			]);
-		}
-
-		return Task.FromResult<IReadOnlyList<CitySuggestion>>([]);
-	}
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyList<CitySuggestion>>([]);
 }


### PR DESCRIPTION
## What

Removes the unreachable `Zzztestdorf` exact-match fixture branch and its two `internal const string` fields from `FakeGeocodingService.SearchCitiesAsync`, which now unconditionally returns an empty list.

## Why

Closes #2163

`#2152` deleted `CityExactNameMatchSuggestionTests`, the fixture's only consumer, leaving the branch unreachable from anywhere in the repo (confirmed: `Zzztestdorf` now appears only in the two now-removed const declarations, nowhere else). The two `internal const`s were also unreferenced elsewhere, which is why the build stayed at 0 warnings despite the dead code.

The issue's real question was whether `#1930`'s scenario - Nominatim returning a place name that echoes the typed query character-for-character, which the frontend must not render identically to an unambiguous match - is still covered after `#2152`, or whether coverage was lost outright. It was relocated, not lost:

- `frontend/src/components/LocationSearchInput.test.tsx`'s "exact-name match" suite exercises the exact two-result scenario directly (one label matching the typed query, one only partially matching) against a mocked `api.searchCities`, and asserts the "Matches exactly" caption renders on the right suggestion and not the other. This is a more direct test of the actual behaviour (the frontend rendering) than the old backend fixture ever was, since the old path had to route fake backend data through a live component to observe the same thing.
- The surrounding empty-list path (every other query returns nothing) stays covered by `backend/tests/IntegrationTests/OutputCachingTests.cs`'s `SearchCities_ShouldCacheEachLanguageSeparately` test against `/v1/maps/cities`.

The docblock the issue flagged (referencing the also-deleted `CityOnlyDeepLinkLocationFilterTests`) had already been removed by `#2167`'s comment cleanup, so there was nothing left to fix there. Likewise, the release-candidate + live-staging verification flow the issue's acceptance criteria pointed at no longer exists in the root `AGENTS.md` - `#2165` removed deployment/staging from the repo entirely, so that step doesn't apply to this PR.

## Testing

- `dotnet build` - succeeds, 0 warnings, 0 errors
- `dotnet run --project tests/Application.UnitTests` - 1017/1017 passed
- `dotnet run --project tests/ArchitectureTests` - 417/417 passed
- `pnpm test` (frontend) - 709/709 passed, including `LocationSearchInput.test.tsx`'s exact-name-match cases confirming the relocated coverage still holds
- Repo-wide grep for `Zzztestdorf`/`ExactMatchFixture*`/the two deleted test class names - no remaining references anywhere

## Checklist

- [x] `/self-review` equivalent checks run (architecture-check agent, build, full backend unit/architecture suites, frontend suite)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior - N/A, no behavior change (the removed branch was already unreachable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UJh4BnTwcKNWtELwXT5t7k)_