### PR TITLE
fix: scope member search to an exact email/username match

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -127,7 +127,7 @@ Because dispatch now happens in a fresh scope after commit (not inline inside th
 
 `Organization` aggregate fields: `Id`, `Name`, `Description?`, `ContactEmail?`, `ContactPhone?`, `Website?`, `Address?` (`Domain.Common.Address`), `CreatedOn`, `ModifiedOn`.
 
-`IKeycloakOrganizationService` methods: `CreateOrganizationAsync`, `AddMemberAsync`, `RemoveMemberAsync`, `AssignOrganizerRoleAsync`, `GetMembersAsync`, `SearchUsersAsync`, `DeleteOrganizationAsync`. Which organizations a user organizes is answered from the local `organization_membership` table (`IApplicationDbContext.GetOrganizerOrganizationsAsync`), not Keycloak.
+`IKeycloakOrganizationService` methods: `CreateOrganizationAsync`, `AddMemberAsync`, `RemoveMemberAsync`, `AssignOrganizerRoleAsync`, `GetMembersAsync`, `FindUserByExactMatchAsync`, `SearchUsersAsync`, `DeleteOrganizationAsync`. `FindUserByExactMatchAsync` is the only one safe to expose in an API response (exact email/username match, at most one result) - `SearchUsersAsync` is a realm-wide infix match, for internal filtering only (#2205). Which organizations a user organizes is answered from the local `organization_membership` table (`IApplicationDbContext.GetOrganizerOrganizationsAsync`), not Keycloak.
 
 ## Implemented endpoints (Organizations)
 

--- a/backend/src/Api/wwwroot/openapi-v1.json
+++ b/backend/src/Api/wwwroot/openapi-v1.json
@@ -8466,7 +8466,8 @@
           "userId",
           "username",
           "firstName",
-          "lastName"
+          "lastName",
+          "status"
         ],
         "type": "object",
         "properties": {
@@ -8488,6 +8489,9 @@
               "null",
               "string"
             ]
+          },
+          "status": {
+            "type": "string"
           }
         }
       },

--- a/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
+++ b/backend/src/Application/Common/Keycloak/IKeycloakOrganizationService.cs
@@ -47,6 +47,11 @@ public interface IKeycloakOrganizationService
 	Task<IReadOnlySet<Guid>> GetRealmOrganisatorUserIdsAsync(
 		CancellationToken cancellationToken = default);
 
+	Task<KeycloakOrganizationMember?> FindUserByExactMatchAsync(
+		string search,
+		CancellationToken cancellationToken = default);
+
+	// Realm-wide infix match - only for filtering results already scoped by another auth check; never return matches directly in a response (#2205).
 	Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 		string search,
 		int max = 20,

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQuery.cs
@@ -9,8 +9,16 @@ public sealed record SearchMemberCandidatesQuery(
 	UserId RequestingUserId)
 	: IQuery<IReadOnlyList<MemberCandidateDto>>;
 
+public enum MemberCandidateStatus
+{
+	Available,
+	AlreadyMember,
+	AlreadyInvited,
+}
+
 public sealed record MemberCandidateDto(
 	Guid UserId,
 	string Username,
 	string? FirstName,
-	string? LastName);
+	string? LastName,
+	string Status);

--- a/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
+++ b/backend/src/Application/Organizations/SearchMemberCandidates/v1/SearchMemberCandidatesQueryHandler.cs
@@ -22,32 +22,28 @@ internal sealed class SearchMemberCandidatesQueryHandler(
 			query.RequestingUserId,
 			cancellationToken);
 
-		var allResults = await keycloak.SearchUsersAsync(
-			query.Search,
-			cancellationToken: cancellationToken);
+		var match = await keycloak.FindUserByExactMatchAsync(query.Search, cancellationToken);
+		if (match is null)
+			return [];
 
