### PR TITLE
fix: keep non-idempotent I/O out of the retried command transaction

### DIFF
--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -1,7 +1,3 @@
-using Application.Common.Email;
-using Application.Common.Exceptions;
-using Application.Common.Keycloak;
-using Application.Common.Localization;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Domain.Notifications;
@@ -19,9 +15,6 @@ internal static class OpportunityNotificationHelper
 		NotificationKind kind,
 		CancellationToken cancellationToken,
 		TimeSlotId? timeSlotId = null,
-		IKeycloakUserService? keycloakUserService = null,
-		IEmailService? emailService = null,
-		IEmailTemplateRenderer? emailTemplateRenderer = null,
 		string? opportunityTitle = null)
 	{
 		var volunteerIds = await engagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync(
@@ -37,38 +30,5 @@ internal static class OpportunityNotificationHelper
 
 			await dbContext.Notifications.AddAsync(notification, cancellationToken);
 		}
-
-		if (keycloakUserService is null || emailService is null || emailTemplateRenderer is null || volunteerIds.Count == 0)
-			return;
-
-		var volunteerUserIds = volunteerIds.Select(id => UserId.Create(id).GetValueOrThrow()).ToList();
-		var volunteerUsersById = (await dbContext.GetOrCreateUsersAsync(volunteerUserIds, cancellationToken))
-			.ToDictionary(u => u.Id);
-
-		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
-
-		var messages = new List<EmailMessage>(volunteerIds.Count);
-		foreach (var volunteerId in volunteerIds)
-		{
-			if (!profileMap.TryGetValue(volunteerId, out var volunteer))
-				continue;
-
-			var volunteerUser = volunteerUsersById[UserId.Create(volunteerId).GetValueOrThrow()];
-			var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
-
-			var content = emailTemplateRenderer.Render(
-				EmailTemplateKind.OpportunityUpdated,
-				volunteerLanguage,
-				new Dictionary<string, string>
-				{
-					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
-					["OpportunityTitle"] = opportunityTitle ?? string.Empty,
-				});
-
-			messages.Add(new EmailMessage(volunteer.Email, content.Subject, content.Body, volunteerId.ToString()));
-		}
-
-		if (messages.Count > 0)
-			await emailService.SendBatchAsync(messages, cancellationToken);
 	}
 }

--- a/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
+++ b/backend/src/Application/Notifications/OpportunityNotificationHelper.cs
@@ -1,3 +1,4 @@
+using Application.Common.Exceptions;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Domain.Notifications;

