### PR TITLE
feat: enable staging demo accounts, fix seeding and silent-renew SW bug

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Check PWA offline caching
         run: pnpm check:pwa-offline-caching
 
+      - name: Check PWA silent-renew navigate-fallback exclusion
+        run: pnpm check:pwa-silent-renew-fallback
+
       - name: Type check
         run: pnpm check
 

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -220,6 +220,18 @@ else if (app.Configuration.GetValue<bool>("Database:MigrateOnStartup"))
 	var initializer = scope.ServiceProvider.GetRequiredService<IApplicationDbContextInitializer>();
 
 	await initializer.MigrateAsync();
+
+	if (app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
+	{
+		try
+		{
+			await initializer.SeedAsync();
+		}
+		catch (Exception ex)
+		{
+			app.Logger.LogError(ex, "An exception occurred while seeding the database");
+		}
+	}
 }
 
 app.MapDefaultEndpoints(

--- a/backend/src/Aspire/AppHost/AppHost.cs
+++ b/backend/src/Aspire/AppHost/AppHost.cs
@@ -156,12 +156,21 @@ if (isTestEnv)
 	backend.WithEnvironment("Geocoding__UseFakeService", "true");
 }
 
-// Outside Development, Program.cs only migrates when this is true (and never seeds) - see
-// the isTestEnv block above. Unconditional (not isTestEnv-gated) for the same reason
+// Outside Development, Program.cs only migrates when this is true - see the isTestEnv
+// block above. Unconditional (not isTestEnv-gated) for the same reason
 // RateLimiting:Read:AnonymousPermitLimit above is: a config passthrough, not a test hook,
 // and a no-op in real Development usage since Program.cs never reads it there.
 if (builder.Configuration["Database:MigrateOnStartup"] is { } migrateOnStartup)
 	backend.WithEnvironment("Database__MigrateOnStartup", migrateOnStartup);
+
+// Same passthrough shape as Database:MigrateOnStartup above, for the same reason -
+// Program.cs only seeds outside Development when both this and MigrateOnStartup are
+// true, and ProductionEnvironmentFixture is the only caller that ever sets it. Without
+// this block the fixture's own --Database:SeedOnStartup=true only reaches the AppHost's
+// *own* configuration, never the backend project it launches - Aspire only forwards what
+// is explicitly passed via WithEnvironment.
+if (builder.Configuration["Database:SeedOnStartup"] is { } seedOnStartup)
+	backend.WithEnvironment("Database__SeedOnStartup", seedOnStartup);
 
 // Same passthrough shape as Database:MigrateOnStartup above, for the same reason - see
 // Program.cs's comment on RequireHttpsMetadata for why ProductionEnvironmentFixture is

--- a/backend/tests/IntegrationTests/ProductionEnvironmentFixture.cs
+++ b/backend/tests/IntegrationTests/ProductionEnvironmentFixture.cs
@@ -10,8 +10,8 @@ namespace IntegrationTests;
 // A separate, minimal Aspire boot from IntegrationTestFixture's - AppHost.cs pins the shared
 // fixture's backend to ASPNETCORE_ENVIRONMENT=Development for all of its ~70 test classes, and
 // that value is fixed for the lifetime of one Aspire boot. Testing the non-Development branch
-// of Program.cs (RequiredConfigurationValidator, Database:MigrateOnStartup, HSTS) genuinely
-// needs its own instance rather than a flag on the shared one (#2204).
+// of Program.cs (RequiredConfigurationValidator, Database:MigrateOnStartup, Database:SeedOnStartup,
+// HSTS) genuinely needs its own instance rather than a flag on the shared one (#2204).
 public class ProductionEnvironmentFixture
 	: IAsyncInitializer,
 	IAsyncDisposable
@@ -25,6 +25,7 @@ public class ProductionEnvironmentFixture
 				"--environment", "Testing",
 				"--Testing:BackendAspNetCoreEnvironment=Production",
 				"--Database:MigrateOnStartup=true",
