### PR TITLE
fix(tests): poll for the agenda scroll-fade opacity instead of one-shot read

### DIFF
--- a/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
+++ b/backend/tests/VisualTests/OrgDashboardCalendarFootprintTests.cs
@@ -197,9 +197,9 @@ public class OrgDashboardCalendarFootprintTests(AspireFixture fixture) : VisualT
 			"the agenda table is wider than the 375px card and must actually scroll horizontally");
 
 		var fadeRight = calendarWidget.GetByTestId("calendar-agenda-fade-right");
-		var opacity = await fadeRight.EvaluateAsync<string>("el => getComputedStyle(el).opacity");
-		opacity.Should().Be("1",
-			"nothing else hints that the clipped TERMIN column/event title is reachable by scrolling");
+		// The fade element transitions its opacity in on mount, so a one-shot EvaluateAsync can
+		// observe it mid-transition (e.g. "0.996173") - ToHaveCSSAsync polls until it settles.
+		await Expect(fadeRight).ToHaveCSSAsync("opacity", "1");
 
 		await DeleteOrganizationAsync(backend, organizationId);
 	}


### PR DESCRIPTION
## What

`OrgDashboardCalendarFootprintTests.AgendaView_AtMobileWidth_ShowsAScrollAffordance_ForTheClippedTable` reads `getComputedStyle(el).opacity` once via `EvaluateAsync` and asserts it equals `"1"`. Swap that for Playwright's `Expect(...).ToHaveCSSAsync("opacity", "1")`, which polls until the property settles instead of taking one snapshot.

## Why

Found while syncing unrelated PRs with `main` after the #2290 fix (PR #2288): this test failed twice in a row on two separate CI runs of PR #2282 (a version-stamping change with nothing in it touching calendar/agenda code), both times with a near-1 opacity mismatch (`"0.996173"` and `"0.645781"` vs. expected `"1"`). The fade-right element transitions its opacity in on mount, so a one-shot read taken right after the agenda view becomes visible can catch it mid-transition instead of settled - a timing race, not a real regression.

## Testing

- `dotnet build tests/VisualTests` - succeeds
- `dotnet format --verify-no-changes` - clean
- Could not run `VisualTests` itself locally (needs real Docker/Aspire container networking this sandbox doesn't provide - see `AGENTS.md`'s Sandbox Limitations). `ToHaveCSSAsync` is Playwright's standard polling-assertion API (same pattern already used elsewhere in this suite via `Expect(...).ToBeVisibleAsync`), so this is a mechanical swap from a racy one-shot check to the retrying equivalent, not new test logic - CI's `dotnet.yml` will confirm.

- [ ] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - test-only change, no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_017kt7YD1kHxkNGCqxtYHUDd)_