### PR TITLE
fix(notifications): link notification items to their subject

### DIFF
--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -8678,6 +8678,12 @@
           "createdOn": {
             "type": "string",
             "format": "date-time"
+          },
+          "relatedTitleEn": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/backend/src/Application/Notifications/NotificationSummary.cs
+++ b/backend/src/Application/Notifications/NotificationSummary.cs
@@ -6,4 +6,5 @@ public sealed record NotificationSummary(
 	string? RelatedTitle,
 	string? ActionUrl,
 	bool IsRead,
-	DateTimeOffset CreatedOn);
+	DateTimeOffset CreatedOn,
+	string? RelatedTitleEn = null);

--- a/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/NotificationReadRepository.cs
@@ -116,21 +116,24 @@ internal sealed class NotificationReadRepository(
 		var allOpportunityIds = opportunityIdsFromEngagements.Union(directOpportunityIds).ToHashSet();
 
 		Dictionary<Guid, string> opportunityTitles = [];
+		Dictionary<Guid, string?> opportunityTitlesEn = [];
 		Dictionary<Guid, Guid> opportunityOrganizations = [];
 		if (allOpportunityIds.Count > 0)
 		{
 			var opportunityIdVOs = allOpportunityIds.Select(id => VolunteerOpportunityId.Create(id).GetValueOrThrow()).ToList();
 			var opportunityRows = await dbContext.VolunteerOpportunitiesQuery
 				.Where(o => opportunityIdVOs.Contains(o.Id))
-				.Select(o => new { o.Id, o.TitleDe, o.OrganizationId })
+				.Select(o => new { o.Id, o.TitleDe, o.TitleEn, o.OrganizationId })
 				.ToListAsync(cancellationToken);
 			opportunityTitles = opportunityRows.ToDictionary(x => x.Id.Value, x => x.TitleDe);
+			opportunityTitlesEn = opportunityRows.ToDictionary(x => x.Id.Value, x => x.TitleEn);
 			opportunityOrganizations = opportunityRows.ToDictionary(x => x.Id.Value, x => x.OrganizationId.Value);
 		}
 
 		return notifications.Select(n =>
 		{
 			string? relatedTitle = null;
+			string? relatedTitleEn = null;
 			string? actionUrl = null;
 
 			if (EngagementKinds.Contains(n.Kind) &&
@@ -138,6 +141,7 @@ internal sealed class NotificationReadRepository(
 			{
 				opportunityTitles.TryGetValue(opportunityId, out relatedTitle);
 				relatedTitle ??= n.TitleSnapshot;
+				opportunityTitlesEn.TryGetValue(opportunityId, out relatedTitleEn);
 
 				actionUrl = n.Kind is NotificationKind.EngagementCreated or NotificationKind.EngagementWithdrawn or NotificationKind.FeedbackSubmitted
 					? (opportunityOrganizations.TryGetValue(opportunityId, out var organizationId)
@@ -148,6 +152,7 @@ internal sealed class NotificationReadRepository(
 			else if (InvitationKinds.Contains(n.Kind))
 			{
 				invitationOrganizationNames.TryGetValue(n.RelatedEntityId, out relatedTitle);
+				relatedTitleEn = relatedTitle;
 				actionUrl = n.Kind == NotificationKind.InvitationReceived
 
 					? "/my-signups"
@@ -159,6 +164,7 @@ internal sealed class NotificationReadRepository(
 			{
 				opportunityTitles.TryGetValue(n.RelatedEntityId, out relatedTitle);
 				relatedTitle ??= n.TitleSnapshot;
+				opportunityTitlesEn.TryGetValue(n.RelatedEntityId, out relatedTitleEn);
 
 				actionUrl = n.Kind == NotificationKind.OpportunityUpdated
 					? $"/volunteer-opportunities/{n.RelatedEntityId}"
@@ -171,7 +177,8 @@ internal sealed class NotificationReadRepository(
 				relatedTitle,
 				actionUrl,
 				n.IsRead,
-				n.CreatedOn);
+				n.CreatedOn,
+				relatedTitleEn);
 		}).ToList();
 	}
 

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -13269,6 +13269,9 @@ namespace IntegrationTests
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.DateTimeOffset CreatedOn { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("relatedTitleEn")]
+        public string? RelatedTitleEn { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/NotificationTests.cs
+++ b/backend/tests/IntegrationTests/NotificationTests.cs
@@ -35,6 +35,31 @@ public class NotificationTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetMyNotifications_EngagementCreated_HasRelatedTitleEn_WhenOpportunityHasEnglishTitle(
+		CancellationToken cancellationToken)
+	{
+		const string opportunityTitleDe = "Notification Deep-Link Test (DE)";
+		const string opportunityTitleEn = "Notification Deep-Link Test (EN)";
+
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(
+			olafClient, orgId, opportunityTitleDe, cancellationToken, opportunityTitleEn);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var olafNotifications = await olafClient.GetMyNotificationsAsync(cancellationToken: cancellationToken);
+
+		var notification = olafNotifications.Items.Single(n => n.Kind == "EngagementCreated");
+		notification.RelatedTitle.Should().Be(opportunityTitleDe);
+		notification.RelatedTitleEn.Should().Be(opportunityTitleEn);
+	}
+
+	[Test]
 	public async Task GetMyNotifications_EngagementCreated_DropsTitleAndDeepLink_AfterOpportunityDeleted(
 		CancellationToken cancellationToken)
 	{
@@ -666,12 +691,13 @@ public class NotificationTests(IntegrationTestFixture fixture)
 	}
 
 	private static async Task<CreateVolunteerOpportunityResponse> CreateOpportunityAsync(
-		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken)
+		EinsatzbereitApi client, Guid orgId, string title, CancellationToken cancellationToken, string? titleEn = null)
 	{
 		return await client.CreateVolunteerOpportunityAsync(
 			new CreateVolunteerOpportunityRequest
 			{
 				TitleDe = title,
+				TitleEn = titleEn,
 				DescriptionDe = "Integration test opportunity for notifications",
 				OrganizationId = orgId,
 				Street = "Test Street",

--- a/backend/tests/VisualTests/NotificationTests.cs
+++ b/backend/tests/VisualTests/NotificationTests.cs
@@ -61,7 +61,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var notificationItem = panel.Locator("li", new() { HasText = oppTitle }).First;
 		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
+		await notificationItem.GetByRole(AriaRole.Link).First.ClickAsync();
 
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements",
@@ -109,7 +109,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var notificationItem = panel.Locator("li", new() { HasText = orgName }).First;
 		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
+		await notificationItem.GetByRole(AriaRole.Link).First.ClickAsync();
 
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/my-signups",
@@ -191,7 +191,7 @@ public class NotificationTests(AspireFixture fixture) : VisualTestBase(fixture)
 		var notificationItem = panel.Locator("li", new() { HasText = oppTitle }).First;
 		await Expect(notificationItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-		await notificationItem.GetByRole(AriaRole.Button).First.ClickAsync();
+		await notificationItem.GetByRole(AriaRole.Link).First.ClickAsync();
 
 		await Page.WaitForURLAsync(
 			$"{frontend.GetLeftPart(UriPartial.Authority)}/app/{organizationId}/dashboard/opportunities/{opportunityId}/engagements",

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6725,6 +6725,7 @@ export interface NotificationSummary {
     actionUrl: string | undefined;
     isRead: boolean;
     createdOn: Date;
+    relatedTitleEn?: string | undefined;
 
     [key: string]: any;
 }

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -53,6 +53,7 @@ export default function EmptyState({
 				(action.to ? (
 					<Button
 						to={action.to}
+						onClick={action.onClick}
 						size={compact ? "sm" : "md"}
 						className={compact ? "mt-3" : "mt-4"}
 						data-testid={action.testId}

--- a/frontend/src/components/Header/AccountControls.test.tsx
+++ b/frontend/src/components/Header/AccountControls.test.tsx
@@ -40,7 +40,6 @@ function render(isAdmin: boolean) {
 			initials={isAdmin ? "PA" : "VV"}
 			isAdmin={isAdmin}
 			onSignOut={() => {}}
-			onNotificationNavigate={() => {}}
 		/>,
 		{ auth: { isAuthenticated: true, roles: isAdmin ? ["admin"] : ["user"] } },
 	);
@@ -83,7 +82,6 @@ describe("account dropdown after navigating", () => {
 				initials="VV"
 				isAdmin={false}
 				onSignOut={() => {}}
-				onNotificationNavigate={() => {}}
 			/>,
 			{ auth: { isAuthenticated: true, roles: ["user"] } },
 		);

--- a/frontend/src/components/Header/AccountControls.tsx
+++ b/frontend/src/components/Header/AccountControls.tsx
@@ -17,7 +17,6 @@ export default function AccountControls({
 	initials,
 	isAdmin = false,
 	onSignOut,
-	onNotificationNavigate,
 }: {
 	transparent?: boolean;
 	menu: AccountMenuState;
@@ -25,7 +24,6 @@ export default function AccountControls({
 	initials: string;
 	isAdmin?: boolean;
 	onSignOut: () => void;
-	onNotificationNavigate: (actionUrl: string | null | undefined) => void;
 }) {
 	const { t } = useTranslation();
 	const { avatarUrl, notifRef, dropdownOpen, setDropdownOpen, dropdownRef } =
@@ -37,7 +35,6 @@ export default function AccountControls({
 				menu={menu}
 				transparent={transparent}
 				containerRef={notifRef}
-				onNavigate={onNotificationNavigate}
 			/>
 
 			<div className="relative" ref={dropdownRef}>

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -17,7 +17,6 @@ export default function DesktopHeader({
 	isAdmin,
 	activeOrg,
 	onSignOut,
-	onNotificationNavigate,
 	onSignIn,
 	onRegister,
 }: {
@@ -30,7 +29,6 @@ export default function DesktopHeader({
 
 	activeOrg: OrganizationSummaryDto | null | undefined;
 	onSignOut: () => void;
-	onNotificationNavigate: (actionUrl: string | null | undefined) => void;
 	onSignIn: () => void;
 	onRegister: () => void;
 }) {
@@ -112,7 +110,6 @@ export default function DesktopHeader({
 					initials={initials}
 					isAdmin={isAdmin}
 					onSignOut={onSignOut}
-					onNotificationNavigate={onNotificationNavigate}
 				/>
 			) : (
 				<div className="flex items-center gap-3">

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
-import { useLocation, useNavigate, Link } from "react-router";
+import { useLocation, Link } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
 import { useMyOrganizations } from "../../hooks/useMyOrganizations";
@@ -24,7 +24,6 @@ export default function Header({
 } = {}) {
 	const auth = useAuth();
 	const { t } = useTranslation();
-	const navigate = useNavigate();
 	const location = useLocation();
 	const isLoggedIn = auth.isAuthenticated;
 	const user = auth.user?.profile;
@@ -68,10 +67,6 @@ export default function Header({
 	}, []);
 
 	const isTransparent = overlaysBand && !scrolled;
-
-	function handleNotificationNavigate(actionUrl: string | null | undefined) {
-		navigate(actionUrl ?? "/my-signups");
-	}
 
 	function handleSignIn() {
 		auth.signinRedirect({
@@ -142,7 +137,6 @@ export default function Header({
 							isAdmin={isAdmin}
 							activeOrg={navOrg}
 							onSignOut={handleSignOut}
-							onNotificationNavigate={handleNotificationNavigate}
 							onSignIn={handleSignIn}
 							onRegister={handleRegister}
 						/>
@@ -155,7 +149,6 @@ export default function Header({
 							menu={menu}
 							notifContainerRef={mobileNotifRef}
 							menuButtonRef={mobileMenuButtonRef}
-							onNotificationNavigate={handleNotificationNavigate}
 						/>
 					</div>
 				</div>

--- a/frontend/src/components/Header/MobileHeader.tsx
+++ b/frontend/src/components/Header/MobileHeader.tsx
@@ -12,7 +12,6 @@ export default function MobileHeader({
 	menu,
 	notifContainerRef,
 	menuButtonRef,
-	onNotificationNavigate,
 }: {
 	isLoggedIn: boolean;
 	isTransparent: boolean;
@@ -21,7 +20,6 @@ export default function MobileHeader({
 	menu: AccountMenuState;
 	notifContainerRef: RefObject<HTMLDivElement | null>;
 	menuButtonRef: RefObject<HTMLButtonElement | null>;
-	onNotificationNavigate: (actionUrl: string | null | undefined) => void;
 }) {
 	const { t } = useTranslation();
 
@@ -33,7 +31,6 @@ export default function MobileHeader({
 					transparent={isTransparent}
 					mobile
 					containerRef={notifContainerRef}
-					onNavigate={onNotificationNavigate}
 					onClose={() => setMobileOpen(false)}
 				/>
 			)}

--- a/frontend/src/components/Header/NotificationDropdown.a11y.test.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.a11y.test.tsx
@@ -57,7 +57,6 @@ function open(menu: AccountMenuState) {
 		<NotificationDropdown
 			menu={menu}
 			containerRef={createRef<HTMLDivElement>()}
-			onNavigate={() => {}}
 			onClose={() => {}}
 		/>,
 		{ auth: { isAuthenticated: true } },

--- a/frontend/src/components/Header/NotificationDropdown.tsx
+++ b/frontend/src/components/Header/NotificationDropdown.tsx
@@ -15,14 +15,12 @@ export default function NotificationDropdown({
 	transparent = false,
 	mobile = false,
 	containerRef,
-	onNavigate,
 	onClose,
 }: {
 	menu: AccountMenuState;
 	transparent?: boolean;
 	mobile?: boolean;
 	containerRef: RefObject<HTMLDivElement | null>;
-	onNavigate: (actionUrl: string | null | undefined) => void;
 	onClose?: () => void;
 }) {
 	const { t } = useTranslation();
@@ -68,7 +66,6 @@ export default function NotificationDropdown({
 		}
 		setNotifOpen(false);
 		onClose?.();
-		onNavigate(n.actionUrl);
 	}
 
 	return (
@@ -166,7 +163,18 @@ export default function NotificationDropdown({
 								</li>
 							) : notifications.length === 0 ? (
 								<li className="px-4">
-									<EmptyState compact title={t("notifications.empty")} />
+									<EmptyState
+										compact
+										title={t("notifications.empty")}
+										action={{
+											label: t("notifications.emptyCta"),
+											to: "/opportunities",
+											onClick: () => {
+												setNotifOpen(false);
+												onClose?.();
+											},
+										}}
+									/>
 								</li>
 							) : (
 								<>

--- a/frontend/src/components/Header/NotificationItem.test.tsx
+++ b/frontend/src/components/Header/NotificationItem.test.tsx
@@ -9,7 +9,7 @@ const notification = (isRead: boolean): NotificationSummary =>
 		id: isRead ? "read-1" : "unread-1",
 		kind: "EngagementConfirmed",
 		relatedTitle: "Deutscher Einsatz",
-		relatedId: "22222222-2222-2222-2222-222222222222",
+		actionUrl: "/app/org-1/dashboard/opportunities/opp-1/engagements",
 		isRead,
 		createdOn: new Date(Date.UTC(2026, 7, 10, 9, 0)),
 	}) as unknown as NotificationSummary;
@@ -30,17 +30,17 @@ function renderRow(isRead: boolean) {
 
 const TEXT = "Your sign-up for Deutscher Einsatz was confirmed";
 
-function rowButton(): HTMLElement {
-	const button = document.querySelector<HTMLElement>("li > button");
-	expect(button).not.toBeNull();
-	return button as HTMLElement;
+function rowLink(): HTMLElement {
+	const link = document.querySelector<HTMLElement>("li > a");
+	expect(link).not.toBeNull();
+	return link as HTMLElement;
 }
 
 describe("NotificationItem unread marker", () => {
 	it("puts 'Unread' into an unread row's own accessible name", () => {
 		renderRow(false);
 
-		const row = rowButton();
+		const row = rowLink();
 		expect(row).toHaveAccessibleName(new RegExp(TEXT));
 		expect(row).toHaveAccessibleName(/Unread/);
 		expect(
@@ -51,7 +51,7 @@ describe("NotificationItem unread marker", () => {
 	it("says nothing of the sort on a read row", () => {
 		renderRow(true);
 
-		const row = rowButton();
+		const row = rowLink();
 		expect(row).toHaveAccessibleName(new RegExp(TEXT));
 		expect(row).not.toHaveAccessibleName(/Unread/);
 		expect(
@@ -68,5 +68,41 @@ describe("NotificationItem unread marker", () => {
 		expect(
 			screen.getByRole("button", { name: `Delete: ${TEXT}` }),
 		).toBeInTheDocument();
+	});
+});
+
+describe("NotificationItem navigation", () => {
+	it("is a real link to the notification's subject", () => {
+		renderRow(false);
+
+		expect(rowLink()).toHaveAttribute(
+			"href",
+			"/app/org-1/dashboard/opportunities/opp-1/engagements",
+		);
+	});
+
+	it("falls back to /my-signups when the notification carries no actionUrl", () => {
+		renderWithProviders(
+			<ul>
+				<NotificationItem
+					notification={{ ...notification(false), actionUrl: undefined }}
+					onSelect={vi.fn()}
+					onMarkUnread={vi.fn()}
+					onDelete={vi.fn()}
+				/>
+			</ul>,
+			{ auth: { isAuthenticated: true } },
+		);
+
+		expect(rowLink()).toHaveAttribute("href", "/my-signups");
+	});
+
+	it("marks a German-only title with lang, while the surrounding English sentence carries none", () => {
+		renderRow(false);
+
+		expect(within(rowLink()).getByText("Deutscher Einsatz")).toHaveAttribute(
+			"lang",
+			"de",
+		);
 	});
 });

--- a/frontend/src/components/Header/NotificationItem.tsx
+++ b/frontend/src/components/Header/NotificationItem.tsx
@@ -1,6 +1,7 @@
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router";
 import type { NotificationSummary } from "../../client/api-client";
-import { formatDateTime } from "../../lib/format";
+import { formatDateTime, pickLocalizedText } from "../../lib/format";
 import { EyeSlashIcon, TrashIcon } from "../icons";
 
 export default function NotificationItem({
@@ -16,16 +17,26 @@ export default function NotificationItem({
 }) {
 	const { t, i18n } = useTranslation();
 	const n = notification;
+	const localizedTitle = pickLocalizedText(
+		n.relatedTitle,
+		n.relatedTitleEn,
+		i18n.language,
+	);
+	const titleText =
+		localizedTitle?.text ?? t("notifications.deletedOpportunityPlaceholder");
+	// kinds.* strings wrap {{title}} in <titleSpan> for the Trans render below;
+	// t() doesn't parse that markup, so strip it for the plain-text aria-labels.
 	const text = t(`notifications.kinds.${n.kind}` as Parameters<typeof t>[0], {
-		title: n.relatedTitle ?? t("notifications.deletedOpportunityPlaceholder"),
+		title: titleText,
 		defaultValue: n.kind,
-	});
+	}).replace(/<\/?titleSpan>/g, "");
+	const href = n.actionUrl ?? "/my-signups";
 
 	return (
 		<li className="relative">
-			<button
-				type="button"
-				className={`w-full cursor-pointer px-4 py-3 pr-16 text-left text-sm transition-colors hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
+			<Link
+				to={href}
+				className={`block w-full px-4 py-3 pr-16 text-sm transition-colors hover:bg-brand-50 ${!n.isRead ? "font-medium text-gray-900" : "text-gray-500"}`}
 				onClick={() => void onSelect(n)}
 			>
 				<span className="flex items-start gap-2">
@@ -39,14 +50,19 @@ export default function NotificationItem({
 						</>
 					)}
 					<span className={!n.isRead ? "" : "pl-4"}>
-						{text}
+						<Trans
+							i18nKey={`notifications.kinds.${n.kind}`}
+							values={{ title: titleText }}
+							components={{ titleSpan: <span lang={localizedTitle?.lang} /> }}
+							defaults={n.kind}
+						/>
 						<br />
 						<span className="text-xs text-gray-500">
 							{formatDateTime(n.createdOn as unknown as string, i18n.language)}
 						</span>
 					</span>
 				</span>
-			</button>
+			</Link>
 			<span className="absolute top-2 right-2 z-10 flex gap-1">
 				{n.isRead && (
 					<button

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -896,6 +896,7 @@
       "clearReadError": "Gelesene Benachrichtigungen konnten nicht gelöscht werden.",
       "loadError": "Benachrichtigungen konnten nicht geladen werden.",
       "empty": "Keine Benachrichtigungen.",
+      "emptyCta": "Einsätze durchsuchen",
       "loadMore": "Mehr laden",
       "loadingMore": "Lädt…",
       "markReadError": "Benachrichtigung konnte nicht als gelesen markiert werden.",
@@ -906,18 +907,18 @@
       "deletedOpportunityPlaceholder": "einen gelöschten Einsatz",
       "unread": "Ungelesen",
       "kinds": {
-        "EngagementCreated": "Neue Anmeldung eingegangen für {{title}}",
-        "EngagementConfirmed": "Deine Anmeldung für {{title}} wurde bestätigt",
-        "EngagementCancelled": "Deine Anmeldung für {{title}} wurde abgesagt",
-        "EngagementWithdrawn": "Eine Anmeldung für {{title}} wurde zurückgezogen",
-        "OpportunityUpdated": "{{title}} wurde aktualisiert",
-        "OpportunityDeleted": "{{title}} wurde entfernt",
-        "OpportunityUnpublished": "{{title}} wurde zurückgezogen und deine Anmeldung wurde abgesagt",
-        "OpportunityCancelled": "Der Einsatz {{title}} wurde abgesagt - deine Anmeldung ist damit hinfällig",
-        "InvitationReceived": "Du wurdest eingeladen, {{title}} beizutreten",
-        "InvitationAccepted": "Deine Einladung, {{title}} beizutreten, wurde angenommen",
-        "InvitationDeclined": "Deine Einladung, {{title}} beizutreten, wurde abgelehnt",
-        "FeedbackSubmitted": "Neues Feedback erhalten für {{title}}"
+        "EngagementCreated": "Neue Anmeldung eingegangen für <titleSpan>{{title}}</titleSpan>",
+        "EngagementConfirmed": "Deine Anmeldung für <titleSpan>{{title}}</titleSpan> wurde bestätigt",
+        "EngagementCancelled": "Deine Anmeldung für <titleSpan>{{title}}</titleSpan> wurde abgesagt",
+        "EngagementWithdrawn": "Eine Anmeldung für <titleSpan>{{title}}</titleSpan> wurde zurückgezogen",
+        "OpportunityUpdated": "<titleSpan>{{title}}</titleSpan> wurde aktualisiert",
+        "OpportunityDeleted": "<titleSpan>{{title}}</titleSpan> wurde entfernt",
+        "OpportunityUnpublished": "<titleSpan>{{title}}</titleSpan> wurde zurückgezogen und deine Anmeldung wurde abgesagt",
+        "OpportunityCancelled": "Der Einsatz <titleSpan>{{title}}</titleSpan> wurde abgesagt - deine Anmeldung ist damit hinfällig",
+        "InvitationReceived": "Du wurdest eingeladen, <titleSpan>{{title}}</titleSpan> beizutreten",
+        "InvitationAccepted": "Deine Einladung, <titleSpan>{{title}}</titleSpan> beizutreten, wurde angenommen",
+        "InvitationDeclined": "Deine Einladung, <titleSpan>{{title}}</titleSpan> beizutreten, wurde abgelehnt",
+        "FeedbackSubmitted": "Neues Feedback erhalten für <titleSpan>{{title}}</titleSpan>"
       }
     },
     "language": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -896,6 +896,7 @@
       "clearReadError": "Failed to clear read notifications.",
       "loadError": "Couldn't load notifications.",
       "empty": "No notifications.",
+      "emptyCta": "Browse opportunities",
       "loadMore": "Load more",
       "loadingMore": "Loading…",
       "markReadError": "Failed to mark notification as read.",
@@ -906,18 +907,18 @@
       "deletedOpportunityPlaceholder": "a deleted opportunity",
       "unread": "Unread",
       "kinds": {
-        "EngagementCreated": "New sign-up received for {{title}}",
-        "EngagementConfirmed": "Your sign-up for {{title}} was confirmed",
-        "EngagementCancelled": "Your sign-up for {{title}} was cancelled",
-        "EngagementWithdrawn": "A sign-up for {{title}} was withdrawn",
-        "OpportunityUpdated": "{{title}} was updated",
-        "OpportunityDeleted": "{{title}} was removed",
-        "OpportunityUnpublished": "{{title}} was taken down and your sign-up was cancelled",
-        "OpportunityCancelled": "The opportunity {{title}} was cancelled - your sign-up no longer stands",
-        "InvitationReceived": "You've been invited to join {{title}}",
-        "InvitationAccepted": "Your invitation to join {{title}} was accepted",
-        "InvitationDeclined": "Your invitation to join {{title}} was declined",
-        "FeedbackSubmitted": "New feedback received for {{title}}"
+        "EngagementCreated": "New sign-up received for <titleSpan>{{title}}</titleSpan>",
+        "EngagementConfirmed": "Your sign-up for <titleSpan>{{title}}</titleSpan> was confirmed",
+        "EngagementCancelled": "Your sign-up for <titleSpan>{{title}}</titleSpan> was cancelled",
+        "EngagementWithdrawn": "A sign-up for <titleSpan>{{title}}</titleSpan> was withdrawn",
+        "OpportunityUpdated": "<titleSpan>{{title}}</titleSpan> was updated",
+        "OpportunityDeleted": "<titleSpan>{{title}}</titleSpan> was removed",
+        "OpportunityUnpublished": "<titleSpan>{{title}}</titleSpan> was taken down and your sign-up was cancelled",
+        "OpportunityCancelled": "The opportunity <titleSpan>{{title}}</titleSpan> was cancelled - your sign-up no longer stands",
+        "InvitationReceived": "You've been invited to join <titleSpan>{{title}}</titleSpan>",
+        "InvitationAccepted": "Your invitation to join <titleSpan>{{title}}</titleSpan> was accepted",
+        "InvitationDeclined": "Your invitation to join <titleSpan>{{title}}</titleSpan> was declined",
+        "FeedbackSubmitted": "New feedback received for <titleSpan>{{title}}</titleSpan>"
       }
     },
     "language": {


### PR DESCRIPTION
## What

Notification list items are now real links to the thing they're about, the embedded opportunity title follows the interface language, and the empty panel gets a designed empty state.

## Why

Fixes three grouped findings from the live-review pass:

1. **No notification links to its subject.** Each row was a plain `<button>` with an `onClick` navigate side effect - not middle-clickable, not open-in-new-tab-able, and not a link at all to assistive tech. `NotificationItem` now renders the row as a `react-router` `<Link>` to `actionUrl` (falling back to `/my-signups`), with the delete/mark-unread controls as sibling buttons rather than nested inside it. Since the anchor's own `to` now drives navigation, the old imperative `navigate()` plumbing (`onNavigate`/`onNotificationNavigate`, threaded through `Header` → `DesktopHeader`/`MobileHeader` → `AccountControls` → `NotificationDropdown`) was dead weight and removed.
2. **Notification text keeps the German opportunity title in the English interface.** The backend only ever resolved `TitleDe` for a notification's related opportunity. `NotificationReadRepository` now resolves both `TitleDe` and `TitleEn` (new `RelatedTitleEn` field on `NotificationSummary`), and the frontend picks the right one via the same `pickLocalizedText` helper `OpportunityCard` uses, marking the embedded title with a `lang` attribute (via a `<titleSpan>` `Trans` component wrapping `{{title}}` in the `notifications.kinds.*` strings) - including the German-only fallback case, matching `OpportunityCard.tsx:157`'s pattern. Invitation-related notifications mirror the organization name into both fields since org names aren't a bilingual field.
3. **The empty state says nothing.** The notifications panel's `EmptyState` now includes a "Browse opportunities" call to action linking to `/opportunities` (required threading `onClick` through `EmptyState`'s `to` branch too, since closing the panel on navigate needed it).

Closes #2235

## Testing

- `Application.UnitTests` (1017 tests) and `ArchitectureTests` (417 tests) - full run, all passing
- New integration test `GetMyNotifications_EngagementCreated_HasRelatedTitleEn_WhenOpportunityHasEnglishTitle` covering the new `RelatedTitleEn` field (not run locally - `IntegrationTests` needs Docker, unavailable in this sandbox; verified it compiles)
- Updated `NotificationTests.cs` (VisualTests/Playwright) to target the row's new link role instead of button (not run locally for the same reason; verified it compiles)
- Frontend: full `pnpm test` (733 tests), `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm format:check` - all passing
- Added `NotificationItem` tests covering the row's `href`, its `/my-signups` fallback, and the `lang` attribute on a German-only title
- Full backend solution build (`dotnet build Einsatzbereit.slnx`) - passing

## Checklist

- [x] CI is green (verified locally: full backend build, Application.UnitTests, ArchitectureTests, and the full frontend lint/check/test/format/i18n suite - IntegrationTests/VisualTests need Docker and can't run in this sandbox)
- [ ] Documentation updated if this change affects behavior (no user-facing docs cover the notification panel's markup)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqW6qb9n4F55M2qB7vUBVB)_