### PR TITLE
fix: show pending-unlock state instead of locked badge style at 100% progress

### DIFF
--- a/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -1,5 +1,7 @@
+using Application.Achievements.BadgeCatalog;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
+using Domain.Achievements;
 using Domain.Common;
 using Domain.Engagements;
 using Domain.Organizations;
@@ -14,6 +16,7 @@ internal sealed class ApplicationDbContextInitializer(
 	ApplicationDbContext dbContext,
 	IKeycloakOrganizationService keycloakOrganizationService,
 	IPinGenerator pinGenerator,
+	IBadgeCatalogService badgeCatalogService,
 	ILogger<ApplicationDbContextInitializer> logger)
 	: IApplicationDbContextInitializer
 {
@@ -241,7 +244,40 @@ internal sealed class ApplicationDbContextInitializer(
 				"Ich würde beim nächsten Blutspendetermin gerne als Freiwillige mithelfen.").GetValueOrThrow(),
 			Engagement.CreateSlotSignUp(opp3.Id, veraUserId, opp3.TimeSlots.First().Id));
 
+		await SeedFirstStepAchievementAsync(veraUserId, cancellationToken);
+
 		await dbContext.SaveChangesAsync(cancellationToken);
+	}
+
+	// opp1PastEngagement above is seeded directly as Confirmed rather than through
+	// ConfirmEngagementCommandHandler, so it must also seed the streak/achievement
+	// state that handler would have produced - otherwise the profile shows 100%
+	// progress toward "first-step" while the achievement was never granted (#2229).
+	private async Task SeedFirstStepAchievementAsync(
+		UserId volunteerId,
+		CancellationToken cancellationToken)
+	{
+		var now = DateTimeOffset.UtcNow;
+
+		var streak = await dbContext.GetOrCreateUserStreakAsync(volunteerId, cancellationToken);
+		streak.RecordActivity(
+			System.Globalization.ISOWeek.GetYear(now.UtcDateTime),
+			System.Globalization.ISOWeek.GetWeekOfYear(now.UtcDateTime));
+		streak.RecordConfirmedEngagement();
+
+		var definition = badgeCatalogService.FindByKey("first-step");
+		if (definition is null)
+			return;
+
+		var achievement = Achievement.Create(
+			volunteerId,
+			definition.Type,
+			definition.Key,
+			definition.Name,
+			definition.Description,
+			now);
+
+		await dbContext.TryAwardAchievementAsync(achievement, cancellationToken);
 	}
 
 	private static DateTimeOffset DayAt(DateTimeOffset from, int daysAhead, int hourUtc) =>

--- a/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
+++ b/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
@@ -1,7 +1,9 @@
 using System.Text.RegularExpressions;
+using Application.Achievements.BadgeCatalog;
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using AwesomeAssertions;
+using Domain.Achievements;
 using Domain.Engagements;
 using Domain.Organizations;
 using Domain.Users;
