### PR TITLE
fix: anchor event times to Europe/Berlin, not the caller's zone

### DIFF
--- a/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
+++ b/backend/src/Api/Common/Middleware/LoginStreakMiddleware.cs
@@ -1,5 +1,6 @@
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
+using Application.Common.Time;
 using Application.Users.RecordLogin.v1;
 using Domain.Users;
 using Microsoft.Extensions.Caching.Memory;
@@ -8,22 +9,7 @@ namespace Api.Common.Middleware;
 
 internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache cache, TimeProvider timeProvider)
 {
-	private static readonly TimeZoneInfo ServerTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
 	private static readonly Lock _lock = new();
-
-	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
-	{
-		if (string.IsNullOrWhiteSpace(ianaId))
-			return ServerTimeZone;
-		try
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
-		}
-		catch
-		{
-			return ServerTimeZone;
-		}
-	}
 
 	public async Task InvokeAsync(HttpContext context, ISender sender)
 	{
@@ -33,10 +19,14 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache c
 			if (subClaim is not null && Guid.TryParse(subClaim, out var userId))
 			{
 				var tzHeader = context.Request.Headers["X-Timezone"].FirstOrDefault();
-				var tz = ResolveTimeZone(tzHeader);
+				var tz = CanonicalTimeZone.Resolve(tzHeader);
 				var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), tz).DateTime);
 
-				var cacheKey = $"login-streak-recorded:{subClaim}";
+				// The date is part of the key (not just the expiration) so that a client
+				// whose local day advances before the next cache rollover - e.g. a caller
+				// far enough ahead of tz's own midnight - still gets recorded for its new
+				// local day instead of being swallowed by yesterday's cached entry (#2203).
+				var cacheKey = $"login-streak-recorded:{subClaim}:{today:O}";
 
 				Task recordTask;
 				lock (_lock)
@@ -49,7 +39,7 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache c
 						cache.Set(cacheKey, recordTask, new MemoryCacheEntryOptions
 						{
 							Size = 1,
-							AbsoluteExpiration = NextServerMidnight(),
+							AbsoluteExpiration = NextMidnight(today, tz),
 						});
 					}
 					else
@@ -84,11 +74,10 @@ internal sealed class LoginStreakMiddleware(RequestDelegate next, IMemoryCache c
 		}
 	}
 
-	private DateTimeOffset NextServerMidnight()
+	private static DateTimeOffset NextMidnight(DateOnly today, TimeZoneInfo tz)
 	{
-		var serverNow = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), ServerTimeZone);
-		var nextMidnight = serverNow.Date.AddDays(1);
+		var nextMidnight = today.AddDays(1).ToDateTime(TimeOnly.MinValue);
 
-		return new DateTimeOffset(nextMidnight, ServerTimeZone.GetUtcOffset(nextMidnight));
+		return new DateTimeOffset(nextMidnight, tz.GetUtcOffset(nextMidnight));
 	}
 }

--- a/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingExtensions.cs
@@ -30,6 +30,14 @@ internal static class OutputCachingExtensions
 			cache.AddPolicy(OutputCachingPolicies.VolunteerOpportunityListing, policy =>
 				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds))
 					.Tag(OutputCachingPolicies.VolunteerOpportunityListingTag));
+
+			// Its own policy rather than reusing VolunteerOpportunityListing above - the
+			// result here depends on the caller's X-Timezone, which the plain listing
+			// doesn't vary by and shouldn't start fragmenting its cache over (#2203).
+			cache.AddPolicy(OutputCachingPolicies.VolunteerOpportunityDateAvailability, policy =>
+				policy.Expire(TimeSpan.FromSeconds(options.ShortPublicReadSeconds))
+					.SetVaryByHeader("X-Timezone")
+					.Tag(OutputCachingPolicies.VolunteerOpportunityListingTag));
 		});
 	}
 

--- a/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
+++ b/backend/src/Api/Common/OutputCaching/OutputCachingPolicies.cs
@@ -10,6 +10,7 @@ public static class OutputCachingPolicies
 	public const string HealthCheck = "output-cache-health-check";
 
 	public const string VolunteerOpportunityListing = "output-cache-volunteer-opportunity-listing";
+	public const string VolunteerOpportunityDateAvailability = "output-cache-volunteer-opportunity-date-availability";
 
 	public const string VolunteerOpportunityListingTag = "volunteer-opportunity-listing";
 }

--- a/backend/src/Api/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsEndpoint.cs
+++ b/backend/src/Api/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsEndpoint.cs
@@ -37,7 +37,6 @@ internal sealed class BulkConfirmEngagementsEndpoint
 		[FromBody] BulkConfirmEngagementsRequest? body,
 		[FromServices] ISender sender,
 		ClaimsPrincipal user,
-		HttpRequest request,
 		CancellationToken cancellationToken)
 	{
 		if (body is null || body.EngagementIds.Count == 0)
@@ -47,13 +46,11 @@ internal sealed class BulkConfirmEngagementsEndpoint
 			return Results.Problem($"Cannot process more than {MaxBatchSize} engagements in a single request.", statusCode: StatusCodes.Status400BadRequest);
 
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? UserId.Create(uid).GetValueOrThrow() : throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
-		var timezone = request.Headers["X-Timezone"].FirstOrDefault();
 
 		var command = new BulkConfirmEngagementsCommand(
 			VolunteerOpportunityId.Create(opportunityId).GetValueOrThrow(),
 			body.EngagementIds.Select(id => EngagementId.Create(id).GetValueOrThrow()).ToList(),
-			userId,
-			timezone);
+			userId);
 
 		var result = await sender.Send(command, cancellationToken);
 

--- a/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
+++ b/backend/src/Api/Engagements/ConfirmEngagement/v1/ConfirmEngagementEndpoint.cs
@@ -34,12 +34,10 @@ internal sealed class ConfirmEngagementEndpoint
 		[FromRoute] Guid engagementId,
 		[FromServices] ISender sender,
 		ClaimsPrincipal user,
