### PR TITLE
fix: correct mismatched pill radius on Opportunities search bar (mobile)

### DIFF
--- a/frontend/src/pages/OpportunitiesPage.tsx
+++ b/frontend/src/pages/OpportunitiesPage.tsx
@@ -38,7 +38,7 @@ export default function OpportunitiesPage() {
 				lead={t("opportunitiesPage.lead")}
 			>
 				<form onSubmit={handleSearch} className="max-w-xl">
-					<div className="flex flex-col gap-3 rounded-full bg-white/10 p-3 shadow-lg backdrop-blur-sm sm:flex-row sm:items-stretch">
+					<div className="flex flex-col gap-3 rounded-3xl bg-white/10 p-3 shadow-lg backdrop-blur-sm sm:flex-row sm:items-stretch sm:rounded-full">
 						<div className="relative flex-1 rounded-full border border-gray-200 bg-gray-50 text-left transition-colors focus-within:border-brand-400 focus-within:bg-white">
 							<MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-4 h-4 w-4 -translate-y-1/2 text-gray-400" />
 							<input


### PR DESCRIPTION
## What

Fixes a visual bug on the `/opportunities` search bar at mobile widths: the outer wrapper around the keyword input and search button used a flat `rounded-full`, which on mobile (where the input and button stack vertically into a two-row block) clamps the corner radius to roughly half the wrapper's height - far larger than the pill radius of the elements actually inside it. This exposed a visible crescent of the translucent `bg-white/10` fill and its `shadow-lg` bleeding out around the inner white search pill, matching the "ghost/duplicate rounded shadow" reported on a mobile screenshot of the page.

## Why

The landing page's near-identical hero search bar (`HomePage.tsx`) already carries the mobile-safe fix (`rounded-3xl` on mobile, `sm:rounded-full` once the bar becomes a single flat row). `OpportunitiesPage.tsx`'s search bar was missing this override, so it never got the fix when `HomePage`'s was introduced. This PR applies the same pattern to `OpportunitiesPage.tsx`.

## Testing

- `pnpm prettier --check` and `pnpm exec eslint` on the changed file - clean
- `pnpm check` (`tsc --noEmit`) - clean
- Manual code comparison against `HomePage.tsx`'s working equivalent

No functional/behavioral change - CSS class change only, so no new automated test was added. (There is currently no visual-regression coverage for this hero search bar's shape at mobile widths; a follow-up Playwright case alongside `backend/tests/VisualTests/OpportunityFilterRowAlignmentTests.cs` would close that gap, but is out of scope for this focused fix.)

## Checklist

- [x] `/self-review` run and findings addressed
- [ ] CI is green
- [ ] Documentation updated if this change affects behavior (N/A - no behavior change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeM9hvNEDDHsXmZHQUYtvB)_