@@ -39,7 +41,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		var existingOrgId = keycloak.SeedExistingOrganization("Lindenauer Nachbarschaftshilfe e.V.");
 
 		var initializer = new ApplicationDbContextInitializer(
-			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+			dbContext, keycloak, new RandomPinGenerator(), new FakeBadgeCatalogService(), NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
 
@@ -64,7 +66,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		keycloak.SeedExistingOrganizerRole(OlafId);
 
 		var initializer = new ApplicationDbContextInitializer(
-			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+			dbContext, keycloak, new RandomPinGenerator(), new FakeBadgeCatalogService(), NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
 
@@ -87,7 +89,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		};
 
 		var initializer = new ApplicationDbContextInitializer(
-			dbContext, keycloak, new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+			dbContext, keycloak, new RandomPinGenerator(), new FakeBadgeCatalogService(), NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		Func<Task> act = async () => await initializer.SeedAsync(cancellationToken);
 
@@ -113,6 +115,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 			dbContext,
 			new FakeKeycloakOrganizationService(),
 			new RandomPinGenerator(),
+			new FakeBadgeCatalogService(),
 			NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
@@ -154,6 +157,7 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 			dbContext,
 			new FakeKeycloakOrganizationService(),
 			new RandomPinGenerator(),
+			new FakeBadgeCatalogService(),
 			NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
@@ -187,7 +191,8 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		await using var dbContext = fixture.CreateApplicationDbContext();
 
 		var initializer = new ApplicationDbContextInitializer(
-			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), new FakeBadgeCatalogService(),
+			NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
 
@@ -215,13 +220,45 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 	}
 
 	[Test]
+	public async Task SeedAsync_AwardsFirstStepAchievementForVeraSeededPastEngagement_SoTheProfileIsNotSelfContradictory(
+		CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+
+		var initializer = new ApplicationDbContextInitializer(
+			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), new FakeBadgeCatalogService(),
+			NullLogger<ApplicationDbContextInitializer>.Instance);
+
+		await initializer.SeedAsync(cancellationToken);
+
+		var veraUserId = UserId.Create(VeraId).GetValueOrThrow();
+
+		var streak = await dbContext.GetUserStreakAsync(veraUserId, cancellationToken);
+		streak.Should().NotBeNull(
+			"Vera's seeded past engagement is Confirmed, so a real confirmation through the normal flow would have "
+			+ "created her streak row too");
+		streak!.TotalConfirmedEngagements.Should().BeGreaterThanOrEqualTo(1,
+			"her one seeded confirmed engagement must count toward the milestone gate, or the profile's header "
+			+ "count and her badge progress silently disagree with what actually earns badges (#2229)");
+
+		var achievements = await dbContext.Set<Achievement>()
+			.Where(a => a.UserId == veraUserId)
+			.ToListAsync(cancellationToken);
+		achievements.Should().Contain(a => a.Key == "first-step",
+			"seeding Vera's past engagement as already Confirmed bypasses ConfirmEngagementCommandHandler, the only "
+			+ "place that normally awards \"first-step\" - without seeding the award to match, her profile shows "
+			+ "100% badge progress for a badge she was never actually granted (#2229)");
+	}
+
+	[Test]
 	public async Task SeedAsync_SeedsLocalMembershipRowForVera_SoHerOwnOrganizationsQueryFindsIt(
 		CancellationToken cancellationToken)
 	{
 		await using var dbContext = fixture.CreateApplicationDbContext();
 
 		var initializer = new ApplicationDbContextInitializer(
-			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), NullLogger<ApplicationDbContextInitializer>.Instance);
+			dbContext, new FakeKeycloakOrganizationService(), new RandomPinGenerator(), new FakeBadgeCatalogService(),
+			NullLogger<ApplicationDbContextInitializer>.Instance);
 
 		await initializer.SeedAsync(cancellationToken);
 
@@ -247,13 +284,14 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 			dbContext,
 			new FakeKeycloakOrganizationService(),
 			new RandomPinGenerator(),
+			new FakeBadgeCatalogService(),
 			NullLogger<ApplicationDbContextInitializer>.Instance).SeedAsync(cancellationToken);
 
 		var logger = new FakeLogger<ApplicationDbContextInitializer>();
 		var keycloak = new FakeKeycloakOrganizationService();
 
 		await new ApplicationDbContextInitializer(
-			dbContext, keycloak, new RandomPinGenerator(), logger).SeedAsync(cancellationToken);
+			dbContext, keycloak, new RandomPinGenerator(), new FakeBadgeCatalogService(), logger).SeedAsync(cancellationToken);
 
 		keycloak.CreateOrganizationCallCount.Should().Be(0, "seeding must not run a second time");
 		(await dbContext.Set<DomainOrganization>().CountAsync(cancellationToken)).Should().Be(
@@ -264,6 +302,14 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 			"the warning has to say the seed set was not applied, not just that seeding was skipped");
 		record.Message.Should().Contain("Wipe the database",
 			"an operator reading this line needs to be told what to do about it");