-		HttpRequest request,
 		CancellationToken cancellationToken)
 	{
 		var userId = Guid.TryParse(user.FindFirstValue("sub"), out var uid) ? UserId.Create(uid).GetValueOrThrow() : throw new ResultFailureException(Error.Validation("User.InvalidId", "Invalid user."));
-		var timezone = request.Headers["X-Timezone"].FirstOrDefault();
-		var command = new ConfirmEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId, timezone);
+		var command = new ConfirmEngagementCommand(EngagementId.Create(engagementId).GetValueOrThrow(), userId);
 		var engagement = await sender.Send(command, cancellationToken);
 		return Results.Ok(new EngagementStatusResponse(engagement.Id.Value, engagement.Status.ToString()));
 	}

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityEndpoint.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityEndpoint.cs
@@ -14,8 +14,6 @@ internal sealed class GetVolunteerOpportunityDateAvailabilityEndpoint
 {
 	private const int MaxWindowDays = 62;
 
-	private const int MaxUtcOffsetMinutes = 14 * 60;
-
 	public void MapEndpoint(
 		IEndpointRouteBuilder app)
 	{
@@ -27,12 +25,13 @@ internal sealed class GetVolunteerOpportunityDateAvailabilityEndpoint
 			.AllowAnonymous()
 			.RequireRateLimiting(RateLimitingPolicies.Read)
 
-			.CacheOutput(OutputCachingPolicies.VolunteerOpportunityListing)
+			.CacheOutput(OutputCachingPolicies.VolunteerOpportunityDateAvailability)
 			.MapToApiVersion(1);
 	}
 
 	private static async Task<IResult> GetVolunteerOpportunityDateAvailabilityAsync(
 		[AsParameters] GetVolunteerOpportunityDateAvailabilityRequest request,
+		HttpRequest httpRequest,
 		[FromServices] ISender sender,
 		CancellationToken cancellationToken)
 	{
@@ -41,10 +40,6 @@ internal sealed class GetVolunteerOpportunityDateAvailabilityEndpoint
 
 		if (request.To - request.From > TimeSpan.FromDays(MaxWindowDays))
 			return Results.Problem($"The requested window must not exceed {MaxWindowDays} days.", statusCode: StatusCodes.Status400BadRequest);
-
-		var utcOffsetMinutes = request.UtcOffsetMinutes ?? 0;
-		if (Math.Abs(utcOffsetMinutes) > MaxUtcOffsetMinutes)
-			return Results.Problem($"UtcOffsetMinutes must be between -{MaxUtcOffsetMinutes} and {MaxUtcOffsetMinutes}.", statusCode: StatusCodes.Status400BadRequest);
 
 		var filterProblem = VolunteerOpportunityFilterValidation.Validate(
 			request.CenterLatitude,
@@ -58,10 +53,12 @@ internal sealed class GetVolunteerOpportunityDateAvailabilityEndpoint
 		if (filterProblem is not null)
 			return filterProblem;
 
+		var timezone = httpRequest.Headers["X-Timezone"].FirstOrDefault();
+
 		var query = new GetVolunteerOpportunityDateAvailabilityQuery(
 			request.From,
 			request.To,
-			utcOffsetMinutes,
+			timezone,
 			request.Occurrence,
 			request.ParticipationType,
 			request.IsRemote,

--- a/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityRequest.cs
+++ b/backend/src/Api/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityRequest.cs
@@ -3,6 +3,12 @@ namespace Api.VolunteerOpportunities.GetVolunteerOpportunityDateAvailability.v1;
 public sealed record GetVolunteerOpportunityDateAvailabilityRequest(
 	DateTimeOffset From,
 	DateTimeOffset To,
+	// Unused - kept only so the currently-committed generated clients
+	// (frontend/src/client/api-client.ts, IntegrationTests/ApiClient.cs) stay
+	// wire-compatible until their next NSwag regeneration, which can drop this
+	// property. The caller's zone comes from the X-Timezone header instead
+	// (see the endpoint) - a single scalar offset can't be right for every
+	// slot in a multi-week window once a DST transition falls inside it (#2203).
 	int? UtcOffsetMinutes,
 	string? Occurrence,
 	string? ParticipationType,

--- a/backend/src/Application/Common/Time/CanonicalTimeZone.cs
+++ b/backend/src/Application/Common/Time/CanonicalTimeZone.cs
@@ -1,0 +1,22 @@
+namespace Application.Common.Time;
+
+public static class CanonicalTimeZone
+{
+	public const string Id = "Europe/Berlin";
+
+	public static readonly TimeZoneInfo Value = TimeZoneInfo.FindSystemTimeZoneById(Id);
+
+	public static TimeZoneInfo Resolve(string? ianaId)
+	{
+		if (string.IsNullOrWhiteSpace(ianaId))
+			return Value;
+		try
+		{
+			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+		}
+		catch
+		{
+			return Value;
+		}
+	}
+}

--- a/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommand.cs
+++ b/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommand.cs
@@ -9,6 +9,5 @@ namespace Application.Engagements.BulkConfirmEngagements.v1;
 public sealed record BulkConfirmEngagementsCommand(
 	VolunteerOpportunityId OpportunityId,
 	IReadOnlyList<EngagementId> EngagementIds,
-	UserId RequestingUserId,
-	string? Timezone = null)
+	UserId RequestingUserId)
 	: ICommand<BulkEngagementActionResult>;

--- a/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommandHandler.cs
+++ b/backend/src/Application/Engagements/BulkConfirmEngagements/v1/BulkConfirmEngagementsCommandHandler.cs
@@ -9,7 +9,8 @@ namespace Application.Engagements.BulkConfirmEngagements.v1;
 
 internal sealed class BulkConfirmEngagementsCommandHandler(
 	IApplicationDbContext dbContext,
-	ISender sender)
+	ISender sender,
+	TimeProvider timeProvider)
 	: ICommandHandler<BulkConfirmEngagementsCommand, BulkEngagementActionResult>
 {
 	public async ValueTask<BulkEngagementActionResult> Handle(
@@ -50,7 +51,7 @@ internal sealed class BulkConfirmEngagementsCommandHandler(
 			}
 
 			var result = await EngagementConfirmationHelper.ConfirmAsync(
-				dbContext, sender, engagement, request.Timezone, cancellationToken);
+				dbContext, sender, engagement, timeProvider, cancellationToken);
 
 			if (result.IsSuccess)
 				succeeded.Add(new BulkEngagementActionSuccess(result.Value.Id.Value, result.Value.Status.ToString()));

--- a/backend/src/Application/Engagements/Common/EngagementConfirmationHelper.cs
+++ b/backend/src/Application/Engagements/Common/EngagementConfirmationHelper.cs
@@ -1,6 +1,7 @@
 using Application.Achievements.AwardAchievement.v1;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Time;
 using Domain.Engagements;
 using Domain.Notifications;
 using Domain.Primitives;
@@ -24,7 +25,7 @@ internal static class EngagementConfirmationHelper
 		IApplicationDbContext dbContext,
 		ISender sender,
 		Engagement engagement,
-		string? timezone,
+		TimeProvider timeProvider,
 		CancellationToken cancellationToken)
 	{
 		var confirmResult = engagement.Confirm();
@@ -40,8 +41,10 @@ internal static class EngagementConfirmationHelper
 
 		await dbContext.Notifications.AddAsync(notification, cancellationToken);
 
-		var tz = ResolveTimeZone(timezone);
-		var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).DateTime;
+		// Bucketed by the platform's canonical zone, not whichever organizer happens to
+		// confirm the engagement - the volunteer whose ActivityStreak this affects has no
+		// say in and no visibility into the confirming organizer's own device zone (#2203).
+		var now = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), CanonicalTimeZone.Value).DateTime;
 		var isoYear = System.Globalization.ISOWeek.GetYear(now);
 		var isoWeek = System.Globalization.ISOWeek.GetWeekOfYear(now);
 		var totalConfirmedEngagements = await RecordActivityStreakAndConfirmationAsync(
@@ -50,20 +53,6 @@ internal static class EngagementConfirmationHelper
 		await EvaluateMilestoneAchievementsAsync(sender, volunteerId, totalConfirmedEngagements, cancellationToken);
 
 		return Result.Success(engagement);
-	}
-
-	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
-	{
-		if (string.IsNullOrWhiteSpace(ianaId))
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		try
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
-		}
-		catch
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		}
 	}
 
 	private static async Task<int> RecordActivityStreakAndConfirmationAsync(

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommand.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommand.cs
@@ -4,5 +4,5 @@ using Domain.Users;
 
 namespace Application.Engagements.ConfirmEngagement.v1;
 
-public sealed record ConfirmEngagementCommand(EngagementId EngagementId, UserId RequestingUserId, string? Timezone = null)
+public sealed record ConfirmEngagementCommand(EngagementId EngagementId, UserId RequestingUserId)
 	: ICommand<Engagement>;

--- a/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
+++ b/backend/src/Application/Engagements/ConfirmEngagement/v1/ConfirmEngagementCommandHandler.cs
@@ -10,7 +10,8 @@ namespace Application.Engagements.ConfirmEngagement.v1;
 
 internal sealed class ConfirmEngagementCommandHandler(
 	IApplicationDbContext dbContext,
-	ISender sender)
+	ISender sender,
+	TimeProvider timeProvider)
 	: ICommandHandler<ConfirmEngagementCommand, Engagement>
 {
 	public async ValueTask<Engagement> Handle(
@@ -30,7 +31,7 @@ internal sealed class ConfirmEngagementCommandHandler(
 			cancellationToken);
 
 		var result = await EngagementConfirmationHelper.ConfirmAsync(
-			dbContext, sender, engagement, request.Timezone, cancellationToken);
+			dbContext, sender, engagement, timeProvider, cancellationToken);
 
 		return result.GetValueOrThrow();
 	}

