### PR TITLE
fix: stop routing organizers to the public profile dead end, redesign it

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1252,7 +1252,10 @@
       "engagementCount": "{{count}} bestätigte Einsätze",
       "engagementCount_other": "{{count}} bestätigte Einsätze",
       "reportUser": "Nutzer:in melden",
-      "engagementCount_one": "{{count}} bestätigter Einsatz"
+      "engagementCount_one": "{{count}} bestätigter Einsatz",
+      "emptyStateTitle": "Dieses Profil ist noch leer",
+      "emptyStateMessage": "Diese:r Nutzer:in hat noch keine Bio, Fähigkeiten oder Sprachen hinzugefügt.",
+      "eyebrow": "Profil"
     },
     "administration": {
       "title": "Administration",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1252,7 +1252,10 @@
       "engagementCount": "{{count}} confirmed opportunities",
       "engagementCount_other": "{{count}} confirmed opportunities",
       "reportUser": "Report user",
-      "engagementCount_one": "{{count}} confirmed opportunity"
+      "engagementCount_one": "{{count}} confirmed opportunity",
+      "emptyStateTitle": "This profile is still empty",
+      "emptyStateMessage": "This volunteer hasn't added a bio, skills, or languages yet.",
+      "eyebrow": "Profile"
     },
     "administration": {
       "title": "Administration",

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { useParams, Link, useOutletContext } from "react-router";
+import { useParams, useOutletContext } from "react-router";
 import { useTranslation } from "react-i18next";
 import type {
 	EngagementSummary,
@@ -736,12 +736,7 @@ export default function EngagementManagementPage() {
 									<div className="min-w-0">
 										<p className="text-sm font-medium text-gray-800">
 											{e.volunteerName ? (
-												<Link
-													to={`/users/${e.volunteerId}`}
-													className="hover:underline"
-												>
-													{e.volunteerName}
-												</Link>
+												e.volunteerName
 											) : e.volunteerId ? (
 												<span className="font-mono text-xs text-gray-500">
 													{t("engagementManagement.volunteer", {

--- a/frontend/src/pages/UserProfilePage.a11y.test.tsx
+++ b/frontend/src/pages/UserProfilePage.a11y.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router";
+import UserProfilePage from "./UserProfilePage";
+import { renderWithProviders } from "../test/render";
+import { expectNoA11yViolations } from "../test/a11y";
+
+const { api } = await vi.hoisted(async () => {
+	const { createApiMock } = await import("../test/apiMock");
+	return { api: createApiMock() };
+});
+
+vi.mock("../hooks/useApiClient", () => ({ useApiClient: () => api }));
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+
+function renderPage() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/users/:userId" element={<UserProfilePage />} />
+		</Routes>,
+		{ route: `/users/${USER_ID}`, auth: { isAuthenticated: true } },
+	);
+}
+
+beforeEach(() => {
+	api.__reset();
+	api.getBadgeCatalog.mockResolvedValue([]);
+});
+
+describe("UserProfilePage a11y", () => {
+	it("has no violations for an empty profile (no bio/skills/languages)", async () => {
+		api.getPublicUserProfile.mockResolvedValue({
+			displayName: "Vera Volunteer",
+			engagementCount: 0,
+			badges: [],
+			avatarUrl: undefined,
+			bio: undefined,
+			skills: [],
+			languages: [],
+		});
+
+		renderPage();
+
+		await screen.findByText("This profile is still empty");
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations for a populated profile", async () => {
+		api.getPublicUserProfile.mockResolvedValue({
+			displayName: "Vera Volunteer",
+			engagementCount: 3,
+			badges: [],
+			avatarUrl: undefined,
+			bio: "I love volunteering on weekends.",
+			skills: ["First aid"],
+			languages: ["German"],
+		});
+
+		renderPage();
+
+		await screen.findByText("First aid");
+		await expectNoA11yViolations();
+	});
+});

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -129,7 +129,7 @@ export default function UserProfilePage() {
 									details: details || undefined,
 								});
 							}}
-							className="relative z-20 ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
+							className="relative z-20 ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-800"
 						/>
 					)}
 				</div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -7,6 +7,8 @@ import type {
 	PublicUserProfileResponse,
 } from "../client/api-client";
 import BadgeGrid from "../components/BadgeGrid";
+import EmptyState from "../components/EmptyState";
+import PageHeaderBand from "../components/PageHeaderBand";
 import ProfileFieldsView from "../components/ProfileFieldsView";
 import ReportFlagButton from "../components/ReportFlagButton";
 import SectionHeading from "../components/SectionHeading";
@@ -14,8 +16,8 @@ import Skeleton from "../components/Skeleton";
 import LoadMoreError from "../components/LoadMoreError";
 import { useApiClient } from "../hooks/useApiClient";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { pageTitleClass } from "../lib/headingClasses";
 import { getApiErrorMessage } from "../lib/apiError";
+import { getInitials } from "../lib/initials";
 
 export default function UserProfilePage() {
 	const { userId } = useParams<{ userId: string }>();
@@ -84,64 +86,78 @@ export default function UserProfilePage() {
 	if (!profile)
 		return <p className="text-gray-500">{t("userProfile.notFound")}</p>;
 
+	const isProfileEmpty =
+		!profile.bio &&
+		profile.skills.length === 0 &&
+		profile.languages.length === 0;
+
 	return (
-		<div className="max-w-5xl">
-			<div className="mb-8 flex items-center gap-4 rounded-card bg-brand-100 p-5 sm:p-6">
-				{profile.avatarUrl ? (
-					<img
-						src={profile.avatarUrl}
-						alt={profile.displayName}
-						width={72}
-						height={72}
-						className="h-18 w-18 rounded-full object-cover ring-3 ring-white"
-					/>
-				) : (
-					<div className="flex h-18 w-18 items-center justify-center rounded-full bg-white text-2xl font-bold text-brand-700 ring-3 ring-white">
-						{profile.displayName.charAt(0).toUpperCase()}
-					</div>
-				)}
-				<div>
-					<h1 className={`text-gray-900 ${pageTitleClass}`}>
-						{profile.displayName}
-					</h1>
-					<p className="mt-0.5 text-sm text-brand-800">
+		<>
+			<PageHeaderBand
+				eyebrow={t("userProfile.eyebrow")}
+				title={profile.displayName}
+			/>
+
+			<div className="max-w-5xl">
+				<div className="mb-8 flex items-center gap-4">
+					{profile.avatarUrl ? (
+						<img
+							src={profile.avatarUrl}
+							alt=""
+							width={64}
+							height={64}
+							className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-brand-100"
+						/>
+					) : (
+						<span className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-brand-100 text-2xl font-semibold text-brand-700">
+							{getInitials(profile.displayName)}
+						</span>
+					)}
+					<p className="text-sm text-gray-600">
 						{t("userProfile.engagementCount", {
 							count: profile.engagementCount,
 						})}
 					</p>
+					{auth.isAuthenticated && auth.user?.profile.sub !== userId && (
+						<ReportFlagButton
+							targetLabel={profile.displayName}
+							ariaLabel={t("userProfile.reportUser")}
+							onReport={async (reason, details) => {
+								if (!userId) return;
+								await api.reportUser(userId, {
+									reason,
+									details: details || undefined,
+								});
+							}}
+							className="relative z-20 ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
+						/>
+					)}
 				</div>
-				{auth.isAuthenticated && auth.user?.profile.sub !== userId && (
-					<ReportFlagButton
-						targetLabel={profile.displayName}
-						ariaLabel={t("userProfile.reportUser")}
-						onReport={async (reason, details) => {
-							if (!userId) return;
-							await api.reportUser(userId, {
-								reason,
-								details: details || undefined,
-							});
-						}}
-						className="relative z-20 ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
-					/>
-				)}
-			</div>
 
-			{(profile.bio ||
-				profile.skills.length > 0 ||
-				profile.languages.length > 0) && (
 				<div data-content-wrapper className="mb-8 max-w-2xl">
-					<ProfileFieldsView
-						bio={profile.bio}
-						skills={profile.skills}
-						languages={profile.languages}
-					/>
+					{isProfileEmpty ? (
+						<EmptyState
+							title={t("userProfile.emptyStateTitle")}
+							message={t("userProfile.emptyStateMessage")}
+						/>
+					) : (
+						<ProfileFieldsView
+							bio={profile.bio}
+							skills={profile.skills}
+							languages={profile.languages}
+						/>
+					)}
 				</div>
-			)}
 
-			<section>
-				<SectionHeading>{t("achievements.badgesTitle")}</SectionHeading>
-				<BadgeGrid earned={profile.badges} catalog={catalog} loading={false} />
-			</section>
-		</div>
+				<section>
+					<SectionHeading>{t("achievements.badgesTitle")}</SectionHeading>
+					<BadgeGrid
+						earned={profile.badges}
+						catalog={catalog}
+						loading={false}
+					/>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -255,12 +255,7 @@ export default function OrgEngagementsPage() {
 									</Link>
 									<p className="mt-0.5 text-sm font-medium text-gray-800">
 										{e.volunteerName ? (
-											<Link
-												to={`/users/${e.volunteerId}`}
-												className="hover:underline"
-											>
-												{e.volunteerName}
-											</Link>
+											e.volunteerName
 										) : e.volunteerId ? (
 											<span className="font-mono text-xs text-gray-500">
 												{t("orgEngagements.volunteer", {


### PR DESCRIPTION
## What

Two changes implementing #2151's recommendation:

1. `EngagementManagementPage` and `OrgEngagementsPage` no longer link an applicant's name to `/users/:userId` - it's now plain text.
2. `/users/:userId` (`UserProfilePage`) gets the `PageHeaderBand` treatment every other content/detail page has used since #1755, plus an explicit empty state when a profile has no bio/skills/languages.

## Why

`/users/:userId` is the page an organizer reaches by clicking an applicant's name on the manage-applications screens. The issue identified it as a structural problem, not just a styling one:

- The endpoint is deliberately `AllowAnonymous()`, so it can never show contact info (email/phone) - the one thing an organizer actually needs. Meanwhile `EngagementManagementPage`/`OrgEngagementsPage` already render name, email, phone, and the application message inline in the same row the organizer clicks from.
- For a brand-new applicant (the person an organizer most needs to evaluate), bio/skills/languages are almost always empty, so the page renders as a near-blank avatar + "1 confirmed opportunity" + a badge grid of locked placeholders.
- It's the one page that never got the `PageHeaderBand` redesign from #1755 - no eyebrow, no lead, straight into a flat `bg-brand-100` box.

Following the issue's own recommendation (option 1, "close to a no-brainer"): stop sending organizers to a page that structurally can't help them - the row they click from already has what they need. Since the page still has legitimate consumers beyond the organizer flow (platform-admin moderation/audit-log links in `AdministrationPage`, and the volunteer's own public-profile/report-user use case from #375), I kept it rather than removing it (option 3), and gave it the `PageHeaderBand` treatment + a deliberate empty state (option 2) so it stops looking broken for the common case of a sparsely-filled profile.

Closes #2151

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm format:check`, `pnpm i18n:check` - all clean
- `pnpm test` - full suite (709 tests) passes, including the existing `UserProfilePage.test.tsx`
- Verified `en.json`/`de.json` key parity for the new `userProfile.eyebrow`/`emptyStateTitle`/`emptyStateMessage` keys
- No backend changes were needed - the fix is entirely in how the frontend links to and renders the existing `PublicUserProfileResponse` data
- `backend/tests/VisualTests/ProfileOverviewTests.cs`'s existing E2E scan of this route (bio/skills labels, content-wrapper left-alignment) wasn't touched by the redesign - `ProfileFieldsView` still renders bio/skills/languages exactly as before when populated

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no docs reference this page)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LguLFeBbz8iJ7sYmRw6pVs)_