### PR TITLE
fix: declare 409 on engagement endpoints whose handlers actually return it

### DIFF
--- a/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CancelEngagement/v1/CancelEngagementEndpoint.cs
@@ -26,6 +26,7 @@ internal sealed class CancelEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)

--- a/backend/src/Api/Engagements/CheckInEngagement/v1/CheckInEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/CheckInEngagement/v1/CheckInEngagementEndpoint.cs
@@ -24,6 +24,7 @@ internal sealed class CheckInEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/Engagements/CheckInWithPin/v1/CheckInWithPinEndpoint.cs
+++ b/backend/src/Api/Engagements/CheckInWithPin/v1/CheckInWithPinEndpoint.cs
@@ -24,6 +24,7 @@ internal sealed class CheckInWithPinEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
@@ -24,6 +24,7 @@ internal sealed class ConfirmEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)

--- a/backend/src/Api/Engagements/DeleteFeedback/v1/DeleteFeedbackEndpoint.cs
+++ b/backend/src/Api/Engagements/DeleteFeedback/v1/DeleteFeedbackEndpoint.cs
@@ -23,6 +23,7 @@ internal sealed class DeleteFeedbackEndpoint
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/Engagements/SubmitFeedback/v1/SubmitFeedbackEndpoint.cs
+++ b/backend/src/Api/Engagements/SubmitFeedback/v1/SubmitFeedbackEndpoint.cs
@@ -23,6 +23,7 @@ internal sealed class SubmitFeedbackEndpoint
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/Engagements/UndoCheckInEngagement/v1/UndoCheckInEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/UndoCheckInEngagement/v1/UndoCheckInEngagementEndpoint.cs
@@ -24,6 +24,7 @@ internal sealed class UndoCheckInEngagementEndpoint
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitOrganisatorPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackEndpoint.cs
+++ b/backend/src/Api/Engagements/UpdateFeedback/v1/UpdateFeedbackEndpoint.cs
@@ -23,6 +23,7 @@ internal sealed class UpdateFeedbackEndpoint
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.RequireAuthorization(AuthorizationPolicies.EinsatzbereitDefaultUserPolicy)
 			.RequireRateLimiting(RateLimitingPolicies.Write)
 			.MapToApiVersion(1);

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -5766,6 +5766,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       },
@@ -5828,6 +5838,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       },
@@ -5873,6 +5893,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5944,6 +5974,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6351,6 +6391,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "content": {
@@ -6441,6 +6491,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -6505,6 +6565,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6592,6 +6662,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -9754,6 +9754,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -9861,6 +9871,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -9959,6 +9979,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -10076,6 +10106,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -10661,6 +10701,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 500)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -10794,6 +10844,16 @@ namespace IntegrationTests
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -10909,6 +10969,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -11029,6 +11099,16 @@ namespace IntegrationTests
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 409)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Conflict", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/backend/tests/IntegrationTests/EngagementUndoCheckInTests.cs
+++ b/backend/tests/IntegrationTests/EngagementUndoCheckInTests.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Headers;
-using System.Text.Json;
 using AwesomeAssertions;
 
 namespace IntegrationTests;
@@ -162,13 +161,13 @@ public class EngagementUndoCheckInTests(IntegrationTestFixture fixture)
 				$"Engagement '{engagementId}' not found in GetEngagements response.");
 	}
 
-	private static async Task<ApiException> CaptureFailureAsync(Func<Task> act)
+	private static async Task<ApiException<ProblemDetails>> CaptureFailureAsync(Func<Task> act)
 	{
 		try
 		{
 			await act();
 		}
-		catch (ApiException ex)
+		catch (ApiException<ProblemDetails> ex)
 		{
 			return ex;
 		}
@@ -176,20 +175,10 @@ public class EngagementUndoCheckInTests(IntegrationTestFixture fixture)
 		throw new Exception("Expected the undo-check-in call to fail, but it succeeded.");
 	}
 
-	private static string? ErrorCodeOf(ApiException ex)
+	private static string? ErrorCodeOf(ApiException<ProblemDetails> ex)
 	{
-		if (ex is ApiException<ProblemDetails> typed)
-		{
-			typed.Result.AdditionalProperties.Should().ContainKey("errorCode",
-				"the API's ProblemDetails carries the domain error code as an extension member");
-			return typed.Result.AdditionalProperties["errorCode"]?.ToString();
-		}
-
-		ex.Response.Should().NotBeNullOrEmpty(
-			"an untyped ApiException carries the unparsed ProblemDetails body as its Response");
-		using var problem = JsonDocument.Parse(ex.Response);
-		problem.RootElement.TryGetProperty("errorCode", out var errorCode).Should().BeTrue(
-			"the API's ProblemDetails carries the domain error code as an extension member");
-		return errorCode.GetString();
+		ex.Result.AdditionalProperties.Should().ContainKey("errorCode",
+			"a Result-pattern failure must carry an errorCode in its ProblemDetails");
+		return ex.Result.AdditionalProperties["errorCode"]?.ToString();
 	}
 }

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -5202,6 +5202,12 @@ export class EinsatzbereitApi {
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
             });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -5261,6 +5267,12 @@ export class EinsatzbereitApi {
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
             });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -5315,6 +5327,12 @@ export class EinsatzbereitApi {
             let result404: any = null;
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
             });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
