### PR TITLE
fix(frontend): explain cross-locale keyword matches on opportunity cards

### DIFF
--- a/frontend/src/components/OpportunityCard.a11y.test.tsx
+++ b/frontend/src/components/OpportunityCard.a11y.test.tsx
@@ -24,10 +24,18 @@ const base: OpportunityCardItem = {
 	nextTimeSlotStart: new Date(Date.UTC(2026, 7, 27, 9, 0)),
 };
 
-function renderCard(item: OpportunityCardItem, headingLevel: 2 | 3 = 2) {
+function renderCard(
+	item: OpportunityCardItem,
+	keyword?: string,
+	headingLevel: 2 | 3 = 2,
+) {
 	return renderWithProviders(
 		<ul>
-			<OpportunityCard item={item} headingLevel={headingLevel} />
+			<OpportunityCard
+				item={item}
+				headingLevel={headingLevel}
+				keyword={keyword}
+			/>
 		</ul>,
 	);
 }
@@ -76,6 +84,11 @@ describe("OpportunityCard a11y", () => {
 				</ul>
 			</section>,
 		);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations with a cross-locale search match notice (#2242)", async () => {
+		renderCard(base, "Strandreinigung");
 		await expectNoA11yViolations();
 	});
 

--- a/frontend/src/components/OpportunityCard.test.tsx
+++ b/frontend/src/components/OpportunityCard.test.tsx
@@ -25,8 +25,10 @@ const base: OpportunityCardItem = {
 	organizationName: "Freiwillige Feuerwehr Kiel",
 };
 
-const renderCard = (item: OpportunityCardItem) =>
-	renderWithProviders(<OpportunityCard item={item} headingLevel={3} />);
+const renderCard = (item: OpportunityCardItem, keyword?: string) =>
+	renderWithProviders(
+		<OpportunityCard item={item} headingLevel={3} keyword={keyword} />,
+	);
 
 describe("OpportunityCard date and capacity contract", () => {
 	it.each([
@@ -132,5 +134,33 @@ describe("OpportunityCard organization badge", () => {
 		const link = screen.getByTestId("opportunity-org-link");
 		expect(link.querySelector("img")).toBeNull();
 		expect(link.querySelector("[aria-hidden='true']")).toHaveTextContent("FK");
+	});
+});
+
+describe("OpportunityCard cross-locale search match notice (#2242)", () => {
+	it("explains a match that only exists in the hidden German title", () => {
+		renderCard(base, "Deutscher");
+
+		expect(
+			screen.getByTestId("opportunity-cross-locale-match"),
+		).toHaveTextContent("Deutscher Titel");
+	});
+
+	it("stays silent when the keyword already appears in the displayed English title", () => {
+		renderCard(base, "English");
+
+		expect(screen.queryByTestId("opportunity-cross-locale-match")).toBeNull();
+	});
+
+	it("stays silent when no keyword is active", () => {
+		renderCard(base);
+
+		expect(screen.queryByTestId("opportunity-cross-locale-match")).toBeNull();
+	});
+
+	it("stays silent when the keyword only matches the already-visible organization name", () => {
+		renderCard(base, "Feuerwehr");
+
+		expect(screen.queryByTestId("opportunity-cross-locale-match")).toBeNull();
 	});
 });

--- a/frontend/src/components/OpportunityCard.tsx
+++ b/frontend/src/components/OpportunityCard.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
+	findCrossLocaleKeywordMatch,
 	formatDate,
 	formatDateTime,
 	formatOccurrence,
@@ -124,10 +125,13 @@ function dateLine(
 export default function OpportunityCard({
 	item,
 	headingLevel = 2,
+	keyword,
 }: {
 	item: OpportunityCardItem;
 
 	headingLevel?: 2 | 3;
+	/** The active search keyword, if this card is shown as a search result (#2242). */
+	keyword?: string;
 }) {
 	const { t, i18n } = useTranslation();
 	const Heading = headingLevel === 3 ? "h3" : "h2";
@@ -145,6 +149,19 @@ export default function OpportunityCard({
 		title.lang !== i18n.language ||
 		(description !== undefined && description.lang !== i18n.language);
 	const hasOrganization = !!item.organizationId && !!item.organizationName;
+
+	const crossLocaleMatch = keyword
+		? findCrossLocaleKeywordMatch(
+				item.titleDe,
+				item.titleEn,
+				item.descriptionDe,
+				item.descriptionEn,
+				item.organizationName ?? "",
+				keyword,
+				title,
+				description,
+			)
+		: undefined;
 
 	const showSignUpMechanismChip = item.participationType === "ScheduledSlots";
 
@@ -203,6 +220,19 @@ export default function OpportunityCard({
 					{isGermanFallback && (
 						<p className="mt-0.5 text-xs text-gray-500">
 							{t("opportunities.germanOnlyNotice")}
+						</p>
+					)}
+					{crossLocaleMatch && (
+						<p
+							data-testid="opportunity-cross-locale-match"
+							className="mt-0.5 text-xs text-gray-500"
+						>
+							{t("opportunities.crossLocaleMatchNotice", {
+								language: t(`language.${crossLocaleMatch.lang}`),
+							})}{" "}
+							<span lang={crossLocaleMatch.lang}>
+								&quot;{crossLocaleMatch.text}&quot;
+							</span>
 						</p>
 					)}
 

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -20,6 +20,7 @@ export default function OpportunityResultsList({
 	loadMoreError,
 	loadMoreErrorIsOffline,
 	onRetryLoadMore,
+	keyword,
 }: {
 	loading: boolean;
 	error: string | null;
@@ -33,6 +34,7 @@ export default function OpportunityResultsList({
 	loadMoreError: string | null;
 	loadMoreErrorIsOffline: boolean;
 	onRetryLoadMore: () => void;
+	keyword?: string;
 }) {
 	const { t } = useTranslation();
 
@@ -114,7 +116,12 @@ export default function OpportunityResultsList({
 					) : (
 						<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
 							{items.map((item: VolunteerOpportunitySummary) => (
-								<OpportunityCard key={item.id} item={item} headingLevel={3} />
+								<OpportunityCard
+									key={item.id}
+									item={item}
+									headingLevel={3}
+									keyword={keyword}
+								/>
 							))}
 						</ul>
 					)}

--- a/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/VolunteerOpportunitiesList.tsx
@@ -671,6 +671,7 @@ export default function VolunteerOpportunitiesList() {
 				loadMoreError={loadMoreError}
 				loadMoreErrorIsOffline={loadMoreErrorIsOffline}
 				onRetryLoadMore={retryLoadMore}
+				keyword={keyword}
 			/>
 		</div>
 	);

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -13,6 +13,7 @@ import {
 	isRecentlyCreatedOrganization,
 	isSlotFull,
 	NEW_ORGANIZATION_THRESHOLD_DAYS,
+	findCrossLocaleKeywordMatch,
 	pickLocalizedText,
 	resolveDateLocale,
 } from "./format";
@@ -190,6 +191,150 @@ describe("pickLocalizedText", () => {
 	it("returns undefined when no German text is available either", () => {
 		expect(pickLocalizedText(undefined, undefined, "en")).toBeUndefined();
 		expect(pickLocalizedText(null, "English Title", "de")).toBeUndefined();
+	});
+});
+
+describe("findCrossLocaleKeywordMatch", () => {
+	it("finds a keyword that only matches the hidden-locale title (#2242)", () => {
+		const title = pickLocalizedText(
+			"Erste-Hilfe-Kurs",
+			"First Aid Course",
+			"en",
+		);
+		const description = pickLocalizedText(
+			"Grundkurs fuer Erwachsene.",
+			"Basic course for adults.",
+			"en",
+		);
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Erste-Hilfe-Kurs",
+				"First Aid Course",
+				"Grundkurs fuer Erwachsene.",
+				"Basic course for adults.",
+				"DRK Kiel",
+				"Erste",
+				title,
+				description,
+			),
+		).toEqual({ text: "Erste-Hilfe-Kurs", lang: "de" });
+	});
+
+	it("returns undefined when the keyword already appears in the displayed title", () => {
+		const title = pickLocalizedText(
+			"Deutscher Titel",
+			"First Aid Course",
+			"en",
+		);
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Deutscher Titel",
+				"First Aid Course",
+				undefined,
+				undefined,
+				"DRK Kiel",
+				"First Aid",
+				title,
+				undefined,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the keyword only matches the visible organization name", () => {
+		const title = pickLocalizedText("Deutscher Titel", "English Title", "en");
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Deutscher Titel",
+				"English Title",
+				undefined,
+				undefined,
+				"DRK Kiel",
+				"DRK",
+				title,
+				undefined,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for a blank keyword", () => {
+		const title = pickLocalizedText("Deutscher Titel", "English Title", "en");
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Deutscher Titel",
+				"English Title",
+				undefined,
+				undefined,
+				"DRK Kiel",
+				"   ",
+				title,
+				undefined,
+			),
+		).toBeUndefined();
+	});
+
+	it("matches case-insensitively", () => {
+		const title = pickLocalizedText(
+			"Erste-Hilfe-Kurs",
+			"First Aid Course",
+			"en",
+		);
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Erste-Hilfe-Kurs",
+				"First Aid Course",
+				undefined,
+				undefined,
+				"DRK Kiel",
+				"ERSTE",
+				title,
+				undefined,
+			),
+		).toEqual({ text: "Erste-Hilfe-Kurs", lang: "de" });
+	});
+
+	it("finds a keyword that only matches the hidden-locale description", () => {
+		const title = pickLocalizedText(
+			"Erste-Hilfe-Kurs",
+			"First Aid Course",
+			"en",
+		);
+		const description = pickLocalizedText(
+			"Fuer Anfaenger geeignet.",
+			"Suitable for beginners.",
+			"en",
+		);
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Erste-Hilfe-Kurs",
+				"First Aid Course",
+				"Fuer Anfaenger geeignet.",
+				"Suitable for beginners.",
+				"DRK Kiel",
+				"Anfaenger",
+				title,
+				description,
+			),
+		).toEqual({ text: "Fuer Anfaenger geeignet.", lang: "de" });
+	});
+
+	it("mirrors the case: an English-only match is hidden on a German-displayed card", () => {
+		const title = pickLocalizedText(
+			"Erste-Hilfe-Kurs",
+			"First Aid Course",
+			"de",
+		);
+		expect(
+			findCrossLocaleKeywordMatch(
+				"Erste-Hilfe-Kurs",
+				"First Aid Course",
+				undefined,
+				undefined,
+				"DRK Kiel",
+				"First Aid",
+				title,
+				undefined,
+			),
+		).toEqual({ text: "First Aid Course", lang: "en" });
 	});
 });
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -86,6 +86,45 @@ export function pickLocalizedText(
 	return textDe != null ? { text: textDe, lang: "de" } : undefined;
 }
 
+// Mirrors the backend's keyword search (title/description in both locales,
+// plus the organization name - see ApplyPubliclyListedFilters), so it can
+// tell whether a match the user can already see on the card explains a hit,
+// or whether the hit only exists in a locale the card isn't displaying (#2242).
+export function findCrossLocaleKeywordMatch(
+	titleDe: string,
+	titleEn: string | null | undefined,
+	descriptionDe: string | null | undefined,
+	descriptionEn: string | null | undefined,
+	organizationName: string,
+	keyword: string,
+	displayedTitle: LocalizedText,
+	displayedDescription: LocalizedText | undefined,
+): LocalizedText | undefined {
+	const needle = keyword.trim().toLowerCase();
+	if (!needle) return undefined;
+
+	const visibleTexts = [
+		displayedTitle.text,
+		displayedDescription?.text,
+		organizationName,
+	];
+	if (visibleTexts.some((text) => text?.toLowerCase().includes(needle))) {
+		return undefined;
+	}
+
+	const hiddenTexts: (LocalizedText | undefined)[] = [
+		{ text: titleDe, lang: "de" },
+		titleEn ? { text: titleEn, lang: "en" } : undefined,
+		descriptionDe ? { text: descriptionDe, lang: "de" } : undefined,
+		descriptionEn ? { text: descriptionEn, lang: "en" } : undefined,
+	];
+
+	return hiddenTexts.find(
+		(candidate): candidate is LocalizedText =>
+			candidate !== undefined && candidate.text.toLowerCase().includes(needle),
+	);
+}
+
 export function resolveDateLocale(lng: string): string {
 	return lng === "de" ? "de-DE" : "en-GB";
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -196,6 +196,7 @@
       "expressInterest": "Interesse bekunden",
       "notFound": "Nicht gefunden.",
       "germanOnlyNotice": "Nur auf Deutsch verfügbar",
+      "crossLocaleMatchNotice": "Trifft Ihre Suche auf {{language}} zu:",
       "flexibleDate": "Flexibler Termin",
       "applyBy": "Interesse bekunden bis {{date}}",
       "startsOn": "Beginnt am {{date}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -196,6 +196,7 @@
       "expressInterest": "Express interest",
       "notFound": "Not found.",
       "germanOnlyNotice": "Only available in German",
+      "crossLocaleMatchNotice": "Matches your search in {{language}}:",
       "flexibleDate": "Flexible date",
       "applyBy": "Express interest by {{date}}",
       "startsOn": "Starts {{date}}",


### PR DESCRIPTION
## What

Opportunity cards now explain a search result that only matched because of a keyword search's cross-locale behavior - a small notice names the language and shows the matched text when the keyword doesn't appear anywhere already visible on the card.

## Why

The backend's opportunity keyword search matches title, description and organization name in both German and English regardless of the active UI locale (`ApplyPubliclyListedFilters` in `VolunteerOpportunityReadRepository.cs`). That's useful - a German speaker browsing the English UI still finds things - but until now the match was invisible: searching "Erste" in the English UI returned "First Aid Course" with no visible connection to the query, so results looked arbitrary.

This implements the issue's first suggested fix (keep the cross-locale match, explain it) rather than scoping search to the active locale, since all the data needed (`titleDe`/`titleEn`/`descriptionDe`/`descriptionEn`/`organizationName`) is already present on `VolunteerOpportunitySummary` - no backend or API change was needed. A new pure function, `findCrossLocaleKeywordMatch` (`frontend/src/lib/format.ts`), mirrors the backend's keyword-matching fields and returns the first hidden-locale field that actually matched, or `undefined` if the match is already visible (including via the organization name, which isn't locale-split). `OpportunityCard` renders that as a small notice, following the same pattern as the existing "Only available in German" fallback notice right above it - both can appear together without conflicting, since they explain different things (a missing translation vs. why a search term matched).

The `keyword` prop is threaded from `VolunteerOpportunitiesList` through `OpportunityResultsList` down to `OpportunityCard`, so this only activates for `/opportunities` search results - the other three surfaces sharing `OpportunityCard` (organization profile, opportunity detail page's "more from this organization", landing page preview) never pass a keyword and are unaffected.

Closes #2242

## Testing

- Added unit tests for `findCrossLocaleKeywordMatch` in `frontend/src/lib/format.test.ts` (hidden-locale title/description matches, already-visible title/org-name matches, case-insensitivity, blank keyword, both locale directions)
- Added behavioral tests in `frontend/src/components/OpportunityCard.test.tsx` for the notice appearing/staying silent
- Added an a11y test case in `frontend/src/components/OpportunityCard.a11y.test.tsx` for the new notice state
- Ran locally: `pnpm check` (tsc), `pnpm lint`, `pnpm i18n:check`, `pnpm format:write`, and the full `pnpm test` suite (109 files / 742 tests, all green)

## Checklist

- [x] `/self-review` run and findings addressed (a11y-check subagent reviewed the new notice - no violations)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no arc42/ADR doc covers this UI copy)


---
_Generated by [Claude Code](https://claude.ai/code/session_017yJ9PLJXCngsryCLdBewDc)_