+	}
+
+	private sealed class FakeBadgeCatalogService : IBadgeCatalogService
+	{
+		public IReadOnlyList<Application.Achievements.BadgeCatalog.BadgeCatalogEntry> GetAll() => [];
+
+		public Application.Achievements.BadgeCatalog.BadgeCatalogEntry? FindByKey(string key) =>
+			new(key, AchievementType.Milestone, key, key, IsHidden: false);
 	}
 
 	private sealed class FakeKeycloakOrganizationService : IKeycloakOrganizationService

--- a/frontend/src/components/BadgeGrid.a11y.test.tsx
+++ b/frontend/src/components/BadgeGrid.a11y.test.tsx
@@ -68,4 +68,23 @@ describe("BadgeGrid a11y", () => {
 		renderWithProviders(<BadgeGrid earned={[]} catalog={catalog} />);
 		await expectNoA11yViolations();
 	});
+
+	it("has no violations when progress reaches the target but the award isn't granted yet (#2229)", async () => {
+		renderWithProviders(
+			<BadgeGrid
+				earned={[]}
+				catalog={[
+					{
+						key: "first-step",
+						type: 0,
+						name: "First Step",
+						description: "Earned on your first confirmed opportunity.",
+						isHidden: false,
+					},
+				]}
+				progress={{ engagements: 1, loginStreak: 0, activityStreak: 0 }}
+			/>,
+		);
+		await expectNoA11yViolations();
+	});
 });

--- a/frontend/src/components/BadgeGrid.test.tsx
+++ b/frontend/src/components/BadgeGrid.test.tsx
@@ -4,6 +4,16 @@ import BadgeGrid from "./BadgeGrid";
 import type { BadgeCatalogEntry } from "../client/api-client";
 import { renderWithProviders } from "../test/render";
 
+const pendingGrantCatalog: BadgeCatalogEntry[] = [
+	{
+		key: "first-step",
+		type: 0,
+		name: "First Step",
+		description: "Earned on your first confirmed opportunity.",
+		isHidden: false,
+	},
+];
+
 const catalog: BadgeCatalogEntry[] = [
 	{
 		key: "centurion-100",
@@ -64,5 +74,67 @@ describe("BadgeGrid German copy", () => {
 		expect(
 			container.querySelector("#badge-name-weekly-hero-4"),
 		).toHaveTextContent("Wochenheld");
+	});
+});
+
+describe("BadgeGrid pending-grant state (#2229)", () => {
+	it("uses the earned treatment and 'unlocking soon' wording once progress reaches the target but no award is granted yet", () => {
+		const { container } = renderWithProviders(
+			<BadgeGrid
+				earned={[]}
+				catalog={pendingGrantCatalog}
+				progress={{ engagements: 1, loginStreak: 0, activityStreak: 0 }}
+			/>,
+		);
+
+		const card = container
+			.querySelector("#badge-name-first-step")
+			?.closest('[role="group"]');
+		expect(card).not.toHaveClass("border-dashed");
+		expect(card).toHaveClass("border-brand-200");
+		expect(screen.getAllByText("Unlocking soon").length).toBeGreaterThan(0);
+		expect(screen.queryByText("1 of 1")).toBeNull();
+	});
+
+	it("keeps the locked style and the numeric label while progress is below the target", () => {
+		const { container } = renderWithProviders(
+			<BadgeGrid
+				earned={[]}
+				catalog={pendingGrantCatalog}
+				progress={{ engagements: 0, loginStreak: 0, activityStreak: 0 }}
+			/>,
+		);
+
+		const card = container
+			.querySelector("#badge-name-first-step")
+			?.closest('[role="group"]');
+		expect(card).toHaveClass("border-dashed");
+		expect(screen.getAllByText("0 of 1").length).toBeGreaterThan(0);
+		expect(screen.queryByText("Unlocking soon")).toBeNull();
+	});
+
+	it("still applies the earned treatment for a genuinely earned badge", () => {
+		const { container } = renderWithProviders(
+			<BadgeGrid
+				earned={[
+					{
+						id: "ach-1",
+						type: "Milestone",
+						key: "first-step",
+						name: "First Step",
+						description: "Earned on your first confirmed opportunity.",
+						unlockedAt: new Date(Date.UTC(2026, 7, 24, 10, 0)),
+					},
+				]}
+				catalog={pendingGrantCatalog}
+				progress={{ engagements: 1, loginStreak: 0, activityStreak: 0 }}
+			/>,
+		);
+
+		const card = container
+			.querySelector("#badge-name-first-step")
+			?.closest('[role="group"]');
+		expect(card).toHaveClass("border-brand-200");
+		expect(screen.queryByText("Unlocking soon")).toBeNull();
 	});
 });

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -151,6 +151,14 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 		progressTarget && progress
 			? Math.min(progress[progressTarget.metric], progressTarget.target)
 			: null;