-		var currentMembers = await keycloak.GetMembersAsync(
-			query.OrganizationId,
-			cancellationToken);
-
-		var memberIds = currentMembers.Select(m => m.UserId).ToHashSet();
+		var currentMembers = await keycloak.GetMembersAsync(query.OrganizationId, cancellationToken);
+		if (currentMembers.Any(m => m.UserId == match.UserId))
+			return [ToDto(match, MemberCandidateStatus.AlreadyMember)];
 
 		var invitations = await dbContext.GetInvitationsForOrganizationAsync(
 			OrganizationId.Create(query.OrganizationId).GetValueOrThrow(),
 			cancellationToken);
 
-		var pendingInviteeIds = invitations
-			.Where(i => i.Status == InvitationStatus.Pending)
-			.Select(i => i.InviteeId.Value)
-			.ToHashSet();
+		var hasPendingInvitation = invitations.Any(i =>
+			i.Status == InvitationStatus.Pending && i.InviteeId.Value == match.UserId);
 
-		return allResults
-			.Where(u => !memberIds.Contains(u.UserId) && !pendingInviteeIds.Contains(u.UserId))
-			.Select(u => new MemberCandidateDto(
-				u.UserId,
-				u.Username,
-				u.FirstName,
-				u.LastName))
-			.ToList();
+		var status = hasPendingInvitation
+			? MemberCandidateStatus.AlreadyInvited
+			: MemberCandidateStatus.Available;
+
+		return [ToDto(match, status)];
 	}
+
+	private static MemberCandidateDto ToDto(KeycloakOrganizationMember member, MemberCandidateStatus status) =>
+		new(member.UserId, member.Username, member.FirstName, member.LastName, status.ToString());
 }

--- a/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOrganizationService.cs
@@ -207,6 +207,52 @@ internal sealed class KeycloakOrganizationService(
 		return users.Select(u => Guid.Parse(u.Id)).ToHashSet();
 	}
 
+	public async Task<KeycloakOrganizationMember?> FindUserByExactMatchAsync(
+		string search,
+		CancellationToken cancellationToken = default)
+	{
+		await EnsureAuthenticatedAsync(cancellationToken);
+
+		var trimmed = search.Trim();
+		var isEmail = trimmed.Contains('@');
+		var field = isEmail ? "email" : "username";
+		var encoded = Uri.EscapeDataString(trimmed);
+
+		HttpResponseMessage response;
+		try
+		{
+			response = await httpClient.GetAsync(
+				$"/admin/realms/{_options.Realm}/users?{field}={encoded}&exact=true",
+				cancellationToken);
+		}
+		catch (ExecutionRejectedException ex)
+		{
+			throw new HttpRequestException(
+				$"Keycloak exact user lookup was rejected by the resilience pipeline: {ex.Message}",
+				ex);
+		}
+
+		await EnsureSuccessAsync(response, cancellationToken);
+
+		var users = await response.Content.ReadFromJsonAsync<List<KeycloakUserResponse>>(
+			JsonOptions, cancellationToken) ?? [];
+
+		// Belt-and-suspenders: don't trust Keycloak's `exact` flag alone for the no-enumeration guarantee.
+		var match = users.FirstOrDefault(u => isEmail
+			? string.Equals(u.Email, trimmed, StringComparison.OrdinalIgnoreCase)
+			: string.Equals(u.Username, trimmed, StringComparison.OrdinalIgnoreCase));
+
+		return match is null
+			? null
+			: new KeycloakOrganizationMember(
+				Guid.Parse(match.Id),
+				match.Username,
+				match.FirstName,
+				match.LastName,
+				match.Email ?? string.Empty,
+				false);
+	}
+
 	public async Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 		string search,
 		int max = 20,

--- a/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/SearchMemberCandidates/SearchMemberCandidatesQueryHandlerTests.cs
@@ -25,8 +25,8 @@ public class SearchMemberCandidatesQueryHandlerTests
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_keycloakService
-			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-			.Returns([]);
+			.FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns((KeycloakOrganizationMember?)null);
 		_keycloakService
 			.GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns([]);