--- a/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
+++ b/backend/src/Application/Engagements/EngagementReminder/v1/EngagementReminderDueHandler.cs
@@ -4,6 +4,7 @@ using Application.Common.Keycloak;
 using Application.Common.Localization;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Time;
 using Domain.Engagements;
 using Domain.Users;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ internal sealed class EngagementReminderDueHandler(
 
 	private static string FormatStart(DateTimeOffset startDateTime, string language)
 	{
-		var berlinTime = TimeZoneInfo.ConvertTime(startDateTime, TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin"));
+		var berlinTime = TimeZoneInfo.ConvertTime(startDateTime, CanonicalTimeZone.Value);
 		var culture = CultureInfo.GetCultureInfo(language == "de" ? "de-DE" : "en-GB");
 		var pattern = language == "de" ? "dddd, d. MMMM yyyy 'um' HH:mm" : "dddd, d. MMMM yyyy 'at' HH:mm";
 		return berlinTime.ToString(pattern, culture);

--- a/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/CreateTimeSlot/v1/CreateTimeSlotCommandHandler.cs
@@ -2,6 +2,7 @@ using Application.Common.Authorization;
 using Application.Common.Exceptions;
 using Application.Common.Messaging;
 using Application.Common.Persistence;
+using Application.Common.Time;
 using Domain.Primitives;
 using Domain.VolunteerOpportunities;
 
@@ -33,7 +34,7 @@ internal sealed class CreateTimeSlotCommandHandler(
 		var duration = request.EndDateTime - request.StartDateTime;
 		var slots = new List<TimeSlot>(count);
 		var now = DateTimeOffset.UtcNow;
-		var timeZone = ResolveTimeZone(request.Timezone);
+		var timeZone = CanonicalTimeZone.Resolve(request.Timezone);
 
 		Guid? seriesId = count > 1 ? Guid.CreateVersion7() : null;
 
@@ -63,19 +64,5 @@ internal sealed class CreateTimeSlotCommandHandler(
 		};
 
 		return new DateTimeOffset(advancedLocal, timeZone.GetUtcOffset(advancedLocal)).ToUniversalTime();
-	}
-
-	private static TimeZoneInfo ResolveTimeZone(string? ianaId)
-	{
-		if (string.IsNullOrWhiteSpace(ianaId))
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		try
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
-		}
-		catch
-		{
-			return TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-		}
 	}
 }

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityQuery.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityQuery.cs
@@ -5,7 +5,7 @@ namespace Application.VolunteerOpportunities.GetVolunteerOpportunityDateAvailabi
 public sealed record GetVolunteerOpportunityDateAvailabilityQuery(
 	DateTimeOffset From,
 	DateTimeOffset To,
-	int UtcOffsetMinutes,
+	string? Timezone,
 	string? Occurrence,
 	string? ParticipationType,
 	bool? IsRemote,

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityQueryHandler.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/GetVolunteerOpportunityDateAvailabilityQueryHandler.cs
@@ -13,7 +13,7 @@ internal sealed class GetVolunteerOpportunityDateAvailabilityQueryHandler(
 		var filter = new VolunteerOpportunityDateAvailabilityFilter(
 			request.From,
 			request.To,
-			request.UtcOffsetMinutes,
+			request.Timezone,
 			request.Occurrence,
 			request.ParticipationType,
 			request.IsRemote,

--- a/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/VolunteerOpportunityDateAvailabilityFilter.cs
+++ b/backend/src/Application/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/v1/VolunteerOpportunityDateAvailabilityFilter.cs
@@ -3,7 +3,7 @@ namespace Application.VolunteerOpportunities.GetVolunteerOpportunityDateAvailabi
 public sealed record VolunteerOpportunityDateAvailabilityFilter(
 	DateTimeOffset From,
 	DateTimeOffset To,
-	int UtcOffsetMinutes,
+	string? Timezone,
 	string? Occurrence = null,
 	string? ParticipationType = null,
 	bool? IsRemote = null,

--- a/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
+++ b/backend/src/Infrastructure/Persistence/Repositories/VolunteerOpportunityReadRepository.cs
@@ -1,6 +1,7 @@
 using Application.Common.Exceptions;
 using Application.Common.Pagination;
 using Application.Common.Sitemap;
+using Application.Common.Time;
 using Application.Organizations.GetOrganizationCalendarEvents.v1;
 using Application.VolunteerOpportunities;
 using Application.VolunteerOpportunities.GetVolunteerOpportunities.v1;
@@ -245,10 +246,10 @@ internal sealed class VolunteerOpportunityReadRepository(
 					s.Longitude.Value) <= filter.RadiusKm!.Value)
 			: slots;
 
-		var offset = TimeSpan.FromMinutes(filter.UtcOffsetMinutes);
+		var timeZone = CanonicalTimeZone.Resolve(filter.Timezone);
 
 		return withinRadius
-			.GroupBy(s => DateOnly.FromDateTime(s.StartDateTime.ToOffset(offset).DateTime))
+			.GroupBy(s => DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(s.StartDateTime, timeZone).DateTime))
 			.OrderBy(g => g.Key)
 			.Select(g => new VolunteerOpportunityAvailableDate(
 				g.Key.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),

--- a/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/BulkConfirmEngagements/BulkConfirmEngagementsCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public class BulkConfirmEngagementsCommandHandlerTests
 		_dbContext
 			.GetEngagementsByIdsAsync(Arg.Any<IReadOnlyCollection<EngagementId>>(), Arg.Any<CancellationToken>())
 			.Returns([]);
-		_sut = new BulkConfirmEngagementsCommandHandler(_dbContext, _sender);
+		_sut = new BulkConfirmEngagementsCommandHandler(_dbContext, _sender, TimeProvider.System);
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Engagements/ConfirmEngagement/ConfirmEngagementCommandHandlerTests.cs
@@ -48,7 +48,7 @@ public class ConfirmEngagementCommandHandlerTests
 		_dbContext
 			.GetOrCreateUserStreakAsync(Arg.Any<UserId>(), Arg.Any<CancellationToken>())
 			.Returns(callInfo => UserStreak.Create(callInfo.Arg<UserId>()));
-		_sut = new ConfirmEngagementCommandHandler(_dbContext, _sender);
+		_sut = new ConfirmEngagementCommandHandler(_dbContext, _sender, TimeProvider.System);
 	}
 
 	[Test]
@@ -307,6 +307,35 @@ public class ConfirmEngagementCommandHandlerTests
 		await _sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
 
 		engagement.Events.Should().ContainSingle(e => e is EngagementConfirmedDomainEvent);
+	}
+
+	[Test]
+	public async Task Handle_ShouldBucketActivityByTheBerlinIsoWeek_NotAWallClockDayEarlierInUtc(
+		CancellationToken cancellationToken)
+	{
+		// 2026-11-01 23:30 UTC is still Sunday in UTC (ISO week 44) but is already
+		// Monday 2026-11-02 00:30 in Europe/Berlin (CET, UTC+1) - the start of ISO
+		// week 45. There is no longer any per-request timezone input that could
+		// move this result (#2203) - it must always resolve via Berlin.
+		var pinnedNow = new DateTimeOffset(2026, 11, 1, 23, 30, 0, TimeSpan.Zero);
+		var sut = new ConfirmEngagementCommandHandler(_dbContext, _sender, new FakeTimeProvider(pinnedNow));
+
+		var engagementId = EngagementId.New();
+		var volunteerId = UserId.New();
+		var engagement = Engagement.CreateSlotSignUp(VolunteerOpportunityId.New(), volunteerId, TimeSlotId.New());
+		_engagementRepo.FindAsync(engagementId, cancellationToken).Returns(engagement);
+		var streak = UserStreak.Create(volunteerId);
+		_dbContext.GetOrCreateUserStreakAsync(volunteerId, cancellationToken).Returns(streak);
+
+		await sut.Handle(new ConfirmEngagementCommand(engagementId, DefaultRequestingUserId), cancellationToken);
+
+		streak.LastActiveIsoYear.Should().Be(2026);
+		streak.LastActiveIsoWeek.Should().Be(45);
+	}
+
+	private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+	{
+		public override DateTimeOffset GetUtcNow() => utcNow;
 	}
 
 	private VolunteerOpportunity CreateDefaultOpportunity() =>

--- a/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/GetVolunteerOpportunityDateAvailabilityQueryHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/VolunteerOpportunities/GetVolunteerOpportunityDateAvailability/GetVolunteerOpportunityDateAvailabilityQueryHandlerTests.cs
@@ -26,7 +26,7 @@ public class GetVolunteerOpportunityDateAvailabilityQueryHandlerTests
 		new(
 			From,
 			To,
-			120,
+			"America/New_York",
 			"Recurring",
 			"ScheduledSlots",
 			true,
@@ -59,7 +59,7 @@ public class GetVolunteerOpportunityDateAvailabilityQueryHandlerTests
 
 		filter.From.Should().Be(From);
 		filter.To.Should().Be(To);
-		filter.UtcOffsetMinutes.Should().Be(120);
+		filter.Timezone.Should().Be("America/New_York");
 		filter.Occurrence.Should().Be("Recurring");
 		filter.ParticipationType.Should().Be("ScheduledSlots");
 		filter.IsRemote.Should().BeTrue();
@@ -82,7 +82,7 @@ public class GetVolunteerOpportunityDateAvailabilityQueryHandlerTests
 	[Test]
 	public void Filter_ShouldNotReportRadiusFiltering_WhenTheRadiusIsMissing()
 	{
-		var filter = new VolunteerOpportunityDateAvailabilityFilter(From, To, 0, CenterLatitude: 52.5, CenterLongitude: 13.4);
+		var filter = new VolunteerOpportunityDateAvailabilityFilter(From, To, null, CenterLatitude: 52.5, CenterLongitude: 13.4);
 
 		filter.HasRadius.Should().BeFalse(
 			"a center without a radius describes no circle to filter by");

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
@@ -74,19 +74,69 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 		var authenticatedClient = await CreateAuthenticatedClientAsync();
 		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
 
+		// Asia/Kolkata (UTC+5:30, no DST) rather than Europe/Berlin here - this test is
+		// about the caller's zone shifting the day at all, not about a DST boundary
+		// specifically (the dedicated DST tests below cover that).
 		var slotStart = UtcDayAt(daysFromToday: 7, hour: 23, minute: 30);
 		await CreateOpportunityWithTimeSlotAsync(authenticatedClient, orgId, "Late night shift", slotStart, cancellationToken);
 
-		var sut = CreateAnonymousClient("10.0.3.3");
+		var sut = CreateAnonymousClient("10.0.3.3", timezone: "Asia/Kolkata");
 
 		var result = await sut.GetVolunteerOpportunityDateAvailabilityAsync(
 			DateTimeOffset.UtcNow.AddDays(1),
 			DateTimeOffset.UtcNow.AddDays(30),
-			utcOffsetMinutes: 120,
 			cancellationToken: cancellationToken);
 
 		result.Should().ContainSingle()
-			.Which.Date.Should().Be(slotStart.AddHours(2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+			.Which.Date.Should().Be(slotStart.AddHours(5).AddMinutes(30).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+	}
+
+	[Test]
+	public async Task GetDateAvailability_ShouldBucketByBerlinDay_ForASlotJustAfterTheSpringForwardTransition(
+		CancellationToken cancellationToken)
+	{
+		// Germany's 2027 DST starts 2027-03-28 (clocks 02:00 -> 03:00 CEST); by
+		// 2027-03-31 Berlin is at UTC+2. A single offset computed earlier in March
+		// (still UTC+1) would shift this slot into the wrong, earlier day (#2203).
+		var authenticatedClient = await CreateAuthenticatedClientAsync();
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var slotStart = new DateTimeOffset(2027, 3, 31, 0, 30, 0, TimeSpan.FromHours(2));
+		await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Post-spring-forward shift", slotStart, cancellationToken);
+
+		var sut = CreateAnonymousClient("10.0.3.11", timezone: "Europe/Berlin");
+
+		var result = await sut.GetVolunteerOpportunityDateAvailabilityAsync(
+			new DateTimeOffset(2027, 3, 25, 0, 0, 0, TimeSpan.Zero),
+			new DateTimeOffset(2027, 4, 5, 0, 0, 0, TimeSpan.Zero),
+			cancellationToken: cancellationToken);
+
+		result.Should().ContainSingle().Which.Date.Should().Be("2027-03-31");
+	}
+
+	[Test]
+	public async Task GetDateAvailability_ShouldBucketByBerlinDay_ForASlotJustBeforeTheFallBackTransitionEnds(
+		CancellationToken cancellationToken)
+	{
+		// Germany's 2026 DST ends 2026-10-25 (clocks 03:00 -> 02:00 CET); by
+		// 2026-10-31 Berlin is back at UTC+1. A single offset computed earlier in
+		// October (still UTC+2) would shift this slot into November instead (#2203).
+		var authenticatedClient = await CreateAuthenticatedClientAsync();
+		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
+
+		var slotStart = new DateTimeOffset(2026, 10, 31, 23, 30, 0, TimeSpan.FromHours(1));
+		await CreateOpportunityWithTimeSlotAsync(
+			authenticatedClient, orgId, "Pre-november shift", slotStart, cancellationToken);
+
+		var sut = CreateAnonymousClient("10.0.3.12", timezone: "Europe/Berlin");
+
+		var result = await sut.GetVolunteerOpportunityDateAvailabilityAsync(
+			new DateTimeOffset(2026, 10, 25, 0, 0, 0, TimeSpan.Zero),
+			new DateTimeOffset(2026, 11, 5, 0, 0, 0, TimeSpan.Zero),
+			cancellationToken: cancellationToken);
+
+		result.Should().ContainSingle().Which.Date.Should().Be("2026-10-31");
 	}
 
 	[Test]
@@ -268,10 +318,12 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 			.AddHours(hour)
 			.AddMinutes(minute);
 
-	private EinsatzbereitApi CreateAnonymousClient(string clientIp)
+	private EinsatzbereitApi CreateAnonymousClient(string clientIp, string? timezone = null)
 	{
 		var httpClient = fixture.CreateHttpClient();
 		httpClient.DefaultRequestHeaders.Add("X-Forwarded-For", clientIp);
+		if (timezone is not null)
+			httpClient.DefaultRequestHeaders.Add("X-Timezone", timezone);
 		return new EinsatzbereitApi(httpClient);
 	}
 

--- a/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
+++ b/backend/tests/IntegrationTests/GetVolunteerOpportunityDateAvailabilityTests.cs
@@ -101,7 +101,10 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 		var authenticatedClient = await CreateAuthenticatedClientAsync();
 		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
 
-		var slotStart = new DateTimeOffset(2027, 3, 31, 0, 30, 0, TimeSpan.FromHours(2));
+		// 2027-03-31 00:30 Berlin (CEST, UTC+2) as its UTC instant - Npgsql's
+		// timestamptz mapping rejects DateTimeOffset values with a non-zero
+		// offset, so every persisted instant in these tests is UTC already.
+		var slotStart = new DateTimeOffset(2027, 3, 30, 22, 30, 0, TimeSpan.Zero);
 		await CreateOpportunityWithTimeSlotAsync(
 			authenticatedClient, orgId, "Post-spring-forward shift", slotStart, cancellationToken);
 
@@ -125,7 +128,9 @@ public class GetVolunteerOpportunityDateAvailabilityTests(IntegrationTestFixture
 		var authenticatedClient = await CreateAuthenticatedClientAsync();
 		var orgId = await CreateOrganizationAsync(authenticatedClient, cancellationToken);
 
-		var slotStart = new DateTimeOffset(2026, 10, 31, 23, 30, 0, TimeSpan.FromHours(1));
+		// 2026-10-31 23:30 Berlin (CET, UTC+1) as its UTC instant - see the
+		// comment in the spring-forward test above for why this must be UTC.
+		var slotStart = new DateTimeOffset(2026, 10, 31, 22, 30, 0, TimeSpan.Zero);
 		await CreateOpportunityWithTimeSlotAsync(
 			authenticatedClient, orgId, "Pre-november shift", slotStart, cancellationToken);
 

--- a/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
+++ b/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
@@ -13,9 +13,8 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldRecordLogin_OnFirstRequestForUser()
 	{
-		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), sender);
 
@@ -25,9 +24,8 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotRecordLoginAgain_OnSecondRequestSameDay()
 	{
-		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -40,12 +38,13 @@ public class LoginStreakMiddlewareTests
 	public async Task InvokeAsync_ShouldRecordOncePerDistinctLocalDay_WhenXTimezoneHeaderAlternatesBetweenExtremeZones()
 	{
 		// Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) are 25 hours apart, so at
-		// any single instant they always disagree about the calendar date. The cache must
-		// still collapse repeats of the SAME local day down to one send each (#2203) -
-		// it must not thrash into more than the 2 distinct days actually implied.
-		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
+		// any single instant they always disagree about the calendar date, regardless of
+		// what that instant is - so this can safely use the real clock (no historical
+		// FakeTimeProvider value to fight IMemoryCache's own real-time expiration check).
+		// The cache must still collapse repeats of the SAME local day down to one send
+		// each (#2203) - it must not thrash into more than the 2 distinct days implied.
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
 		for (var i = 0; i < 10; i++)
@@ -61,35 +60,54 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldRecordBothVisits_WhenTheClientsLocalDayAdvancesBeforeServerMidnight()
 	{
-		// A caller in Asia/Tokyo (UTC+9, no DST) visiting at 10:00 and 20:00 Berlin time
-		// (both well before the next Berlin midnight) has already crossed into their own
-		// next local day by the second visit - the memo must not swallow it just because
-		// Berlin's own midnight hasn't passed yet (#2203).
-		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.Zero)); // 10:00 CET
+		// A caller in Asia/Tokyo (UTC+9, no DST) can cross into their own next local day
+		// well before Berlin's own midnight. Anchored to the real clock (not a hardcoded
+		// date) so the computed cache expiration is always ahead of whatever IMemoryCache's
+		// own real clock reads. The advance is derived from the current Tokyo time-of-day
+		// so it always lands just past midnight the next calendar day - exactly one day
+		// boundary crossed - no matter what time this test actually runs (#2203).
+		var tokyo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+		var firstVisit = DateTimeOffset.UtcNow;
+		var hoursUntilNextTokyoMidnight = 24 - TimeZoneInfo.ConvertTime(firstVisit, tokyo).TimeOfDay.TotalHours;
+		var secondVisit = firstVisit.AddHours(hoursUntilNextTokyoMidnight + 1);
+		var firstDay = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(firstVisit, tokyo).DateTime);
+		var secondDay = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(secondVisit, tokyo).DateTime);
+		secondDay.Should().Be(firstDay.AddDays(1),
+			"the chosen advance must cross exactly one Tokyo local day for this test to mean anything");
+
+		var timeProvider = new FakeTimeProvider(firstVisit);
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, "Asia/Tokyo"), sender);
-		timeProvider.Advance(TimeSpan.FromHours(10)); // 19:00 UTC = 20:00 CET, still the same Berlin day
+		timeProvider.Advance(TimeSpan.FromHours(hoursUntilNextTokyoMidnight + 1));
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, "Asia/Tokyo"), sender);
 
 		sender.SentRequests.Should().HaveCount(2,
 			"the caller's own local day had already advanced by the second visit, even though Berlin's midnight had not");
-		sender.SentRequests.OfType<RecordLoginCommand>().Select(r => r.Date).Should().Equal(
-			new DateOnly(2026, 1, 15), new DateOnly(2026, 1, 16));
+		sender.SentRequests.OfType<RecordLoginCommand>().Select(r => r.Date).Should().Equal(firstDay, secondDay);
 	}
 
 	[Test]
 	public async Task InvokeAsync_ShouldRecordLoginAgain_AfterServerMidnightRollover()
 	{
-		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero));
+		// No X-Timezone header means the middleware falls back to the canonical
+		// Europe/Berlin zone. The advance is derived from the current Berlin time-of-day
+		// so it always lands just past midnight the next calendar day - exactly one day
+		// boundary crossed - no matter what time this test actually runs, and always
+		// safely ahead of IMemoryCache's own real clock (#2203).
+		var berlin = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+		var firstVisit = DateTimeOffset.UtcNow;
+		var hoursUntilNextBerlinMidnight = 24 - TimeZoneInfo.ConvertTime(firstVisit, berlin).TimeOfDay.TotalHours;
+
+		var timeProvider = new FakeTimeProvider(firstVisit);
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
-		timeProvider.Advance(TimeSpan.FromHours(13));
+		timeProvider.Advance(TimeSpan.FromHours(hoursUntilNextBerlinMidnight + 1));
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
 
 		sender.SentRequests.Should().HaveCount(2);