--- a/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
+++ b/backend/src/Application/Organizations/CreateOrganization/v1/CreateOrganizationCommandHandler.cs
@@ -6,12 +6,15 @@ using Domain.Common;
 using Domain.Organizations;
 using Domain.Primitives;
 using Domain.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Organizations.CreateOrganization.v1;
 
 internal sealed class CreateOrganizationCommandHandler(
 	IKeycloakOrganizationService keycloakOrganizationService,
-	IApplicationDbContext dbContext)
+	IApplicationDbContext dbContext,
+	IUnitOfWork unitOfWork,
+	ILogger<CreateOrganizationCommandHandler> logger)
 	: ICommandHandler<CreateOrganizationCommand, Organization>
 {
 	public async ValueTask<Organization> Handle(
@@ -27,34 +30,66 @@ internal sealed class CreateOrganizationCommandHandler(
 		var keycloakId = await keycloakOrganizationService.CreateOrganizationAsync(
 			request.Name, cancellationToken);
 
-		await keycloakOrganizationService.AddMemberAsync(
-			keycloakId, request.UserId, cancellationToken);
+		try
+		{
+			await keycloakOrganizationService.AddMemberAsync(
+				keycloakId, request.UserId, cancellationToken);
 
-		await keycloakOrganizationService.AssignOrganizerRoleAsync(
-			request.UserId, cancellationToken);
+			await keycloakOrganizationService.AssignOrganizerRoleAsync(
+				request.UserId, cancellationToken);
 
-		var organization = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), request.Name)
-			.GetValueOrThrow();
+			var organization = Organization.Create(OrganizationId.Create(keycloakId).GetValueOrThrow(), request.Name)
+				.GetValueOrThrow();
 
-		var address = request.Address is null
-			? null
-			: Address.Create(
-				request.Address.Street,
-				request.Address.HouseNumber,
-				request.Address.ZipCode,
-				request.Address.City).GetValueOrThrow();
+			var address = request.Address is null
+				? null
+				: Address.Create(
+					request.Address.Street,
+					request.Address.HouseNumber,
+					request.Address.ZipCode,
+					request.Address.City).GetValueOrThrow();
 
-		organization.ChangeDescription(request.Description);
-		organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website).ThrowIfFailure();
-		organization.Relocate(address);
+			organization.ChangeDescription(request.Description);
+			organization.ChangeContactInfo(request.ContactEmail, request.ContactPhone, request.Website).ThrowIfFailure();
+			organization.Relocate(address);
 
-		await dbContext.Organizations.AddAsync(organization, cancellationToken);
+			await dbContext.Organizations.AddAsync(organization, cancellationToken);
 
-		var membership = OrganizationMembership.Create(
-			organization.Id, UserId.Create(request.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer);
+			var membership = OrganizationMembership.Create(
+				organization.Id, UserId.Create(request.UserId).GetValueOrThrow(), OrganizationMemberRole.Organizer);
 
-		await dbContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
+			await dbContext.OrganizationMemberships.AddAsync(membership, cancellationToken);
 
-		return organization;
+			// Flushed here, rather than left to TransactionPipelineBehavior's own
+			// SaveChangesAsync after Handle returns, so a DB-level failure (e.g. a unique
+			// constraint) is caught by the compensation below instead of leaving the
+			// Keycloak organization orphaned.
+			await unitOfWork.SaveChangesAsync(cancellationToken);
+
+			return organization;
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(
+				ex,
+				"Organization creation failed after Keycloak organization {KeycloakOrganizationId} was created; compensating by deleting it",
+				keycloakId);
+
+			try
+			{
+				// CancellationToken.None: this cleanup must run even if the original
+				// operation failed because the caller's token was cancelled.
+				await keycloakOrganizationService.DeleteOrganizationAsync(keycloakId, CancellationToken.None);
+			}
+			catch (Exception cleanupException)
+			{
+				logger.LogError(
+					cleanupException,
+					"Failed to compensate orphaned Keycloak organization {KeycloakOrganizationId} - manual cleanup required",
+					keycloakId);
+			}
+
+			throw;
+		}
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandler.cs
@@ -1,0 +1,72 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Localization;
+using Application.Common.Messaging;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.VolunteerOpportunities.Common;
+
+internal sealed class VolunteerOpportunityUpdatedNotificationHandler(
+	IApplicationDbContext dbContext,
+	IEngagementReadRepository engagementReadRepository,
+	IKeycloakUserService keycloakUserService,
+	IEmailService emailService,
+	IEmailTemplateRenderer emailTemplateRenderer,
+	ILogger<VolunteerOpportunityUpdatedNotificationHandler> logger)
+	: INotificationHandler<VolunteerOpportunityUpdatedDomainEvent>
+{
+	public async Task Handle(
+		VolunteerOpportunityUpdatedDomainEvent notification,
+		CancellationToken cancellationToken)
+	{
+		var opportunity = await dbContext.VolunteerOpportunities.FindAsync(
+			notification.OpportunityId, cancellationToken);
+		if (opportunity is null)
+		{
+			logger.LogWarning(
+				"Skipping opportunity-updated email for opportunity {OpportunityId}: it no longer exists",
+				notification.OpportunityId.Value);
+			return;
+		}
+
+		var volunteerIds = await engagementReadRepository.GetActiveVolunteerIdsByOpportunityAsync(
+			notification.OpportunityId, notification.TimeSlotId, cancellationToken);
+
+		if (volunteerIds.Count == 0)
+			return;
+
+		var volunteerUserIds = volunteerIds.Select(id => UserId.Create(id).GetValueOrThrow()).ToList();
+		var volunteerUsersById = (await dbContext.GetOrCreateUsersAsync(volunteerUserIds, cancellationToken))
+			.ToDictionary(u => u.Id);
+
+		var profileMap = await keycloakUserService.GetUserProfilesAsync(volunteerIds, cancellationToken);
+
+		var messages = new List<EmailMessage>(volunteerIds.Count);
+		foreach (var volunteerId in volunteerIds)
+		{
+			if (!profileMap.TryGetValue(volunteerId, out var volunteer))
+				continue;
+
+			var volunteerUser = volunteerUsersById[UserId.Create(volunteerId).GetValueOrThrow()];
+			var volunteerLanguage = SupportedLanguages.Resolve(volunteerUser.PreferredLanguage);
+
+			var content = emailTemplateRenderer.Render(
+				EmailTemplateKind.OpportunityUpdated,
+				volunteerLanguage,
+				new Dictionary<string, string>
+				{
+					["VolunteerName"] = volunteer.FirstName ?? volunteer.Username,
+					["OpportunityTitle"] = opportunity.TitleDe,
+				});
+
+			messages.Add(new EmailMessage(volunteer.Email, content.Subject, content.Body, volunteerId.ToString()));
+		}
+
+		if (messages.Count > 0)
+			await emailService.SendBatchAsync(messages, cancellationToken);
+	}
+}

--- a/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandler.cs
@@ -1,4 +1,5 @@
 using Application.Common.Email;
+using Application.Common.Exceptions;
 using Application.Common.Keycloak;
 using Application.Common.Localization;
 using Application.Common.Messaging;

--- a/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateTimeSlot/v1/UpdateTimeSlotCommandHandler.cs
@@ -1,7 +1,5 @@
 using Application.Common.Authorization;
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -14,10 +12,7 @@ namespace Application.VolunteerOpportunities.UpdateTimeSlot.v1;
 
 internal sealed class UpdateTimeSlotCommandHandler(
 	IApplicationDbContext dbContext,
-	IEngagementReadRepository engagementReadRepository,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer)
+	IEngagementReadRepository engagementReadRepository)
 	: ICommandHandler<UpdateTimeSlotCommand, UpdateTimeSlotResult>
 {
 	public async ValueTask<UpdateTimeSlotResult> Handle(
@@ -78,10 +73,9 @@ internal sealed class UpdateTimeSlotCommandHandler(
 			NotificationKind.OpportunityUpdated,
 			cancellationToken,
 			timeSlotId,
-			keycloakUserService,
-			emailService,
-			emailTemplateRenderer,
 			opportunity.TitleDe);
+
+		opportunity.NotifyVolunteersOfUpdate(timeSlotId);
 
 		return new UpdateTimeSlotResult(1, []);
 	}

--- a/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/UpdateVolunteerOpportunity/v1/UpdateVolunteerOpportunityCommandHandler.cs
@@ -1,7 +1,5 @@
 using Application.Common.Authorization;
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
 using Application.Engagements;
@@ -16,10 +14,7 @@ namespace Application.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
 internal sealed class UpdateVolunteerOpportunityCommandHandler(
 	IApplicationDbContext dbContext,
 	IEngagementReadRepository engagementReadRepository,
-	IPinGenerator pinGenerator,
-	IKeycloakUserService keycloakUserService,
-	IEmailService emailService,
-	IEmailTemplateRenderer emailTemplateRenderer)
+	IPinGenerator pinGenerator)
 	: ICommandHandler<UpdateVolunteerOpportunityCommand, bool>
 {
 	public async ValueTask<bool> Handle(
@@ -69,16 +64,17 @@ internal sealed class UpdateVolunteerOpportunityCommandHandler(
 			AddressTextChanged(prevAddress, request.Address);
 
 		if (materialChanged)
+		{
 			await OpportunityNotificationHelper.NotifyActiveVolunteersAsync(
 				dbContext,
 				engagementReadRepository,
 				opportunityId,
 				NotificationKind.OpportunityUpdated,
 				cancellationToken,
-				keycloakUserService: keycloakUserService,
-				emailService: emailService,
-				emailTemplateRenderer: emailTemplateRenderer,
 				opportunityTitle: opportunity.TitleDe);
+
+			opportunity.NotifyVolunteersOfUpdate();
+		}
 
 		return true;
 	}

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunity.cs
@@ -528,6 +528,12 @@ public sealed class VolunteerOpportunity
 		return Result.Success();
 	}
 
+	// Callers decide "material change" from a before/after snapshot the aggregate
+	// itself doesn't retain (see UpdateVolunteerOpportunityCommandHandler), so this is
+	// an explicit trigger rather than something raised from within a single mutator.
+	public void NotifyVolunteersOfUpdate(TimeSlotId? timeSlotId = null) =>
+		AddEvent(new VolunteerOpportunityUpdatedDomainEvent(Id, timeSlotId));
+
 	public Result<TimeSlot> AddTimeSlot(
 		DateTimeOffset startDateTime,
 		DateTimeOffset endDateTime,

--- a/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityUpdatedDomainEvent.cs
+++ b/backend/src/Domain/VolunteerOpportunities/VolunteerOpportunityUpdatedDomainEvent.cs
@@ -1,0 +1,8 @@
+using Domain.Primitives;
+
+namespace Domain.VolunteerOpportunities;
+
+public sealed record VolunteerOpportunityUpdatedDomainEvent(
+	VolunteerOpportunityId OpportunityId,
+	TimeSlotId? TimeSlotId)
+	: DomainEvent;

--- a/backend/src/Infrastructure/Keycloak/KeycloakOptions.cs
+++ b/backend/src/Infrastructure/Keycloak/KeycloakOptions.cs
@@ -9,4 +9,6 @@ internal sealed class KeycloakOptions
 	public string ClientId { get; set; } = string.Empty;
 
 	public string ClientSecret { get; set; } = string.Empty;
+
+	public int TimeoutSeconds { get; set; } = 10;
 }

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -69,7 +69,11 @@ public static class ServiceCollectionExtensions
 				{
 					npg.MigrationsAssembly("Infrastructure");
 
-					npg.EnableRetryOnFailure(5, TimeSpan.FromSeconds(10), null);
+					// No EnableRetryOnFailure: ExecuteInTransactionAsync (ApplicationDbContext)
+					// wraps a manual BeginTransactionAsync around the whole command handler,
+					// including any non-idempotent I/O it performs (Keycloak calls, SMTP sends).
+					// A retrying execution strategy would replay all of that on a transient
+					// error instead of just the DB write.
 				});
 
 			options.UseSnakeCaseNamingConvention();