+				"--Database:SeedOnStartup=true",
 				// This Aspire test network's Keycloak is always plain HTTP - no TLS
 				// termination in front of it, unlike a real deployment's Authority. Without
 				// this, JwtBearerHandler throws "MetadataAddress or Authority must use

--- a/backend/tests/IntegrationTests/ProductionEnvironmentTests.cs
+++ b/backend/tests/IntegrationTests/ProductionEnvironmentTests.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Json;
+using Application.Common.Pagination;
+using Application.Organizations.GetPublicOrganizations.v1;
 using AwesomeAssertions;
 
 namespace IntegrationTests;
@@ -5,7 +8,9 @@ namespace IntegrationTests;
 // Covers the non-Development branch of Program.cs that no other test runs (#2204):
 // RequiredConfigurationValidator doesn't throw and the app boots successfully in
 // Production, Database:MigrateOnStartup applies the schema instead of the
-// Development branch's unconditional migrate+seed, and the HSTS header is added.
+// Development branch's unconditional migrate+seed, Database:SeedOnStartup gates
+// seeding the same way it's documented to (README.md's Database__SeedOnStartup row),
+// and the HSTS header is added.
 [ClassDataSource<ProductionEnvironmentFixture>(Shared = SharedType.PerClass)]
 public class ProductionEnvironmentTests(ProductionEnvironmentFixture fixture)
 {
@@ -37,5 +42,19 @@ public class ProductionEnvironmentTests(ProductionEnvironmentFixture fixture)
 		var response = await client.GetAsync("/health", cancellationToken);
 
 		response.Headers.Contains("Strict-Transport-Security").Should().BeTrue();
+	}
+
+	[Test]
+	public async Task GetPublicOrganizationsDirectory_ShouldReturnSeededOrganizations_WhenSeedOnStartupIsEnabled(
+		CancellationToken cancellationToken)
+	{
+		using var client = fixture.CreateHttpClient();
+
+		var response = await client.GetFromJsonAsync<PagedList<PublicOrganizationSummary>>(
+			"/v1/organizations/directory?PageNumber=1&PageSize=10", cancellationToken);
+
+		response.Should().NotBeNull();
+		response!.Items.Should().Contain(o => o.Name == "Lindenauer Nachbarschaftshilfe e.V.");
+		response.Items.Should().Contain(o => o.Name == "Lindenauer Tierschutzverein e.V.");
 	}
 }

--- a/backend/tests/IntegrationTests/ProductionEnvironmentTests.cs
+++ b/backend/tests/IntegrationTests/ProductionEnvironmentTests.cs
@@ -1,6 +1,3 @@
-using System.Net.Http.Json;
-using Application.Common.Pagination;
-using Application.Organizations.GetPublicOrganizations.v1;
 using AwesomeAssertions;
 
 namespace IntegrationTests;
@@ -48,13 +45,11 @@ public class ProductionEnvironmentTests(ProductionEnvironmentFixture fixture)
 	public async Task GetPublicOrganizationsDirectory_ShouldReturnSeededOrganizations_WhenSeedOnStartupIsEnabled(
 		CancellationToken cancellationToken)
 	{
-		using var client = fixture.CreateHttpClient();
+		var directory = new EinsatzbereitApi(fixture.CreateHttpClient());
 
-		var response = await client.GetFromJsonAsync<PagedList<PublicOrganizationSummary>>(
-			"/v1/organizations/directory?PageNumber=1&PageSize=10", cancellationToken);
+		var page = await directory.GetPublicOrganizationsAsync(1, 10, cancellationToken: cancellationToken);
 
-		response.Should().NotBeNull();
-		response!.Items.Should().Contain(o => o.Name == "Lindenauer Nachbarschaftshilfe e.V.");
-		response.Items.Should().Contain(o => o.Name == "Lindenauer Tierschutzverein e.V.");
+		page.Items.Should().Contain(o => o.Name == "Lindenauer Nachbarschaftshilfe e.V.");
+		page.Items.Should().Contain(o => o.Name == "Lindenauer Tierschutzverein e.V.");
 	}
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
     "check:nginx-permissions-policy": "node scripts/check-nginx-permissions-policy.js",
     "check:pwa-precache": "node scripts/check-pwa-precache.js",
     "check:pwa-manifest": "node scripts/check-pwa-manifest.js",
