### PR TITLE
fix: announce client-side route changes to assistive tech

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { AuthStatusProvider } from "./contexts/AuthStatusContext";
 import { signinLocaleArgs } from "./lib/authLocale";
 import ErrorBanner from "./components/ErrorBanner";
 import Button from "./components/Button";
+import RouteAnnouncer from "./components/RouteAnnouncer";
 import AppLayout from "./layouts/AppLayout";
 import ProtectedRoute from "./layouts/ProtectedRoute";
 import OrgAppLayout, { type OrgAppContext } from "./layouts/OrgAppLayout";
@@ -107,94 +108,97 @@ function AppRoutes() {
 	useSessionExpiryHandler();
 	useSilentSsoProbe();
 	return (
-		<Routes>
-			<Route path="/callback" element={<CallbackPage />} />
-			<Route
-				path="/app/:organizationId"
-				element={
-					<ProtectedRoute>
-						<OrgAppLayout />
-					</ProtectedRoute>
-				}
-			>
-				<Route index element={<Navigate to="dashboard" replace />} />
-
-				<Route path="dashboard" element={<OrgAppOutletRelay />}>
-					<Route index element={<OrgDashboardPage />} />
-					<Route path="opportunities" element={<OrgOpportunitiesPage />} />
-					<Route
-						path="opportunities/:opportunityId/engagements"
-						element={<EngagementManagementPage />}
-					/>
-					<Route path="engagements" element={<OrgEngagementsPage />} />
-					<Route path="members" element={<OrgMembersPage />} />
-					<Route path="settings" element={<OrgSettingsPage />} />
-				</Route>
-			</Route>
-			<Route element={<AppLayout />}>
-				<Route path="/" element={<HomePage />} />
-
-				<Route path="/opportunities" element={<OpportunitiesPage />} />
-				<Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
-				<Route path="/imprint" element={<ImprintPage />} />
-				<Route path="/terms-of-use" element={<TermsOfUsePage />} />
-				<Route path="/contact" element={<ContactPage />} />
-				<Route path="/help" element={<HelpPage />} />
-				<Route path="/unsubscribe" element={<UnsubscribeConfirmPage />} />
-				<Route path="/unsubscribed" element={<UnsubscribePage />} />
+		<>
+			<RouteAnnouncer />
+			<Routes>
+				<Route path="/callback" element={<CallbackPage />} />
 				<Route
-					path="/volunteer-opportunities/:opportunityId"
-					element={<VolunteerOpportunityDetailPage />}
-				/>
-				<Route path="/organizations" element={<OrganizationsPage />} />
-				<Route
-					path="/organizations/:organizationId"
-					element={<OrganizationProfilePage />}
-				/>
-
-				<Route
-					path="/my-signups"
+					path="/app/:organizationId"
 					element={
 						<ProtectedRoute>
-							<MyEngagementsPage />
-						</ProtectedRoute>
-					}
-				/>
-				<Route
-					path="/profile"
-					element={
-						<ProtectedRoute>
-							<ProfileOverviewPage />
-						</ProtectedRoute>
-					}
-				/>
-				<Route
-					path="/profile/settings"
-					element={
-						<ProtectedRoute>
-							<ProfileSettingsPage />
-						</ProtectedRoute>
-					}
-				/>
-				<Route path="/users/:userId" element={<UserProfilePage />} />
-
-				<Route
-					path="/administration"
-					element={
-						<ProtectedRoute requiredRole="admin">
-							<AdministrationPage />
+							<OrgAppLayout />
 						</ProtectedRoute>
 					}
 				>
-					<Route index element={<Navigate to="organizations" replace />} />
-					<Route path="organizations" element={<AdminOrganizationsPage />} />
-					<Route path="users" element={<AdminUsersPage />} />
-					<Route path="reports" element={<AdminReportsPage />} />
-					<Route path="audit-log" element={<AdminAuditLogPage />} />
+					<Route index element={<Navigate to="dashboard" replace />} />
+
+					<Route path="dashboard" element={<OrgAppOutletRelay />}>
+						<Route index element={<OrgDashboardPage />} />
+						<Route path="opportunities" element={<OrgOpportunitiesPage />} />
+						<Route
+							path="opportunities/:opportunityId/engagements"
+							element={<EngagementManagementPage />}
+						/>
+						<Route path="engagements" element={<OrgEngagementsPage />} />
+						<Route path="members" element={<OrgMembersPage />} />
+						<Route path="settings" element={<OrgSettingsPage />} />
+					</Route>
 				</Route>
-				<Route path="*" element={<NotFoundPage />} />
-			</Route>
-		</Routes>
+				<Route element={<AppLayout />}>
+					<Route path="/" element={<HomePage />} />
+
+					<Route path="/opportunities" element={<OpportunitiesPage />} />
+					<Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+					<Route path="/imprint" element={<ImprintPage />} />
+					<Route path="/terms-of-use" element={<TermsOfUsePage />} />
+					<Route path="/contact" element={<ContactPage />} />
+					<Route path="/help" element={<HelpPage />} />
+					<Route path="/unsubscribe" element={<UnsubscribeConfirmPage />} />
+					<Route path="/unsubscribed" element={<UnsubscribePage />} />
+					<Route
+						path="/volunteer-opportunities/:opportunityId"
+						element={<VolunteerOpportunityDetailPage />}
+					/>
+					<Route path="/organizations" element={<OrganizationsPage />} />
+					<Route
+						path="/organizations/:organizationId"
+						element={<OrganizationProfilePage />}
+					/>
+
+					<Route
+						path="/my-signups"
+						element={
+							<ProtectedRoute>
+								<MyEngagementsPage />
+							</ProtectedRoute>
+						}
+					/>
+					<Route
+						path="/profile"
+						element={
+							<ProtectedRoute>
+								<ProfileOverviewPage />
+							</ProtectedRoute>
+						}
+					/>
+					<Route
+						path="/profile/settings"
+						element={
+							<ProtectedRoute>
+								<ProfileSettingsPage />
+							</ProtectedRoute>
+						}
+					/>
+					<Route path="/users/:userId" element={<UserProfilePage />} />
+
+					<Route
+						path="/administration"
+						element={
+							<ProtectedRoute requiredRole="admin">
+								<AdministrationPage />
+							</ProtectedRoute>
+						}
+					>
+						<Route index element={<Navigate to="organizations" replace />} />
+						<Route path="organizations" element={<AdminOrganizationsPage />} />
+						<Route path="users" element={<AdminUsersPage />} />
+						<Route path="reports" element={<AdminReportsPage />} />
+						<Route path="audit-log" element={<AdminAuditLogPage />} />
+					</Route>
+					<Route path="*" element={<NotFoundPage />} />
+				</Route>
+			</Routes>
+		</>
 	);
 }
 

