### PR TITLE
fix: hold neutral header state during SSO probe and expiry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { useSessionExpiryHandler } from "./hooks/useSessionExpiryHandler";
 import { useSilentSsoProbe } from "./hooks/useSilentSsoProbe";
+import { AuthStatusProvider } from "./contexts/AuthStatusContext";
 import { signinLocaleArgs } from "./lib/authLocale";
 import ErrorBanner from "./components/ErrorBanner";
 import Button from "./components/Button";
@@ -102,7 +103,7 @@ function CallbackPage() {
 	);
 }
 
-export default function App() {
+function AppRoutes() {
 	useSessionExpiryHandler();
 	useSilentSsoProbe();
 	return (
@@ -194,5 +195,13 @@ export default function App() {
 				<Route path="*" element={<NotFoundPage />} />
 			</Route>
 		</Routes>
+	);
+}
+
+export default function App() {
+	return (
+		<AuthStatusProvider>
+			<AppRoutes />
+		</AuthStatusProvider>
 	);
 }

--- a/frontend/src/components/Header/DesktopHeader.a11y.test.tsx
+++ b/frontend/src/components/Header/DesktopHeader.a11y.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, vi } from "vitest";
+import { createRef } from "react";
+import DesktopHeader from "./DesktopHeader";
+import type { AccountMenuState } from "../../hooks/useAccountMenu";
+import { renderWithProviders } from "../../test/render";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+function menuState(): AccountMenuState {
+	return {
+		avatarUrl: null,
+		notifications: [],
+		unreadCount: 0,
+		notifHasMore: false,
+		notifLoadingMore: false,
+		loadMoreNotifications: vi.fn(),
+		notifError: null,
+		notifLoading: false,
+		retryNotifications: vi.fn(),
+		notifOpen: false,
+		setNotifOpen: vi.fn(),
+		notifRef: createRef<HTMLDivElement>(),
+		dropdownOpen: false,
+		setDropdownOpen: vi.fn(),
+		dropdownRef: createRef<HTMLDivElement>(),
+		markAllRead: vi.fn(),
+		markOneRead: vi.fn(),
+		markOneUnread: vi.fn(),
+		deleteOne: vi.fn(),
+		deleteAllRead: vi.fn(),
+		deletingAllRead: false,
+	} as AccountMenuState;
+}
+
+describe("DesktopHeader a11y", () => {
+	const base = {
+		isTransparent: false,
+		menu: menuState(),
+		displayName: "Vera Volunteer",
+		initials: "VV",
+		isAdmin: false,
+		activeOrg: null,
+		onSignOut: () => {},
+		onSignIn: () => {},
+		onRegister: () => {},
+	};
+
+	it("has no violations for a signed-out visitor", async () => {
+		renderWithProviders(<DesktopHeader {...base} authStatus="signedOut" />);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations for a signed-in visitor", async () => {
+		renderWithProviders(<DesktopHeader {...base} authStatus="signedIn" />, {
+			auth: { isAuthenticated: true },
+		});
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations while probing for a live Keycloak session", async () => {
+		renderWithProviders(<DesktopHeader {...base} authStatus="pending" />);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations for an expired session", async () => {
+		renderWithProviders(
+			<DesktopHeader {...base} authStatus="sessionExpired" />,
+		);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations over the transparent landing-page header", async () => {
+		renderWithProviders(
+			<DesktopHeader {...base} authStatus="pending" isTransparent />,
+		);
+		await expectNoA11yViolations();
+	});
+});

--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -4,12 +4,14 @@ import AccountControls from "./AccountControls";
 import LanguageSelector from "./LanguageSelector";
 import OrgAvatar from "../OrgAvatar";
 import Button from "../Button";
+import { SpinnerIcon } from "../Spinner";
 import type { AccountMenuState } from "../../hooks/useAccountMenu";
+import type { AuthDisplayStatus } from "../../hooks/useAuthDisplayStatus";
 import type { OrganizationSummaryDto } from "../../client/api-client";
 import { buildPrimaryNav } from "../../lib/headerNav";
 
 export default function DesktopHeader({
-	isLoggedIn,
+	authStatus,
 	isTransparent,
 	menu,
 	displayName,
@@ -20,7 +22,7 @@ export default function DesktopHeader({
 	onSignIn,
 	onRegister,
 }: {
-	isLoggedIn: boolean;
+	authStatus: AuthDisplayStatus;
 	isTransparent: boolean;
 	menu: AccountMenuState;
 	displayName: string;
@@ -104,7 +106,7 @@ export default function DesktopHeader({
 				className={`h-6 w-px ${isTransparent ? "bg-white/30" : "bg-gray-200"}`}
 			/>
 
-			{isLoggedIn ? (
+			{authStatus === "signedIn" && (
 				<AccountControls
 					transparent={isTransparent}
 					menu={menu}
@@ -113,7 +115,9 @@ export default function DesktopHeader({
 					isAdmin={isAdmin}
 					onSignOut={onSignOut}
 				/>
-			) : (
+			)}
+
+			{authStatus === "signedOut" && (
 				<div className="flex items-center gap-3">
 					<Button
 						type="button"
@@ -130,6 +134,25 @@ export default function DesktopHeader({
 						{t("nav.register")}
 					</Button>
 				</div>
+			)}
+
+			{authStatus === "pending" && (
+				<div className="flex items-center px-2" role="status">
+					<SpinnerIcon
+						className={`h-5 w-5 ${isTransparent ? "brightness-0 invert" : ""}`}
+					/>
+					<span className="sr-only">{t("nav.checkingSignIn")}</span>
+				</div>
+			)}
+
+			{authStatus === "sessionExpired" && (
+				<Button
+					type="button"
+					onClick={onSignIn}
+					variant={isTransparent ? "onDark" : "primary"}
+				>
+					{t("nav.sessionExpired")}
+				</Button>
 			)}
 			<div
 				className={`h-6 w-px ${isTransparent ? "bg-white/30" : "bg-gray-200"}`}

--- a/frontend/src/components/Header/Header.test.tsx
+++ b/frontend/src/components/Header/Header.test.tsx
@@ -28,6 +28,40 @@ describe("Header for an anonymous visitor", () => {
 	});
 });
 
+describe("Header while the silent-SSO probe is in flight (#2224)", () => {
+	it("holds a neutral state instead of offering to sign in", () => {
+		renderWithProviders(<Header />, {
+			auth: { isAuthenticated: false, isLoading: true },
+		});
+
+		expect(screen.queryAllByRole("button", { name: "Sign in" })).toHaveLength(
+			0,
+		);
+		expect(screen.queryByRole("button", { name: "Register" })).toBeNull();
+		expect(screen.queryByRole("button", { name: "User menu" })).toBeNull();
+		expect(
+			screen.getAllByText("Checking sign-in status…")[0],
+		).toBeInTheDocument();
+	});
+});
+
+describe("Header after a failed token renewal (#2224)", () => {
+	it("surfaces an explicit expired state instead of reverting to the anonymous interface", () => {
+		renderWithProviders(<Header />, {
+			auth: { isAuthenticated: true },
+			sessionExpired: true,
+		});
+
+		expect(
+			screen.getAllByRole("button", {
+				name: "Session expired - sign in again",
+			})[0],
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
+		expect(screen.queryByRole("button", { name: "User menu" })).toBeNull();
+	});
+});
+
 const ORG = {
 	id: "77777777-7777-7777-7777-777777777777",
 	name: "Freiwillige Feuerwehr Kiel",

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation, Link } from "react-router";
 import OrganizationSwitcher from "./OrganizationSwitcher";
 import { useAccountMenu } from "../../hooks/useAccountMenu";
+import { useAuthDisplayStatus } from "../../hooks/useAuthDisplayStatus";
 import { useMyOrganizations } from "../../hooks/useMyOrganizations";
 import { signinRedirectForRegistration } from "../../lib/keycloakRegistration";
 import { signinLocaleArgs } from "../../lib/authLocale";
@@ -25,7 +26,8 @@ export default function Header({
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const location = useLocation();
-	const isLoggedIn = auth.isAuthenticated;
+	const authStatus = useAuthDisplayStatus();
+	const isLoggedIn = authStatus === "signedIn";
 	const user = auth.user?.profile;
 	const displayName = (user?.name ??
 		user?.preferred_username ??
@@ -129,7 +131,7 @@ export default function Header({
 						)}
 
 						<DesktopHeader
-							isLoggedIn={isLoggedIn}
+							authStatus={authStatus}
 							isTransparent={isTransparent}
 							menu={menu}
 							displayName={displayName}
@@ -156,7 +158,7 @@ export default function Header({
 				{mobileOpen && (
 					<MobileMenu
 						isTransparent={isTransparent}
-						isLoggedIn={isLoggedIn}
+						authStatus={authStatus}
 						avatarUrl={avatarUrl}
 						initials={initials}
 						displayName={displayName}

--- a/frontend/src/components/Header/MobileMenu.a11y.test.tsx
+++ b/frontend/src/components/Header/MobileMenu.a11y.test.tsx
@@ -21,7 +21,7 @@ describe("MobileMenu a11y", () => {
 	};
 
 	it("has no violations for a signed-out visitor", async () => {
-		renderWithProviders(<MobileMenu {...base} isLoggedIn={false} />);
+		renderWithProviders(<MobileMenu {...base} authStatus="signedOut" />);
 		await expectNoA11yViolations();
 	});
 
@@ -29,7 +29,7 @@ describe("MobileMenu a11y", () => {
 		renderWithProviders(
 			<MobileMenu
 				{...base}
-				isLoggedIn
+				authStatus="signedIn"
 				activeOrg={{
 					id: "org-1",
 					name: "Freiwillige Feuerwehr",
@@ -46,17 +46,29 @@ describe("MobileMenu a11y", () => {
 	});
 
 	it("has no violations for a platform admin", async () => {
-		renderWithProviders(<MobileMenu {...base} isLoggedIn isAdmin />);
+		renderWithProviders(<MobileMenu {...base} authStatus="signedIn" isAdmin />);
 		await expectNoA11yViolations();
 	});
 
 	it("has no violations over the transparent landing-page header", async () => {
-		renderWithProviders(<MobileMenu {...base} isLoggedIn isTransparent />);
+		renderWithProviders(
+			<MobileMenu {...base} authStatus="signedIn" isTransparent />,
+		);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations while probing for a live Keycloak session", async () => {
+		renderWithProviders(<MobileMenu {...base} authStatus="pending" />);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations for an expired session", async () => {
+		renderWithProviders(<MobileMenu {...base} authStatus="sessionExpired" />);
 		await expectNoA11yViolations();
 	});
 
 	it("no longer links out to Keycloak's own account console (#1675)", () => {
-		renderWithProviders(<MobileMenu {...base} isLoggedIn />);
+		renderWithProviders(<MobileMenu {...base} authStatus="signedIn" />);
 
 		expect(
 			screen.getByRole("link", { name: "My profile" }),

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -6,7 +6,9 @@ import Button from "../Button";
 import { FOCUSABLE_SELECTOR } from "../Modal";
 import LanguageSelector from "./LanguageSelector";
 import OrgAvatar from "../OrgAvatar";
+import { SpinnerIcon } from "../Spinner";
 import type { OrganizationSummaryDto } from "../../client/api-client";
+import type { AuthDisplayStatus } from "../../hooks/useAuthDisplayStatus";
 import { ORG_TABS, orgTabPath } from "../../lib/orgTabs";
 import { buildPrimaryNav } from "../../lib/headerNav";
 import { useDismissableOverlay } from "../../hooks/useDismissableOverlay";
@@ -14,7 +16,7 @@ import { lockScroll } from "../../lib/scrollLock";
 
 export default function MobileMenu({
 	isTransparent,
-	isLoggedIn,
+	authStatus,
 	avatarUrl,
 	initials,
 	displayName,
@@ -27,7 +29,7 @@ export default function MobileMenu({
 	onSignOut,
 }: {
 	isTransparent: boolean;
-	isLoggedIn: boolean;
+	authStatus: AuthDisplayStatus;
 	avatarUrl: string | null;
 	initials: string;
 	displayName: string;
@@ -175,7 +177,7 @@ export default function MobileMenu({
 					<div className="pb-2">
 						<LanguageSelector transparent={isTransparent} />
 					</div>
-					{isLoggedIn ? (
+					{authStatus === "signedIn" && (
 						<div className="space-y-1">
 							<div className="flex items-center gap-3 px-3 py-2">
 								{avatarUrl ? (
@@ -236,7 +238,9 @@ export default function MobileMenu({
 								{t("nav.signOut")}
 							</button>
 						</div>
-					) : (
+					)}
+
+					{authStatus === "signedOut" && (
 						<div className="space-y-2">
 							<Button
 								type="button"
@@ -255,6 +259,29 @@ export default function MobileMenu({
 								{t("nav.register")}
 							</Button>
 						</div>
+					)}
+
+					{authStatus === "pending" && (
+						<div
+							role="status"
+							className={`flex items-center gap-2 px-3 py-2 text-sm ${isTransparent ? "text-white/70" : "text-gray-500"}`}
+						>
+							<SpinnerIcon
+								className={`h-4 w-4 ${isTransparent ? "brightness-0 invert" : ""}`}
+							/>
+							<span>{t("nav.checkingSignIn")}</span>
+						</div>
+					)}
+
+					{authStatus === "sessionExpired" && (
+						<Button
+							type="button"
+							onClick={onSignIn}
+							variant={isTransparent ? "onDark" : "primary"}
+							fullWidth
+						>
+							{t("nav.sessionExpired")}
+						</Button>
 					)}
 				</div>
 			</div>

--- a/frontend/src/contexts/AuthStatusContext.tsx
+++ b/frontend/src/contexts/AuthStatusContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+interface AuthStatusValue {
+	sessionExpired: boolean;
+	setSessionExpired: (expired: boolean) => void;
+}
+
+const AuthStatusContext = createContext<AuthStatusValue>({
+	sessionExpired: false,
+	setSessionExpired: () => undefined,
+});
+
+// Bridges a session-expiry detected inside useSessionExpiryHandler (mounted
+// once at the app root) to every Header instance, so the account area can
+// show an explicit expired state instead of silently falling back to the
+// signed-out UI while the redirect to Keycloak is still pending (#2224).
+export function AuthStatusProvider({
+	children,
+	initialSessionExpired = false,
+}: {
+	children: ReactNode;
+	initialSessionExpired?: boolean;
+}) {
+	const [sessionExpired, setSessionExpired] = useState(initialSessionExpired);
+
+	const value = useMemo(
+		() => ({ sessionExpired, setSessionExpired }),
+		[sessionExpired],
+	);
+
+	return (
+		<AuthStatusContext.Provider value={value}>
+			{children}
+		</AuthStatusContext.Provider>
+	);
+}
+
+export function useSessionExpiredFlag(): boolean {
+	return useContext(AuthStatusContext).sessionExpired;
+}
+
+export function useSetSessionExpiredFlag(): (expired: boolean) => void {
+	return useContext(AuthStatusContext).setSessionExpired;
+}

--- a/frontend/src/hooks/useAuthDisplayStatus.ts
+++ b/frontend/src/hooks/useAuthDisplayStatus.ts
@@ -1,0 +1,18 @@
+import { useAuth } from "react-oidc-context";
+import { useSessionExpiredFlag } from "../contexts/AuthStatusContext";
+
+export type AuthDisplayStatus =
+	"signedIn" | "signedOut" | "pending" | "sessionExpired";
+
+// isLoading covers both the initial bootstrap and the returning-visitor
+// silent-SSO probe (useSilentSsoProbe) - either way the account area should
+// hold a neutral state rather than assume signed-out (#2224).
+export function useAuthDisplayStatus(): AuthDisplayStatus {
+	const auth = useAuth();
+	const sessionExpired = useSessionExpiredFlag();
+
+	if (sessionExpired) return "sessionExpired";
+	if (auth.isAuthenticated) return "signedIn";
+	if (auth.isLoading) return "pending";
+	return "signedOut";
+}

--- a/frontend/src/hooks/useSessionExpiryHandler.test.tsx
+++ b/frontend/src/hooks/useSessionExpiryHandler.test.tsx
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, screen, waitFor } from "@testing-library/react";
 import { useSessionExpiryHandler } from "./useSessionExpiryHandler";
+import { useAuthDisplayStatus } from "./useAuthDisplayStatus";
 import { notifySessionExpired } from "../lib/sessionExpiryBus";
 import { renderWithProviders } from "../test/render";
 
 function Harness() {
 	useSessionExpiryHandler();
 	return <div>App body</div>;
+}
+
+function StatusHarness() {
+	useSessionExpiryHandler();
+	const status = useAuthDisplayStatus();
+	return <div data-testid="auth-display-status">{status}</div>;
 }
 
 const signinRedirect = vi.fn();
@@ -75,5 +82,23 @@ describe("session expiry", () => {
 		});
 		await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
 		expect(signinRedirect).not.toHaveBeenCalled();
+	});
+
+	it("flips the shared auth display status to sessionExpired instead of signedOut (#2224)", async () => {
+		renderWithProviders(<StatusHarness />, {
+			auth: { isAuthenticated: true, signinRedirect },
+		});
+
+		expect(screen.getByTestId("auth-display-status")).toHaveTextContent(
+			"signedIn",
+		);
+
+		act(() => notifySessionExpired());
+
+		await waitFor(() =>
+			expect(screen.getByTestId("auth-display-status")).toHaveTextContent(
+				"sessionExpired",
+			),
+		);
 	});
 });

--- a/frontend/src/hooks/useSessionExpiryHandler.ts
+++ b/frontend/src/hooks/useSessionExpiryHandler.ts
@@ -5,11 +5,13 @@ import { useLocation } from "react-router";
 import { dispatchToast } from "../lib/toastBus";
 import { subscribeSessionExpired } from "../lib/sessionExpiryBus";
 import { signinLocaleArgs } from "../lib/authLocale";
+import { useSetSessionExpiredFlag } from "../contexts/AuthStatusContext";
 
 export function useSessionExpiryHandler() {
 	const auth = useAuth();
 	const { t } = useTranslation();
 	const location = useLocation();
+	const setSessionExpired = useSetSessionExpiredFlag();
 	const handledRef = useRef(false);
 	const locationRef = useRef(location);
 	locationRef.current = location;
@@ -29,6 +31,7 @@ export function useSessionExpiryHandler() {
 			if (handledRef.current) return;
 			handledRef.current = true;
 
+			setSessionExpired(true);
 			dispatchToast("error", t("error.sessionExpired"));
 
 			redirectTimer = setTimeout(() => {
@@ -50,5 +53,5 @@ export function useSessionExpiryHandler() {
 			unsubscribeSilentRenewError();
 			if (redirectTimer !== null) clearTimeout(redirectTimer);
 		};
-	}, [auth, t]);
+	}, [auth, t, setSessionExpired]);
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -32,6 +32,8 @@
       "signOut": "Abmelden",
       "signIn": "Anmelden",
       "register": "Registrieren",
+      "checkingSignIn": "Anmeldestatus wird geprüft…",
+      "sessionExpired": "Sitzung abgelaufen - bitte erneut anmelden",
       "openMenu": "Menü öffnen",
       "menu": "Menü"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -32,6 +32,8 @@
       "signOut": "Sign out",
       "signIn": "Sign in",
       "register": "Register",
+      "checkingSignIn": "Checking sign-in status…",
+      "sessionExpired": "Session expired - sign in again",
       "openMenu": "Open menu",
       "menu": "Menu"
     },

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -8,10 +8,12 @@ import { ToastProvider } from "../contexts/ToastContext";
 import { QuickActionsProvider } from "../contexts/QuickActionsContext";
 import { HeaderOverlayProvider } from "../contexts/HeaderOverlayContext";
 import { OrgBreadcrumbProvider } from "../contexts/OrgBreadcrumbContext";
+import { AuthStatusProvider } from "../contexts/AuthStatusContext";
 import { createTestI18n } from "./i18n";
 
 export interface TestAuth {
 	isAuthenticated?: boolean;
+	isLoading?: boolean;
 	roles?: string[];
 	sub?: string;
 	name?: string;
@@ -26,6 +28,7 @@ export interface TestAuth {
 function buildAuthValue(auth: TestAuth): AuthContextProps {
 	const {
 		isAuthenticated = false,
+		isLoading = false,
 		roles = [],
 		sub = "test-user",
 		name = "Test User",
@@ -38,7 +41,7 @@ function buildAuthValue(auth: TestAuth): AuthContextProps {
 
 	return {
 		isAuthenticated,
-		isLoading: false,
+		isLoading,
 		activeNavigator: undefined,
 		error: undefined,
 		settings: {},
@@ -80,11 +83,17 @@ export interface RenderOptions {
 
 	route?: string;
 	auth?: TestAuth;
+	sessionExpired?: boolean;
 }
 
 export function renderWithProviders(
 	ui: ReactElement,
-	{ lng = "en", route = "/", auth = {} }: RenderOptions = {},
+	{
+		lng = "en",
+		route = "/",
+		auth = {},
+		sessionExpired = false,
+	}: RenderOptions = {},
 ): RenderResult {
 	const i18n = createTestI18n(lng);
 	const authValue = buildAuthValue(auth);
@@ -95,11 +104,13 @@ export function renderWithProviders(
 				<AuthContext.Provider value={authValue}>
 					<I18nextProvider i18n={i18n}>
 						<MemoryRouter initialEntries={[route]}>
-							<QuickActionsProvider>
-								<HeaderOverlayProvider>
-									<OrgBreadcrumbProvider>{children}</OrgBreadcrumbProvider>
-								</HeaderOverlayProvider>
-							</QuickActionsProvider>
+							<AuthStatusProvider initialSessionExpired={sessionExpired}>
+								<QuickActionsProvider>
+									<HeaderOverlayProvider>
+										<OrgBreadcrumbProvider>{children}</OrgBreadcrumbProvider>
+									</HeaderOverlayProvider>
+								</QuickActionsProvider>
+							</AuthStatusProvider>
 						</MemoryRouter>
 					</I18nextProvider>
 				</AuthContext.Provider>


### PR DESCRIPTION
## What

The header's account area now derives a shared `authStatus` (`signedIn` / `signedOut` / `pending` / `sessionExpired`) instead of a plain `isLoggedIn` boolean, so a returning visitor with a live Keycloak session sees a neutral state instead of the full logged-out UI while things are being sorted out.

## Why

Per #2224: the silent-renew iframe currently gets rejected by the deployed Keycloak realm (config drift, out of this repo's scope per #2165 - the checked-in realm template already has the right redirect URIs). That leaves two frontend-side symptoms that are in scope and worth fixing regardless:

- While `useSilentSsoProbe`'s `signinSilent()` call (or the initial auth bootstrap) is in flight, `auth.isLoading` is `true` and `auth.isAuthenticated` is `false` - the header rendered the full "Anmelden / Registrieren" CTAs, making a transient probe indistinguishable from actually being signed out.
- When `automaticSilentRenew` fails, `useSessionExpiryHandler` already showed a toast and redirected to Keycloak after 2s, but during that window the header silently reverted to the same anonymous CTAs instead of something explicit.

This PR:
- Adds `AuthStatusContext` + `useAuthDisplayStatus()` to compute a 4-way status (`signedIn`/`signedOut`/`pending`/`sessionExpired`) from `auth.isLoading`/`auth.isAuthenticated` plus a shared "session just expired" flag.
- `useSessionExpiryHandler` sets that flag the instant a renewal failure or API 401 is detected, before its existing toast+redirect fires.
- `DesktopHeader`/`MobileMenu` render a neutral spinner placeholder for `pending`, and an explicit "Sitzung abgelaufen - bitte erneut anmelden" button for `sessionExpired`, instead of falling back to the sign-in/register CTAs in either case.
- New locale keys `nav.checkingSignIn` / `nav.sessionExpired` (en/de).

The deploy-side Keycloak redirect-URI fix (adding `/silent-renew.html` to the deployed `frontend` client) is out of this repository's scope, as noted in the issue.

Closes #2224

## Testing

- `pnpm lint`, `pnpm check`, `pnpm i18n:check`, `pnpm build` - all pass
- `pnpm test` - full suite (111 files / 782 tests) passes
- Added/updated tests:
  - `Header.test.tsx`: new describe blocks for the `pending` state (silent-SSO probe in flight) and the `sessionExpired` state (after a failed renewal)
  - `MobileMenu.a11y.test.tsx`: switched to the new `authStatus` prop, added a11y coverage for `pending` and `sessionExpired`
  - `useSessionExpiryHandler.test.tsx`: new test asserting the shared auth display status flips to `sessionExpired` (not `signedOut`) once a renewal failure is detected

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior (no docs reference this internal header state machine)


---
_Generated by [Claude Code](https://claude.ai/code/session_016gH4ATp2S86GViH5aVCZy2)_