### PR TITLE
fix: draw select chevrons as inline SVGs instead of a CSP-blocked data: background

### DIFF
--- a/frontend/src/components/Select.a11y.test.tsx
+++ b/frontend/src/components/Select.a11y.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it } from "vitest";
+import { render } from "@testing-library/react";
+import Select from "./Select";
+import { expectNoA11yViolations } from "../test/a11y";
+
+describe("Select a11y", () => {
+	it("has no violations when labelled via htmlFor", async () => {
+		render(
+			<div>
+				<label htmlFor="status-filter">Status</label>
+				<Select id="status-filter" value="open" onChange={() => {}}>
+					<option value="open">Open</option>
+					<option value="closed">Closed</option>
+				</Select>
+			</div>,
+		);
+		await expectNoA11yViolations();
+	});
+});

--- a/frontend/src/components/Select.test.tsx
+++ b/frontend/src/components/Select.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Select from "./Select";
+
+describe("Select", () => {
+	it("renders a native select carrying the passed-through props", () => {
+		render(
+			<label htmlFor="status">
+				Status
+				<Select id="status" value="open" onChange={() => {}}>
+					<option value="open">Open</option>
+					<option value="closed">Closed</option>
+				</Select>
+			</label>,
+		);
+
+		const select = screen.getByRole("combobox", { name: "Status" });
+		expect(select).toHaveValue("open");
+		expect(screen.getByRole("option", { name: "Closed" })).toBeInTheDocument();
+	});
+
+	it("fires onChange when a different option is picked", async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+
+		render(
+			<label htmlFor="status">
+				Status
+				<Select id="status" value="open" onChange={onChange}>
+					<option value="open">Open</option>
+					<option value="closed">Closed</option>
+				</Select>
+			</label>,
+		);
+
+		await user.selectOptions(
+			screen.getByRole("combobox", { name: "Status" }),
+			"closed",
+		);
+		expect(onChange).toHaveBeenCalled();
+	});
+
+	it("hides the chevron it draws from assistive tech (#2225)", () => {
+		const { container } = render(
+			<Select value="open" onChange={() => {}}>
+				<option value="open">Open</option>
+			</Select>,
+		);
+
+		const chevron = container.querySelector("svg");
+		expect(chevron).not.toBeNull();
+		expect(chevron).toHaveAttribute("aria-hidden", "true");
+	});
+});

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,0 +1,23 @@
+import type { SelectHTMLAttributes } from "react";
+import { ChevronDownIcon } from "./icons";
+import { selectClass } from "../lib/formClasses";
+
+// The one native <select> wrapper every dropdown filter/field should render
+// through (#2225) - it draws the chevron as an inline <svg> layered on top of
+// the control instead of a CSS `data:` background image, which the deployed
+// CSP's img-src blocks (no `data:` there), leaving `appearance-none` selects
+// with no visible arrow at all.
+export default function Select({
+	className = "",
+	...rest
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+	return (
+		<div className="relative">
+			<select
+				className={`${selectClass}${className ? ` ${className}` : ""}`}
+				{...rest}
+			/>
+			<ChevronDownIcon className="pointer-events-none absolute top-1/2 right-2 h-5 w-5 -translate-y-1/2 text-gray-500" />
+		</div>
+	);
+}

--- a/frontend/src/lib/formClasses.test.ts
+++ b/frontend/src/lib/formClasses.test.ts
@@ -45,19 +45,15 @@ describe("formClasses", () => {
 		expect(labelClass).toContain("text-gray-600");
 	});
 
-	it("keeps the select chevron's data URI free of raw whitespace Tailwind can't parse (#2051)", () => {
-		const urlToken = selectClass.match(/bg-\[url\('([^']+)'\)\]/);
-		expect(urlToken).not.toBeNull();
-		const dataUri = urlToken?.[1] ?? "";
-		expect(dataUri).not.toBe("");
-		expect(/\s/.test(dataUri)).toBe(false);
-
-		const svgMarkup = decodeURIComponent(
-			dataUri.slice(dataUri.indexOf(",") + 1),
-		);
-		const doc = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
-		expect(doc.querySelector("parsererror")).toBeNull();
-		expect(doc.querySelector("svg")).not.toBeNull();
+	it("never paints the select chevron as a data: background image (#2225)", () => {
+		// The deployed CSP's img-src has no `data:` - a `bg-[url('data:...')]` chevron
+		// is silently blocked while appearance-none has already removed the native
+		// arrow, leaving the control looking disabled. components/Select.tsx draws
+		// the chevron as an inline <svg> instead; this class must stay free of any
+		// background-image so that fix can't silently regress.
+		expect(selectClass).not.toContain("data:");
+		expect(selectClass).not.toContain("bg-[url(");
+		expect(selectClass).toContain("appearance-none");
 	});
 
 	it("gives every invalid field the same red border/focus treatment (#2239)", () => {

--- a/frontend/src/lib/formClasses.ts
+++ b/frontend/src/lib/formClasses.ts
@@ -31,6 +31,11 @@ export const inputClass = getInputClass();
 
 export const textareaClass = getTextareaClass();
 
-export const selectClass = `${inputClass} appearance-none bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat pr-9 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20fill=%22none%22%20viewBox=%220%200%2024%2024%22%20stroke-width=%221.5%22%20stroke=%22%236b7280%22%3E%3Cpath%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20d=%22m19.5%208.25-7.5%207.5-7.5-7.5%22/%3E%3C/svg%3E')]`;
+// No background-image chevron here (#2225) - the deployed CSP's img-src has no
+// `data:`, which silently strips a CSS-painted arrow while appearance-none has
+// already removed the native one. `components/Select.tsx` draws the chevron as
+// an inline <svg> instead, so every consumer should render through that
+// component rather than applying this class to a bare <select>.
+export const selectClass = `${inputClass} appearance-none pr-9`;
 
 export const labelClass = getLabelClass();

--- a/frontend/src/pages/EngagementManagementPage.tsx
+++ b/frontend/src/pages/EngagementManagementPage.tsx
@@ -17,6 +17,7 @@ import Chip from "../components/Chip";
 import LoadMoreError from "../components/LoadMoreError";
 import LoadMoreButton from "../components/LoadMoreButton";
 import ModalLoadingFallback from "../components/ModalLoadingFallback";
+import Select from "../components/Select";
 import NotFoundPage from "./NotFoundPage";
 import {
 	formatDate,
@@ -29,12 +30,7 @@ import { useSetOrgBreadcrumbExtra } from "../contexts/OrgBreadcrumbContext";
 import { dispatchToast } from "../lib/toastBus";
 import { getApiErrorMessage, isApiNotFoundError } from "../lib/apiError";
 import { ENGAGEMENT_STATUS_COLORS } from "../lib/engagementStatus";
-import {
-	inputClass,
-	labelClass,
-	textareaClass,
-	selectClass,
-} from "../lib/formClasses";
+import { inputClass, labelClass, textareaClass } from "../lib/formClasses";
 import { cardClass } from "../lib/surfaceClasses";
 import {
 	CheckIconSolid,
@@ -555,11 +551,10 @@ export default function EngagementManagementPage() {
 						<label htmlFor="engagement-status-filter" className={labelClass}>
 							{t("engagementManagement.filterLabelStatus")}
 						</label>
-						<select
+						<Select
 							id="engagement-status-filter"
 							value={statusFilter}
 							onChange={(e) => setStatusFilter(e.target.value)}
-							className={selectClass}
 						>
 							<option value="">{t("engagementManagement.allStatuses")}</option>
 							{Object.entries(STATUS_LABELS).map(([value, label]) => (
@@ -567,7 +562,7 @@ export default function EngagementManagementPage() {
 									{label}
 								</option>
 							))}
-						</select>
+						</Select>
 					</div>
 					{opportunity && opportunity.timeSlots.length > 1 && (
 						<div>
@@ -577,11 +572,10 @@ export default function EngagementManagementPage() {
 							>
 								{t("engagementManagement.filterLabelTimeSlot")}
 							</label>
-							<select
+							<Select
 								id="engagement-timeslot-filter"
 								value={timeSlotFilter}
 								onChange={(e) => setTimeSlotFilter(e.target.value)}
-								className={selectClass}
 							>
 								<option value="">
 									{t("engagementManagement.allTimeSlots")}
@@ -595,7 +589,7 @@ export default function EngagementManagementPage() {
 										)}
 									</option>
 								))}
-							</select>
+							</Select>
 						</div>
 					)}
 					<form

--- a/frontend/src/pages/app/OrgEngagementsPage.tsx
+++ b/frontend/src/pages/app/OrgEngagementsPage.tsx
@@ -8,7 +8,7 @@ import { usePageTitle } from "../../hooks/usePageTitle";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { formatDate } from "../../lib/format";
-import { inputClass, labelClass, selectClass } from "../../lib/formClasses";
+import { inputClass, labelClass } from "../../lib/formClasses";
 import { ENGAGEMENT_STATUS_COLORS } from "../../lib/engagementStatus";
 import { cardClass } from "../../lib/surfaceClasses";
 import ConfirmDialog from "../../components/ConfirmDialog";
@@ -17,6 +17,7 @@ import Skeleton from "../../components/Skeleton";
 import Button from "../../components/Button";
 import LoadMoreError from "../../components/LoadMoreError";
 import LoadMoreButton from "../../components/LoadMoreButton";
+import Select from "../../components/Select";
 import { TrashIcon } from "../../components/icons";
 import type { OrgAppContext } from "../../layouts/OrgAppLayout";
 
@@ -165,11 +166,10 @@ export default function OrgEngagementsPage() {
 					<label htmlFor="org-engagement-status-filter" className={labelClass}>
 						{t("orgEngagements.filterLabelStatus")}
 					</label>
-					<select
+					<Select
 						id="org-engagement-status-filter"
 						value={statusFilter}
 						onChange={(e) => handleStatusChange(e.target.value)}
-						className={selectClass}
 					>
 						<option value="">{t("orgEngagements.allStatuses")}</option>
 						{Object.entries(STATUS_LABELS).map(([value, label]) => (
@@ -177,7 +177,7 @@ export default function OrgEngagementsPage() {
 								{label}
 							</option>
 						))}
-					</select>
+					</Select>
 				</div>
 				<form
 					onSubmit={handleSearchSubmit}

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -10,12 +10,13 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { getApiErrorMessage } from "../../lib/apiError";
 import { looksLikeEmail } from "../../lib/emailLike";
-import { inputClass, labelClass, selectClass } from "../../lib/formClasses";
+import { inputClass, labelClass } from "../../lib/formClasses";
 import { orgTabPath } from "../../lib/orgTabs";
 import EmptyState from "../../components/EmptyState";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import Button from "../../components/Button";
 import Chip from "../../components/Chip";
+import Select from "../../components/Select";
 import SectionHeading from "../../components/SectionHeading";
 import ErrorBanner from "../../components/ErrorBanner";
 import SuccessBanner from "../../components/SuccessBanner";
@@ -288,19 +289,18 @@ export default function OrgMembersPage() {
 								<label htmlFor="invite-role" className={labelClass}>
 									{t("orgSettings.inviteRoleLabel")}
 								</label>
-								<select
+								<Select
 									id="invite-role"
 									value={inviteRole}
 									onChange={(e) =>
 										setInviteRole(e.target.value as "Member" | "Organizer")
 									}
-									className={selectClass}
 								>
 									<option value="Member">{t("orgSettings.roleMember")}</option>
 									<option value="Organizer">
 										{t("orgSettings.organisator")}
 									</option>
-								</select>
+								</Select>
 							</div>
 						</div>
 						{memberSearch.length > 0 && memberSearch.length < 4 && (


### PR DESCRIPTION
## What

`selectClass` (`frontend/src/lib/formClasses.ts`) no longer paints the dropdown chevron with a `bg-[url('data:image/svg+xml;...')]` background. A new shared `Select` component (`frontend/src/components/Select.tsx`) wraps the native `<select>` and layers an inline `<svg>` chevron (`ChevronDownIcon`, the same icon component `OrganizationSwitcher`/`LanguageSelector`/`FilterDropdown` already use) on top instead. The four `<select>` usages that relied on `selectClass` now render through `<Select>`:

- `frontend/src/pages/app/OrgEngagementsPage.tsx`
- `frontend/src/pages/app/OrgMembersPage.tsx`
- `frontend/src/pages/EngagementManagementPage.tsx` (two selects: status + time slot)

## Why

The deployed CSP's `img-src` (`frontend/nginx.conf.template`) has no `data:`, so the `data:` background image that used to draw the chevron was silently blocked by the browser, while `appearance-none` had already stripped the native arrow. Every native select on the site rendered as a plain rounded box with no visible arrow, making organizers unable to tell the status filter was interactive.

Closes #2225

## Testing

- Added `frontend/src/lib/formClasses.test.ts` assertion that `selectClass` never reintroduces a `data:`/`bg-[url(...)]` background, replacing the now-obsolete data-URI-whitespace test for the removed background image.
- Added `frontend/src/components/Select.test.tsx` (renders/forwards props, fires `onChange`) and `frontend/src/components/Select.a11y.test.tsx` (no violations, chevron correctly `aria-hidden`).
- `pnpm test` (781 tests), `pnpm lint`, `pnpm exec tsc --noEmit` all pass locally.
- Backend/Aspire E2E suite (`VisualTests`) needs real container networking and can't run in this sandbox; `AccessibilityTests.cs` already scans `EngagementManagementPage` and will exercise the new markup once CI runs it.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmSNWM1Ew4JzcMigsCykBY)_