--- a/frontend/src/components/RouteAnnouncer.test.tsx
+++ b/frontend/src/components/RouteAnnouncer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { Link, Route, Routes } from "react-router";
@@ -20,8 +20,9 @@ function SecondPage() {
 }
 
 // Stands in for a lazy-loaded route whose chunk (and h1) isn't there yet
-// when the location changes - the reveal is a click instead of a real delay
-// so the test doesn't depend on timing.
+// when the location changes. The reveal is fired with fireEvent rather than
+// userEvent so it doesn't itself move focus - a chunk finishing download
+// isn't a focus-relevant interaction in production either.
 function SlowSecondPage() {
 	const [ready, setReady] = useState(false);
 	return ready ? (
@@ -35,6 +36,7 @@ function renderApp(route: string, slow = false) {
 	return renderWithProviders(
 		<>
 			<RouteAnnouncer />
+			<button type="button">Persistent control</button>
 			<main id="main-content" tabIndex={-1}>
 				<Routes>
 					<Route path="/first" element={<FirstPage />} />
@@ -95,10 +97,54 @@ describe("RouteAnnouncer", () => {
 			document.getElementById("main-content"),
 		);
 
-		await user.click(screen.getByRole("button", { name: "reveal" }));
+		fireEvent.click(screen.getByRole("button", { name: "reveal" }));
 
 		const heading = await screen.findByRole("heading", { name: "Second page" });
 		await waitFor(() => expect(document.activeElement).toBe(heading));
 		await waitFor(() => expect(liveRegion()).toHaveTextContent("Second page"));
+	});
+
+	it("does not steal focus back once the user has already moved on before a late heading mounts", async () => {
+		const user = userEvent.setup();
+		renderApp("/first", true);
+
+		await user.click(screen.getByRole("link", { name: "Go to second" }));
+		expect(document.activeElement).toBe(
+			document.getElementById("main-content"),
+		);
+
+		const persistentControl = screen.getByRole("button", {
+			name: "Persistent control",
+		});
+		await user.click(persistentControl);
+		expect(document.activeElement).toBe(persistentControl);
+
+		fireEvent.click(screen.getByRole("button", { name: "reveal" }));
+		await screen.findByRole("heading", { name: "Second page" });
+
+		expect(document.activeElement).toBe(persistentControl);
+	});
+
+	it("does not move focus, scroll, or announce while a modal dialog is open", async () => {
+		const user = userEvent.setup();
+		renderApp("/first");
+
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.setAttribute("aria-modal", "true");
+		document.body.appendChild(dialog);
+
+		try {
+			await user.click(screen.getByRole("link", { name: "Go to second" }));
+
+			const heading = await screen.findByRole("heading", {
+				name: "Second page",
+			});
+			expect(document.activeElement).not.toBe(heading);
+			expect(window.scrollTo).not.toHaveBeenCalled();
+			expect(liveRegion()).toHaveTextContent("");
+		} finally {
+			document.body.removeChild(dialog);
+		}
 	});
 });

--- a/frontend/src/components/RouteAnnouncer.test.tsx
+++ b/frontend/src/components/RouteAnnouncer.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Link, Route, Routes } from "react-router";
+import RouteAnnouncer from "./RouteAnnouncer";
+import { renderWithProviders } from "../test/render";
+
+function FirstPage() {
+	return (
+		<div>
+			<h1>First page</h1>
+			<Link to="/second">Go to second</Link>
+		</div>
+	);
+}
+
+function SecondPage() {
+	return <h1>Second page</h1>;
+}
+
+// Stands in for a lazy-loaded route whose chunk (and h1) isn't there yet
+// when the location changes - the reveal is a click instead of a real delay
+// so the test doesn't depend on timing.
+function SlowSecondPage() {
+	const [ready, setReady] = useState(false);
+	return ready ? (
+		<h1>Second page</h1>
+	) : (
+		<button onClick={() => setReady(true)}>reveal</button>
+	);
+}
+
+function renderApp(route: string, slow = false) {
+	return renderWithProviders(
+		<>
+			<RouteAnnouncer />
+			<main id="main-content" tabIndex={-1}>
+				<Routes>
+					<Route path="/first" element={<FirstPage />} />
+					<Route
+						path="/second"
+						element={slow ? <SlowSecondPage /> : <SecondPage />}
+					/>
+				</Routes>
+			</main>
+		</>,
+		{ route },
+	);
+}
+
+function liveRegion() {
+	const region = document.querySelector('[aria-live="polite"]');
+	if (!region) throw new Error("live region not found");
+	return region;
+}
+
+beforeEach(() => {
+	vi.mocked(window.scrollTo).mockClear();
+});
+
+describe("RouteAnnouncer", () => {
+	it("leaves focus and the live region alone on the initial page load", () => {
+		renderApp("/first");
+
+		expect(document.activeElement).toBe(document.body);
+		expect(liveRegion()).toHaveTextContent("");
+		expect(window.scrollTo).not.toHaveBeenCalled();
+	});
+
+	it("moves focus to the new page's h1, resets scroll and announces it after a client-side navigation", async () => {
+		const user = userEvent.setup();
+		renderApp("/first");
+
+		await user.click(screen.getByRole("link", { name: "Go to second" }));
+
+		const heading = await screen.findByRole("heading", { name: "Second page" });
+		expect(document.activeElement).toBe(heading);
+		expect(heading).toHaveAttribute("tabindex", "-1");
+		expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+		expect(liveRegion()).toHaveTextContent("Second page");
+	});
+
+	it("falls back to #main-content and still catches the heading once it mounts later", async () => {
+		const user = userEvent.setup();
+		renderApp("/first", true);
+
+		await user.click(screen.getByRole("link", { name: "Go to second" }));
+
+		expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+		expect(
+			screen.queryByRole("heading", { name: "Second page" }),
+		).not.toBeInTheDocument();
+		expect(document.activeElement).toBe(
+			document.getElementById("main-content"),
+		);
+
+		await user.click(screen.getByRole("button", { name: "reveal" }));
+
+		const heading = await screen.findByRole("heading", { name: "Second page" });
+		await waitFor(() => expect(document.activeElement).toBe(heading));
+		await waitFor(() => expect(liveRegion()).toHaveTextContent("Second page"));
+	});
+});

