### PR TITLE
fix(header): fix org switcher truncation, naming, and app-only scope

### DIFF
--- a/frontend/src/components/Header/Header.test.tsx
+++ b/frontend/src/components/Header/Header.test.tsx
@@ -84,7 +84,7 @@ describe("Header organization entry", () => {
 		).toBeNull();
 	});
 
-	it("offers a switcher instead of a single link once a member belongs to more than one organization", async () => {
+	it("offers a switcher alongside the direct link once a member belongs to more than one organization", async () => {
 		const ORG_B = {
 			id: "88888888-8888-8888-8888-888888888888",
 			name: "Foerderverein Hamburg",
@@ -98,12 +98,18 @@ describe("Header organization entry", () => {
 				name: "Switch organization, currently Foerderverein Hamburg",
 			}),
 		).toBeInTheDocument();
-		expect(screen.queryByTestId("nav-organization")).toBeNull();
+		// The alphabetically-first org (ORG_B) is the resolved active one -
+		// the direct nav entry still points at it, same as a single-org
+		// member, so the mobile menu keeps offering direct sub-tab links.
+		expect(await screen.findByTestId("nav-organization")).toHaveAttribute(
+			"href",
+			`/app/${ORG_B.id}/dashboard`,
+		);
 		expect(
 			container.ownerDocument.querySelector(
 				'[data-testid="nav-forOrganizations"]',
 			),
-		).toBeInTheDocument();
+		).toBeNull();
 	});
 
 	it("keeps the pitch for a signed-in non-member", async () => {

--- a/frontend/src/components/Header/Header.test.tsx
+++ b/frontend/src/components/Header/Header.test.tsx
@@ -84,6 +84,28 @@ describe("Header organization entry", () => {
 		).toBeNull();
 	});
 
+	it("offers a switcher instead of a single link once a member belongs to more than one organization", async () => {
+		const ORG_B = {
+			id: "88888888-8888-8888-8888-888888888888",
+			name: "Foerderverein Hamburg",
+		};
+		api.getOrganizations.mockResolvedValue([ORG, ORG_B]);
+
+		const { container } = renderWithProviders(<Header />, { auth: signedIn });
+
+		expect(
+			await screen.findByRole("button", {
+				name: "Switch organization, currently Foerderverein Hamburg",
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByTestId("nav-organization")).toBeNull();
+		expect(
+			container.ownerDocument.querySelector(
+				'[data-testid="nav-forOrganizations"]',
+			),
+		).toBeInTheDocument();
+	});
+
 	it("keeps the pitch for a signed-in non-member", async () => {
 		api.getOrganizations.mockResolvedValue([]);
 

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -51,7 +51,12 @@ export default function Header({
 		(orgs.length > 1 && activeOrg
 			? { currentOrgId: activeOrg.id, currentTab: "dashboard" }
 			: undefined);
-	const navOrg = effectiveOrgSwitcher ? null : activeOrg;
+	// Only the org app's own route context makes the primary-nav "go to my
+	// org" entry redundant (its own in-app navigation already covers that).
+	// Outside the app, keep it even once the switcher fallback above also
+	// renders - for a multi-org user it's still the one place the mobile
+	// menu offers direct links into the org's sub-tabs.
+	const navOrg = orgSwitcher ? null : activeOrg;
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
 	const mobileNotifRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -45,7 +45,12 @@ export default function Header({
 
 	// A member of more than one organization needs a way to switch between
 	// them from outside the org app too (#2226), not just once they're
-	// already inside /app/:orgId/*.
+	// already inside /app/:orgId/*. Below lg:, that's the only org control
+	// in the collapsed header at all (the rest lives a tap deep in the
+	// hamburger menu), so the fallback switcher pill renders there; at lg:+
+	// the existing primary-nav "go to my org" entry already fills that role
+	// and there isn't room for both without overflowing the row (see the
+	// lg:hidden below), so the fallback stays mobile/tablet-only.
 	const effectiveOrgSwitcher =
 		orgSwitcher ??
 		(orgs.length > 1 && activeOrg
@@ -130,7 +135,9 @@ export default function Header({
 						</Link>
 
 						{effectiveOrgSwitcher && (
-							<div className="min-w-0 flex-1 sm:flex-none">
+							<div
+								className={`min-w-0 flex-1 sm:flex-none ${orgSwitcher ? "" : "lg:hidden"}`}
+							>
 								<OrganizationSwitcher
 									currentOrgId={effectiveOrgSwitcher.currentOrgId}
 									currentTab={effectiveOrgSwitcher.currentTab}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -43,7 +43,15 @@ export default function Header({
 		error: orgsError,
 	} = useMyOrganizations();
 
-	const navOrg = orgSwitcher ? null : activeOrg;
+	// A member of more than one organization needs a way to switch between
+	// them from outside the org app too (#2226), not just once they're
+	// already inside /app/:orgId/*.
+	const effectiveOrgSwitcher =
+		orgSwitcher ??
+		(orgs.length > 1 && activeOrg
+			? { currentOrgId: activeOrg.id, currentTab: "dashboard" }
+			: undefined);
+	const navOrg = effectiveOrgSwitcher ? null : activeOrg;
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [scrolled, setScrolled] = useState(false);
 	const mobileNotifRef = useRef<HTMLDivElement>(null);
@@ -103,11 +111,11 @@ export default function Header({
 			>
 				<div className="mx-auto max-w-page px-4 sm:px-6 lg:px-8">
 					<div
-						className={`flex h-16 items-center justify-between ${orgSwitcher ? "gap-3 sm:gap-4" : ""}`}
+						className={`flex h-16 items-center justify-between ${effectiveOrgSwitcher ? "gap-3 sm:gap-4" : ""}`}
 					>
 						<Link
 							to="/"
-							className={`flex shrink-0 items-center ${orgSwitcher ? "w-8 overflow-hidden sm:w-auto sm:overflow-visible" : ""}`}
+							className={`flex shrink-0 items-center ${effectiveOrgSwitcher ? "w-8 overflow-hidden sm:w-auto sm:overflow-visible" : ""}`}
 						>
 							<img
 								src="/logo.svg"
@@ -116,14 +124,15 @@ export default function Header({
 							/>
 						</Link>
 
-						{orgSwitcher && (
+						{effectiveOrgSwitcher && (
 							<div className="min-w-0 flex-1 sm:flex-none">
 								<OrganizationSwitcher
-									currentOrgId={orgSwitcher.currentOrgId}
-									currentTab={orgSwitcher.currentTab}
+									currentOrgId={effectiveOrgSwitcher.currentOrgId}
+									currentTab={effectiveOrgSwitcher.currentTab}
 									orgs={orgs}
 									loading={orgsLoading}
 									error={orgsError}
+									transparent={isTransparent}
 								/>
 							</div>
 						)}

--- a/frontend/src/components/Header/OrganizationSwitcher.a11y.test.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.a11y.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import OrganizationSwitcher from "./OrganizationSwitcher";
+import { renderWithProviders } from "../../test/render";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const ORG_A = "11111111-1111-1111-1111-111111111111";
+const ORG_B = "22222222-2222-2222-2222-222222222222";
+
+const ORGS = [
+	{ id: ORG_A, name: "Freiwillige Feuerwehr Kiel", logoUrl: undefined },
+	{ id: ORG_B, name: "Foerderverein Hamburg", logoUrl: undefined },
+];
+
+function renderSwitcher() {
+	return renderWithProviders(
+		<OrganizationSwitcher
+			currentOrgId={ORG_A}
+			currentTab="dashboard"
+			orgs={ORGS}
+			loading={false}
+			error={null}
+		/>,
+		{ route: `/app/${ORG_A}/dashboard`, auth: { isAuthenticated: true } },
+	);
+}
+
+describe("OrganizationSwitcher a11y", () => {
+	it("has no violations while collapsed", async () => {
+		renderSwitcher();
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations in the error state", async () => {
+		renderWithProviders(
+			<OrganizationSwitcher
+				currentOrgId={ORG_A}
+				currentTab="dashboard"
+				orgs={[]}
+				loading={false}
+				error="Couldn't load your organizations."
+			/>,
+			{ auth: { isAuthenticated: true } },
+		);
+		await expectNoA11yViolations();
+	});
+
+	it("has no violations with the switcher open", async () => {
+		renderSwitcher();
+		await userEvent.click(screen.getByRole("button"));
+		await expectNoA11yViolations();
+	});
+
+	it("names the trigger after the active organization and marks it as current in the list", async () => {
+		renderSwitcher();
+		const trigger = screen.getByRole("button", {
+			name: "Switch organization, currently Freiwillige Feuerwehr Kiel",
+		});
+		expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+		await userEvent.click(trigger);
+		expect(trigger).toHaveAttribute("aria-expanded", "true");
+		expect(screen.queryByRole("menu")).toBeNull();
+		expect(screen.queryByRole("listbox")).toBeNull();
+		expect(screen.getByRole("list")).toHaveAccessibleName(
+			"Switch organization",
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Freiwillige Feuerwehr Kiel" }),
+		).toHaveAttribute("aria-current", "page");
+		expect(
+			screen.getByRole("button", { name: "Foerderverein Hamburg" }),
+		).not.toHaveAttribute("aria-current");
+	});
+});

--- a/frontend/src/components/Header/OrganizationSwitcher.test.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.test.tsx
@@ -38,7 +38,9 @@ function renderSwitcher(currentTab: string) {
 async function openAndPick(currentTab: string, name: string) {
 	renderSwitcher(currentTab);
 	await userEvent.click(
-		screen.getByRole("button", { name: "Switch organization" }),
+		screen.getByRole("button", {
+			name: "Switch organization, currently Freiwillige Feuerwehr Kiel",
+		}),
 	);
 	const list = screen.getByRole("list");
 	await userEvent.click(within(list).getByRole("button", { name }));
@@ -59,5 +61,39 @@ describe("OrganizationSwitcher", () => {
 		expect(await openAndPick("members", "Freiwillige Feuerwehr Kiel")).toBe(
 			`/app/${ORG_A}/dashboard/members`,
 		);
+	});
+
+	it("falls back to the plain trigger label when the organizations failed to load", () => {
+		renderWithProviders(
+			<OrganizationSwitcher
+				currentOrgId={ORG_A}
+				currentTab="dashboard"
+				orgs={[]}
+				loading={false}
+				error="Couldn't load your organizations."
+			/>,
+			{ auth: { isAuthenticated: true } },
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Switch organization" }),
+		).toBeInTheDocument();
+	});
+
+	it("names the trigger after the select placeholder when no organization is resolved yet", () => {
+		renderWithProviders(
+			<OrganizationSwitcher
+				currentOrgId={ORG_A}
+				currentTab="dashboard"
+				orgs={[]}
+				loading={false}
+				error={null}
+			/>,
+			{ auth: { isAuthenticated: true } },
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Select organization" }),
+		).toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/Header/OrganizationSwitcher.tsx
+++ b/frontend/src/components/Header/OrganizationSwitcher.tsx
@@ -23,6 +23,7 @@ export default function OrganizationSwitcher({
 	orgs,
 	loading,
 	error,
+	transparent = false,
 }: {
 	currentOrgId: string;
 	currentTab: string;
@@ -31,6 +32,7 @@ export default function OrganizationSwitcher({
 	loading: boolean;
 
 	error: string | null;
+	transparent?: boolean;
 }) {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
@@ -73,10 +75,20 @@ export default function OrganizationSwitcher({
 					className={`flex w-full min-w-0 items-center gap-2 rounded-xl border px-3 py-1.5 text-sm font-medium transition-colors ${
 						error
 							? "border-red-200 bg-red-50 text-red-700 hover:bg-red-100"
-							: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+							: transparent
+								? "border-white/30 bg-white/10 text-white hover:bg-white/20"
+								: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
 					}`}
 					aria-expanded={open}
-					aria-label={t("organization.switchLabel")}
+					aria-label={
+						error
+							? t("organization.switchLabel")
+							: currentOrg
+								? t("organization.switchLabelCurrent", {
+										name: currentOrg.name,
+									})
+								: t("organization.selectPlaceholder")
+					}
 				>
 					{!error && (
 						<OrgAvatar
@@ -113,13 +125,18 @@ export default function OrganizationSwitcher({
 					</span>
 					<ChevronDownIcon
 						open={open}
-						className={`h-3.5 w-3.5 shrink-0 ${error ? "text-red-400" : "text-gray-400"}`}
+						className={`h-3.5 w-3.5 shrink-0 ${error ? "text-red-400" : transparent ? "text-white/70" : "text-gray-400"}`}
 					/>
 				</button>
 
 				{open && (
-					<div className="absolute top-full left-0 z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white shadow-modal">
-						<ul className="max-h-60 overflow-y-auto py-1">
+					<div
+						className={`absolute top-full left-0 z-50 mt-2 w-64 rounded-lg border shadow-modal ${transparent ? "border-white/20 bg-brand-800" : "border-gray-200 bg-white"}`}
+					>
+						<ul
+							aria-label={t("organization.switchLabel")}
+							className="max-h-60 overflow-y-auto py-1"
+						>
 							{orgs.map((org) => (
 								<li key={org.id}>
 									<button
@@ -127,10 +144,14 @@ export default function OrganizationSwitcher({
 										data-testid="org-switch-row"
 										onClick={() => handleSwitch(org)}
 										aria-current={org.id === currentOrgId ? "page" : undefined}
-										className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${
-											org.id === currentOrgId
-												? "bg-brand-50 font-medium text-brand-700"
-												: "text-gray-700 hover:bg-gray-50"
+										className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+											transparent
+												? org.id === currentOrgId
+													? "bg-white/15 font-medium text-white"
+													: "text-white/80 hover:bg-white/10 hover:text-white"
+												: org.id === currentOrgId
+													? "bg-brand-50 font-medium text-brand-700"
+													: "text-gray-700 hover:bg-gray-50"
 										}`}
 									>
 										<OrgAvatar name={org.name} logoUrl={org.logoUrl} lazy />
@@ -141,14 +162,16 @@ export default function OrganizationSwitcher({
 							))}
 						</ul>
 
-						<div className="border-t border-gray-100">
+						<div
+							className={`border-t ${transparent ? "border-white/20" : "border-gray-100"}`}
+						>
 							<button
 								type="button"
 								onClick={() => {
 									setOpen(false);
 									setShowModal(true);
 								}}
-								className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-brand-700 transition-colors hover:bg-brand-50"
+								className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors ${transparent ? "text-white hover:bg-white/10" : "text-brand-700 hover:bg-brand-50"}`}
 							>
 								<PlusIcon className="h-4 w-4" />
 								{t("organization.create")}

--- a/frontend/src/layouts/OrgAppLayout.test.tsx
+++ b/frontend/src/layouts/OrgAppLayout.test.tsx
@@ -174,7 +174,9 @@ describe("OrgAppLayout shell", () => {
 		renderOrgApp();
 
 		expect(
-			await screen.findByRole("button", { name: "Switch organization" }),
+			await screen.findByRole("button", {
+				name: "Switch organization, currently Freiwillige Feuerwehr Kiel",
+			}),
 		).toBeInTheDocument();
 		const rail = screen.getByRole("navigation", {
 			name: "Organization sections",

--- a/frontend/src/lib/middleTruncateSplit.test.ts
+++ b/frontend/src/lib/middleTruncateSplit.test.ts
@@ -19,6 +19,27 @@ describe("splitForMiddleTruncation", () => {
 		expect(splitForMiddleTruncation("ABCD")).toEqual(["AB", "CD"]);
 	});
 
+	it("falls back to a character midpoint split for a long single-word name with no word boundary", () => {
+		expect(splitForMiddleTruncation("Naturschutzbundesverband")).toEqual([
+			"Naturschutzb",
+			"undesverband",
+		]);
+	});
+
+	it("keeps the last whole word intact as the tail instead of splitting mid-word", () => {
+		expect(
+			splitForMiddleTruncation("Lindenauer Nachbarschaftshilfe e.V."),
+		).toEqual(["Lindenauer Nachbarschaftshilfe", " e.V."]);
+	});
+
+	it("keeps only the final token in the tail, not every word after the midpoint", () => {
+		expect(
+			splitForMiddleTruncation(
+				"Bund fuer Umwelt und Naturschutz Deutschland e.V.",
+			),
+		).toEqual(["Bund fuer Umwelt und Naturschutz Deutschland", " e.V."]);
+	});
+
 	it("keeps the diverging word out of the shared head for two similar org names", () => {
 		const [headA] = splitForMiddleTruncation(
 			"Lindenauer Nachbarschaftshilfe e.V.",

--- a/frontend/src/lib/middleTruncateSplit.ts
+++ b/frontend/src/lib/middleTruncateSplit.ts
@@ -1,4 +1,12 @@
 export function splitForMiddleTruncation(text: string): [string, string] {
-	const headLength = Math.ceil(text.length / 2);
-	return [text.slice(0, headLength), text.slice(headLength)];
+	// Whitespace directly followed by only non-whitespace to the end of the
+	// string can only match the last word boundary - keeping that whole
+	// trailing token (e.g. a legal suffix like "e.V.") intact as the tail
+	// instead of slicing through the middle of it.
+	const lastWordStart = text.search(/\s(?=\S*$)/);
+	if (lastWordStart === -1) {
+		const headLength = Math.ceil(text.length / 2);
+		return [text.slice(0, headLength), text.slice(headLength)];
+	}
+	return [text.slice(0, lastWordStart), text.slice(lastWordStart)];
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -403,6 +403,7 @@
     "organization": {
       "create": "Organisation erstellen",
       "switchLabel": "Organisation wechseln",
+      "switchLabelCurrent": "Organisation wechseln, aktuell {{name}}",
       "selectPlaceholder": "Organisation wählen",
       "loadError": "Deine Organisationen konnten nicht geladen werden.",
       "nameLabel": "Name",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -403,6 +403,7 @@
     "organization": {
       "create": "Create organization",
       "switchLabel": "Switch organization",
+      "switchLabelCurrent": "Switch organization, currently {{name}}",
       "selectPlaceholder": "Select organization",
       "loadError": "Couldn't load your organizations.",
       "nameLabel": "Name",


### PR DESCRIPTION
## What

Fixes three related problems with the header's organization switcher: it truncated names mid-word, never announced the active organization to assistive tech, and only existed inside `/app/:orgId/*`.

## Why

Closes #2226

The organization switcher is the one control whose entire job is to say which organization you're acting on behalf of, but:
1. `splitForMiddleTruncation` split names at a raw character midpoint with no word-boundary awareness, so e.g. "Lindenauer Nachbarschaftshilfe e.V." rendered as "Lin... schaftshilfe e.V." - a broken word, and (since the split halves are separate flex children) broken `innerText`/copy-paste too.
2. The trigger's `aria-label` was a static "Switch organization" with no indication of which org is currently active, so a screen-reader user had no accessible way to tell which org context they were in.
3. An organizer belonging to more than one organization had no way to switch organizations from any public or profile route - the switcher only rendered inside the org app shell.

## Changes

- `middleTruncateSplit.ts`: snaps the split to the last word boundary so the tail is always a whole word/token (e.g. head `"Lindenauer Nachbarschaftshilfe"`, tail `" e.V."`), falling back to the previous character-midpoint split only when a name has no word boundary at all (a single long word).
- `OrganizationSwitcher.tsx`: the trigger's accessible name now names the active organization (`"Switch organization, currently <name>"`, localized), falling back appropriately in the error/no-selection states; the dropdown list now has its own accessible name too, matching the disclosure pattern already used by `LanguageSelector`. The selected option was already marked via `aria-current="page"`.
- `Header.tsx`: the same switcher component now also renders outside `/app/:orgId/*` below the `lg:` breakpoint whenever a signed-in user belongs to more than one organization (previously gated entirely behind the org-app route passing it a prop). Below `lg:`, that pill is the only place the collapsed header offers any org-switching at all (otherwise it's a tap deep in the hamburger menu), so it's worth the space; at `lg:`+ the existing primary-nav "go to my org" link already gives multi-org users an active-org indicator, and there wasn't room for both without pushing the header into horizontal overflow, so the switcher pill yields to it there instead of duplicating it. Added a `transparent` variant to `OrganizationSwitcher` (mirroring `LanguageSelector`'s existing pattern) so it reads correctly on the transparent/overlaid hero-band header state used by several public/profile pages, which it can now appear on.

## Testing

- Added test cases to `middleTruncateSplit.test.ts` pinning the word-boundary split (including the exact org name from the issue) and the single-long-word fallback.
- Added `OrganizationSwitcher.a11y.test.tsx` (axe scans collapsed/open/error states, plus a test asserting the disclosure pattern: labelled list, no `menu`/`listbox` role, accessible name naming the active org).
- Extended `OrganizationSwitcher.test.tsx` for the new accessible-name branches (error / has org / no org resolved yet) and `Header.test.tsx` for the new outside-app multi-org switcher behavior.
- Updated the existing RTL assertions (`OrganizationSwitcher.test.tsx`, `OrgAppLayout.test.tsx`) that queried the trigger by its old static accessible name - the equivalent Playwright visual tests needed no change since Playwright matches accessible names by substring.
- `pnpm check`, `pnpm lint`, `pnpm test` (787 tests), `pnpm format:check`, and `pnpm i18n:check` all pass locally. `VisualTests`/Aspire can't run in this sandbox (no Docker); two rounds of CI feedback on this PR surfaced a real regression (the primary-nav org entry silently disappearing for multi-org users, breaking `MobileMenu_UserWithOrg_ListsEveryOrgSection_AndNavigatesToThem` and a desktop counterpart) and a real layout overflow (the new pill and the existing nav entry both rendering at desktop width) - both fixed and pushed; watching for the next CI run to confirm green.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no docs changes needed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMTrWipPxCRhCxxvkQjv7a)_