### PR TITLE
revert: restore CodeQL and image scanning, but report-only

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -9,6 +9,7 @@
 ├── frontend-checks.yml         Reusable (workflow_call): lint → test/build/container-smoke-test - shared by frontend.yml and publish.yml so the release path can't skip checks the PR gate runs (#1733)
 ├── docs.yml                    Docs: AsciiDoc build (push + PR) → GitHub Pages deploy (push only)
 ├── keycloak-realm-import.yml   Verifies the committed realm still imports on the Keycloak version the released image is built from, and that its ${VAR} placeholders actually resolve
+├── codeql.yml                  CodeQL advanced setup (csharp + javascript-typescript), report-only findings in the Security tab - see "CodeQL" below
 ├── publish.yml                 Tag-triggered: build + push backend/frontend/keycloak to GHCR, create a GitHub Release - see "Publish Workflows" below
 ├── release-rc.yml              Promotes a release/v* branch into a real tag (used by Claude Code on the web)
 ├── mutation-tests.yml          Manual (workflow_dispatch): Stryker.NET over Domain + Application and StrykerJS over frontend src/lib, report-only
@@ -37,6 +38,10 @@ workflows now always triggers, and:
 GitHub UI, job id `required`), not any individual job - an individual job may not run at all
 on a given PR, and in `visual-tests`' case is four matrix legs, not one. This is a one-time
 manual change in Settings → Branches this repository's tooling cannot make on its own.
+
+`codeql.yml` has no `paths:` filter and needs no sentinel - both languages scan the whole
+repository on every run regardless of which half changed, so there's no "skip when
+irrelevant" case to gate.
 
 ## CI Workflows (run on push/PR to main)
 
@@ -79,9 +84,21 @@ Publishing is where this repository's involvement ends. Nothing here runs, hosts
 1. Run full test suite - three parallel jobs (`backend-fast-tests`/`backend-integration-tests`/`backend-visual-tests`, same split as `dotnet.yml`) that `publish-backend`, `publish-frontend`, and `publish-keycloak` all wait on via `needs:` before building anything, so a test failure blocks every image, not just the backend's. `publish-frontend` additionally `needs:` the `frontend-checks` job, which calls the reusable `frontend-checks.yml` workflow (lint/format/i18n/nginx-header checks + type-check + unit tests + a container smoke test) - see that workflow's own header comment for what `publish-frontend` skipped before #1733; keycloak has no additional test gate beyond the shared backend suite. `publish-backend` additionally `needs:` `backend-image-health-check` (#2204): a job that builds the real backend image, boots Postgres/Keycloak/MinIO containers on a Docker network, runs the image against them with `ASPNETCORE_ENVIRONMENT=Production` and `Database__MigrateOnStartup=true`, and asserts `/health` goes green before any image is allowed to publish - this is the only place the released image itself (not `dotnet run`) is ever booted before it ships, and the only place the backend's Production startup path runs against real backing services
 2. Login to GHCR
 3. Extract version from tag (strips leading `v`)
