### PR TITLE
fix: normalize German umlauts and eszett in keyword search

### DIFF
--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -309,13 +309,20 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 		if (!string.IsNullOrWhiteSpace(keyword))
 		{
-			var loweredKeyword = keyword.ToLower();
+			// Folds German umlauts/eszett the way people actually type them on a
+			// phone keyboard ("Muenchen", "Fussball") so a search matches the native
+			// spelling and vice versa (#2221). The fold is repeated inline on every
+			// column instead of factored into a shared method: EF Core translates
+			// ToLower/Replace/Contains calls to SQL individually, but can't look
+			// inside a call to a method of our own to do the same.
+			var normalizedKeyword = FoldGermanText(keyword);
 			query = query.Where(vo =>
-				vo.TitleDe.ToLower().Contains(loweredKeyword) ||
-				(vo.TitleEn != null && vo.TitleEn.ToLower().Contains(loweredKeyword)) ||
-				vo.DescriptionDe.ToLower().Contains(loweredKeyword) ||
-				(vo.DescriptionEn != null && vo.DescriptionEn.ToLower().Contains(loweredKeyword)) ||
-				dbContext.OrganizationsQuery.Any(o => o.Id == vo.OrganizationId && o.Name.ToLower().Contains(loweredKeyword)));
+				vo.TitleDe.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue").Contains(normalizedKeyword) ||
+				(vo.TitleEn != null && vo.TitleEn.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue").Contains(normalizedKeyword)) ||
+				vo.DescriptionDe.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue").Contains(normalizedKeyword) ||
+				(vo.DescriptionEn != null && vo.DescriptionEn.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue").Contains(normalizedKeyword)) ||
+				dbContext.OrganizationsQuery.Any(o => o.Id == vo.OrganizationId &&
+					o.Name.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue").Contains(normalizedKeyword)));
 		}
 
 		if (boundingBox is GeoBoundingBox box)
@@ -327,6 +334,12 @@ internal sealed class VolunteerOpportunityReadRepository(
 
 		return query;
 	}
+
+	// Kept in sync by hand with the inline column fold in ApplyPubliclyListedFilters's
+	// keyword predicate above - EF Core can translate the same ToLower/Replace chain
+	// applied to a column, but not a call to this method itself, so it can't be shared.
+	private static string FoldGermanText(string value) =>
+		value.ToLower().Replace("ß", "ss").Replace("ä", "ae").Replace("ö", "oe").Replace("ü", "ue");
 
 	private static GeoBoundingBox? ResolveBoundingBox(double? centerLatitude, double? centerLongitude, double? radiusKm) =>
 		centerLatitude.HasValue && centerLongitude.HasValue && radiusKm is > 0

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunitiesTests.cs
@@ -705,6 +705,30 @@ public class GetVolunteerOpportunitiesTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task GetVolunteerOpportunities_ShouldFilterByKeyword_NormalizingGermanUmlautsAndEszett(
+		CancellationToken cancellationToken)
+	{
+		var authenticatedClient = await CreateAuthenticatedClientAsync(cancellationToken);
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		await CreateVolunteerOpportunityAsync(
+			authenticatedClient, orgId, "Fußball", "A friendly match in München", cancellationToken);
+
+		var sut = new EinsatzbereitApi(fixture.CreateHttpClient());
+
+		var asciiTranscriptionOfEszett = await sut.GetVolunteerOpportunitiesAsync(1, 10, keyword: "Fussball", cancellationToken: cancellationToken);
+		var asciiTranscriptionOfUmlaut = await sut.GetVolunteerOpportunitiesAsync(1, 10, keyword: "Muenchen", cancellationToken: cancellationToken);
+		var nativeSpelling = await sut.GetVolunteerOpportunitiesAsync(1, 10, keyword: "Fußball", cancellationToken: cancellationToken);
+
+		asciiTranscriptionOfEszett.TotalItems.Should().Be(1);
+		asciiTranscriptionOfEszett.Items.Single().TitleDe.Should().Be("Fußball");
+		asciiTranscriptionOfUmlaut.TotalItems.Should().Be(1);
+		asciiTranscriptionOfUmlaut.Items.Single().TitleDe.Should().Be("Fußball");
+		nativeSpelling.TotalItems.Should().Be(1);
+		nativeSpelling.Items.Single().TitleDe.Should().Be("Fußball");
+	}
+
+	[Test]
 	public async Task GetVolunteerOpportunities_ShouldFilterByRadius_AndOrderResultsByDistanceAscending(
 		CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
## What

The opportunity keyword search now folds the eszett to "ss" and each umlaut (a, o, u with an umlaut) to its two-letter form on both sides of the comparison, so an ASCII transliteration a German user actually types (e.g. on a phone keyboard) matches the native spelling, and vice versa.

## Why

Closes #2221

The keyword predicate in `VolunteerOpportunityReadRepository.ApplyPubliclyListedFilters` only lowercased both sides before comparing, so a title like "Fussball" (native spelling with an eszett) never matched a search for the ASCII transliteration "Fussball" (typed with a plain "ss"), and the umlauted vowels had the same problem. That's a silent zero-results path for a large share of German users, especially on phone keyboards.

The fix chains `.Replace()` calls for the eszett and each umlaut onto the existing `.ToLower().Contains(...)` check, applied identically to `TitleDe`, `TitleEn`, `DescriptionDe`, `DescriptionEn`, `Organization.Name`, and the search term itself. The fold is duplicated inline per column rather than factored into a shared method, because EF Core can only translate calls it recognizes (`ToLower`/`Replace`/`Contains`) into SQL - a call to a method of our own wouldn't translate. No schema or migration change is needed since this only changes how existing columns are compared in a `WHERE` clause (confirmed by a dedicated `ef-migration-check` pass).

I also checked the city/location autocomplete per the issue's note - `GermanCityDirectory`/`GermanCityNameNormalizer` already fold umlauts and the eszett on both the stored city names and the query (already covered by `GermanCityDirectoryTests`'s `SearchByPrefix_AsciiTranscriptionOfAnUmlaut_MatchesTheNativeSpelling` / `SearchByPrefix_EszettTranscribedAsSs_MatchesTheNativeSpelling`), so that path isn't affected by this defect and needed no change.

## Testing

Added `GetVolunteerOpportunities_ShouldFilterByKeyword_NormalizingGermanUmlautsAndEszett` to `GetVolunteerOpportunitiesTests.cs`, covering the exact repro from the issue: a published opportunity titled "Fussball" (native spelling) with "Munchen" in its description is found by searching the ASCII transliteration of each ("Fussball", "Muenchen") as well as the native spelling itself (regression guard).

This integration test needs a real Postgres instance (Aspire/Docker), which isn't available in this sandbox, so I wasn't able to run it or `dotnet build` locally here - egress to the host that serves the .NET SDK installer is blocked by this session's network policy. I reviewed the diff carefully by hand (balanced expressions, existing nullability-narrowing pattern, tab indentation, no stray Unicode dashes) in lieu of compiling, and will watch CI on this PR to confirm the build and the full test suite.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - internal search-matching behavior, no user-facing docs describe the old behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1eKFT8GqAKZspa8cjoZSA)_