@@ -98,14 +116,13 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotCallNext_ForAnyConcurrentRequest_UntilTheSharedWriteCompletes()
 	{
-		var timeProvider = new FakeTimeProvider();
 		var writeGate = new TaskCompletionSource();
 		var sender = new GatedRecordingSender(writeGate.Task);
 		var nextCallCount = 0;
 		var sut = new LoginStreakMiddleware(
 			_ => { Interlocked.Increment(ref nextCallCount); return Task.CompletedTask; },
-			CreateCache(timeProvider),
-			timeProvider);
+			new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
+			new FakeTimeProvider());
 		var subClaim = Guid.NewGuid().ToString();
 
 		var task1 = sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -130,9 +147,8 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotCallSender_WhenUserIsNotAuthenticated()
 	{
-		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 		var context = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
 
 		await sut.InvokeAsync(context, sender);
@@ -143,23 +159,13 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldAlwaysCallNext()
 	{
-		var timeProvider = new FakeTimeProvider();
 		var nextCalled = false;
-		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, CreateCache(timeProvider), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), new RecordingSender());
 
 		nextCalled.Should().BeTrue();
 	}
-
-	// IMemoryCache evaluates AbsoluteExpiration against its own internal clock, which
-	// defaults to real wall-clock time regardless of what TimeProvider the middleware
-	// itself was given - without wiring the same one in here, every entry this suite
-	// sets with a historical FakeTimeProvider "now" computes an expiration that is
-	// already in the past by the time the real clock reads it, so nothing ever hits
-	// the cache at all (#2203 caught this: 10 sends instead of 2, i.e. no caching).
-	private static MemoryCache CreateCache(TimeProvider timeProvider) =>
-		new(new MemoryCacheOptions { SizeLimit = 100, TimeProvider = timeProvider });
 
 	private static DefaultHttpContext CreateAuthenticatedContext(string subClaim, string? tzHeader = null)
 	{

--- a/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
+++ b/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
@@ -35,10 +35,15 @@ public class LoginStreakMiddlewareTests
 	}
 
 	[Test]
