### PR TITLE
fix: remove active-nav underline on transparent header and visible result counts

### DIFF
--- a/frontend/src/components/Header/DesktopHeader.tsx
+++ b/frontend/src/components/Header/DesktopHeader.tsx
@@ -49,7 +49,7 @@ export default function DesktopHeader({
 						? "text-brand-100 hover:text-white"
 						: "text-gray-600 hover:text-brand-800";
 					const activeClass = isTransparent
-						? "border-white font-semibold text-white"
+						? "font-semibold text-white"
 						: "border-brand-700 font-semibold text-brand-800";
 
 					if (link.kind === "organization") {

--- a/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
+++ b/frontend/src/components/VolunteerOpportunitiesList/OpportunityResultsList.tsx
@@ -56,11 +56,7 @@ export default function OpportunityResultsList({
 			<p
 				role="status"
 				data-testid="opportunities-live-region"
-				className={
-					!error && items.length > 0
-						? "mb-4 text-center text-sm text-gray-600"
-						: "sr-only"
-				}
+				className="sr-only"
 			>
 				{liveMessage}
 			</p>
@@ -163,7 +159,7 @@ export default function OpportunityResultsList({
 									<p
 										role="status"
 										data-testid="opportunities-load-more-progress"
-										className="mb-2 text-center text-sm text-gray-600"
+										className="sr-only"
 									>
 										{t("opportunities.loadedOfTotal", {
 											loaded: items.length,

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -128,11 +128,7 @@ export default function OrganizationsPage() {
 			<p
 				role="status"
 				data-testid="organizations-result-count"
-				className={
-					!error && items.length > 0
-						? "mb-4 text-center text-sm text-gray-600"
-						: "sr-only"
-				}
+				className="sr-only"
 			>
 				{liveMessage}
 			</p>


### PR DESCRIPTION
## What

Two small UI cleanups requested directly by the user:

1. The primary nav's active-link underline (`border-white`) is now removed when the header sits transparent over the green hero band (`DesktopHeader.tsx`) - it read as an unwanted stray line against that background. The underline on the solid white header is unchanged.
2. The "X found" total-count text on `/opportunities` and `/organizations` (and the "X of Y loaded" progress line while paginating) is now screen-reader only instead of visible body text, so the number is no longer shown on screen while the `role="status"` live-region announcement for assistive tech is preserved.

## Why

User feedback: the underline on the green header looked bad, and the visible total counts on the opportunities/organizations pages weren't wanted.

## Testing

- `pnpm lint` - clean
- `pnpm check` (tsc --noEmit) - clean
- `pnpm vitest run` on the affected test files (`OrganizationsPage`, `VolunteerOpportunitiesList`, `Header`) - all 85 tests passed
- `pnpm format:write` applied

## Checklist

- [x] CI expected to be green (lint/check/tests run locally)
- [ ] Documentation updated if this change affects behavior (no doc changes needed - pure UI styling)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BQEeEQsYxkYRRBgs9RpZYP)_