### PR TITLE
fix(keycloak): set cache entry Size for the user profile cache

### DIFF
--- a/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakUserService.cs
@@ -60,7 +60,13 @@ internal sealed class KeycloakUserService(
 			NullIfEmpty(user.LastName),
 			user.Email ?? string.Empty);
 
-		cache.Set(cacheKey, profile, ProfileCacheDuration);
+		// Nominal Size - the shared cache's SizeLimit budget is denominated in the
+		// tile bytes OpenStreetMapTileService caches, which dwarf this payload (#2215).
+		cache.Set(cacheKey, profile, new MemoryCacheEntryOptions
+		{
+			Size = 1,
+			AbsoluteExpirationRelativeToNow = ProfileCacheDuration,
+		});
 
 		return profile;
 	}


### PR DESCRIPTION
## What

`KeycloakUserService.GetUserAsync` caches the resolved Keycloak user profile with `cache.Set(cacheKey, profile, ProfileCacheDuration)` - the overload that builds a `MemoryCacheEntryOptions` without a `Size`. Give it an explicit `Size = 1`, matching every other cache-entry write in the codebase.

## Why

Closes #2290

#2273 set a `SizeLimit` on the shared `IMemoryCache` and updated every `cache.Set` call site it touched (city search, both geocoding caches, the login-streak dedup memo) to supply a nominal `Size`, since `MemoryCache.Set` throws once `SizeLimit` is set if any entry omits `Size`. It missed `KeycloakUserService.cs:63` - a pre-existing call site outside that PR's diff.

Since `GetUserAsync` backs nearly every authenticated code path that resolves a Keycloak user's profile (`GET /v1/users/me`, invitation accept/decline, admin user listing, `GetDisplayNamesAsync`/`GetUserProfilesAsync` batch lookups), this turned into a systemic 500 on `main`'s tip: 59/568 `IntegrationTests` failing with `ApiException: Internal Server Error` (`Status: 500`, empty body), mostly bottoming out in `EinsatzbereitApi.GetUserProfileAsync`/`CreateInvitationAsync`, across unrelated suites (`OrganizationSettingsTests`, `UpdateUserProfileTests`, `OrganizerRoleRevocationTests`, `AccountDeletionTests`, `AdminEndpointAuthorizationTests`, ...) - see #2290 for the full evidence trail (three independent CI runs with an identical failure signature).

No other `cache.Set` call site in the codebase is missing `Size` (verified by grep) - this was the only oversight.

## Testing

- `dotnet build` - succeeds
- `dotnet run --project tests/Application.UnitTests` - 1021/1021 passed
- `dotnet run --project tests/ArchitectureTests` - 417/417 passed
- `dotnet format --verify-no-changes` - clean
- Could not run `IntegrationTests`/`VisualTests` locally (need real container networking this sandbox doesn't provide - see `AGENTS.md`'s Sandbox Limitations); CI's `dotnet.yml` will exercise the actual regression this fixes. Given the failure is a straightforward missing-`Size` throw on a cache write reached by nearly every profile-resolving request, and every other call site follows this exact pattern, I'm confident this is the fix rather than a partial one - but flagging that I couldn't reproduce-then-fix locally.

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (no behavior change - restores the pre-#2273 caching behavior, no user-visible or API contract change)

---
_Generated by [Claude Code](https://claude.ai/code/session_017kt7YD1kHxkNGCqxtYHUDd)_