### PR TITLE
fix: set RequireHttpsMetadata=false for the backend image health-check smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -338,6 +338,14 @@ jobs:
           # RequiredConfigurationValidator (#2285) fails startup outside Development if
           # they're blank, but this smoke test never triggers an email send, so nothing
           # ever dials them.
+          #
+          # smoke-keycloak is plain HTTP - no TLS termination in front of it, unlike a
+          # real deployment's Authority. Without Authentication__RequireHttpsMetadata=false,
+          # JwtBearerHandler throws "MetadataAddress or Authority must use HTTPS" on every
+          # request (including anonymous ones, since authentication runs before endpoint
+          # routing), which crashes /health and /alive before they can respond. Same fix as
+          # ProductionEnvironmentFixture.cs/AppHost.cs use for the same reason - see
+          # Program.cs's comment on RequireHttpsMetadata.
           docker run -d --name smoke-backend --network backend-smoke-test -p 18081:8080 \
             -e ASPNETCORE_ENVIRONMENT=Production \
             -e ConnectionStrings__einsatzbereit="Host=smoke-postgres;Database=einsatzbereit;Username=einsatzbereit;Password=einsatzbereit" \
@@ -345,6 +353,7 @@ jobs:
             -e Keycloak__BaseUrl=http://smoke-keycloak:8080 \
             -e Keycloak__Realm=einsatzbereit \
             -e Authentication__Authority=http://smoke-keycloak:8080/realms/einsatzbereit \
+            -e Authentication__RequireHttpsMetadata=false \
             -e Authentication__ValidIssuers__0=http://smoke-keycloak:8080/realms/einsatzbereit \
             -e Cors__Origins__0=http://localhost \
             -e Smtp__Host=localhost \


### PR DESCRIPTION
## What

Sets `Authentication__RequireHttpsMetadata=false` on the `smoke-backend` container in `publish.yml`'s `backend-image-health-check` job.

## Why

The publish workflow's [backend-image-health-check](https://github.com/maik-hasler/einsatzbereit/actions/runs/33101258887/job/98619997206) job was failing: `/health` never went green.

Root cause: `smoke-backend` boots with `ASPNETCORE_ENVIRONMENT=Production` against `smoke-keycloak`, which serves plain HTTP with no TLS termination. In `Program.cs`, `Authentication:RequireHttpsMetadata` defaults to `!builder.Environment.IsDevelopment()`, i.e. `true` outside Development. With that default, `JwtBearerHandler` throws `"The MetadataAddress or Authority must use HTTPS unless disabled for development..."` - and it throws on *every* request, including anonymous ones like `/health` and `/alive`, because ASP.NET Core's authentication middleware runs before endpoint routing. That's why the health endpoint itself looked broken: it was crashing with a 500 on every call before it could ever answer.

This exact scenario is already documented and handled in two other places that boot the Production branch of `Program.cs` against a plain-HTTP Keycloak - `backend/tests/IntegrationTests/ProductionEnvironmentFixture.cs` and `backend/src/Aspire/AppHost/AppHost.cs` - both pass `Authentication:RequireHttpsMetadata=false` for the same reason. The smoke-test step added in `publish.yml` (#2204) was missed when that convention was established, since it configures the container directly with `docker run -e ...` rather than going through Aspire's environment wiring.

Closes #

## Testing

- Reproduced the failure by reading the CI job log for the referenced run: unauthenticated `/health` and `/alive` requests returned `500` with `System.InvalidOperationException: The MetadataAddress or Authority must use HTTPS...`.
- No test suite runs `publish.yml`'s `backend-image-health-check` job locally (needs Docker container networking against real Postgres/Keycloak/MinIO); the fix mirrors the exact env var already proven correct by `ProductionEnvironmentFixture.cs`'s equivalent case, and the workflow YAML was validated for syntax.
- Verified no other workflow boots the backend image the same way (`grep -r "ASPNETCORE_ENVIRONMENT=Production" .github` matches only `publish.yml`).

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green (pending - this fix targets a tag-triggered workflow, so it can only be exercised on an actual release tag)
- [ ] Documentation updated if this change affects behavior (not applicable - CI-only fix, no user-facing or documented behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_013sEJbePv4tnUe6e7Qp2DjY)_