### PR TITLE
fix(maps): give the shared memory cache a size limit so it evicts

### DIFF
--- a/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
+++ b/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
@@ -44,7 +44,13 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache c
 					if (!cache.TryGetValue(cacheKey, out Task? existing) || existing is null)
 					{
 						recordTask = RecordLoginSafeAsync(sender, userId, today);
-						cache.Set(cacheKey, recordTask, NextServerMidnight());
+						// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+						// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+						cache.Set(cacheKey, recordTask, new MemoryCacheEntryOptions
+						{
+							Size = 1,
+							AbsoluteExpiration = NextServerMidnight(),
+						});
 					}
 					else
 					{

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -112,6 +112,9 @@
     "LongPublicReadSeconds": 3600,
     "ShortPublicReadSeconds": 60
   },
+  "MemoryCache": {
+    "SizeLimitBytes": 104857600
+  },
   "TrustedNetworks": {
     "Cidrs": [ "127.0.0.0/8", "::1/128", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" ]
   }

--- a/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQueryHandler.cs
+++ b/backend/src/Application/Maps/GeocodeAddress/v1/GeocodeAddressQueryHandler.cs
@@ -25,7 +25,15 @@ internal sealed class GeocodeAddressQueryHandler(
 			address.Street, address.HouseNumber, address.ZipCode, address.City, cancellationToken);
 
 		if (result.Outcome != GeocodingOutcome.TransientFailure)
-			cache.Set(cacheKey, result, CacheDuration);
+		{
+			// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+			// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+			cache.Set(cacheKey, result, new MemoryCacheEntryOptions
+			{
+				Size = 1,
+				AbsoluteExpirationRelativeToNow = CacheDuration,
+			});
+		}
 
 		return result;
 	}

--- a/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
+++ b/backend/src/Application/Maps/SearchCities/v1/SearchCitiesQueryHandler.cs
@@ -26,7 +26,15 @@ internal sealed class SearchCitiesQueryHandler(
 		var results = await geocodingService.SearchCitiesAsync(request.Query, request.Language, cancellationToken);
 
 		if (results.Count > 0)
-			cache.Set(cacheKey, results, CacheDuration);
+		{
+			// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+			// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+			cache.Set(cacheKey, results, new MemoryCacheEntryOptions
+			{
+				Size = 1,
+				AbsoluteExpirationRelativeToNow = CacheDuration,
+			});
+		}
 
 		return results;
 	}

--- a/backend/src/Application/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/v1/GeocodeVolunteerOpportunityAddressHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/v1/GeocodeVolunteerOpportunityAddressHandler.cs
@@ -52,7 +52,15 @@ internal sealed class GeocodeVolunteerOpportunityAddressHandler(
 			}
 
 			if (result.Outcome != GeocodingOutcome.TransientFailure)
-				cache.Set(cacheKey, result, CacheDuration);
+			{
+				// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+				// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+				cache.Set(cacheKey, result, new MemoryCacheEntryOptions
+				{
+					Size = 1,
+					AbsoluteExpirationRelativeToNow = CacheDuration,
+				});
+			}
 		}
 
 		switch (result.Outcome)

--- a/backend/src/Infrastructure/Maps/OpenStreetMapTileService.cs
+++ b/backend/src/Infrastructure/Maps/OpenStreetMapTileService.cs
@@ -38,7 +38,11 @@ internal sealed class OpenStreetMapTileService(
 
 			var content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
 
-			cache.Set(cacheKey, content, TimeSpan.FromMinutes(_options.CacheDurationMinutes));
+			cache.Set(cacheKey, content, new MemoryCacheEntryOptions
+			{
+				Size = content.Length,
+				AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(_options.CacheDurationMinutes),
+			});
 
 			return new MapTile(content, ContentType);
 		}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -144,7 +144,11 @@ public static class ServiceCollectionExtensions
 				.AddStandardResilienceHandler(options => options.Retry.MaxRetryAttempts = 1);
 		}
 
-		services.AddMemoryCache();
+		// SizeLimit makes the shared cache evict under pressure instead of growing without
+		// bound (#2215) - every cache.Set call site across the codebase must supply a Size
+		// once this is set, or MemoryCache.Set throws at runtime.
+		var memoryCacheSizeLimitBytes = configuration.GetValue("MemoryCache:SizeLimitBytes", 100L * 1024 * 1024);
+		services.AddMemoryCache(o => o.SizeLimit = memoryCacheSizeLimitBytes);
 		services.ConfigureOptions<MapTileOptionsSetup>();
 		services.AddHttpClient<IMapTileService, OpenStreetMapTileService>(
 			(sp, client) =>

--- a/backend/tests/Application.UnitTests/Maps/GeocodeAddress/GeocodeAddressQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Maps/GeocodeAddress/GeocodeAddressQueryHandlerTests.cs
@@ -12,7 +12,7 @@ public sealed class GeocodeAddressQueryHandlerTests : IDisposable
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
 
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
-	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = 100 });
 	private readonly GeocodeAddressQueryHandler _sut;
 
 	public GeocodeAddressQueryHandlerTests()

--- a/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Maps/SearchCities/SearchCitiesQueryHandlerTests.cs
@@ -9,7 +9,7 @@ namespace Application.UnitTests.Maps.SearchCities;
 public sealed class SearchCitiesQueryHandlerTests : IDisposable
 {
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
-	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = 100 });
 	private readonly SearchCitiesQueryHandler _sut;
 
 	public SearchCitiesQueryHandlerTests()

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/GeocodeVolunteerOpportunityAddressHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/GeocodeVolunteerOpportunityAddressHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class GeocodeVolunteerOpportunityAddressHandlerTests : IDisposable
 	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 	private readonly IGeocodingService _geocodingService = Substitute.For<IGeocodingService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
