### PR TITLE
docs: fix six architecture-doc drifts from the 1.0 readiness analysis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ dotnet build
 ### Frontend (TypeScript)
 - Named exports preferred over default exports
 - Explicit return types on functions
-- Feature folders mirroring the backend structure
+- Cut by artifact kind, not by feature - the opposite of the backend: pages, components, hooks and helpers live in their own top-level folders (`pages/`, `components/`, `hooks/`, `lib/`) and are shared across domains; see chapter 5 of the arc42 docs
 
 ### General
 - Comments explain *why*, not *what*

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The app itself is served in German by default, since Einsatzbereit's primary aud
 - **Organizations post opportunities** with scheduled time slots (occurrences) and defined participation types.
 - **Organizer dashboard** with a customizable widget layout: upcoming opportunities, calendar, to-do list, quick check-in, and a create-opportunity shortcut.
 - **Organization management** covering membership, roles, a public directory of organizations, and multi-organization support with an org switcher.
-- **Platform administration** to verify organizations, manage users, and toggle admin/enabled status.
+- **Platform administration** to manage users and toggle admin/enabled status.
 - **Notifications and a language selector** (German by default, English as a secondary language).
 - **Keycloak-backed authentication** via OIDC/PKCE, with Keycloak Organizations powering org membership.
 - **Achievements and badges** awarded for volunteering milestones, shown on the profile.
@@ -108,9 +108,9 @@ The Aspire AppHost provisions PostgreSQL, Keycloak, the backend API, and the Vit
 |---|---|---|
 | Frontend | http://localhost:4321 | - |
 | Backend API | *dynamic port - see the Aspire dashboard* | - |
-| Keycloak | http://localhost:8080 | admin / admin |
-| pgAdmin | http://localhost:5050 | admin@admin.com / admin |
-| PostgreSQL | localhost:5432 | postgres / postgres |
+| Keycloak | http://localhost:8080 | - (no master-realm admin console login is bootstrapped locally; sign in to the app itself with a test user below) |
+| pgAdmin | http://localhost:5050 | - (opens straight to the dashboard, no login prompt) |
+| PostgreSQL | localhost:5432 | postgres / *auto-generated per run - see the `postgres` resource in the Aspire dashboard* |
 | Mailpit | http://localhost:1080 | - (no auth, captures outgoing email) |
 
 ### Test users

--- a/docs/ADRs/4_geocoding_and_geo_search.adoc
+++ b/docs/ADRs/4_geocoding_and_geo_search.adoc
@@ -14,12 +14,17 @@ depends on those persisted coordinates. We need to decide where geocoding
 runs and how spatial filtering is implemented in PostgreSQL.
 
 === Decision
-Geocode addresses synchronously in the `CreateVolunteerOpportunity` /
-`UpdateVolunteerOpportunity` application command handlers via an
-`IGeocodingService` abstraction backed by OpenStreetMap Nominatim, and persist
-the coordinates on the `Address` value object. Reads never geocode. Spatial
-filtering uses a SQL bounding-box prefilter plus an in-memory Haversine
-refinement for radius queries. We do not adopt PostGIS.
+Geocode addresses in the `CreateVolunteerOpportunity` / `UpdateVolunteerOpportunity`
+application command handlers via an `IGeocodingService` abstraction backed by
+OpenStreetMap Nominatim, and persist the coordinates on the `Address` value
+object. Reads never geocode. Spatial filtering uses a SQL bounding-box
+prefilter plus an in-memory Haversine refinement for radius queries. We do not
+adopt PostGIS.
+
+[NOTE]
+====
+*How geocoding is triggered changed after this ADR was accepted - see the Amendment section at the end of this record.* The command handlers no longer call `IGeocodingService` synchronously; they raise a domain event handled asynchronously. The rest of this Decision (write-time only, no PostGIS, bbox + Haversine for search) is still accurate.
+====
 
 === Rationale
 * Geocoding once at write time keeps reads fast and deterministic, and avoids hammering Nominatim on every list request.
@@ -58,7 +63,17 @@ Raise `OpportunityCreated`, handle it asynchronously, update coordinates later.
 ** Eventual consistency for pin visibility complicates the UX
 ** Extra moving parts (outbox / worker) not warranted yet
 