+	// Requirement met but the backend hasn't granted the award yet - keep the
+	// filled bar, but don't render it in the locked style (#2229).
+	const isPendingGrant =
+		!isEarned &&
+		!isHidden &&
+		progressTarget !== undefined &&
+		currentProgress === progressTarget.target;
+	const showsEarnedTreatment = isEarned || isPendingGrant;
 	const tooltipId = `badge-tooltip-${catalog.key}`;
 	const nameId = `badge-name-${catalog.key}`;
 	const cardRef = useRef<HTMLDivElement>(null);
@@ -182,7 +190,7 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 			ref={cardRef}
 
 			className={`group relative flex flex-col items-center rounded-card border p-4 text-center transition-all ${
-				isEarned
+				showsEarnedTreatment
 					? "border-brand-200 bg-white shadow-resting hover:shadow-raised"
 					: "border-dashed border-gray-200 bg-transparent"
 			}`}
@@ -193,7 +201,7 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 		>
 			<div
 				className={`mb-3 flex h-14 w-14 items-center justify-center rounded-full ${
-					isEarned ? "bg-brand-50" : "bg-gray-50"
+					showsEarnedTreatment ? "bg-brand-50" : "bg-gray-50"
 				}`}
 			>
 				{isHidden ? (
@@ -204,14 +212,14 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 					<AchievementTypeIcon
 						badgeKey={catalog.key}
 						type={typeName}
-						className={`h-7 w-7 ${isEarned ? "text-brand-600" : "text-gray-400"}`}
+						className={`h-7 w-7 ${showsEarnedTreatment ? "text-brand-600" : "text-gray-400"}`}
 					/>
 				)}
 			</div>
 			<p
 				id={nameId}
 				className={`text-sm leading-snug font-semibold ${
-					isEarned ? "text-gray-900" : "text-gray-500"
+					showsEarnedTreatment ? "text-gray-900" : "text-gray-500"
 				}`}
 			>
 				{isHidden
@@ -251,10 +259,12 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 						/>
 					</div>
 					<p className="mt-1 text-xs font-medium text-brand-700">
-						{t("achievements.badgeProgress", {
-							current: currentProgress,
-							target: progressTarget.target,
-						})}
+						{isPendingGrant
+							? t("achievements.pendingUnlock")
+							: t("achievements.badgeProgress", {
+									current: currentProgress,
+									target: progressTarget.target,
+								})}
 					</p>
 				</div>
 			)}