@@ -37,19 +37,50 @@ public class SearchMemberCandidatesQueryHandlerTests
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnCandidates_ExcludingExistingMembers(
+	public async Task Handle_ShouldReturnEmpty_WhenNoExactMatchExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "nosuchuser", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		result.Should().BeEmpty();
+		await _keycloakService.DidNotReceive().GetMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnAvailable_WhenMatchIsNotAMemberOrInvitee(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var candidate = Guid.NewGuid();
+		_keycloakService
+			.FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakOrganizationMember(candidate, "vera", "Vera", "Smith", "vera@test.de", false));
+
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "vera", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(query, cancellationToken);
+
+		// Assert
+		var single = result.Should().ContainSingle().Which;
+		single.UserId.Should().Be(candidate);
+		single.Status.Should().Be(MemberCandidateStatus.Available.ToString());
+	}
+
+	[Test]
+	public async Task Handle_ShouldReturnAlreadyMember_WhenMatchIsAnExistingMember(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var existingMember = Guid.NewGuid();
-		var candidate = Guid.NewGuid();
 		_keycloakService
-			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
-			[
-				new KeycloakOrganizationMember(existingMember, "olaf", "Olaf", "Miller", "olaf@test.de", true),
-				new KeycloakOrganizationMember(candidate, "vera", "Vera", "Smith", "vera@test.de", false),
-			]);
+			.FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakOrganizationMember(existingMember, "olaf", "Olaf", "Miller", "olaf@test.de", true));
 		_keycloakService
 			.GetMembersAsync(DefaultOrgId, cancellationToken)
 			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
@@ -57,29 +88,24 @@ public class SearchMemberCandidatesQueryHandlerTests
 				new KeycloakOrganizationMember(existingMember, "olaf", "Olaf", "Miller", "olaf@test.de", true),
 			]);
 
-		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "olaf", DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
-		result.Should().ContainSingle(c => c.UserId == candidate);
+		result.Should().ContainSingle().Which.Status.Should().Be(MemberCandidateStatus.AlreadyMember.ToString());
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnCandidates_ExcludingUsersWithPendingInvitation(
+	public async Task Handle_ShouldReturnAlreadyInvited_WhenMatchHasAPendingInvitation(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
 		var pendingInvitee = Guid.NewGuid();
-		var candidate = Guid.NewGuid();
 		_keycloakService
-			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
-			[
-				new KeycloakOrganizationMember(pendingInvitee, "olaf", "Olaf", "Miller", "olaf@test.de", false),
-				new KeycloakOrganizationMember(candidate, "vera", "Vera", "Smith", "vera@test.de", false),
-			]);
+			.FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakOrganizationMember(pendingInvitee, "vera", "Vera", "Smith", "vera@test.de", false));
 
 		var organizationId = OrganizationId.Create(DefaultOrgId).GetValueOrThrow();
 		var pendingInvitation = OrganizationInvitation.Create(
@@ -92,28 +118,24 @@ public class SearchMemberCandidatesQueryHandlerTests
 			.GetInvitationsForOrganizationAsync(organizationId, cancellationToken)
 			.Returns([pendingInvitation]);
 
-		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "vera", DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
-		result.Should().ContainSingle(c => c.UserId == candidate);
+		result.Should().ContainSingle().Which.Status.Should().Be(MemberCandidateStatus.AlreadyInvited.ToString());
 	}
 
 	[Test]