+NOTE: Adopted after all, on 2026-08-18 - see the Amendment section at the end of this record. The "extra moving parts" already existed by then (the outbox shipped for #828); the eventual-consistency window this ADR worried about turned out to be the outbox's own poll interval (seconds), not something worth rejecting the alternative over.
+
 === Consequences
-* On-site opportunities created or updated while Nominatim is unreachable are persisted with null coordinates; they appear in the list but not on the map until a subsequent update succeeds.
-* Geocoding adds a per-request latency of up to one second plus network round-trip on create/update; acceptable for a low-write workload.
+* On-site opportunities created or updated while Nominatim is unreachable are persisted with null coordinates; they appear in the list but not on the map until `GeocodeVolunteerOpportunityAddressHandler` or `GeocodingRetryJob` fills them in - see the Amendment below; this is no longer conditioned on the organizer making a subsequent edit.
+* Geocoding no longer adds request latency to create/update - see the Amendment below.
 * If the platform scales or expands beyond Germany, or dense geographic filtering becomes a hotspot, record the scaling risk as a TDR and, if triggered, capture the PostGIS adoption in a new ADR that supersedes this one.
+
+=== Amendment (2026-08-18): Geocoding Moved to an Async Domain-Event Handler
+
+The Decision above no longer matches shipped code. `CreateVolunteerOpportunityCommandHandler` and `UpdateVolunteerOpportunityCommandHandler` (via `VolunteerOpportunity.Create` / `.Relocate`) do not call `IGeocodingService` at all; they raise `VolunteerOpportunityGeocodingRequestedDomainEvent`, which the transactional outbox (ADR-adjacent to #828) dispatches to `GeocodeVolunteerOpportunityAddressHandler` (`Application/VolunteerOpportunities/GeocodeVolunteerOpportunityAddress/v1/`) - normally within the outbox's own poll interval (5 seconds by default, `Outbox:PollIntervalSeconds`), not synchronously inside the write request. That handler calls `IGeocodingService.GeocodeAsync`, caches a non-transient result for 24h keyed on the address, and applies it via `VolunteerOpportunity.ApplyGeocodingResult(...)` on success or `MarkAddressGeocodingFailed()` on a definitive `NotFound`.
+
+A separate `GeocodingRetryJob` (`Infrastructure/BackgroundJobs/GeocodingRetryJob.cs`) backstops the one case the handler above leaves unresolved: a `TransientFailure` outcome (Nominatim unreachable or throttled at that moment), which the handler logs and otherwise ignores rather than retrying inline. `GeocodingRetryJob` is an `IHostedService` on a `PeriodicTimer` firing every hour; each tick it re-queries every `VolunteerOpportunity` with `Address.Latitude == null && !AddressGeocodingFailed && !IsRemote` and retries `IGeocodingService.GeocodeAsync` for each, applying the same `ApplyGeocodingResult` / `MarkAddressGeocodingFailed` outcomes. It shares `NominatimGeocodingService`'s process-wide throttle with every other Nominatim caller (ADR-5).
+
+Net effect on this ADR's own reasoning: the "Domain event + background geocoder" alternative in Considered Alternatives was adopted, not rejected. Its "eventual consistency complicates the UX" con did not materialize as feared, because the common path still resolves in the outbox's single-digit-second poll interval; only a Nominatim outage or rate-limit hit waits on the hourly retry job. Its "extra moving parts" con was already paid for by the outbox existing for other domain events. Write-time-only geocoding, no PostGIS, and the bbox-plus-Haversine search strategy are all unaffected and remain this ADR's decision.

--- a/docs/ADRs/7_repository_scope_stops_at_image_publishing.adoc
+++ b/docs/ADRs/7_repository_scope_stops_at_image_publishing.adoc
@@ -1,0 +1,50 @@
+== 7. Repository Scope Stops at Image Publishing
+
+=== Status
+Accepted
+
+=== Date
+2026-08-22
+
+=== Context
+Through 2026-08 this repository owned not just building the app but deploying and operating it: `docker-compose.yml` defined a shared staging/production host (TDR-3) running a Prometheus/Grafana/Loki/Tempo observability stack (ADR-6), `publish.yml` had `deploy-staging`/`deploy-production` jobs targeting that host, and `reset-staging.yml` could wipe its data. TDR-3's own 2026-08-21 update already recorded a first step away from that: the `deploy-staging`/`deploy-production` jobs had moved, largely unchanged, into a separate `mgmt-hetzner` repository's `deploy-einsatzbereit.yaml`, triggered by hand rather than automatically from this repo's `publish.yml`, specifically so no deploy credential needed to flow into `mgmt-hetzner` from here. Issue #2165 completed that separation the following day.
+
+=== Decision
+This repository's scope stops at `publish.yml` pushing versioned images to GitHub Container Registry (see chapter 7's "Image Publishing"). It does not describe, configure, or drive a deployed environment. Concretely, #2165:
+
+* Rewrote `07_deployment_view.adoc` to cover only the local Aspire stack and a generic deployed runtime (the three released images plus the PostgreSQL, S3 and SMTP services they consume) - no host, domain, reverse proxy, monitoring stack, backup sidecar, network segmentation, or staging/production split.
+* Deleted `reset-staging.yml`; stopped `publish.yml` tagging release-candidate images `staging` or baking a specific host's origins into the frontend image.
+* Removed the Prometheus exporter, the second metrics-port Kestrel listener and the `/metrics` scraping endpoint from the backend - they existed only to feed the now-external Prometheus. OTLP export itself stays, since it is inert until `OTEL_EXPORTER_OTLP_ENDPOINT` is set and costs nothing to leave wired up.
+* Deleted ADR-6 (Grafana Tempo tracing) and TDR-3 (shared staging/production host) outright rather than marking them superseded. That omission is corrected by this record: both are restored - ADR-6 as ADR-8 (its original number was reused before the omission was caught), TDR-3 at its original number - marked superseded/resolved by this ADR rather than left deleted.
+
+=== Rationale
+* Whoever runs the images decides how and where (their own infrastructure, a different cloud, a home lab); this repository does not need to encode one operator's choices as if they were the application's architecture.
+* Each released image is already configured entirely through environment variables at container start (see `keycloak/README.md` for that image's variables; the backend and frontend images follow the same pattern) - the images are self-describing, so a deploying operator does not need this repository's docs to run them.
+* Narrows what a contributor needs to reason about: this is a monorepo for one application shipped as three images, not also an infrastructure repository for one specific operator's host.
+* The deleted observability stack and shared host were specific to that one operator's deployment (a Hetzner box also running unrelated services), not properties of the application itself - unlike the backend's own OTLP export, which is generic and stays.
+
+=== Considered Alternatives
+
+==== Keep deployment in this repository, documented as one optional example
+Leave `docker-compose.yml`, the observability stack and the `deploy-*` jobs in place, framed as "one possible way to run this" rather than removed.
+
+* Pros
+** No information lost; a deploy-focused example stays available to anyone forking the project
+** No ADR-6/TDR-3 supersession bookkeeping needed
+* Cons
+** The docs (chapter 7, ADR-6, TDR-3, and the staging/observability references then still scattered across chapters 2-5, 8, 9, 11, 12) keep describing one specific operator's infrastructure as if it were part of the application's own architecture - exactly the kind of drift this ADR exists to stop
+** CI (`reset-staging.yml`, the `deploy-*` jobs) keeps depending on secrets and a host that belong to one operator, not the project, which is confusing for a fork or a new contributor reading `publish.yml`
+
+==== Move deployment out, but leave ADR-6/TDR-3 unedited as historical record
+Delete the docker-compose/CI/backend pieces but leave the two records exactly as originally accepted, without a status change.
+
+* Pros
+** Simplest possible edit
+* Cons
+** An ADR with `Status: Accepted` describing a Tempo container that no longer exists anywhere in this repository is actively misleading rather than merely stale - arc42's own convention is that a superseded decision is marked as such, not left to read as current
+
+=== Consequences
+* Chapter 7 (Deployment View) now documents only what this repository actually produces and controls: two runtime shapes (local Aspire, and a generic "the three images plus their consumed services") and the CI/CD pipeline that builds and publishes them.
+* Nothing in this repository can be used to stand up a real deployment end-to-end any more - that capability now lives entirely in the private `mgmt-hetzner` repository. That is the intended outcome (see Rationale), but it means this repository alone no longer answers "how is this hosted."
+* ADR-6 and TDR-3 are restored (as ADR-8 and TDR-3 respectively), marked Superseded/Resolved by this ADR instead of left deleted, so the reasoning behind both the original tracing/hosting decisions and this reversal stays in the record, per arc42's convention for superseded decisions.
+* Observability beyond what the local Aspire dashboard shows (traces, metrics, log aggregation) is now entirely the deploying operator's responsibility; this repository's contribution is limited to emitting OTLP when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, per <<section-concepts>>.

--- a/docs/ADRs/8_distributed_tracing_via_tempo.adoc
+++ b/docs/ADRs/8_distributed_tracing_via_tempo.adoc
@@ -1,0 +1,70 @@
+== 8. Distributed Tracing via Grafana Tempo
+
+=== Status
+Superseded by ADR-7 (2026-08-22)
+
+=== Date
+2026-07-29
+
+[NOTE]
+====
+*Restored 2026-08-26 (issue #2214).* This record was originally filed and accepted as ADR-6 on 2026-07-29. Issue #2165 (2026-08-22) deleted it outright when deployment, staging and observability moved out of this repository's scope, instead of marking it superseded - the arc42 convention this repository otherwise follows. By the time that omission was caught, a later and unrelated decision (light-only theme) had already been accepted as the new ADR-6, so this record is restored under a new number, ADR-8, rather than reclaiming its original one. Everything below is otherwise unchanged from the original 2026-07-29 acceptance; see ADR-7 for why it no longer applies.
+====
+
+=== Context
+Issue #1352 (filed from the 2026-07-25 1.0 readiness audit) found that `Microsoft.AspNetCore: Warning` in `appsettings.json`'s `LogLevel` map was the longest matching prefix for the `Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware` category, so `Program.cs`'s `AddHttpLogging`/`UseHttpLogging` calls produced no output in any deployed environment - the middleware ran, but every Information-level entry it emitted was filtered out before reaching a provider. The same audit noted that `ServiceDefaults/Extensions.cs`'s `AddOpenTelemetryExporters` only calls `UseOtlpExporter()` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, which `docker-compose.yml` never did, so distributed traces were never exported anywhere in staging/production - `08_concepts.adoc` had documented this as "any OTLP-compatible backend in production when `OTEL_EXPORTER_OTLP_ENDPOINT` is set", but no such backend was ever deployed to receive it.
+
+Metrics were not actually broken - `AddPrometheusExporter` plus the existing `prometheus`/`grafana` services already give a working metrics pipeline - and container stdout was already shipped to Loki via Alloy (ADR-adjacent addition, #1341-era). The gap was specifically: (1) HTTP request logs suppressed by log level, and (2) no destination at all for OTLP traces.
+
+=== Decision
+Add `"Microsoft.AspNetCore.HttpLogging": "Information"` to `Api/appsettings.json`'s `LogLevel` map, restoring HTTP request logs (they now reach stdout and, from there, Loki via the existing Alloy pipeline) without re-enabling the framework-noise categories `Microsoft.AspNetCore: Warning` was set to suppress.
+
+Add a `tempo` service (`grafana/tempo`, single-binary mode, local-disk storage, 48h block retention) to `docker-compose.yml`, on the same internal-only `monitoring` network as Prometheus/Loki, and point the backend's `OTEL_EXPORTER_OTLP_ENDPOINT` at it (`http://tempo:4317`, gRPC - the OTLP exporter's default protocol, so no separate `OTEL_EXPORTER_OTLP_PROTOCOL` override is needed). Add Tempo as a third Grafana datasource alongside Prometheus and Loki, so traces are queryable (TraceQL) from the same dashboard as metrics and logs.
+
+=== Rationale
+* The log-level fix is a one-line, zero-risk config change: it only widens what already-written, already-wired-up middleware is allowed to emit, and only for its own category.
+* Grafana, Prometheus, and Loki are already deployed and already the operational home for this app's metrics and logs; adding Tempo alongside them keeps all three observability signals in one place instead of introducing a second dashboard/vendor for traces only.
+* Tempo's single-binary mode (no separate ingester/querier/compactor processes) matches how Loki is already run in this stack - proportionate to this project's own trace volume, and consistent with the "self-hosting over SaaS" trade-off already made for the rest of the monitoring stack.
+* The backend already emits OTLP traces unconditionally (`ConfigureOpenTelemetry`'s `WithTracing(...)`); `AddOpenTelemetryExporters` already gates the exporter itself behind `OTEL_EXPORTER_OTLP_ENDPOINT` being set, so wiring this up is purely a `docker-compose.yml`/deployment change - no application code changes.
+* Pushing traces directly from the backend to Tempo over OTLP (rather than via a shipper, the way Alloy fronts Loki) needs no extra component: the backend already speaks OTLP natively, unlike its logs, which only reach Loki because Alloy tails container stdout.
+
+=== Considered Alternatives
+
+==== Log-level fix only, defer tracing
+Ship `"Microsoft.AspNetCore.HttpLogging": "Information"` and leave `OTEL_EXPORTER_OTLP_ENDPOINT` unset, as originally scoped for this "Minor" severity issue.
+
+* Pros
+** Smallest possible change; no new container, volume, or resource budget on a memory-constrained (4GB) staging VM
+** Matches the issue's own severity label and `08_concepts.adoc`'s previously-documented "not wired in by default" trade-off
+* Cons
+** Leaves distributed tracing permanently unusable in every deployed environment - the OTLP exporter code path exists and is unconditionally configured, but has nowhere to send data
+** A production incident spanning multiple services (backend -> Keycloak, backend -> Postgres) still has to be diagnosed from logs and metrics alone, with no request-scoped trace to tie them together
+
+==== Jaeger instead of Tempo
+Use Jaeger as the OTLP trace collector/store instead of Tempo.
+
+* Pros
+** Also a well-established, purpose-built distributed tracing backend with native OTLP support
+* Cons
+** Would be the only non-Grafana-family component in a monitoring stack otherwise entirely built on Prometheus/Loki/Grafana/Alloy, needing its own UI, its own datasource plugin for Grafana (extra config, worse integration than Tempo's first-party Grafana datasource), and its own storage/retention story to reason about
+** No material capability advantage for this project's scale that would justify the inconsistency
+
+==== Third-party observability SaaS (Grafana Cloud, Honeycomb, Datadog, etc.)
+Point `OTEL_EXPORTER_OTLP_ENDPOINT` at a hosted vendor instead of self-hosting a collector.
+
+* Pros
+** No new container to operate; vendor handles storage, retention, and scaling
+* Cons
+** Recurring cost and a new data-processing relationship with a third party, for a project whose staging environment is explicitly disposable demo/QA infrastructure (see root `AGENTS.md`)
+** Contradicts the "no third-party observability SaaS" trade-off `08_concepts.adoc` had already documented for metrics and logs; a self-hosted option (Tempo) achieves the same goal without reversing it
+
+=== Consequences
+* Tempo adds one more container to the staging host's resource budget (160m memory / 0.25 CPU limit, matching Loki's sizing) and one more named Docker volume (`tempo_data`) with a fixed 48h trace retention - old traces are not kept indefinitely, unlike metrics (Prometheus) or logs (Loki), which currently have no equivalent explicit retention cap.
+* Unlike Loki (fed by Alloy, which discovers and ships *any* container's stdout), Tempo only ever receives what the backend itself pushes over OTLP - if another service in this stack needs distributed tracing later, it must be wired up individually, there is no shared shipper for traces the way Alloy is for logs.
+* No Docker healthcheck is defined for the `tempo` service, since (unlike Loki, confirmed lacking wget/shell on staging) whether the `grafana/tempo` image ships either has not been verified; nothing currently depends on it via `condition: service_healthy`, so this does not block or gate any other service's startup.
+* `08_concepts.adoc`'s Logging and Observability section and `07_deployment_view.adoc`'s service table/diagram were updated to describe Tempo as the actual OTLP destination, replacing the previous "any OTLP-compatible backend... when set" phrasing that described a code path with nothing behind it.
+
+[NOTE]
+====
+*Mooted 2026-08-22 (ADR-7).* Every artifact this record's Decision and Consequences describe - `docker-compose.yml`, the `tempo` service, the staging host's Grafana/Prometheus/Loki stack - was removed when this repository stopped describing or driving any deployed environment. Whether a deployed instance of this application has distributed tracing today is a question for whichever repository now owns its deployment, not this one.
+====

--- a/docs/Architecture/src/03_context_and_scope.adoc
+++ b/docs/Architecture/src/03_context_and_scope.adoc
@@ -64,7 +64,11 @@ include::../images/technical-context.puml[]
 
 |Backend → Nominatim (OpenStreetMap)
 |Outbound
-|The backend geocodes opportunity addresses via the public OpenStreetMap Nominatim service, throttled to about one request per second. The frontend additionally calls it for city autocomplete and loads OSM map tiles. See ADR-4.
+|The backend geocodes opportunity addresses via the public OpenStreetMap Nominatim service at write time (see ADR-4), and proxies the frontend's city-autocomplete search requests to the same service (`GET /v1/maps/cities`). Both share one throttle of about one request per second. Nominatim never sees the visitor - only the backend's IP address - because the frontend calls the backend, not Nominatim, directly. See ADR-5.
+
+|Backend → OpenStreetMap tile server
+|Outbound
+|The backend proxies map tile requests (`GET /v1/maps/tiles/{zoom}/{x}/{y}.png`) to `tile.openstreetmap.org` and caches fetched tiles in-process for 24h. The frontend loads tiles from the backend, never from OpenStreetMap directly, so visitor IP addresses are not exposed to it. See ADR-5.
 
 |Backend → SMTP mail server
 |Outbound

--- a/docs/Architecture/src/07_deployment_view.adoc
+++ b/docs/Architecture/src/07_deployment_view.adoc
@@ -116,7 +116,10 @@ Container images are the release artifacts, pulled by tag from GHCR. The backend
 |Outbound notification and reminder email
 
 |OpenStreetMap Nominatim
-|Address geocoding, called from both the backend and the frontend (ADR-4)
+|Address geocoding at write time and city-autocomplete search, both proxied through the backend so the frontend never calls it directly (ADR-4, ADR-5)
+
+|OpenStreetMap tile server
+|Map tiles, proxied through the backend and cached in-process for 24h so the frontend never calls it directly (ADR-5)
 |===
 
 ==== CI/CD Pipeline

--- a/docs/Architecture/src/09_architecture_decisions.adoc
+++ b/docs/Architecture/src/09_architecture_decisions.adoc
@@ -52,6 +52,20 @@ The following table lists the relevant architecture decisions. Each decision lin
 |2026-08-25
 |link:ADRs/6_light_only_theme.html[Light-only theme]
 
+|7
+|Repository scope
+|Stop this repository's scope at building and publishing container images; deployment, staging/production and observability now live in a separate private repository.
+|Accepted
+|2026-08-22
+|link:ADRs/7_repository_scope_stops_at_image_publishing.html[Repository scope]
+
+|8
+|Distributed tracing (historical)
+|Add Grafana Tempo tracing to the (since-removed) deployed observability stack. Originally ADR-6; restored 2026-08-26 after being deleted instead of superseded - see ADR-7.
+|Superseded by ADR-7
+|2026-07-29
+|link:ADRs/8_distributed_tracing_via_tempo.html[Distributed tracing]
+
 |===
 
 See <<section-solution-strategy>> for how the key decisions map to the quality goals.

--- a/docs/Architecture/src/11_technical_risks.adoc
+++ b/docs/Architecture/src/11_technical_risks.adoc
@@ -20,10 +20,18 @@ The following table lists the relevant risks and technical debts. Each risk or t
 
 |2
 |CI Pipeline Performance
-|Steadily growing backend CI pipeline dominated by end-to-end tests; critical path cut from ~10 min to ~6 min by splitting into parallel jobs (#773), full resolution still pending.
-|Low-Medium
+|Steadily growing backend CI pipeline dominated by end-to-end tests; a 2026-08-20 re-measurement found a 21 min 58 s median wall-clock and a 36.4% completion rate (53% of `visual-tests` runs failing). Sharding `visual-tests` across four jobs (#2145) and rebalancing the test pyramid (#2148) since cut wall-clock back to roughly 7-10 min, but severity stays High until the failure rate is confirmed back under 20% - runtime was only ever half of what made this debt expensive.
+|High
 |In Progress
-|2026-07-18
+|2026-08-20
 |link:TDRs/2_slow_ci_pipeline.html[Slow CI Pipeline]
+
+|3
+|Shared Staging/Production Host
+|Staging and production shared one host with no isolation between a release-candidate deploy and real traffic. Overtaken by #2165 (ADR-7) moving all deployment out of this repository's scope entirely, so the underlying risk is no longer this repository's to track.
+|Medium
+|Resolved
+|2026-08-22
+|link:TDRs/3_shared_staging_production_host.html[Shared Staging/Production Host]
 
 |===

--- a/docs/TDRs/3_shared_staging_production_host.adoc
+++ b/docs/TDRs/3_shared_staging_production_host.adoc
@@ -1,0 +1,69 @@
+== 3. Shared Staging/Production Host
+
+- *Author:* @maik-hasler
+- *Version:* v1.0.0 (pre-release)
+- *Date:* 2026-08-03
+- *Status:* Resolved (out of this repository's scope - see Resolution below)
+
+[NOTE]
+====
+*Restored 2026-08-26 (issue #2214).* This record was deleted outright by issue #2165 (2026-08-22) when deployment, staging and observability moved out of this repository's scope, instead of being marked resolved - the arc42 convention this repository otherwise follows for a record that no longer applies. Its original content, through the 2026-08-21 "deploy ownership moved to mgmt-hetzner" update below, is unchanged; the Resolution section at the end is new.
+====
+
+=== Description
+
+Einsatzbereit has exactly one deployed host (`einsatzbereit.maik-hasler.de` and its `*.maik-hasler.de` siblings), and it is deliberately staging/demo infrastructure rather than a hardened production box - shared `vera`/`olaf`/`admin` test credentials with full admin access are intentionally public on it (see root `AGENTS.md`'s Test Users note). There is no second, separate production host.
+
+Before issue #1344, `publish.yml` only had a `deploy-staging` job, gated on release-candidate tags. A stable (non-RC) tag published images to GHCR and moved the `latest` tag, but nothing ever deployed them - the architecture docs claimed deployment was "release-driven" for both staging and production, which was not true for stable tags.
+
+=== Links
+
+- Resolves the deploy gap from issue #1344.
+- ADR-3 (Keycloak): the shared realm/test-credential model this TDR's host-sharing builds on.
+
+=== Impact
+
+==== Technical Impact
+
+- *Environment separation:* Staging and production share compute, database, and object storage. A bad RC deploy and a bad stable deploy are both one `docker compose up -d` away from affecting the same running site - there is no isolation between "testing a release candidate" and "serving real traffic." Unchanged by the capacity upgrade below - a bigger box is still one box.
+- *Blast radius:* `reset-staging.yml`'s destructive Postgres/MinIO wipe, if ever run after real users exist, would delete real data, not just demo data - the workflow's current framing ("wipes staging test data") assumes no real production data has accumulated yet.
+- *Capacity (updated 2026-08-05):* Moved to a Hetzner `cx43` (8 vCPU / 16 GB RAM / 40 GB disk - see `docs/Architecture/src/07_deployment_view.adoc`), well above the smaller box this stack had outgrown - the observability stack's (Prometheus/Grafana/Loki/Tempo/Alertmanager) resource limits, previously trimmed down for a memory-constrained box, have been removed now that headroom is no longer a concern. The host is now managed via Terraform (a separate, private infrastructure repository, brought in via `terraform import` rather than hand-clicked), and also runs Blogfolio and Traefik on the same box. The environment-separation and blast-radius concerns above are unchanged.
+
+==== Business Impact
+
+- *Cost:* A second host is an ongoing hosting cost the project does not yet carry; deferring it keeps the project's infrastructure spend at its current (minimal) level while pre-1.0.
+- *Risk exposure:* Once the site carries real user data, an RC deploy problem (bad migration, crash-looping container) directly risks that data, not just disposable demo state.
+
+=== Symptoms
+
+- *Docs/reality mismatch (pre-#1344):* `07_deployment_view.adoc` described a single release-driven deployment path; the actual `publish.yml` silently skipped deployment for stable tags.
+- *Naming mismatch:* A GitHub Environment and job named `production` currently target the same secrets/host as `staging` - anyone reading the workflow in isolation could assume a real second environment exists.
+
+=== Severity
+
+Medium, rising to High once the project is generally available and carries real user data (issue #1344's report was filed pre-1.0, before any stable tag existed).
+
+=== Proposed Solution
+
+- *Short term (implemented, #1344):* Split `deploy-staging`/`deploy-production` into separate jobs and GitHub Environments now, both currently pointed at the one existing host, so the *workflow* shape doesn't need to change again later - only the `production` Environment's secrets need to change once a real second host exists.
+- *Medium term:* Before or shortly after a real stable v1.0.0 release accumulates real user data, provision a genuinely separate production host (or at minimum, separate its database/object storage from staging's), and repoint mgmt-hetzner's `einsatzbereit-production` GitHub Environment secrets at it (see the "Update" note below for where this now lives).
+- *Longer term:* Reassess whether `reset-staging.yml`'s destructive reset should remain scoped to a shared host once staging and production diverge, and whether staging needs its own smaller, cheaper host once production is real.
+
+=== Consequences of Delay
+
+Acceptable pre-1.0: no stable tag has been cut yet, so no real user data exists on the host to put at risk. Once a stable release genuinely goes out to real users, delaying the host split further means every subsequent RC deploy (testing the *next* release) runs directly against production data, with no isolation and no cheap way to test destructively.
+
+=== Dependencies
+
+- *Hosting budget/capacity:* A second host requires the repo owner to provision and pay for it - not something achievable from within the repository alone.
+- *GitHub Environment secrets:* the SSH/app secrets for reaching the new host need to be updated when it exists. As of the mgmt-hetzner deploy split (below), these live in that repo's `einsatzbereit-staging`/`einsatzbereit-production` GitHub Environments, not here - see mgmt-hetzner's `README.md` and this repo's `.github/AGENTS.md` "Deployment moved to mgmt-hetzner" section.
+
+=== Update: deploy ownership moved to mgmt-hetzner (2026-08-21)
+
+The `deploy-staging`/`deploy-production` jobs this TDR describes no longer live in this repo's `publish.yml` - they moved, largely unchanged, to `maik-hasler/mgmt-hetzner`'s `deploy-einsatzbereit.yaml` (`einsatzbereit-staging`/`einsatzbereit-production` GitHub Environments there), triggered manually (`workflow_dispatch`, version + environment as inputs) rather than automatically from this repo's `publish.yml` - deliberately, so no credential needs to flow from this repo into mgmt-hetzner just to kick off a deploy. This is an ownership change, not a resolution of this TDR - the environment-separation and blast-radius analysis above is unchanged: staging and production still share the same single host, database, and object storage, just via a workflow in a different repository, triggered by hand.
+
+=== Resolution
+
+Issue #2165 (2026-08-22, ADR-7) completed the separation this TDR's 2026-08-21 update already saw coming: this repository no longer describes, configures, or drives any deployed environment at all, `mgmt-hetzner` included - it builds and publishes images and stops. `docker-compose.yml`, `reset-staging.yml` and every staging/production reference this repository carried are gone.
+
+Resolved here on that basis, specifically: whether staging and production still share one host, and whether the environment-separation and blast-radius risk this TDR documents still holds, is no longer something this repository's documentation is positioned to track or answer. That is now `mgmt-hetzner`'s question, not this one's - this TDR is not asserting the underlying infrastructure risk was actually fixed, only that it moved out of this repository's scope along with everything else deployment-related.


### PR DESCRIPTION
## What

Fixes six documentation drifts identified by the 1.0 readiness analysis, all the same root cause: a decision landed in code without the corresponding record being updated or superseded.

## Why

Closes #2214

The arc42 docs are published to GitHub Pages and are the project's public face alongside the README, so a contradiction between them and the shipped code (or between docs, like the privacy policy vs. chapter 3) is exactly the kind of thing a 1.0 gets read for.

1. **Chapter 3's external-interface table** described the pre-ADR-5 architecture (the browser calling OpenStreetMap directly). Updated to match ADR-5/chapter 8: both map tiles and city search are proxied through the backend, so Nominatim/the tile server only ever see the backend's IP. Chapter 7's deployment view had the identical stale claim in its "Consumed Services" table and is fixed alongside it, since it's the same root cause.
2. **ADR-4** said geocoding runs synchronously inside the `CreateVolunteerOpportunity`/`UpdateVolunteerOpportunity` command handlers. It no longer does - those handlers now raise `VolunteerOpportunityGeocodingRequestedDomainEvent`, dispatched through the outbox to `GeocodeVolunteerOpportunityAddressHandler`, backstopped by an hourly `GeocodingRetryJob` for transient failures. This is, in substance, the "Domain event + background geocoder" alternative the ADR originally rejected. Amended in place (Decision/Alternatives/Consequences annotated, plus a new Amendment section with the actual current flow) rather than superseded, since the core decision (write-time only, no PostGIS, bbox+Haversine search) is unchanged.
3. **Chapter 11's CI risk row** carried Severity "Low-Medium" and a superseded ~10min/~6min figure. TDR-2's own Severity section has been "High" since 2026-08-20 (21 min 58 s median, 36.4% completion rate) and stays High until the failure rate is confirmed back under 20%, even though sharding since brought wall-clock back down. Chapter 11 now matches that.
4. **The #2165 decision** (repository scope stops at image publishing) had no ADR of its own, and deleted ADR-6 (Grafana Tempo tracing) and TDR-3 (shared staging/production host) outright instead of marking them superseded - losing the reasoning behind both the original choices and the reversal. Added **ADR-7** for the #2165 decision itself, restored the tracing record as **ADR-8** (ADR-6's number had already been reused for an unrelated "light-only theme" decision by the time this was caught, so the restored record can't reclaim its original number - it says so explicitly) marked *Superseded by ADR-7*, and restored **TDR-3** at its original free number marked *Resolved*. Both restorations keep their original content intact and add a dated note explaining the restoration, per arc42's own convention that a superseded decision stays in the record rather than disappearing.
5. **`README.md`** no longer claims platform admins can "verify organizations" - `is_verified` was dropped in migration `20260731170951_RemoveOrganizationIsVerified` (#1530) and no endpoint replaced it (confirmed: no verify endpoint exists under `backend/src/Api/Organizations`). The rest of that bullet (manage users, toggle admin/enabled status) is still accurate and kept.
6. **README's local-stack credentials** didn't match `AppHost.cs`: PostgreSQL's password is auto-generated per run (Aspire's `AddPostgres`), not literally `postgres`; pgAdmin opens straight to the dashboard with no login prompt (`PGADMIN_CONFIG_SERVER_MODE=False`); Keycloak has no bootstrap admin account configured for local dev at all (`AppHost.cs` sets no `KC_BOOTSTRAP_ADMIN_*`/`KEYCLOAK_ADMIN*`, confirmed by `keycloak/README.md`'s own "Local development" note). The app-level test users table (vera/olaf/admin) was already correct and is unchanged. **CONTRIBUTING.md**'s "Feature folders mirroring the backend structure" line for the frontend directly contradicted chapter 5, which says the frontend is cut by artifact kind - "the opposite of the backend" - and is corrected to match.

## Testing

Documentation-only change; no tests apply. Verification was against primary sources rather than assumption:

- Chapter 3/7/ADR-4 fixes cross-checked against ADR-5's text and the actual handler/job source (`GeocodeVolunteerOpportunityAddressHandler.cs`, `GeocodingRetryJob.cs`, `Maps` endpoints).
- Chapter 11 fix cross-checked against TDR-2's own current Severity section and 2026-08-20 measurement.
- ADR-6/TDR-3 restoration sourced from `git show` on the deletion commit (`1fdbb67`, #2165) for the original content, and `git log` to confirm ADR-6's number was reused afterward.
- README bullet fix cross-checked against the `Organizations` API folder (no verify endpoint) and the `RemoveOrganizationIsVerified` migration.
- Credentials fix cross-checked against `AppHost.cs`, `keycloak/realms/einsatzbereit-realm.json`, `keycloak/README.md`, and (for Aspire's own default behavior) the pinned `Aspire.Hosting.PostgreSQL` version's source.
- CONTRIBUTING fix cross-checked against chapter 5's building-block view.

## Checklist

- [ ] `/self-review` run and findings addressed - a manual review pass was done instead; the repo's domain-specific check subagents (nswag/EF migration/architecture/a11y/i18n) don't apply to a docs-only change
- [x] CI is green - all 6 applicable checks passed (dashes/apostrophe/editorconfig lint, PR title, docs build); `dotnet.yml`/`frontend.yml` don't trigger, since nothing under `backend/**`/`frontend/**`/`keycloak/**` changed
- [x] Documentation updated if this change affects behavior - this change *is* the documentation fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBouhucQFnVkFL7uHrjSva)_