@@ -173,6 +177,7 @@ public static class ServiceCollectionExtensions
 		{
 			var keycloakOptions = sp.GetRequiredService<IOptions<KeycloakOptions>>().Value;
 			client.BaseAddress = new Uri(keycloakOptions.BaseUrl);
+			client.Timeout = TimeSpan.FromSeconds(keycloakOptions.TimeoutSeconds);
 		});
 
 		services.AddHttpClient<IKeycloakOrganizationService, KeycloakOrganizationService>(
@@ -180,6 +185,7 @@ public static class ServiceCollectionExtensions
 			{
 				var keycloakOptions = sp.GetRequiredService<IOptions<KeycloakOptions>>().Value;
 				client.BaseAddress = new Uri(keycloakOptions.BaseUrl);
+				client.Timeout = TimeSpan.FromSeconds(keycloakOptions.TimeoutSeconds);
 			});
 
 		services.AddHttpClient<IKeycloakUserService, KeycloakUserService>(
@@ -187,6 +193,7 @@ public static class ServiceCollectionExtensions
 			{
 				var keycloakOptions = sp.GetRequiredService<IOptions<KeycloakOptions>>().Value;
 				client.BaseAddress = new Uri(keycloakOptions.BaseUrl);
+				client.Timeout = TimeSpan.FromSeconds(keycloakOptions.TimeoutSeconds);
 			});
 
 		return services;