-	public async Task Handle_ShouldReturnCandidate_WhenInvitationIsNotPending(
+	public async Task Handle_ShouldReturnAvailable_WhenInvitationIsNotPending(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
-
 		var declinedInvitee = Guid.NewGuid();
 		_keycloakService
-			.SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-			.Returns((IReadOnlyList<KeycloakOrganizationMember>)
-			[
-				new KeycloakOrganizationMember(declinedInvitee, "olaf", "Olaf", "Miller", "olaf@test.de", false),
-			]);
+			.FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(new KeycloakOrganizationMember(declinedInvitee, "olaf", "Olaf", "Miller", "olaf@test.de", false));
 
 		var organizationId = OrganizationId.Create(DefaultOrgId).GetValueOrThrow();
 		var declinedInvitation = OrganizationInvitation.Create(
@@ -127,24 +149,25 @@ public class SearchMemberCandidatesQueryHandlerTests
 			.GetInvitationsForOrganizationAsync(organizationId, cancellationToken)
 			.Returns([declinedInvitation]);
 
-		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "olaf", DefaultRequestingUserId);
 
 		// Act
 		var result = await _sut.Handle(query, cancellationToken);
 
 		// Assert
-		result.Should().ContainSingle(c => c.UserId == declinedInvitee);
+		result.Should().ContainSingle().Which.Status.Should().Be(MemberCandidateStatus.Available.ToString());
 	}
 
 	[Test]
 	public async Task Handle_ShouldThrow_WhenRequestingUserIsNotOrganizer(
 		CancellationToken cancellationToken)
 	{
+		// Arrange
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(false);
 
-		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "v", DefaultRequestingUserId);
+		var query = new SearchMemberCandidatesQuery(DefaultOrgId, "vera", DefaultRequestingUserId);
 
 		// Act
 		Func<Task> act = async () => await _sut.Handle(query, cancellationToken);
@@ -152,6 +175,6 @@ public class SearchMemberCandidatesQueryHandlerTests
 		// Assert
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
-		await _keycloakService.DidNotReceive().SearchUsersAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+		await _keycloakService.DidNotReceive().FindUserByExactMatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/backend/tests/IntegrationTests/ApiClient.cs
+++ b/backend/tests/IntegrationTests/ApiClient.cs
@@ -13093,6 +13093,10 @@ namespace IntegrationTests
         [System.Text.Json.Serialization.JsonPropertyName("lastName")]
         public string? LastName { get; set; } = default!;
 
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Status { get; set; } = default!;
+
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 
         [System.Text.Json.Serialization.JsonExtensionData]

--- a/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
+++ b/backend/tests/IntegrationTests/ApplicationDbContextInitializerSeedAsyncTests.cs
@@ -394,5 +394,9 @@ public class ApplicationDbContextInitializerSeedAsyncTests(IntegrationTestFixtur
 		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 			string search, int max = 20, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();
+
+		public Task<KeycloakOrganizationMember?> FindUserByExactMatchAsync(
+			string search, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
 	}
 }

--- a/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
+++ b/backend/tests/IntegrationTests/OrganizationMembershipBackfillJobTests.cs
@@ -227,5 +227,9 @@ public class OrganizationMembershipBackfillJobTests(IntegrationTestFixture fixtu
 		public Task<IReadOnlyList<KeycloakOrganizationMember>> SearchUsersAsync(
 			string search, int max = 20, CancellationToken cancellationToken = default) =>
 			throw new NotSupportedException();
+
+		public Task<KeycloakOrganizationMember?> FindUserByExactMatchAsync(
+			string search, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
 	}
 }

--- a/backend/tests/IntegrationTests/SearchMemberCandidatesTests.cs
+++ b/backend/tests/IntegrationTests/SearchMemberCandidatesTests.cs
@@ -29,7 +29,7 @@ public class SearchMemberCandidatesTests(
 	}
 
 	[Test]
-	public async Task SearchMemberCandidates_ShouldFindTheUser_WhenQueryReachesFourCharacters(
+	public async Task SearchMemberCandidates_ShouldFindTheUser_WhenQueryIsTheExactUsername(
 		CancellationToken cancellationToken)
 	{
 		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
@@ -38,8 +38,73 @@ public class SearchMemberCandidatesTests(
 		var candidates = await client.SearchMemberCandidatesAsync(
 			organizationId, "vera", cancellationToken);
 
-		candidates.Should().ContainSingle()
-			.Which.Username.Should().Be("vera");
+		var candidate = candidates.Should().ContainSingle().Which;
+		candidate.Username.Should().Be("vera");
+		candidate.Status.Should().Be("Available");
+	}
+
+	[Test]
+	public async Task SearchMemberCandidates_ShouldFindTheUser_WhenQueryIsTheExactEmail(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organizationId = await CreateOrganizationAsync(client, cancellationToken);
+		var (userId, username, _) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+
+		var candidates = await client.SearchMemberCandidatesAsync(
+			organizationId, $"{username}@example.com", cancellationToken);
+
+		candidates.Should().ContainSingle(c => c.UserId == userId);
+	}
+
+	[Test]
+	public async Task SearchMemberCandidates_ShouldFindNobody_WhenQueryIsOnlyAPrefixOfTheUsername(
+		CancellationToken cancellationToken)
+	{
+		// This is the regression test for the realm-wide enumeration this endpoint used to allow
+		// (#2205): a query that used to match dozens of users via Keycloak's infix `search` must
+		// now match nobody unless it names one user's full username or email exactly.
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organizationId = await CreateOrganizationAsync(client, cancellationToken);
+		var (_, username, _) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		var prefix = username[..^1];
+
+		var candidates = await client.SearchMemberCandidatesAsync(
+			organizationId, prefix, cancellationToken);
+
+		candidates.Should().BeEmpty();
+	}
+
+	[Test]
+	public async Task SearchMemberCandidates_ShouldReportAlreadyMember_WhenTheExactMatchIsAlreadyInTheOrganization(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organizationId = await CreateOrganizationAsync(client, cancellationToken);
+		var (userId, username, _) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+		await fixture.AddPlainMemberDirectlyAsync(organizationId, userId, cancellationToken);
+
+		var candidates = await client.SearchMemberCandidatesAsync(
+			organizationId, username, cancellationToken);
+
+		candidates.Should().ContainSingle().Which.Status.Should().Be("AlreadyMember");
+	}
+
+	[Test]
+	public async Task SearchMemberCandidates_ShouldReportAlreadyInvited_WhenTheExactMatchHasAPendingInvitation(
+		CancellationToken cancellationToken)
+	{
+		var client = await CreateAuthenticatedClientAsync("olaf", "olaf123");
+		var organizationId = await CreateOrganizationAsync(client, cancellationToken);
+		var (userId, username, _) = await fixture.CreateEphemeralUserAsync(cancellationToken);
+
+		await client.CreateInvitationAsync(
+			organizationId, new CreateInvitationRequest { InviteeId = userId, Role = "Member" }, cancellationToken);
+
+		var candidates = await client.SearchMemberCandidatesAsync(
+			organizationId, username, cancellationToken);
+
+		candidates.Should().ContainSingle().Which.Status.Should().Be("AlreadyInvited");
 	}
 
 	[Test]
@@ -57,7 +122,7 @@ public class SearchMemberCandidatesTests(
 		typeof(MemberCandidateDto).GetProperties()
 			.Select(property => property.Name)
 			.Should().BeEquivalentTo(
-				"UserId", "Username", "FirstName", "LastName", "AdditionalProperties");
+				"UserId", "Username", "FirstName", "LastName", "Status", "AdditionalProperties");
 
 		candidate.AdditionalProperties.Should().BeEmpty();
 

--- a/frontend/src/client/api-client.ts
+++ b/frontend/src/client/api-client.ts
@@ -6671,6 +6671,7 @@ export interface MemberCandidateDto {
     username: string;
     firstName: string | undefined;
     lastName: string | undefined;
+    status: string;
 
     [key: string]: any;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -576,6 +576,8 @@
       "searchMinChars": "Mindestens 4 Zeichen eingeben",
       "noSearchResults": "Keine Nutzer:innen gefunden.",
       "noSearchResultsEmail": "Für diese E-Mail-Adresse existiert noch kein Konto – bitte die Person, sich zuerst zu registrieren, dann kannst du sie hier einladen.",
+      "searchResultAlreadyMember": "Bereits Mitglied",
+      "searchResultAlreadyInvited": "Bereits eingeladen",
       "memberSearchError": "Nutzer:innen konnten nicht gesucht werden.",
       "inviteLabel": "Mitglied einladen",
       "invitePlaceholder": "Nach Benutzername oder E-Mail suchen…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -576,6 +576,8 @@
       "searchMinChars": "Enter at least 4 characters",
       "noSearchResults": "No users found.",
       "noSearchResultsEmail": "No account exists for this email yet - ask the person to sign up first, then you can invite them here.",
+      "searchResultAlreadyMember": "Already a member",
+      "searchResultAlreadyInvited": "Already invited",
       "memberSearchError": "Could not search for users.",
       "inviteLabel": "Invite member",
       "invitePlaceholder": "Search by username or email…",

--- a/frontend/src/pages/app/OrgMembersPage.test.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.test.tsx
@@ -241,6 +241,7 @@ const candidate = {
 	username: "ingo",
 	firstName: "Ingo",
 	lastName: "Invitee",
+	status: "Available",
 };
 
 function renderManage(members: unknown[], invitations: unknown[] = []) {
@@ -413,5 +414,44 @@ describe("OrgMembersPage inviting rather than adding", () => {
 		expect(list).toHaveTextContent(invitation.inviteeName);
 
 		expect(api.addOrganizationMember).not.toHaveBeenCalled();
+	});
+});
+
+describe("OrgMembersPage invite search result states", () => {
+	it("shows Already a member instead of an Invite button", async () => {
+		api.searchMemberCandidates.mockResolvedValue([
+			{ ...candidate, status: "AlreadyMember" },
+		]);
+		renderManage([olaf]);
+
+		await userEvent.type(await screen.findByLabelText("Invite member"), "ingo");
+
+		expect(await screen.findByText("Already a member")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Invite" })).toBeNull();
+	});
+
+	it("shows Already invited instead of an Invite button", async () => {
+		api.searchMemberCandidates.mockResolvedValue([
+			{ ...candidate, status: "AlreadyInvited" },
+		]);
+		renderManage([olaf]);
+
+		await userEvent.type(await screen.findByLabelText("Invite member"), "ingo");
+
+		expect(await screen.findByText("Already invited")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Invite" })).toBeNull();
+	});
+
+	it("still offers Invite for an available candidate", async () => {
+		api.searchMemberCandidates.mockResolvedValue([candidate]);
+		renderManage([olaf]);
+
+		await userEvent.type(await screen.findByLabelText("Invite member"), "ingo");
+
+		expect(
+			await screen.findByRole("button", { name: "Invite" }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Already a member")).toBeNull();
+		expect(screen.queryByText("Already invited")).toBeNull();
 	});
 });

--- a/frontend/src/pages/app/OrgMembersPage.test.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.test.tsx
@@ -454,4 +454,28 @@ describe("OrgMembersPage invite search result states", () => {
 		expect(screen.queryByText("Already a member")).toBeNull();
 		expect(screen.queryByText("Already invited")).toBeNull();
 	});
+
+	it("has no a11y violations across the Available/AlreadyMember/AlreadyInvited states", async () => {
+		api.searchMemberCandidates.mockResolvedValue([
+			candidate,
+			{
+				...candidate,
+				userId: "77777777-7777-7777-7777-777777777777",
+				status: "AlreadyMember",
+			},
+			{
+				...candidate,
+				userId: "88888888-8888-8888-8888-888888888888",
+				status: "AlreadyInvited",
+			},
+		]);
+		renderManage([olaf]);
+
+		await userEvent.type(await screen.findByLabelText("Invite member"), "ingo");
+		await screen.findByRole("button", { name: "Invite" });
+		await screen.findByText("Already a member");
+		await screen.findByText("Already invited");
+
+		await expectNoA11yViolations();
+	});
 });

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -363,7 +363,6 @@ export default function OrgMembersPage() {
 																: "neutral"
 														}
 														size="sm"
-														role="status"
 														className="ml-3 shrink-0"
 													>
 														{candidate.status === "AlreadyInvited"

--- a/frontend/src/pages/app/OrgMembersPage.tsx
+++ b/frontend/src/pages/app/OrgMembersPage.tsx
@@ -345,15 +345,32 @@ export default function OrgMembersPage() {
 														</p>
 													)}
 												</div>
-												<Button
-													type="button"
-													onClick={() => handleInviteMember(candidate.userId)}
-													disabled={invitingUserId === candidate.userId}
-													size="sm"
-													className="ml-3 shrink-0"
-												>
-													{t("orgSettings.invite")}
-												</Button>
+												{candidate.status === "Available" ? (
+													<Button
+														type="button"
+														onClick={() => handleInviteMember(candidate.userId)}
+														disabled={invitingUserId === candidate.userId}
+														size="sm"
+														className="ml-3 shrink-0"
+													>
+														{t("orgSettings.invite")}
+													</Button>
+												) : (
+													<Chip
+														tone={
+															candidate.status === "AlreadyInvited"
+																? "warning"
+																: "neutral"
+														}
+														size="sm"
+														role="status"
+														className="ml-3 shrink-0"
+													>
+														{candidate.status === "AlreadyInvited"
+															? t("orgSettings.searchResultAlreadyInvited")
+															: t("orgSettings.searchResultAlreadyMember")}
+													</Chip>
+												)}
 											</li>
 										))}
 									</ul>


### PR DESCRIPTION
## What

`GET /organizations/{id}/members/search` no longer answers with Keycloak's realm-wide infix `search` (username/first/last/email, 20 results, no minimum length) - it now answers only an exact email or exact username match, at most one result. `MemberCandidateDto` gains a `Status` field (`Available`/`AlreadyMember`/`AlreadyInvited`) so the organizer can tell "nobody by that name/email" apart from "found them, they're already a member/already invited" instead of both collapsing into a bare "No users found."

## Why

Any authenticated user can self-serve into the `organisator` role via `POST /organizations` (no verification gate since #1530 removed `is_verified`), and that role's "invite member" search was answering with 20 arbitrary realm users per query and no minimum search length. Since Keycloak's `search` does an infix match across username/first name/last name/email, an organizer could walk the alphabet and harvest `UserId`/`Username`/`FirstName`/`LastName` for every registered user - a realm-wide user directory disclosure (DSGVO-relevant for a German volunteering platform), and the harvested `UserId`s are directly usable against the anonymous public-profile endpoint.

`SearchMemberCandidatesQueryHandler` now calls a new `IKeycloakOrganizationService.FindUserByExactMatchAsync(search)` (exact `email=&exact=true` if the input contains `@`, else exact `username=&exact=true`, with a client-side equality check as a second guard so a permissive Keycloak version can't reopen the enumeration) instead of the old infix `SearchUsersAsync`. That old method stays on the interface - `GetEngagementsQueryHandler` and `GetOrganizationEngagementsQueryHandler` legitimately use it to filter an already org/opportunity-scoped engagement list by volunteer name, and that result never reaches an API response, so it was never the vulnerability the issue describes.

This addresses the issue's suggested fix (a) (scope the search to an exact match) plus the empty-state confusion its follow-up comment identified as the same code path. Fix (b) (an email-based invitation path for people without an account yet) and (c) (making `organisator` non-self-service, or gating this search behind a verified organization) are both explicitly framed as optional/follow-on in the issue and are left out of this PR to keep it focused on the security fix; (c) in particular is a bigger product decision (removing organizer self-service, or adding an org verification gate) that deserves its own discussion rather than riding along here.

Closes #2205

## Testing

- `dotnet build backend/src/Api/Api.csproj` (regenerates `openapi-v1.json` + both NSwag clients - verified the `status` field landed in all three)
- `dotnet run --project backend/tests/Application.UnitTests` - 1023/1023 passed
- `dotnet run --project backend/tests/ArchitectureTests` - 417/417 passed
- `backend/tests/IntegrationTests/SearchMemberCandidatesTests.cs` updated with new coverage (can't run locally - no Docker in this sandbox, per `AGENTS.md`; CI's `dotnet.yml` runs it): exact username/email match still finds the user, a near-full-length username *prefix* (the old infix vector) now finds nobody, `AlreadyMember`/`AlreadyInvited` statuses, and the DTO's property list (including the new `Status` field)
- `pnpm lint` / `pnpm check` / `pnpm i18n:check` / `pnpm test` (843/843) / `pnpm format:write` - all clean
- Proactive `architecture-check`/`nswag-check`/`i18n-check`/`a11y-check` subagents run against the diff per this repo's Claude Code conventions; i18n-check reported no issues, the other three were still finishing as of this PR - I'll push follow-ups here if they surface anything

## Checklist

- [x] `/self-review`-equivalent proactive subagents run (architecture-check, nswag-check, i18n-check, a11y-check) - see Testing
- [ ] CI is green
- [x] Documentation updated (`backend/AGENTS.md`'s `IKeycloakOrganizationService` method list)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuV7os8oMnPYP5vLCtxN9Q)_