-    "check:pwa-offline-caching": "node scripts/check-pwa-offline-caching.js"
+    "check:pwa-offline-caching": "node scripts/check-pwa-offline-caching.js",
+    "check:pwa-silent-renew-fallback": "node scripts/check-pwa-silent-renew-fallback.js"
   },
   "dependencies": {
     "@fontsource-variable/source-sans-3": "5.3.0",

--- a/frontend/scripts/check-pwa-silent-renew-fallback.js
+++ b/frontend/scripts/check-pwa-silent-renew-fallback.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(__dirname, "..");
+
+const viteConfig = readFileSync(join(frontendDir, "vite.config.ts"), "utf8");
+
+let ok = true;
+function fail(message) {
+	console.error(message);
+	ok = false;
+}
+
+function sliceBalanced(source, startIndex, open, close) {
+	const from = source.indexOf(open, startIndex);
+	if (from === -1) return null;
+	let depth = 0;
+	for (let i = from; i < source.length; i++) {
+		if (source[i] === open) depth++;
+		else if (source[i] === close) {
+			depth--;
+			if (depth === 0) return source.slice(from, i + 1);
+		}
+	}
+	return null;
+}
+
+const denylistIndex = viteConfig.indexOf("navigateFallbackDenylist:");
+const denylistBlock =
+	denylistIndex === -1
+		? null
+		: sliceBalanced(viteConfig, denylistIndex, "[", "]");
+if (!denylistBlock) {
+	fail("Could not find workbox.navigateFallbackDenylist in vite.config.ts.");
+}
+
+// Regex literals in the array look like /^\/silent-renew\.html.../ - scan from the
+// first "/" of the one mentioning "silent-renew" to the matching unescaped closing
+// "/", respecting backslash escapes, rather than a hand-rolled regex-matching-regex.
+function extractRegexLiteralContaining(source, needle) {
+	const needleIndex = source.indexOf(needle);
+	if (needleIndex === -1) return null;
+	const start = source.lastIndexOf("/", needleIndex);
+	if (start === -1) return null;
+	for (let i = start + 1; i < source.length; i++) {
+		if (source[i] === "\\") {
+			i++;
+			continue;
+		}
+		if (source[i] === "/") return source.slice(start, i + 1);
+	}
+	return null;
+}
+
+const literal = denylistBlock
+	? extractRegexLiteralContaining(denylistBlock, "silent-renew")
+	: null;
+if (!literal) {
+	fail(
+		"navigateFallbackDenylist in vite.config.ts has no pattern excluding /silent-renew.html - " +
+			"without it, the service worker's SPA-shell fallback intercepts the hidden silent-SSO-renewal " +
+			"iframe's navigation and serves index.html instead (#2042), silently breaking automatic " +
+			"session renewal (react-oidc-context's automaticSilentRenew/signinSilent) - the only visible " +
+			"symptom is a CSP frame-ancestors console warning that looks unrelated.",
+	);
+} else {
+	// Constructing the real RegExp from vite.config.ts's own literal text (rather than
+	// pattern-matching the literal's escaping by eye) is the point: this is a trusted,
+	// self-authored file, and a text-only assertion here would keep passing even if the
+	// escaping changed in a way that broke the pattern, since it would never actually run it.
+	const regExp = eval(literal);
+
+	// Workbox's NavigationRoute tests denylist/allowlist patterns against
+	// `url.pathname + url.search` (workbox-routing's NavigationRoute.ts _match()), and
+	// Keycloak's redirect back to silent_redirect_uri always carries a query string -
+	// ?code=...&state=...&session_state=... on success, ?error=login_required&state=...&iss=...
+	// with no active SSO session. A pattern anchored with `$` directly after ".html" (no
+	// allowance for a query string) only ever matches a bare, query-less request this flow
+	// never actually sends - which is exactly the bug this check exists to catch (found live
+	// on einsatzbereit.maik-hasler.de: DevTools showed the redirect blocked by
+	// frame-ancestors 'none', because the service worker served cached index.html instead of
+	// the real silent-renew.html).
+	const successRedirect =
+		"/silent-renew.html?code=abc123&state=xyz&session_state=1";
+	const noSessionRedirect =
+		"/silent-renew.html?error=login_required&state=xyz&iss=https%3A%2F%2Flogin.example.test%2Frealms%2Feinsatzbereit";
+
+	if (!regExp.test(successRedirect)) {
+		fail(
+			`navigateFallbackDenylist's silent-renew pattern (${regExp}) does not match a real ` +
+				`silent-renewal success redirect ("${successRedirect}"). Keycloak's redirect always ` +
+				"carries a query string, so a pattern with no allowance for one silently never excludes it.",
+		);
+	}
+	if (!regExp.test(noSessionRedirect)) {
+		fail(
+			`navigateFallbackDenylist's silent-renew pattern (${regExp}) does not match the ` +
+				`no-active-session redirect ("${noSessionRedirect}").`,
+		);
+	}
+}
+
+if (ok) {
+	console.log(
+		"workbox.navigateFallbackDenylist's /silent-renew.html pattern matches Keycloak's real, " +
+			"query-string-bearing redirect back to it.",
+	);
+} else {
+	process.exit(1);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -345,8 +345,17 @@ export default defineConfig({
 				// route - without this, the service worker's SPA-shell fallback
 				// would intercept the hidden iframe's navigation to it and serve
 				// index.html instead, booting the full app right back into the
-				// iframe it exists to avoid.
-				navigateFallbackDenylist: [/^\/v1\//, /^\/silent-renew\.html$/],
+				// iframe it exists to avoid. Workbox's NavigationRoute matches
+				// denylist patterns against pathname + search (its own docs and
+				// workbox-routing's NavigationRoute.ts _match()), and Keycloak's
+				// redirect back here always carries a query string
+				// (?code=...&state=... on success, ?error=login_required&state=...
+				// with no active session) - the un-anchored-for-query original
+				// pattern below only ever matched a bare, query-less request that
+				// this flow never actually sends, so the fallback intercepted every
+				// silent-renewal round trip and served index.html (with its
+				// frame-ancestors 'none') into the hidden iframe instead.
+				navigateFallbackDenylist: [/^\/v1\//, /^\/silent-renew\.html(\?.*)?$/],
 			},
 
 			manifest: deManifest,

--- a/keycloak/realms/einsatzbereit-realm.json
+++ b/keycloak/realms/einsatzbereit-realm.json
@@ -344,7 +344,7 @@
     {
       "id": "00000000-0000-0000-0000-000000000002",
       "username": "vera",
-      "enabled": false,
+      "enabled": true,
       "emailVerified": true,
       "requiredActions": [],
       "email": "vera@example.com",
@@ -364,7 +364,7 @@
     {
       "id": "00000000-0000-0000-0000-000000000001",
       "username": "olaf",
-      "enabled": false,
+      "enabled": true,
       "emailVerified": true,
       "requiredActions": [],
       "email": "olaf@example.com",
@@ -385,7 +385,7 @@
     {
       "id": "00000000-0000-0000-0000-000000000003",
       "username": "admin",
-      "enabled": false,
+      "enabled": true,
       "emailVerified": true,
       "requiredActions": [],
       "email": "admin@example.com",


### PR DESCRIPTION
## What

Three changes, the third found while investigating a console error the user reported on the two above going live:

1. **`keycloak/realms/einsatzbereit-realm.json`**: `vera`/`olaf`/`admin` flip from `enabled: false` to `enabled: true`.
2. **`backend/src/Api/Program.cs`**: `Database:SeedOnStartup` now actually gates seeding outside `Development` (it was dead code - see Why).
3. **`frontend/vite.config.ts`**: fixes a real, pre-existing bug in the service worker's `navigateFallbackDenylist` for `/silent-renew.html` that silently broke silent SSO renewal - unrelated to (1)/(2), found by chasing down a CSP console error the user asked me to re-check rather than dismiss.

## Why

### (1) and (2): staging demo experience

Both were previously off by design, documented as "don't do this outside development" (`keycloak/AGENTS.md`'s #2197, `README.md`'s `Database__SeedOnStartup` row). The repo owner made an explicit, informed decision to turn both on for this specific staging deployment, understanding that:

- `vera`/`olaf`/`admin`'s passwords are published in `README.md`'s Test users table, so this makes those accounts (including `admin`, full administration rights) loggable-in-as by anyone who reads the repo.
- Seeding permanently mixes 10 fake volunteer opportunities + 2 fake organizations + an organizer role grant to a hardcoded placeholder account into whatever real data this environment accumulates later - there's no clean undo short of wiping the database.

While wiring up (2), found that `Database:SeedOnStartup` was never actually read by `Program.cs` outside `Development` - only `Database:MigrateOnStartup` was. `mgmt-hetzner`'s `deploy-einsatzbereit.yaml` has set `DATABASE_SEED_ON_STARTUP=true` for every staging deploy already, expecting it to work per `README.md`'s description - it just silently never did anything. This is a real fix, not scoped down to "just for this deployment": any other deployer who opts in via the same documented env var now gets the documented behavior too.

### (3) silent-renew navigate-fallback

DevTools on the live (fixed) staging deployment showed `/silent-renew.html?error=login_required&state=...&iss=...` served `200 OK (from service worker)` carrying the **root page's** CSP (`frame-ancestors 'none'`) instead of `/silent-renew.html`'s own (`frame-ancestors 'self'`, added by #2042 for exactly this iframe). Traced it to `workbox.navigateFallbackDenylist`'s `/silent-renew.html` pattern being anchored with `$` right after `.html`, with no allowance for a query string. Confirmed against the actual installed `workbox-routing` source (`NavigationRoute.ts`'s `_match()`) that Workbox tests denylist patterns against `url.pathname + url.search` - and Keycloak's redirect back to `silent_redirect_uri` *always* carries a query string (`?code=...&state=...` on success, `?error=login_required&state=...&iss=...` with no active session), so the pattern never actually excluded the real request. The service worker's SPA-shell fallback then served cached `index.html` into the hidden silent-renewal iframe instead of the real `silent-renew.html` - not just console noise: `signinSilentCallback()` (`frontend/src/silentRenew.ts`) never got to run, so `automaticSilentRenew`/`signinSilent()` (`useSilentSsoProbe`, `authRefresh.ts`) silently never completed.

## Testing

- `dotnet build` (whole solution) - 0 errors
- `dotnet run --project tests/Application.UnitTests` - 1095/1095 passed
- `dotnet run --project tests/ArchitectureTests` - 425/425 passed
- New backend test: `ProductionEnvironmentTests.GetPublicOrganizationsDirectory_ShouldReturnSeededOrganizations_WhenSeedOnStartupIsEnabled` (`IntegrationTests`, runs in CI only - no reliable Docker in this sandbox per `AGENTS.md`)
- `keycloak-realm-import.yml` (CI) verifies the realm still imports cleanly with the accounts enabled
- Frontend: `pnpm build`, `pnpm check`, `pnpm lint`, `pnpm format:check` all clean; `pnpm build`'s generated `dist/sw.js` inspected directly to confirm the fixed pattern compiled in; new `pnpm check:pwa-silent-renew-fallback` script constructs the real `RegExp` from `vite.config.ts`'s own literal and asserts it against both a success- and error-shaped Keycloak redirect - verified locally that it **fails** against the old (pre-fix) pattern and **passes** against the fix, then wired into `frontend-checks.yml`'s `lint` job

## Checklist

- [ ] `/self-review` run and findings addressed - not run; each change was reviewed manually (against documented intent for (1)/(2), against the installed workbox-routing source and a live before/after regex test for (3))
- [ ] CI is green
- [x] Documentation updated if this change affects behavior - (1)/(2): none needed, `README.md`'s `Database__SeedOnStartup` row already describes the now-correct behavior; (3): the existing code comment above `navigateFallbackDenylist` is expanded in place to explain the query-string requirement