-	public async Task InvokeAsync_ShouldNotRecordLoginRepeatedly_WhenXTimezoneHeaderAlternatesAcrossRequests()
+	public async Task InvokeAsync_ShouldRecordOncePerDistinctLocalDay_WhenXTimezoneHeaderAlternatesBetweenExtremeZones()
 	{
+		// Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) are 25 hours apart, so at
+		// any single instant they always disagree about the calendar date. The cache must
+		// still collapse repeats of the SAME local day down to one send each (#2203) -
+		// it must not thrash into more than the 2 distinct days actually implied.
+		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		for (var i = 0; i < 10; i++)
@@ -47,8 +52,30 @@ public class LoginStreakMiddlewareTests
 			await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, tzHeader), sender);
 		}
 
-		sender.SentRequests.Should().ContainSingle(
-			"X-Timezone must only shape the streak's local date, never thrash the shared dedup cache");
+		sender.SentRequests.Should().HaveCount(2,
+			"exactly the 2 distinct local days the alternating header genuinely implies at this instant - one send each, not one per request and not a single shared one");
+	}
+
+	[Test]
+	public async Task InvokeAsync_ShouldRecordBothVisits_WhenTheClientsLocalDayAdvancesBeforeServerMidnight()
+	{
+		// A caller in Asia/Tokyo (UTC+9, no DST) visiting at 10:00 and 20:00 Berlin time
+		// (both well before the next Berlin midnight) has already crossed into their own
+		// next local day by the second visit - the memo must not swallow it just because
+		// Berlin's own midnight hasn't passed yet (#2203).
+		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.Zero)); // 10:00 CET
+		var sender = new RecordingSender();
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
+		var subClaim = Guid.NewGuid().ToString();
+
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, "Asia/Tokyo"), sender);
+		timeProvider.Advance(TimeSpan.FromHours(10)); // 19:00 UTC = 20:00 CET, still the same Berlin day
+		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, "Asia/Tokyo"), sender);
+
+		sender.SentRequests.Should().HaveCount(2,
+			"the caller's own local day had already advanced by the second visit, even though Berlin's midnight had not");
+		sender.SentRequests.OfType<RecordLoginCommand>().Select(r => r.Date).Should().Equal(
+			new DateOnly(2026, 1, 15), new DateOnly(2026, 1, 16));
 	}
 
 	[Test]

--- a/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
+++ b/backend/tests/IntegrationTests/LoginStreakMiddlewareTests.cs
@@ -13,8 +13,9 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldRecordLogin_OnFirstRequestForUser()
 	{
+		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), sender);
 
@@ -24,8 +25,9 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotRecordLoginAgain_OnSecondRequestSameDay()
 	{
+		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -43,7 +45,7 @@ public class LoginStreakMiddlewareTests
 		// it must not thrash into more than the 2 distinct days actually implied.
 		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		for (var i = 0; i < 10; i++)
@@ -65,7 +67,7 @@ public class LoginStreakMiddlewareTests
 		// Berlin's own midnight hasn't passed yet (#2203).
 		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.Zero)); // 10:00 CET
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim, "Asia/Tokyo"), sender);
@@ -83,7 +85,7 @@ public class LoginStreakMiddlewareTests
 	{
 		var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero));
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), timeProvider);
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -96,13 +98,14 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotCallNext_ForAnyConcurrentRequest_UntilTheSharedWriteCompletes()
 	{
+		var timeProvider = new FakeTimeProvider();
 		var writeGate = new TaskCompletionSource();
 		var sender = new GatedRecordingSender(writeGate.Task);
 		var nextCallCount = 0;
 		var sut = new LoginStreakMiddleware(
 			_ => { Interlocked.Increment(ref nextCallCount); return Task.CompletedTask; },
-			new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
-			new FakeTimeProvider());
+			CreateCache(timeProvider),
+			timeProvider);
 		var subClaim = Guid.NewGuid().ToString();
 
 		var task1 = sut.InvokeAsync(CreateAuthenticatedContext(subClaim), sender);
@@ -127,8 +130,9 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldNotCallSender_WhenUserIsNotAuthenticated()
 	{
+		var timeProvider = new FakeTimeProvider();
 		var sender = new RecordingSender();
-		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => Task.CompletedTask, CreateCache(timeProvider), timeProvider);
 		var context = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
 
 		await sut.InvokeAsync(context, sender);
@@ -139,13 +143,23 @@ public class LoginStreakMiddlewareTests
 	[Test]
 	public async Task InvokeAsync_ShouldAlwaysCallNext()
 	{
+		var timeProvider = new FakeTimeProvider();
 		var nextCalled = false;
-		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }), new FakeTimeProvider());
+		var sut = new LoginStreakMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, CreateCache(timeProvider), timeProvider);
 
 		await sut.InvokeAsync(CreateAuthenticatedContext(Guid.NewGuid().ToString()), new RecordingSender());
 
 		nextCalled.Should().BeTrue();
 	}
