### PR TITLE
fix: make updateFilter use functional setSearchParams like its siblings

### DIFF
--- a/backend/tests/VisualTests/VolunteerOpportunityTests.cs
+++ b/backend/tests/VisualTests/VolunteerOpportunityTests.cs
@@ -21,24 +21,6 @@ public class VolunteerOpportunityTests(AspireFixture fixture) : VisualTestBase(f
 	}
 
 	[Test]
-	public async Task MultipleFilters_AllReflectedInUrl()
-	{
-		var frontend = Fixture.GetEndpoint("frontend");
-		var origin = frontend.GetLeftPart(UriPartial.Authority);
-
-		await Page.GotoAsync($"{origin}/opportunities");
-		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-		await Page.GetByTestId("filter-frequency").ClickAsync();
-		await Page.GetByRole(AriaRole.Button, new() { Name = "One-time" }).ClickAsync();
-		await Page.GetByTestId("filter-type").ClickAsync();
-		await Page.GetByRole(AriaRole.Button, new() { Name = "Scheduled slots" }).ClickAsync();
-
-		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*occurrence=OneTime"));
-		await Expect(Page).ToHaveURLAsync(new Regex(@"\?.*participationType=ScheduledSlots"));
-	}
-
-	[Test]
 	public async Task FrequencyFilter_PanelStaysBelowHeader()
 	{
 		var frontend = Fixture.GetEndpoint("frontend");

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.test.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.test.tsx
@@ -176,6 +176,21 @@ describe("opportunity list filters and the URL", () => {
 			"ScheduledSlots",
 		);
 	});
+
+	it("keeps both filters in the query string when applied one after another", async () => {
+		renderList();
+
+		await userEvent.click(await screen.findByTestId("filter-frequency"));
+		await userEvent.click(screen.getByRole("button", { name: "One-time" }));
+		await userEvent.click(await screen.findByTestId("filter-type"));
+		await userEvent.click(
+			screen.getByRole("button", { name: "Scheduled slots" }),
+		);
+
+		const params = new URLSearchParams(search());
+		expect(params.get("occurrence")).toBe("OneTime");
+		expect(params.get("participationType")).toBe("ScheduledSlots");
+	});
 });
 
 describe("opportunity list with a city-only deep link", () => {

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -176,10 +176,15 @@ export default function VolunteerOpportunitiesList() {
 	});
 
 	function updateFilter(key: string, value: string) {
-		const next = new URLSearchParams(window.location.search);
-		if (value) next.set(key, value);
-		else next.delete(key);
-		setSearchParams(next, { replace: true });
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (value) next.set(key, value);
+				else next.delete(key);
+				return next;
+			},
+			{ replace: true },
+		);
 	}
 
 	function clearFilters() {


### PR DESCRIPTION
## What

`updateFilter` in `VolunteerOpportunitiesList.tsx` now derives the next `URLSearchParams` from react-router's functional `setSearchParams((prev) => ...)` form, matching its five sibling handlers, instead of rebuilding from the global `window.location.search`.

## Why

`updateFilter` - the handler every filter dropdown calls - was the one handler in the file that read `window.location.search` directly instead of the router's own `prev` state. That made its correctness depend on an invariant it doesn't control (that something else already synced `window.location`, true under `BrowserRouter`, not under `MemoryRouter`), and made the "two filters applied in sequence" case untestable at the component level - which is why `MultipleFilters_AllReflectedInUrl` had to stay in the Playwright suite during #2148's wave 8 test rebalance instead of moving down with its single-filter siblings.

Closes #2157

## Testing

- Moved `MultipleFilters_AllReflectedInUrl` from `backend/tests/VisualTests/VolunteerOpportunityTests.cs` down to a new case in `frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.test.tsx` ("keeps both filters in the query string when applied one after another"), asserting both `occurrence` and `participationType` survive when the two filters are applied in sequence under `MemoryRouter`.
- Verified the new test actually catches the bug: reverted the `updateFilter` fix locally and confirmed the new test fails (`expected null to be 'OneTime'`); restored the fix and confirmed it passes.
- `pnpm test` - all 710 frontend tests pass.
- `pnpm lint`, `pnpm check` (tsc), `pnpm format:write` - clean.
- `dotnet build` - backend builds with 0 warnings/errors after removing the moved Playwright case.

## Checklist

- [x] `/self-review` run and findings addressed (clean; `a11y-check` subagent confirmed no a11y test is needed since no markup/DOM changed)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no behavior change; internal state-update mechanism only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvxEKssRbnHUWbf1Eqpeyq)_