-	private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+	private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = 100 });
 	private readonly GeocodeVolunteerOpportunityAddressHandler _sut;
 
 	public GeocodeVolunteerOpportunityAddressHandlerTests()

--- a/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
+++ b/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
@@ -14,7 +14,7 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldRecordLogin_OnFirstRequestForUser()
 	{
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), sender);
 
@@ -25,7 +25,7 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldNotRecordLoginAgain_OnSecondRequestSameDay()
 	{
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -38,7 +38,7 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldNotRecordLoginRepeatedly_WhenXTimezoneHeaderAlternatesAcrossRequests()
 	{
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
 		for (var i = 0; i < 10; i++)
@@ -56,7 +56,7 @@ public class LoginStreakMiddlewareTests
 	{
 		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero));
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -74,7 +74,7 @@ public class LoginStreakMiddlewareTests
 		var nextCallCount = 0;
 		var sut = new LoginStreakMiddleware(
 			_ => { Interlocked.Increment(ref nextCallCount); return Task.CompletedTask; },
-			new MemoryCache(new MemoryCacheOptions()),
+			new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
 			new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
@@ -101,7 +101,7 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldNotCallSender_WhenUserIsNotAuthenticated()
 	{
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var context = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
 
 		await sut.InvokeAsync(context, sender);
@@ -113,7 +113,7 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldAlwaysCallNext()
 	{
 		var nextCalled = false;
-		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, new MemoryCache(new MemoryCacheOptions()), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), new RecordingSender());
 


### PR DESCRIPTION
## What

Bound the shared `IMemoryCache` instance with a `SizeLimit`, and gave every `cache.Set` call site on that instance an explicit entry `Size` - the tile cache uses the tile's real byte length so LRU eviction is driven by actual memory used, closing the unbounded-growth path.

## Why

`OpenStreetMapTileService` wrote fetched map tiles into `IMemoryCache` with a 24h TTL and no `Size`, and the cache was registered with no `SizeLimit`. The tile endpoint is anonymous, so an unauthenticated caller iterating distinct tile coordinates within the rate limit could grow the process's tile bytes without bound for 24 hours, eventually OOM-killing the API container and taking down the whole platform.

Since `IMemoryCache` is a single process-wide instance, setting `SizeLimit` means *every* `cache.Set` call on that instance must supply a `Size` or `MemoryCache.Set` throws at runtime. Grepping for all consumers turned up four other call sites sharing the same cache: the city-search cache, both geocoding caches (direct address geocoding and the volunteer-opportunity geocoding domain-event handler), and the login-streak dedup memo. Each now supplies a nominal `Size` (their payloads are negligible next to a tile's), documented inline so the invariant is clear from any one of the five call sites in isolation.

`SizeLimit` defaults to 100 MB and is configurable via `MemoryCache:SizeLimitBytes` in `appsettings.json`.

**Out of scope:** the issue's suggestion to add a dedicated rate-limiting policy for the tile endpoint is explicitly tied to #2208 and left for that issue.

Closes #2215

## Testing

- The existing unit tests for the three Application-layer cache consumers (`SearchCitiesQueryHandlerTests`, `GeocodeAddressQueryHandlerTests`, `GeocodeVolunteerOpportunityAddressHandlerTests`) and the `LoginStreakMiddlewareTests` integration tests now construct their `MemoryCache` fixtures with a `SizeLimit` set too, so they exercise the exact invariant the production code now depends on - if a future change ever drops `Size` from one of these calls, these tests fail immediately instead of only surfacing as a production incident.
- **Could not run `dotnet build` or the test suite in this session**: the sandbox's egress policy denies `builds.dotnet.microsoft.com` (used by the official `.NET` SDK installer), so the pinned SDK (`backend/global.json`, `10.0.400`) could not be installed. I verified the change by careful manual review instead: exhaustive grep confirmed all five `IMemoryCache` consumers/`cache.Set` call sites in the codebase are updated, no others exist (no `GetOrCreate`/`CreateEntry` usage either); indentation/brace/trailing-comma style was cross-checked byte-for-byte against existing patterns in each touched file; `appsettings.json` validated as well-formed; diff checked for stray Unicode dashes and trailing whitespace. CI's `dotnet.yml` ran on the PR and is green (see below).
- Did not add a new automated test exercising real LRU eviction against `OpenStreetMapTileService` itself under `SizeLimit` pressure: it's Infrastructure-layer code with a live HTTP dependency on the OSM tile server, this repo has no unit-test project for `Infrastructure`, and there's no existing HTTP-stub pattern for that upstream - adding one felt like scope creep beyond this fix.
- `visual-tests (2)` failed once on an unrelated test (`OrgDashboardCalendarFootprintTests.AgendaView_AtMobileWidth_ShowsAScrollAffordance_ForTheClippedTable`, a CSS opacity-transition timing assertion in the org-dashboard calendar - unrelated to this diff, and `main` at this PR's base commit passed the same suite in full). Re-ran it once per the standing-down comment below and it passed, confirming the flake.

## Checklist

- [x] `/self-review` run and findings addressed (performed manually against the skill's priority table, since none of its domain-specific subagent triggers - nswag/EF/architecture/a11y/i18n - apply to this diff; the one finding, test fixtures not guarding the new "every Set needs a Size" invariant, is fixed in this PR)
- [x] CI is green (all 13 checks passing on the current head; see note above about the one flake re-run)
- [ ] Documentation updated if this change affects behavior - not applicable; no user-facing or architecture doc describes the previous unbounded-cache behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdU9vLzvYXBuys3HRHH3F9)_