@@ -282,10 +292,12 @@ function BadgeCard({ catalog, earned, progress }: BadgeCardProps) {
 					</p>
 					{!isEarned && progressTarget && currentProgress !== null && (
 						<p className="mt-1 text-brand-300">
-							{t("achievements.badgeProgress", {
-								current: currentProgress,
-								target: progressTarget.target,
-							})}
+							{isPendingGrant
+								? t("achievements.pendingUnlock")
+								: t("achievements.badgeProgress", {
+										current: currentProgress,
+										target: progressTarget.target,
+									})}
 						</p>
 					)}
 					{isEarned && (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1182,6 +1182,7 @@
       "lockedBadge": "Geheimes Abzeichen",
       "hiddenBadgeTeaser": "Eine Überraschung für Freiwillige, die dabeibleiben.",
       "badgeProgress": "{{current}} von {{target}}",
+      "pendingUnlock": "Wird in Kürze freigeschaltet",
       "badgesTitle": "Abzeichen",
       "activityStreak": "Wochen in Serie · {{badge}}",
       "activityStreak_one": "Woche in Serie · {{badge}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1182,6 +1182,7 @@
       "lockedBadge": "Mystery Badge",
       "hiddenBadgeTeaser": "A surprise for volunteers who stick around.",
       "badgeProgress": "{{current}} of {{target}}",
+      "pendingUnlock": "Unlocking soon",
       "badgesTitle": "Badges",
       "activityStreak": "Weeks in a row · {{badge}}",
       "activityStreak_one": "Week in a row · {{badge}}",


### PR DESCRIPTION
## What

`BadgeGrid` now treats "progress complete but not yet granted" as its own visual state instead of falling through to the locked style. The seed data for the demo `vera` account is also fixed to actually grant the "first-step" achievement it was always supposed to have.

## Why

Closes #2229

On `/profile`, "Erster Schritt" showed a fully filled progress bar and "1 von 1" while still rendering with the locked treatment (grey icon, grey title, dashed border, transparent background) - contradicting the profile header, which already counted the same confirmed engagement. A completed requirement that still looks unmet reads as the system withholding something the user earned.

Investigating the backend half (as the issue asked): the grant genuinely was missing, not just late. The dev/demo seed data (`ApplicationDbContextInitializer.SeedAsync`) creates Vera's past engagement by calling `Engagement.Confirm()`/`CheckIn()` directly on the domain aggregate, bypassing `ConfirmEngagementCommandHandler` entirely - the only place that increments the `UserStreak.TotalConfirmedEngagements` counter and evaluates milestone achievements. So her live confirmed-engagement count (used for the frontend's progress bar) was 1, but the award-gating counter behind `first-step` was never incremented, and the achievement was never inserted.

## Changes

**Frontend** (`components/BadgeGrid.tsx`): added `isPendingGrant` (progress complete, not hidden, not yet earned) and `showsEarnedTreatment = isEarned || isPendingGrant`. The card now uses the earned colour treatment (icon, border, title) once progress is complete, and the progress-bar label switches from "X of Y" to a new `achievements.pendingUnlock` string ("Unlocking soon" / "Wird in Kürze freigeschaltet") instead of implying the badge is still locked. A genuinely earned badge is unaffected.

**Backend** (`Infrastructure/Persistence/ApplicationDbContextInitializer.cs`): after seeding Vera's confirmed past engagement, `SeedFirstStepAchievementAsync` now records the same `UserStreak` state and awards the same "first-step" achievement that `ConfirmEngagementCommandHandler` would have produced for a real confirmation, using the same `IApplicationDbContext` helpers (`GetOrCreateUserStreakAsync`, `TryAwardAchievementAsync`) the production handler and other seed-time code already call directly.

## Testing

- `frontend/src/components/BadgeGrid.test.tsx`: 3 new cases covering below-target (locked), at-target-but-ungranted (pending, earned treatment + new wording), and genuinely earned.
- `frontend/src/components/BadgeGrid.a11y.test.tsx`: 1 new case scanning the pending-grant state for a11y violations (none of the existing cases used a catalog key that actually exercises the progress-bar branch).
- `backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs`: 1 new integration test asserting the seed produces both the `UserStreak` counter and the "first-step" `Achievement` row for Vera.
- `pnpm test` (734 tests), `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm format:check` all pass.
- `dotnet build`, `dotnet run --project tests/Application.UnitTests` (1017 tests), `dotnet run --project tests/ArchitectureTests` (417 tests) all pass. `IntegrationTests`/`VisualTests` need real container networking unavailable in this sandbox (per `AGENTS.md`) - they'll run in CI.
- Ran the `architecture-check`, `a11y-check`, `i18n-check`, and `ef-migration-check` subagents plus `/self-review`; no issues found (no EF migration needed - no entity/model changes, only seed-time use of existing helpers).

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (none needed - internal fix, no documented behavior changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXcUgSSGZfDPK6wmMC31By)_