@@ -5379,6 +5397,12 @@ export class EinsatzbereitApi {
             let result404: any = null;
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
             });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
@@ -5715,6 +5739,12 @@ export class EinsatzbereitApi {
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
             });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
         } else if (status === 500) {
             return response.text().then((_responseText) => {
             let result500: any = null;
@@ -5789,6 +5819,12 @@ export class EinsatzbereitApi {
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
             });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
+            });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -5852,6 +5888,12 @@ export class EinsatzbereitApi {
             let result404: any = null;
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
             });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
@@ -5921,6 +5963,12 @@ export class EinsatzbereitApi {
             let result404: any = null;
             result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("Not Found", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("Conflict", status, _responseText, _headers, result409);
             });
         } else if (status === 500) {
             return response.text().then((_responseText) => {


### PR DESCRIPTION
## What

`UndoCheckInEngagementEndpoint` returns 409 Conflict for two domain errors (`Engagement.AlreadyTerminated`, `Engagement.CheckInNotActive`) but only declared 400/401/403/404 in its OpenAPI metadata, so NSwag generated an untyped `ApiException` branch for that status instead of a typed `ApiException<ProblemDetails>` one. Sweeping the other Engagements endpoints for the same gap found it on seven more: `CheckInWithPin`, `CheckInEngagement`, `ConfirmEngagement`, `CancelEngagement`, `SubmitFeedback`, `UpdateFeedback`, and `DeleteFeedback` - each calls a domain method (`Engagement.Confirm`/`Cancel`/`CheckIn`/`UndoCheckIn`/`SubmitFeedback`/`UpdateFeedback`/`DeleteFeedback`) that can return `Error.Conflict(...)` without the endpoint declaring 409.

## Why

Closes #2158

The consequence was in the generated clients: a 409 from an endpoint that didn't declare it fell through to the non-generic `ApiException`, with the body only as a raw string and no parsed `.Result`. A `catch (ApiException<ProblemDetails>)` never matched it, which is exactly how this surfaced in PR #2152's `EngagementUndoCheckInTests`.

## Changes

- Added `.ProducesProblem(StatusCodes.Status409Conflict)` to the 8 affected endpoints, matching the repo's existing convention (see `WithdrawEngagementEndpoint`/`CreateEngagementEndpoint`, which already declared it correctly).
- Regenerated `backend/src/Api/wwwroot/openapi-v1.json` and both NSwag clients (`backend/tests/IntegrationTests/ApiClient.cs`, `frontend/src/client/api-client.ts`) via the normal `dotnet build` - not hand-edited.
- Simplified `EngagementUndoCheckInTests`'s `CaptureFailureAsync`/`ErrorCodeOf` back to the typed `ApiException<ProblemDetails>` now that the 409 branch exists for that endpoint (the untyped-fallback comment referencing this issue had already been removed by PR #2152's comment-density sweep, per the issue's correction comment).

Endpoints already correctly declaring 409 (`WithdrawEngagementEndpoint`, `CreateEngagementEndpoint`) and the two bulk endpoints (`BulkConfirmEngagements`/`BulkCancelEngagements`, which catch per-item `ResultFailureException` internally and always return 200 with a success/failure list rather than letting a Conflict escape to the HTTP layer) were left unchanged.

## Testing

- `dotnet build` (regenerates OpenAPI doc + both clients, 0 warnings/errors)
- `dotnet run --project tests/Application.UnitTests` - 1017/1017 passed
- `dotnet run --project tests/ArchitectureTests` - 417/417 passed
- `dotnet format --verify-no-changes` - clean
- `pnpm check` (frontend typecheck) - clean
- `IntegrationTests`/`VisualTests` need real container networking and can't run in this sandbox (see `AGENTS.md`); CI's `dotnet.yml` runs them, including the `UndoCheckIn_Returns409_*` cases this issue was found from.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (N/A - OpenAPI doc is generated, not hand-maintained docs)


---
_Generated by [Claude Code](https://claude.ai/code/session_0156ZBncWNa42bTdJhzHYXxs)_