### PR TITLE
fix(frontend): mark organization description text as German

### DIFF
--- a/frontend/src/components/OrganizationProfileView.tsx
+++ b/frontend/src/components/OrganizationProfileView.tsx
@@ -153,7 +153,10 @@ export default function OrganizationProfileView({
 				>
 					<div className="min-w-0">
 						{description && (
-							<p className="mb-6 max-w-2xl leading-relaxed text-gray-700">
+							<p
+								lang="de"
+								className="mb-6 max-w-2xl leading-relaxed text-gray-700"
+							>
 								{description}
 							</p>
 						)}

--- a/frontend/src/pages/OrganizationProfilePage.test.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router";
+import OrganizationProfilePage from "./OrganizationProfilePage";
+import { renderWithProviders } from "../test/render";
+
+const { api } = await vi.hoisted(async () => {
+	const { createApiMock } = await import("../test/apiMock");
+	return { api: createApiMock() };
+});
+
+vi.mock("../hooks/useApiClient", () => ({ useApiClient: () => api }));
+
+const ORGANIZATION_ID = "33333333-3333-3333-3333-333333333333";
+
+beforeEach(() => {
+	api.__reset();
+	api.getPublicOrganizationProfile.mockResolvedValue({
+		id: ORGANIZATION_ID,
+		name: "Nachbarschaftshilfe Leipzig",
+		description: "Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+		openOpportunities: [],
+	});
+});
+
+function renderProfile() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/organizations/:organizationId"
+				element={<OrganizationProfilePage />}
+			/>
+		</Routes>,
+		{ lng: "en", route: `/organizations/${ORGANIZATION_ID}` },
+	);
+}
+
+describe("OrganizationProfilePage description language", () => {
+	it("marks the organization's German description as German on an English page", async () => {
+		renderProfile();
+
+		const description = await screen.findByText(
+			"Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+		);
+		expect(description).toHaveAttribute("lang", "de");
+	});
+});

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -105,6 +105,7 @@ export default function OrganizationProfilePage() {
 				eyebrow={t("orgProfile.eyebrow")}
 				title={profile.name}
 				lead={profile.description ?? undefined}
+				leadLang="de"
 			>
 				{profile.website && (
 					<Button

--- a/frontend/src/pages/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/OrganizationsPage.test.tsx
@@ -45,4 +45,28 @@ describe("OrganizationsPage directory cards", () => {
 		expect(screen.getByText("FK")).toBeInTheDocument();
 		expect(screen.getByText("FH")).toBeInTheDocument();
 	});
+
+	it("marks an organization's German description as German on an English page", async () => {
+		api.getPublicOrganizations.mockResolvedValue({
+			items: [
+				{
+					...org("aaaa0001-0000-0000-0000-000000000001", "Nachbarschaftshilfe"),
+					description: "Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+				},
+			],
+			pageCount: 1,
+			totalCount: 1,
+			currentPage: 1,
+		});
+
+		renderWithProviders(<OrganizationsPage />, {
+			lng: "en",
+			route: "/organizations",
+		});
+
+		const description = await screen.findByText(
+			"Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+		);
+		expect(description).toHaveAttribute("lang", "de");
+	});
 });

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -252,7 +252,10 @@ export default function OrganizationsPage() {
 											</div>
 											<div className="min-w-0 flex-1">
 												{org.description && (
-													<p className="line-clamp-2 text-sm text-gray-500">
+													<p
+														lang="de"
+														className="line-clamp-2 text-sm text-gray-500"
+													>
 														{org.description}
 													</p>
 												)}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
@@ -134,6 +134,24 @@ describe("opportunity detail page content language", () => {
 	});
 });
 
+describe("about this organization section", () => {
+	it("marks the organization's German description as German on an English page", async () => {
+		api.getPublicOrganizationProfile.mockResolvedValue({
+			id: details.organizationId,
+			name: details.organizationName,
+			description: "Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+			openOpportunities: [],
+		});
+
+		renderDetail("en");
+
+		const description = await screen.findByText(
+			"Wir unterstuetzen Menschen in Leipzig und Umgebung.",
+		);
+		expect(description).toHaveAttribute("lang", "de");
+	});
+});
+
 const scheduledSlots = {
 	...details,
 	participationType: "ScheduledSlots",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -895,7 +895,10 @@ export default function VolunteerOpportunityDetailPage() {
 											{t("opportunities.aboutOrganization")}
 										</SectionHeading>
 										{orgProfile.description && (
-											<p className="mb-3 leading-relaxed text-gray-600">
+											<p
+												lang="de"
+												className="mb-3 leading-relaxed text-gray-600"
+											>
 												{orgProfile.description}
 											</p>
 										)}

--- a/frontend/src/pages/app/OrgSettingsPage.test.tsx
+++ b/frontend/src/pages/app/OrgSettingsPage.test.tsx
@@ -131,6 +131,16 @@ describe("OrgSettingsPage edit form", () => {
 	});
 });
 
+describe("OrgSettingsPage profile preview", () => {
+	it("marks the organization's German description as German on an English page", () => {
+		renderPage();
+
+		expect(
+			screen.getByText("Wir helfen, wo Hilfe gebraucht wird."),
+		).toHaveAttribute("lang", "de");
+	});
+});
+
 describe("OrgSettingsPage danger zone", () => {
 	it("is headed by the action it performs, in sentence case matching its button", () => {
 		renderPage();


### PR DESCRIPTION
## What

Add `lang="de"` to the organization-supplied description text everywhere it renders, so it carries a correct language marker even on an English-language page.

## Why

Organizations have no English fields at all (unlike volunteer opportunities, which have `titleDe`/`titleEn` and resolve through `pickLocalizedText`), so their description is always German prose. On an English page it rendered with no `lang` attribute at all, so a screen reader announces German prose using English pronunciation rules - a WCAG 2.2 AA 3.1.2 (Language of Parts) violation.

This is the short-term, frontend-only fix suggested in the issue. Since organizations have no possible non-German description, `lang="de"` is hardcoded rather than made conditional - there's no other value it could take. The longer-term fix (giving organizations `nameEn`/`descriptionEn` fields like opportunities have) is a larger, separate change spanning the entity/API/wizard and is left for a follow-up.

Closes #2243

## Changes

- `VolunteerOpportunityDetailPage.tsx` - "About this organization" section's description paragraph
- `OrganizationsPage.tsx` - organizations directory card description
- `OrganizationProfileView.tsx` - shared component's description paragraph (used by `OrganizationProfilePage` and `OrgSettingsPage`'s own-profile preview)
- `OrganizationProfilePage.tsx` - `leadLang="de"` on `PageHeaderBand`'s description lead (the component already supports this prop, used the same way for opportunity titles/descriptions elsewhere)

## Testing

- Added a regression test to `OrganizationsPage.test.tsx` asserting the directory card's description carries `lang="de"` on an English page.
- Added a regression test to `VolunteerOpportunityDetailPage.test.tsx` asserting the "about this organization" description carries `lang="de"` on an English page.
- `pnpm test`, `pnpm lint`, `pnpm check`, `pnpm format:write` all pass.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no user-facing docs cover this)


---
_Generated by [Claude Code](https://claude.ai/code/session_016xHqtcCWXGpBAxwVrCBojc)_