### PR TITLE
fix(auth): return signed-in visitors to the page they signed in from

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "./App";
 import { renderWithProviders } from "./test/render";
 
@@ -41,6 +42,33 @@ describe("retired routes", () => {
 		expect(
 			screen.getByRole("link", { name: "Back to home" }),
 		).toBeInTheDocument();
+	});
+});
+
+describe("the callback error retry", () => {
+	it("never sends a successful retry back to the callback route itself", async () => {
+		const signinRedirect = vi.fn().mockResolvedValue(undefined);
+		renderWithProviders(<App />, {
+			route: "/callback",
+			auth: {
+				isAuthenticated: false,
+				error: new Error("token exchange failed"),
+				signinRedirect,
+			},
+		});
+
+		await userEvent.click(
+			await screen.findByRole("button", { name: "Try again" }),
+		);
+
+		expect(signinRedirect).toHaveBeenCalledTimes(1);
+		const args = signinRedirect.mock.calls[0][0] as
+			{ state?: { returnTo?: string } } | undefined;
+		// /callback has no route-away for "authenticated, no error, no code in
+		// the URL" (see App.tsx), so returning here would strand the user on
+		// the completing-signin screen forever - unlike the other signin call
+		// sites, this one must NOT default returnTo to the current location.
+		expect(args?.state?.returnTo).not.toBe("/callback");
 	});
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,6 +87,12 @@ function CallbackPage() {
 				<div className="flex gap-3">
 					<Button
 						variant="secondary"
+						// No returnTo here deliberately: we're on /callback, which is
+						// never a meaningful place to send the user back to - Keycloak
+						// always redirects here regardless of where signin started, and
+						// CallbackPage has no route-away for "authenticated, no error,
+						// no code in the URL", so a successful retry would strand the
+						// user on the completing-signin screen forever (#2223).
 						onClick={() => void auth.signinRedirect(signinLocaleArgs())}
 					>
 						{t("orgApp.retry")}

--- a/frontend/src/lib/authLocale.test.ts
+++ b/frontend/src/lib/authLocale.test.ts
@@ -18,4 +18,16 @@ describe("signinLocaleArgs", () => {
 		i18nMock.language = "de";
 		expect(signinLocaleArgs()).toEqual({ ui_locales: "de" });
 	});
+
+	it("omits state when no return path is given", () => {
+		expect(signinLocaleArgs()).not.toHaveProperty("state.returnTo");
+	});
+
+	it("carries the given return path in state.returnTo", () => {
+		i18nMock.language = "en";
+		expect(signinLocaleArgs("/opportunities/123")).toEqual({
+			ui_locales: "en",
+			state: { returnTo: "/opportunities/123" },
+		});
+	});
 });

--- a/frontend/src/lib/authLocale.ts
+++ b/frontend/src/lib/authLocale.ts
@@ -1,5 +1,11 @@
 import i18n from "../i18n";
 
-export function signinLocaleArgs(): { ui_locales: string } {
-	return { ui_locales: i18n.language };
+export function signinLocaleArgs(returnTo?: string): {
+	ui_locales: string;
+	state?: { returnTo: string };
+} {
+	return {
+		ui_locales: i18n.language,
+		state: returnTo !== undefined ? { returnTo } : undefined,
+	};
 }

--- a/frontend/src/pages/OrganizationProfilePage.test.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Route, Routes } from "react-router";
 import OrganizationProfilePage from "./OrganizationProfilePage";
-import { renderWithProviders } from "../test/render";
+import { renderWithProviders, type TestAuth } from "../test/render";
 
 const { api } = await vi.hoisted(async () => {
 	const { createApiMock } = await import("../test/apiMock");
@@ -23,7 +24,7 @@ beforeEach(() => {
 	});
 });
 
-function renderProfile() {
+function renderProfile(auth?: TestAuth) {
 	return renderWithProviders(
 		<Routes>
 			<Route
@@ -31,7 +32,7 @@ function renderProfile() {
 				element={<OrganizationProfilePage />}
 			/>
 		</Routes>,
-		{ lng: "en", route: `/organizations/${ORGANIZATION_ID}` },
+		{ lng: "en", route: `/organizations/${ORGANIZATION_ID}`, auth },
 	);
 }
 
@@ -43,5 +44,20 @@ describe("OrganizationProfilePage description language", () => {
 			"Wir unterstuetzen Menschen in Leipzig und Umgebung.",
 		);
 		expect(description).toHaveAttribute("lang", "de");
+	});
+});
+
+describe("OrganizationProfilePage anonymous visitor", () => {
+	it("returns the visitor to this organization after signing in from the report action", async () => {
+		const signinRedirect = vi.fn().mockResolvedValue(undefined);
+		renderProfile({ isAuthenticated: false, signinRedirect });
+
+		await userEvent.click(await screen.findByTestId("report-organization"));
+
+		expect(signinRedirect).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: { returnTo: `/organizations/${ORGANIZATION_ID}` },
+			}),
+		);
 	});
 });

