### PR TITLE
fix(ci): exclude packages.lock.json from the final-newline linter

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -5,6 +5,7 @@
     "ApiClient\\.cs$",
     "api-client\\.ts$",
     "openapi-v1\\.json$",
+    "packages\\.lock\\.json$",
     "node_modules"
   ]
 }


### PR DESCRIPTION
## What

Excludes `packages.lock.json` from the `editorconfig` job's final-newline check in `.editorconfig-checker.json`.

## Why

Most currently-open Renovate PRs (`#2176`, `#2179`, `#2180`, `#2182`, `#2185`, `#2186`, ...) are failing the `Lint / editorconfig` check. All of them bump a backend NuGet package and, as part of that, Renovate regenerates one of the 10 `backend/**/packages.lock.json` files. NuGet's lock-file writer never emits a trailing newline, which trips the `.editorconfig`'s `insert_final_newline = true` rule.

`#2174` (already merged) patched the newline on the lock files as they existed at the time, but that fix doesn't survive the next regeneration - it's NuGet's own serializer behavior, not something under this repo's control, so every future NuGet-bump PR hits the same failure again.

The fix follows the existing convention in the same file: `ApiClient.cs`, `api-client.ts`, and `openapi-v1.json` are already excluded from this check because they're generated, not hand-formatted. `packages.lock.json` is exactly the same kind of file, generated fresh by `dotnet restore`/NuGet on every dependency bump.

Since `actions/checkout` on `pull_request` events checks out GitHub's auto-merge ref (PR head merged into the latest base), once this lands on `main` the already-open Renovate PRs should pick up the fix on their next CI run without needing to be individually rebased or touched.

Closes #

## Testing

- Verified via the GitHub Actions API that the `editorconfig` job is the one failing on the affected Renovate PRs (not `ban-typographic-dashes` or `ban-unescaped-keycloak-apostrophes`), and that each of those PRs modifies a `packages.lock.json`.
- Confirmed `packages.lock.json` on `main` currently ends with a trailing newline (from `#2174`'s manual fix), consistent with the regenerate-loses-it-again theory.
- Could not run `editorconfig-checker` itself in this sandbox (GitHub binary download blocked by the session's repo-scoped proxy), so this relies on the regex-exclusion pattern matching the same style already used for the three existing entries, plus CI itself on this PR.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (none needed - CI config only, no documented list of excluded files exists elsewhere in the repo)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ViwATvgipLstXKXMAWdTKq)_