### PR TITLE
fix: give the Keycloak user profile cache entry a Size

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -60,7 +60,13 @@ internal sealed class KeycloakUserService(
 			NullIfEmpty(user.LastName),
 			user.Email ?? string.Empty);
 
-		cache.Set(cacheKey, profile, ProfileCacheDuration);
+		// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+		// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+		cache.Set(cacheKey, profile, new MemoryCacheEntryOptions
+		{
+			Size = 1,
+			AbsoluteExpirationRelativeToNow = ProfileCacheDuration,
+		});
 
 		return profile;
 	}


### PR DESCRIPTION
## What

`KeycloakUserService.GetUserAsync`'s `cache.Set(cacheKey, profile, ProfileCacheDuration)` call used the bare `TimeSpan` overload, which never sets `Size` on the cache entry.

## Why

`main` is red: every "Build and Test Backend" run since commit `8e0149d` fails `integration-tests` and 3 of 4 `visual-tests` shards, with essentially every test that touches an authenticated user failing with `ApiException: Internal Server Error (500)` at `GetUserProfileAsync`.

Root cause is a semantic merge conflict between two individually-fine commits in the same landing batch:
- `59905e9` ("perf: batch four organizer hot paths...") added a 45s Keycloak profile cache in `GetUserAsync`, via `cache.Set(cacheKey, profile, ProfileCacheDuration)` - the `TimeSpan` overload, which sets no `Size`.
- `a41ecd7` ("fix(maps): give the shared memory cache a size limit so it evicts (#2273)"), landing right after, put a `SizeLimit` on the shared `IMemoryCache` and updated every *other* `cache.Set` call site it knew about (city search, both geocoding caches, the login-streak dedup memo) to supply a nominal `Size`. Its own commit message says: *"MemoryCache.Set throws once SizeLimit is set if any entry omits Size"* - but it couldn't have known about `59905e9`'s new call site, since that commit hadn't merged into its base.

No textual conflict, so both merged cleanly - but together, `GetUserAsync` now throws `InvalidOperationException` on every call, which the exception middleware turns into a 500. `GetUserAsync` backs `GetDisplayNamesAsync`, `GetUserProfilesAsync`, and any endpoint that resolves a user's Keycloak profile (including the one the integration test client calls `GetUserProfileAsync`), which is why the failure is so broad.

I confirmed this is the only remaining offender: a repo-wide grep for cache `.Set(` calls turns up 6 files, and the other 5 all already follow the `MemoryCacheEntryOptions { Size = 1, ... }` pattern this PR now applies to the 6th.

## Testing

- Matched the existing `Size = 1` nominal-size pattern used by the 5 other `cache.Set` call sites in the codebase (same comment, same shape).
- No test constructs a real `MemoryCache` against `KeycloakUserService` directly (the `Application.UnitTests` under `Users/`/`Organizations/` mock the `IKeycloakUserService` interface via NSubstitute, never a real `IMemoryCache`), so no test fixture needed the `SizeLimit` treatment `a41ecd7` applied to `LoginStreakMiddlewareTests.cs`.
- Could not run `dotnet build` or the test suites in this sandbox: the .NET SDK isn't preinstalled here, and the `SessionStart` hook's install fell through to `builds.dotnet.microsoft.com`, which this session's egress policy blocks (403). This is a one-line semantic fix mirroring 5 proven-working sibling call sites in the same file/PR, but it hasn't been locally build-verified - please confirm CI (which has full network access) goes green.

## Checklist

- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (n/a - no behavior change, restores intended caching behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3oNZ4FedSw327tScKEi8A)_