--- a/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Organizations/CreateOrganization/CreateOrganizationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Application.Common.Persistence;
 using Application.Organizations.CreateOrganization.v1;
 using AwesomeAssertions;
 using Domain.Organizations;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -14,6 +15,7 @@ public class CreateOrganizationCommandHandlerTests
 {
 	private readonly IKeycloakOrganizationService _keycloakService = Substitute.For<IKeycloakOrganizationService>();
 	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 	private readonly IAggregateRepository<OrganizationMembership, OrganizationMembershipId> _membershipRepo =
 		Substitute.For<IAggregateRepository<OrganizationMembership, OrganizationMembershipId>>();
 	private readonly CreateOrganizationCommandHandler _sut;
@@ -23,7 +25,9 @@ public class CreateOrganizationCommandHandlerTests
 		_dbContext.OrganizationMemberships.Returns(_membershipRepo);
 		_sut = new CreateOrganizationCommandHandler(
 			_keycloakService,
-			_dbContext);
+			_dbContext,
+			_unitOfWork,
+			NullLogger<CreateOrganizationCommandHandler>.Instance);
 	}
 
 	[Test]
@@ -186,6 +190,9 @@ public class CreateOrganizationCommandHandlerTests
 		await act.Should().ThrowAsync<HttpRequestException>();
 		await _dbContext.Organizations.DidNotReceive().AddAsync(
 			Arg.Any<Organization>(), Arg.Any<CancellationToken>());
