### PR TITLE
fix: stop toasting every unhandled rejection as a server error

### DIFF
--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -15,6 +15,7 @@ vi.mock("../i18n", () => ({
 import {
 	getApiErrorMessage,
 	getApiErrorStatus,
+	hasActionableErrorCode,
 	isApiErrorCode,
 	isApiForbiddenError,
 	isApiNotFoundError,
@@ -221,5 +222,47 @@ describe("isApiForbiddenError", () => {
 
 	it("returns false for a non-object value", () => {
 		expect(isApiForbiddenError("403")).toBe(false);
+	});
+});
+
+describe("hasActionableErrorCode", () => {
+	beforeEach(() => {
+		existsMock.mockReset();
+		tMock.mockReset();
+	});
+
+	it("returns true when errorCode has a matching translation", () => {
+		existsMock.mockReturnValue(true);
+		expect(hasActionableErrorCode({ errorCode: "Org.NotFound" })).toBe(true);
+		expect(existsMock).toHaveBeenCalledWith("apiError.Org.NotFound");
+	});
+
+	it("returns false when errorCode has no matching translation", () => {
+		existsMock.mockReturnValue(false);
+		expect(hasActionableErrorCode({ errorCode: "Unmapped.Code" })).toBe(false);
+	});
+
+	it("returns false when there is no errorCode (e.g. a network failure)", () => {
+		expect(hasActionableErrorCode(new TypeError("Failed to fetch"))).toBe(
+			false,
+		);
+		expect(existsMock).not.toHaveBeenCalled();
+	});
+
+	it("returns false when errorCode is only whitespace", () => {
+		expect(hasActionableErrorCode({ errorCode: "   " })).toBe(false);
+		expect(existsMock).not.toHaveBeenCalled();
+	});
+
+	it("returns false for a status-only rejection with no errorCode", () => {
+		expect(hasActionableErrorCode({ status: 500 })).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(hasActionableErrorCode(null)).toBe(false);
+	});
+
+	it("returns false for a non-object value", () => {
+		expect(hasActionableErrorCode("boom")).toBe(false);
 	});
 });

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -39,3 +39,14 @@ export function isApiErrorCode(err: unknown, code: string): boolean {
 export function isApiForbiddenError(err: unknown): boolean {
 	return getApiErrorStatus(err) === 403;
 }
+
+// A rejection only counts as user-actionable when it carries an errorCode
+// this app has a specific, translated message for (see getApiErrorMessage) -
+// a bare status or a generic JS error gives the user nothing to act on and
+// should not be surfaced as a toast (#2241).
+export function hasActionableErrorCode(err: unknown): boolean {
+	if (!err || typeof err !== "object") return false;
+	const errorCode = (err as { errorCode?: unknown }).errorCode;
+	if (typeof errorCode !== "string" || !errorCode.trim()) return false;
+	return i18next.exists(`apiError.${errorCode}`);
+}

--- a/frontend/src/lib/unhandledRejection.test.ts
+++ b/frontend/src/lib/unhandledRejection.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { existsMock, tMock } = vi.hoisted(() => ({
+	existsMock: vi.fn(),
+	tMock: vi.fn(),
+}));
+
+vi.mock("../i18n", () => ({
+	default: {
+		exists: existsMock,
+		t: tMock,
+	},
+}));
+
+import { handleUnhandledRejection } from "./unhandledRejection";
+import { subscribeToasts, type ToastEvent } from "./toastBus";
+
+describe("handleUnhandledRejection", () => {
+	let toasts: ToastEvent[];
+	let unsubscribe: () => void;
+
+	beforeEach(() => {
+		existsMock.mockReset();
+		tMock.mockReset();
+		tMock.mockImplementation((key: string) => key);
+		toasts = [];
+		unsubscribe = subscribeToasts((event) => toasts.push(event));
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		unsubscribe();
+		vi.restoreAllMocks();
+	});
+
+	it("logs but does not toast a rejection with no errorCode (e.g. a missed .catch())", () => {
+		handleUnhandledRejection(new TypeError("something exploded"));
+
+		expect(console.error).toHaveBeenCalledWith(
+			"[unhandledrejection]",
+			expect.any(TypeError),
+		);
+		expect(toasts).toHaveLength(0);
+	});
+
+	it("logs but does not toast a plain network failure", () => {
+		handleUnhandledRejection({ status: null });
+
+		expect(toasts).toHaveLength(0);
+	});
+
+	it("logs every rejection unconditionally, actionable or not", () => {
+		handleUnhandledRejection("a string rejection");
+		expect(console.error).toHaveBeenCalledWith(
+			"[unhandledrejection]",
+			"a string rejection",
+		);
+	});
+
+	it("toasts a translated, user-actionable message when errorCode has a known translation", () => {
+		existsMock.mockReturnValue(true);
+		tMock.mockReturnValue("This request was incomplete.");
+
+		handleUnhandledRejection({ errorCode: "AchievementId.Empty" });
+
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].level).toBe("error");
+		expect(toasts[0].message).toBe("This request was incomplete.");
+		expect(tMock).toHaveBeenCalledWith("apiError.AchievementId.Empty");
+	});
+
+	it("does not toast when errorCode has no matching translation", () => {
+		existsMock.mockReturnValue(false);
+
+		handleUnhandledRejection({ errorCode: "Unmapped.Code" });
+
+		expect(toasts).toHaveLength(0);
+	});
+});

--- a/frontend/src/lib/unhandledRejection.ts
+++ b/frontend/src/lib/unhandledRejection.ts
@@ -1,0 +1,19 @@
+import i18n from "../i18n";
+import { dispatchToast } from "./toastBus";
+import { getApiErrorMessage, hasActionableErrorCode } from "./apiError";
+
+// Most promise rejections that reach `window`'s unhandledrejection event are
+// a missed .catch() somewhere in the app, not something the user did or can
+// react to - toasting "unexpected error" (and blaming the server) for those
+// teaches people to ignore every toast, including the ones that matter
+// (#2241). Still logged unconditionally so it stays visible for debugging.
+export function handleUnhandledRejection(reason: unknown): void {
+	console.error("[unhandledrejection]", reason);
+
+	if (!hasActionableErrorCode(reason)) return;
+
+	dispatchToast(
+		"error",
+		getApiErrorMessage(reason, i18n.t("error.serverError")),
+	);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { ToastProvider } from "./contexts/ToastContext";
 import { runtimeConfig } from "./lib/runtimeConfig";
 import { dispatchToast } from "./lib/toastBus";
+import { handleUnhandledRejection } from "./lib/unhandledRejection";
 
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "@fontsource-variable/source-sans-3";
@@ -57,8 +58,7 @@ const oidcConfig = {
 };
 
 window.addEventListener("unhandledrejection", (event) => {
-	console.error("[unhandledrejection]", event.reason);
-	dispatchToast("error", i18n.t("error.serverError"));
+	handleUnhandledRejection(event.reason);
 });
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(


### PR DESCRIPTION
## What

The global `unhandledrejection` handler in `main.tsx` no longer toasts unconditionally. It still logs every rejection, but only shows the error toast when the rejection carries an `errorCode` the app has a specific, translated `apiError.<code>` message for.

## Why

Closes #2241

`main.tsx`'s `window.addEventListener("unhandledrejection", ...)` unconditionally dispatched the generic "Ein unerwarteter Fehler ist aufgetreten..." toast for *any* rejection that reached it - including a missed `.catch()` somewhere in the app, which is a client-side bug, not a server failure and not something the user can act on. This produced a phantom error toast on the organiser dashboard and `/my-signups` a couple seconds after load, with nothing visibly wrong.

I audited every promise-producing call reachable on initial render of both routes (dashboard widgets, `/my-signups`, the shared `Header`/layouts, notification polling, `useSharedOrgFetch`) and found no remaining unguarded fire-and-forget promise in the frontend - every candidate already has a `.catch()`/try-catch. The only rejection source still unaccounted for is the silent-renew iframe's HTTP 400 from the deployed Keycloak realm, which is tracked separately in #2224 and explicitly out of this repo's scope (it's a deploy-side realm config drift, not app code). Regardless of that root cause, the handler itself was wrong to blame the server and toast unconditionally, which is what this PR fixes.

## Testing

- Added `hasActionableErrorCode` to `frontend/src/lib/apiError.ts` (+ tests in `apiError.test.ts`) to classify whether a rejection carries a translated, user-facing `errorCode`.
- Extracted the handler logic into `frontend/src/lib/unhandledRejection.ts` with its own test suite (`unhandledRejection.test.ts`), covering: a missed-`.catch()`-style rejection (no errorCode) logs but does not toast, a network failure does not toast, and a rejection with a known translated `errorCode` does toast with the translated message.
- `pnpm test` (742 tests), `pnpm check` (tsc), `pnpm lint`, `pnpm format:check` all pass locally.

## Checklist

- [x] `/self-review` run and findings addressed (none found)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - internal error-handling behavior, no docs reference this handler)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jo7qzeRXTLwTfT6CZGeQpt)_