--- a/frontend/src/components/RouteAnnouncer.tsx
+++ b/frontend/src/components/RouteAnnouncer.tsx
@@ -13,12 +13,19 @@ export default function RouteAnnouncer() {
 		if (previousPathname.current === location.pathname) return;
 		previousPathname.current = location.pathname;
 
+		// A dialog (e.g. "create organization", opened from the header) can
+		// stay open across a pathname change it didn't cause - e.g. browser
+		// back/forward - so don't rip focus out of its trap.
+		if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+
 		window.scrollTo(0, 0);
 
 		let headingFocused = false;
+		let lastFocusTarget: HTMLElement | null = null;
 
 		const observer = new MutationObserver(() => {
 			if (headingFocused) return;
+			if (document.activeElement !== lastFocusTarget) return;
 			const lateHeading = document.querySelector<HTMLElement>("h1");
 			if (lateHeading) focusHeading(lateHeading);
 		});
@@ -30,6 +37,7 @@ export default function RouteAnnouncer() {
 				heading.setAttribute("tabindex", "-1");
 			}
 			heading.focus({ preventScroll: true });
+			lastFocusTarget = heading;
 			setAnnouncement(heading.textContent?.trim() || document.title);
 		}
 
@@ -37,7 +45,9 @@ export default function RouteAnnouncer() {
 		if (heading) {
 			focusHeading(heading);
 		} else {
-			document.getElementById("main-content")?.focus({ preventScroll: true });
+			const main = document.getElementById("main-content");
+			main?.focus({ preventScroll: true });
+			lastFocusTarget = main;
 			setAnnouncement(document.title);
 			observer.observe(document.body, { childList: true, subtree: true });
 		}

--- a/frontend/src/components/RouteAnnouncer.tsx
+++ b/frontend/src/components/RouteAnnouncer.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router";
+
+// Pages are lazy-loaded, so the h1 may not exist yet when the route changes -
+// fall back to #main-content and let the MutationObserver pick up the real
+// heading once its chunk finishes mounting.
+export default function RouteAnnouncer() {
+	const location = useLocation();
+	const [announcement, setAnnouncement] = useState("");
+	const previousPathname = useRef(location.pathname);
+
+	useEffect(() => {
+		if (previousPathname.current === location.pathname) return;
+		previousPathname.current = location.pathname;
+
+		window.scrollTo(0, 0);
+
+		let headingFocused = false;
+
+		const observer = new MutationObserver(() => {
+			if (headingFocused) return;
+			const lateHeading = document.querySelector<HTMLElement>("h1");
+			if (lateHeading) focusHeading(lateHeading);
+		});
+
+		function focusHeading(heading: HTMLElement) {
+			headingFocused = true;
+			observer.disconnect();
+			if (!heading.hasAttribute("tabindex")) {
+				heading.setAttribute("tabindex", "-1");
+			}
+			heading.focus({ preventScroll: true });
+			setAnnouncement(heading.textContent?.trim() || document.title);
+		}
+
+		const heading = document.querySelector<HTMLElement>("h1");
+		if (heading) {
+			focusHeading(heading);
+		} else {
+			document.getElementById("main-content")?.focus({ preventScroll: true });
+			setAnnouncement(document.title);
+			observer.observe(document.body, { childList: true, subtree: true });
+		}
+
+		return () => observer.disconnect();
+	}, [location.pathname]);
+
+	return (
+		<div aria-live="polite" aria-atomic="true" className="sr-only">
+			{announcement}
+		</div>
+	);
+}


### PR DESCRIPTION
## What

Adds a `RouteAnnouncer` component that runs on every client-side navigation: it moves focus to the new page's `h1` (falling back to the layout's `#main-content` skip target, with a `MutationObserver` re-check for lazy-loaded pages whose heading isn't mounted yet), resets scroll to the top, and announces the new heading text via a polite live region.

## Why

Client-side route changes were completely silent for assistive tech: focus stayed on the clicked element, nothing was announced, and scroll position carried over from the previous route - on a mobile-first volunteer platform whose whole flow is browse -> detail -> sign up, this made the primary navigation path unusable with a screen reader. Axe-based a11y tests structurally can't catch this, since they audit a static snapshot rather than a transition.

Closes #2209

**Out of scope for this PR:** the issue's "Additional Information" section separately flags extending a11y coverage (including a keyboard alternative for widget placement) to the dashboard drag-and-drop grid, `QRScannerModal`, and `CreateVolunteerOpportunityModal`. That's a distinct, materially larger effort (new keyboard interaction models, not focus management) - the issue itself calls it out with "Separately", and a related closed issue (#2234) also treats it as a different piece of work than the route-focus fix here.

## Testing

- Added `frontend/src/components/RouteAnnouncer.test.tsx` - a router-level test asserting `document.activeElement` and the live-region content after a real client-side navigation (the level of test the issue asked for, since axe cannot see this). Covers: the initial page load is a no-op (no hijacked focus/scroll/announcement), a synchronous navigation moves focus to the new `h1`/resets scroll/announces it, and a page whose heading mounts later (simulating a lazy-loaded chunk) still gets picked up via the `MutationObserver` fallback after first resting focus on `#main-content`.
- `pnpm test` (832/832), `pnpm lint`, `pnpm check`, `pnpm format:check`, and `pnpm build` all pass locally.
- Not run in this sandbox: `dotnet run --project backend/src/Aspire/AppHost` and the Playwright `VisualTests` suite need real container networking (see `AGENTS.md`'s Sandbox Limitations) - CI's `dotnet.yml` covers those. Real focus movement/announcement was not manually verified against an actual screen reader in this session.

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJRLGbu9MkgPT9kfr4vuh8)_