+		// No Keycloak organization was ever created, so there is nothing to compensate.
+		await _keycloakService.DidNotReceive().DeleteOrganizationAsync(
+			Arg.Any<Guid>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -263,6 +270,85 @@ public class CreateOrganizationCommandHandlerTests
 		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
 
 		// Assert
+		await act.Should().ThrowAsync<HttpRequestException>()
+			.WithMessage("*User does not exist*");
+	}
+
+	[Test]
+	public async Task Handle_ShouldCompensateByDeletingKeycloakOrganization_WhenAddMemberFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var keycloakId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
+
+		_keycloakService
+			.CreateOrganizationAsync("Test Org", cancellationToken)
+			.Returns(keycloakId);
+
+		_keycloakService
+			.AddMemberAsync(keycloakId, userId, cancellationToken)
+			.ThrowsAsync(new HttpRequestException("User does not exist"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+		await act.Should().ThrowAsync<HttpRequestException>();
+
+		// Assert
+		await _keycloakService.Received(1).DeleteOrganizationAsync(keycloakId, Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldCompensateByDeletingKeycloakOrganization_WhenDbSaveFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var keycloakId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
+
+		_keycloakService
+			.CreateOrganizationAsync("Test Org", cancellationToken)
+			.Returns(keycloakId);
+
+		_unitOfWork
+			.SaveChangesAsync(cancellationToken)
+			.ThrowsAsync(new InvalidOperationException("Unique constraint violated"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+		await _keycloakService.Received(1).DeleteOrganizationAsync(keycloakId, Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldPropagateOriginalException_WhenCompensationAlsoFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var keycloakId = Guid.NewGuid();
+		var userId = Guid.NewGuid();
+		var command = new CreateOrganizationCommand("Test Org", userId, null, null, null, null, null);
+
+		_keycloakService
+			.CreateOrganizationAsync("Test Org", cancellationToken)
+			.Returns(keycloakId);
+
+		_keycloakService
+			.AddMemberAsync(keycloakId, userId, cancellationToken)
+			.ThrowsAsync(new HttpRequestException("User does not exist"));
+
+		_keycloakService
+			.DeleteOrganizationAsync(keycloakId, Arg.Any<CancellationToken>())
+			.ThrowsAsync(new HttpRequestException("Keycloak is down"));
+
+		// Act
+		Func<Task> act = async () => await _sut.Handle(command, cancellationToken);
+
+		// Assert - the original failure surfaces, not the cleanup failure.
 		await act.Should().ThrowAsync<HttpRequestException>()
 			.WithMessage("*User does not exist*");
 	}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/Common/VolunteerOpportunityUpdatedNotificationHandlerTests.cs
@@ -1,0 +1,190 @@
+using Application.Common.Email;
+using Application.Common.Keycloak;
+using Application.Common.Persistence;
+using Application.Engagements;
+using Application.VolunteerOpportunities.Common;
+using AwesomeAssertions;
+using Domain.Common;
+using Domain.Organizations;
+using Domain.Users;
+using Domain.VolunteerOpportunities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Application.UnitTests.VolunteerOpportunities.Common;
+
+public class VolunteerOpportunityUpdatedNotificationHandlerTests
+{
+	private readonly IApplicationDbContext _dbContext = Substitute.For<IApplicationDbContext>();
+	private readonly IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId> _opportunityRepo =
+		Substitute.For<IAggregateRepository<VolunteerOpportunity, VolunteerOpportunityId>>();
+	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
+	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
+	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
+	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
+	private readonly VolunteerOpportunityUpdatedNotificationHandler _sut;
+
+	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
+	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
+
+	public VolunteerOpportunityUpdatedNotificationHandlerTests()
+	{
+		_dbContext.VolunteerOpportunities.Returns(_opportunityRepo);
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns(CreateDefaultOpportunity());
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<IReadOnlyList<Guid>>()!
+				.ToDictionary(id => id, id => new KeycloakUserProfile(id, "user", null, null, "user@example.com")));
+		_emailService
+			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
+		_emailTemplateRenderer
+			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+			.Returns(callInfo =>
+			{
+				var placeholders = (IReadOnlyDictionary<string, string>)callInfo[2]!;
+				return new EmailContent("Test Subject", $"Test Body {string.Join(" ", placeholders.Values)}");
+			});
+		_sut = new VolunteerOpportunityUpdatedNotificationHandler(
+			_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer,
+			NullLogger<VolunteerOpportunityUpdatedNotificationHandler>.Instance);
+	}
+
+	private VolunteerOpportunity CreateDefaultOpportunity(string title = "Geänderte Aktion") =>
+		VolunteerOpportunity.Create(
+			DefaultOrgId, title, null, "Beschreibung", null, false, DefaultAddress, Occurrence.OneTime,
+			ParticipationType.IndividualContact, CheckInMethod.None, _pinGenerator,
+			validUntil: DateTimeOffset.UtcNow.AddDays(30)).Value;
+
+	[Test]
+	public async Task Handle_ShouldEmailActiveVolunteers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var activeVolunteer = Guid.NewGuid();
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunityId, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteer]);
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(opportunityId, null);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		await _emailService.Received(1).SendBatchAsync(
+			Arg.Is<IReadOnlyList<EmailMessage>>(messages =>
+				messages!.Count == 1 && messages[0].To == "user@example.com" && messages[0].Body.Contains("Geänderte Aktion")),
+			cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldFilterVolunteers_ByGivenTimeSlot(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var timeSlotId = TimeSlotId.New();
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(opportunityId, timeSlotId);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		await _engagementReadRepository.Received(1).GetActiveVolunteerIdsByOpportunityAsync(
+			opportunityId, timeSlotId, cancellationToken);
+	}
+
+	[Test]
+	public async Task Handle_ShouldRenderEmail_InVolunteersPreferredLanguage(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var activeVolunteerId = UserId.New();
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunityId, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteerId.Value]);
+
+		var activeVolunteer = User.Create(activeVolunteerId);
+		activeVolunteer.SetPreferredLanguage("en");
+		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
+			.Returns([activeVolunteer]);
+
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(opportunityId, null);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		_emailTemplateRenderer.Received(1).Render(
+			EmailTemplateKind.OpportunityUpdated,
+			"en",
+			Arg.Any<IReadOnlyDictionary<string, string>>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkipVolunteer_WhenKeycloakProfileLookupFails(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var opportunityId = VolunteerOpportunityId.New();
+		var activeVolunteer = Guid.NewGuid();
+		_engagementReadRepository
+			.GetActiveVolunteerIdsByOpportunityAsync(opportunityId, Arg.Any<TimeSlotId?>(), cancellationToken)
+			.Returns([activeVolunteer]);
+		_keycloakUserService
+			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
+
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(opportunityId, null);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldDoNothing_WhenNoActiveVolunteers(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Handle_ShouldSkip_WhenOpportunityNoLongerExists(
+		CancellationToken cancellationToken)
+	{
+		// Arrange
+		_opportunityRepo
+			.FindAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<CancellationToken>())
+			.Returns((VolunteerOpportunity?)null);
+		var notification = new VolunteerOpportunityUpdatedDomainEvent(VolunteerOpportunityId.New(), null);
+
+		// Act
+		await _sut.Handle(notification, cancellationToken);
+
+		// Assert
+		await _emailService.DidNotReceive().SendBatchAsync(
+			Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateTimeSlot/UpdateTimeSlotCommandHandlerTests.cs
@@ -1,6 +1,4 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.UpdateTimeSlot.v1;
@@ -24,9 +22,6 @@ public class UpdateTimeSlotCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
-	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly UpdateTimeSlotCommandHandler _sut;
 
 	private static readonly OrganizationId DefaultOrgId = OrganizationId.New();
@@ -51,19 +46,7 @@ public class UpdateTimeSlotCommandHandlerTests
 		_engagementReadRepository
 			.GetActiveVolunteerIdsByOpportunityAsync(Arg.Any<VolunteerOpportunityId>(), Arg.Any<TimeSlotId?>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_keycloakUserService
-			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-			.Returns(callInfo => callInfo.Arg<IReadOnlyList<Guid>>()!
-				.ToDictionary(id => id, id => new KeycloakUserProfile(id, "user", null, null, "user@example.com")));
-		_emailService
-			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
-			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(new EmailContent("Test Subject", "Test Body"));
-		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository, _keycloakUserService, _emailService, _emailTemplateRenderer);
+		_sut = new UpdateTimeSlotCommandHandler(_dbContext, _engagementReadRepository);
 	}
 
 	private VolunteerOpportunity CreateScheduledSlotsOpportunity() =>
@@ -260,13 +243,13 @@ public class UpdateTimeSlotCommandHandlerTests
 		await _notifRepo.DidNotReceive().AddAsync(
 			Arg.Is<Notification>(n => n!.RecipientId.Value == otherSlotVolunteer),
 			cancellationToken);
-		await _emailService.Received(1).SendBatchAsync(
-			Arg.Is<IReadOnlyList<EmailMessage>>(messages => messages!.Count == 1 && messages[0].To == "user@example.com"),
-			cancellationToken);
+		opportunity.Events.OfType<VolunteerOpportunityUpdatedDomainEvent>()
+			.Should().ContainSingle()
+			.Which.TimeSlotId.Should().Be(editedSlot.Id);
 	}
 
 	[Test]
-	public async Task Handle_ShouldNotEmail_WhenNoActiveVolunteersOnEditedSlot(
+	public async Task Handle_ShouldRaiseUpdatedDomainEvent_EvenWhenNoActiveVolunteersOnEditedSlot(
 		CancellationToken cancellationToken)
 	{
 		// Arrange
@@ -285,9 +268,10 @@ public class UpdateTimeSlotCommandHandlerTests
 		await _sut.Handle(command, cancellationToken);
 
 		// Assert
-		await _emailService.DidNotReceive().SendBatchAsync(
-			Arg.Any<IReadOnlyList<EmailMessage>>(),
-			Arg.Any<CancellationToken>());
+		await _notifRepo.DidNotReceive().AddAsync(Arg.Any<Notification>(), Arg.Any<CancellationToken>());
+		opportunity.Events.OfType<VolunteerOpportunityUpdatedDomainEvent>()
+			.Should().ContainSingle()
+			.Which.TimeSlotId.Should().Be(editedSlot.Id);
 	}
 
 	[Test]

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/UpdateVolunteerOpportunity/UpdateVolunteerOpportunityCommandHandlerTests.cs
@@ -1,6 +1,4 @@
-using Application.Common.Email;
 using Application.Common.Exceptions;
-using Application.Common.Keycloak;
 using Application.Common.Persistence;
 using Application.Engagements;
 using Application.VolunteerOpportunities.UpdateVolunteerOpportunity.v1;
@@ -24,9 +22,6 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		Substitute.For<IAggregateRepository<Notification, NotificationId>>();
 	private readonly IEngagementReadRepository _engagementReadRepository = Substitute.For<IEngagementReadRepository>();
 	private readonly IPinGenerator _pinGenerator = Substitute.For<IPinGenerator>();
-	private readonly IKeycloakUserService _keycloakUserService = Substitute.For<IKeycloakUserService>();
-	private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-	private readonly IEmailTemplateRenderer _emailTemplateRenderer = Substitute.For<IEmailTemplateRenderer>();
 	private readonly UpdateVolunteerOpportunityCommandHandler _sut;
 
 	private static readonly Address DefaultAddress = Address.Create("Hauptstraße", "1", "12345", "Berlin").Value;
@@ -46,29 +41,10 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		_dbContext
 			.IsOrganizerAsync(Arg.Any<OrganizationId>(), Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(true);
-		_keycloakUserService
-			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-			.Returns(callInfo => callInfo.Arg<IReadOnlyList<Guid>>()!
-				.ToDictionary(id => id, id => new KeycloakUserProfile(id, "user", null, null, "user@example.com")));
-		_emailService
-			.SendBatchAsync(Arg.Any<IReadOnlyList<EmailMessage>>(), Arg.Any<CancellationToken>())
-			.Returns(callInfo => callInfo.Arg<IReadOnlyList<EmailMessage>>()!.Select(_ => true).ToList());
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns(call => ((IReadOnlyCollection<UserId>)call[0]!).Select(User.Create).ToList());
-		_emailTemplateRenderer
-			.Render(Arg.Any<EmailTemplateKind>(), Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, string>>())
-			.Returns(callInfo =>
-			{
-				var placeholders = (IReadOnlyDictionary<string, string>)callInfo[2]!;
-				return new EmailContent("Test Subject", $"Test Body {string.Join(" ", placeholders.Values)}");
-			});
 		_sut = new UpdateVolunteerOpportunityCommandHandler(
 			_dbContext,
 			_engagementReadRepository,
-			_pinGenerator,
-			_keycloakUserService,
-			_emailService,
-			_emailTemplateRenderer);
+			_pinGenerator);
 	}
 
 	private VolunteerOpportunity CreateOpportunity(string title = "Altes Thema", string description = "Alte Beschreibung") =>
@@ -438,46 +414,9 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		await _notifRepo.Received(1).AddAsync(
 			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
 			cancellationToken);
-		await _emailService.Received(1).SendBatchAsync(
-			Arg.Is<IReadOnlyList<EmailMessage>>(messages =>
-				messages!.Count == 1 && messages[0].To == "user@example.com" && messages[0].Body.Contains("Neues Thema")),
-			cancellationToken);
-	}
-
-	[Test]
-	public async Task Handle_ShouldRenderOpportunityUpdatedEmail_InVolunteersPreferredLanguage(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-		var opportunityId = Guid.CreateVersion7();
-		var opportunity = CreateOpportunity();
-		var activeVolunteerId = UserId.New();
-
-		_opportunityRepo
-			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(opportunity);
-
-		_engagementReadRepository
-			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
-			.Returns([activeVolunteerId.Value]);
-
-		var activeVolunteer = User.Create(activeVolunteerId);
-		activeVolunteer.SetPreferredLanguage("en");
-		_dbContext.GetOrCreateUsersAsync(Arg.Any<IReadOnlyCollection<UserId>>(), Arg.Any<CancellationToken>())
-			.Returns([activeVolunteer]);
-
-		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
-		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		_emailTemplateRenderer.Received(1).Render(
-			EmailTemplateKind.OpportunityUpdated,
-			"en",
-			Arg.Any<IReadOnlyDictionary<string, string>>());
+		opportunity.Events.OfType<VolunteerOpportunityUpdatedDomainEvent>()
+			.Should().ContainSingle()
+			.Which.TimeSlotId.Should().BeNull();
 	}
 
 	[Test]
@@ -507,9 +446,7 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		await _notifRepo.DidNotReceive().AddAsync(
 			Arg.Any<Notification>(),
 			cancellationToken);
-		await _emailService.DidNotReceive().SendBatchAsync(
-			Arg.Any<IReadOnlyList<EmailMessage>>(),
-			Arg.Any<CancellationToken>());
+		opportunity.Events.Should().NotContain(e => e is VolunteerOpportunityUpdatedDomainEvent);
 	}
 
 	[Test]
@@ -534,44 +471,6 @@ public class UpdateVolunteerOpportunityCommandHandlerTests
 		// Assert
 		await act.Should().ThrowAsync<ResultFailureException>()
 			.WithMessage("*cannot have more than*");
-	}
-
-	[Test]
-	public async Task Handle_ShouldSkipVolunteer_WhenKeycloakProfileLookupFails(
-		CancellationToken cancellationToken)
-	{
-		// Arrange
-
-		var opportunityId = Guid.CreateVersion7();
-		var opportunity = CreateOpportunity();
-		var activeVolunteer = Guid.NewGuid();
-
-		_opportunityRepo
-			.FindAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), cancellationToken)
-			.Returns(opportunity);
-
-		_engagementReadRepository
-			.GetActiveVolunteerIdsByOpportunityAsync(VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(), Arg.Any<TimeSlotId?>(), cancellationToken)
-			.Returns([activeVolunteer]);
-
-		_keycloakUserService
-			.GetUserProfilesAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-			.Returns(new Dictionary<Guid, KeycloakUserProfile>());
-
-		var newAddress = Address.Create("Neue Straße", "99", "20095", "Hamburg").Value;
-		var command = new UpdateVolunteerOpportunityCommand(
-			opportunityId, "Neues Thema", null, "Neue Beschreibung", null, false, newAddress, Occurrence.OneTime, ParticipationType.IndividualContact, CheckInMethod.None, null, [], DefaultRequestingUserId);
-
-		// Act
-		await _sut.Handle(command, cancellationToken);
-
-		// Assert
-		await _notifRepo.Received(1).AddAsync(
-			Arg.Is<Notification>(n => n!.Kind == NotificationKind.OpportunityUpdated && n.RecipientId.Value == activeVolunteer),
-			cancellationToken);
-		await _emailService.DidNotReceive().SendBatchAsync(
-			Arg.Any<IReadOnlyList<EmailMessage>>(),
-			Arg.Any<CancellationToken>());
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
+++ b/backend/tests/IntegrationTests/OutboxMessageSerializationTests.cs
@@ -77,5 +77,7 @@ public class OutboxMessageSerializationTests
 			VolunteerOpportunityId.New(), CoreOrganizationId.New());
 		yield return new VolunteerOpportunityUnpublishedDomainEvent(
 			VolunteerOpportunityId.New(), CoreOrganizationId.New());