+
+	// IMemoryCache evaluates AbsoluteExpiration against its own internal clock, which
+	// defaults to real wall-clock time regardless of what TimeProvider the middleware
+	// itself was given - without wiring the same one in here, every entry this suite
+	// sets with a historical FakeTimeProvider "now" computes an expiration that is
+	// already in the past by the time the real clock reads it, so nothing ever hits
+	// the cache at all (#2203 caught this: 10 sends instead of 2, i.e. no caching).
+	private static MemoryCache CreateCache(TimeProvider timeProvider) =>
+		new(new MemoryCacheOptions { SizeLimit = 100, TimeProvider = timeProvider });
 
 	private static DefaultHttpContext CreateAuthenticatedContext(string subClaim, string? tzHeader = null)
 	{

--- a/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/DetailsStep.tsx
@@ -8,6 +8,10 @@ import ErrorBanner from "../ErrorBanner";
 import Chip from "../Chip";
 import { formatDateTimeRange } from "../../lib/format";
 import { inputSurfaceClass, labelClass } from "../../lib/formClasses";
+import {
+	CANONICAL_TIME_ZONE,
+	toZonedDatetimeLocalValue,
+} from "../../lib/timezone";
 import type { OpportunityFormValues } from "./schema";
 
 export type SeriesEditScope = "Only" | "ThisAndFollowing" | "EntireSeries";
@@ -433,11 +437,10 @@ export default function DetailsStep({
 									value={newSlot.startDateTime}
 									min={
 										!isEditMode
-											? new Date(
-													Date.now() - new Date().getTimezoneOffset() * 60000,
+											? toZonedDatetimeLocalValue(
+													new Date(),
+													CANONICAL_TIME_ZONE,
 												)
-													.toISOString()
-													.slice(0, 16)
 											: undefined
 									}
 									onChange={(e) =>

--- a/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
+++ b/frontend/src/components/CreateVolunteerOpportunityModal/index.tsx
@@ -13,6 +13,11 @@ import { useApiClient } from "../../hooks/useApiClient";
 import { dispatchToast } from "../../lib/toastBus";
 import { getApiErrorMessage, isApiErrorCode } from "../../lib/apiError";
 import { validateImageUpload } from "../../lib/imageUpload";
+import {
+	CANONICAL_TIME_ZONE,
+	toZonedDatetimeLocalValue,
+	zonedDatetimeLocalToUtc,
+} from "../../lib/timezone";
 import ConfirmDialog from "../ConfirmDialog";
 import Modal from "../Modal";
 import Button from "../Button";
@@ -37,18 +42,33 @@ import type { OpportunityFormValues } from "./schema";
 
 const BLOCKED_JUMP_MESSAGE_ID = "create-opportunity-step-blocked";
 
+// Steps `origin` by whole weeks/months in Berlin wall-clock terms (not the
+// browser's own timezone), so an organizer outside Europe/Berlin previewing
+// a recurring series before it's saved sees the same occurrences the backend
+// would authoritatively generate (CreateTimeSlotCommandHandler.Advance, #2203).
 function advanceDate(
 	origin: Date,
 	frequency: string | undefined,
 	steps: number,
 ): Date {
-	const d = new Date(origin);
+	if (!frequency || steps === 0) return new Date(origin);
+
+	const local = toZonedDatetimeLocalValue(origin, CANONICAL_TIME_ZONE);
+	const [datePart, timePart] = local.split("T");
+	const [year, month, day] = datePart.split("-").map(Number);
+
+	const steppedDate = new Date(Date.UTC(year, month - 1, day));
 	if (frequency === "Weekly") {
-		d.setDate(d.getDate() + 7 * steps);
+		steppedDate.setUTCDate(steppedDate.getUTCDate() + 7 * steps);
 	} else if (frequency === "Monthly") {
-		d.setMonth(d.getMonth() + steps);
+		steppedDate.setUTCMonth(steppedDate.getUTCMonth() + steps);
 	}
-	return d;
+
+	const steppedDatePart = steppedDate.toISOString().slice(0, 10);
+	return zonedDatetimeLocalToUtc(
+		`${steppedDatePart}T${timePart}`,
+		CANONICAL_TIME_ZONE,
+	);
 }
 
 function resolveCheckInPin(
@@ -105,9 +125,7 @@ interface EditingSlot {
 
 function toDatetimeLocalValue(value: Date | string): string {
 	const date = value instanceof Date ? value : new Date(value);
-	return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
-		.toISOString()
-		.slice(0, 16);
+	return toZonedDatetimeLocalValue(date, CANONICAL_TIME_ZONE);
 }
 
 function toDateInputValue(value: Date | string): string {
@@ -459,8 +477,14 @@ export default function CreateVolunteerOpportunityModal({
 	async function handleAddSlot() {
 		if (!newSlot.startDateTime || !newSlot.endDateTime) return;
 		setSlotError(null);
-		const start = new Date(newSlot.startDateTime);
-		const end = new Date(newSlot.endDateTime);
+		const start = zonedDatetimeLocalToUtc(
+			newSlot.startDateTime,
+			CANONICAL_TIME_ZONE,
+		);
+		const end = zonedDatetimeLocalToUtc(
+			newSlot.endDateTime,
+			CANONICAL_TIME_ZONE,
+		);
 		if (end <= start) {
 			setSlotError(t("timeSlots.addError"));
 			return;
@@ -595,9 +619,13 @@ export default function CreateVolunteerOpportunityModal({
 		try {
 			const result = await api.updateTimeSlot(initialOpportunity.id, edit.id, {
 				startDateTime:
-					edit.scope === "Only" ? new Date(edit.startDateTime) : undefined,
+					edit.scope === "Only"
+						? zonedDatetimeLocalToUtc(edit.startDateTime, CANONICAL_TIME_ZONE)
+						: undefined,
 				endDateTime:
-					edit.scope === "Only" ? new Date(edit.endDateTime) : undefined,
+					edit.scope === "Only"
+						? zonedDatetimeLocalToUtc(edit.endDateTime, CANONICAL_TIME_ZONE)
+						: undefined,
 				maxParticipants: edit.maxParticipants ?? undefined,
 				scope: edit.scope,
 			});
@@ -607,8 +635,14 @@ export default function CreateVolunteerOpportunityModal({
 						s.id === edit.id
 							? {
 									...s,
-									startDateTime: new Date(edit.startDateTime),
-									endDateTime: new Date(edit.endDateTime),
+									startDateTime: zonedDatetimeLocalToUtc(
+										edit.startDateTime,
+										CANONICAL_TIME_ZONE,
+									),
+									endDateTime: zonedDatetimeLocalToUtc(
+										edit.endDateTime,
+										CANONICAL_TIME_ZONE,
+									),
 									maxParticipants: edit.maxParticipants ?? undefined,
 								}
 							: s,
@@ -644,8 +678,14 @@ export default function CreateVolunteerOpportunityModal({
 			return;
 		}
 		if (!editingSlot.startDateTime || !editingSlot.endDateTime) return;
-		const start = new Date(editingSlot.startDateTime);
-		const end = new Date(editingSlot.endDateTime);
+		const start = zonedDatetimeLocalToUtc(
+			editingSlot.startDateTime,
+			CANONICAL_TIME_ZONE,
+		);
+		const end = zonedDatetimeLocalToUtc(
+			editingSlot.endDateTime,
+			CANONICAL_TIME_ZONE,
+		);
 		if (end <= start) {
 			setSlotError(t("timeSlots.editError"));
 			return;

--- a/frontend/src/components/SignUpModal.test.tsx
+++ b/frontend/src/components/SignUpModal.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import SignUpModal from "./SignUpModal";
 import type { TimeSlotDetail } from "../client/api-client";
 import { renderWithProviders } from "../test/render";
+import { formatDateTimeRange } from "../lib/format";
 
 const { api } = await vi.hoisted(async () => {
 	const { createApiMock } = await import("../test/apiMock");
@@ -49,11 +50,18 @@ beforeEach(() => {
 
 describe("SignUpModal time-slot preselection (#657)", () => {
 	it("preselects the only available slot", () => {
-		open([slot("only", 9)]);
+		const only = slot("only", 9);
+		open([only]);
 
 		const trigger = screen.getByRole("combobox");
 		expect(trigger).not.toHaveTextContent("Please select");
-		expect(trigger).toHaveTextContent("09:00-13:00");
+		expect(trigger).toHaveTextContent(
+			formatDateTimeRange(
+				only.startDateTime as unknown as string,
+				only.endDateTime as unknown as string,
+				"en",
+			),
+		);
 	});
 
 	it("leaves the dropdown empty when there is a real choice to make", () => {

--- a/frontend/src/components/VolunteerOpportunitiesList/useOpportunityDateAvailability.ts
+++ b/frontend/src/components/VolunteerOpportunitiesList/useOpportunityDateAvailability.ts
@@ -63,8 +63,6 @@ export function useOpportunityDateAvailability(
 			{
 				from,
 				to,
-
-				utcOffsetMinutes: -from.getTimezoneOffset(),
 				occurrence: occurrence || undefined,
 				participationType: participationType || undefined,
 				isRemote:

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -376,44 +376,76 @@ describe("resolveDateLocale", () => {
 	});
 });
 
+// Intl.DateTimeFormat rejects timeZoneName alongside dateStyle/timeStyle, so
+// (like the production formatter) the base styled string and the zone name
+// are resolved by two separate formatters and joined - see format.ts.
+function expectedDateTimeWithZone(iso: string, locale: string): string {
+	const date = new Date(iso);
+	const base = date.toLocaleString(locale, {
+		dateStyle: "medium",
+		timeStyle: "short",
+		timeZone: "Europe/Berlin",
+	});
+	const zoneName = new Intl.DateTimeFormat(locale, {
+		timeZone: "Europe/Berlin",
+		timeZoneName: "short",
+	})
+		.formatToParts(date)
+		.find((part) => part.type === "timeZoneName")?.value;
+	return `${base} ${zoneName}`;
+}
+
 describe("formatDateTime", () => {
-	it("formats using en-GB style for en", () => {
+	it("formats using en-GB style for en, pinned to the Berlin zone with its name shown", () => {
 		const iso = "2024-03-15T14:30:00Z";
-		const expected = new Date(iso).toLocaleString("en-GB", {
-			dateStyle: "medium",
-			timeStyle: "short",
-		});
-		expect(formatDateTime(iso, "en")).toBe(expected);
+		expect(formatDateTime(iso, "en")).toBe(
+			expectedDateTimeWithZone(iso, "en-GB"),
+		);
 	});
 
-	it("formats using de-DE style when locale is de", () => {
+	it("formats using de-DE style when locale is de, pinned to the Berlin zone with its name shown", () => {
 		const iso = "2024-03-15T14:30:00Z";
-		const expected = new Date(iso).toLocaleString("de-DE", {
-			dateStyle: "medium",
-			timeStyle: "short",
-		});
-		expect(formatDateTime(iso, "de")).toBe(expected);
+		expect(formatDateTime(iso, "de")).toBe(
+			expectedDateTimeWithZone(iso, "de-DE"),
+		);
 	});
 
 	it("produces a different format for de than for en", () => {
 		const iso = "2024-03-15T14:30:00Z";
 		expect(formatDateTime(iso, "de")).not.toBe(formatDateTime(iso, "en"));
 	});
+
+	it("renders the same Berlin wall-clock time regardless of the viewer's own device timezone (#2203)", () => {
+		const iso = "2026-08-27T07:00:00Z"; // 09:00 in Berlin (CEST, UTC+2)
+
+		vi.stubEnv("TZ", "Pacific/Kiritimati");
+		const fromKiritimati = formatDateTime(iso, "de");
+
+		vi.stubEnv("TZ", "Europe/Lisbon");
+		const fromLisbon = formatDateTime(iso, "de");
+
+		vi.unstubAllEnvs();
+
+		expect(fromKiritimati).toBe(fromLisbon);
+		expect(fromKiritimati).toContain("09:00");
+	});
 });
 
 describe("formatDate", () => {
-	it("formats using en-GB style for en, with no time-of-day", () => {
+	it("formats using en-GB style for en, with no time-of-day, pinned to the Berlin zone", () => {
 		const iso = "2026-08-15T23:59:59.999Z";
 		const expected = new Date(iso).toLocaleDateString("en-GB", {
 			dateStyle: "medium",
+			timeZone: "Europe/Berlin",
 		});
 		expect(formatDate(iso, "en")).toBe(expected);
 	});
 
-	it("formats using de-DE style when locale is de", () => {
+	it("formats using de-DE style when locale is de, pinned to the Berlin zone", () => {
 		const iso = "2026-08-15T23:59:59.999Z";
 		const expected = new Date(iso).toLocaleDateString("de-DE", {
 			dateStyle: "medium",
+			timeZone: "Europe/Berlin",
 		});
 		expect(formatDate(iso, "de")).toBe(expected);
 	});
@@ -428,40 +460,51 @@ describe("formatDate", () => {
 });
 
 describe("formatDateTimeRange", () => {
-	it("collapses a same-day range to one date with a hyphen-joined time range", () => {
-		const start = new Date(2026, 7, 27, 9, 0);
-		const end = new Date(2026, 7, 27, 17, 0);
+	it("collapses a same-Berlin-day range to one date with a hyphen-joined time range and the zone name once", () => {
+		// 07:00-15:00 UTC is 09:00-17:00 Berlin (CEST, UTC+2) - the same calendar day there.
+		const startIso = "2026-08-27T07:00:00Z";
+		const endIso = "2026-08-27T15:00:00Z";
+		const start = new Date(startIso);
+		const end = new Date(endIso);
+		const options = { timeZone: "Europe/Berlin" } as const;
 		const datePart = new Intl.DateTimeFormat("de-DE", {
 			dateStyle: "medium",
+			...options,
 		}).format(start);
 		const startTime = new Intl.DateTimeFormat("de-DE", {
 			timeStyle: "short",
+			...options,
 		}).format(start);
 		const endTime = new Intl.DateTimeFormat("de-DE", {
 			timeStyle: "short",
+			...options,
 		}).format(end);
-		expect(
-			formatDateTimeRange(start.toISOString(), end.toISOString(), "de"),
-		).toBe(`${datePart}, ${startTime}-${endTime}`);
+		const zoneName = new Intl.DateTimeFormat("de-DE", {
+			...options,
+			timeZoneName: "short",
+		})
+			.formatToParts(start)
+			.find((part) => part.type === "timeZoneName")?.value;
+		expect(formatDateTimeRange(startIso, endIso, "de")).toBe(
+			`${datePart}, ${startTime}-${endTime} ${zoneName}`,
+		);
 	});
 
-	it("falls back to two full formatDateTime calls once the range crosses a calendar day", () => {
-		const start = new Date(2026, 7, 27, 23, 0);
-		const end = new Date(2026, 7, 28, 1, 0);
-		const startIso = start.toISOString();
-		const endIso = end.toISOString();
+	it("falls back to two full formatDateTime calls once the range crosses a Berlin calendar day", () => {
+		// 21:00-23:00 UTC on the same UTC day is 23:00 Berlin -> 01:00 Berlin the
+		// next day - a Berlin-day crossing that a UTC-day comparison would miss.
+		const startIso = "2026-08-27T21:00:00Z";
+		const endIso = "2026-08-27T23:00:00Z";
 		expect(formatDateTimeRange(startIso, endIso, "de")).toBe(
 			`${formatDateTime(startIso, "de")} - ${formatDateTime(endIso, "de")}`,
 		);
 	});
 
 	it("uses en-GB style time-of-day for en", () => {
-		const start = new Date(2026, 7, 27, 9, 0);
-		const end = new Date(2026, 7, 27, 17, 0);
-		expect(
-			formatDateTimeRange(start.toISOString(), end.toISOString(), "en"),
-		).not.toBe(
-			formatDateTimeRange(start.toISOString(), end.toISOString(), "de"),
+		const startIso = "2026-08-27T07:00:00Z";
+		const endIso = "2026-08-27T15:00:00Z";
+		expect(formatDateTimeRange(startIso, endIso, "en")).not.toBe(
+			formatDateTimeRange(startIso, endIso, "de"),
 		);
 	});
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,7 +1,8 @@
 import type { TFunction } from "i18next";
-import { differenceInCalendarDays, isSameDay } from "date-fns";
+import { differenceInCalendarDays } from "date-fns";
 import type { TimeSlotDetail } from "../client/api-client";
 import type { OpportunityCapacity } from "./opportunityCapacity";
+import { CANONICAL_TIME_ZONE } from "./timezone";
 
 export function formatOccurrence(occurrence: string, t: TFunction): string {
 	return occurrence === "Recurring"
@@ -132,6 +133,33 @@ export function resolveDateLocale(lng: string): string {
 	return lng === "de" ? "de-DE" : "en-GB";
 }
 
+// Intl.DateTimeFormat rejects timeZoneName combined with dateStyle/timeStyle
+// (the "style" presets and individual field options - which timeZoneName is
+// one of - are mutually exclusive), so the zone name is always resolved via
+// its own field-only formatter and appended, never baked into a styled one.
+const zoneNameFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getZoneNameFormatter(lng: string): Intl.DateTimeFormat {
+	const resolvedLocale = resolveDateLocale(lng);
+	let formatter = zoneNameFormatters.get(resolvedLocale);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(resolvedLocale, {
+			timeZone: CANONICAL_TIME_ZONE,
+			timeZoneName: "short",
+		});
+		zoneNameFormatters.set(resolvedLocale, formatter);
+	}
+	return formatter;
+}
+
+function formatZoneName(date: Date, lng: string): string {
+	return (
+		getZoneNameFormatter(lng)
+			.formatToParts(date)
+			.find((part) => part.type === "timeZoneName")?.value ?? ""
+	);
+}
+
 const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
 
 function getDateTimeFormatter(lng: string): Intl.DateTimeFormat {
@@ -141,6 +169,7 @@ function getDateTimeFormatter(lng: string): Intl.DateTimeFormat {
 		formatter = new Intl.DateTimeFormat(resolvedLocale, {
 			dateStyle: "medium",
 			timeStyle: "short",
+			timeZone: CANONICAL_TIME_ZONE,
 		});
 		dateTimeFormatters.set(resolvedLocale, formatter);
 	}
@@ -148,7 +177,8 @@ function getDateTimeFormatter(lng: string): Intl.DateTimeFormat {
 }
 
 export function formatDateTime(dt: string, lng: string): string {
-	return getDateTimeFormatter(lng).format(new Date(dt));
+	const date = new Date(dt);
+	return `${getDateTimeFormatter(lng).format(date)} ${formatZoneName(date, lng)}`;
 }
 
 const timeFormatters = new Map<string, Intl.DateTimeFormat>();
@@ -157,7 +187,10 @@ function getTimeFormatter(lng: string): Intl.DateTimeFormat {
 	const resolvedLocale = resolveDateLocale(lng);
 	let formatter = timeFormatters.get(resolvedLocale);
 	if (!formatter) {
-		formatter = new Intl.DateTimeFormat(resolvedLocale, { timeStyle: "short" });
+		formatter = new Intl.DateTimeFormat(resolvedLocale, {
+			timeStyle: "short",
+			timeZone: CANONICAL_TIME_ZONE,
+		});
 		timeFormatters.set(resolvedLocale, formatter);
 	}
 	return formatter;
@@ -170,13 +203,14 @@ export function formatDateTimeRange(
 ): string {
 	const start = new Date(startDt);
 	const end = new Date(endDt);
-	if (!isSameDay(start, end)) {
+	const startDatePart = getDateFormatter(lng).format(start);
+	const endDatePart = getDateFormatter(lng).format(end);
+	if (startDatePart !== endDatePart) {
 		return `${formatDateTime(startDt, lng)} - ${formatDateTime(endDt, lng)}`;
 	}
-	const datePart = getDateFormatter(lng).format(start);
 	const startTime = getTimeFormatter(lng).format(start);
 	const endTime = getTimeFormatter(lng).format(end);
-	return `${datePart}, ${startTime}-${endTime}`;
+	return `${startDatePart}, ${startTime}-${endTime} ${formatZoneName(start, lng)}`;
 }
 
 const dateFormatters = new Map<string, Intl.DateTimeFormat>();
@@ -187,6 +221,7 @@ function getDateFormatter(lng: string): Intl.DateTimeFormat {
 	if (!formatter) {
 		formatter = new Intl.DateTimeFormat(resolvedLocale, {
 			dateStyle: "medium",
+			timeZone: CANONICAL_TIME_ZONE,
 		});
 		dateFormatters.set(resolvedLocale, formatter);
 	}

--- a/frontend/src/lib/timezone.test.ts
+++ b/frontend/src/lib/timezone.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+	CANONICAL_TIME_ZONE,
+	toZonedDatetimeLocalValue,
+	zonedDatetimeLocalToUtc,
+} from "./timezone";
+
+describe("zonedDatetimeLocalToUtc", () => {
+	it("interprets a datetime-local value as Berlin wall-clock time in summer (CEST, UTC+2)", () => {
+		expect(
+			zonedDatetimeLocalToUtc("2026-08-27T09:00", CANONICAL_TIME_ZONE),
+		).toEqual(new Date("2026-08-27T07:00:00.000Z"));
+	});
+
+	it("interprets a datetime-local value as Berlin wall-clock time in winter (CET, UTC+1)", () => {
+		expect(
+			zonedDatetimeLocalToUtc("2026-01-15T09:00", CANONICAL_TIME_ZONE),
+		).toEqual(new Date("2026-01-15T08:00:00.000Z"));
+	});
+
+	it("resolves the post-transition CEST offset for a slot just after Germany's 2027 spring-forward", () => {
+		// Germany's 2027 DST starts 2027-03-28 (clocks 02:00 -> 03:00 CEST).
+		expect(
+			zonedDatetimeLocalToUtc("2027-03-31T00:30", CANONICAL_TIME_ZONE),
+		).toEqual(new Date("2027-03-30T22:30:00.000Z"));
+	});
+
+	it("resolves the post-transition CET offset for a slot just before Germany's 2026 fall-back ends", () => {
+		// Germany's 2026 DST ends 2026-10-25 (clocks 03:00 -> 02:00 CET).
+		expect(
+			zonedDatetimeLocalToUtc("2026-10-31T23:30", CANONICAL_TIME_ZONE),
+		).toEqual(new Date("2026-10-31T22:30:00.000Z"));
+	});
+
+	it("works for a non-Berlin, non-DST zone", () => {
+		expect(zonedDatetimeLocalToUtc("2026-06-01T09:00", "Asia/Kolkata")).toEqual(
+			new Date("2026-06-01T03:30:00.000Z"),
+		);
+	});
+});
+
+describe("toZonedDatetimeLocalValue", () => {
+	it("renders a UTC instant as Berlin wall-clock time in summer (CEST, UTC+2)", () => {
+		expect(
+			toZonedDatetimeLocalValue(
+				new Date("2026-08-27T07:00:00.000Z"),
+				CANONICAL_TIME_ZONE,
+			),
+		).toBe("2026-08-27T09:00");
+	});
+
+	it("renders a UTC instant as Berlin wall-clock time in winter (CET, UTC+1)", () => {
+		expect(
+			toZonedDatetimeLocalValue(
+				new Date("2026-01-15T08:00:00.000Z"),
+				CANONICAL_TIME_ZONE,
+			),
+		).toBe("2026-01-15T09:00");
+	});
+
+	it("round-trips through zonedDatetimeLocalToUtc", () => {
+		const original = "2026-08-27T09:00";
+		const utc = zonedDatetimeLocalToUtc(original, CANONICAL_TIME_ZONE);
+		expect(toZonedDatetimeLocalValue(utc, CANONICAL_TIME_ZONE)).toBe(original);
+	});
+});

--- a/frontend/src/lib/timezone.ts
+++ b/frontend/src/lib/timezone.ts
@@ -1,0 +1,59 @@
+// The platform's canonical timezone (#2203) - every opportunity/slot time is
+// authored and displayed against this zone rather than whatever zone the
+// current viewer's device happens to report. Mirrors the backend's own
+// Europe/Berlin fallback (CanonicalTimeZone.cs).
+export const CANONICAL_TIME_ZONE = "Europe/Berlin";
+
+function formatPartsMap(date: Date, timeZone: string, withSeconds: boolean) {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone,
+		hourCycle: "h23",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		...(withSeconds ? { second: "2-digit" as const } : {}),
+	}).formatToParts(date);
+	const get = (type: string) =>
+		parts.find((p) => p.type === type)?.value ?? "00";
+	return get;
+}
+
+function offsetMinutesAt(instantMs: number, timeZone: string): number {
+	const get = formatPartsMap(new Date(instantMs), timeZone, true);
+	const asUtc = Date.UTC(
+		Number(get("year")),
+		Number(get("month")) - 1,
+		Number(get("day")),
+		Number(get("hour")),
+		Number(get("minute")),
+		Number(get("second")),
+	);
+	return (asUtc - instantMs) / 60000;
+}
+
+// Converts a `datetime-local` input value (e.g. "2026-08-27T09:00"), read as
+// wall-clock time in `timeZone`, into the UTC instant it represents. Resolves
+// the zone's offset from a first guess of the target instant, which is exact
+// everywhere except inside the one skipped/repeated hour of a DST transition
+// itself - the same single-lookup approach CreateTimeSlotCommandHandler.cs
+// already uses server-side.
+export function zonedDatetimeLocalToUtc(
+	datetimeLocalValue: string,
+	timeZone: string,
+): Date {
+	const naiveUtcMs = new Date(`${datetimeLocalValue}:00.000Z`).getTime();
+	const offsetMinutes = offsetMinutesAt(naiveUtcMs, timeZone);
+	return new Date(naiveUtcMs - offsetMinutes * 60000);
+}
+
+// The inverse of zonedDatetimeLocalToUtc: renders `date` as a `datetime-local`
+// input value showing its wall-clock time in `timeZone`.
+export function toZonedDatetimeLocalValue(
+	date: Date,
+	timeZone: string,
+): string {
+	const get = formatPartsMap(date, timeZone, false);
+	return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`;
+}

--- a/frontend/src/lib/volunteerOpportunities.test.ts
+++ b/frontend/src/lib/volunteerOpportunities.test.ts
@@ -115,20 +115,23 @@ describe("fetchVolunteerOpportunities", () => {
 });
 
 describe("fetchVolunteerOpportunityDateAvailability", () => {
-	it("forwards the window and offset, leaving every filter undefined", async () => {
+	it("forwards the window and leaves every filter (including the unused timezone slot) undefined", async () => {
 		const api = fakeAvailabilityApi();
 		const from = new Date("2026-08-01T00:00:00");
 		const to = new Date("2026-08-31T23:59:59.999");
 
 		await fetchVolunteerOpportunityDateAvailability(
 			api as unknown as EinsatzbereitApi,
-			{ from, to, utcOffsetMinutes: 120 },
+			{ from, to },
 		);
 
+		// The 3rd positional slot is the generated client's legacy utcOffsetMinutes
+		// param - always undefined now that the server derives the caller's zone
+		// from the X-Timezone header instead (see volunteerOpportunities.ts, #2203).
 		expect(api.getVolunteerOpportunityDateAvailability).toHaveBeenCalledWith(
 			from,
 			to,
-			120,
+			undefined,
 			undefined,
 			undefined,
 			undefined,
@@ -153,7 +156,6 @@ describe("fetchVolunteerOpportunityDateAvailability", () => {
 			{
 				from,
 				to,
-				utcOffsetMinutes: -60,
 				occurrence: "Recurring",
 				participationType: "ScheduledSlots",
 				isRemote: false,
@@ -170,7 +172,7 @@ describe("fetchVolunteerOpportunityDateAvailability", () => {
 		expect(api.getVolunteerOpportunityDateAvailability).toHaveBeenCalledWith(
 			from,
 			to,
-			-60,
+			undefined,
 			"Recurring",
 			"ScheduledSlots",
 			false,
@@ -196,7 +198,6 @@ describe("fetchVolunteerOpportunityDateAvailability", () => {
 			{
 				from: new Date("2026-08-01T00:00:00"),
 				to: new Date("2026-08-31T23:59:59.999"),
-				utcOffsetMinutes: 0,
 			},
 		);
 

--- a/frontend/src/lib/volunteerOpportunities.ts
+++ b/frontend/src/lib/volunteerOpportunities.ts
@@ -46,8 +46,6 @@ export function fetchVolunteerOpportunities(
 export interface FetchVolunteerOpportunityDateAvailabilityOptions {
 	from: Date;
 	to: Date;
-
-	utcOffsetMinutes: number;
 	occurrence?: string;
 	participationType?: string;
 	isRemote?: boolean;
@@ -67,7 +65,11 @@ export function fetchVolunteerOpportunityDateAvailability(
 	return api.getVolunteerOpportunityDateAvailability(
 		options.from,
 		options.to,
-		options.utcOffsetMinutes,
+		// The server derives the caller's zone from the X-Timezone header
+		// (sent on every request, see api-instance.ts) rather than this
+		// scalar offset - a single offset can't be right for every slot in
+		// a multi-week window once a DST transition falls inside it (#2203).
+		undefined,
 		options.occurrence,
 		options.participationType,
 		options.isRemote,


### PR DESCRIPTION
## What

Fixes four related timezone bugs grouped under one root cause: no canonical zone was applied consistently, so the same event could disagree with itself across surfaces and drift across DST transitions.

## Why

`Europe/Berlin` was already treated as the app's canonical zone in a few places (the reminder email, three independently-duplicated fallback helpers) but not consistently - see the issue for the four concrete scenarios (a volunteer's slot time disagreeing between the app and its own email, browse-calendar dots landing on the wrong day around a DST weekend, a login streak silently reset by a caching bug, and a volunteer's weekly streak bucketed by whichever organizer happened to confirm their engagement).

Closes #2203

Fixed at the root with a shared `CanonicalTimeZone` helper (backend, `Application/Common/Time/`) and a `timezone.ts` module (frontend), replacing four independently-duplicated ad hoc `"Europe/Berlin"` fallbacks:

- `frontend/src/lib/format.ts`'s formatters, and the opportunity wizard's `datetime-local` inputs, now render/parse against Europe/Berlin explicitly, with the zone name shown (`27 Aug 2026, 09:00 CEST`)
- `GetDateAvailabilityAsync` now resolves each slot's own offset via the caller's `X-Timezone` header instead of applying one scalar offset to every slot in the request window, fixing day-bucketing around DST transitions
- the login-streak memo's cache key now includes the computed day, and its expiry follows the caller's own zone instead of always Berlin midnight, so a client whose local day advances first is no longer swallowed by yesterday's cached entry
- confirm-engagement's ISO week is now always derived from Europe/Berlin rather than the confirming organizer's own header, so a volunteer's `ActivityStreak` no longer depends on which organizer clicks confirm

**One deliberate compromise worth a reviewer's attention:** `GetVolunteerOpportunityDateAvailabilityRequest.UtcOffsetMinutes` stays on the wire (now unused server-side, documented with a comment) rather than being removed. The two NSwag-generated clients (`frontend/src/client/api-client.ts`, `backend/tests/IntegrationTests/ApiClient.cs`) couldn't be regenerated in this sandbox - the .NET SDK download is blocked by network policy here - and both files are hook-protected from hand-editing, so removing the field would have left the checked-in generated clients silently out of sync with no way to fix them in this environment. A `dotnet build` regeneration whenever this next gets touched can drop it cleanly.

## Testing

- Added regression tests for both DST dates named in the issue (`2027-03-31 00:30` and `2026-10-31 23:30` Berlin) in `GetVolunteerOpportunityDateAvailabilityTests`
- Added a login-streak test reproducing the issue's own Asia/Tokyo example (the client's local day advances before Berlin midnight), and reconciled the existing test that had asserted the old (buggy) cache-key behavior as intentional
- Added a confirm-engagement test proving the ISO week is now always Berlin-derived
- Added `frontend/src/lib/timezone.test.ts` covering both DST transitions plus a non-Berlin, non-DST zone
- Updated `frontend/src/lib/format.test.ts` (including a host-timezone-independence test via `vi.stubEnv`) and fixed a pre-existing `SignUpModal.test.tsx` assertion that only ever passed by coincidence of the CI runner's own UTC clock matching a UTC-labeled fixture
- **Backend: could not run `dotnet build`/the test suite locally** - this sandbox's network policy blocks the .NET SDK download (confirmed via the proxy status endpoint: `builds.dotnet.microsoft.com` returns 403). Verified instead via two independent read-only review passes (Clean Architecture/`ArchitectureTests` compliance, and an adversarial signature/call-site/DST-math check across every changed file) that found no issues. CI's `dotnet.yml` will be the first real compilation check on this PR - I'll be watching it.
- Frontend: `pnpm check`, `pnpm lint`, `pnpm format:check`, and `pnpm test` (927/927) all pass locally

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (no docs described the old per-surface behavior, so there's nothing to update)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKNrwoq4SurDXzicU81N1t)_