### PR TITLE
fix: stop the opportunity map from looking interactive and vanishing

### DIFF
--- a/frontend/src/components/SingleMarkerMap.css
+++ b/frontend/src/components/SingleMarkerMap.css
@@ -4,6 +4,13 @@
 	filter: grayscale(1) brightness(1.05) contrast(0.9);
 }
 
+/* This map is a fixed location snapshot (dragging/zoom disabled in SingleMarkerMap.tsx) -
+   pin the cursor to default so it never reads as pannable, regardless of which
+   interaction classes Leaflet itself decides to toggle. */
+.leaflet-container {
+	cursor: default;
+}
+
 .leaflet-popup-content-wrapper {
 	border-radius: 0.75rem;
 	box-shadow:

--- a/frontend/src/components/SingleMarkerMap.css
+++ b/frontend/src/components/SingleMarkerMap.css
@@ -5,8 +5,8 @@
 }
 
 /* This map is a fixed location snapshot (dragging/zoom disabled in SingleMarkerMap.tsx) -
-   pin the cursor to default so it never reads as pannable, regardless of which
-   interaction classes Leaflet itself decides to toggle. */
+pin the cursor to default so it never reads as pannable, regardless of which
+interaction classes Leaflet itself decides to toggle. */
 .leaflet-container {
 	cursor: default;
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -205,7 +205,7 @@
       "pastTimeSlots_one": "{{count}} vergangener Zeitslot",
       "pastTimeSlots_other": "{{count}} vergangene Zeitslots",
       "mapLabel": "Karte mit dem Standort von {{location}}",
-      "getDirections": "Route planen",
+      "getDirections": "Route über Google Maps planen",
       "joinWaitlist": "Für Zeitslot eintragen",
       "expressInterest": "Interesse bekunden",
       "notFound": "Nicht gefunden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -205,7 +205,7 @@
       "pastTimeSlots_one": "{{count}} past time slot",
       "pastTimeSlots_other": "{{count}} past time slots",
       "mapLabel": "Map showing the location of {{location}}",
-      "getDirections": "Get directions",
+      "getDirections": "Get directions via Google Maps",
       "joinWaitlist": "Sign up for a slot",
       "expressInterest": "Express interest",
       "notFound": "Not found.",

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.a11y.test.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.a11y.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router";
+import VolunteerOpportunityDetailPage from "./VolunteerOpportunityDetailPage";
+import { renderWithProviders } from "../test/render";
+import { expectNoA11yViolations } from "../test/a11y";
+
+const { api } = await vi.hoisted(async () => {
+	const { createApiMock } = await import("../test/apiMock");
+	return { api: createApiMock() };
+});
+
+vi.mock("../hooks/useApiClient", () => ({ useApiClient: () => api }));
+
+const OPPORTUNITY_ID = "11111111-1111-1111-1111-111111111111";
+
+function renderDetail() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/volunteer-opportunities/:opportunityId"
+				element={<VolunteerOpportunityDetailPage />}
+			/>
+		</Routes>,
+		{ route: `/volunteer-opportunities/${OPPORTUNITY_ID}` },
+	);
+}
+
+beforeEach(() => {
+	api.__reset();
+	api.getVolunteerOpportunities.mockResolvedValue({
+		items: [],
+		pageCount: 1,
+		totalCount: 0,
+	});
+});
+
+describe("VolunteerOpportunityDetailPage a11y", () => {
+	it("has no violations when coordinates are missing and the address fallback renders", async () => {
+		api.getVolunteerOpportunityDetails.mockResolvedValue({
+			id: OPPORTUNITY_ID,
+			organizationId: "22222222-2222-2222-2222-222222222222",
+			organizationName: "Bilingual Org",
+			titleDe: "Deutscher Titel",
+			titleEn: "English Title",
+			descriptionDe: "Deutsche Beschreibung.",
+			descriptionEn: "English description.",
+			street: "Teststrasse",
+			houseNumber: "1",
+			zipCode: "24103",
+			city: "Kiel",
+			isRemote: false,
+			latitude: undefined,
+			longitude: undefined,
+			occurrence: "OneTime",
+			participationType: "IndividualContact",
+			checkInMethod: "None",
+			status: "Published",
+			timeSlots: [],
+			tags: [],
+			currentUserEngagements: [],
+			validUntil: undefined,
+			createdOn: new Date(Date.UTC(2026, 7, 1, 9, 0)),
+		});
+
+		renderDetail();
+
+		await screen.findByTestId("opportunity-location-fallback");
+		await expectNoA11yViolations();
+	});
+});

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.test.tsx
@@ -257,7 +257,7 @@ describe("opportunity detail page anonymous visitor", () => {
 });
 
 describe("opportunity detail page without coordinates", () => {
-	it("collapses the map and offers directions by address instead", async () => {
+	it("shows an address fallback instead of the map, and offers directions by address", async () => {
 		api.getVolunteerOpportunityDetails.mockResolvedValue({
 			...details,
 			isRemote: false,
@@ -269,6 +269,9 @@ describe("opportunity detail page without coordinates", () => {
 
 		await screen.findByTestId("opportunity-detail-when");
 		expect(screen.queryByTestId("opportunity-map")).toBeNull();
+		expect(
+			screen.getByTestId("opportunity-location-fallback"),
+		).toHaveTextContent("Teststrasse 1, 24103 Kiel");
 
 		const directions = screen.getByTestId("opportunity-directions-link");
 		const href = directions.getAttribute("href") ?? "";

--- a/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
+++ b/frontend/src/pages/VolunteerOpportunityDetailPage.tsx
@@ -51,6 +51,7 @@ import { signinLocaleArgs } from "../lib/authLocale";
 import { cardClass } from "../lib/surfaceClasses";
 import {
 	ArrowTopRightOnSquareIcon,
+	BuildingOfficeIcon,
 	CalendarIcon,
 	CheckIconSolid,
 	ChevronRightIcon,
@@ -872,19 +873,30 @@ export default function VolunteerOpportunityDetailPage() {
 							{!opportunity.isRemote && (
 								<div className="mb-6">
 									{opportunity.latitude != null &&
-										opportunity.longitude != null && (
-											<div className="overflow-hidden rounded-card border border-gray-100 shadow-resting">
-												<Suspense
-													fallback={<Skeleton className="h-64 w-full" />}
-												>
-													<SingleMarkerMap
-														latitude={opportunity.latitude}
-														longitude={opportunity.longitude}
-														label={address}
-													/>
-												</Suspense>
-											</div>
-										)}
+									opportunity.longitude != null ? (
+										<div
+											className="overflow-hidden rounded-card border border-gray-100 shadow-resting"
+											data-testid="opportunity-map"
+										>
+											<Suspense fallback={<Skeleton className="h-64 w-full" />}>
+												<SingleMarkerMap
+													latitude={opportunity.latitude}
+													longitude={opportunity.longitude}
+													label={address}
+												/>
+											</Suspense>
+										</div>
+									) : (
+										<div
+											className={`flex items-center gap-3 ${cardClass}`}
+											data-testid="opportunity-location-fallback"
+										>
+											<MapPinIcon className="h-4 w-4 shrink-0 text-brand-700" />
+											<span className="text-sm font-medium text-gray-900">
+												{address}
+											</span>
+										</div>
+									)}
 
 									<a
 										href={directionsUrl}
@@ -1066,7 +1078,7 @@ export default function VolunteerOpportunityDetailPage() {
 												)}
 												{orgProfile.address && (
 													<div className="flex items-center gap-3">
-														<MapPinIcon className="h-4 w-4 shrink-0 text-brand-700" />
+														<BuildingOfficeIcon className="h-4 w-4 shrink-0 text-brand-700" />
 														<span>
 															{orgProfile.address.street}{" "}
 															{orgProfile.address.houseNumber},{" "}


### PR DESCRIPTION
## What

Fixes four problems on the volunteer-opportunity detail page's location map: the frozen map now visually reads as static instead of a broken pannable map, a missing-coordinates opportunity shows an address fallback instead of the map silently vanishing, the organization's registered address gets its own icon distinct from the opportunity's meeting-point pin, and the "get directions" link now names Google Maps as its destination.

## Why

Issue #2238 flagged four problems on `/volunteer-opportunities/:id`:

1. The map renders full interactive-looking Leaflet chrome (tiles, marker, attribution) but has dragging, scroll/touch zoom, and keyboard all disabled - it presents an affordance it doesn't honor.
2. The map silently disappears with no fallback when an opportunity's coordinates fail to geocode, with no way to tell whether the location is missing or the map failed.
3. The organization's registered address and the opportunity's own meeting-point address are visually indistinguishable - both used the same pin icon.
4. The "get directions" link hands the user off to Google Maps without saying so, on a page whose own map is deliberately proxied through the backend (ADR-5) specifically to avoid third-party disclosure.

The issue was explicitly labelled `needs-decision`: two review passes disagreed on whether the frozen map (#1) is a bug or a deliberate mobile-safe design. I asked and the repo owner chose to keep the map frozen (Option A) rather than make it genuinely interactive - so this PR makes the frozen map *look* frozen (no residual cursor affordance suggesting it's pannable) instead of adding gesture-based interactivity. Fixes #2-4 are independent of that choice, as the issue notes.

Closes #2238

## Testing

- `pnpm test` - 919 tests pass. Added `VolunteerOpportunityDetailPage.a11y.test.tsx` (no violations for the new address-fallback state, per `a11y-check` agent review); updated the existing "without coordinates" test to assert the fallback block's address text.
- `pnpm lint`, `pnpm check`, `pnpm i18n:check` - all clean.
- `pnpm build` - production build succeeds.
- Reviewed the existing Playwright coverage in `backend/tests/VisualTests/SingleMarkerMapStaticTests.cs`, `SingleMarkerMapTouchScrollTests.cs`, and `AccessibilityTests.cs`: none assert on the visible link text or the map wrapper's DOM structure this change touches, so none should regress. CI's `dotnet.yml` (which runs them) is green on the current head.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior (not applicable - no ADR/arc42 changes, this is a bug fix to existing behavior)