### PR TITLE
fix: three contrast failures the axe suite structurally cannot see

### DIFF
--- a/backend/tests/VisualTests/AccessibilityTests.cs
+++ b/backend/tests/VisualTests/AccessibilityTests.cs
@@ -308,6 +308,26 @@ public class AccessibilityTests(AspireFixture fixture) : VisualTestBase(fixture)
 		await Expect(Page.Locator("#main-content")).ToBeFocusedAsync();
 	}
 
+	// Edit mode is reached by one click ("Bearbeiten"/"Edit") and is otherwise
+	// unscanned by the resting-state check above - #2232 found three contrast
+	// failures here (widget content washed out by the tile-dimming treatment)
+	// that only show up once editing is active.
+	[Test]
+	public async Task OrgDashboardPage_AsOlaf_EditMode_HasNoSeriousA11yViolations()
+	{
+		var frontend = Fixture.GetEndpoint("frontend");
+		await NavigateToOrgAppDashboardAsOlafAsync(frontend);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(Page.GetByTestId("quick-action-edit")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+		await Page.GetByTestId("quick-action-edit").ClickAsync();
+		await Expect(Page.GetByTestId("quick-action-save")).ToBeVisibleAsync(new() { Timeout = 10_000 });
+		await Expect(Page.GetByTestId("widget-tile-CreateOpportunity")).ToBeVisibleAsync();
+
+		var result = await Page.RunAxe();
+		AssertNoViolations(result);
+	}
+
 	[Test]
 	public async Task EngagementManagementPage_AsOlaf_HasNoSeriousA11yViolations()
 	{

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -44,11 +44,13 @@ export default function DesktopHeader({
 			<ul className="mr-2 flex items-center gap-2">
 				{buildPrimaryNav(activeOrg).map((link) => {
 					const base =
-						"rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors";
+						"rounded-lg border-b-2 border-transparent px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors";
 					const idle = isTransparent
 						? "text-brand-100 hover:text-white"
 						: "text-gray-600 hover:text-brand-800";
-					const activeClass = isTransparent ? "text-white" : "text-brand-800";
+					const activeClass = isTransparent
+						? "border-white font-semibold text-white"
+						: "border-brand-700 font-semibold text-brand-800";
 
 					if (link.kind === "organization") {
 						return (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -301,6 +301,7 @@ export default function HomePage() {
 									type="submit"
 									size="lg"
 									pill
+									variant="onDark"
 									disabled={resolvingHeroLocation}
 									className="shrink-0 shadow-md"
 								>

--- a/frontend/src/pages/OpportunitiesPage.tsx
+++ b/frontend/src/pages/OpportunitiesPage.tsx
@@ -49,7 +49,13 @@ export default function OpportunitiesPage() {
 								className="w-full rounded-full border-0 bg-transparent py-3 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-600 focus:outline-none"
 							/>
 						</div>
-						<Button type="submit" size="lg" pill className="shrink-0 shadow-md">
+						<Button
+							type="submit"
+							size="lg"
+							pill
+							variant="onDark"
+							className="shrink-0 shadow-md"
+						>
 							{t("landing.heroSearchButton")}
 						</Button>
 					</div>

--- a/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
+++ b/frontend/src/pages/app/OrgDashboardPage/EditableWidgetTile.tsx
@@ -98,11 +98,17 @@ export default function EditableWidgetTile({
 					: editing
 						? "pointer-events-none"
 						: ""
-			} ${editing && isPlacing ? "ring-2 ring-brand-500" : ""}`}
+			} ${
+				editing
+					? isPlacing
+						? "ring-2 ring-brand-500"
+						: "ring-1 ring-brand-600"
+					: ""
+			}`}
 		>
 			<div
 				inert={editing}
-				className={`h-full ${editing ? "opacity-60" : ""} ${
+				className={`h-full ${
 					// Reserves room for the grip button below (absolutely positioned,
 					// centered at the tile's top edge) instead of letting it sit on
 					// top of WidgetCard's own title - on a narrow tile the two used to


### PR DESCRIPTION
## What

Fixes three WCAG contrast failures found by a live manual review, none of which axe-core can catch structurally (a non-text UI-component boundary, a post-interaction state, and a color-only cue with correct ARIA).

## Why

Closes #2232

1. **Hero search CTA (`/` and `/opportunities`)** - the button used the default `primary` variant (`bg-brand-700` fill, white text) with no visible edge against the `bg-white/10` glass panel it sits in over the `brand-800` hero: 1.26:1 against WCAG 1.4.11's 3:1 non-text-contrast floor. Axe misses it because the white *label* passes text contrast; only the missing boundary fails. Switched to the existing `onDark` `Button` variant (white fill, `brand-800` text) - already the established pattern for every other CTA in this exact hero band (`PageHeaderBand.tsx`, `DesktopHeader.tsx`, `OrganizationProfilePage.tsx`).

2. **Dashboard edit mode (`/app/:orgId/dashboard`)** - entering edit mode ("Bearbeiten") applied a blanket `opacity-60` to each widget tile's entire rendered content, washing out already-high-contrast elements (the "Einsatz erstellen" button, calendar event chips, the active "Monat" toolbar state, weekday headers) down to ~3:1-4.5:1. Axe never sees this because it's a one-click modal state, not the page at rest. Removed the opacity dimming - functional non-interactivity during editing is already enforced separately via the `inert` attribute - and replaced it with an always-visible `ring-1 ring-brand-600` per tile to signal edit mode, alongside the existing stronger ring for the tile actively being placed.

3. **Header active nav link** - the current page was distinguished from idle links only by a 1.20:1 lightness difference (`text-white`/`text-brand-800` vs a slightly dimmer idle color), with `aria-current="page"` correctly set but no visible cue for sighted users. Added the 2px-underline-plus-font-weight treatment already established by the organizer tab bar (`OrgPageHeader.tsx`) so both navigations read as one system.

## Testing

- `pnpm check`, `pnpm lint`, `pnpm format:write` (no changes) all pass
- `pnpm test` - full suite (109 files / 730 tests) passes
- `dotnet build tests/VisualTests/VisualTests.csproj` succeeds
- Added `OrgDashboardPage_AsOlaf_EditMode_HasNoSeriousA11yViolations` to `backend/tests/VisualTests/AccessibilityTests.cs` - an axe scan that clicks into dashboard edit mode before scanning, since that state was previously unscanned (the issue's own root-cause finding for why #2 slipped through). Not run locally (no Docker/Aspire in this sandbox); will run in CI's `dotnet.yml` `visual-tests` shards.
- Could not visually verify in a live browser (no Docker/Aspire in this sandbox) - contrast ratios were hand-verified via the WCAG relative-luminance formula against the exact hex values in `frontend/src/styles/global.css`'s `@theme` block.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no docs reference these specific styling choices)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DisjRW2Me7rY8dsoPRxX15)_