+		yield return new VolunteerOpportunityUpdatedDomainEvent(
+			VolunteerOpportunityId.New(), TimeSlotId: null);
 	}
 }


### PR DESCRIPTION
## What

Fixes four related problems that all trace back to the same root cause: external I/O running inside `TransactionPipelineBehavior`'s transaction — untimed, uncapped, and replayed by the EF Core execution strategy on retry.

## Why

Closes #2200

`ApplicationDbContext.ExecuteInTransactionAsync` wraps a manual `BeginTransactionAsync` around the whole command handler using `Database.CreateExecutionStrategy()`, while `ServiceCollectionExtensions.cs` had `EnableRetryOnFailure(5, ...)` configured. That combination is the documented EF Core anti-pattern: on a transient DB error, the execution strategy replays the *entire* handler delegate, including any non-idempotent I/O it already performed (Keycloak calls, SMTP sends) — turning one click into duplicate Keycloak organizations, duplicate emails, etc. Three other findings share this root cause (uncapped fan-out inside the transaction, unbounded Keycloak client timeouts, no compensation for a partially-created organization).

### Changes

- **Drop `EnableRetryOnFailure`.** Without a retrying execution strategy, `ExecuteInTransactionAsync`'s delegate runs exactly once — a transient error now surfaces as a single failed request instead of being silently replayed. The outbox processor's own 5s polling loop already gives its claim transaction equivalent resilience, so nothing else needed to change there.
- **Explicit timeout on all three Keycloak `HttpClient`s** (admin token provider, `IKeycloakOrganizationService`, `IKeycloakUserService`) via a new `KeycloakOptions.TimeoutSeconds` (default 10s), matching the pattern the geocoding/map-tile clients already use instead of falling back to `HttpClient`'s 100s default.
- **Move the opportunity-update email fan-out out of the transaction.** `UpdateVolunteerOpportunityCommandHandler` and `UpdateTimeSlotCommandHandler` used to call Keycloak (`GetUserProfilesAsync`) and send a batch of emails synchronously, inside the open transaction. A new `VolunteerOpportunityUpdatedDomainEvent` + outbox-dispatched `VolunteerOpportunityUpdatedNotificationHandler` now does that work post-commit — the same transactional-outbox pattern already used for engagement-confirmation emails (`EngagementConfirmedNotificationHandler`). The in-app `Notification` rows stay synchronous (cheap, DB-only, no longer at risk now that retries are gone).
  - Note: `VolunteerOpportunityEngagementCascadeHelper` (cancel/unpublish/delete paths) never actually passed the Keycloak/email parameters at its call sites, so despite being named in the issue it was already DB-only, and it's already invoked exclusively from post-commit domain event handlers — no change was needed there.