--- a/frontend/src/pages/OrganizationProfilePage.tsx
+++ b/frontend/src/pages/OrganizationProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router";
+import { useParams, useLocation } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import type { PublicOrganizationProfileResponse } from "../client/api-client";
@@ -26,6 +26,7 @@ export default function OrganizationProfilePage() {
 	const { organizationId } = useParams<{ organizationId: string }>();
 	const api = useApiClient();
 	const auth = useAuth();
+	const location = useLocation();
 	const { t } = useTranslation();
 
 	const [profile, setProfile] =
@@ -152,7 +153,9 @@ export default function OrganizationProfilePage() {
 						onClick={() =>
 							auth.isAuthenticated
 								? setShowReport(true)
-								: auth.signinRedirect(signinLocaleArgs())
+								: auth.signinRedirect(
+										signinLocaleArgs(location.pathname + location.search),
+									)
 						}
 						data-testid="report-organization"
 						aria-label={t("orgProfile.reportOrganization")}

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
@@ -216,6 +216,32 @@ describe("opportunity detail page anonymous visitor", () => {
 		expect(signIn).toHaveClass("bg-brand-700");
 	});
 
+	it("returns the visitor to this opportunity after signing in from the primary CTA", async () => {
+		const signinRedirect = vi.fn().mockResolvedValue(undefined);
+		renderAs({ isAuthenticated: false, signinRedirect });
+
+		await userEvent.click(await screen.findByTestId("opportunity-signin"));
+
+		expect(signinRedirect).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: { returnTo: `/volunteer-opportunities/${OPPORTUNITY_ID}` },
+			}),
+		);
+	});
+
+	it("returns the visitor to this opportunity after signing in from the report action", async () => {
+		const signinRedirect = vi.fn().mockResolvedValue(undefined);
+		renderAs({ isAuthenticated: false, signinRedirect });
+
+		await userEvent.click(await screen.findByTestId("report-opportunity"));
+
+		expect(signinRedirect).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: { returnTo: `/volunteer-opportunities/${OPPORTUNITY_ID}` },
+			}),
+		);
+	});
+
 	it("still lists the time slots, but none of them as a control", async () => {
 		api.getVolunteerOpportunityDetails.mockResolvedValue(scheduledSlots);
 

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, useLocation } from "react-router";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -153,6 +153,7 @@ function describeHowFact(
 export default function VolunteerOpportunityDetailPage() {
 	const { opportunityId } = useParams<{ opportunityId: string }>();
 	const auth = useAuth();
+	const location = useLocation();
 	const api = useApiClient();
 	const { t, i18n } = useTranslation();
 
@@ -588,7 +589,11 @@ export default function VolunteerOpportunityDetailPage() {
 							{t("opportunities.loginPrompt")}
 						</p>
 						<Button
-							onClick={() => auth.signinRedirect(signinLocaleArgs())}
+							onClick={() =>
+								auth.signinRedirect(
+									signinLocaleArgs(location.pathname + location.search),
+								)
+							}
 							data-testid={`opportunity-signin${testIdSuffix}`}
 							fullWidth
 							size="lg"
@@ -682,7 +687,11 @@ export default function VolunteerOpportunityDetailPage() {
 												onClick={() =>
 													isAuthenticated
 														? setShowReport(true)
-														: auth.signinRedirect(signinLocaleArgs())
+														: auth.signinRedirect(
+																signinLocaleArgs(
+																	location.pathname + location.search,
+																),
+															)
 												}
 												data-testid="report-opportunity"
 												title={t("opportunities.report")}

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -19,6 +19,7 @@ export interface TestAuth {
 	name?: string;
 	email?: string;
 	accessToken?: string;
+	error?: Error;
 
 	signinRedirect?: () => Promise<void>;
 	signoutRedirect?: () => Promise<void>;
@@ -34,6 +35,7 @@ function buildAuthValue(auth: TestAuth): AuthContextProps {
 		name = "Test User",
 		email = "test.user@example.test",
 		accessToken = "test-token",
+		error = undefined,
 		signinRedirect = async () => {},
 		signoutRedirect = async () => {},
 		removeUser = async () => {},
@@ -43,7 +45,7 @@ function buildAuthValue(auth: TestAuth): AuthContextProps {
 		isAuthenticated,
 		isLoading,
 		activeNavigator: undefined,
-		error: undefined,
+		error,
 		settings: {},
 
 		events: {


### PR DESCRIPTION
## What

`signinLocaleArgs()` gains an optional `returnTo` argument, and the two opportunity-detail sign-in/report actions plus the org-profile report action now pass their current location through it, so signing in from any of them returns the visitor to the same page instead of the homepage.

## Why

`main.tsx`'s `onSigninCallback` resolves the post-login target from `user.state.returnTo`, defaulting to `/` when it's missing. `signinLocaleArgs()` only ever returned `{ ui_locales }`, so every call site that relied on it alone silently lost the visitor's place. `Header.tsx`, `ProtectedRoute.tsx`, and `useSessionExpiryHandler.ts` already worked around this by passing `state: { returnTo: ... }` explicitly alongside it - this PR gives `signinLocaleArgs()` the same capability directly, so the remaining call sites don't have to duplicate that shape.

Fixed:
- `VolunteerOpportunityDetailPage.tsx` - the primary "Sign in" CTA on a logged-out visit
- `VolunteerOpportunityDetailPage.tsx` - the report-opportunity action
- `OrganizationProfilePage.tsx` - the report-organization action

The fourth site the issue flags, `App.tsx`'s callback-error "Try again" button, is a deliberate exception rather than a fourth fix: it always runs on `/callback`, which Keycloak's `redirect_uri` points to regardless of where signin started. `CallbackPage` has no route-away for "authenticated, no error, no code in the URL," so defaulting its `returnTo` to the current location (`/callback`) would strand a *successful* retry on the completing-signin screen forever - worse than the current fallback to `/`. This is called out inline in `App.tsx` and pinned down by a regression test in `App.test.tsx`.

Closes #2223

## Testing

- `pnpm check` (tsc), `pnpm lint`, `pnpm format:check`, `pnpm i18n:check`, `pnpm build` - all pass
- `pnpm test` - full suite green (117 files / 835 tests), no regressions
- Added/updated:
  - `src/lib/authLocale.test.ts` - `returnTo` included/omitted from `state` correctly
  - `src/pages/VolunteerOpportunityDetailPage.test.tsx` - clicking the primary sign-in CTA and the report action each call `signinRedirect` with `state.returnTo` set to the current opportunity URL
  - `src/pages/OrganizationProfilePage.test.tsx` - clicking the report action calls `signinRedirect` with `state.returnTo` set to the current organization URL
  - `src/App.test.tsx` - the callback retry button never sets `returnTo` back to `/callback`
  - `src/test/render.tsx` - test harness's `TestAuth` now supports simulating `auth.error`, needed to render `CallbackPage`'s error branch

## Checklist

- [x] Self-review run and findings addressed (no `.claude/agents/self-review` command available in this environment; manually reviewed the diff against its priority table instead - no P1/P2 findings, diff touches no markup so `a11y-check`/`i18n-check` don't apply)
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no user-facing docs describe this flow)


---
_Generated by [Claude Code](https://claude.ai/code/session_0133nmcrC6dmepwUoHtCH2he)_