-4. **Build and push.** Each `publish-*` job builds and pushes its image in a single step (cached via `cache-from`/`cache-to: type=gha` - the backend image reuses the cache warmed by `backend-image-health-check`'s own build) with `sbom: true` and `provenance: mode=max`, so every pushed image still carries an SBOM and a max-mode provenance attestation. No vulnerability scan gates this step (dropped - see `SECURITY.md`'s "Scope" section for the current state of container image scanning); nothing here uploads to the Security tab.
+4. **Build (no push) -> Trivy scan (report-only) -> build and push.** Each `publish-*` job builds its image once with `push: false, load: true` (cached via `cache-from`/`cache-to: type=gha`, reused from `backend-image-health-check` for the backend image), scans it with `aquasecurity/trivy-action` (`severity: CRITICAL,HIGH`), uploads the SARIF results to the Security tab (`github/codeql-action/upload-sarif`, `category: <component>-image`, `if: always()` so a failing scan's findings still land there), then builds again with `push: true` plus `sbom: true` and `provenance: mode=max` so every pushed image carries an SBOM and a max-mode provenance attestation. The second build reuses the first's cache, so this costs one cold build, not two. **Report-only, not a gate:** the scan step sets `continue-on-error: true`, so a CRITICAL/HIGH finding is uploaded and visible in the Security tab but never fails the job or blocks the push - see `SECURITY.md`'s "Scope" section. This was previously a hard `exit-code: 1` gate (#2305); the Keycloak image in particular can carry a CVE with no available fix path (UBI9-micro base layer, no newer Keycloak patch, no package manager to patch in place), which blocked every release with no actionable next step from this repo alone.
 5. Tag with version, plus `latest` if the tag is not an RC. Each `publish-*` job's final push step declares `id: push` and the job exposes its `outputs.digest`; `publish-backend` also still declares `outputs.version`/`outputs.prerelease`, consumed by `github-release`'s image table below (`github-release` also re-derives its own copy of the version from the tag directly)
 6. `github-release` job (`needs: [publish-backend, publish-frontend, publish-keycloak]`, so it runs for both stable and RC tags, and is the last job in this workflow) creates a GitHub Release for the tag via `gh release create`, using the default `GITHUB_TOKEN` (job-scoped `permissions: contents: write`, no `RELEASE_TOKEN` needed - creating a release doesn't push a ref, so it doesn't hit the "tags pushed with `GITHUB_TOKEN` don't trigger workflows" restriction that `release-rc.yml` works around). Notes are generated from commit subjects since the previous tag (found by semver sort across both stable and RC tags, via `git tag --sort=-v:refname`), grouped by Conventional Commit type - a `!` after the type/scope (e.g. `feat!:`) surfaces under a "Breaking Changes" section, followed by an Images table (component, image ref, digest) built from the three `publish-*` jobs' `outputs.digest` (#2204) - pin by digest straight from the release notes instead of a separate registry lookup. See [VERSIONING.md](../VERSIONING.md)'s "Release Notes" section - GitHub Releases is the canonical record, there is no `CHANGELOG.md` file.
+
+### `codeql.yml`
+CodeQL **advanced setup** (a workflow file), not GitHub's zero-config "default setup" -
+default setup is a Settings -> Code security -> Code scanning toggle, not something a commit
+can express, and the two are mutually exclusive (#2204). A maintainer who prefers default
+setup can enable it in Settings and delete this file instead. `analyze` is a two-language
+matrix (`csharp`, `javascript-typescript`), both with `build-mode: none` (no-build/interpreted
+extraction - simpler and faster than teaching CodeQL to build the whole Aspire solution, and
+the modern recommended mode where a language supports it). No `paths:` filter - see "Required
+status checks" above for why that's fine here specifically. Runs on push/PR to main plus a
+weekly `schedule:`; findings land in the Security tab, same as the Trivy scans above. Never a
+required check, so it cannot block a merge or a release either way.
 
 ## Cutting a release from Claude Code on the web
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+# Advanced setup (this workflow), not GitHub's zero-config "default setup" - default
+# setup is a repository Settings toggle (Settings -> Code security -> Code scanning),
+# not something a commit can express, and the two are mutually exclusive. This
+# workflow is the code-reviewable equivalent (#2204); a maintainer who prefers
+# default setup instead can enable it in Settings and delete this file.
+#
+# No `paths:` filter, unlike dotnet.yml/frontend.yml/etc. - both languages scan the
+# whole repository on every run regardless of which half changed, so there is no
+# "skip when irrelevant" case to gate and no sentinel job needed here.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -398,6 +398,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     outputs:
       prerelease: ${{ steps.version.outputs.prerelease }}
       version: ${{ steps.version.outputs.version }}
@@ -435,6 +436,38 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest,enable=${{ steps.version.outputs.prerelease == 'false' }}
 
+      - name: Build image for scanning
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: backend
+          file: backend/src/Api/Dockerfile
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=backend-image
+          cache-to: type=gha,mode=max,scope=backend-image
+
+      - name: Scan image for vulnerabilities
+        # Report-only: a finding is uploaded to the Security tab but never fails this
+        # step or blocks the push below - see SECURITY.md's "Scope" section.
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload vulnerability scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: trivy-results.sarif
+          category: backend-image
+
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -445,7 +478,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=backend-image
-          cache-to: type=gha,mode=max,scope=backend-image
           sbom: true
           provenance: mode=max
           build-args: |
@@ -472,6 +504,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
@@ -507,6 +540,37 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest,enable=${{ steps.version.outputs.prerelease == 'false' }}
 
+      - name: Build image for scanning
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: frontend
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=frontend-image
+          cache-to: type=gha,mode=max,scope=frontend-image
+
+      - name: Scan image for vulnerabilities
+        # Report-only: a finding is uploaded to the Security tab but never fails this
+        # step or blocks the push below - see SECURITY.md's "Scope" section.
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload vulnerability scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: trivy-results.sarif
+          category: frontend-image
+
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -516,7 +580,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=frontend-image
-          cache-to: type=gha,mode=max,scope=frontend-image
           sbom: true
           provenance: mode=max
           build-args: |
@@ -532,6 +595,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
@@ -575,6 +639,41 @@ jobs:
           labels: |
             org.opencontainers.image.base.version=${{ steps.keycloak.outputs.upstream_version }}
 
+      - name: Build image for scanning
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: keycloak
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=keycloak-image
+          cache-to: type=gha,mode=max,scope=keycloak-image
+
+      - name: Scan image for vulnerabilities
+        # Report-only: a finding is uploaded to the Security tab but never fails this
+        # step or blocks the push below - see SECURITY.md's "Scope" section. The
+        # Keycloak base image in particular has a known CVE with no fix path today
+        # (UBI9-micro base layer, no newer Keycloak patch, no package manager to
+        # patch in place) - blocking here would fail every release with no
+        # actionable next step from this repo alone.
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload vulnerability scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: trivy-results.sarif
+          category: keycloak-image
+
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -584,7 +683,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=keycloak-image
-          cache-to: type=gha,mode=max,scope=keycloak-image
           sbom: true
           provenance: mode=max
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,11 @@ frontend, or the Keycloak realm configuration) as well as in a dependency -
 there is currently no automated dependency vulnerability scan, so a report
 is the only way a dependency CVE affecting this project gets noticed.
 
-Known gaps, not yet covered by any workflow: dependency vulnerability
-scanning (no NuGet/npm audit step), static application security testing (no
-CodeQL or equivalent SAST scan), and container image scanning (no
-Trivy/Grype step in `publish.yml` before images are pushed to GHCR).
+Static application security testing (CodeQL, `.github/workflows/codeql.yml`)
+and container image scanning (Trivy, in `publish.yml`) both run, but neither
+gates anything - a finding is uploaded to the [Security tab](../../security)
+and nothing else, so a report is still the fastest way to get a vulnerability
+looked at rather than waiting on either scan to surface it.
+
+Known gap, not yet covered by any workflow: dependency vulnerability scanning
+(no NuGet/npm audit step).


### PR DESCRIPTION
## What

Reverts the "drop CodeQL and image scanning" part of [8ded589](https://github.com/maik-hasler/einsatzbereit/commit/8ded5892d74eac6a099e2825e0e8694739d40f85) (#2305), but restores both as report-only instead of the old blocking behavior.

## Why

8ded589 dropped CodeQL and Trivy image scanning entirely because Trivy's `exit-code: 1` was blocking every publish run - most immediately on a Keycloak base-image CVE with no available fix path (UBI9-micro base layer, no newer Keycloak patch, no package manager to patch in place).

Rather than leave the repo with no scanning at all, this brings both back non-blocking:

- `.github/workflows/codeql.yml` restored unchanged - it was already report-only (not a required check, runs on its own weekly schedule in addition to push/PR).
- `publish.yml`'s Trivy step restored for all three `publish-*` jobs, but with `continue-on-error: true` instead of a hard exit-code gate. A CRITICAL/HIGH finding still uploads to the Security tab, it just never fails the job or blocks the image push.
- `.github/AGENTS.md` and `SECURITY.md` updated to describe the restored, non-blocking workflows.

The unrelated fixes bundled into 8ded589 - the backend smoke-test's dummy `Smtp__Host`/`Smtp__Port` config and the frontend image's `apk --no-cache upgrade` step - are left in place; they're real bug fixes independent of the scanning question.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` and the same for `codeql.yml` - both parse.
- No app code changed; this is CI workflow + docs only. `dotnet.yml`/`frontend.yml` aren't affected. Behavior of `publish.yml` can only be verified on a real tag push (out of scope here - see `AGENTS.md`'s Sandbox Limitations).

## Checklist

- [x] CI is green (docs/workflow-only change, no build/test impact expected)
- [x] Documentation updated (`.github/AGENTS.md`, `SECURITY.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G78jgyTTrmu3mJnzfNnWy9)_