- **Compensate orphaned Keycloak organizations.** `CreateOrganizationCommandHandler` now wraps `AddMemberAsync`, role assignment, and the DB save (flushed early via `IUnitOfWork` so a unique-constraint failure is caught too, not just a Keycloak failure) in a try/catch. Any failure after the Keycloak organization is created triggers a best-effort `DeleteOrganizationAsync` (using `CancellationToken.None` so cleanup isn't itself aborted by the caller's cancellation) before the original exception is rethrown.

## Testing

- Updated `CreateOrganizationCommandHandlerTests` with new cases: compensates on `AddMemberAsync` failure, compensates on DB save failure, original exception (not the cleanup exception) propagates when compensation itself fails, and no compensation is attempted when nothing was created yet.
- Updated `UpdateVolunteerOpportunityCommandHandlerTests` / `UpdateTimeSlotCommandHandlerTests` to assert the new `VolunteerOpportunityUpdatedDomainEvent` is raised (or not, for the cosmetic-change/no-op cases) instead of asserting direct email sends.
- New `VolunteerOpportunityUpdatedNotificationHandlerTests` covering the email fan-out that moved out of the two command handlers: batch send, time-slot filtering, language rendering, skipping a volunteer with no Keycloak profile, no-op when the opportunity or volunteers are gone.
- Added the required round-trip coverage case for the new domain event to `IntegrationTests/OutboxMessageSerializationTests.cs` (it's the first domain event with a nullable value-object-ID field, so the added case exercises the null path through the custom `ValueObjectIdJsonConverterFactory`).
- Ran the `architecture-check` and `ef-migration-check` subagents against the full diff — both reported no violations (no layer/naming/rate-limiting issues, no missing EF migration).
- Couldn't run `dotnet build`/tests locally in the session that authored this (sandbox egress policy blocked the .NET SDK download). The first push hit a real compile error as a result (a dropped `using Application.Common.Exceptions;` needed for the `GetValueOrThrow()` extension method, in two files) — fixed in the second commit once CI's `build` job caught it.
- CI is now green end to end: `build`, `format-check`, `fast-tests` (Application.UnitTests + ArchitectureTests), `integration-tests`, all four `visual-tests` shards, CodeQL, and the lint checks.

## Checklist

- [x] `/self-review` run and findings addressed
- [x] CI is green
- [ ] Documentation updated if this change affects behavior — not applicable, this is an internal reliability fix with no user-facing or architectural-doc-worthy behavior change