### PR TITLE
fix(header): reduce mobile nav density

### DIFF
--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -113,12 +113,12 @@ export default function MobileMenu({
 						<div className="absolute -top-8 -right-16 h-48 w-48 rounded-full bg-brand-600 opacity-40 blur-3xl" />
 					</div>
 				)}
-				<div className="relative space-y-2 px-4 py-4">
+				<div className="relative space-y-1.5 px-3 py-3">
 					<div
-						className={`space-y-1 border-b pb-3 ${isTransparent ? "border-white/20" : "border-gray-100"}`}
+						className={`space-y-0.5 border-b pb-2 ${isTransparent ? "border-white/20" : "border-gray-100"}`}
 					>
 						{buildPrimaryNav(activeOrg).map((link) => {
-							const rowBase = `rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`;
+							const rowBase = `rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${menuItemVariant}`;
 
 							if (link.kind === "organization") {
 								return (
@@ -138,7 +138,7 @@ export default function MobileMenu({
 										</Link>
 
 										<div
-											className={`ml-3 space-y-1 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
+											className={`ml-3 space-y-0.5 border-l pl-3 ${isTransparent ? "border-white/20" : "border-gray-200"}`}
 										>
 											{ORG_TABS.filter((tab) => tab.key !== "dashboard").map(
 												(tab) => (
@@ -146,7 +146,7 @@ export default function MobileMenu({
 														key={tab.key}
 														to={orgTabPath(link.org.id, tab.key)}
 														onClick={onClose}
-														className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-700"}`}
+														className={`block rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${isTransparent ? "text-white/80 hover:bg-white/10 hover:text-white" : "text-gray-600 hover:bg-brand-50 hover:text-brand-700"}`}
 													>
 														{t(tab.labelKey)}
 													</Link>
@@ -180,23 +180,25 @@ export default function MobileMenu({
 							);
 						})}
 					</div>
-					<div className="pb-2">
+					<div className="pb-1.5">
 						<LanguageSelector transparent={isTransparent} />
 					</div>
 					{authStatus === "signedIn" && (
-						<div className="space-y-1">
-							<div className="flex items-center gap-3 px-3 py-2">
+						<div className="space-y-0.5">
+							<div
+								className={`mb-0.5 flex items-center gap-2.5 border-b px-3 pb-2 ${isTransparent ? "border-white/20" : "border-gray-100"}`}
+							>
 								{avatarUrl ? (
 									<img
 										src={avatarUrl}
 										alt=""
-										width={36}
-										height={36}
+										width={32}
+										height={32}
 										loading="lazy"
-										className="h-9 w-9 rounded-full object-cover"
+										className="h-8 w-8 rounded-full object-cover"
 									/>
 								) : (
-									<div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-700 text-sm font-semibold tracking-widest text-white">
+									<div className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-700 text-xs font-semibold tracking-widest text-white">
 										{initials}
 									</div>
 								)}
@@ -209,21 +211,21 @@ export default function MobileMenu({
 							<Link
 								to="/profile"
 								onClick={onClose}
-								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+								className={`block rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${menuItemVariant}`}
 							>
 								{t("nav.myProfile")}
 							</Link>
 							<Link
 								to="/my-signups"
 								onClick={onClose}
-								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+								className={`block rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${menuItemVariant}`}
 							>
 								{t("nav.myEngagements")}
 							</Link>
 							<Link
 								to="/profile/settings"
 								onClick={onClose}
-								className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+								className={`block rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${menuItemVariant}`}
 							>
 								{t("nav.profileSettings")}
 							</Link>
@@ -231,7 +233,7 @@ export default function MobileMenu({
 								<Link
 									to="/administration"
 									onClick={onClose}
-									className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${menuItemVariant}`}
+									className={`block rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${menuItemVariant}`}
 								>
 									{t("nav.administration")}
 								</Link>
@@ -239,7 +241,7 @@ export default function MobileMenu({
 							<button
 								type="button"
 								onClick={onSignOut}
-								className={`block w-full rounded-lg border-t px-3 py-2 text-left text-sm font-medium transition-colors ${isTransparent ? "border-white/20" : "border-gray-100"} ${menuItemVariant}`}
+								className={`block w-full rounded-lg px-3 py-1.5 text-left text-sm font-medium transition-colors ${menuItemVariant}`}
 							>
 								{t("nav.signOut")}
 							</button>


### PR DESCRIPTION
## What

Tightens the mobile nav's spacing so the menu feels less crowded on a phone screen - same links, less vertical bulk.

## Why

The mobile nav (`MobileMenu.tsx`) looked very full/cramped on a real device: every row used `py-2` padding regardless of hierarchy, and the signed-in account section's name row looked identical to every other nav item instead of reading as a header.

No links or functionality were removed - this is a spacing-only pass:
- Row padding: `py-2` → `py-1.5` on every nav row, org sub-tab, and account link
- Section gaps tightened (`space-y-1`/`space-y-2` → `space-y-0.5`/`space-y-1.5`), outer container `px-4 py-4` → `px-3 py-3`
- Account avatar shrunk from 36px to 32px
- The account name row now sits above a `border-b` separator (moved from where it previously sat above "Sign out"), so it reads as a section header rather than another nav row

## Testing

- `pnpm exec eslint src/components/Header/MobileMenu.tsx` - clean
- `pnpm exec prettier --check src/components/Header/MobileMenu.tsx` - clean
- `pnpm exec vitest run src/components/Header/MobileMenu.a11y.test.tsx src/components/Header/Header.test.tsx src/App.test.tsx` - 30/30 passing

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [x] Documentation updated if this change affects behavior (n/a - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MsUre77XVhgoTrNREyQYwY)_