### PR TITLE
fix: remove or quarantine images on every content deletion path

### DIFF
--- a/backend/src/Application/Common/Storage/IFileStorageService.cs
+++ b/backend/src/Application/Common/Storage/IFileStorageService.cs
@@ -11,6 +11,13 @@ public interface IFileStorageService
 
 	Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default);
 
+	// Moves the object out of the publicly-readable prefix instead of deleting
+	// it, so a moderation reversal (UnquarantineAsync) can move it back - see
+	// einsatzbereit#2198.
+	Task QuarantineAsync(string objectKey, CancellationToken cancellationToken = default);
+
+	Task UnquarantineAsync(string objectKey, CancellationToken cancellationToken = default);
+
 	string? GetObjectKeyFromPublicUrl(string publicUrl);
 
 	Task PingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Application/Organizations/AdminRestoreOrganization/v1/AdminRestoreOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/AdminRestoreOrganization/v1/AdminRestoreOrganizationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Domain.AuditLogs;
 using Domain.Organizations;
 using Domain.Primitives;
@@ -8,7 +9,8 @@ using Domain.Primitives;
 namespace Application.Organizations.AdminRestoreOrganization.v1;
 
 internal sealed class AdminRestoreOrganizationCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IFileStorageService fileStorage)
 	: ICommandHandler<AdminRestoreOrganizationCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -21,6 +23,25 @@ internal sealed class AdminRestoreOrganizationCommandHandler(
 			?? throw new ResultFailureException(Error.NotFound("Organization.NotFound", $"Organization '{request.OrganizationId}' not found."));
 
 		organization.Restore().ThrowIfFailure();
+
+		if (organization.LogoUrl is not null)
+		{
+			var logoObjectKey = fileStorage.GetObjectKeyFromPublicUrl(organization.LogoUrl);
+			if (logoObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.UnquarantineAsync(logoObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be public (never actually quarantined, e.g. a
+					// row shadow-deleted before this existed) or storage may be
+					// transiently unavailable; continue - the DB-level restore is what
+					// actually makes the organization visible again.
+				}
+			}
+		}
 
 		var auditLog = AuditLog.Create(
 			request.AdminUserId,

--- a/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/AdminShadowDeleteOrganization/v1/AdminShadowDeleteOrganizationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.Common;
 using Domain.AuditLogs;
@@ -14,6 +15,7 @@ namespace Application.Organizations.AdminShadowDeleteOrganization.v1;
 internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 	IApplicationDbContext dbContext,
 	IEngagementReadRepository engagementReadRepository,
+	IFileStorageService fileStorage,
 	ILogger<AdminShadowDeleteOrganizationCommandHandler> logger)
 	: ICommandHandler<AdminShadowDeleteOrganizationCommand, bool>
 {
@@ -33,6 +35,7 @@ internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 			await VolunteerOpportunityDeletionHelper.ShadowDeleteAsync(
 				dbContext,
 				engagementReadRepository,
+				fileStorage,
 				opportunity,
 				opportunity.Id,
 				request.AdminUserId,
@@ -49,6 +52,24 @@ internal sealed class AdminShadowDeleteOrganizationCommandHandler(
 		}
 
 		organization.MarkDeleted(now).ThrowIfFailure();
+
+		if (organization.LogoUrl is not null)
+		{
+			var logoObjectKey = fileStorage.GetObjectKeyFromPublicUrl(organization.LogoUrl);
+			if (logoObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.QuarantineAsync(logoObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be gone, already quarantined, or storage may be
+					// transiently unavailable; continue - the DB-level shadow delete is
+					// what actually hides the organization from all read paths.
+				}
+			}
+		}
 
 		var auditLog = AuditLog.Create(
 			request.AdminUserId,

--- a/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/DeleteOrganization/v1/DeleteOrganizationCommandHandler.cs
@@ -3,6 +3,7 @@ using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.Common;
 using Domain.Organizations;
@@ -16,6 +17,7 @@ internal sealed class DeleteOrganizationCommandHandler(
 	IApplicationDbContext dbContext,
 	IKeycloakOrganizationService keycloakOrganizationService,
 	IEngagementReadRepository engagementReadRepository,
+	IFileStorageService fileStorage,
 	ILogger<DeleteOrganizationCommandHandler> logger)
 	: ICommandHandler<DeleteOrganizationCommand, bool>
 {
@@ -76,6 +78,7 @@ internal sealed class DeleteOrganizationCommandHandler(
 			await VolunteerOpportunityDeletionHelper.DeleteAsync(
 				dbContext,
 				engagementReadRepository,
+				fileStorage,
 				opportunity,
 				opportunity.Id,
 				request.RequestingUserId,
@@ -89,6 +92,22 @@ internal sealed class DeleteOrganizationCommandHandler(
 		foreach (var report in openReports)
 		{
 			report.MarkActioned(request.RequestingUserId, DateTimeOffset.UtcNow).ThrowIfFailure();
+		}
+
+		if (organization.LogoUrl is not null)
+		{
+			var logoObjectKey = fileStorage.GetObjectKeyFromPublicUrl(organization.LogoUrl);
+			if (logoObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.DeleteAsync(logoObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be gone or storage may be transiently unavailable; continue.
+				}
+			}
 		}
 
 		organization.Delete();

--- a/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
+++ b/backend/src/Application/Organizations/UploadOrganizationLogo/v1/UploadOrganizationLogoCommandHandler.cs
@@ -29,6 +29,8 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
+		var previousLogoUrl = organization.LogoUrl;
+
 		var ext = ImageUploadValidator.GetExtension(contentType);
 		var objectKey = $"organization-logos/{request.OrganizationId}{ext}";
 
@@ -37,6 +39,30 @@ internal sealed class UploadOrganizationLogoCommandHandler(
 
 		organization.SetLogoUrl(url);
 
+		await DeletePreviousLogoIfOrphanedAsync(previousLogoUrl, objectKey, cancellationToken);
+
 		return true;
+	}
+
+	private async Task DeletePreviousLogoIfOrphanedAsync(string? previousLogoUrl, string newObjectKey, CancellationToken cancellationToken)
+	{
+		if (previousLogoUrl is null)
+			return;
+
+		var previousObjectKey = fileStorage.GetObjectKeyFromPublicUrl(previousLogoUrl);
+		// Extension unchanged - the previous upload lives at the same object key,
+		// so this new upload already overwrote it; deleting it now would delete
+		// the file just uploaded.
+		if (previousObjectKey is null || previousObjectKey == newObjectKey)
+			return;
+
+		try
+		{
+			await fileStorage.DeleteAsync(previousObjectKey, cancellationToken);
+		}
+		catch
+		{
+			// Object may already be gone or storage may be transiently unavailable; continue.
+		}
 	}
 }

--- a/backend/src/Application/Users/AdminRestoreUser/v1/AdminRestoreUserCommandHandler.cs
+++ b/backend/src/Application/Users/AdminRestoreUser/v1/AdminRestoreUserCommandHandler.cs
@@ -1,13 +1,15 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Domain.AuditLogs;
 using Domain.Primitives;
 
 namespace Application.Users.AdminRestoreUser.v1;
 
 internal sealed class AdminRestoreUserCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IFileStorageService fileStorage)
 	: ICommandHandler<AdminRestoreUserCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -20,6 +22,25 @@ internal sealed class AdminRestoreUserCommandHandler(
 			?? throw new ResultFailureException(Error.NotFound("User.NotFound", $"User '{request.UserId}' not found."));
 
 		user.Restore().ThrowIfFailure();
+
+		if (user.AvatarUrl is not null)
+		{
+			var avatarObjectKey = fileStorage.GetObjectKeyFromPublicUrl(user.AvatarUrl);
+			if (avatarObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.UnquarantineAsync(avatarObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be public (never actually quarantined, e.g. a
+					// row shadow-deleted before this existed) or storage may be
+					// transiently unavailable; continue - the DB-level restore is what
+					// actually makes the user visible again.
+				}
+			}
+		}
 
 		var auditLog = AuditLog.Create(
 			request.AdminUserId,

--- a/backend/src/Application/Users/AdminShadowDeleteUser/v1/AdminShadowDeleteUserCommandHandler.cs
+++ b/backend/src/Application/Users/AdminShadowDeleteUser/v1/AdminShadowDeleteUserCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Domain.AuditLogs;
 using Domain.Primitives;
 using Domain.Reports;
@@ -8,7 +9,8 @@ using Domain.Reports;
 namespace Application.Users.AdminShadowDeleteUser.v1;
 
 internal sealed class AdminShadowDeleteUserCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IFileStorageService fileStorage)
 	: ICommandHandler<AdminShadowDeleteUserCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -29,6 +31,24 @@ internal sealed class AdminShadowDeleteUserCommandHandler(
 		}
 
 		user.MarkDeleted(now).ThrowIfFailure();
+
+		if (user.AvatarUrl is not null)
+		{
+			var avatarObjectKey = fileStorage.GetObjectKeyFromPublicUrl(user.AvatarUrl);
+			if (avatarObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.QuarantineAsync(avatarObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be gone, already quarantined, or storage may be
+					// transiently unavailable; continue - the DB-level shadow delete is
+					// what actually hides the user from all read paths.
+				}
+			}
+		}
 
 		var auditLog = AuditLog.Create(
 			request.AdminUserId,

--- a/backend/src/Application/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/v1/AdminRestoreVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/v1/AdminRestoreVolunteerOpportunityCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Domain.AuditLogs;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
@@ -8,7 +9,8 @@ using Domain.VolunteerOpportunities;
 namespace Application.VolunteerOpportunities.AdminRestoreVolunteerOpportunity.v1;
 
 internal sealed class AdminRestoreVolunteerOpportunityCommandHandler(
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IFileStorageService fileStorage)
 	: ICommandHandler<AdminRestoreVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -21,6 +23,25 @@ internal sealed class AdminRestoreVolunteerOpportunityCommandHandler(
 			?? throw new ResultFailureException(Error.NotFound("VolunteerOpportunity.NotFound", $"Volunteer opportunity '{request.OpportunityId}' not found."));
 
 		opportunity.Restore().ThrowIfFailure();
+
+		if (opportunity.BannerImageUrl is not null)
+		{
+			var bannerObjectKey = fileStorage.GetObjectKeyFromPublicUrl(opportunity.BannerImageUrl);
+			if (bannerObjectKey is not null)
+			{
+				try
+				{
+					await fileStorage.UnquarantineAsync(bannerObjectKey, cancellationToken);
+				}
+				catch
+				{
+					// Object may already be public (never actually quarantined, e.g. a
+					// row shadow-deleted before this existed) or storage may be
+					// transiently unavailable; continue - the DB-level restore is what
+					// actually makes the opportunity visible again.
+				}
+			}
+		}
 
 		var auditLog = AuditLog.Create(
 			request.AdminUserId,

--- a/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/v1/AdminShadowDeleteVolunteerOpportunityCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.Common;
 using Domain.AuditLogs;
@@ -20,6 +21,7 @@ namespace Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportuni
 internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
 	IEngagementReadRepository engagementReadRepository,
+	IFileStorageService fileStorage,
 	ILogger<AdminShadowDeleteVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<AdminShadowDeleteVolunteerOpportunityCommand, bool>
 {
@@ -36,6 +38,7 @@ internal sealed class AdminShadowDeleteVolunteerOpportunityCommandHandler(
 		await VolunteerOpportunityDeletionHelper.ShadowDeleteAsync(
 			dbContext,
 			engagementReadRepository,
+			fileStorage,
 			opportunity,
 			opportunityId,
 			request.AdminUserId,

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityDeletionHelper.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Domain.Notifications;
 using Domain.Reports;
@@ -14,6 +15,7 @@ internal static class VolunteerOpportunityDeletionHelper
 	public static async Task DeleteAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
+		IFileStorageService fileStorage,
 		VolunteerOpportunity opportunity,
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
@@ -25,11 +27,14 @@ internal static class VolunteerOpportunityDeletionHelper
 			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, logger, cancellationToken);
 
 		dbContext.VolunteerOpportunities.Delete(opportunity);
+
+		await DeleteBannerAsync(fileStorage, opportunity, cancellationToken);
 	}
 
 	public static async Task ShadowDeleteAsync(
 		IApplicationDbContext dbContext,
 		IEngagementReadRepository engagementReadRepository,
+		IFileStorageService fileStorage,
 		VolunteerOpportunity opportunity,
 		VolunteerOpportunityId opportunityId,
 		UserId actingUserId,
@@ -41,6 +46,48 @@ internal static class VolunteerOpportunityDeletionHelper
 			dbContext, engagementReadRepository, opportunity, opportunityId, actingUserId, now, logger, cancellationToken);
 
 		opportunity.MarkDeleted(now).ThrowIfFailure();
+
+		await QuarantineBannerAsync(fileStorage, opportunity, cancellationToken);
+	}
+
+	private static async Task DeleteBannerAsync(
+		IFileStorageService fileStorage, VolunteerOpportunity opportunity, CancellationToken cancellationToken)
+	{
+		var objectKey = opportunity.BannerImageUrl is not null
+			? fileStorage.GetObjectKeyFromPublicUrl(opportunity.BannerImageUrl)
+			: null;
+		if (objectKey is null)
+			return;
+
+		try
+		{
+			await fileStorage.DeleteAsync(objectKey, cancellationToken);
+		}
+		catch
+		{
+			// Object may already be gone or storage may be transiently unavailable; continue.
+		}
+	}
+
+	private static async Task QuarantineBannerAsync(
+		IFileStorageService fileStorage, VolunteerOpportunity opportunity, CancellationToken cancellationToken)
+	{
+		var objectKey = opportunity.BannerImageUrl is not null
+			? fileStorage.GetObjectKeyFromPublicUrl(opportunity.BannerImageUrl)
+			: null;
+		if (objectKey is null)
+			return;
+
+		try
+		{
+			await fileStorage.QuarantineAsync(objectKey, cancellationToken);
+		}
+		catch
+		{
+			// Object may already be gone, already quarantined, or storage may be
+			// transiently unavailable; continue - the DB-level shadow delete is
+			// what actually hides the opportunity from all read paths.
+		}
 	}
 
 	private static async Task ResolveEngagementsAndReportsAsync(

--- a/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/DeleteVolunteerOpportunity/v1/DeleteVolunteerOpportunityCommandHandler.cs
@@ -2,6 +2,7 @@ using Application.Common.Authorization;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.Common;
 using Domain.Primitives;
@@ -13,6 +14,7 @@ namespace Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 internal sealed class DeleteVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
 	IEngagementReadRepository engagementReadRepository,
+	IFileStorageService fileStorage,
 	ILogger<DeleteVolunteerOpportunityCommandHandler> logger)
 	: ICommandHandler<DeleteVolunteerOpportunityCommand, bool>
 {
@@ -35,6 +37,7 @@ internal sealed class DeleteVolunteerOpportunityCommandHandler(
 		await VolunteerOpportunityDeletionHelper.DeleteAsync(
 			dbContext,
 			engagementReadRepository,
+			fileStorage,
 			opportunity,
 			opportunityId,
 			request.RequestingUserId,

--- a/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UploadOpportunityBanner/v1/UploadOpportunityBannerCommandHandler.cs
@@ -29,6 +29,8 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 			request.RequestingUserId,
 			cancellationToken);
 
+		var previousBannerUrl = opportunity.BannerImageUrl;
+
 		var ext = ImageUploadValidator.GetExtension(contentType);
 		var objectKey = $"opportunity-banners/{request.OpportunityId}{ext}";
 
@@ -37,6 +39,30 @@ internal sealed class UploadOpportunityBannerCommandHandler(
 
 		opportunity.SetBannerImageUrl(url).ThrowIfFailure();
 
+		await DeletePreviousBannerIfOrphanedAsync(previousBannerUrl, objectKey, cancellationToken);
+
 		return true;
+	}
+
+	private async Task DeletePreviousBannerIfOrphanedAsync(string? previousBannerUrl, string newObjectKey, CancellationToken cancellationToken)
+	{
+		if (previousBannerUrl is null)
+			return;
+
+		var previousObjectKey = fileStorage.GetObjectKeyFromPublicUrl(previousBannerUrl);
+		// Extension unchanged - the previous upload lives at the same object key,
+		// so this new upload already overwrote it; deleting it now would delete
+		// the file just uploaded.
+		if (previousObjectKey is null || previousObjectKey == newObjectKey)
+			return;
+
+		try
+		{
+			await fileStorage.DeleteAsync(previousObjectKey, cancellationToken);
+		}
+		catch
+		{
+			// Object may already be gone or storage may be transiently unavailable; continue.
+		}
 	}
 }

--- a/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
+++ b/backend/src/Infrastructure/Storage/MinioFileStorageService.cs
@@ -11,6 +11,12 @@ internal sealed class MinioFileStorageService : IFileStorageService
 
 	private const string PublicPrefix = "public/";
 
+	// Not covered by the bucket policy set up in EnsureBucketReadyAsync (which
+	// only grants anonymous reads under PublicPrefix), so moving an object here
+	// makes it unreachable by its old public URL without discarding it - see
+	// einsatzbereit#2198.
+	private const string QuarantinePrefix = "quarantined/";
+
 	private readonly IMinioClient _minio;
 	private readonly StorageSettings _settings;
 	private static readonly SemaphoreSlim _initLock = new(1, 1);
@@ -71,6 +77,39 @@ internal sealed class MinioFileStorageService : IFileStorageService
 			new RemoveObjectArgs()
 				.WithBucket(_settings.BucketName)
 				.WithObject(PublicPrefix + objectKey),
+			cancellationToken);
+	}
+
+	public async Task QuarantineAsync(string objectKey, CancellationToken cancellationToken = default)
+	{
+		await EnsureBucketReadyAsync(cancellationToken);
+
+		await MoveAsync(PublicPrefix + objectKey, QuarantinePrefix + objectKey, cancellationToken);
+	}
+
+	public async Task UnquarantineAsync(string objectKey, CancellationToken cancellationToken = default)
+	{
+		await EnsureBucketReadyAsync(cancellationToken);
+
+		await MoveAsync(QuarantinePrefix + objectKey, PublicPrefix + objectKey, cancellationToken);
+	}
+
+	private async Task MoveAsync(string sourceKey, string destinationKey, CancellationToken cancellationToken)
+	{
+		await _minio.CopyObjectAsync(
+			new CopyObjectArgs()
+				.WithBucket(_settings.BucketName)
+				.WithObject(destinationKey)
+				.WithCopyObjectSource(
+					new CopySourceObjectArgs()
+						.WithBucket(_settings.BucketName)
+						.WithObject(sourceKey)),
+			cancellationToken);
+
+		await _minio.RemoveObjectAsync(
+			new RemoveObjectArgs()
+				.WithBucket(_settings.BucketName)
+				.WithObject(sourceKey),
 			cancellationToken);
 	}
 

--- a/backend/tests/Application.UnitTests/Organizations/AdminRestoreOrganization/AdminRestoreOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminRestoreOrganization/AdminRestoreOrganizationCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Organizations.AdminRestoreOrganization.v1;
 using AwesomeAssertions;
 using Domain.AuditLogs;
@@ -7,6 +8,7 @@ using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Organizations.AdminRestoreOrganization;
 
@@ -15,6 +17,7 @@ public class AdminRestoreOrganizationCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<AuditLog, AuditLogId> _auditLogRepo =
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly AdminRestoreOrganizationCommandHandler _sut;
 
 	private static readonly UserId DefaultAdminUserId = UserId.New();
@@ -22,7 +25,7 @@ public class AdminRestoreOrganizationCommandHandlerTests
 	public AdminRestoreOrganizationCommandHandlerTests()
 	{
 		_dbContext.AuditLogs.Returns(_auditLogRepo);
-		_sut = new AdminRestoreOrganizationCommandHandler(_dbContext);
+		_sut = new AdminRestoreOrganizationCommandHandler(_dbContext, _fileStorage);
 	}
 
 	private static Organization CreateShadowDeletedOrganization(OrganizationId organizationId)
@@ -89,5 +92,67 @@ public class AdminRestoreOrganizationCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*not shadow-deleted*");
 		await _auditLogRepo.DidNotReceive().AddAsync(Arg.Any<AuditLog>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldUnquarantineTheLogoObject_WhenOrganizationHasALogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var organization = CreateShadowDeletedOrganization(organizationId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_dbContext.FindOrganizationIncludingDeletedAsync(organizationId, cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+
+		// Act
+		await _sut.Handle(new AdminRestoreOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).UnquarantineAsync($"organization-logos/{orgId}.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptUnquarantine_WhenOrganizationHasNoLogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var organization = CreateShadowDeletedOrganization(organizationId);
+		_dbContext.FindOrganizationIncludingDeletedAsync(organizationId, cancellationToken).Returns(organization);
+
+		// Act
+		await _sut.Handle(new AdminRestoreOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().UnquarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenUnquarantiningTheLogoObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var organization = CreateShadowDeletedOrganization(organizationId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_dbContext.FindOrganizationIncludingDeletedAsync(organizationId, cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+		_fileStorage
+			.UnquarantineAsync($"organization-logos/{orgId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminRestoreOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/AdminShadowDeleteOrganization/AdminShadowDeleteOrganizationCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.Organizations.AdminShadowDeleteOrganization.v1;
 using AwesomeAssertions;
@@ -14,6 +15,7 @@ using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Organizations.AdminShadowDeleteOrganization;
 
@@ -32,6 +34,7 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly AdminShadowDeleteOrganizationCommandHandler _sut;
 
@@ -58,7 +61,7 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_sut = new AdminShadowDeleteOrganizationCommandHandler(
-			_dbContext, _engagementReadRepository, NullLogger<AdminShadowDeleteOrganizationCommandHandler>.Instance);
+			_dbContext, _engagementReadRepository, _fileStorage, NullLogger<AdminShadowDeleteOrganizationCommandHandler>.Instance);
 	}
 
 	private static Organization CreateOrganization(Guid id) =>
@@ -206,5 +209,90 @@ public class AdminShadowDeleteOrganizationCommandHandlerTests
 		// Assert
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuarantineTheLogoObject_WhenOrganizationHasALogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).QuarantineAsync($"organization-logos/{orgId}.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptQuarantine_WhenOrganizationHasNoLogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().QuarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenQuarantiningTheLogoObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+		_fileStorage
+			.QuarantineAsync($"organization-logos/{orgId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminShadowDeleteOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuarantineTheBannerObject_OfACascadedOpportunity_WhenItHasOne(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(organizationId, cancellationToken).Returns(organization);
+
+		var opportunity = CreateOpportunity(organizationId);
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_dbContext
+			.GetOpportunitiesForOrganizationAsync(organizationId, cancellationToken)
+			.Returns([opportunity]);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunity.Id.Value}.png");
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteOrganizationCommand(orgId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).QuarantineAsync($"opportunity-banners/{opportunity.Id.Value}.png", cancellationToken);
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/DeleteOrganization/DeleteOrganizationCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.Organizations.DeleteOrganization.v1;
 using AwesomeAssertions;
@@ -10,6 +11,7 @@ using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Organizations.DeleteOrganization;
 
@@ -22,6 +24,7 @@ public class DeleteOrganizationCommandHandlerTests
 		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
 	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
 	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly DeleteOrganizationCommandHandler _sut;
 
@@ -51,7 +54,7 @@ public class DeleteOrganizationCommandHandlerTests
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Guid>());
 		_sut = new DeleteOrganizationCommandHandler(
-			_dbContext, _keycloakService, _engagementReadRepository, NullLogger<DeleteOrganizationCommandHandler>.Instance);
+			_dbContext, _keycloakService, _engagementReadRepository, _fileStorage, NullLogger<DeleteOrganizationCommandHandler>.Instance);
 	}
 
 	private void AllowRequestingUserInOrg(Guid orgId) =>
@@ -287,5 +290,104 @@ public class DeleteOrganizationCommandHandlerTests
 
 		// Assert
 		await _keycloakService.DidNotReceive().RevokeOrganizerRoleAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheLogoObject_WhenOrganizationHasALogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).DeleteAsync($"organization-logos/{orgId}.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptDeletion_WhenOrganizationHasNoLogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenDeletingTheLogoObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/logo.png");
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/logo.png")
+			.Returns($"organization-logos/{orgId}.png");
+		_fileStorage
+			.DeleteAsync($"organization-logos/{orgId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheBannerObject_OfACascadedOpportunity_WhenItHasOne(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_organizationRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		AllowRequestingUserInOrg(orgId);
+		SetMembers(orgId, DefaultRequestingUserId.Value);
+		var organizationId = OrganizationId.Create(orgId).GetValueOrThrow();
+		var finishedOpportunity = VolunteerOpportunity.Create(
+			organizationId, "Finished Opportunity", null, "Beschreibung", null, true, null, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
+			status: OpportunityStatus.Published, validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
+		finishedOpportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_dbContext
+			.GetOpportunitiesForOrganizationAsync(organizationId, cancellationToken)
+			.Returns([finishedOpportunity]);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{finishedOpportunity.Id.Value}.png");
+		var command = new DeleteOrganizationCommand(orgId, DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).DeleteAsync($"opportunity-banners/{finishedOpportunity.Id.Value}.png", cancellationToken);
 	}
 }

--- a/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/UploadOrganizationLogo/UploadOrganizationLogoCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Organizations.UploadOrganizationLogo;
 
@@ -78,5 +79,90 @@ public class UploadOrganizationLogoCommandHandlerTests
 		organization.LogoUrl.Should().BeNull();
 		await _fileStorage.DidNotReceive().UploadAsync(
 			Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteThePreviousLogoObject_WhenReuploadedWithADifferentExtension(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/old.jpg");
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/old.jpg")
+			.Returns($"organization-logos/{orgId}.jpg");
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _fileStorage.Received(1).DeleteAsync($"organization-logos/{orgId}.jpg", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotDeleteAnything_WhenReuploadedWithTheSameExtension(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/old.png");
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/old.png")
+			.Returns($"organization-logos/{orgId}.png");
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert - re-uploading with the same extension overwrote the object at
+		// that key in place, so deleting it now would delete the file just uploaded.
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptDeletion_WhenOrganizationHadNoPreviousLogo(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenDeletingThePreviousLogoObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var orgId = Guid.NewGuid();
+		var organization = CreateOrganization(orgId);
+		organization.SetLogoUrl("https://example.com/organization-logos/old.jpg");
+		_orgRepo.FindAsync(OrganizationId.Create(orgId).GetValueOrThrow(), cancellationToken).Returns(organization);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/organization-logos/old.jpg")
+			.Returns($"organization-logos/{orgId}.jpg");
+		_fileStorage
+			.DeleteAsync($"organization-logos/{orgId}.jpg", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+		var command = new UploadOrganizationLogoCommand(orgId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/Users/AdminRestoreUser/AdminRestoreUserCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/AdminRestoreUser/AdminRestoreUserCommandHandlerTests.cs
@@ -1,11 +1,13 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Users.AdminRestoreUser.v1;
 using AwesomeAssertions;
 using Domain.AuditLogs;
 using Domain.Primitives;
 using Domain.Users;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Users.AdminRestoreUser;
 
@@ -14,6 +16,7 @@ public class AdminRestoreUserCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<AuditLog, AuditLogId> _auditLogRepo =
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly AdminRestoreUserCommandHandler _sut;
 
 	private static readonly UserId DefaultAdminUserId = UserId.New();
@@ -21,7 +24,7 @@ public class AdminRestoreUserCommandHandlerTests
 	public AdminRestoreUserCommandHandlerTests()
 	{
 		_dbContext.AuditLogs.Returns(_auditLogRepo);
-		_sut = new AdminRestoreUserCommandHandler(_dbContext);
+		_sut = new AdminRestoreUserCommandHandler(_dbContext, _fileStorage);
 	}
 
 	private static User CreateShadowDeletedUser(UserId userId)
@@ -85,5 +88,64 @@ public class AdminRestoreUserCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*not shadow-deleted*");
 		await _auditLogRepo.DidNotReceive().AddAsync(Arg.Any<AuditLog>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldUnquarantineTheAvatarObject_WhenUserHasAnAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = CreateShadowDeletedUser(UserId.Create(userId).GetValueOrThrow());
+		user.SetAvatarUrl("https://example.com/user-avatars/avatar.png");
+		_dbContext.FindUserIncludingDeletedAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/avatar.png")
+			.Returns("user-avatars/avatar.png");
+
+		// Act
+		await _sut.Handle(new AdminRestoreUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).UnquarantineAsync("user-avatars/avatar.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptUnquarantine_WhenUserHasNoAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = CreateShadowDeletedUser(UserId.Create(userId).GetValueOrThrow());
+		_dbContext.FindUserIncludingDeletedAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+
+		// Act
+		await _sut.Handle(new AdminRestoreUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().UnquarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenUnquarantiningTheAvatarObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = CreateShadowDeletedUser(UserId.Create(userId).GetValueOrThrow());
+		user.SetAvatarUrl("https://example.com/user-avatars/avatar.png");
+		_dbContext.FindUserIncludingDeletedAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/avatar.png")
+			.Returns("user-avatars/avatar.png");
+		_fileStorage
+			.UnquarantineAsync("user-avatars/avatar.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminRestoreUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/Users/AdminShadowDeleteUser/AdminShadowDeleteUserCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Users/AdminShadowDeleteUser/AdminShadowDeleteUserCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Users.AdminShadowDeleteUser.v1;
 using AwesomeAssertions;
 using Domain.AuditLogs;
@@ -7,6 +8,7 @@ using Domain.Primitives;
 using Domain.Reports;
 using Domain.Users;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.Users.AdminShadowDeleteUser;
 
@@ -17,6 +19,7 @@ public class AdminShadowDeleteUserCommandHandlerTests
 		Substitute.For<IAggregateRepository<User, UserId>>();
 	private readonly IAggregateRepository<AuditLog, AuditLogId> _auditLogRepo =
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly AdminShadowDeleteUserCommandHandler _sut;
 
 	private static readonly UserId DefaultAdminUserId = UserId.New();
@@ -28,7 +31,7 @@ public class AdminShadowDeleteUserCommandHandlerTests
 		_dbContext
 			.GetOpenReportsForTargetAsync(Arg.Any<ReportTargetType>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
 			.Returns(new List<Report>());
-		_sut = new AdminShadowDeleteUserCommandHandler(_dbContext);
+		_sut = new AdminShadowDeleteUserCommandHandler(_dbContext, _fileStorage);
 	}
 
 	[Test]
@@ -107,5 +110,64 @@ public class AdminShadowDeleteUserCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*already shadow-deleted*");
 		await _auditLogRepo.DidNotReceive().AddAsync(Arg.Any<AuditLog>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuarantineTheAvatarObject_WhenUserHasAnAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = User.Create(UserId.Create(userId).GetValueOrThrow());
+		user.SetAvatarUrl("https://example.com/user-avatars/avatar.png");
+		_userRepo.FindAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/avatar.png")
+			.Returns("user-avatars/avatar.png");
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).QuarantineAsync("user-avatars/avatar.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptQuarantine_WhenUserHasNoAvatar(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = User.Create(UserId.Create(userId).GetValueOrThrow());
+		_userRepo.FindAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().QuarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenQuarantiningTheAvatarObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var userId = Guid.NewGuid();
+		var user = User.Create(UserId.Create(userId).GetValueOrThrow());
+		user.SetAvatarUrl("https://example.com/user-avatars/avatar.png");
+		_userRepo.FindAsync(UserId.Create(userId).GetValueOrThrow(), cancellationToken).Returns(user);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/user-avatars/avatar.png")
+			.Returns("user-avatars/avatar.png");
+		_fileStorage
+			.QuarantineAsync("user-avatars/avatar.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminShadowDeleteUserCommand(userId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/AdminRestoreVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminRestoreVolunteerOpportunity/AdminRestoreVolunteerOpportunityCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.VolunteerOpportunities.AdminRestoreVolunteerOpportunity.v1;
 using AwesomeAssertions;
 using Domain.AuditLogs;
@@ -9,6 +10,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.VolunteerOpportunities.AdminRestoreVolunteerOpportunity;
 
@@ -17,6 +19,7 @@ public class AdminRestoreVolunteerOpportunityCommandHandlerTests
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
 	private readonly IAggregateRepository<AuditLog, AuditLogId> _auditLogRepo =
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly AdminRestoreVolunteerOpportunityCommandHandler _sut;
 
@@ -27,7 +30,7 @@ public class AdminRestoreVolunteerOpportunityCommandHandlerTests
 	public AdminRestoreVolunteerOpportunityCommandHandlerTests()
 	{
 		_dbContext.AuditLogs.Returns(_auditLogRepo);
-		_sut = new AdminRestoreVolunteerOpportunityCommandHandler(_dbContext);
+		_sut = new AdminRestoreVolunteerOpportunityCommandHandler(_dbContext, _fileStorage);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
@@ -94,5 +97,73 @@ public class AdminRestoreVolunteerOpportunityCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>().WithMessage("*not shadow-deleted*");
 		await _auditLogRepo.DidNotReceive().AddAsync(Arg.Any<AuditLog>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldUnquarantineTheBannerObject_WhenOpportunityHasABanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+		_dbContext
+			.FindVolunteerOpportunityIncludingDeletedAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+
+		// Act
+		await _sut.Handle(new AdminRestoreVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).UnquarantineAsync($"opportunity-banners/{opportunityId}.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptUnquarantine_WhenOpportunityHasNoBanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+		_dbContext
+			.FindVolunteerOpportunityIncludingDeletedAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		// Act
+		await _sut.Handle(new AdminRestoreVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().UnquarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenUnquarantiningTheBannerObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		opportunity.MarkDeleted(DateTimeOffset.UtcNow);
+		_dbContext
+			.FindVolunteerOpportunityIncludingDeletedAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+		_fileStorage
+			.UnquarantineAsync($"opportunity-banners/{opportunityId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminRestoreVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/AdminShadowDeleteVolunteerOpportunity/AdminShadowDeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity.v1;
 using AwesomeAssertions;
@@ -14,6 +15,7 @@ using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.VolunteerOpportunities.AdminShadowDeleteVolunteerOpportunity;
 
@@ -30,6 +32,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		Substitute.For<IAggregateRepository<AuditLog, AuditLogId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly AdminShadowDeleteVolunteerOpportunityCommandHandler _sut;
 
@@ -53,7 +56,7 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
 		_sut = new AdminShadowDeleteVolunteerOpportunityCommandHandler(
-			_dbContext, _engagementReadRepository, NullLogger<AdminShadowDeleteVolunteerOpportunityCommandHandler>.Instance);
+			_dbContext, _engagementReadRepository, _fileStorage, NullLogger<AdminShadowDeleteVolunteerOpportunityCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
@@ -162,5 +165,71 @@ public class AdminShadowDeleteVolunteerOpportunityCommandHandlerTests
 		// Assert
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.NotFound);
+	}
+
+	[Test]
+	public async Task Handle_ShouldQuarantineTheBannerObject_WhenOpportunityHasABanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).QuarantineAsync($"opportunity-banners/{opportunityId}.png", cancellationToken);
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptQuarantine_WhenOpportunityHasNoBanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		// Act
+		await _sut.Handle(new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().QuarantineAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenQuarantiningTheBannerObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+		_fileStorage
+			.QuarantineAsync($"opportunity-banners/{opportunityId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new AdminShadowDeleteVolunteerOpportunityCommand(opportunityId, DefaultAdminUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/DeleteVolunteerOpportunity/DeleteVolunteerOpportunityCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Persistence;
+using Application.Common.Storage;
 using Application.Engagements;
 using Application.VolunteerOpportunities.DeleteVolunteerOpportunity.v1;
 using AwesomeAssertions;
@@ -13,6 +14,7 @@ using Domain.Users;
 using Domain.VolunteerOpportunities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.VolunteerOpportunities.DeleteVolunteerOpportunity;
 
@@ -25,6 +27,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository =
 		Substitute.For<IEngagementReadRepository>();
+	private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
 	private readonly DeleteVolunteerOpportunityCommandHandler _sut;
 
@@ -49,7 +52,7 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
 		_sut = new DeleteVolunteerOpportunityCommandHandler(
-			_dbContext, _engagementReadRepository, NullLogger<DeleteVolunteerOpportunityCommandHandler>.Instance);
+			_dbContext, _engagementReadRepository, _fileStorage, NullLogger<DeleteVolunteerOpportunityCommandHandler>.Instance);
 	}
 
 	private VolunteerOpportunity CreateOpportunity() =>
@@ -307,5 +310,70 @@ public class DeleteVolunteerOpportunityCommandHandlerTests
 		(await act.Should().ThrowAsync<ResultFailureException>())
 			.Which.Error.Type.Should().Be(ErrorType.Forbidden);
 		_opportunityRepo.DidNotReceive().Delete(Arg.Any<VolunteerOpportunity>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteTheBannerObject_WhenOpportunityHasABanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+
+		// Act
+		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.Received(1).DeleteAsync($"opportunity-banners/{opportunityId}.png", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptDeletion_WhenOpportunityHasNoBanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+
+		// Act
+		await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenDeletingTheBannerObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/banner.png");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/banner.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+		_fileStorage
+			.DeleteAsync($"opportunity-banners/{opportunityId}.png", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(new DeleteVolunteerOpportunityCommand(opportunityId, DefaultRequestingUserId), cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UploadOpportunityBanner/UploadOpportunityBannerCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using Domain.Primitives;
 using Domain.Users;
 using Domain.VolunteerOpportunities;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Application.UnitTests.VolunteerOpportunities.UploadOpportunityBanner;
 
@@ -87,5 +88,98 @@ public class UploadOpportunityBannerCommandHandlerTests
 		opportunity.BannerImageUrl.Should().BeNull();
 		await _fileStorage.DidNotReceive().UploadAsync(
 			Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDeleteThePreviousBannerObject_WhenReuploadedWithADifferentExtension(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/old.jpg");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/old.jpg")
+			.Returns($"opportunity-banners/{opportunityId}.jpg");
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		var result = await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		await _fileStorage.Received(1).DeleteAsync($"opportunity-banners/{opportunityId}.jpg", cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotDeleteAnything_WhenReuploadedWithTheSameExtension(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/old.png");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/old.png")
+			.Returns($"opportunity-banners/{opportunityId}.png");
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert - re-uploading with the same extension overwrote the object at
+		// that key in place, so deleting it now would delete the file just uploaded.
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotAttemptDeletion_WhenOpportunityHadNoPreviousBanner(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await _fileStorage.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldNotThrow_WhenDeletingThePreviousBannerObjectFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = Guid.CreateVersion7();
+		var opportunity = CreateOpportunity();
+		opportunity.SetBannerImageUrl("https://example.com/opportunity-banners/old.jpg");
+		_opportunityRepo
+			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
+			.Returns(opportunity);
+		_fileStorage
+			.GetObjectKeyFromPublicUrl("https://example.com/opportunity-banners/old.jpg")
+			.Returns($"opportunity-banners/{opportunityId}.jpg");
+		_fileStorage
+			.DeleteAsync($"opportunity-banners/{opportunityId}.jpg", Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("MinIO unavailable"));
+		var command = new UploadOpportunityBannerCommand(opportunityId, PngBytes, "image/png", DefaultRequestingUserId);
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().NotThrowAsync();
 	}
 }


### PR DESCRIPTION
## What

Every deletion path except account deletion left the opportunity banner, organization logo, or user avatar sitting untouched in object storage, publicly readable at a deterministic URL, even after the owning row was hard-deleted or shadow-deleted. This wires object storage cleanup into all of those paths.

## Why

Actioning an abuse report is supposed to remove the reported content. Because `IFileStorageService` was never called on shadow-delete, hard-delete, or re-upload, a moderator takedown removed the row from every read path but left the actual image served anonymously forever - the object key is reconstructible from the id in the public detail-page route. Under DDG s.10 the hosting-liability privilege depends on removing content once the operator has actual knowledge, and an actioned report is actual knowledge; leaving the file served is not removal. It's also an Art. 17 erasure gap for any image containing personal data.

Closes #2198

### Approach

- `IFileStorageService` gets two new methods, `QuarantineAsync`/`UnquarantineAsync`, implemented in `MinioFileStorageService` as a copy-then-delete move between the public prefix and a non-public one. Anonymous reads are only ever allowed under the public prefix by the bucket policy, so moving an object out of it makes the old public URL unreachable without discarding the object.
- **Hard delete** (`VolunteerOpportunityDeletionHelper.DeleteAsync`, `DeleteOrganizationCommandHandler`) now deletes the banner/logo object outright, via the same swallow-on-failure `try`/`catch` `DeleteMyAccountCommandHandler` already uses for the avatar.
- **Shadow delete** (`VolunteerOpportunityDeletionHelper.ShadowDeleteAsync`, `AdminShadowDeleteOrganizationCommandHandler`, `AdminShadowDeleteUserCommandHandler`) quarantines the object instead of deleting it, since restorability is the point of shadow delete (#1075).
- **Restore** (`AdminRestoreVolunteerOpportunityCommandHandler`, `AdminRestoreOrganizationCommandHandler`, `AdminRestoreUserCommandHandler`) unquarantines the object, moving it back to the public prefix.
- **Re-upload** (`UploadOrganizationLogoCommandHandler`, `UploadOpportunityBannerCommandHandler`) now deletes the previous object when the new upload lands at a different object key (i.e. the file extension changed), mirroring `UploadUserAvatarCommandHandler`'s existing `DeletePreviousAvatarAsync`. When the extension is unchanged the new upload already overwrote the same key in place, so no delete is attempted (deleting it would delete the file just uploaded).

## Testing

- Added unit tests in `Application.UnitTests` for every new code path: the happy path (object gets deleted/quarantined/unquarantined with the right key), the guard when there's nothing to do, and that a storage failure is swallowed rather than failing the moderation/upload action.
- `dotnet build` (whole solution), `Application.UnitTests` (1055/1055 passing), and `ArchitectureTests` (417/417 passing) all run clean locally.
- Could not run `IntegrationTests`/`VisualTests` locally (no Docker in this sandbox); CI's `dotnet.yml` covers those.

## Checklist

- [x] `/self-review` run and findings addressed (no blocking findings - see PR conversation)
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (no user-facing or architectural doc changes needed - internal storage-layer fix only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph6pnuowc5BQ3NVzqbZox6)_