### PR TITLE
perf: batch four organizer hot paths instead of looping per item

### DIFF
--- a/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
+++ b/backend/src/Application/Common/Persistence/IApplicationDbContext.cs
@@ -178,12 +178,20 @@ public interface IApplicationDbContext
 		UserId volunteerId,
 		CancellationToken cancellationToken = default);
 
+	Task<List<Engagement>> GetEngagementsByIdsAsync(
+		IReadOnlyCollection<EngagementId> engagementIds,
+		CancellationToken cancellationToken = default);
+
 	Task<int> CountConfirmedEngagementsForVolunteerAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default);
 
 	Task<int> CountActiveEngagementsForTimeSlotAsync(
 		TimeSlotId timeSlotId,
+		CancellationToken cancellationToken = default);
+
+	Task<Dictionary<TimeSlotId, int>> CountActiveEngagementsForTimeSlotsAsync(
+		IReadOnlyCollection<TimeSlotId> timeSlotIds,
 		CancellationToken cancellationToken = default);
 
 	Task LockTimeSlotForUpdateAsync(

--- a/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommandHandler.cs
+++ b/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommandHandler.cs
@@ -3,7 +3,6 @@ using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements.Common;
-using Application.Engagements.ConfirmEngagement.v1;
 using Domain.Primitives;
 
 namespace Application.Engagements.BulkConfirmEngagements.v1;
@@ -26,39 +25,37 @@ internal sealed class BulkConfirmEngagementsCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
+		var requestedIds = request.EngagementIds.Distinct().ToList();
+		var engagementsById = (await dbContext.GetEngagementsByIdsAsync(requestedIds, cancellationToken))
+			.ToDictionary(e => e.Id);
+
 		var succeeded = new List<BulkEngagementActionSuccess>();
 		var failed = new List<BulkEngagementActionFailure>();
 
-		foreach (var engagementId in request.EngagementIds.Distinct())
+		foreach (var engagementId in requestedIds)
 		{
-			// The nested ConfirmEngagementCommand re-derives ownership from the
-			// engagement's own OpportunityId, independent of this route's
-			// {opportunityId} segment - so without this check, an id from a
-			// different opportunity the caller also organizes would silently
-			// succeed instead of being rejected as out of scope for this batch.
-			var engagement = await dbContext.Engagements.FindAsync(engagementId, cancellationToken);
-			if (engagement is null)
+			if (!engagementsById.TryGetValue(engagementId, out var engagement))
 			{
 				failed.Add(new BulkEngagementActionFailure(engagementId.Value, "Engagement.NotFound", $"Engagement '{engagementId.Value}' not found."));
 				continue;
 			}
+
+			// An id from a different opportunity the caller also organizes is rejected as out
+			// of scope for this batch, rather than silently confirmed under this route's
+			// {opportunityId} segment - this opportunity's own ownership was already checked once above.
 			if (engagement.OpportunityId != request.OpportunityId)
 			{
 				failed.Add(new BulkEngagementActionFailure(engagementId.Value, "Engagement.WrongOpportunity", "Engagement does not belong to this volunteer opportunity."));
 				continue;
 			}
 
-			try
-			{
-				var confirmed = await sender.Send(
-					new ConfirmEngagementCommand(engagementId, request.RequestingUserId, request.Timezone),
-					cancellationToken);
-				succeeded.Add(new BulkEngagementActionSuccess(confirmed.Id.Value, confirmed.Status.ToString()));
-			}
-			catch (ResultFailureException ex)
-			{
-				failed.Add(new BulkEngagementActionFailure(engagementId.Value, ex.Error.Code, ex.Error.Description));
-			}
+			var result = await EngagementConfirmationHelper.ConfirmAsync(
+				dbContext, sender, engagement, request.Timezone, cancellationToken);
+
+			if (result.IsSuccess)
+				succeeded.Add(new BulkEngagementActionSuccess(result.Value.Id.Value, result.Value.Status.ToString()));
+			else
+				failed.Add(new BulkEngagementActionFailure(engagementId.Value, result.Error.Code, result.Error.Description));
 		}
 
 		return new BulkEngagementActionResult(succeeded, failed);

--- a/backend/src/Application/Engagements/Common/EngagementConfirmationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementConfirmationHelper.cs
@@ -1,0 +1,103 @@
+using Application.Achievements.AwardAchievement.v1;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Domain.Engagements;
+using Domain.Notifications;
+using Domain.Primitives;
+using Domain.Users;
+
+namespace Application.Engagements.Common;
+
+// Shared by ConfirmEngagementCommandHandler and BulkConfirmEngagementsCommandHandler so the
+// latter can confirm each already-loaded, already-authorized engagement in-process instead of
+// replaying engagement/opportunity lookups and the ownership check through ISender.Send per item.
+internal static class EngagementConfirmationHelper
+{
+	private static readonly (int Threshold, string Key)[] MilestoneThresholds =
+	[
+		(1, "first-step"),
+		(5, "dedicated-5"),
+		(100, "centurion-100"),
+	];
+
+	public static async Task<Result<Engagement>> ConfirmAsync(
+		IApplicationDbContext dbContext,
+		ISender sender,
+		Engagement engagement,
+		string? timezone,
+		CancellationToken cancellationToken)
+	{
+		var confirmResult = engagement.Confirm();
+		if (confirmResult.IsFailure)
+			return Result.Failure<Engagement>(confirmResult.Error);
+
+		var volunteerId = engagement.VolunteerId!.Value;
+
+		var notification = Notification.Create(
+			volunteerId,
+			NotificationKind.EngagementConfirmed,
+			engagement.Id.Value);
+
+		await dbContext.Notifications.AddAsync(notification, cancellationToken);
+
+		var tz = ResolveTimeZone(timezone);
+		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
+		var isoYear = System.Globalization.ISOWeek.GetYear(now);
+		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
+		var totalConfirmedEngagements = await RecordActivityStreakAndConfirmationAsync(
+			dbContext, sender, volunteerId, isoYear, isoWeek, cancellationToken);
+
+		await EvaluateMilestoneAchievementsAsync(sender, volunteerId, totalConfirmedEngagements, cancellationToken);
+
+		return Result.Success(engagement);
+	}
+
+	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
+	{
+		if (string.IsNullOrWhiteSpace(ianaId))
+			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		try
+		{
+			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+		}
+		catch
+		{
+			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		}
+	}
+
+	private static async Task<int> RecordActivityStreakAndConfirmationAsync(
+		IApplicationDbContext dbContext,
+		ISender sender,
+		UserId volunteerId,
+		int isoYear,
+		int isoWeek,
+		CancellationToken cancellationToken)
+	{
+		var streak = await dbContext.GetOrCreateUserStreakAsync(volunteerId, cancellationToken);
+		streak.RecordActivity(isoYear, isoWeek);
+		streak.RecordConfirmedEngagement();
+
+		if (streak.ActivityStreak >= 4)
+		{
+			await sender.Send(new AwardAchievementCommand(volunteerId, "weekly-hero-4"), cancellationToken);
+		}
+
+		return streak.TotalConfirmedEngagements;
+	}
+
+	private static async Task EvaluateMilestoneAchievementsAsync(
+		ISender sender,
+		UserId volunteerId,
+		int totalConfirmedEngagements,
+		CancellationToken cancellationToken)
+	{
+		foreach (var (threshold, key) in MilestoneThresholds)
+		{
+			if (totalConfirmedEngagements >= threshold)
+			{
+				await sender.Send(new AwardAchievementCommand(volunteerId, key), cancellationToken);
+			}
+		}
+	}
+}

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -1,12 +1,10 @@
-using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Authorization;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Engagements.Common;
 using Domain.Engagements;
-using Domain.Notifications;
 using Domain.Primitives;
-using Domain.Users;
 
 namespace Application.Engagements.ConfirmEngagement.v1;
 
@@ -31,79 +29,9 @@ internal sealed class ConfirmEngagementCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
-		engagement.Confirm().ThrowIfFailure();
+		var result = await EngagementConfirmationHelper.ConfirmAsync(
+			dbContext, sender, engagement, request.Timezone, cancellationToken);
 
-		var volunteerId = engagement.VolunteerId!.Value;
-
-		var notification = Notification.Create(
-			volunteerId,
-			NotificationKind.EngagementConfirmed,
-			engagement.Id.Value);
-
-		await dbContext.Notifications.AddAsync(notification, cancellationToken);
-
-		var tz = ResolveTimeZone(request.Timezone);
-		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
-		var isoYear = System.Globalization.ISOWeek.GetYear(now);
-		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
-		var totalConfirmedEngagements = await RecordActivityStreakAndConfirmationAsync(
-			volunteerId, isoYear, isoWeek, cancellationToken);
-
-		await EvaluateMilestoneAchievementsAsync(volunteerId, totalConfirmedEngagements, cancellationToken);
-
-		return engagement;
-	}
-
-	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
-	{
-		if (string.IsNullOrWhiteSpace(ianaId))
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		try
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
-		}
-		catch
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		}
-	}
-
-	private async Task<int> RecordActivityStreakAndConfirmationAsync(
-		UserId volunteerId,
-		int isoYear,
-		int isoWeek,
-		CancellationToken cancellationToken)
-	{
-		var streak = await dbContext.GetOrCreateUserStreakAsync(volunteerId, cancellationToken);
-		streak.RecordActivity(isoYear, isoWeek);
-		streak.RecordConfirmedEngagement();
-
-		if (streak.ActivityStreak >= 4)
-		{
-			await sender.Send(new AwardAchievementCommand(volunteerId, "weekly-hero-4"), cancellationToken);
-		}
-
-		return streak.TotalConfirmedEngagements;
-	}
-
-	private static readonly (int Threshold, string Key)[] MilestoneThresholds =
-	[
-		(1, "first-step"),
-		(5, "dedicated-5"),
-		(100, "centurion-100"),
-	];
-
-	private async Task EvaluateMilestoneAchievementsAsync(
-		UserId volunteerId,
-		int totalConfirmedEngagements,
-		CancellationToken cancellationToken)
-	{
-		foreach (var (threshold, key) in MilestoneThresholds)
-		{
-			if (totalConfirmedEngagements >= threshold)
-			{
-				await sender.Send(new AwardAchievementCommand(volunteerId, key), cancellationToken);
-			}
-		}
+		return result.GetValueOrThrow();
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -105,12 +105,15 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			.OrderBy(ts => ts.StartDateTime)
 			.ToList();
 
+		var activeCountsBySlot = await dbContext.CountActiveEngagementsForTimeSlotsAsync(
+			affectedSlots.Select(ts => ts.Id).ToList(), cancellationToken);
+
 		var skipped = new List<Guid>();
 		var updatedCount = 0;
 
 		foreach (var slot in affectedSlots)
 		{
-			var activeCount = await dbContext.CountActiveEngagementsForTimeSlotAsync(slot.Id, cancellationToken);
+			var activeCount = activeCountsBySlot.GetValueOrDefault(slot.Id);
 			if (request.MaxParticipants < activeCount)
 			{
 				skipped.Add(slot.Id.Value);

--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Application.Common.Keycloak;
 using Application.Common.Pagination;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -12,6 +13,7 @@ namespace Infrastructure.Keycloak;
 internal sealed class KeycloakUserService(
 	HttpClient httpClient,
 	KeycloakAdminTokenProvider tokenProvider,
+	IMemoryCache cache,
 	IOptions<KeycloakOptions> options,
 	ILogger<KeycloakUserService> logger)
 	: IKeycloakUserService
@@ -20,6 +22,11 @@ internal sealed class KeycloakUserService(
 	{
 		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 	};
+
+	// Keycloak's admin API has no bulk multi-id endpoint (only per-id GET or a
+	// realm-wide page scan), so this cache - not a single network call - is what
+	// keeps GetUserProfilesAsync/GetDisplayNamesAsync cheap on repeat page views.
+	private static readonly TimeSpan ProfileCacheDuration = TimeSpan.FromSeconds(45);
 
 	private const int RoleLookupConcurrency = 8;
 
@@ -31,6 +38,10 @@ internal sealed class KeycloakUserService(
 		Guid userId,
 		CancellationToken cancellationToken = default)
 	{
+		var cacheKey = ProfileCacheKey(userId);
+		if (cache.TryGetValue(cacheKey, out KeycloakUserProfile? cached) && cached is not null)
+			return cached;
+
 		var response = await SendAuthorizedAsync(
 			() => new HttpRequestMessage(
 				HttpMethod.Get, $"/admin/realms/{_options.Realm}/users/{userId}"),
@@ -42,12 +53,16 @@ internal sealed class KeycloakUserService(
 			JsonOptions, cancellationToken)
 			?? throw new InvalidOperationException("Keycloak returned null user.");
 
-		return new KeycloakUserProfile(
+		var profile = new KeycloakUserProfile(
 			Guid.Parse(user.Id),
 			user.Username,
 			NullIfEmpty(user.FirstName),
 			NullIfEmpty(user.LastName),
 			user.Email ?? string.Empty);
+
+		cache.Set(cacheKey, profile, ProfileCacheDuration);
+
+		return profile;
 	}
 
 	public async Task<IReadOnlyDictionary<Guid, string>> GetDisplayNamesAsync(
@@ -136,6 +151,8 @@ internal sealed class KeycloakUserService(
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
+
+		cache.Remove(ProfileCacheKey(userId));
 	}
 
 	public async Task DeleteUserAsync(
@@ -148,6 +165,8 @@ internal sealed class KeycloakUserService(
 			cancellationToken);
 
 		await EnsureSuccessAsync(response, cancellationToken);
+
+		cache.Remove(ProfileCacheKey(userId));
 	}
 
 	public async Task<PagedList<AdminUserListItem>> ListUsersAsync(
@@ -353,6 +372,8 @@ internal sealed class KeycloakUserService(
 
 	private static string? NullIfEmpty(string? value) =>
 		string.IsNullOrEmpty(value) ? null : value;
+
+	private static string ProfileCacheKey(Guid userId) => $"keycloak-user-profile:{userId}";
 
 	private async Task EnsureSuccessAsync(
 		HttpResponseMessage response,

--- a/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -394,6 +394,13 @@ internal sealed class ApplicationDbContext(
 			.Where(e => e.VolunteerId == volunteerId)
 			.ToListAsync(cancellationToken);
 
+	public async Task<List<Engagement>> GetEngagementsByIdsAsync(
+		IReadOnlyCollection<EngagementId> engagementIds,
+		CancellationToken cancellationToken = default) =>
+		await Set<Engagement>()
+			.Where(e => engagementIds.Contains(e.Id))
+			.ToListAsync(cancellationToken);
+
 	public async Task<int> CountConfirmedEngagementsForVolunteerAsync(
 		UserId volunteerId,
 		CancellationToken cancellationToken = default) =>
@@ -407,6 +414,24 @@ internal sealed class ApplicationDbContext(
 			.CountAsync(e => e.TimeSlotId == timeSlotId
 				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed),
 				cancellationToken);
+
+	public async Task<Dictionary<TimeSlotId, int>> CountActiveEngagementsForTimeSlotsAsync(
+		IReadOnlyCollection<TimeSlotId> timeSlotIds,
+		CancellationToken cancellationToken = default)
+	{
+		var nullableIds = timeSlotIds.Select(id => (TimeSlotId?)id).ToList();
+
+		var activeTimeSlotIds = await Set<Engagement>()
+			.Where(e => nullableIds.Contains(e.TimeSlotId)
+				&& (e.Status == EngagementStatus.Pending || e.Status == EngagementStatus.Confirmed))
+			.Select(e => e.TimeSlotId)
+			.ToListAsync(cancellationToken);
+
+		return activeTimeSlotIds
+			.Where(id => id.HasValue)
+			.GroupBy(id => id!.Value)
+			.ToDictionary(g => g.Key, g => g.Count());
+	}
 
 	public async Task LockTimeSlotForUpdateAsync(
 		TimeSlotId timeSlotId,

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -19,6 +19,13 @@ internal sealed class VolunteerOpportunityReadRepository(
 	ApplicationDbContext dbContext)
 	: IVolunteerOpportunityReadRepository
 {
+	// The date-availability window is already capped at 62 days (see
+	// GetVolunteerOpportunityDateAvailabilityEndpoint.MaxWindowDays), but the number of
+	// publicly-listed opportunities with slots inside that window has no ceiling - it grows
+	// with the platform's total published data. This bounds the raw row count regardless,
+	// ordered soonest-first so a cap that ever kicks in drops the least actionable slots.
+	private const int MaxDateAvailabilitySlotRows = 10_000;
+
 	public async ValueTask<IReadOnlyList<SitemapEntry>> GetPublishedForSitemapAsync(
 		CancellationToken cancellationToken = default)
 	{
@@ -225,6 +232,8 @@ internal sealed class VolunteerOpportunityReadRepository(
 					Latitude = vo.Address != null ? vo.Address.Latitude : null,
 					Longitude = vo.Address != null ? vo.Address.Longitude : null,
 				}))
+			.OrderBy(s => s.StartDateTime)
+			.Take(MaxDateAvailabilitySlotRows)
 			.ToListAsync(cancellationToken);
 
 		var withinRadius = filter.HasRadius

--- a/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
@@ -1,13 +1,13 @@
+using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements.BulkConfirmEngagements.v1;
-using Application.Engagements.ConfirmEngagement.v1;
 using AwesomeAssertions;
 using Domain.Common;
 using Domain.Engagements;
+using Domain.Notifications;
 using Domain.Organizations;
-using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
@@ -19,8 +19,8 @@ public class BulkConfirmEngagementsCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
-	private readonly IAggregateRepository<Engagement, EngagementId> _engagementRepo =
-		Substitute.For<IAggregateRepository<Engagement, EngagementId>>();
+	private readonly IAggregateRepository<Notification, NotificationId> _notificationRepo =
+		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly ISender _sender = Substitute.For<ISender>();
 	private readonly BulkConfirmEngagementsCommandHandler _sut;
@@ -33,42 +33,41 @@ public class BulkConfirmEngagementsCommandHandlerTests
 	public BulkConfirmEngagementsCommandHandlerTests()
 	{
 		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
-		_dbContext.Engagements.Returns(_engagementRepo);
+		_dbContext.Notifications.Returns(_notificationRepo);
 		_opportunityRepo
 			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
 			.Returns(CreateDefaultOpportunity());
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
+		_dbContext
+			.GetOrCreateUserStreakAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => UserStreak.Create(callInfo.Arg<UserId>()));
+		_dbContext
+			.GetEngagementsByIdsAsync(Arg.Any<IReadOnlyCollection<EngagementId>>(), Arg.Any<CancellationToken>())
+			.Returns([]);
 		_sut = new BulkConfirmEngagementsCommandHandler(_dbContext, _sender);
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>
 		VolunteerOpportunity.Create(DefaultOrgId, "Test", null, "Test", null, false, DefaultAddress, Occurrence.OneTime, ParticipationType.ScheduledSlots, CheckInMethod.None, _pinGenerator, status: OpportunityStatus.Draft).Value;
 
-	private static Engagement CreateConfirmedEngagement(VolunteerOpportunityId? opportunityId = null)
-	{
-		var engagement = Engagement.CreateSlotSignUp(opportunityId ?? DefaultOpportunityId, UserId.New(), TimeSlotId.New());
-		engagement.Confirm();
-		return engagement;
-	}
+	private static Engagement CreatePendingEngagement(VolunteerOpportunityId? opportunityId = null) =>
+		Engagement.CreateSlotSignUp(opportunityId ?? DefaultOpportunityId, UserId.New(), TimeSlotId.New());
 
-	private void SeedEngagement(Engagement engagement) =>
-		_engagementRepo.FindAsync(engagement.Id, Arg.Any<CancellationToken>()).Returns(engagement);
+	private void SeedEngagements(params Engagement[] engagements) =>
+		_dbContext
+			.GetEngagementsByIdsAsync(Arg.Any<IReadOnlyCollection<EngagementId>>(), Arg.Any<CancellationToken>())
+			.Returns(engagements.ToList());
 
 	[Test]
-	public async Task Handle_ShouldReturnSucceeded_ForEveryEngagementConfirmedByTheNestedCommand(
+	public async Task Handle_ShouldReturnSucceeded_ForEveryConfirmableEngagement(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var engagementA = CreateConfirmedEngagement();
-		var engagementB = CreateConfirmedEngagement();
-		SeedEngagement(engagementA);
-		SeedEngagement(engagementB);
-		_sender.Send(Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == engagementA.Id), Arg.Any<CancellationToken>())
-			.Returns(engagementA);
-		_sender.Send(Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == engagementB.Id), Arg.Any<CancellationToken>())
-			.Returns(engagementB);
+		var engagementA = CreatePendingEngagement();
+		var engagementB = CreatePendingEngagement();
+		SeedEngagements(engagementA, engagementB);
 
 		var command = new BulkConfirmEngagementsCommand(
 			DefaultOpportunityId,
@@ -83,21 +82,19 @@ public class BulkConfirmEngagementsCommandHandlerTests
 		result.Succeeded.Should().HaveCount(2);
 		result.Succeeded.Should().Contain(s => s.EngagementId == engagementA.Id.Value && s.Status == "Confirmed");
 		result.Succeeded.Should().Contain(s => s.EngagementId == engagementB.Id.Value && s.Status == "Confirmed");
+		engagementA.Status.Should().Be(EngagementStatus.Confirmed);
+		engagementB.Status.Should().Be(EngagementStatus.Confirmed);
 	}
 
 	[Test]
-	public async Task Handle_ShouldCollectFailure_WithoutAbortingTheRestOfTheBatch_WhenANestedConfirmFails(
+	public async Task Handle_ShouldCollectFailure_WithoutAbortingTheRestOfTheBatch_WhenAConfirmFails(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var okEngagement = CreateConfirmedEngagement();
-		var badEngagement = CreateConfirmedEngagement();
-		SeedEngagement(okEngagement);
-		SeedEngagement(badEngagement);
-		_sender.Send(Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == okEngagement.Id), Arg.Any<CancellationToken>())
-			.Returns(okEngagement);
-		_sender.Send(Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == badEngagement.Id), Arg.Any<CancellationToken>())
-			.Returns<Engagement>(_ => throw new ResultFailureException(Error.Conflict("Engagement.NotPending", "Only pending engagements can be confirmed.")));
+		var okEngagement = CreatePendingEngagement();
+		var badEngagement = CreatePendingEngagement();
+		badEngagement.Confirm();
+		SeedEngagements(okEngagement, badEngagement);
 
 		var command = new BulkConfirmEngagementsCommand(
 			DefaultOpportunityId,
@@ -115,12 +112,11 @@ public class BulkConfirmEngagementsCommandHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldCollectFailure_WithoutCallingTheNestedCommand_WhenEngagementDoesNotExist(
+	public async Task Handle_ShouldCollectFailure_WhenEngagementDoesNotExist(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var missingId = EngagementId.New();
-		_engagementRepo.FindAsync(missingId, Arg.Any<CancellationToken>()).Returns((Engagement?)null);
 
 		var command = new BulkConfirmEngagementsCommand(DefaultOpportunityId, [missingId], DefaultRequestingUserId);
 
@@ -130,16 +126,16 @@ public class BulkConfirmEngagementsCommandHandlerTests
 		// Assert
 		result.Succeeded.Should().BeEmpty();
 		result.Failed.Should().ContainSingle(f => f.EngagementId == missingId.Value && f.ErrorCode == "Engagement.NotFound");
-		await _sender.DidNotReceive().Send(Arg.Any<ConfirmEngagementCommand>(), Arg.Any<CancellationToken>());
+		await _sender.DidNotReceive().Send(Arg.Any<AwardAchievementCommand>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
-	public async Task Handle_ShouldCollectFailure_WithoutCallingTheNestedCommand_WhenEngagementBelongsToADifferentOpportunity(
+	public async Task Handle_ShouldCollectFailure_WhenEngagementBelongsToADifferentOpportunity(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var foreignEngagement = CreateConfirmedEngagement(VolunteerOpportunityId.New());
-		SeedEngagement(foreignEngagement);
+		var foreignEngagement = CreatePendingEngagement(VolunteerOpportunityId.New());
+		SeedEngagements(foreignEngagement);
 
 		var command = new BulkConfirmEngagementsCommand(DefaultOpportunityId, [foreignEngagement.Id], DefaultRequestingUserId);
 
@@ -149,18 +145,17 @@ public class BulkConfirmEngagementsCommandHandlerTests
 		// Assert
 		result.Succeeded.Should().BeEmpty();
 		result.Failed.Should().ContainSingle(f => f.EngagementId == foreignEngagement.Id.Value && f.ErrorCode == "Engagement.WrongOpportunity");
-		await _sender.DidNotReceive().Send(Arg.Any<ConfirmEngagementCommand>(), Arg.Any<CancellationToken>());
+		foreignEngagement.Status.Should().Be(EngagementStatus.Pending);
+		await _sender.DidNotReceive().Send(Arg.Any<AwardAchievementCommand>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
-	public async Task Handle_ShouldSendEachDistinctEngagementIdOnlyOnce_WhenDuplicatesArePassed(
+	public async Task Handle_ShouldConfirmEachDistinctEngagementIdOnlyOnce_WhenDuplicatesArePassed(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-		var engagement = CreateConfirmedEngagement();
-		SeedEngagement(engagement);
-		_sender.Send(Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == engagement.Id), Arg.Any<CancellationToken>())
-			.Returns(engagement);
+		var engagement = CreatePendingEngagement();
+		SeedEngagements(engagement);
 
 		var command = new BulkConfirmEngagementsCommand(
 			DefaultOpportunityId,
@@ -172,8 +167,9 @@ public class BulkConfirmEngagementsCommandHandlerTests
 
 		// Assert
 		result.Succeeded.Should().ContainSingle();
-		await _sender.Received(1).Send(
-			Arg.Is<ConfirmEngagementCommand>(c => c!.EngagementId == engagement.Id),
+		engagement.Status.Should().Be(EngagementStatus.Confirmed);
+		await _dbContext.Received(1).GetEngagementsByIdsAsync(
+			Arg.Is<IReadOnlyCollection<EngagementId>>(ids => ids.Count == 1 && ids.Contains(engagement.Id)),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -192,7 +188,8 @@ public class BulkConfirmEngagementsCommandHandlerTests
 
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage($"*{opportunityId.Value}*");
-		await _sender.DidNotReceive().Send(Arg.Any<ConfirmEngagementCommand>(), Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().GetEngagementsByIdsAsync(
+			Arg.Any<IReadOnlyCollection<EngagementId>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -209,31 +206,8 @@ public class BulkConfirmEngagementsCommandHandlerTests
 
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*permission*");
-		await _sender.DidNotReceive().Send(Arg.Any<ConfirmEngagementCommand>(), Arg.Any<CancellationToken>());
-	}
-
-	[Test]
-	public async Task Handle_ShouldPassTimezoneThrough_ToEachNestedConfirmCommand(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var engagement = CreateConfirmedEngagement();
-		SeedEngagement(engagement);
-		_sender.Send(Arg.Any<ConfirmEngagementCommand>(), Arg.Any<CancellationToken>())
-			.Returns(engagement);
-		var command = new BulkConfirmEngagementsCommand(
-			DefaultOpportunityId,
-			[engagement.Id],
-			DefaultRequestingUserId,
-			"Europe/Berlin");
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		await _sender.Received(1).Send(
-			Arg.Is<ConfirmEngagementCommand>(c => c!.Timezone == "Europe/Berlin"),
-			Arg.Any<CancellationToken>());
+		await _dbContext.DidNotReceive().GetEngagementsByIdsAsync(
+			Arg.Any<IReadOnlyCollection<EngagementId>>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -45,6 +45,9 @@ public class UpdateTimeSlotCommandHandlerTests
 		_dbContext
 			.CountActiveEngagementsForTimeSlotAsync(Arg.Any<TimeSlotId>(), Arg.Any<CancellationToken>())
 			.Returns(0);
+		_dbContext
+			.CountActiveEngagementsForTimeSlotsAsync(Arg.Any<IReadOnlyCollection<TimeSlotId>>(), Arg.Any<CancellationToken>())
+			.Returns([]);
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
@@ -416,8 +419,8 @@ public class UpdateTimeSlotCommandHandlerTests
 			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
 			.Returns(opportunity);
 		_dbContext
-			.CountActiveEngagementsForTimeSlotAsync(slot2.Id, Arg.Any<CancellationToken>())
-			.Returns(8);
+			.CountActiveEngagementsForTimeSlotsAsync(Arg.Any<IReadOnlyCollection<TimeSlotId>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<TimeSlotId, int> { [slot2.Id] = 8 });
 
 		var command = new UpdateTimeSlotCommand(
 			opportunityId, slot1.Id.Value, null, null, 3, DefaultRequestingUserId, SeriesEditScope.EntireSeries);


### PR DESCRIPTION
## What

Fixes the four per-item hot paths flagged by the 1.0 readiness analysis - each is per-item work where a set-based or batched alternative now exists nearby, matching the pattern the rest of the data-access layer already follows.

## Why

Closes #2216

1. **Keycloak profile lookups** (`GetUserProfilesAsync`/`GetDisplayNamesAsync`) were an uncached per-id `GET` against Keycloak's admin API - I verified against Keycloak 26.7.2's actual `UsersResource` source that there is no multi-id bulk endpoint (only per-id `GET` or a full realm-wide page scan), so a short-TTL cache is what actually eliminates the fan-out on repeat page views and pagination clicks, not a single network call. `GetUserAsync` now fronts itself with a 45s `IMemoryCache` entry (this repo's existing cache-aside pattern, used the same way in `GeocodeAddressQueryHandler`/`OpenStreetMapTileService`), invalidated in `UpdateUserAsync`/`DeleteUserAsync` so a profile edit is visible immediately - `UpdateUserProfileTests.cs`'s existing update-then-read assertion exercises exactly that path.
2. **Bulk confirm** looped up to 200 ids through `ISender.Send(ConfirmEngagementCommand)`, each nested dispatch redundantly re-fetching the (already-loaded) engagement and opportunity, re-checking organizer ownership (already checked once for the batch), and going through the full pipeline behaviour chain. Extracted the actual confirm logic (domain call, notification, streak, achievements) into a shared `EngagementConfirmationHelper` used by both the single-item and bulk handlers; the bulk handler now batch-fetches all requested engagements in one query (`GetEngagementsByIdsAsync`) and calls the helper directly in-process instead of replaying the pipeline per item.
3. **Series capacity edit** ran `CountActiveEngagementsForTimeSlotAsync` once per occurrence (up to 52). Added `CountActiveEngagementsForTimeSlotsAsync`, computed once before the loop.
4. **Public date-availability endpoint** materialized every matching time-slot row with no `Take` before grouping - unbounded by the platform's total published data (the date window itself was already capped at 62 days, but the number of opportunities-with-slots inside that window isn't). Added `.OrderBy(StartDateTime).Take(10_000)` so it's bounded regardless, biased toward keeping the soonest (most actionable) slots if the cap is ever hit.

**Deliberately out of scope** (noted for transparency, not silently skipped): bulk confirm still does one streak read per engagement (each is typically a different volunteer, so batching would need a new "get-or-create many" method with real insert-branching - a materially bigger change than "stop replaying the pipeline"), and the series capacity edit still sends one notification batch per updated slot (each slot has a different active-volunteer set). Both match the acceptance criteria's literal scope; #2200 (Keycloak `client.Timeout`) and #2215 (the process-wide `IMemoryCache` `SizeLimit` caveat) are the two related, separately-filed concerns the issue itself calls out.

## Testing

- `BulkConfirmEngagementsCommandHandlerTests.cs`: rewritten to seed real pending engagements and assert actual domain-state transitions (e.g. confirmed status, or an out-of-scope engagement staying untouched at `Pending`) instead of mocking the now-removed nested `ConfirmEngagementCommand` dispatch. Added a regression assertion that duplicate ids are deduped *before* the batch fetch.
- `UpdateTimeSlotCommandHandlerTests.cs`: updated its one capacity-skip test to seed the new batched-count method instead of the removed per-slot one.
- `ConfirmEngagementCommandHandlerTests.cs`: unchanged and still exercises the same behaviour, now indirectly through the shared helper.
- Ran the `architecture-check` and `ef-migration-check` subagents against the full diff (both pass: no layer/naming/rate-limit violations, no missing migration - the two new `IApplicationDbContext` methods are read-only LINQ over the existing model).
- **Could not run `dotnet build`/the test suites locally in this session** - `builds.dotnet.microsoft.com` (the SDK installer's redirect target) is blocked by this session's egress policy (403), and per the proxy's own guidance a policy denial must be reported, not retried or routed around. I cross-checked every new/changed method signature and EF LINQ translation by hand against existing proven call sites in this codebase instead. CI's `dotnet.yml` will be the first actual compiler/test run on this diff - flagging this explicitly rather than claiming a local green run I didn't get.

## Checklist

- [x] `/self-review` run and findings addressed (no P1/P2 findings; two scope-boundary notes called out above)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - internal perf-only change, no API/behavior contract changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqqeYMA8ZpzEvpArWdv2ke)_