### PR TITLE
fix: enforce deadlines, expiry, and reactivation budget server-side

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -206,7 +206,7 @@ public interface IApplicationDbContext
 		OrganizationId organizationId,
 		CancellationToken cancellationToken = default);
 
-	Task<bool> HasOpenReportAsync(
+	Task<bool> HasDuplicateReportAsync(
 		ReportTargetType targetType,
 		Guid targetId,
 		UserId reporterId,

--- a/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/CreateEngagement/v1/CreateEngagementCommandHandler.cs
@@ -28,6 +28,11 @@ internal sealed class CreateEngagementCommandHandler(
 		if (opportunity.Status != OpportunityStatus.Published)
 			throw new ResultFailureException(Error.Conflict("Engagement.OpportunityNotPublished", "Conflict: this opportunity is not open for sign-ups."));
 
+		if (opportunity.ParticipationType == ParticipationType.IndividualContact
+			&& opportunity.ValidUntil is { } validUntil
+			&& validUntil <= DateTimeOffset.UtcNow)
+			throw new ResultFailureException(Error.Conflict("Engagement.ApplicationDeadlinePassed", "Conflict: the application deadline for this opportunity has passed."));
+
 		if (opportunity.ParticipationType == ParticipationType.ScheduledSlots && request.TimeSlotId is null)
 			throw new ResultFailureException(Error.Validation("Engagement.TimeSlotRequired", "A time slot is required to sign up for this opportunity."));
 

--- a/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
+++ b/backend/src/Application/Invitations/AcceptInvitation/v1/AcceptInvitationCommandHandler.cs
@@ -23,6 +23,12 @@ internal sealed class AcceptInvitationCommandHandler(
 		if (invitation.InviteeId != request.UserId)
 			throw new ResultFailureException(Error.Forbidden("OrganizationInvitation.NotRecipient", "You are not the recipient of this invitation."));
 
+		// InvitationExpiryJob only sweeps Pending invitations to Expired periodically, so a
+		// Pending invitation past its ExpiresOn can still reach here in the gap before the
+		// next sweep - Accept() itself only checks Status, not the date (einsatzbereit#2212).
+		if (invitation.Status == InvitationStatus.Pending && invitation.ExpiresOn <= DateTimeOffset.UtcNow)
+			throw new ResultFailureException(Error.Conflict("OrganizationInvitation.Expired", "This invitation has expired."));
+
 		// A double-accept (two in-flight requests for the same invitation) races
 		// on organization_membership's unique index - without this check both
 		// pass invitation.Accept() and both try to insert a membership row, and

--- a/backend/src/Application/Organizations/ReportOrganization/v1/ReportOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/ReportOrganization/v1/ReportOrganizationCommandHandler.cs
@@ -20,7 +20,7 @@ internal sealed class ReportOrganizationCommandHandler(
 		_ = await dbContext.Organizations.FindAsync(organizationId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("Organization.NotFound", $"Organization '{request.OrganizationId}' not found."));
 
-		var alreadyReported = await dbContext.HasOpenReportAsync(
+		var alreadyReported = await dbContext.HasDuplicateReportAsync(
 			ReportTargetType.Organization, request.OrganizationId, request.ReporterId, cancellationToken);
 		if (alreadyReported)
 			throw new ResultFailureException(Error.Conflict("Report.AlreadyReported", "You have already reported this."));

--- a/backend/src/Application/Users/ReportUser/v1/ReportUserCommandHandler.cs
+++ b/backend/src/Application/Users/ReportUser/v1/ReportUserCommandHandler.cs
@@ -22,7 +22,7 @@ internal sealed class ReportUserCommandHandler(
 		_ = await dbContext.Users.FindAsync(targetUserId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("User.NotFound", $"User '{request.UserId}' not found."));
 
-		var alreadyReported = await dbContext.HasOpenReportAsync(
+		var alreadyReported = await dbContext.HasDuplicateReportAsync(
 			ReportTargetType.User, request.UserId, request.ReporterId, cancellationToken);
 		if (alreadyReported)
 			throw new ResultFailureException(Error.Conflict("Report.AlreadyReported", "You have already reported this."));

--- a/backend/src/Application/VolunteerOpportunities/ReportVolunteerOpportunity/v1/ReportVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/ReportVolunteerOpportunity/v1/ReportVolunteerOpportunityCommandHandler.cs
@@ -20,7 +20,7 @@ internal sealed class ReportVolunteerOpportunityCommandHandler(
 		_ = await dbContext.VolunteerOpportunities.FindAsync(opportunityId, cancellationToken)
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId}' not found."));
 
-		var alreadyReported = await dbContext.HasOpenReportAsync(
+		var alreadyReported = await dbContext.HasDuplicateReportAsync(
 			ReportTargetType.VolunteerOpportunity, request.OpportunityId, request.ReporterId, cancellationToken);
 		if (alreadyReported)
 			throw new ResultFailureException(Error.Conflict("Report.AlreadyReported", "You have already reported this."));

--- a/backend/src/Domain/Engagements/Engagement.cs
+++ b/backend/src/Domain/Engagements/Engagement.cs
@@ -178,6 +178,12 @@ public sealed class Engagement
 		if (timeSlotId is null && string.IsNullOrWhiteSpace(message))
 			return Result.Failure(Error.Validation("Engagement.MessageRequired", "Message is required for individual contact."));
 
+		// Only a withdrawal is the volunteer's own action - an organizer-side Cancel()
+		// must not consume the same budget, or repeated unpublish/republish or bulk
+		// cancellation cycles by the organizer would eventually lock the volunteer out
+		// of a slot they never withdrew from (einsatzbereit#2212).
+		var wasWithdrawnByVolunteer = Status == EngagementStatus.Withdrawn;
+
 		TimeSlotId = timeSlotId;
 		TimeSlotStartDateTime = timeSlotId is null ? null : timeSlotStartDateTime;
 		TimeSlotEndDateTime = timeSlotId is null ? null : timeSlotEndDateTime;
@@ -189,7 +195,8 @@ public sealed class Engagement
 		FeedbackSubmittedAt = null;
 		ReminderSentAt = null;
 		Status = EngagementStatus.Pending;
-		ReactivationCount++;
+		if (wasWithdrawnByVolunteer)
+			ReactivationCount++;
 		AddEvent(new EngagementReactivatedDomainEvent(Id, VolunteerId!.Value, OpportunityId, IsSlotSignUp: timeSlotId is not null));
 		return Result.Success();
 	}

--- a/backend/src/Domain/Reports/Report.cs
+++ b/backend/src/Domain/Reports/Report.cs
@@ -9,6 +9,12 @@ public sealed class Report
 {
 	public const int MaxDetailsLength = 1000;
 
+	// How long a resolved report keeps blocking the same reporter from re-filing against the
+	// same target. A Dismissed report blocks indefinitely regardless of this window (see
+	// IApplicationDbContext.HasDuplicateReportAsync) - this only bounds the cooldown after a
+	// report was Actioned, so a target that reoffends after being actioned can be re-reported.
+	public const int DuplicateWindowDays = 30;
+
 	public ReportTargetType TargetType { get; private set; }
 
 	public Guid TargetId { get; private set; }

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -478,16 +478,26 @@ internal sealed class ApplicationDbContext(
 			.Where(vo => vo.OrganizationId == organizationId)
 			.ToListAsync(cancellationToken);
 
-	public async Task<bool> HasOpenReportAsync(
+	public async Task<bool> HasDuplicateReportAsync(
 		ReportTargetType targetType,
 		Guid targetId,
 		UserId reporterId,
-		CancellationToken cancellationToken = default) =>
-		await Set<Report>()
+		CancellationToken cancellationToken = default)
+	{
+		// Open always blocks (still under review); Dismissed blocks indefinitely so a
+		// reporter cannot force a moderator to re-adjudicate the same claim on a loop
+		// (einsatzbereit#2212); anything else (Actioned) only blocks for a cooldown window,
+		// so a target that reoffends after being actioned can still be re-reported later.
+		var cutoff = DateTimeOffset.UtcNow.AddDays(-Report.DuplicateWindowDays);
+
+		return await Set<Report>()
 			.AnyAsync(r => r.TargetType == targetType
 				&& r.TargetId == targetId
 				&& r.ReporterId == reporterId
-				&& r.Status == ReportStatus.Open, cancellationToken);
+				&& (r.Status == ReportStatus.Open
+					|| r.Status == ReportStatus.Dismissed
+					|| r.CreatedOn >= cutoff), cancellationToken);
+	}
 
 	public async Task<List<Report>> GetOpenReportsForTargetAsync(
 		ReportTargetType targetType,

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -569,6 +569,15 @@ internal sealed class VolunteerOpportunityReadRepository(
 		if (status is OpportunityStatus s)
 			orgQuery = orgQuery.Where(vo => vo.Status == s);
 
+		// Published doesn't mean still open - an opportunity whose only time slots have
+		// ended, or whose IndividualContact deadline has passed, must not keep surfacing
+		// on the organization's public profile (einsatzbereit#2212). Matches the predicate
+		// ApplyPubliclyListedFilters already applies to the browse listing.
+		if (status == OpportunityStatus.Published)
+			orgQuery = orgQuery.Where(vo =>
+				vo.TimeSlots.Any(ts => ts.EndDateTime >= now) ||
+				(!vo.TimeSlots.Any() && vo.ValidUntil != null && vo.ValidUntil >= now));
+
 		var rows = await orgQuery
 			.Join(
 				dbContext.OrganizationsQuery,

--- a/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/CreateEngagement/CreateEngagementCommandHandlerTests.cs
@@ -224,6 +224,41 @@ public class CreateEngagementCommandHandlerTests
 	}
 
 	[Test]
+	public async Task Handle_ShouldThrow_WhenIndividualContactApplicationDeadlineHasPassed(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var farPast = DateTimeOffset.UtcNow.AddDays(-30);
+		var opportunity = VolunteerOpportunity.Create(
+			OrganizationId.New(),
+			"Test Opportunity",
+			null,
+			"Description",
+			null,
+			false,
+			TestAddress,
+			Occurrence.OneTime,
+			ParticipationType.IndividualContact,
+			CheckInMethod.None,
+			_pinGenerator,
+			status: OpportunityStatus.Draft,
+			validUntil: farPast.AddDays(1),
+			now: farPast).Value;
+		opportunity.Publish().ThrowIfFailure();
+		_opportunityRepo.FindAsync(opportunityId, Arg.Any<CancellationToken>()).Returns(opportunity);
+		var command = new CreateEngagementCommand(opportunityId, UserId.New(), TimeSlotId: null, "Ich helfe gerne!");
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
+		await _engagementRepo.DidNotReceive().AddAsync(Arg.Any<Engagement>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
 	public async Task Handle_ShouldCreateScheduledSlotsEngagement_WhenTimeSlotIdIsProvided(
 		CancellationToken cancellationToken)
 	{

--- a/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/EngagementTests.cs
@@ -312,6 +312,44 @@ public class EngagementTests
 	}
 
 	[Test]
+	public void Reactivate_ShouldNotIncrementReactivationCount_WhenPreviouslyCancelledByOrganizer()
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Cancel();
+
+		engagement.Reactivate(AnyTimeSlotId(), message: null);
+
+		engagement.ReactivationCount.Should().Be(0);
+	}
+
+	[Test]
+	public void Reactivate_ShouldNotHitReactivationLimit_WhenOrganizerRepeatedlyCancels()
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+
+		for (var i = 0; i < 10; i++)
+		{
+			engagement.Cancel();
+			engagement.Reactivate(AnyTimeSlotId(), message: null).IsSuccess.Should().BeTrue();
+		}
+
+		engagement.ReactivationCount.Should().Be(0);
+	}
+
+	[Test]
+	public void Reactivate_ShouldStillIncrementReactivationCount_WhenVolunteerWithdrawsAfterAnOrganizerCancellation()
+	{
+		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());
+		engagement.Cancel();
+		engagement.Reactivate(AnyTimeSlotId(), message: null);
+
+		engagement.Withdraw();
+		engagement.Reactivate(AnyTimeSlotId(), message: null);
+
+		engagement.ReactivationCount.Should().Be(1);
+	}
+
+	[Test]
 	public void CheckIn_ShouldSetIsCheckedIn_WhenConfirmed()
 	{
 		var engagement = Engagement.CreateSlotSignUp(AnyOpportunityId(), AnyUserId(), AnyTimeSlotId());

--- a/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Invitations/AcceptInvitation/AcceptInvitationCommandHandlerTests.cs
@@ -39,6 +39,14 @@ public class AcceptInvitationCommandHandlerTests
 		OrganizationMemberRole intendedRole = OrganizationMemberRole.Organizer) =>
 		OrganizationInvitation.Create(OrgId, InviteeId, InviterId, intendedRole, DateTimeOffset.UtcNow);
 
+	private static OrganizationInvitation CreateExpiredInvitation() =>
+		OrganizationInvitation.Create(
+			OrgId,
+			InviteeId,
+			InviterId,
+			OrganizationMemberRole.Organizer,
+			DateTimeOffset.UtcNow.AddDays(-(OrganizationInvitation.ExpiryWindowDays + 1)));
+
 	[Test]
 	public async Task Handle_ShouldGrantOrganizerCapability_OnAccept(
 		CancellationToken cancellationToken)
@@ -139,6 +147,26 @@ public class AcceptInvitationCommandHandlerTests
 
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>();
+		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldThrow_WhenInvitationHasExpired(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var invitation = CreateExpiredInvitation();
+		_invitationRepo.FindAsync(invitation.Id, cancellationToken).Returns(invitation);
+		var command = new AcceptInvitationCommand(invitation.Id, InviteeId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		(await act.Should().ThrowAsync<ResultFailureException>())
+			.Which.Error.Type.Should().Be(ErrorType.Conflict);
 		await _keycloakService.DidNotReceive().AddMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 		await _membershipRepo.DidNotReceive().AddAsync(Arg.Any<OrganizationMembership>(), Arg.Any<CancellationToken>());
 		await _dbContext.DidNotReceive().DeleteInvitationReceivedNotificationsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());

--- a/backend/tests/Application.UnitTests/Organizations/ReportOrganization/ReportOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/ReportOrganization/ReportOrganizationCommandHandlerTests.cs
@@ -26,7 +26,7 @@ public class ReportOrganizationCommandHandlerTests
 		_dbContext.Organizations.Returns(_organizationRepo);
 		_dbContext.Reports.Returns(_reportRepo);
 		_dbContext
-			.HasOpenReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.HasDuplicateReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 		_sut = new ReportOrganizationCommandHandler(_dbContext);
 	}
@@ -93,7 +93,7 @@ public class ReportOrganizationCommandHandlerTests
 			.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken)
 			.Returns(organization);
 		_dbContext
-			.HasOpenReportAsync(ReportTargetType.Organization, orgId, DefaultReporterId, cancellationToken)
+			.HasDuplicateReportAsync(ReportTargetType.Organization, orgId, DefaultReporterId, cancellationToken)
 			.Returns(true);
 
 		var command = new ReportOrganizationCommand(orgId, DefaultReporterId, ReportReason.Fraud, null);

--- a/backend/tests/Application.UnitTests/Users/ReportUser/ReportUserCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/ReportUser/ReportUserCommandHandlerTests.cs
@@ -25,7 +25,7 @@ public class ReportUserCommandHandlerTests
 		_dbContext.Users.Returns(_userRepo);
 		_dbContext.Reports.Returns(_reportRepo);
 		_dbContext
-			.HasOpenReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.HasDuplicateReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 		_sut = new ReportUserCommandHandler(_dbContext);
 	}
@@ -108,7 +108,7 @@ public class ReportUserCommandHandlerTests
 			.FindAsync(UserId.Create(targetUserGuid).GetValueOrThrow(), cancellationToken)
 			.Returns(targetUser);
 		_dbContext
-			.HasOpenReportAsync(ReportTargetType.User, targetUserGuid, DefaultReporterId, cancellationToken)
+			.HasDuplicateReportAsync(ReportTargetType.User, targetUserGuid, DefaultReporterId, cancellationToken)
 			.Returns(true);
 
 		var command = new ReportUserCommand(targetUserGuid, DefaultReporterId, ReportReason.Spam, null);

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/ReportVolunteerOpportunity/ReportVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/ReportVolunteerOpportunity/ReportVolunteerOpportunityCommandHandlerTests.cs
@@ -29,7 +29,7 @@ public class ReportVolunteerOpportunityCommandHandlerTests
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
 		_dbContext.Reports.Returns(_reportRepo);
 		_dbContext
-			.HasOpenReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.HasDuplicateReportAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 		_sut = new ReportVolunteerOpportunityCommandHandler(_dbContext);
 	}
@@ -97,7 +97,7 @@ public class ReportVolunteerOpportunityCommandHandlerTests
 			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
 			.Returns(opportunity);
 		_dbContext
-			.HasOpenReportAsync(ReportTargetType.VolunteerOpportunity, opportunityId, DefaultReporterId, cancellationToken)
+			.HasDuplicateReportAsync(ReportTargetType.VolunteerOpportunity, opportunityId, DefaultReporterId, cancellationToken)
 			.Returns(true);
 
 		var command = new ReportVolunteerOpportunityCommand(opportunityId, DefaultReporterId, ReportReason.Spam, null);

--- a/backend/tests/IntegrationTests/AdminReportsTests.cs
+++ b/backend/tests/IntegrationTests/AdminReportsTests.cs
@@ -58,6 +58,52 @@ public class AdminReportsTests(
 		flagged.OpenReportCount.Should().Be(1);
 	}
 
+	[Test]
+	public async Task ReportVolunteerOpportunity_ShouldReturn409_WhenAPriorReportByTheSameReporterWasDismissed(
+		CancellationToken cancellationToken)
+	{
+		var organizer = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var suffix = Guid.NewGuid().ToString("N")[..8];
+
+		var organization = await organizer.CreateOrganizationAsync(
+			new CreateOrganizationRequest { Name = $"Admin Reports Org {suffix}" }, cancellationToken);
+
+		var title = $"Dismissed Report Opportunity {suffix}";
+		var opportunity = await organizer.CreateVolunteerOpportunityAsync(
+			new CreateVolunteerOpportunityRequest
+			{
+				TitleDe = title,
+				DescriptionDe = "Regression coverage for re-filing after a dismissal.",
+				OrganizationId = organization.Id.Value,
+				IsRemote = true,
+				Occurrence = "OneTime",
+				ParticipationType = "IndividualContact",
+				CheckInMethod = "None",
+				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
+				IsDraft = true,
+			}, cancellationToken);
+		await organizer.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+
+		var reporter = await CreateAuthenticatedClientAsync("vera", "vera123");
+		await reporter.ReportVolunteerOpportunityAsync(
+			opportunity.Id,
+			new ReportVolunteerOpportunityRequest { Reason = "Spam", Details = $"First report {suffix}." },
+			cancellationToken);
+
+		var admin = await CreateAuthenticatedClientAsync("admin", "admin123");
+		var history = await admin.GetReportHistoryForTargetAsync("VolunteerOpportunity", opportunity.Id, cancellationToken);
+		var reportId = history.Single().Id;
+		await admin.DismissReportAsync(reportId, cancellationToken);
+
+		var act = () => reporter.ReportVolunteerOpportunityAsync(
+			opportunity.Id,
+			new ReportVolunteerOpportunityRequest { Reason = "Spam", Details = $"Re-filed after dismissal {suffix}." },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)
 	{
 		var token = await fixture.GetAccessTokenAsync(username, password);

--- a/backend/tests/IntegrationTests/EngagementTests.cs
+++ b/backend/tests/IntegrationTests/EngagementTests.cs
@@ -70,6 +70,26 @@ public class EngagementTests(IntegrationTestFixture fixture)
 	}
 
 	[Test]
+	public async Task CreateEngagement_ShouldReturn409_WhenIndividualContactApplicationDeadlineHasPassed(
+		CancellationToken cancellationToken)
+	{
+		var olafClient = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var orgId = await CreateOrganizationAsync(olafClient, cancellationToken);
+		var opportunity = await CreateOpportunityAsync(olafClient, orgId, cancellationToken);
+		await SetExpiredValidUntilDirectlyAsync(opportunity.Id, cancellationToken);
+
+		var veraClient = await CreateAuthenticatedClientAsync("vera", "vera123");
+
+		var act = () => veraClient.CreateEngagementAsync(
+			opportunity.Id,
+			new CreateEngagementRequest { Message = "I want to help!" },
+			cancellationToken);
+
+		var exception = await act.Should().ThrowAsync<ApiException>();
+		exception.Which.StatusCode.Should().Be(409);
+	}
+
+	[Test]
 	public async Task GetEngagements_ShouldReturnSignedUpVolunteer(
 		CancellationToken cancellationToken)
 	{
@@ -2195,6 +2215,19 @@ public class EngagementTests(IntegrationTestFixture fixture)
 				ValidUntil = DateTimeOffset.UtcNow.AddDays(30),
 			},
 			cancellationToken);
+	}
+
+	private async Task SetExpiredValidUntilDirectlyAsync(Guid opportunityId, CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var opportunityId_ = VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow();
+		var aggregate = await dbContext.VolunteerOpportunities.FindAsync(opportunityId_, cancellationToken)
+			?? throw new InvalidOperationException($"Seeded opportunity '{opportunityId}' not found.");
+
+		var farPast = DateTimeOffset.UtcNow.AddDays(-30);
+		aggregate.SetValidUntil(farPast.AddDays(1), now: farPast).ThrowIfFailure();
+
+		await dbContext.SaveChangesAsync(cancellationToken);
 	}
 
 	private static async Task<CreateVolunteerOpportunityResponse> CreateScheduledSlotsOpportunityAsync(

--- a/backend/tests/IntegrationTests/GetPublicOrganizationProfileTests.cs
+++ b/backend/tests/IntegrationTests/GetPublicOrganizationProfileTests.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Headers;
+using Application.Common.Exceptions;
 using AwesomeAssertions;
+using Domain.VolunteerOpportunities;
 
 namespace IntegrationTests;
 
@@ -71,6 +73,35 @@ public class GetPublicOrganizationProfileTests(
 		summary.CurrentParticipantCount.Should().Be(0);
 	}
 
+	[Test]
+	public async Task GetPublicOrganizationProfile_ShouldExcludeOpportunity_WhenIndividualContactDeadlineHasPassed(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organizationId = await CreateOrganizationAsync(client, cancellationToken);
+		var opportunity = await PublishInterestBasedOpportunityAsync(
+			client, organizationId, "Expired interest based", DateTimeOffset.UtcNow.AddDays(30), cancellationToken);
+		await SetExpiredValidUntilDirectlyAsync(opportunity.Id, cancellationToken);
+
+		var profile = await new EinsatzbereitApi(fixture.CreateHttpClient())
+			.GetPublicOrganizationProfileAsync(organizationId, cancellationToken);
+
+		profile.OpenOpportunities.Should().BeEmpty();
+	}
+
+	private async Task SetExpiredValidUntilDirectlyAsync(Guid opportunityId, CancellationToken cancellationToken)
+	{
+		await using var dbContext = fixture.CreateApplicationDbContext();
+		var opportunityId_ = VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow();
+		var aggregate = await dbContext.VolunteerOpportunities.FindAsync(opportunityId_, cancellationToken)
+			?? throw new InvalidOperationException($"Seeded opportunity '{opportunityId}' not found.");
+
+		var farPast = DateTimeOffset.UtcNow.AddDays(-30);
+		aggregate.SetValidUntil(farPast.AddDays(1), now: farPast).ThrowIfFailure();
+
+		await dbContext.SaveChangesAsync(cancellationToken);
+	}
+
 	private static async Task<Guid> CreateOrganizationAsync(
 		EinsatzbereitApi client, CancellationToken cancellationToken)
 	{
@@ -117,7 +148,7 @@ public class GetPublicOrganizationProfileTests(
 		await client.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
 	}
 
-	private static async Task PublishInterestBasedOpportunityAsync(
+	private static async Task<CreateVolunteerOpportunityResponse> PublishInterestBasedOpportunityAsync(
 		EinsatzbereitApi client,
 		Guid organizationId,
 		string title,
@@ -139,6 +170,7 @@ public class GetPublicOrganizationProfileTests(
 			}, cancellationToken);
 
 		await client.PublishVolunteerOpportunityAsync(opportunity.Id, cancellationToken);
+		return opportunity;
 	}
 
 	private async Task<EinsatzbereitApi> CreateAuthenticatedClientAsync(string username, string password)


### PR DESCRIPTION
## What

Closes the gap between four rules the UI displays and what the corresponding command handler actually enforces.

## Why

Closes #2212

Each of these is a constraint the product shows as real, but that a request bypassing the UI (or a background job running late) could ignore:

1. **`IndividualContact` application deadline was decorative.** `CreateEngagementCommandHandler` never checked `ValidUntil` against the current time, so sign-up succeeded for opportunities whose deadline had already passed. The opportunity also kept appearing on the organization's public profile, because `GetSummariesByOrganizationAsync` lacked the `ValidUntil == null || ValidUntil >= now` predicate the browse listing already applies.
2. **Invitation expiry was not checked at acceptance.** `InvitationExpiryJob` only sweeps `Pending` invitations to `Expired` periodically, so a `Pending` invitation past its `ExpiresOn` could still be accepted in the gap before the next sweep - `AcceptInvitationCommandHandler` only checked `Status`, not the date.
3. **A dismissed report could be re-filed immediately, forever.** The duplicate check (`HasOpenReportAsync`, now `HasDuplicateReportAsync`) only looked at reports with `Status == Open`. A reporter could re-file against the same target right after a moderator dismissed it, on a loop, costing the moderator one action per cycle.
4. **Organizer-side cancellations consumed the volunteer's own reactivation budget.** `Engagement.Reactivate()` incremented the same `ReactivationCount` regardless of whether the prior terminal state was `Withdrawn` (the volunteer's own action) or `Cancelled` (the organizer's). An organizer who unpublished/republished, or bulk-cancelled a slot's sign-ups, five times could permanently lock out every affected volunteer from that slot even though they never withdrew.

## Changes

- `CreateEngagementCommandHandler`: reject `IndividualContact` sign-ups once `ValidUntil` has passed (`Engagement.ApplicationDeadlinePassed`, 409).
- `VolunteerOpportunityReadRepository.GetSummariesByOrganizationAsync`: apply the same "still open" predicate the public browse listing already uses.
- `AcceptInvitationCommandHandler`: reject an expired-but-still-`Pending` invitation (`OrganizationInvitation.Expired`, 409).
- `IApplicationDbContext.HasOpenReportAsync` renamed to `HasDuplicateReportAsync` and widened to also match a `Dismissed` report from the same reporter against the same target, or any report of theirs created within `Report.DuplicateWindowDays` (30 days) - covers the case a report was `Actioned` too, so a target that reoffends after being actioned on can still be re-reported once the cooldown lapses.
- `Engagement.Reactivate()`: only increments `ReactivationCount` when the prior status was `Withdrawn`; a `Cancel()`-originated reactivation no longer spends the volunteer's budget.

## Testing

- Unit tests: `CreateEngagementCommandHandlerTests` (deadline rejection), `AcceptInvitationCommandHandlerTests` (expiry rejection), `EngagementTests` (reactivation budget only spent on volunteer withdrawal, not organizer cancellation), plus the three `Report*CommandHandlerTests` updated for the `HasDuplicateReportAsync` rename.
- Integration tests: `EngagementTests` (sign-up returns 409 past the deadline), `GetPublicOrganizationProfileTests` (expired opportunity excluded from the public listing), `AdminReportsTests` (re-filing after a dismissal returns 409).
- Ran locally: `dotnet build`, `Application.UnitTests` (1022/1022 passed), `ArchitectureTests` (417/417 passed), and `dotnet ef migrations has-pending-model-changes` (no pending changes - none of these changes alter the EF model shape). `IntegrationTests`/`VisualTests` need Docker/Aspire, which this sandbox can't run (compiled successfully, but not executed locally); CI's `dotnet.yml` runs them on a real runner.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (none of the four fixes change documented/public behavior - each closes a gap between already-documented intent and enforcement)


---
_Generated by [Claude Code](https://claude.ai/code/session_011frZMEqgrFhbpGH8JibLda)_